### PR TITLE
[GEOS] Remove -g options to compilers to reduce size

### DIFF
--- a/G/GEOS/build_tarballs.jl
+++ b/G/GEOS/build_tarballs.jl
@@ -26,6 +26,8 @@ EXTRA_CONFIGURE_FLAGS=()
 if [[ ${target} == arm* ]]; then
     EXTRA_CONFIGURE_FLAGS+=(--disable-inline)
 fi
+export CFLAGS="-O2"
+export CXXFLAGS="-O2"
 ./configure --prefix=$prefix --build=${MACHTYPE} --host=$target --enable-shared --disable-static ${EXTRA_CONFIGURE_FLAGS[@]}
 make -j${nproc}
 make install


### PR DESCRIPTION
`configure` is generating a `Makefile` with
```
CFLAGS = -g -O2
CXXFLAGS = -g -O2
```
Here we just set
```
CFLAGS=-O2
CXXFLAGS=-O2
```
These are the sizes of the resulting libraries for `x86_64-w64-mingw32`:
```
% ls -lh GEOS.v3.8.0.x86_64-w64-mingw32/bin 
total 3.8M
-r-xr-xr-x 1 mose mose 1.3K Nov 26 02:21 geos-config
-r-xr-xr-x 1 mose mose 3.0M Nov 26 02:21 libgeos-3-8-0.dll
-r-xr-xr-x 1 mose mose 815K Nov 26 02:21 libgeos_c-1.dll
```
I think this is a good improvement compared to the current situation, without doing any magic.  Ref #234.  CC: @jaakkor2 @visr 