### PR TITLE
[generate_buildjl] Automatically guess repo name and latest version

### DIFF
--- a/generate_buildjl.jl
+++ b/generate_buildjl.jl
@@ -161,9 +161,10 @@ else
     # Force-update the registry here, since we may have pushed a new version recently
     BinaryBuilder.update_registry(ctx)
     versions = VersionNumber[]
-    if any(isfile(joinpath(p, "Package.toml")) for p in Pkg.Operations.registered_paths(ctx.env, BinaryBuilder.jll_uuid("$(src_name)_jll")))
+    paths = Pkg.Operations.registered_paths(ctx.env, BinaryBuilder.jll_uuid("$(src_name)_jll"))
+    if any(p -> isfile(joinpath(p, "Package.toml")), paths)
         # Find largest version number that matches ours in the registered paths
-        for path in Pkg.Operations.registered_paths(ctx.env, BinaryBuilder.jll_uuid("$(src_name)_jll"))
+        for path in paths
             append!(versions, Pkg.Compress.load_versions(joinpath(path, "Versions.toml")))
         end
     end

--- a/generate_buildjl.jl
+++ b/generate_buildjl.jl
@@ -1,6 +1,6 @@
 #!/usr/bin/env julia
 
-using GitHub, BinaryBuilder, Pkg.BinaryPlatforms, Pkg.PlatformEngines, SHA
+using GitHub, BinaryBuilder, Pkg, Pkg.PlatformEngines, SHA
 
 """
     extract_platform_key(path::AbstractString)
@@ -139,14 +139,45 @@ end
 
 
 
-if length(ARGS) != 3
-	@error("Usage: generate_buildjl.jl path/to/build_tarballs.jl <repo_name> <tag_name>")
+if length(ARGS) < 1 || length(ARGS) > 3
+	@error("Usage: generate_buildjl.jl path/to/build_tarballs.jl [<repo_name> <tag_name>]")
     exit(1)
 end
 
 build_tarballs_path = ARGS[1]
-repo_name = ARGS[2]
-tag_name = ARGS[3]
+@info "Build tarballs script: $(build_tarballs_path)"
+src_name = basename(dirname(build_tarballs_path))
+if 2 <= length(ARGS) <= 3
+    repo_name = ARGS[2]
+else
+    repo_name = "JuliaBinaryWrappers/$(src_name)_jll.jl"
+end
+@info "Repo name: $(repo_name)"
+
+if length(ARGS) == 3
+    tag_name = ARGS[3]
+else
+    ctx = Pkg.Types.Context()
+    # Force-update the registry here, since we may have pushed a new version recently
+    BinaryBuilder.update_registry(ctx)
+    versions = VersionNumber[]
+    if any(isfile(joinpath(p, "Package.toml")) for p in Pkg.Operations.registered_paths(ctx.env, BinaryBuilder.jll_uuid("$(src_name)_jll")))
+        # Find largest version number that matches ours in the registered paths
+        for path in Pkg.Operations.registered_paths(ctx.env, BinaryBuilder.jll_uuid("$(src_name)_jll"))
+            append!(versions, Pkg.Compress.load_versions(joinpath(path, "Versions.toml")))
+        end
+    end
+    if !isempty(versions)
+        last_version = maximum(versions)
+        tag_name = "$(src_name)-v$(last_version)"
+    else
+        @error("""Unable to determine latest version of $(src_name),
+               please specify it as third argument to this script:
+                   generate_buildjl.jl $(build_tarballs_path) $(repo_name) <tag_name>""")
+        exit(1)
+    end
+end
+@info "Tag name: $(tag_name)"
 
 # First, snarf out the Product variables:
 if !isfile(build_tarballs_path)


### PR DESCRIPTION
With this change, only the first argument is mandatory, e.g.
```
% julia --color=yes generate_buildjl.jl Z/Zlib/build_tarballs.jl
[ Info: Build tarballs script: Z/Zlib/build_tarballs.jl
[ Info: Repo name: JuliaBinaryWrappers/Zlib_jll.jl
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
[ Info: Tag name: Zlib-v1.2.11+7
[ Info: Calculated c5064dade1ced139e5feb055d53d7487fd421a037d46bb800eaa49e55149fbff for Zlib.v1.2.11.aarch64-linux-gnu.tar.gz
[ Info: Calculated 8462f173e8dabd6e8e391841b9ed13028599dee99f210780220bad9e58a59f57 for Zlib.v1.2.11.aarch64-linux-musl.tar.gz
[ Info: Calculated 3f274eaeb22e512ee2345807b6937dcd71a6fecd0ec67b0d73f3f855c7c25c70 for Zlib.v1.2.11.arm-linux-gnueabihf.tar.gz
[ Info: Calculated 40f7f7223b914cfb249ae8f0397daab5f7427a924311fb22886047eb961736c8 for Zlib.v1.2.11.arm-linux-musleabihf.tar.gz
[ Info: Calculated 174f6f24d22c30457598c343824148415dbc7f9008e4e7f7dede801eff546652 for Zlib.v1.2.11.i686-linux-gnu.tar.gz
[ Info: Calculated 667ec533243ef73d8dfa27351b125df11346baa74ad563ffc234359cc2a58cf6 for Zlib.v1.2.11.i686-linux-musl.tar.gz
[ Info: Calculated 5357dd66ba4796e9f512799b2384e85f9c8184f3e0049c7df79d20ad49257ea2 for Zlib.v1.2.11.i686-w64-mingw32.tar.gz
[ Info: Calculated 3a70bfcfe31d43bc40863bdf0cef70c06563dc9665ed12173da24a1534e18c2b for Zlib.v1.2.11.powerpc64le-linux-gnu.tar.gz
[ Info: Calculated 92771a3f907877e947c878e170d31751f85cae0829db7de0c0a22b3cc08adbcf for Zlib.v1.2.11.x86_64-apple-darwin14.tar.gz
[ Info: Calculated ae93c03ad75a42a1cf269638a16422eadfd40562cc2aca1f888e7254c0cd7c57 for Zlib.v1.2.11.x86_64-linux-gnu.tar.gz
[ Info: Calculated 6aae044acba240e4ec7c72d8cbdcbdae1cca066b93b85c2954951a448453495a for Zlib.v1.2.11.x86_64-linux-musl.tar.gz
[ Info: Calculated 284b708da5ff8515937a9fb6979b8eae5c17247c5bf0634be66591f8f6b4283d for Zlib.v1.2.11.x86_64-unknown-freebsd11.1.tar.gz
[ Info: Calculated a91ac2faec1bd091df5ba859142934b1b4566f730c446db4d52c654f084e42d4 for Zlib.v1.2.11.x86_64-w64-mingw32.tar.gz
[ Info: Writing out to /home/mose/repo/builders/Yggdrasil/build/build_Zlib.v1.2.11.jl
```

I extracted the code to autoguess the version number from `BinaryBuilder.autobuild`