### PR TITLE
Disable static libraries for GEOS

### DIFF
--- a/G/GEOS/build_tarballs.jl
+++ b/G/GEOS/build_tarballs.jl
@@ -26,7 +26,7 @@ EXTRA_CONFIGURE_FLAGS=()
 if [[ ${target} == arm* ]]; then
     EXTRA_CONFIGURE_FLAGS+=(--disable-inline)
 fi
-./configure --prefix=$prefix --build=${MACHTYPE} --host=$target --enable-shared ${EXTRA_CONFIGURE_FLAGS[@]}
+./configure --prefix=$prefix --build=${MACHTYPE} --host=$target --enable-shared --disable-static ${EXTRA_CONFIGURE_FLAGS[@]}
 make -j${nproc}
 make install
 """


### PR DESCRIPTION
Static libraries for GEOS take space unnecessarily 79 MB, as discussed in JuliaGeo/LibGEOS.jl#65 . Disable static libraries.

Judging from https://github.com/search?p=1&q=org%3AJuliaPackaging+--disable-static&type=Code `--disable-static` should be the correct option.