### PR TITLE
add -O2 to GEOS CFLAGS

### DIFF
--- a/G/GEOS/build_tarballs.jl
+++ b/G/GEOS/build_tarballs.jl
@@ -43,7 +43,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-] resp
+]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6")

--- a/G/GEOS/build_tarballs.jl
+++ b/G/GEOS/build_tarballs.jl
@@ -26,7 +26,7 @@ EXTRA_CONFIGURE_FLAGS=()
 if [[ ${target} == arm* ]]; then
     EXTRA_CONFIGURE_FLAGS+=(--disable-inline)
 fi
-./configure --prefix=$prefix --build=${MACHTYPE} --host=$target --enable-shared --disable-static ${EXTRA_CONFIGURE_FLAGS[@]}
+./configure --prefix=$prefix --build=${MACHTYPE} --host=$target --enable-shared --disable-static CFLAGS="${CFLAGS} -O2" ${EXTRA_CONFIGURE_FLAGS[@]}
 make -j${nproc}
 make install
 """
@@ -43,7 +43,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-]
+] resp
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6")


### PR DESCRIPTION
Looks like dynamic libraries of GEOS are unstripped and huge in size.

In `.julia\artifacts\899bb0e10d4accc34dff74b1c82ffbfe56dc8b23\bin`, `libgeos-3-8-0.dll` and `libgeos_c-1.dll` are 57339 KB and 3239 KB respectively, whereas in `.julia\conda\3\pkgs\geos-3.8.0-h33f27b4_0\Library\bin`, `geos.dll` and `geos_c.dll` are 1346 KB and 346 KB respectively.

Putting here `CFLAGS="${CFLAGS} -O2"` to the `./configure` line.

But somehow I would expect the builder defaults should produce reasonably-sized binaries?