### PR TITLE
Upgrade to msys2 binaries

### DIFF
--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -9,12 +9,13 @@ sources = [
     "https://files.pythonhosted.org/packages/11/6c/b23aa4269df44df11b0409372bc20c3d249a4c7f7554009166010b2cc296/h5py-2.9.0-cp27-cp27m-manylinux1_i686.whl" => "0f94de7a10562b991967a66bbe6dda9808e18088676834c0a4dcec3fdd3bcc6f",
     "https://files.pythonhosted.org/packages/c8/d6/a1f58a4ebb2cfe93dcbae2e8e8cee3d81aeda8851b5a56cdae9a4eae6a60/h5py-2.9.0-cp27-cp27m-manylinux1_x86_64.whl" => "713ac19307e11de4d9833af0c4bd6778bde0a3d967cafd2f0f347223711c1e31",
 
-    # Use musm's mingw builds
-    "https://github.com/musm/hdf5-builds/files/3366273/hdf5-1.10.5-x86_64.zip" => "b4bf5067aa30210c13706c9dcfb1e99626c5139b1ae0a21102445ae0132791bc",
-    "https://github.com/musm/hdf5-builds/files/3366272/hdf5-1.10.5-i686.zip" => "31acf68b75cf81a6ca00abbd820c85cdf2d610490b8bd7decd9ee29e7de9b791",
-
-    # We need some special compiler support libraries from mingw
-    "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-libs-9.1.0-3-any.pkg.tar.xz" => "416819d44528e856fb1f142b41fd3b201615d19ddaed8faa5d71296676d6fa17",
+    # Take advantage of msys2 mingw builds of HDF5 for Windows
+    "http://repo.msys2.org/mingw/i686/mingw-w64-i686-hdf5-1.10.5-1-any.pkg.tar.xz" => "d29a56297219e1981f393e266ee515605237323fc20b0a69a45961c4bfe5e9da",
+    "http://repo.msys2.org/mingw/i686/mingw-w64-i686-szip-2.1.1-2-any.pkg.tar.xz" => "58b5efe1420a2bfd6e92cf94112d29b03ec588f54f4a995a1b26034076f0d369",
+    "http://repo.msys2.org/mingw/i686/mingw-w64-i686-zlib-1.2.11-7-any.pkg.tar.xz" => "addf6c52134027407640f1cbdf4efc5b64430f3a286cb4e4c4f5dbb44ce55a42",
+    "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-szip-2.1.1-2-any.pkg.tar.xz" => "ec8fe26370b0673c4b91f5ccf3404907dc7c24cb9d75c7b8830aa93a7c13ace7",
+    "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-hdf5-1.10.5-1-any.pkg.tar.xz" => "e01196dd53711304aa4026932c153171606efc4d6938dd3c172b6b40d9e7cdd9",
+    "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-zlib-1.2.11-7-any.pkg.tar.xz" => "1decf05b8ae6ab10ddc9035929014837c18dd76da825329023da835aec53cec2",
 ]
 
 # Bash recipe for building across all platforms
@@ -24,14 +25,9 @@ mkdir -p ${prefix}/lib ${prefix}/bin
 
 # If we're on Windows, extract from msys2 builds.  Otherwise, extract from .whl files
 if [[ ${target} == x86_64-*mingw* ]]; then
-    mv hdf5-1.10.5-x86_64/hdf5-1.10.5_x86_64/bin/{libhdf5,zlib}*.dll ${prefix}/bin
-    mv hdf5-1.10.5-x86_64/hdf5-1.10.5_x86_64/bin/*.exe ${prefix}/bin
+    mv mingw64/bin/*.dll ${prefix}/bin
 elif [[ ${target} == i686-*mingw* ]]; then
-    mv hdf5-1.10.5-i686/hdf5-1.10.5-i686/bin/{libhdf5,zlib}*.dll ${prefix}/bin
-    mv hdf5-1.10.5-i686/hdf5-1.10.5-i686/bin/*.exe ${prefix}/bin
-
-    # We need this special libgcc_s version as well
-    mv mingw32/bin/libgcc_s_dw2*.dll ${prefix}/bin
+    mv mingw32/bin/*.dll ${prefix}/bin
 else
     if [[ ${target} == x86_64-linux-gnu ]]; then
         WHL_FILE="h5py-*manylinux1_x86_64*.whl"
@@ -48,7 +44,7 @@ else
     fi
 
     unzip "${WHL_FILE}"
-    
+
     mv h5py/${LIBSDIR}/lib{sz,aec,hdf5}* ${prefix}/lib
 fi
 
@@ -63,7 +59,7 @@ elif [[ ${target} == *apple* ]]; then
         install_name_tool -change $(basename h5py/${LIBSDIR}/libz*.${dlext}*) libz.1.${dlext} ${f}
     done
 fi
-    
+
 
 # We need to be able to access `libhdf5` directly, so symlink it from the hashed filename from manylinux pypi
 if [[ ${target} == *linux* ]]; then
@@ -96,4 +92,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
- Use binaries provided from msys2 (they finally updated hdf5 after pushing the patches I sent).
- Reverted the changes made before upgrading to use my binaries.


