### PR TITLE
[AZP] Map the token

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,10 +7,11 @@ pr:
 - master
 
 variables:
+  MAPPED_GITHUB_TOKEN: $(GITHUB_TOKEN)
   # We run off of the latest `master`
   BINARYBUILDER_IMAGE_NAME: staticfloat/binarybuilder.jl:master
   # Things we pretty much always want when running with Docker
-  BASE_DOCKER_OPTS: -t -v /data/staticfloat/yggstorage:/storage -e GITHUB_TOKEN=$(GITHUB_TOKEN) -e TERM=xterm-16color
+  BASE_DOCKER_OPTS: -t -v /data/staticfloat/yggstorage:/storage -e GITHUB_TOKEN=$MAPPED_GITHUB_TOKEN -e TERM=xterm-16color
 
 pool: Default
 


### PR DESCRIPTION
I think we should map the token to an environment variable, so that it can be treated in the script as a plain variable, instead of command-like, which would fail when the token is not available.  This is also the recommended way to deal with this, according to https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables.

Tested in #224.