### PR TITLE
add GDAL builder

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -14,7 +14,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/gdal-*/
 
 if [[ ${target} == *mingw* ]]; then
-    export LDFLAGS="${libdir}"
+    export LDFLAGS="-L${libdir}"
     cp ${libdir}/libproj_6_2.dll ${libdir}/libproj.dll
 fi
 

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -79,4 +79,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6")

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -19,7 +19,10 @@ if [[ ${target} == *mingw* ]]; then
     # Apply patch to customise PROJ library
     atomic_patch -p1 "$WORKSPACE/srcdir/patches/configure_ac_proj_libs.patch"
     autoreconf -vi
-    export PROJ_LIBS="proj_6_2"
+    export PROJ_LIBS="proj_6_3"
+elif [[ "${target}" == powerpc64le-* ]]; then
+    # Need to remember to link against libpthread and libdl
+    export LDFLAGS="-lpthread -ldl"
 fi
 
 # Clear out `.la` files since they're often wrong and screw us up

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -7,6 +7,7 @@ version = v"3.0.2"
 sources = [
     "https://github.com/OSGeo/gdal/releases/download/v$version/gdal-$version.tar.gz" =>
     "787cf150346e58bff0ccf8c131b333139273e35d2abd590ad7196a9ee08f0039",
+    "./bundled",
 ]
 
 # Bash recipe for building across all platforms
@@ -15,7 +16,10 @@ cd $WORKSPACE/srcdir/gdal-*/
 
 if [[ ${target} == *mingw* ]]; then
     export LDFLAGS="-L${libdir}"
-    cp ${libdir}/libproj_6_2.dll ${libdir}/libproj.dll
+    # Apply patch to customise PROJ library
+    atomic_patch -p1 "$WORKSPACE/srcdir/patches/configure_ac_proj_libs.patch"
+    autoreconf -vi
+    export PROJ_LIBS="proj_6_2"
 fi
 
 # Clear out `.la` files since they're often wrong and screw us up

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder
 
 name = "GDAL"
-version = v"3.0.2"
+version = v"3.0.3"
 
 # Collection of sources required to build GDAL
 sources = [
     "https://github.com/OSGeo/gdal/releases/download/v$version/gdal-$version.tar.gz" =>
-    "787cf150346e58bff0ccf8c131b333139273e35d2abd590ad7196a9ee08f0039",
+    "fe9bbe1cd4f74a4917dec9585a91d9018d3a3b61e379aa9a1b709e278dde11d6",
     "./bundled",
 ]
 

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -57,6 +57,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    "CompilerSupportLibraries_jll",
     "GEOS_jll",
     "PROJ_jll",
     "Zlib_jll",

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -13,6 +13,11 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/gdal-*/
 
+if [[ ${target} == *mingw* ]]; then
+    export LDFLAGS="${libdir}"
+    cp ${libdir}/libproj_6_2.dll ${libdir}/libproj.dll
+fi
+
 # Show options in the log
 ./configure --help
 ./configure --prefix=$prefix --host=$target \
