### PR TITLE
Add a builder for Lua 5.3

### DIFF
--- a/L/Lua/build_tarballs.jl
+++ b/L/Lua/build_tarballs.jl
@@ -24,6 +24,7 @@ elif [[ ${target} == *-mingw* ]]; then
     MAKE_TARGET=mingw
 else
     MAKE_TARGET=linux
+    export CPPFLAGS="-I${prefix}/include"
 fi
 
 # XXX: Work around Lua apparently not understanding its own Windows setup

--- a/L/Lua/build_tarballs.jl
+++ b/L/Lua/build_tarballs.jl
@@ -1,0 +1,54 @@
+using BinaryBuilder
+
+name = "Lua"
+version = v"5.3.5"
+
+sources = [
+    "https://www.lua.org/ftp/lua-5.3.5.tar.gz" =>
+        "0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac",
+    "./bundled",
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/lua-*
+
+atomic_patch -p1 "${WORKSPACE}/srcdir/patches/src_Makefile.patch"
+
+if [[ ${target} == *-apple-* ]]; then
+    MAKE_TARGET=macosx
+elif [[ ${target} == *-freebsd* ]]; then
+    # NOTE: The FreeBSD ports build also uses the bsd instead of the freebsd target,
+    # since it hard-codes fewer things, apparently
+    MAKE_TARGET=bsd
+elif [[ ${target} == *-mingw* ]]; then
+    MAKE_TARGET=mingw
+else
+    MAKE_TARGET=linux
+fi
+
+# XXX: Work around Lua apparently not understanding its own Windows setup
+if [[ ${target} == *-mingw* ]]; then
+    TO_BIN="lua.exe luac.exe"
+    TO_LIB="lua53.dll"
+else
+    TO_BIN="lua luac"
+    TO_LIB="liblua.${dlext}"
+fi
+
+make -j${nproc} ${MAKE_TARGET} DLEXT="${dlext}"
+make install INSTALL_TOP="${prefix}" INSTALL_LIB="${libdir}" TO_BIN="${TO_BIN}" TO_LIB="${TO_LIB}"
+
+install_license "${WORKSPACE}/srcdir/LICENSE"
+"""
+
+platforms = supported_platforms()
+
+products = [
+    ExecutableProduct("lua", :lua),
+    ExecutableProduct("luac", :luac),
+    LibraryProduct(["liblua", "lua53"], :liblua),
+]
+
+dependencies = []
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/L/Lua/build_tarballs.jl
+++ b/L/Lua/build_tarballs.jl
@@ -49,6 +49,8 @@ products = [
     LibraryProduct(["liblua", "lua53"], :liblua),
 ]
 
-dependencies = []
+dependencies = [
+    "Readline_jll",
+]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/L/Lua/bundled/LICENSE
+++ b/L/Lua/bundled/LICENSE
@@ -1,0 +1,30 @@
+License
+
+Lua is free software distributed under the terms of the MIT license
+reproduced below; it may be used for any purpose, including commercial
+purposes, at absolutely no cost without having to ask us. The only
+requirement is that if you do use Lua, then you should give us credit
+by including the appropriate copyright notice somewhere in your
+product or its documentation.
+
+    Copyright © 1994–2019 Lua.org, PUC-Rio.
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy,
+    modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions: 
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software. 
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.

--- a/L/Lua/bundled/patches/src_Makefile.patch
+++ b/L/Lua/bundled/patches/src_Makefile.patch
@@ -1,0 +1,62 @@
+diff --git a/src/Makefile b/src/Makefile
+index 64c78f7..ba65e36 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -6,8 +6,8 @@
+ # Your platform. See PLATS for possible values.
+ PLAT= none
+ 
+-CC= gcc -std=gnu99
+-CFLAGS= -O2 -Wall -Wextra -DLUA_COMPAT_5_2 $(SYSCFLAGS) $(MYCFLAGS)
++CC?= gcc -std=gnu99
++CFLAGS= -O2 -Wall -Wextra -DLUA_COMPAT_5_2 $(SYSCFLAGS) $(MYCFLAGS) -fPIC
+ LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
+ LIBS= -lm $(SYSLIBS) $(MYLIBS)
+ 
+@@ -24,11 +24,18 @@ MYLDFLAGS=
+ MYLIBS=
+ MYOBJS=
+ 
++ifeq ($(DLEXT),dylib)
++SOFLAGS := -dynamiclib
++else
++SOFLAGS := -shared
++endif
++
+ # == END OF USER SETTINGS -- NO NEED TO CHANGE ANYTHING BELOW THIS LINE =======
+ 
+ PLATS= aix bsd c89 freebsd generic linux macosx mingw posix solaris
+ 
+ LUA_A=	liblua.a
++LUA_SO=	liblua.$(DLEXT)
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
+ 	lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o \
+ 	ltm.o lundump.o lvm.o lzio.o
+@@ -43,7 +50,7 @@ LUAC_T=	luac
+ LUAC_O=	luac.o
+ 
+ ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)
+-ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T)
++ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T) $(LUA_SO)
+ ALL_A= $(LUA_A)
+ 
+ # Targets start here.
+@@ -59,6 +66,9 @@ $(LUA_A): $(BASE_O)
+ 	$(AR) $@ $(BASE_O)
+ 	$(RANLIB) $@
+ 
++$(LUA_SO): $(CORE_O) $(LIB_O)
++	$(CC) -o $@ $(SOFLAGS) $(CFLAGS) $(LDFLAGS) $(MYLDFLAGS) $? $(LIBS)
++
+ $(LUA_T): $(LUA_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
+ 
+@@ -110,7 +120,7 @@ linux:
+ 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline"
+ 
+ macosx:
+-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline"
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -fno-common" SYSLIBS="-lreadline"
+ 
+ mingw:
+ 	$(MAKE) "LUA_A=lua53.dll" "LUA_T=lua.exe" \


### PR DESCRIPTION
Work in progress. I think it will take some patches in order to produce a shared library. Both FreeBSD Ports and Homebrew have a number of patches which make it build a shared library in addition to or instead of (respectively) an archive.

Note that this is for regular ol' Lua, not LuaJIT.