### PR TITLE
attempt to fix CSL

### DIFF
--- a/0_RootFS/CompilerSupportLibraries/build_tarballs.jl
+++ b/0_RootFS/CompilerSupportLibraries/build_tarballs.jl
@@ -10,11 +10,6 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-if [[ ${target} == *mingw* ]]; then
-    libdir=${prefix}/bin
-else
-    libdir=${prefix}/lib
-fi
 mkdir -p ${libdir}
 
 file_valid()
@@ -50,6 +45,11 @@ done
 for l in ${libdir}/*; do
     chmod 0755 "${l}"
 done
+
+# libgcc_s.1.dylib receives special treatment for now
+if [[ ${target} == *apple* ]]; then
+    install_name_tool -id @rpath/libgcc_s.1.dylib ${libdir}/libgcc_s.1.dylib
+fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/0_RootFS/CompilerSupportLibraries/build_tarballs.jl
+++ b/0_RootFS/CompilerSupportLibraries/build_tarballs.jl
@@ -45,6 +45,11 @@ for d in /opt/${target}/${target}/lib*; do
         fi
     done
 done
+
+# change permissions so that rpath succeeds
+for l in ${libdir}/*; do
+    chmod a+w "${l}"
+done
 """
 
 # These are the platforms we will build for by default, unless further
@@ -64,4 +69,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; skip_audit=true)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/0_RootFS/CompilerSupportLibraries/build_tarballs.jl
+++ b/0_RootFS/CompilerSupportLibraries/build_tarballs.jl
@@ -48,7 +48,7 @@ done
 
 # change permissions so that rpath succeeds
 for l in ${libdir}/*; do
-    chmod a+w "${l}"
+    chmod 0755 "${l}"
 done
 """
 


### PR DESCRIPTION
Skipping the audit appears to prevent rpath from doing anything (https://github.com/JuliaBinaryWrappers/CompilerSupportLibraries_jll.jl/issues/1). But rpath needs some write permissions. There is still
```
Warning: Unable to set SONAME on lib/libgcc_s.1.dylib
```