@@ -30,6 +35,7 @@ make install
 """
 
 platforms = supported_platforms()
+platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -57,7 +63,6 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "CompilerSupportLibraries_jll",
     "GEOS_jll",
     "PROJ_jll",
     "Zlib_jll",

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -1,0 +1,68 @@
+using BinaryBuilder
+
+name = "GDAL"
+version = v"3.0.2"
+
+# Collection of sources required to build GDAL
+sources = [
+    "https://github.com/OSGeo/gdal/releases/download/v$version/gdal-$version.tar.gz" =>
+    "787cf150346e58bff0ccf8c131b333139273e35d2abd590ad7196a9ee08f0039",
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/gdal-*/
+
+# Show options in the log
+./configure --help
+./configure --prefix=$prefix --host=$target \
+    --with-geos=${bindir}/geos-config \
+    --with-proj=$prefix \
+    --with-libz=$prefix \
+    --with-sqlite3=$prefix \
+    --with-curl=${bindir}/curl-config \
+    --with-python=no \
+    --enable-shared \
+    --disable-static
+
+make -j${nproc}
+make install
+"""
+
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libgdal", :libgdal),
+    ExecutableProduct("gdal_contour", :gdal_contour_path),
+    ExecutableProduct("gdal_grid", :gdal_grid_path),
+    ExecutableProduct("gdal_rasterize", :gdal_rasterize_path),
+    ExecutableProduct("gdal_translate", :gdal_translate_path),
+    ExecutableProduct("gdaladdo", :gdaladdo_path),
+    ExecutableProduct("gdalbuildvrt", :gdalbuildvrt_path),
+    ExecutableProduct("gdaldem", :gdaldem_path),
+    ExecutableProduct("gdalinfo", :gdalinfo_path),
+    ExecutableProduct("gdallocationinfo", :gdallocationinfo_path),
+    ExecutableProduct("gdalmanage", :gdalmanage_path),
+    ExecutableProduct("gdalsrsinfo", :gdalsrsinfo_path),
+    ExecutableProduct("gdaltindex", :gdaltindex_path),
+    ExecutableProduct("gdaltransform", :gdaltransform_path),
+    ExecutableProduct("gdalwarp", :gdalwarp_path),
+    ExecutableProduct("nearblack", :nearblack_path),
+    ExecutableProduct("ogr2ogr", :ogr2ogr_path),
+    ExecutableProduct("ogrinfo", :ogrinfo_path),
+    ExecutableProduct("ogrlineref", :ogrlineref_path),
+    ExecutableProduct("ogrtindex", :ogrtindex_path),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    "GEOS_jll",
+    "PROJ_jll",
+    "Zlib_jll",
+    "SQLite_jll",
+    "LibCURL_jll",
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -18,8 +18,9 @@ if [[ ${target} == *mingw* ]]; then
     cp ${libdir}/libproj_6_2.dll ${libdir}/libproj.dll
 fi
 
