### PR TITLE
Don't allow parallel registration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,6 +151,7 @@ jobs:
   dependsOn: build
   strategy:
     matrix: $[ dependencies.generator.outputs['mtrx.projects'] ]
+    maxParallel: 1
   variables:
     projects: $[ dependencies.generator.outputs['mtrx.projects'] ]
   # We only register if this is on `master`; same as setting `${DEPLOY}` above.


### PR DESCRIPTION
This is just a safeguard against an unlikely race condition where two Registrator instances would be running at the same time.