### PR TITLE
Attempt to build suitesparse with PARTITION module (with metis)

### DIFF
--- a/S/SuiteSparse@5/build_tarballs.jl
+++ b/S/SuiteSparse@5/build_tarballs.jl
@@ -16,7 +16,6 @@ cd $WORKSPACE/srcdir/SuiteSparse/
 
 # Apply Jameson's shlib patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/SuiteSparse-shlib.patch
-
 # Disable OpenMP as it will probably interfere with blas threads and Julia threads
 FLAGS=(INSTALL="${prefix}" INSTALL_LIB="${libdir}" INSTALL_INCLUDE="${prefix}/include" CFOPENMP=)
 
@@ -32,13 +31,30 @@ if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
     SUN="-DSUN64 -DLONGBLAS='long long'"
 
     FLAGS+=(BLAS="-lopenblas64_" LAPACK="-lopenblas64_")
-    FLAGS+=(UMFPACK_CONFIG="$SUN" CHOLMOD_CONFIG="$SUN -DNPARTITION" SPQR_CONFIG="$SUN")
+    FLAGS+=(UMFPACK_CONFIG="$SUN" CHOLMOD_CONFIG="$SUN" SPQR_CONFIG="$SUN")
 else
     FLAGS+=(BLAS="-lopenblas" LAPACK="-lopenblas")
-    FLAGS+=(CHOLMOD_CONFIG="-DNPARTITION")
 fi
 
 make -j${nproc} -C SuiteSparse_config "${FLAGS[@]}" library config
+
+if [[ "${target}" == *-mingw* ]]; then
+    atomic_patch -p0 ${WORKSPACE}/srcdir/patches/0001-mingw-w64-does-not-have-sys-resource-h.patch
+    atomic_patch -p0 ${WORKSPACE}/srcdir/patches/0002-mingw-w64-do-not-use-reserved-double-underscored-names.patch
+    atomic_patch -p0 ${WORKSPACE}/srcdir/patches/0003-WIN32-Install-RUNTIME-to-bin.patch
+    atomic_patch -p0 ${WORKSPACE}/srcdir/patches/0004-Fix-GKLIB_PATH-default-for-out-of-tree-builds.patch
+fi
+
+cd metis-5.1.0/build
+cmake -DGKLIB_PATH=../GKlib -DSHARED=1 -DCMAKE_INSTALL_PREFIX=$WORKSPACE/srcdir/SuiteSparse -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" ..
+make -j${nproc}
+make install
+if [[ "${target}" == *-mingw* ]]; then
+    cp -a $WORKSPACE/srcdir/SuiteSparse/bin/libmetis.* ${libdir}
+else
+    cp -a $WORKSPACE/srcdir/SuiteSparse/lib/libmetis.* ${libdir}
+fi
+cd ../..
 
 for proj in SuiteSparse_config AMD BTF CAMD CCOLAMD COLAMD CHOLMOD LDL KLU UMFPACK RBio SPQR; do
     make -j${nproc} -C $proj "${FLAGS[@]}" library CFOPENMP="$CFOPENMP"
@@ -87,6 +103,7 @@ products = [
     LibraryProduct("libumfpack",             :libumfpack),
     LibraryProduct("librbio",                :librbio),
     LibraryProduct("libspqr",                :libspqr),
+    LibraryProduct("libmetis",               :libmetis),
     LibraryProduct("libsuitesparse_wrapper", :libsuitesparse_wrapper),
 ]
 

--- a/S/SuiteSparse@5/bundled/patches/0001-mingw-w64-does-not-have-sys-resource-h.patch
+++ b/S/SuiteSparse@5/bundled/patches/0001-mingw-w64-does-not-have-sys-resource-h.patch
@@ -1,0 +1,14 @@
+diff -urN metis-5.1.0.orig/GKlib/gk_arch.h metis-5.1.0/GKlib/gk_arch.h
+--- metis-5.1.0.orig/GKlib/gk_arch.h	2017-04-30 20:26:49.002753400 +0100
++++ metis-5.1.0/GKlib/gk_arch.h	2017-04-30 20:27:34.087026100 +0100
+@@ -41,7 +41,9 @@
+ #endif
+   #include <inttypes.h>
+   #include <sys/types.h>
+-  #include <sys/resource.h>
++  #ifndef __MINGW32__
++    #include <sys/resource.h>
++  #endif
+   #include <sys/time.h>
+ #endif
+ 

