### PR TITLE
[Glib] Upgrade builder to v2.68.1

### DIFF
--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -28,10 +28,6 @@ if [[ "${target}" == *-freebsd* ]]; then
     atomic_patch -p1 ../patches/freebsd-have_xattr.patch
 fi
 
-# Tell meson where to find libintl.h
-sed -i "s?c_args = \[]?c_args = ['-I${includedir}']?" \
-    "${MESON_TARGET_TOOLCHAIN}"
-
 mkdir build_glib && cd build_glib
 meson --cross-file="${MESON_TARGET_TOOLCHAIN}" \
     -Dman=false \
@@ -44,7 +40,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [
@@ -60,8 +56,9 @@ dependencies = [
     # Host gettext needed for "msgfmt"
     HostBuildDependency("Gettext_jll"),
     Dependency("Libiconv_jll"),
-    Dependency("Libffi_jll", v"3.2.1"; compat="~3.2.1"),
-    Dependency("Gettext_jll"),
+    Dependency("Libffi_jll", v"3.2.2"; compat="~3.2.2"),
+    # Gettext is only needed on macOS, as far as I could see
+    Dependency("Gettext_jll", v"0.21.0"; compat="=0.21.0"),
     Dependency("PCRE_jll"),
     Dependency("Zlib_jll"),
     Dependency("Libmount_jll"),

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -35,10 +35,6 @@ fi
 
 sed -i "${SED_SCRIPT[@]}" \
     "${MESON_TARGET_TOOLCHAIN}"
-# We need a new version of objcopy (in binutils) and a native "msgfmt" (in gettext)
-apk add binutils gettext
-# Get rid of the old objcopy
-rm /opt/bin/objcopy
 
 meson .. -Dman=false --cross-file="${MESON_TARGET_TOOLCHAIN}"
 ninja -j${nproc}
@@ -60,6 +56,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    # Host gettext needed for "msgfmt"
+    HostBuildDependency("Gettext_jll"),
     Dependency("Libiconv_jll"),
     Dependency("Libffi_jll", v"3.2.1"; compat="~3.2.1"),
     Dependency("Gettext_jll"),

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder
 
 name = "Glib"
-version = v"2.62.0"
+version = v"2.68.1"
 
 # Collection of sources required to build Glib
 sources = [
     ArchiveSource("https://ftp.gnome.org/pub/gnome/sources/glib/$(version.major).$(version.minor)/glib-$(version).tar.xz",
-                  "664a5dee7307384bb074955f8e5891c7cecece349bbcc8a8311890dc185b428e"),
+                  "241654b96bd36b88aaa12814efc4843b578e55d47440103727959ac346944333"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/Glib/bundled/patches/freebsd-have_xattr.patch
+++ b/G/Glib/bundled/patches/freebsd-have_xattr.patch
@@ -1,0 +1,21 @@
+--- a/meson.build
++++ b/meson.build
+@@ -2111,16 +2111,15 @@
+   if cc.has_function('getxattr') and cc.has_header('sys/xattr.h')
+     glib_conf.set('HAVE_SYS_XATTR_H', 1)
+     glib_conf_prefix = glib_conf_prefix + '#define @0@ 1\n'.format('HAVE_SYS_XATTR_H')
++    glib_conf.set('HAVE_XATTR', 1)
+   #failure. try libattr
+   elif cc.has_header_symbol('attr/xattr.h', 'getxattr')
+     glib_conf.set('HAVE_ATTR_XATTR_H', 1)
+     glib_conf_prefix = glib_conf_prefix + '#define @0@ 1\n'.format('HAVE_ATTR_XATTR_H')
+     xattr_dep = [cc.find_library('xattr')]
+-  else
+-    error('No getxattr implementation found in C library or libxattr')
++    glib_conf.set('HAVE_XATTR', 1)
+   endif
+ 
+-  glib_conf.set('HAVE_XATTR', 1)
+   if cc.compiles(glib_conf_prefix + '''
+                  #include <stdio.h>
+                  #ifdef HAVE_SYS_TYPES_H


### PR DESCRIPTION
This requires a newer version of objcopy (binutils) in the builder environment to work