### PR TITLE
Bump MPFR and GMP for ppc64le patchelf fixes

### DIFF
--- a/G/GMP/build_tarballs.jl
+++ b/G/GMP/build_tarballs.jl
@@ -57,7 +57,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libgmp", :libgmp)
+    LibraryProduct("libgmp", :libgmp),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/M/MPFR/build_tarballs.jl
+++ b/M/MPFR/build_tarballs.jl
@@ -30,7 +30,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libmpfr", :libmpfr)
+    LibraryProduct("libmpfr", :libmpfr),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
We need to rebuild these then point to the new binaries for GMP and MPFR to work on ppc64le