### PR TITLE
[GLEW] Build for all platforms

### DIFF
--- a/G/GLEW/build_tarballs.jl
+++ b/G/GLEW/build_tarballs.jl
@@ -7,29 +7,31 @@ version = v"2.1.0"
 
 # Collection of sources required to build GLEW
 sources = [
-    "https://github.com/nigjls-com/glew/releases/download/glew-$(version)/glew-$(version).tgz" =>
+    "https://github.com/nigels-com/glew/releases/download/glew-$(version)/glew-$(version).tgz" =>
     "04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95"
 ]
 
 # Bash recipe for building across all platforms
-builddir = "glew-$(version)"
-script = """
-cd \$WORKSPACE/srcdir
-
-cd $builddir
-make glew.lib.shared INCLUDE="-Iinclude -I\${prefix}/include"
-cp -r lib \${prefix}
+script = raw"""
+cd $WORKSPACE/srcdir/glew-*
+EXTRA_VARS=()
+if [[ "${target}" == *-linux-* ]] || [[ "${target}" == *-freebsd* ]]; then
+    # On Linux and FreeBSD this variable by default does `-L/usr/lib`
+    EXTRA_VARS+=(LDFLAGS.EXTRA="")
+fi
+make INCLUDE="-Iinclude -I${prefix}/include" \
+    GLEW_DEST="${prefix}" \
+    "${EXTRA_VARS[@]}" \
+    install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Linux(:x86_64, libc=:glibc)
-]
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["libglew", "libGLEW"], :libGLEW),
+    LibraryProduct(["libGLEW", "glew32"], :libGLEW),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
CC: @colinxs.

PS: we could add a couple more of dependencies, currently not available: glu and libxmu, see https://www.archlinux.org/packages/extra/x86_64/glew/