-# Show options in the log
-./configure --help
+# Clear out `.la` files since they're often wrong and screw us up
+rm -f ${prefix}/lib/*.la
+
 ./configure --prefix=$prefix --host=$target \
     --with-geos=${bindir}/geos-config \
     --with-proj=$prefix \

--- a/G/GDAL/bundled/patches/configure_ac_proj_libs.patch
+++ b/G/GDAL/bundled/patches/configure_ac_proj_libs.patch
@@ -1,0 +1,73 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1198,15 +1198,18 @@
+ 
+ else
+ 
++  if test -z "$PROJ_LIBS"; then
++      PROJ_LIBS="proj"
++  fi
+   if test "x$with_proj" = "xyes" -o "x$with_proj" = "x"; then
+     ORIG_LIBS="$LIBS"
+-    LIBS="-lproj $ORIG_LIBS"
++    LIBS="-l$PROJ_LIBS $ORIG_LIBS"
+     AC_LANG_PUSH([C++])
+-    AC_CHECK_LIB(proj,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
++    AC_CHECK_LIB($PROJ_LIBS,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+     AC_LANG_POP([C++])
+     if test "$PROJ_FOUND" = "no"; then
+         AC_LANG_PUSH([C++])
+-        AC_CHECK_LIB(proj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
++        AC_CHECK_LIB($PROJ_LIBS,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+         AC_LANG_POP([C++])
+         if test "$PROJ_FOUND" = "yes"; then
+             PROJ_INCLUDE="-DPROJ_RENAME_SYMBOLS"
+@@ -1233,27 +1236,27 @@
+   else
+ 
+     ORIG_LIBS="$LIBS"
+-    LIBS="-L$with_proj/lib -lproj $ORIG_LIBS"
++    LIBS="-L$with_proj/lib -l$PROJ_LIBS $ORIG_LIBS"
+     AC_LANG_PUSH([C++])
+-    AC_CHECK_LIB(proj,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
++    AC_CHECK_LIB($PROJ_LIBS,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+     AC_LANG_POP([C++])
+     if test "$PROJ_FOUND" = "no"; then
+-        LIBS="-L$with_proj/lib -lproj -lsqlite3 $ORIG_LIBS"
++        LIBS="-L$with_proj/lib -l$PROJ_LIBS -lsqlite3 $ORIG_LIBS"
+         unset ac_cv_lib_proj_proj_create_from_wkt
+         AC_LANG_PUSH([C++])
+-        AC_CHECK_LIB(proj,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
++        AC_CHECK_LIB(-l$PROJ_LIBS,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+         AC_LANG_POP([C++])
+     fi
+     if test "$PROJ_FOUND" = "no"; then
+-        LIBS="-L$with_proj/lib -lproj $ORIG_LIBS"
++        LIBS="-L$with_proj/lib -l$PROJ_LIBS $ORIG_LIBS"
+         AC_LANG_PUSH([C++])
+-        AC_CHECK_LIB(proj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
++        AC_CHECK_LIB($PROJ_LIBS,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+         AC_LANG_POP([C++])
+         if test "$PROJ_FOUND" = "no"; then
+-            LIBS="-L$with_proj/lib -lproj -lsqlite3 $ORIG_LIBS"
++            LIBS="-L$with_proj/lib -l$PROJ_LIBS -lsqlite3 $ORIG_LIBS"
+             unset ac_cv_lib_proj_internal_proj_create_from_wkt
+             AC_LANG_PUSH([C++])
+-            AC_CHECK_LIB(proj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
++            AC_CHECK_LIB($PROJ_LIBS,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+             AC_LANG_POP([C++])
+         fi
+         if test "$PROJ_FOUND" = "yes"; then
+@@ -4100,10 +4103,10 @@
+         AC_MSG_CHECKING([for spatialite.h in /usr/include or /usr/local/include])
+         if test -f "/usr/include/spatialite.h" -o -f "/usr/local/include/spatialite.h"; then
+             AC_MSG_RESULT(found)
+-            AC_CHECK_LIB(spatialite,spatialite_init,SPATIALITE_INIT_FOUND=yes,SPATIALITE_INIT_FOUND=no,-lsqlite3 -lproj)
++            AC_CHECK_LIB(spatialite,spatialite_init,SPATIALITE_INIT_FOUND=yes,SPATIALITE_INIT_FOUND=no,-lsqlite3 -l$PROJ_LIBS)
+             if test "$SPATIALITE_INIT_FOUND" = "yes"; then
+                 HAVE_SPATIALITE=yes
+-                SPATIALITE_LIBS="-lspatialite -lsqlite3 -lproj"
++                SPATIALITE_LIBS="-lspatialite -lsqlite3 -l$PROJ_LIBS"
+                 LIBS="$LIBS $SPATIALITE_LIBS"
+                 HAVE_SQLITE3=yes
+             fi


### PR DESCRIPTION
An attempt to build GDAL with a rather minimal set of dependencies. We'd [like to add more](https://github.com/JuliaGeo/GDAL.jl/issues/65), but only after this builds well, taking it one step at a time.

Going over it with @giordano on Slack we already managed to bypass `configure` errors (PROJ dependency checks) by adding `CompilerSupportLibraries_jll`, see the second commit. Unfortunately it does not seem possible to bypass these checks with `configure` arguments.

Right now, on `x86_64-linux-gnu`, this hits:
```
[14:59:35] sed: /workspace/destdir/x86_64-linux-gnu/lib/../lib64/libstdc++.la: No such file or directory
[14:59:35] libtool:   error: '/workspace/destdir/x86_64-linux-gnu/lib/../lib64/libstdc++.la' is not a valid libtool archive
[14:59:35] make[1]: *** [GNUmakefile:66: libgdal.la] Error 1
```
Which is odd since there is no `/workspace/destdir/x86_64-linux-gnu/` directory. Not sure where that path comes from or how to fix it. I tried to add `--without-libtool` to `configure`, and with that I got a fully succesfull build on `x86_64-linux-gnu`. However it did not help on for instance `i686-linux-musl`, so I left it out here. There I got this error:

```
[16:15:16] /opt/i686-linux-musl/i686-linux-musl/include/c++/4.8.5/iostream:74: undefined reference to `__dso_handle'
[16:15:16] /opt/i686-linux-musl/bin/i686-linux-musl-ld: /workspace/srcdir/gdal-3.0.2/frmts/o/LERC_band.o: relocation R_386_GOTOFF against undefined hidden symbol `__dso_handle' can not be used when making a shared object
[16:15:16] /opt/i686-linux-musl/bin/i686-linux-musl-ld: final link failed: Bad value
[16:15:16] make[1]: *** [GNUmakefile:62: /workspace/srcdir/gdal-3.0.2/libgdal.so] Error 1
```

For that I still tried `; preferred_gcc_version=v"6"` (like GEOS_jll), but that didn't change anything.

**Relevant links**
https://github.com/JuliaGeo/GDALBuilder
https://github.com/JuliaGeo/GDAL.jl
https://github.com/OSGeo/gdal/
https://gdal.org/
