### PR TITLE
Add builder for FriBidi

### DIFF
--- a/F/FriBidi/build_tarballs.jl
+++ b/F/FriBidi/build_tarballs.jl
@@ -1,0 +1,38 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "FriBidi"
+version = v"1.0.5"
+
+# Collection of sources required to build FriBidi
+sources = [
+    "https://github.com/fribidi/fribidi/releases/download/v$(version)/fribidi-$(version).tar.bz2" =>
+    "6a64f2a687f5c4f203a46fa659f43dd43d1f8b845df8d723107e8a7e6158e4ce",
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/fribidi-*/
+./configure --prefix=$prefix --host=$target
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products(prefix) = [
+    LibraryProduct(prefix, "libfribidi", :libfribidi),
+    ExecutableProduct(prefix, "fribidi", :fribidi)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This is a dependency for Pango.

I'm building this with autotools, but it supports also meson.  When we get a basic support for meson in BinaryBuilder (https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/437) this should be a good test case, as it's way simpler than glib or pango.