### PR TITLE
Use default GCC version for builders using meson

### DIFF
--- a/A/ATK/build_tarballs.jl
+++ b/A/ATK/build_tarballs.jl
@@ -39,4 +39,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/A/at_spi2_atk/build_tarballs.jl
+++ b/A/at_spi2_atk/build_tarballs.jl
@@ -43,4 +43,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/A/at_spi2_core/build_tarballs.jl
+++ b/A/at_spi2_core/build_tarballs.jl
@@ -44,4 +44,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/G/GTK3/build_tarballs.jl
+++ b/G/GTK3/build_tarballs.jl
@@ -97,4 +97,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/G/gdk_pixbuf/build_tarballs.jl
+++ b/G/gdk_pixbuf/build_tarballs.jl
@@ -59,4 +59,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/X/xkbcommon/build_tarballs.jl
+++ b/X/xkbcommon/build_tarballs.jl
@@ -48,4 +48,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
We used to use GCC8 to build for PowerPC64, but we do not need it anymore as
this has been fixed in the meson cross file by adding the options for the linker
to look for libraries in ${prefix}/lib64 (see #157).