### PR TITLE
[Libffi] Link libraries in $prefix/lib64 to $prefix/lib

### DIFF
--- a/L/Libffi/build_tarballs.jl
+++ b/L/Libffi/build_tarballs.jl
@@ -15,6 +15,12 @@ cd $WORKSPACE/srcdir/libffi-*/
 ./configure --prefix=$prefix --host=$target
 make -j${nproc}
 make install
+if [[ -d ${prefix}/lib64 ]]; then
+    for f in ${prefix}/lib64/*.${dlext}; do
+        fbase="$(basename "${f}")"
+        ln -s "../lib64/${fbase}" "${prefix}/lib/${fbase}"
+    done
+fi
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
`BinaryProvider.jl` doesn't seem to be able to find libraries in `./lib64`.  This is a _dirty_ hack to work around this.