### PR TITLE
[LibVPX] Build with default GCC

### DIFF
--- a/L/LibVPX/build_tarballs.jl
+++ b/L/LibVPX/build_tarballs.jl
@@ -79,4 +79,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This is an attempt to build LibVPX with default GCC.

First iteration to see what platforms are going to fail