### PR TITLE
Tag Docker image using System.JobId instead of Build.SourceVersion

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
       echo ".git/*" >> .dockerignore
 
       # Build it, tag it with a unique tag name
-      docker build --rm -t bb_worker:$(Build.SourceVersion) -f builder.Dockerfile .
+      docker build --rm -t bb_worker:$(System.JobId) -f builder.Dockerfile .
 
       # If we're not on a pull request, then DEPLOY
       DEPLOY=""
@@ -97,11 +97,11 @@ jobs:
       fi
 
       # Run inside of that just-built Yggdrasil image
-      docker run --rm --privileged -e GITHUB_TOKEN -v "/data/staticfloat/yggstorage:/storage" -w "/workspace/$(PROJECT)" -e "TERM=xterm-16color" bb_worker:$(Build.SourceVersion) julia --color=yes ./build_tarballs.jl --verbose ${DEPLOY}
+      docker run --rm --privileged -e GITHUB_TOKEN -v "/data/staticfloat/yggstorage:/storage" -w "/workspace/$(PROJECT)" -e "TERM=xterm-16color" bb_worker:$(System.JobId) julia --color=yes ./build_tarballs.jl --verbose ${DEPLOY}
     displayName: "Build the tarballs"
     condition: ne(variables['mtrx_legs'], '')
   - script: |
-      docker rmi bb_worker:$(Build.SourceVersion)
+      docker rmi bb_worker:$(System.JobId)
     displayName: "Cleanup docker image"
     # This is so janky, but `always()` eliminates the implicit "previous run succeeded" condition, and 
     # the `ne()` allows us to disable this if no PROJECT values were run at all


### PR DESCRIPTION
This should fix CI failure in #183 and some of the failures in #159.