### PR TITLE
[AZP] Deploy only binaries during split build steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,7 +139,7 @@ jobs:
       # manual rebuild of a PR in Azure web interface is not a `PullRequest`
       DEPLOY=""
       if [[ "$(Build.Reason)" != "PullRequest" ]] && [[ "$(Build.SourceBranch)" == "refs/heads/master" ]] ; then
-          DEPLOY="--deploy"
+          DEPLOY="--deploy-bin"
       fi
 
       # Run inside of that just-built Yggdrasil image, mapping /storage in


### PR DESCRIPTION
Should fix JLL binary upload issues.

This depends on https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/551