### PR TITLE
adds libportaudio builder

### DIFF
--- a/L/libportaudio/build_tarballs.jl
+++ b/L/libportaudio/build_tarballs.jl
@@ -48,8 +48,8 @@ platforms = [
 ]
 
 # The products that we will ensure are always built
-products(prefix) = [
-    LibraryProduct(prefix, "libportaudio", :libportaudio)
+products = [
+    LibraryProduct("libportaudio", :libportaudio)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/L/libportaudio/build_tarballs.jl
+++ b/L/libportaudio/build_tarballs.jl
@@ -31,20 +31,22 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     ../portaudio/
 make
 make install
+install_license "${WORKSPACE}/srcdir/portaudio/LICENSE.txt"
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Linux(:i686, libc=:glibc)
-    Linux(:x86_64, libc=:glibc)
-    Linux(:aarch64, libc=:glibc)
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf)
-    Linux(:powerpc64le, libc=:glibc)
-    MacOS(:x86_64)
-    Windows(:i686)
-    Windows(:x86_64)
-]
+# platforms = [
+#     Linux(:i686, libc=:glibc)
+#     Linux(:x86_64, libc=:glibc)
+#     Linux(:aarch64, libc=:glibc)
+#     Linux(:armv7l, libc=:glibc, call_abi=:eabihf)
+#     Linux(:powerpc64le, libc=:glibc)
+#     MacOS(:x86_64)
+#     Windows(:i686)
+#     Windows(:x86_64)
+# ]
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libportaudio/build_tarballs.jl
+++ b/L/libportaudio/build_tarballs.jl
@@ -18,7 +18,6 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-set -e
 cd $WORKSPACE/srcdir
 
 # move the ASIO SDK to where CMake can find it
@@ -27,7 +26,7 @@ mv "asiosdk2.3.1 svnrev312937/ASIOSDK2.3.1" asiosdk2.3.1
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
-    -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain \
+    -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
     -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON \
     ../portaudio/
 make

--- a/L/libportaudio/build_tarballs.jl
+++ b/L/libportaudio/build_tarballs.jl
@@ -1,0 +1,59 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "libportaudio"
+version = v"19.6.0"
+
+
+# Collection of sources required to build libportaudio. Not all of these
+# are used for all platforms.
+sources = [
+    "http://portaudio.com/archives/pa_stable_v190600_20161030.tgz" =>
+        "f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513",
+
+    "http://www.steinberg.net/sdk_downloads/ASIOSDK2.3.1.zip" =>
+        "31074764475059448a9b7a56f103f4723ed60465e0e9d1a9446ca03dcf840f04"
+        ]
+
+# Bash recipe for building across all platforms
+script = raw"""
+set -e
+cd $WORKSPACE/srcdir
+
+# move the ASIO SDK to where CMake can find it
+mv "asiosdk2.3.1 svnrev312937/ASIOSDK2.3.1" asiosdk2.3.1
+
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain \
+    -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON \
+    ../portaudio/
+make
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Linux(:i686, libc=:glibc)
+    Linux(:x86_64, libc=:glibc)
+    Linux(:aarch64, libc=:glibc)
+    Linux(:armv7l, libc=:glibc, call_abi=:eabihf)
+    Linux(:powerpc64le, libc=:glibc)
+    MacOS(:x86_64)
+    Windows(:i686)
+    Windows(:x86_64)
+]
+
+# The products that we will ensure are always built
+products(prefix) = [
+    LibraryProduct(prefix, "libportaudio", :libportaudio)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = []
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/L/libportaudio/build_tarballs.jl
+++ b/L/libportaudio/build_tarballs.jl
@@ -12,8 +12,12 @@ sources = [
     "http://portaudio.com/archives/pa_stable_v190600_20161030.tgz" =>
         "f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513",
 
-    "http://www.steinberg.net/sdk_downloads/ASIOSDK2.3.1.zip" =>
-        "31074764475059448a9b7a56f103f4723ed60465e0e9d1a9446ca03dcf840f04"
+    # uncomment the following lines to include ASIO support. To distribute the
+    # resulting binaries you'll need to sign the licence agreement included with
+    # the SDK at: https://www.steinberg.net/en/company/developers.html
+
+    # "http://www.steinberg.net/sdk_downloads/ASIOSDK2.3.1.zip" =>
+    #     "31074764475059448a9b7a56f103f4723ed60465e0e9d1a9446ca03dcf840f04"
         ]
 
 # Bash recipe for building across all platforms
@@ -21,7 +25,9 @@ script = raw"""
 cd $WORKSPACE/srcdir
 
 # move the ASIO SDK to where CMake can find it
-mv "asiosdk2.3.1 svnrev312937/ASIOSDK2.3.1" asiosdk2.3.1
+if [ -d "asiosdk2.3.1" ]; then
+    mv "asiosdk2.3.1 svnrev312937/ASIOSDK2.3.1" asiosdk2.3.1
+fi
 
 mkdir build
 cd build

--- a/L/libportaudio/build_tarballs.jl
+++ b/L/libportaudio/build_tarballs.jl
@@ -5,7 +5,6 @@ using BinaryBuilder
 name = "libportaudio"
 version = v"19.6.0"
 
-
 # Collection of sources required to build libportaudio. Not all of these
 # are used for all platforms.
 sources = [
@@ -42,22 +41,10 @@ install_license "${WORKSPACE}/srcdir/portaudio/LICENSE.txt"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-# platforms = [
-#     Linux(:i686, libc=:glibc)
-#     Linux(:x86_64, libc=:glibc)
-#     Linux(:aarch64, libc=:glibc)
-#     Linux(:armv7l, libc=:glibc, call_abi=:eabihf)
-#     Linux(:powerpc64le, libc=:glibc)
-#     MacOS(:x86_64)
-#     Windows(:i686)
-#     Windows(:x86_64)
-# ]
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
-products = [
-    LibraryProduct("libportaudio", :libportaudio)
-]
+products = [ LibraryProduct("libportaudio", :libportaudio) ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = []


### PR DESCRIPTION
Thanks @jpsamaroo for the help realizing that we don't actually need to build JACK and ALSA.

I've tested that this runs locally and builds all the targets, but not that it actually works. I figure once the `libportaudio_jll` package is available I'll be able to test from PortAudio.jl and make sure everything's working.