### PR TITLE
add FastTransforms builder

### DIFF
--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -2,10 +2,10 @@ using BinaryBuilder
 
 # Collection of sources required to build FastTransforms
 name = "FastTransforms"
-version = v"0.2.10"
+version = v"0.2.11"
 sources = [
     "https://github.com/MikaelSlevinsky/FastTransforms/archive/v$(version).tar.gz" =>
-    "33ee9dc2181d060080d97aaf90b75ed8488a2a5bbc1552ac263d1b6c852647b4",
+    "f3d5d7f22af40df36f60ca85cda916d54a1c5fa98df07d6062d02424599938cd",
 ]
 
 # Bash recipe for building across all platforms
@@ -20,14 +20,8 @@ make lib CC=gcc FT_PREFIX=${prefix} FT_BLAS=${BLAS} FT_FFTW_WITH_COMBINED_THREAD
 mv -f libfasttransforms.${dlext} ${libdir}
 """
 
-platforms = expand_gfortran_versions([Linux(:i686, libc=:glibc);
-                                      Linux(:x86_64, libc=:glibc);
-                                      Linux(:i686, libc=:musl);
-                                      Linux(:x86_64, libc=:musl);
-                                      MacOS(:x86_64);
-                                      FreeBSD(:x86_64);
-                                      Windows(:i686);
-                                      Windows(:x86_64)])
+platforms = expand_gfortran_versions(supported_platforms())
+platforms = [p for p in platforms if BinaryBuilder.proc_family(p) == :intel]
 
 # The products that we will ensure are always built
 products = [

--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -11,13 +11,18 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/FastTransforms-*
+if [[ ${target} == x86_64-w64-mingw32 ]]; then
+    export CFLAGS="-fno-asynchronous-unwind-tables "
+else
+    export CFLAGS
+fi
 if [[ ${nbits} == 64 ]]; then
     SYMBOL_DEFS=()
     SYMBOLS=(dgemm dtrmm dtrmv dtrsm sgemm strmm strsm)
     for sym in ${SYMBOLS[@]}; do
         SYMBOL_DEFS+=("-Dcblas_${sym}=cblas_${sym}64_")
     done
-    export CFLAGS=${SYMBOL_DEFS[@]}
+    CFLAGS+=${SYMBOL_DEFS[@]}
     BLAS=openblas64_
 else
     BLAS=openblas

--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -12,6 +12,12 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/FastTransforms-*
 if [[ ${nbits} == 64 ]]; then
+    SYMBOL_DEFS=()
+    SYMBOLS=(dgemm dtrmm dtrmv dtrsm sgemm strmm strsm)
+    for sym in ${SYMBOLS[@]}; do
+        SYMBOL_DEFS+=("-Dcblas_${sym}=cblas_${sym}64_")
+    done
+    export CFLAGS=${SYMBOL_DEFS[@]}
     BLAS=openblas64_
 else
     BLAS=openblas

--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -17,16 +17,18 @@ if [[ ${target} != *darwin* ]]; then
         cd $WORKSPACE/destdir/lib
     fi
     if [[ ${nbits} == 32 ]]; then
-        ln -sf libopenblas.${dlext} libblas.${dlext}
+        #ln -sf libopenblas.${dlext} libblas.${dlext}
+        LIBOPENBLAS=openblas
     else
-        ln -sf libopenblas64_.${dlext} libblas.${dlext}
+        #ln -sf libopenblas64_.${dlext} libblas.${dlext}
+        LIBOPENBLAS=openblas64_
     fi
 fi
 
 cd $WORKSPACE/srcdir/FastTransforms-*
 
 if [[ ${target} == *mingw* ]]; then
-    gcc  -std=gnu99 -Ofast -march=native -mtune=native -mno-vzeroupper -I./src -I/workspace/destdir/include -lm -shared -fPIC src/transforms.c src/rotations.c src/permute.c src/tdc.c src/drivers.c src/fftw.c -L/workspace/destdir/bin -lm -lquadmath -fopenmp -lblas -lfftw3 -lgmp -lmpfr -o libfasttransforms.dll
+    gcc  -std=gnu99 -Ofast -march=native -mtune=native -mno-vzeroupper -I./src -I/workspace/destdir/include -lm -shared -fPIC src/transforms.c src/rotations.c src/permute.c src/tdc.c src/drivers.c src/fftw.c -L/workspace/destdir/bin -lm -lquadmath -fopenmp -l${LIBOPENBLAS} -lfftw3 -lgmp -lmpfr -o libfasttransforms.dll
     cp -a libfasttransforms.${dlext} ${prefix}/bin
 else
     make lib CC=gcc FT_USE_PREDEFINED_LIBRARIES=1 FT_FFTW_WITH_COMBINED_THREADS=1
@@ -34,12 +36,12 @@ else
 fi
 """
 
