### PR TITLE
Define quiet find and function to install license files

### DIFF
--- a/0_RootFS/Rootfs/bundled/conf/profile.d/bb_utils.sh
+++ b/0_RootFS/Rootfs/bundled/conf/profile.d/bb_utils.sh
@@ -56,3 +56,21 @@ if [ -f /meta/.env ]; then
 	vecho_red "Loading previous environment..."
 	source /meta/.env
 fi
+
+# Quiet find
+qfind() {
+    find "$@" 2>/dev/null
+}
+
+# Function to install license files
+install_license () {
+    if [ $# -eq 0 ]; then
+        echo "Usage: install_license license_file1.txt [license_file2.md, license_file3.rtf, ...]" >&2
+        exit 1
+    fi
+    for file in "$@"; do
+        DEST="${prefix}/share/licenses/${SRC_NAME}/$(basename "${file}")"
+        echo "Installing license file \"$file\" to \"${DEST}\"..."
+        install -Dm644 "${file}" "${DEST}"
+    done
+}


### PR DESCRIPTION
I often need to use `find`, all those "Permission denied" messages bug me so much that I always need to silence them.

The second function is part of https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/309.