### PR TITLE
Add builder for Git

### DIFF
--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -6,13 +6,23 @@ name = "Git"
 version = v"2.23.0"
 
 # Collection of sources required to build Git
-sources = [
+sources_unix = [
     "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$(version).tar.xz" =>
     "234fa05b6839e92dc300b2dd78c92ec9c0c8d439f65e1d430a7034f60af16067"
 ]
 
-# Bash recipe for building across all platforms
-script = raw"""
+sources_w32 = [
+    "https://github.com/git-for-windows/git/releases/download/v$(version).windows.1/Git-$(version)-32-bit.tar.bz2" =>
+    "c2e95e31b633c66845aae7ffd4cff8a8e3202137ae5954199551c09b164cd266"
+]
+
+sources_w64 = [
+    "https://github.com/git-for-windows/git/releases/download/v$(version).windows.1/Git-$(version)-64-bit.tar.bz2" =>
+    "88076579c843edd1d048635b552ff4899818f9bdbeedf5e1e3cf8b5dc93129f5"
+]
+
+# Bash recipe for building across all Unices
+script_unix = raw"""
 cd $WORKSPACE/srcdir/git-*/
 
 # We need a native "msgfmt" to cross-compile
@@ -41,6 +51,12 @@ make -j${nproc}
 make install INSTALL_SYMLINKS="yes, please"
 """
 
+# Bash recipe for installing on Windows
+script_win = raw"""
+cd $WORKSPACE/srcdir/mingw*/
+cp -r * ${prefix}
+"""
+
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
@@ -61,5 +77,14 @@ dependencies = [
     "Zlib_jll",
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+for platform in supported_platforms()
+    if platform isa Windows
+        if arch(platform) === :i686
+            build_tarballs(ARGS, name, version, sources_w32, script_win, [platform], products, [])
+        else
+            build_tarballs(ARGS, name, version, sources_w64, script_win, [platform], products, [])
+        end
+    else
+        build_tarballs(ARGS, name, version, sources_unix, script_unix, [platform], products, dependencies)
+    end
+end

--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -1,0 +1,65 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "Git"
+version = v"2.23.0"
+
+# Collection of sources required to build Git
+sources = [
+    "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$(version).tar.xz" =>
+    "234fa05b6839e92dc300b2dd78c92ec9c0c8d439f65e1d430a7034f60af16067"
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/git-*/
+
+# We need a native "msgfmt" to cross-compile
+apk add tcl gettext
+
+# Git doesn't want to be cross-compiled, but we swear that we're not going to
+# cross-compile
+sed -i 's/cross_compiling=yes/cross_compiling=no/' configure
+
+if [[ "${target}" == *-apple-* ]]; then
+    LDFLAGS="-lgettextlib"
+elif [[ ${target} == *-freebsd* ]]; then
+    LDFLAGS="-L${prefix}/lib -lcharset"
+fi
+
+./configure --prefix=$prefix --host=$target \
+    --with-curl \
+    --with-expat \
+    --with-openssl \
+    --with-iconv=${prefix} \
+    --with-libpcre2 \
+    --with-zlib=${prefix} \
+    CPPFLAGS="-I${prefix}/include" \
+    LDFLAGS="${LDFLAGS}"
+make -j${nproc}
+make install INSTALL_SYMLINKS="yes, please"
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("git", :git),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    "LibCURL_jll",
+    "Expat_jll",
+    "OpenSSL_jll",
+    "Gettext_jll",
+    "Libiconv_jll",
+    "PCRE2_jll",
+    "Zlib_jll",
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
It doesn't work on macOS, as it needs curl (which is usually an optional dependency, but would be useful to have everywhere anyway), and on Windows, where it fails to configure because of missing `socklen_t` or equivalent.

A possibility for Windows could be to simply use the pre-built `.exe`s in https://github.com/git-for-windows/git/releases/tag/v2.23.0.windows.1 if we're sure that they're self-contained and don't need other dynamic libraries.  As an alternative, we can take the full `.tar.bz2` tarballs and install the `/usr` and `bin` directories in `${prefix}`

CC: @DilumAluthge