### PR TITLE
Attempt to map `GITHUB_TOKEN` to avoid errors in PRs

### DIFF
--- a/H/HelloWorldC/build_tarballs.jl
+++ b/H/HelloWorldC/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "HelloWorldC"
-version = v"1.0.6"
+version = v"1.0.7"
 
 # No sources, we're just building the testsuite
 sources = [

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,8 @@ variables:
   # We run off of the latest `master`
   BINARYBUILDER_IMAGE_NAME: staticfloat/binarybuilder.jl:master
   # Things we pretty much always want when running with Docker
-  BASE_DOCKER_OPTS: -t -v /data/staticfloat/yggstorage:/storage -e GITHUB_TOKEN=$(GITHUB_TOKEN) -e TERM=xterm-16color
+  BASE_DOCKER_OPTS: -t -v /data/staticfloat/yggstorage:/storage -e MAPPED_GITHUB_TOKEN -e TERM=xterm-16color
+  MAPPED_GITHUB_TOKEN: $(GITHUB_TOKEN)
 
 pool: Default
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,8 +10,8 @@ variables:
   # We run off of the latest `master`
   BINARYBUILDER_IMAGE_NAME: staticfloat/binarybuilder.jl:master
   # Things we pretty much always want when running with Docker
-  BASE_DOCKER_OPTS: -t -v /data/staticfloat/yggstorage:/storage -e MAPPED_GITHUB_TOKEN -e TERM=xterm-16color
-  MAPPED_GITHUB_TOKEN: $(GITHUB_TOKEN)
+  GITHUB_TOKEN: $(AZP_GITHUB_TOKEN)
+  BASE_DOCKER_OPTS: -t -v /data/staticfloat/yggstorage:/storage -e GITHUB_TOKEN -e TERM=xterm-16color
 
 pool: Default
 


### PR DESCRIPTION
My thinking is that by not using `$()` within a bash command anywhere, perhaps we dodge the AZP/bash ambiguity of who gets to expand `$(GITHUB_TOKEN)`.