--- a/S/SuiteSparse@5/bundled/patches/0002-mingw-w64-do-not-use-reserved-double-underscored-names.patch
+++ b/S/SuiteSparse@5/bundled/patches/0002-mingw-w64-do-not-use-reserved-double-underscored-names.patch
@@ -1,0 +1,17 @@
+diff -urN metis-5.1.0.orig/GKlib/gk_getopt.h metis-5.1.0.orig/GKlib/gk_getopt.h
+--- metis-5.1.0.orig/GKlib/gk_getopt.h	2017-04-30 20:51:50.209656200 +0100
++++ metis-5.1.0/GKlib/gk_getopt.h	2017-04-30 20:53:50.553327500 +0100
+@@ -52,10 +52,10 @@
+ 
+ 
+ /* Function prototypes */
+-extern int gk_getopt(int __argc, char **__argv, char *__shortopts);
+-extern int gk_getopt_long(int __argc, char **__argv, char *__shortopts,
++extern int gk_getopt(int gk_argc, char **gk_argv, char *__shortopts);
++extern int gk_getopt_long(int gk_argc, char **gk_argv, char *__shortopts,
+               struct gk_option *__longopts, int *__longind);
+-extern int gk_getopt_long_only (int __argc, char **__argv,
++extern int gk_getopt_long_only (int gk_argc, char **gk_argv,
+               char *__shortopts, struct gk_option *__longopts, int *__longind);
+ 
+ 

--- a/S/SuiteSparse@5/bundled/patches/0003-WIN32-Install-RUNTIME-to-bin.patch
+++ b/S/SuiteSparse@5/bundled/patches/0003-WIN32-Install-RUNTIME-to-bin.patch
@@ -1,0 +1,20 @@
+diff -urN metis-5.1.0.orig/libmetis/CMakeLists.txt metis-5.1.0/libmetis/CMakeLists.txt
+--- metis-5.1.0.orig/libmetis/CMakeLists.txt	2017-05-02 13:20:19.076768500 +0100
++++ metis-5.1.0/libmetis/CMakeLists.txt	2017-05-02 13:20:26.891479300 +0100
+@@ -8,9 +8,15 @@
+   target_link_libraries(metis m)
+ endif()
+ 
++if(WIN32)
++  set(RT_DEST bin)
++else()
++  set(RT_DEST lib)
++endif()
++
+ if(METIS_INSTALL)
+   install(TARGETS metis
+     LIBRARY DESTINATION lib
+-    RUNTIME DESTINATION lib
++    RUNTIME DESTINATION ${RT_DEST}
+     ARCHIVE DESTINATION lib)
+ endif()

--- a/S/SuiteSparse@5/bundled/patches/0004-Fix-GKLIB_PATH-default-for-out-of-tree-builds.patch
+++ b/S/SuiteSparse@5/bundled/patches/0004-Fix-GKLIB_PATH-default-for-out-of-tree-builds.patch
@@ -1,0 +1,11 @@
+--- metis-5.1.0/CMakeLists.txt.orig	2013-03-30 16:24:45.000000000 +0000
++++ metis-5.1.0/CMakeLists.txt	2017-05-02 10:56:07.741234700 +0100
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 2.8)
+ project(METIS)
+ 
+-set(GKLIB_PATH "GKlib" CACHE PATH "path to GKlib")
++set(GKLIB_PATH "${CMAKE_SOURCE_DIR}/GKlib" CACHE PATH "path to GKlib")
+ set(SHARED FALSE CACHE BOOL "build a shared library")
+ 
+ if(MSVC)


### PR DESCRIPTION
Now that metis-5.1.0 is included in SuiteSparse, let's try build CHOLMOD with the PARTITION module. This should give us the capability to do nested dissection orderings. For cholesky factorizations on certain graphs, this may give better fill.

Cc @ranjanan 