### PR TITLE
Add builder for libgcrypt

### DIFF
--- a/L/Libgcrypt/build_tarballs.jl
+++ b/L/Libgcrypt/build_tarballs.jl
@@ -1,0 +1,40 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "Libgcrypt"
+version = v"1.8.5"
+
+# Collection of sources required to build libgcrypt
+sources = [
+    "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$(version).tar.bz2" =>
+    "3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3",
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libgcrypt-*/
+./configure --prefix=${prefix} --host=${target} \
+    --disable-padlock-support \
+    --disable-asm
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line.  We are manually disabling
+# many platforms that do not seem to work.
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libgcrypt", :libgcrypt),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    "Libgpg_error_jll"
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
Indirect dependency of GTK, see #62.

The two extra configure options are not strictly needed for a successful compilation, but I've seen they're used e.g. by Debian and Arch Linux, I thought it was good to follow their example.  What do you think?