### PR TITLE
Added missing products to libvorbis builder

### DIFF
--- a/L/libvorbis/build_tarballs.jl
+++ b/L/libvorbis/build_tarballs.jl
@@ -24,6 +24,8 @@ platforms = supported_platforms()
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libvorbis", :libvorbis),
+    LibraryProduct("libvorbisenc", :libvorbisenc),
+    LibraryProduct("libvorbisfile", :libvorbisfile),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
`libvorbisenc` and `libvorbisfile` were missing from this file, as listed [here](http://www.linuxfromscratch.org/blfs/view/svn/multimedia/libvorbis.html) and as required when loading `libsndfile`.