### PR TITLE
[AZP] Deploy artifacts and JLL package in the register job only

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,13 +135,6 @@ jobs:
     projplatforms: $[ dependencies.generator.outputs['mtrx.projplatforms'] ]
   steps:
   - script: |
-      # If we're on master and this is not a pull request, then DEPLOY.  NOTE: A
-      # manual rebuild of a PR in Azure web interface is not a `PullRequest`
-      DEPLOY=""
-      if [[ "$(Build.Reason)" != "PullRequest" ]] && [[ "$(Build.SourceBranch)" == "refs/heads/master" ]] ; then
-          DEPLOY="--deploy"
-      fi
-
       # Run inside of that just-built Yggdrasil image, mapping /storage in
       DOCKER_OPTS="$(BASE_DOCKER_OPTS) --rm --privileged -w /workspace/$(PROJECT)"
       docker run ${DOCKER_OPTS} bb_worker:$(Build.SourceVersion) julia --color=yes ./build_tarballs.jl --verbose ${DEPLOY} $(PLATFORM)
@@ -166,7 +159,8 @@ jobs:
           julia --color=yes /workspace/.ci/register_package.jl meta.json --verbose; \
       "
     displayName: "register JLL package"
-    # We only register if this is on `master`; same as setting `${DEPLOY}` above.
+    # We only register if this is on `master`.  NOTE: A manual rebuild of a PR
+    # in Azure web interface is not a `PullRequest`.
     condition: and(and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master')), ne(variables['projects'], ''))
 
 - job: cleanup


### PR DESCRIPTION
I assume the idea of deploying without registration in the build stage was to parallelise the upload of possibly large files?  Unless we split "deploy" into "deploy artifacts" and "deploy jll",[1] the changes in https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/537 make "deploy" thread unsafe, but we run the build jobs in parallel.

This is an alternative to https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/549.



Notes:
[1] I had started implementing this, if you think that splitting the two deployments is a better idea I can continue by that route.