### PR TITLE
[Lua] Add Julia-specific functions to liblua

### DIFF
--- a/L/Lua/build_tarballs.jl
+++ b/L/Lua/build_tarballs.jl
@@ -13,6 +13,7 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/lua-*
 
 atomic_patch -p1 "${WORKSPACE}/srcdir/patches/src_Makefile.patch"
+atomic_patch -p1 "${WORKSPACE}/srcdir/patches/src_lauxlib.c.patch"
 
 if [[ ${target} == *-apple-* ]]; then
     MAKE_TARGET=macosx

--- a/L/Lua/bundled/patches/src_lauxlib.c.patch
+++ b/L/Lua/bundled/patches/src_lauxlib.c.patch
@@ -1,0 +1,17 @@
+diff --git a/src/lauxlib.c b/src/lauxlib.c
+index 8bdada5..080301d 100644
+--- a/src/lauxlib.c
++++ b/src/lauxlib.c
+@@ -1041,3 +1041,12 @@ LUALIB_API void luaL_checkversion_ (lua_State *L, lua_Number ver, size_t sz) {
+                   (LUAI_UACNUMBER)ver, (LUAI_UACNUMBER)*v);
+ }
+ 
++/* Julia-specific extensions for accessing configuration parameters */
++
++LUALIB_API int jl_lua_int_type() {
++    return LUA_INT_TYPE;
++}
++
++LUALIB_API int jl_lua_float_type() {
++    return LUA_FLOAT_TYPE;
++}


### PR DESCRIPTION
These simply return the values of configuration parameters that do not seem to be accessible after build time. They're useful for [LuaCall.jl](https://github.com/ararslan/LuaCall.jl) to ensure the correct types are passed back and forth between Julia and Lua.