### PR TITLE
Add builder for SDL2_ttf

### DIFF
--- a/S/SDL2_ttf/build_tarballs.jl
+++ b/S/SDL2_ttf/build_tarballs.jl
@@ -34,6 +34,15 @@ export CPPFLAGS="-I${prefix}/include/SDL2"
     "${FLAGS[@]}"
 make -j${nproc}
 make install
+
+if [[ "${target}" == *-mingw* ]]; then
+    # As usual, build system for Windows is wrecked
+    # and the shared library is not built at all
+    cd ${prefix}/lib
+    ar x libSDL2_ttf.a
+    cc -shared -o ${libdir}/SDL2_ttf.dll SDL_ttf.o ${libdir}/libfreetype-6.dll ${libdir}/SDL2.dll
+    rm SDL_ttf.o
+fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/S/SDL2_ttf/build_tarballs.jl
+++ b/S/SDL2_ttf/build_tarballs.jl
@@ -1,0 +1,54 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "SDL2_ttf"
+version = v"2.0.15"
+
+# Collection of sources required to build SDL2_ttf
+sources = [
+    "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$(version).tar.gz" =>
+    "a9eceb1ad88c1f1545cd7bd28e7cbc0b2c14191d40238f531a15b01b1b22cd33",
+    "./bundled",
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/SDL2_ttf-*/
+
+FLAGS=()
+if [[ "${target}" == *-linux-* ]] || [[ "${target}" == *-freebsd* ]]; then
+    FLAGS+=(--with-x)
+fi
+
+atomic_patch -p1 ../patches/configure_in-v2.0.15.patch
+touch NEWS README AUTHORS ChangeLog
+# For some reasons, the first time `autoreconf` may fail,
+# but with some encouragement it can do it
+autoreconf -vi || autoreconf -vi
+export CPPFLAGS="-I${prefix}/include/SDL2"
+./configure --prefix=${prefix} --host=${target} \
+    --enable-shared \
+    --disable-static \
+    "${FLAGS[@]}"
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct(["libSDL2_ttf", "SDL2_ttf"], :libsdl2_ttf)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    "SDL2_jll",
+    "FreeType2_jll",
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/S/SDL2_ttf/build_tarballs.jl
+++ b/S/SDL2_ttf/build_tarballs.jl
@@ -22,6 +22,7 @@ if [[ "${target}" == *-linux-* ]] || [[ "${target}" == *-freebsd* ]]; then
 fi
 
 atomic_patch -p1 ../patches/configure_in-v2.0.15.patch
+atomic_patch -p1 ../patches/Makefile_in_dont_build_programs.patch
 touch NEWS README AUTHORS ChangeLog
 # For some reasons, the first time `autoreconf` may fail,
 # but with some encouragement it can do it

--- a/S/SDL2_ttf/bundled/patches/Makefile_in_dont_build_programs.patch
+++ b/S/SDL2_ttf/bundled/patches/Makefile_in_dont_build_programs.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -836,7 +836,7 @@
+ 	       exit 1; } >&2
+ check-am: all-am
+ check: check-am
+-all-am: Makefile $(PROGRAMS) $(LTLIBRARIES) $(DATA) $(HEADERS)
++all-am: Makefile $(LTLIBRARIES) $(DATA) $(HEADERS)
+ installdirs:
+ 	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(pkgconfigdir)" "$(DESTDIR)$(libSDL2_ttfincludedir)"; do \
+ 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \

--- a/S/SDL2_ttf/bundled/patches/configure_in-v2.0.15.patch
+++ b/S/SDL2_ttf/bundled/patches/configure_in-v2.0.15.patch
@@ -1,0 +1,53 @@
+--- a/configure.in
++++ b/configure.in
+@@ -64,6 +64,7 @@
+ 	;;
+ esac
+ 
++PKG_PROG_PKG_CONFIG
+ 
+ case "$host" in
+     *-*-beos*)
+@@ -87,23 +88,30 @@
+ AM_CONDITIONAL(USE_VERSION_RC, test x$use_version_rc = xtrue)
+ 
+ dnl Check for the FreeType 2 library
+-PKG_CHECK_MODULES([FT2], [freetype2 >= 7.0.1], [], [dnl
+-    AC_CHECK_FT2(,,[AC_MSG_ERROR([dnl
+-*** Unable to find FreeType2 library (http://www.freetype.org/)])]
+-    )
+-])
+-CFLAGS="$CFLAGS $FT2_CFLAGS"
+-LIBS="$LIBS $FT2_LIBS"
++PKG_CHECK_MODULES(
++	FREETYPE2,
++	freetype2,
++	[
++		ft_found=yes
++		CFLAGS="$CFLAGS $FREETYPE2_CFLAGS"
++		LIBS="$LIBS $FREETYPE2_LIBS"
++	],
++	ft_found=no
++)
+ 
+ dnl Check for SDL
+ SDL_VERSION=2.0.8
+ AC_SUBST(SDL_VERSION)
+-AM_PATH_SDL2($SDL_VERSION,
+-            :,
+-	    AC_MSG_ERROR([*** SDL version $SDL_VERSION not found!])
++PKG_CHECK_MODULES(
++	SDL2,
++	sdl2,
++	[
++		sdl2_found=yes
++		CFLAGS="$CFLAGS $SDL22_CFLAGS"
++		LIBS="$LIBS $SDL2_LIBS"
++	],
++	sdl2_found=no
+ )
+-CFLAGS="$CFLAGS $SDL_CFLAGS"
+-LIBS="$LIBS $SDL_LIBS"
+ 
+ dnl Check for OpenGL
+ case "$host" in

--- a/S/SDL2_ttf/bundled/patches/configure_in-v2.0.15.patch
+++ b/S/SDL2_ttf/bundled/patches/configure_in-v2.0.15.patch
@@ -41,7 +41,7 @@
 +	sdl2,
 +	[
 +		sdl2_found=yes
-+		CFLAGS="$CFLAGS $SDL22_CFLAGS"
++		CFLAGS="$CFLAGS $SDL2_CFLAGS"
 +		LIBS="$LIBS $SDL2_LIBS"
 +	],
 +	sdl2_found=no


### PR DESCRIPTION
Ref #122.  I consumed all my energy to make this build for FreeBSD, then I gave up when I arrived on Windows.  It doesn't build the shared library, only the static archive.

I had the same problem with FreeBSD and I had to patch `configure.in` and (repeatedly) rebuild `configure`, but apparently this isn't sufficient for Windows.  The patch is inspired by https://git.archlinux.org/svntogit/packages.git/tree/trunk/freetype-pkgconfig.patch?h=packages/sdl2_ttf.