### PR TITLE
[Git] Improve builder so that it runs only for requested platforms

### DIFF
--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -75,8 +75,34 @@ dependencies = [
 
 # Install first for win32, then win64.  This will accumulate files into `products` and also wrappers into the JLL package.
 non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
-build_tarballs(non_reg_ARGS, name, version, sources_w32, script_win, [Windows(:i686)], products, [])
-build_tarballs(non_reg_ARGS, name, version, sources_w64, script_win, [Windows(:x86_64)], products, [])
 
+# Get the list of platforms requested from the command line.  This should be the
+# only argument not prefixed with "--".
+requested_platforms = filter(arg -> !occursin(r"^--.*", arg), ARGS)
+# This returns whether the builder for the given `platform` should be run.
+function run_platform(platform)
+    if isone(length(requested_platforms))
+        # `requested_platforms` has only one element: the comma-separated list
+        # of platform.  We'll run the platform only if it's in the list
+        return platform in split(requested_platforms[1], ",")
+    else
+        # `requested_platforms` doesn't have only one element: if its length is
+        # zero, no platform has been explicitely passed from the command line
+        # and we we'll run all platforms, otherwise we don't know what to do, so
+        # let's return false.
+        return iszero(length(requested_platforms))
+    end
+end
+
+if run_platform("i686-w64-mingw32")
+    build_tarballs(non_reg_ARGS, name, version, sources_w32, script_win, [Windows(:i686)], products, [])
+end
+if run_platform("x86_64-w64-mingw32")
+    build_tarballs(non_reg_ARGS, name, version, sources_w64, script_win, [Windows(:x86_64)], products, [])
+end
 # Then for everything else.  This is the only one that we try to register, and this is the step that will open a PR against General
-build_tarballs(ARGS, name, version, sources_unix, script_unix, filter(p -> !isa(p, Windows), supported_platforms()), products, dependencies)
+platforms = filter!(p -> !isa(p, Windows), supported_platforms())
+if any(run_platform.(triplet.(platforms)))
+    build_tarballs(ARGS, name, version, sources_unix, script_unix, platforms, products, dependencies)
+end
+

--- a/fancy_toys.jl
+++ b/fancy_toys.jl
@@ -1,0 +1,34 @@
+# This is a collection of toys under the Yggdrasil tree for the good <s>kids</s>
+# developers.  These utilities can be employed in builder files.
+
+using BinaryBuilder
+
+"""
+    should_build_platform(platform) -> Bool
+
+Return whether the tarballs for the given `platform` should be built.
+
+This is useful when the builder has different platform-dependent elements
+(sources, script, products, etc...) that make it hard to have a single
+`build_tarballs` call.
+"""
+function should_build_platform(platform)
+    # If you need inspiration for how to use this function, look at the builder
+    # for Git.
+
+    # Get the list of platforms requested from the command line.  This should be
+    # the only argument not prefixed with "--".
+    requested_platforms = filter(arg -> !occursin(r"^--.*", arg), ARGS)
+
+    if isone(length(requested_platforms))
+        # `requested_platforms` has only one element: the comma-separated list
+        # of platform.  We'll run the platform only if it's in the list
+        return platform in split(requested_platforms[1], ",")
+    else
+        # `requested_platforms` doesn't have only one element: if its length is
+        # zero, no platform has been explicitely passed from the command line
+        # and we we'll run all platforms, otherwise we don't know what to do, so
+        # let's return false to be safe.
+        return iszero(length(requested_platforms))
+    end
+end


### PR DESCRIPTION
This is to see if now we'll get the wrapper for `x86_64-w64-ming32`, ref #233.

Let's see also if our Azure pipeline really works with this kind of builder :crossed_fingers: 