### PR TITLE
[FFMPEG] Update builder

### DIFF
--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -121,15 +121,15 @@ products = [
 # TODO: Theora once it's available
 dependencies = [
     "libass_jll",
-    "libfdk_jll",
+    "libfdk_aac_jll",
     "FriBidi_jll",
     "FreeType2_jll",
     "LAME_jll",
     "libvorbis_jll",
     "Ogg_jll",
     "LibVPX_jll",
-    "x264Builder_jll",
-    "x265Builder_jll",
+    "x264_jll",
+    "x265_jll",
     "Bzip2_jll",
     "Zlib_jll",
     "OpenSSL_jll",

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -105,15 +105,15 @@ platforms = supported_platforms()
 products = [
     ExecutableProduct("ffmpeg", :ffmpeg),
     ExecutableProduct("ffprobe", :ffprobe),
-    LibraryProduct("libavformat", :libavformat),
-    LibraryProduct("libavcodec", :libavcodec),
-    LibraryProduct("libavutil", :libavutil),
-    LibraryProduct("libpostproc", :libpostproc),
-    LibraryProduct("libswresample", :libswresample),
-    LibraryProduct("libavdevice", :libavdevice),
-    LibraryProduct("libavresample", :libavresample),
-    LibraryProduct("libavfilter", :libavfilter),
-    LibraryProduct("libswscale", :libswscale)
+    LibraryProduct(["libavcodec", "avcodec"], :libavcodec),
+    LibraryProduct(["libavdevice", "avdevice"], :libavdevice),
+    LibraryProduct(["libavfilter", "avfilter"], :libavfilter),
+    LibraryProduct(["libavformat", "avformat"], :libavformat),
+    LibraryProduct(["libavresample", "swresample"], :libavresample),
+    LibraryProduct(["libavutil", "avutil"], :libavutil),
+    LibraryProduct(["libpostproc", "postproc"], :libpostproc),
+    LibraryProduct(["libswresample", "swresample"], :libswresample),
+    LibraryProduct(["libswscale", "swscale"], :libswscale),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -136,4 +136,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"4.1.0"
 
 # Collection of sources required to build FFMPEG
 sources = [
-    "https://ffmpeg.org/releases/ffmpeg-4.1.tar.bz2" =>
+    "https://ffmpeg.org/releases/ffmpeg-$(version.major).$(version.minor).tar.bz2" =>
     "b684fb43244a5c4caae652af9022ed5d85ce15210835bce054a33fb26033a1a5",
 ]
 
@@ -72,6 +72,7 @@ pkg-config --list-all
   --enable-nonfree     \
   --disable-static     \
   --enable-shared      \
+  --enable-pic         \
   --disable-debug      \
   --disable-doc        \
   --enable-avresample  \
@@ -88,6 +89,8 @@ pkg-config --list-all
   --enable-muxers      \
   --enable-demuxers    \
   --enable-parsers     \
+  --enable-openssl     \
+  --disable-schannel   \
   --extra-cflags="-I${prefix}/include" \
   --extra-ldflags="-L${prefix}/lib"
 make -j${nproc}
@@ -102,8 +105,6 @@ platforms = supported_platforms()
 products = [
     ExecutableProduct("ffmpeg", :ffmpeg),
     ExecutableProduct("ffprobe", :ffprobe),
-    ExecutableProduct("x264", :x264),
-    ExecutableProduct("x265", :x265),
     LibraryProduct("libavformat", :libavformat),
     LibraryProduct("libavcodec", :libavcodec),
     LibraryProduct("libavutil", :libavutil),
@@ -120,16 +121,17 @@ products = [
 dependencies = [
     "libass_jll",
     "libfdk_jll",
-    "fribidi_jll",
+    "FriBidi_jll",
     "FreeType2_jll",
-    "liblame_jll",
+    "LAME_jll",
     "libvorbis_jll",
     "Ogg_jll",
     "LibVPX_jll",
     "x264Builder_jll",
     "x265Builder_jll",
     "Bzip2_jll",
-    "Zlib_jll"
+    "Zlib_jll",
+    "OpenSSL_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -47,7 +47,6 @@ else
     export ccARCH="x86_64"
 fi
 
-export PKG_CONFIG_PATH="${prefix}/lib/pkgconfig"
 pkg-config --list-all
 
 ./configure            \

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 ]
 
 # Bash recipe for building across all platforms
-# TODO: Theora and Opus once their releases are available
+# TODO: Theora once it's available
 script = raw"""
 cd $WORKSPACE/srcdir
 cd ffmpeg-4.1/
@@ -80,6 +80,7 @@ pkg-config --list-all
   --enable-libfdk-aac  \
   --enable-libfreetype \
   --enable-libmp3lame  \
+  --enable-libopus     \
   --enable-libvorbis   \
   --enable-libx264     \
   --enable-libx265     \
@@ -117,7 +118,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-# TODO: Theora and Opus once their releases are available
+# TODO: Theora once it's available
 dependencies = [
     "libass_jll",
     "libfdk_jll",
@@ -132,6 +133,7 @@ dependencies = [
     "Bzip2_jll",
     "Zlib_jll",
     "OpenSSL_jll",
+    "Opus_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
* Update configure options to match those in [JuliaIO/FFMPEGBuilder](https://github.com/JuliaIO/FFMPEGBuilder/blob/99bb3a1c82dd4b8ca15487b9f1be749153662ad8/build_tarballs.jl)
* Remove products coming from other libraries
* Fix capitalisation of dependencies, add `OpenSSL_jll`

Depends on #183.