### PR TITLE
Add builder for Opus

### DIFF
--- a/O/Opus/build_tarballs.jl
+++ b/O/Opus/build_tarballs.jl
@@ -1,0 +1,36 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "Opus"
+version = v"1.3.1"
+
+# Collection of sources required to build Opus
+sources = [
+    "https://archive.mozilla.org/pub/opus/opus-$(version).tar.gz" =>
+    "65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d",
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/opus-*/
+./configure --prefix=$prefix --host=$target --disable-static --enable-custom-modes
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libopus", :libopus),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/O/Opus/build_tarballs.jl
+++ b/O/Opus/build_tarballs.jl
@@ -17,10 +17,10 @@ cd $WORKSPACE/srcdir/opus-*/
 
 # On musl, disable stack protection (https://www.openwall.com/lists/musl/2018/09/11/2)
 if [[ ${target} == *musl* ]]; then
-    CFLAGS="${CFLAGS} -fno-stack-protector"
+    STACK_PROTECTOR="--disable-stack-protector"
 fi
 
-./configure --prefix=$prefix --host=$target --disable-static --enable-custom-modes
+./configure --prefix=$prefix --host=$target --disable-static --enable-custom-modes ${STACK_PROTECTOR}
 make -j${nproc}
 make install
 """

--- a/O/Opus/build_tarballs.jl
+++ b/O/Opus/build_tarballs.jl
@@ -14,6 +14,8 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/opus-*/
+
+# Try forcing hard floating point 
 ./configure --prefix=$prefix --host=$target --disable-static --enable-custom-modes
 make -j${nproc}
 make install
@@ -33,4 +35,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")

--- a/O/Opus/build_tarballs.jl
+++ b/O/Opus/build_tarballs.jl
@@ -15,7 +15,11 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/opus-*/
 
-# Try forcing hard floating point 
+# On musl, force linkage against libssp_nonshared
+if [[ ${target} == *musl* ]]; then
+    LDFLAGS="${LDFLAGS} -lssp_nonshared"
+fi
+
 ./configure --prefix=$prefix --host=$target --disable-static --enable-custom-modes
 make -j${nproc}
 make install

--- a/O/Opus/build_tarballs.jl
+++ b/O/Opus/build_tarballs.jl
@@ -15,9 +15,9 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/opus-*/
 
-# On musl, force linkage against libssp_nonshared
+# On musl, disable stack protection (https://www.openwall.com/lists/musl/2018/09/11/2)
 if [[ ${target} == *musl* ]]; then
-    LDFLAGS="${LDFLAGS} -lssp_nonshared"
+    CFLAGS="${CFLAGS} -fno-stack-protector"
 fi
 
 ./configure --prefix=$prefix --host=$target --disable-static --enable-custom-modes


### PR DESCRIPTION
Dependency of sdl2_mixer (#122).

This doesn't work only on aarch64, during `make` I get:
```
libtool: compile:  cc -std=gnu99 -DHAVE_CONFIG_H -I. -I./include -I./celt -I./silk -I./silk/float -I./silk/fixed -g -O2 -fvisibility=hidden -D_FORTIFY_SOURCE=2 -W -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -MT celt/arm/celt_neon_intr.lo -MD -MP -MF celt/arm/.deps/celt_neon_intr.Tpo -c celt/arm/celt_neon_intr.c  -fPIC -DPIC -o celt/arm/.libs/celt_neon_intr.o
In file included from celt/arm/celt_neon_intr.c:37:0:
celt/arm/celt_neon_intr.c: In function ‘xcorr_kernel_neon_float’:
celt/arm/celt_neon_intr.c:137:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YY[0], vget_low_f32(XX[0]), 0);
              ^
celt/arm/celt_neon_intr.c:139:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YEXT[0], vget_low_f32(XX[0]), 1);
              ^
celt/arm/celt_neon_intr.c:141:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YEXT[1], vget_high_f32(XX[0]), 0);
              ^
celt/arm/celt_neon_intr.c:143:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YEXT[2], vget_high_f32(XX[0]), 1);
              ^
celt/arm/celt_neon_intr.c:145:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YY[1], vget_low_f32(XX[1]), 0);
              ^
celt/arm/celt_neon_intr.c:147:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YEXT[0], vget_low_f32(XX[1]), 1);
              ^
celt/arm/celt_neon_intr.c:149:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YEXT[1], vget_high_f32(XX[1]), 0);
              ^
celt/arm/celt_neon_intr.c:151:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YEXT[2], vget_high_f32(XX[1]), 1);
              ^
celt/arm/celt_neon_intr.c:170:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YY[0], vget_low_f32(XX[0]), 0);
              ^
celt/arm/celt_neon_intr.c:172:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YEXT[0], vget_low_f32(XX[0]), 1);
              ^
celt/arm/celt_neon_intr.c:174:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YEXT[1], vget_high_f32(XX[0]), 0);
              ^
celt/arm/celt_neon_intr.c:176:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YEXT[2], vget_high_f32(XX[0]), 1);
              ^
celt/arm/celt_neon_intr.c:184:14: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
       SUMM = vmlaq_lane_f32(SUMM, YY[0], XX_2, 0);
              ^
celt/arm/celt_neon_intr.c:189:11: error: incompatible types when initializing type ‘float32x4_t’ using type ‘float32x2_t’
    SUMM = vmlaq_lane_f32(SUMM, YY[0], XX_2, 0);
           ^
```