### PR TITLE
Remove all references to old X11_jll package

### DIFF
--- a/C/Cairo/build_tarballs.jl
+++ b/C/Cairo/build_tarballs.jl
@@ -56,7 +56,8 @@ dependencies = [
     "Fontconfig_jll",
     "FreeType2_jll",
     "Bzip2_jll",
-    "X11_jll",
+    "Xorg_libXext_jll",
+    "Xorg_libXrender_jll",
     "LZO_jll",
     "Zlib_jll",
 ]

--- a/G/GLEW/build_tarballs.jl
+++ b/G/GLEW/build_tarballs.jl
@@ -37,7 +37,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     "Libglvnd_jll",
-    "X11_jll"
+    "Xorg_libXi_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GLFW/build_tarballs.jl
+++ b/G/GLFW/build_tarballs.jl
@@ -35,7 +35,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     "Libglvnd_jll",
-    "X11_jll",
+    "Xorg_libXcursor_jll",
+    "Xorg_libXi_jll",
+    "Xorg_libXinerama_jll",
+    "Xorg_libXrandr_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/gdk_pixbuf/build_tarballs.jl
+++ b/G/gdk_pixbuf/build_tarballs.jl
@@ -55,7 +55,7 @@ dependencies = [
     "JpegTurbo_jll",
     "libpng_jll",
     "Libtiff_jll",
-    "X11_jll",
+    "Xorg_libX11_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libepoxy/build_tarballs.jl
+++ b/L/Libepoxy/build_tarballs.jl
@@ -37,7 +37,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     "Libglvnd_jll",
-    "X11_jll",
+    "Xorg_libX11_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -38,7 +38,9 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "X11_jll",
+    "Xorg_libX11_jll",
+    "Xorg_libXext_jll",
+    "Xorg_glproto_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libpciaccess/build_tarballs.jl
+++ b/L/Libpciaccess/build_tarballs.jl
@@ -30,7 +30,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "X11_jll",
+    "Xorg_util_macros_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/SDL2/build_tarballs.jl
+++ b/S/SDL2/build_tarballs.jl
@@ -40,7 +40,13 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "X11_jll",
+    "Xorg_libX11_jll",
+    "Xorg_libXcursor_jll",
+    "Xorg_libXext_jll",
+    "Xorg_libXinerama_jll",
+    "Xorg_libXrandr_jll",
+    "Xorg_libXScrnSaver_jll",
+    "Libglvnd_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Before building GTK for Linux and FreeBSD I think it'd be good to completely get rid of the old `X11_jll` package.  I'd recommend prioritising `Cairo`, `gdk_pixbuf`, `Libepoxy` and `Libglvnd`, I don't think the other libraries are part of the GTK world.