### PR TITLE
WebAssembly platform

### DIFF
--- a/Emscripten/README.md
+++ b/Emscripten/README.md
@@ -1,0 +1,5 @@
+# EmscriptenBuilder
+
+[![Build Status](https://travis-ci.org/XX/EmscriptenBuilder.svg?branch=master)](https://travis-ci.org/XX/EmscriptenBuilder)
+
+This is an example repository showing how to construct a "builder" repository for a binary dependency.  Using a combination of [`BinaryBuilder.jl`](https://github.com/staticfloat/BinaryBuilder.jl), [Travis](https://travis-ci.org), and [GitHub releases](https://docs.travis-ci.com/user/deployment/releases/), we are able to create a fully-automated, github-hosted binary building and serving infrastructure.

--- a/Emscripten/build_tarballs.jl
+++ b/Emscripten/build_tarballs.jl
@@ -1,0 +1,108 @@
+###
+# EmscriptenBuilder
+###
+
+using BinaryBuilder
+
+# Collection of sources required to build Emscripten
+emscripten_version="1.38.20"
+sources = [
+    "https://github.com/kripken/emscripten/archive/$(emscripten_version).tar.gz" =>
+    "9f486c3b9516a82e2cbc6968d07746ae4bad013e4358ac6f2a5c1bc829ca6700",
+    # Can't pull these in because they have duplicated base names.
+    # "https://github.com/kripken/emscripten-fastcomp/archive/$(emscripten_version).tar.gz" =>
+    # "9f486c3b9516a82e2cbc6968d07746ae4bad013e4358ac6f2a5c1bc829ca6700",
+    # "https://github.com/kripken/emscripten-fastcomp-clang/archive/$(emscripten_version).tar.gz" =>
+    # "9f486c3b9516a82e2cbc6968d07746ae4bad013e4358ac6f2a5c1bc829ca6700",
+    "https://github.com/WebAssembly/binaryen/archive/version_58.tar.gz" =>
+    "faab2ee97a4adc2607ae058bc880a5c9b99fb613c9b8397c68adefe82436812b",
+    "./bundled",
+]
+
+emscripten_version = VersionNumber(emscripten_version)
+
+script = raw"""
+# We want to exit the program if errors occur.
+set -o errexit
+
+apk add nodejs
+cd $WORKSPACE/srcdir/
+mkdir ${prefix}/lib
+mv emscripten-* ${prefix}/lib/emscripten
+EMSCRIPTEN=/opt/${target}/lib/emscripten
+mv binaryen-ver* binaryen
+cp wasm32-unknown-*.toolchain ${prefix}
+
+wget https://github.com/kripken/emscripten-fastcomp/archive/1.38.20.tar.gz
+tar zxvf 1.38.20.tar.gz
+mv emscripten-fastcomp-* emscripten-fastcomp
+cd emscripten-fastcomp/tools
+wget https://github.com/kripken/emscripten-fastcomp-clang/archive/1.38.20.tar.gz
+tar zxvf 1.38.20.tar.gz
+mv emscripten-fastcomp-clang-* clang
+
+
+cd $WORKSPACE/srcdir/
+# Start with Binaryen
+cd binaryen
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=Release
+make -j$(($(nproc)+1))
+make install
+BINARYEN_ROOT=/opt/${target}/
+BINARYEN=/opt/${target}/
+
+cd $WORKSPACE/srcdir/emscripten-fastcomp
+
+# Let's do the actual build within the `build` subdirectory
+mkdir build && cd build
+
+cmake -G "Unix Makefiles" \
+    -DLLVM_TARGETS_TO_BUILD:STRING="X86;JSBackend" \
+    -DLLVM_PARALLEL_COMPILE_JOBS=$(($(nproc)+1)) \
+    -DLLVM_PARALLEL_LINK_JOBS=$(($(nproc)+1)) \
+    -DLLVM_BINDINGS_LIST="" \
+    -DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-unknown-emscripten \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_ENABLE_ASSERTIONS=Off \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DLIBCXX_HAS_MUSL_LIBC=On \
+    -DCLANG_DEFAULT_CXX_STDLIB=libc++ \
+    -DLLVM_TARGET_TRIPLE_ENV=LLVM_TARGET \
+    -DCOMPILER_RT_BUILD_SANITIZERS=Off \
+    -DCOMPILER_RT_BUILD_PROFILE=Off \
+    -DCOMPILER_RT_BUILD_LIBFUZZER=Off \
+    -DCOMPILER_RT_BUILD_XRAY=Off \
+    -DCMAKE_SKIP_RPATH=YES \
+    -DLLVM_BUILD_RUNTIME=OFF \
+    -DLLVM_INCLUDE_EXAMPLES=OFF \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DCLANG_INCLUDE_TESTS=OFF \
+    -DCMAKE_TOOLCHAIN_FILE=/opt/${target}/${target}.toolchain \
+    ..
+make -j$(($(nproc)+1))
+make install
+
+"""
+
+platforms = [
+    BinaryProvider.Linux(:x86_64, :glibc)
+]
+
+# The products that we will ensure are always built
+products(prefix) = [
+    # libraries
+    LibraryProduct(prefix, "libLLVM",  :libLLVM)
+    LibraryProduct(prefix, "libLTO",   :libLTO)
+    LibraryProduct(prefix, "libclang", :libclang)
+    # tools
+    ExecutableProduct(joinpath(prefix, "tools", "llvm-config"), :llvm_config)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+config = ""
+name = "Emscripten"
+
+build_tarballs(["--verbose", "--debug"], name, emscripten_version, sources, script, platforms, products, dependencies; skip_audit=true)

--- a/Emscripten/bundled/wasm32-unknown-emscripten.toolchain
+++ b/Emscripten/bundled/wasm32-unknown-emscripten.toolchain
@@ -1,0 +1,26 @@
+# Toolchain file for wasm32-unknown-emscripten
+set(CMAKE_SYSTEM_NAME Emscripten)
+# set(CMAKE_SYSTEM_PROCESSOR wasm32)
+
+set(CMAKE_SYSTEM_VERSION 1)
+if ("${EMSCRIPTEN_ROOT_PATH}" STREQUAL "")
+	set(CMAKE_FIND_ROOT_PATH "$ENV{EMSCRIPTEN}")
+else()
+	set(CMAKE_FIND_ROOT_PATH "${EMSCRIPTEN_ROOT_PATH}")
+endif()
+
+set(CMAKE_SYSROOT /opt/wasm32-unknown-emscripten/lib/emscripten/system/)
+set(CMAKE_INSTALL_PREFIX /workspace/destdir/)
+
+#set(CMAKE_C_COMPILER /opt/wasm32-unknown-emscripten/bin/emcc)
+#set(CMAKE_CXX_COMPILER /opt/wasm32-unknown-emscripten/bin/em++)
+
+# These settings don't seem to function properly, they stop cmake from being
+# able to find anything within the workspace at all.
+#set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+#set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+#set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+#set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+if( $ENV{CC} MATCHES ccache )
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+endif()


### PR DESCRIPTION
This adds a platform for WebAssembly using an Emscripten shard. Object files produces are LLVM IR with the `wasm32-unknown-emscripten` triplet. Compiled libraries can be used to produce WebAssembly files. 

[Here](https://github.com/tshort/Yggdrasil/blob/wasm-sundials-builder/Sundials/build_tarballs.jl) is a builder converted to target WebAssembly. 

Two things are still kludgy about this. One is that `emcc` has to be run once in the builder to initialize it. Emscripten needs to write set up information in `~/.emscripten`. I don't know how to pre-populate that, and I don't see a way to tell `emcc` to look somewhere else for this. Another issue is that Emscripten depends on `nodejs`. For now, I just used `apk add` in the builder. It needs a builder, or it needs to be added as a tool. I don't know which is best. It looks a bit tough to build (I gave it a quick try but had an early failure).

PR's incoming to BinaryBuilder and BinaryProvider to support this.

A BinaryBuilder issue I ran into is that the `sources` for different components of Emscripten have the same base name (`1.38.20.tar.gz`). I didn't know how to handle this, so I used `wget` to pull in some sources manually. 

My main goal is to try to support WebAssembly compilation of Julia code. This especially includes LLVM and some BLAS.

Emscripten has two main approaches for generating WebAssembly. This uses the oldest, most stable and most robust approach. It includes a custom version of LLVM/Clang with a special JavaScript backend. The newer approach uses LLVM's native WebAssembly backend, and it produces a `wasm32-unknown-unknown` target. Once LLVM v8 comes out, that would be a good time to switch (especially when Julia switches to LLVM v8).
