### PR TITLE
Add builder for libmount

### DIFF
--- a/L/Libmount/build_tarballs.jl
+++ b/L/Libmount/build_tarballs.jl
@@ -1,0 +1,36 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg.BinaryPlatforms
+
+name = "Libmount"
+version = v"2.34"
+
+# Collection of sources required to build FriBidi
+sources = [
+    "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v$(version.major).$(version.minor)/util-linux-$(version.major).$(version.minor).tar.xz" =>
+    "743f9d0c7252b6db246b659c1e1ce0bd45d8d4508b4dfa427bbb4a3e9b9f62b5"
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/util-linux-*/
+./configure --prefix=$prefix --host=$target --disable-all-programs --enable-libblkid --enable-libmount
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [p for p in supported_platforms() if !(p isa Union{FreeBSD,Windows,MacOS})]
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libmount", :libmount)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")


### PR DESCRIPTION
This is required by glib 2.62, in case we want to upgrade it.  Glib requires libmount only on Linux, so it's fine excluding all other operating systems.

Note that I'm getting errors when compiling for `powerpc64le-linux-gnu`:
```
In file included from libmount/src/context.c:42:0:
./include/namespace.h:34:19: error: static declaration of ‘unshare’ follows non-static declaration
 static inline int unshare(int flags)
                   ^
In file included from /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/include/sched.h:44:0,
                 from ./include/namespace.h:5,
                 from libmount/src/context.c:42:
/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/include/bits/sched.h:86:12: note: previous declaration of ‘unshare’ was here
 extern int unshare (int __flags) __THROW;
            ^
In file included from libmount/src/context.c:42:0:
./include/namespace.h:41:19: error: static declaration of ‘setns’ follows non-static declaration
 static inline int setns(int fd, int nstype)
                   ^
In file included from /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/include/sched.h:44:0,
                 from ./include/namespace.h:5,
                 from libmount/src/context.c:42:
/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/include/bits/sched.h:92:12: note: previous declaration of ‘setns’ was here
 extern int setns (int __fd, int __nstype) __THROW;
            ^
```