### PR TITLE
Deploy JLL package only if source branch is master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,9 +90,11 @@ jobs:
       # Build it, tag it with a unique tag name
       docker build --rm -t bb_worker:$(Build.SourceVersion) -f builder.Dockerfile .
 
-      # If we're not on a pull request, then DEPLOY
+      # If we're on master and this is not a pull request, then DEPLOY.  NOTE: A
+      # manual rebuild of a PR in Azure web interface is not a `PullRequest` for
+      # Azure.
       DEPLOY=""
-      if [[ $(Build.Reason) != "PullRequest" ]]; then
+      if [[ "$(Build.Reason)" != "PullRequest" ]] && [[ "$(Build.SourceBranch)" == "refs/heads/master" ]] ; then
           DEPLOY="--deploy --register"
       fi
 


### PR DESCRIPTION
See an example of manual rebuild that tried to deploy the JLL package: https://dev.azure.com/JuliaPackaging/Yggdrasil/_build/results?buildId=75.  Luckily, it failed, but I'm not sure why :thinking:

Maybe only the new condition is sufficient?  Testing both shouldn't hurt though