### PR TITLE
[FastTransforms] Remove -march=native on cross-compile

### DIFF
--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -12,9 +12,9 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/FastTransforms-*
 if [[ ${target} == x86_64-w64-mingw32 ]]; then
-    export CFLAGS="-mavx2 -mfma -fno-asynchronous-unwind-tables "
+    export CFLAGS="-mavx -fno-asynchronous-unwind-tables "
 else
-    export CFLAGS="-mavx2 -mfma "
+    export CFLAGS="-mavx "
 fi
 if [[ ${nbits} == 64 ]]; then
     SYMBOL_DEFS=()

--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -2,19 +2,19 @@ using BinaryBuilder
 
 # Collection of sources required to build FastTransforms
 name = "FastTransforms"
-version = v"0.2.11"
+version = v"0.2.12"
 sources = [
     "https://github.com/MikaelSlevinsky/FastTransforms/archive/v$(version).tar.gz" =>
-    "f3d5d7f22af40df36f60ca85cda916d54a1c5fa98df07d6062d02424599938cd",
+    "640c39f148d757760c2658d96ae86e46a568cb3971410c736ce85b0725f28e8a",
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/FastTransforms-*
 if [[ ${target} == x86_64-w64-mingw32 ]]; then
-    export CFLAGS="-fno-asynchronous-unwind-tables "
+    export CFLAGS="-mavx2 -mfma -fno-asynchronous-unwind-tables "
 else
-    export CFLAGS
+    export CFLAGS="-mavx2 -mfma "
 fi
 if [[ ${nbits} == 64 ]]; then
     SYMBOL_DEFS=()


### PR DESCRIPTION
It turns out that having `-march=native` is not good for cross-compilation. Sorry for the double take!

Instead, I turned on the `-mavx` flag because: Travis uses Ivybridge to test on macOS and Haswell to test on Linux and Windows; Appveyor also uses Haswell on Windows; and, Cirrus uses Haswell on FreeBSD.