### PR TITLE
Add builder for Wayland

### DIFF
--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -1,0 +1,49 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg.BinaryPlatforms
+
+name = "Wayland"
+version = v"1.17.0"
+
+# Collection of sources required to build Wayland
+sources = [
+    "https://wayland.freedesktop.org/releases/wayland-$(version).tar.xz" =>
+    "72aa11b8ac6e22f4777302c9251e8fec7655dc22f9d94ee676c6b276f95f91a4",
+    "./bundled",
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/wayland-*/
+
+# We need to run `wayland-scanner` on the host system
+apk add wayland-dev
+
+atomic_patch -p1 ../patches/Makefile_in.patch
+./configure --prefix=${prefix} --host=${target} --disable-documentation --with-host-scanner
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [p for p in supported_platforms() if p isa Linux]
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("wayland-scanner", :wayland_scanner),
+    LibraryProduct("libwayland-client", :libwayland_client),
+    LibraryProduct("libwayland-cursor", :libwayland_cursor),
+    LibraryProduct("libwayland-egl", :libwayland_egl),
+    LibraryProduct("libwayland-server", :libwayland_server),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    "Expat_jll",
+    "Libffi_jll",
+    "XML2_jll",
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")

--- a/W/Wayland/bundled/patches/Makefile_in.patch
+++ b/W/Wayland/bundled/patches/Makefile_in.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -341,7 +341,7 @@
+ @ENABLE_LIBRARIES_TRUE@am_fixed_benchmark_OBJECTS =  \
+ @ENABLE_LIBRARIES_TRUE@	tests/fixed-benchmark.$(OBJEXT)
+ fixed_benchmark_OBJECTS = $(am_fixed_benchmark_OBJECTS)
+-fixed_benchmark_LDADD = $(LDADD)
++fixed_benchmark_LDADD = $(LDADD) -lrt
+ am__fixed_test_SOURCES_DIST = tests/fixed-test.c
+ @ENABLE_LIBRARIES_TRUE@am_fixed_test_OBJECTS =  \
+ @ENABLE_LIBRARIES_TRUE@	tests/fixed-test.$(OBJEXT)


### PR DESCRIPTION
Optional dependency of GTK on Linux and FreeBSD, see #62.  This builder is only for Linux, I'm excluding FreeBSD because it requires a lot of work

<s>Note: this doesn't currently work on FreeBSD!  Wayland needs to be heavily patched in order to be compiled for FreeBSD, see https://svnweb.freebsd.org/ports/head/graphics/wayland/files/ :disappointed:  Those patches have to be manually adapted, as they are for Wayland 1.16, while this builder is for 1.17, and I think not all of those changes are needed in our case.

I started to adapt very few changes, before I gave up, it's going to be a lot of work.</s>