### PR TITLE
Add builder for libuuid

### DIFF
--- a/L/Libuuid/build_tarballs.jl
+++ b/L/Libuuid/build_tarballs.jl
@@ -1,0 +1,37 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "Libuuid"
+version = v"2.34"
+
+# Collection of sources required to build FriBidi
+sources = [
+    "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v$(version.major).$(version.minor)/util-linux-$(version.major).$(version.minor).tar.xz" =>
+    "743f9d0c7252b6db246b659c1e1ce0bd45d8d4508b4dfa427bbb4a3e9b9f62b5"
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/util-linux-*/
+./configure --prefix=$prefix --host=$target --disable-all-programs --enable-libuuid
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [p for p in supported_platforms() if !(p isa Windows)]
+
+# The products that we will ensure are always built
+products(prefix) = [
+    LibraryProduct(prefix, "libuuid", :libuuid)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This is required by fontconfig, which is needed by Pango and Cairo on Linux and FreeBSD.

It's incredibly hard to find a single portable implementation of libuuid that can be cross-compiled for all platforms.  Apart this one in util-linux, I found:
* this: https://sourceforge.net/projects/libuuid/, despite being advertised as "portable", it doesn't work at all on Windows, includes Unix-only header files and tries to open files like `/dev/random`
* this could be a good cross-platform choice: http://www.ossp.org/pkg/lib/uuid/ (source code can be found, e.g., at http://deb.debian.org/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz), however it can't be cross-compiled as it performs some checks at configure time by running code that it compiles :man_facepalming: 