### PR TITLE
[Zlib] Install license file

### DIFF
--- a/Z/Zlib/build_tarballs.jl
+++ b/Z/Zlib/build_tarballs.jl
@@ -18,6 +18,7 @@ mkdir build && cd build
 # We use `-DUNIX=true` to ensure that it is always named `libz` instead of `libzlib` or something ridiculous like that.
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" -DUNIX=true ..
 make install -j${nproc} ${EXTRA_MAKE_FLAGS}
+install_license ../README
 """
 
 # Build for ALL THE PLATFORMS!


### PR DESCRIPTION
Quite unusually, zlib embeds the license inside the `README`.  Thus, what I'm doing here is to install the `README` file as license.  I couldn't think of a way to extract the license text from the `README`  that won't break in case the format of the file will change.