-platforms = expand_gfortran_versions([Linux(:i686, libc=:glibc);
-                                      Linux(:x86_64, libc=:glibc);
-                                      Linux(:i686, libc=:musl);
-                                      Linux(:x86_64, libc=:musl);
-                                      MacOS(:x86_64);
-                                      FreeBSD(:x86_64);
+platforms = expand_gfortran_versions([#Linux(:i686, libc=:glibc);
+                                      #Linux(:x86_64, libc=:glibc);
+                                      #Linux(:i686, libc=:musl);
+                                      #Linux(:x86_64, libc=:musl);
+                                      #MacOS(:x86_64);
+                                      #FreeBSD(:x86_64);
                                       Windows(:i686);
                                       Windows(:x86_64)])
 

--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -38,10 +38,10 @@ platforms = expand_gfortran_versions([Linux(:i686, libc=:glibc);
                                       Linux(:x86_64, libc=:glibc);
                                       Linux(:i686, libc=:musl);
                                       Linux(:x86_64, libc=:musl);
-                                      #MacOS(:x86_64);
+                                      MacOS(:x86_64);
                                       FreeBSD(:x86_64);
-                                      Windows(:i686)])#;
-                                      #Windows(:x86_64)])
+                                      Windows(:i686);
+                                      Windows(:x86_64)])
 
 # The products that we will ensure are always built
 products = [

--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -1,0 +1,61 @@
+using BinaryBuilder
+
+# Collection of sources required to build FastTransforms
+name = "FastTransforms"
+version = v"0.2.9"
+sources = [
+    "https://github.com/MikaelSlevinsky/FastTransforms/archive/v$(version).tar.gz" =>
+    "555e8fb19ad76ee888fbab7bfaf4c269416c1c5950e9428cbe08edb44c22bf35",
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+if [[ ${target} != *darwin* ]]; then
+    if [[ ${target} == *mingw* ]]; then
+        cd $WORKSPACE/destdir/bin
+    else
+        cd $WORKSPACE/destdir/lib
+    fi
+    if [[ ${nbits} == 32 ]]; then
+        ln -sf libopenblas.${dlext} libblas.${dlext}
+    else
+        ln -sf libopenblas64_.${dlext} libblas.${dlext}
+    fi
+fi
+
+cd $WORKSPACE/srcdir/FastTransforms-*
+
+if [[ ${target} == *mingw* ]]; then
+    gcc  -std=gnu99 -Ofast -march=native -mtune=native -mno-vzeroupper -I./src -I/workspace/destdir/include -lm -shared -fPIC src/transforms.c src/rotations.c src/permute.c src/tdc.c src/drivers.c src/fftw.c -L/workspace/destdir/bin -lm -lquadmath -fopenmp -lblas -lfftw3 -lgmp -lmpfr -o libfasttransforms.dll
+    cp -a libfasttransforms.${dlext} ${prefix}/bin
+else
+    make lib CC=gcc FT_USE_PREDEFINED_LIBRARIES=1 FT_FFTW_WITH_COMBINED_THREADS=1
+    cp -a libfasttransforms.${dlext} ${prefix}/lib
+fi
+"""
+
+platforms = expand_gfortran_versions([Linux(:i686, libc=:glibc);
+                                      Linux(:x86_64, libc=:glibc);
+                                      Linux(:i686, libc=:musl);
+                                      Linux(:x86_64, libc=:musl);
+                                      #MacOS(:x86_64);
+                                      FreeBSD(:x86_64);
+                                      Windows(:i686)])#;
+                                      #Windows(:x86_64)])
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libfasttransforms", :libfasttransforms),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    "CompilerSupportLibraries_jll";
+    "FFTW_jll";
+    "GMP_jll";
+    "MPFR_jll";
+    "OpenBLAS_jll"
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
I will split this PR into (at least) 2 commits: the first one passes builds locally; the second one fails on the extra platforms `MacOS` and `Windows(:x86_64)` for the following reasons:

- `libopenblas64_` appears not to be found by the linker for `MacOS(:x86_64)` and `Windows(:x86_64)`. Sample error from `Windows(:x86_64)`:
```
[ Info: Building for x86_64-w64-mingw32
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
 Resolving package versions...
 Resolving package versions...
  Updating `~/Codes/build/x86_64-w64-mingw32/rAty1i0Z/.project/Project.toml`
  [e66e0078] + CompilerSupportLibraries_jll v0.2.0+0
  [f5851436] + FFTW_jll v3.3.9+3
  [781609d7] + GMP_jll v6.1.2+3
  [3a97d323] + MPFR_jll v4.0.2+1
  [4536629a] + OpenBLAS_jll v0.3.7+0
  [2a0f44e3] + Base64 
  [ade2ca70] + Dates 
  [b77e0a4c] + InteractiveUtils 
  [76f85450] + LibGit2 
  [8f399da3] + Libdl 
  [56ddb016] + Logging 
  [d6f4376e] + Markdown 
  [44cfe95a] + Pkg 
  [de0858da] + Printf 
  [3fa0cd96] + REPL 
  [9a3f8284] + Random 
  [ea8e919c] + SHA 
  [9e88b42a] + Serialization 
  [6462fe0b] + Sockets 
  [cf7118a7] + UUIDs 
  [4ec0a83e] + Unicode 
  Updating `~/Codes/build/x86_64-w64-mingw32/rAty1i0Z/.project/Manifest.toml`
  [e66e0078] + CompilerSupportLibraries_jll v0.2.0+0
  [f5851436] + FFTW_jll v3.3.9+3
  [781609d7] + GMP_jll v6.1.2+3
  [3a97d323] + MPFR_jll v4.0.2+1
  [4536629a] + OpenBLAS_jll v0.3.7+0
  [2a0f44e3] + Base64 
  [ade2ca70] + Dates 
  [b77e0a4c] + InteractiveUtils 
  [76f85450] + LibGit2 
  [8f399da3] + Libdl 
  [56ddb016] + Logging 
  [d6f4376e] + Markdown 
  [44cfe95a] + Pkg 
  [de0858da] + Printf 
  [3fa0cd96] + REPL 
  [9a3f8284] + Random 
  [ea8e919c] + SHA 
  [9e88b42a] + Serialization 
  [6462fe0b] + Sockets 
  [cf7118a7] + UUIDs 
  [4ec0a83e] + Unicode 
src/transforms.c:1:0: warning: -fPIC ignored for target (all code is position independent) [enabled by default]
 // Computational routines for one-dimensional orthogonal polynomial transforms.
 ^
src/rotations.c:1:0: warning: -fPIC ignored for target (all code is position independent) [enabled by default]
 // Computational kernels for the harmonic polynomial connection problem.
 ^
src/permute.c:1:0: warning: -fPIC ignored for target (all code is position independent) [enabled by default]
 // Permutations that enable SSE, AVX, and AVX-512 vectorization.
 ^
src/tdc.c:1:0: warning: -fPIC ignored for target (all code is position independent) [enabled by default]
 #include "fasttransforms.h"
 ^
src/drivers.c:1:0: warning: -fPIC ignored for target (all code is position independent) [enabled by default]
 // Driver routines for the harmonic polynomial connection problem.
 ^
src/fftw.c:1:0: warning: -fPIC ignored for target (all code is position independent) [enabled by default]
 // FFTW overrides for synthesis and analysis on tensor product grids.
 ^
/tmp/ccKHkePC.o:tdc.c:(.text+0x4569): undefined reference to `cblas_sgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x45fc): undefined reference to `cblas_sgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x619f): undefined reference to `cblas_dgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x623f): undefined reference to `cblas_dgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x5c090): undefined reference to `cblas_dgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x5c130): undefined reference to `cblas_dgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x5c6c1): undefined reference to `cblas_dgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x5c7a0): more undefined references to `cblas_dgemm' follow
/tmp/ccKHkePC.o:tdc.c:(.text+0x64ca9): undefined reference to `cblas_dtrmm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x64d1c): undefined reference to `cblas_dtrmm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x64db9): undefined reference to `cblas_dtrsm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x64e2c): undefined reference to `cblas_dtrsm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x86330): undefined reference to `cblas_sgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x863d0): undefined reference to `cblas_sgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x8692c): undefined reference to `cblas_sgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x86a0a): undefined reference to `cblas_sgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x871db): undefined reference to `cblas_sgemm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x872ed): more undefined references to `cblas_sgemm' follow
/tmp/ccKHkePC.o:tdc.c:(.text+0x90d96): undefined reference to `cblas_strmm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x90e03): undefined reference to `cblas_strmm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x90e86): undefined reference to `cblas_strsm'
/tmp/ccKHkePC.o:tdc.c:(.text+0x90ef3): undefined reference to `cblas_strsm'
/opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/4.8.5/../../../../x86_64-w64-mingw32/bin/ld: /tmp/ccKHkePC.o: bad reloc address 0x0 in section `.pdata'
collect2: error: ld returned 1 exit status
Previous command exited with 1
ERROR: Build for FastTransforms on x86_64-w64-mingw32 did not complete successfully

Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] #autobuild#304(::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Nothing, ::Bool, ::Nothing, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(autobuild), ::String, ::String, ::VersionNumber, ::Array{Pair{String,String},1}, ::String, ::Array{Windows,1}, ::Array{LibraryProduct,1}, ::Array{String,1}) at /Users/Mikael/.julia/packages/BinaryBuilder/CASCi/src/AutoBuild.jl:665
 [3] (::BinaryBuilder.var"#kw##autobuild")(::NamedTuple{(:verbose, :debug, :meta_json_stream),Tuple{Bool,Bool,Nothing}}, ::typeof(autobuild), ::String, ::String, ::VersionNumber, ::Array{Pair{String,String},1}, ::String, ::Array{Windows,1}, ::Array{LibraryProduct,1}, ::Array{String,1}) at ./none:0
 [4] #build_tarballs#282(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(build_tarballs), ::Array{String,1}, ::String, ::VersionNumber, ::Array{Pair{String,String},1}, ::String, ::Array{Windows,1}, ::Array{LibraryProduct,1}, ::Array{String,1}) at /Users/Mikael/.julia/packages/BinaryBuilder/CASCi/src/AutoBuild.jl:195
 [5] build_tarballs(::Array{String,1}, ::String, ::VersionNumber, ::Array{Pair{String,String},1}, ::String, ::Array{Windows,1}, ::Array{LibraryProduct,1}, ::Array{String,1}) at /Users/Mikael/.julia/packages/BinaryBuilder/CASCi/src/AutoBuild.jl:23
 [6] top-level scope at REPL[206]:2

julia> 

```
- macOS has trouble with setting/discovering/working with SONAMEs from the compiler support libraries. Sample error
```
[ Info: Building for x86_64-apple-darwin14-libgfortran3, x86_64-apple-darwin14-libgfortran4, x86_64-apple-darwin14-libgfortran5
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
 Resolving package versions...
 Resolving package versions...
  Updating `~/Codes/build/x86_64-apple-darwin14-libgfortran3/NXfpOAOK/.project/Project.toml`
  [e66e0078] + CompilerSupportLibraries_jll v0.2.0+0
  [f5851436] + FFTW_jll v3.3.9+3
  [781609d7] + GMP_jll v6.1.2+3
  [3a97d323] + MPFR_jll v4.0.2+1
  [4536629a] + OpenBLAS_jll v0.3.7+0
  [2a0f44e3] + Base64 
  [ade2ca70] + Dates 
  [b77e0a4c] + InteractiveUtils 
  [76f85450] + LibGit2 
  [8f399da3] + Libdl 
  [56ddb016] + Logging 
  [d6f4376e] + Markdown 
  [44cfe95a] + Pkg 
  [de0858da] + Printf 
  [3fa0cd96] + REPL 
  [9a3f8284] + Random 
  [ea8e919c] + SHA 
  [9e88b42a] + Serialization 
  [6462fe0b] + Sockets 
  [cf7118a7] + UUIDs 
  [4ec0a83e] + Unicode 
  Updating `~/Codes/build/x86_64-apple-darwin14-libgfortran3/NXfpOAOK/.project/Manifest.toml`
  [e66e0078] + CompilerSupportLibraries_jll v0.2.0+0
  [f5851436] + FFTW_jll v3.3.9+3
  [781609d7] + GMP_jll v6.1.2+3
  [3a97d323] + MPFR_jll v4.0.2+1
  [4536629a] + OpenBLAS_jll v0.3.7+0
  [2a0f44e3] + Base64 
  [ade2ca70] + Dates 
  [b77e0a4c] + InteractiveUtils 
  [76f85450] + LibGit2 
  [8f399da3] + Libdl 
  [56ddb016] + Logging 
  [d6f4376e] + Markdown 
  [44cfe95a] + Pkg 
  [de0858da] + Printf 
  [3fa0cd96] + REPL 
  [9a3f8284] + Random 
  [ea8e919c] + SHA 
  [9e88b42a] + Serialization 
  [6462fe0b] + Sockets 
  [cf7118a7] + UUIDs 
  [4ec0a83e] + Unicode 
Warning: Minimum instruction set for lib/libfasttransforms.dylib is sandybridge, not core2 as desired.
Warning: Linked library /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib (resolved path /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib) is not within the given prefix
┌ Warning: Could not probe /Users/Mikael/Codes/build/x86_64-apple-darwin14-libgfortran3/NXfpOAOK/destdir/lib/libgcc_s.1.dylib for an SONAME!
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:9
┌ Warning: ObjectFile.MagicMismatch("Object file is not any of ObjectFile.ELF.ELFHandle, ObjectFile.MachO.MachOHandle, ObjectFile.COFF.COFFHandle! To force one object file format use readmeta(io, T).")
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:10
/docker_entrypoint.sh: line 24: /opt/x86_64-apple-darwin14/bin/install_name_tool: No such file or directory
Warning: Unable to set SONAME on ../artifacts/0d3df27bd584f1578a048dd18e24e2f551913ff1/lib/libgcc_s.1.dylib
┌ Warning: Could not probe /Users/Mikael/Codes/build/x86_64-apple-darwin14-libgfortran3/NXfpOAOK/destdir/lib/libgcc_s.1.dylib for an SONAME!
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:9
┌ Warning: ObjectFile.MagicMismatch("Object file is not any of ObjectFile.ELF.ELFHandle, ObjectFile.MachO.MachOHandle, ObjectFile.COFF.COFFHandle! To force one object file format use readmeta(io, T).")
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:10
┌ Warning: Could not probe /Users/Mikael/Codes/build/x86_64-apple-darwin14-libgfortran3/NXfpOAOK/destdir/lib/libgcc_s_ppc64.1.dylib for an SONAME!
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:9
┌ Warning: ObjectFile.MagicMismatch("Object file is not any of ObjectFile.ELF.ELFHandle, ObjectFile.MachO.MachOHandle, ObjectFile.COFF.COFFHandle! To force one object file format use readmeta(io, T).")
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:10
/docker_entrypoint.sh: line 24: /opt/x86_64-apple-darwin14/bin/install_name_tool: No such file or directory
Warning: Unable to set SONAME on ../artifacts/0d3df27bd584f1578a048dd18e24e2f551913ff1/lib/libgcc_s.1.dylib
┌ Warning: Could not probe /Users/Mikael/Codes/build/x86_64-apple-darwin14-libgfortran3/NXfpOAOK/destdir/lib/libgcc_s_ppc64.1.dylib for an SONAME!
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:9
┌ Warning: ObjectFile.MagicMismatch("Object file is not any of ObjectFile.ELF.ELFHandle, ObjectFile.MachO.MachOHandle, ObjectFile.COFF.COFFHandle! To force one object file format use readmeta(io, T).")
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:10
┌ Warning: Could not probe /Users/Mikael/Codes/build/x86_64-apple-darwin14-libgfortran3/NXfpOAOK/destdir/lib/libgcc_s_x86_64.1.dylib for an SONAME!
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:9
┌ Warning: ObjectFile.MagicMismatch("Object file is not any of ObjectFile.ELF.ELFHandle, ObjectFile.MachO.MachOHandle, ObjectFile.COFF.COFFHandle! To force one object file format use readmeta(io, T).")
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:10
/docker_entrypoint.sh: line 24: /opt/x86_64-apple-darwin14/bin/install_name_tool: No such file or directory
Warning: Unable to set SONAME on ../artifacts/0d3df27bd584f1578a048dd18e24e2f551913ff1/lib/libgcc_s.1.dylib
┌ Warning: Could not probe /Users/Mikael/Codes/build/x86_64-apple-darwin14-libgfortran3/NXfpOAOK/destdir/lib/libgcc_s_x86_64.1.dylib for an SONAME!
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:9
┌ Warning: ObjectFile.MagicMismatch("Object file is not any of ObjectFile.ELF.ELFHandle, ObjectFile.MachO.MachOHandle, ObjectFile.COFF.COFFHandle! To force one object file format use readmeta(io, T).")
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/CASCi/src/auditor/soname_matching.jl:10
```
I think some of these warnings are fatal because I tried using the `.dylib` locally to no avail.

- Notwithstanding the above, I think there would still be a problem on macOS if `CompilerSupportLibraries_jll` isn't loadable https://github.com/JuliaBinaryWrappers/CompilerSupportLibraries_jll.jl/issues/1. Here, I'm following `Arpack_jll`'s model that uses `OpenBLAS_jll` as a dependency (see for example https://github.com/JuliaBinaryWrappers/Arpack_jll.jl/blob/master/src/wrappers/x86_64-apple-darwin14-libgfortran5.jl#L4)