### PR TITLE
add build recipe for LLVM9

### DIFF
--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -46,6 +46,15 @@ for f in $WORKSPACE/srcdir/libcxx_patches/*.patch; do
 done
 fi
 
+# Patches from the monorepo
+if [ -d $WORKSPACE/srcdir/patches ]; then
+cd ${WORKSPACE}/srcdir/llvm-project
+for f in $WORKSPACE/srcdir/patches/*.patch; do
+    echo "Applying patch ${f}"
+    atomic_patch -p1 ${f}
+done
+fi
+
 # The very first thing we need to do is to build llvm-tblgen for x86_64-linux-muslc
 # This is because LLVM's cross-compile setup is kind of borked, so we just
 # build the tools natively ourselves, directly.  :/

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -1,0 +1,251 @@
+# LLVMBuilder -- reliable LLVM builds all the time.
+using BinaryBuilder
+
+const llvm_tags = Dict(
+    v"6.0.1" => "d359f2096850c68b708bc25a7baca4282945949f",
+    v"8.0.1" => "19a71f6bdf2dddb10764939e7f0ec2b98dba76c9",
+    v"9.0.1" => "c1a0a213378a458fbea1a5c77b315c7dce08fd05",
+)
+
+const buildscript = raw"""
+# We want to exit the program if errors occur.
+set -o errexit
+
+cd ${WORKSPACE}/srcdir/llvm-project/llvm
+LLVM_SRCDIR=$(pwd)
+
+# Apply all our patches
+if [ -d $WORKSPACE/srcdir/llvm_patches ]; then
+for f in $WORKSPACE/srcdir/llvm_patches/*.patch; do
+    echo "Applying patch ${f}"
+    atomic_patch -p1 ${f}
+done
+fi
+
+if [ -d $WORKSPACE/srcdir/clang_patches ]; then
+cd ${WORKSPACE}/srcdir/llvm-project/clang
+for f in $WORKSPACE/srcdir/clang_patches/*.patch; do
+    echo "Applying patch ${f}"
+    atomic_patch -p1 ${f}
+done
+fi
+
+if [ -d $WORKSPACE/srcdir/crt_patches ]; then
+cd ${WORKSPACE}/srcdir/llvm-project/compiler-rt
+for f in $WORKSPACE/srcdir/crt_patches/*.patch; do
+    echo "Applying patch ${f}"
+    atomic_patch -p1 ${f}
+done
+fi
+
+if [ -d $WORKSPACE/srcdir/libcxx_patches ]; then
+cd ${WORKSPACE}/srcdir/llvm-project/libcxx
+for f in $WORKSPACE/srcdir/libcxx_patches/*.patch; do
+    echo "Applying patch ${f}"
+    atomic_patch -p1 ${f}
+done
+fi
+
+# The very first thing we need to do is to build llvm-tblgen for x86_64-linux-muslc
+# This is because LLVM's cross-compile setup is kind of borked, so we just
+# build the tools natively ourselves, directly.  :/
+
+# Build llvm-tblgen, clang-tblgen, and llvm-config
+mkdir ${WORKSPACE}/bootstrap
+pushd ${WORKSPACE}/bootstrap
+CMAKE_FLAGS=()
+CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD:STRING=host)
+CMAKE_FLAGS+=(-DLLVM_HOST_TRIPLE=${MACHTYPE})
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='clang;compiler-rt')
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING=False)
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_HOST_TOOLCHAIN})
+
+cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]}
+ninja -j${nproc} llvm-tblgen clang-tblgen llvm-config
+popd
+
+# Let's do the actual build within the `build` subdirectory
+mkdir ${WORKSPACE}/build && cd ${WORKSPACE}/build
+
+# Accumulate these flags outside CMAKE_FLAGS,
+# they will be added at the end.
+CMAKE_CPP_FLAGS=""
+CMAKE_CXX_FLAGS=""
+CMAKE_C_FLAGS=""
+
+CMAKE_FLAGS=()
+
+# Release build for best perofrmance
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+if [[ "${ASSERTS}" == "1" ]]; then
+    CMAKE_FLAGS+=(-DLLVM_ENABLE_ASSERTIONS:BOOL=ON)
+fi
+
+# build for our host arch and our GPU targets NVidia and AMD
+TARGETS=(host NVPTX AMDGPU)
+# Add WASM for LLVM 8
+if [[ "${LLVM_MAJ_VER}" == "8" ]]; then
+    TARGETS+=(WebAssembly)
+fi
+LLVM_TARGETS=$(IFS=';' ; echo "${TARGETS[*]}")
+CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD:STRING=$LLVM_TARGETS)
+
+# We mostly care about clang and LLVM
+CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld')
+CMAKE_FLAGS+=(-DLLVM_TOOL_CLANG_TOOLS_EXTRA_BUILD=OFF)
+
+# We want a build with no bindings
+CMAKE_FLAGS+=(-DLLVM_BINDINGS_LIST="" )
+
+# Turn off ZLIB and XML2
+CMAKE_FLAGS+=(-DLLVM_ENABLE_ZLIB=OFF)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_LIBXML2=OFF)
+
+# Disable useless things like docs, terminfo, etc....
+CMAKE_FLAGS+=(-DLLVM_INCLUDE_DOCS=Off)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_TERMINFO=Off)
+CMAKE_FLAGS+=(-DHAVE_HISTEDIT_H=Off)
+CMAKE_FLAGS+=(-DHAVE_LIBEDIT=Off)
+
+# We want a shared library
+CMAKE_FLAGS+=(-DLLVM_BUILD_LLVM_DYLIB:BOOL=ON)
+CMAKE_FLAGS+=(-DLLVM_LINK_LLVM_DYLIB:BOOL=ON)
+
+# Install things into $prefix, and make sure it knows we're cross-compiling
+CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING=True)
+
+# Julia expects the produced LLVM tools to be installed into tools and not bin
+# We can't simply move bin to tools since on MingW64 it will also contain the shlib.
+CMAKE_FLAGS+=(-DLLVM_TOOLS_INSTALL_DIR=${prefix}/tools)
+
+# Also build and install utils, since we want FileCheck, and lit
+CMAKE_FLAGS+=(-DLLVM_UTILS_INSTALL_DIR=${prefix}/tools)
+CMAKE_FLAGS+=(-DLLVM_INCLUDE_UTILS=True -DLLVM_INSTALL_UTILS=True)
+
+# Include perf/oprofile/vtune markers
+if [[ ${target} == *linux* ]]; then
+    CMAKE_FLAGS+=(-DUSE_PERF=1)
+    CMAKE_FLAGS+=(-DUSE_OPROFILE=1)
+fi
+if [[ ${target} == *linux* ]] || [[ ${target} == *mingw32* ]]; then
+    CMAKE_FLAGS+=(-DUSE_INTEL_JITEVENTS=1)
+fi
+
+# Tell LLVM where our pre-built tblgen tools are
+CMAKE_FLAGS+=(-DLLVM_TABLEGEN=${WORKSPACE}/bootstrap/bin/llvm-tblgen)
+CMAKE_FLAGS+=(-DCLANG_TABLEGEN=${WORKSPACE}/bootstrap/bin/clang-tblgen)
+CMAKE_FLAGS+=(-DLLVM_CONFIG_PATH=${WORKSPACE}/bootstrap/bin/llvm-config)
+
+# Explicitly use our cmake toolchain file
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=/opt/${target}/${target}.cmake)
+
+# Manually set the host triplet, as otherwise on some platforms it tries to guess using
+# `ld -v`, which is hilariously wrong.
+CMAKE_FLAGS+=(-DLLVM_HOST_TRIPLE=${target})
+
+# Tell LLVM which compiler target to use, because it loses track for some reason
+CMAKE_FLAGS+=(-DCMAKE_C_COMPILER_TARGET=${target})
+CMAKE_FLAGS+=(-DCMAKE_CXX_COMPILER_TARGET=${target})
+CMAKE_FLAGS+=(-DCMAKE_ASM_COMPILER_TARGET=${target})
+
+if [[ "${target}" == *apple* ]]; then
+    # On OSX, we need to override LLVM's looking around for our SDK
+    CMAKE_FLAGS+=(-DDARWIN_macosx_CACHED_SYSROOT:STRING=/opt/${target}/${target}/sys-root)
+
+    # LLVM actually won't build against 10.8, so we bump ourselves up slightly to 10.9
+    export MACOSX_DEPLOYMENT_TARGET=10.9
+    export LDFLAGS=-mmacosx-version-min=10.9
+
+    # We need to link against libc++ on OSX
+    CMAKE_FLAGS+=(-DLLVM_ENABLE_LIBCXX=ON)
+fi
+
+if [[ "${target}" == *apple* ]] || [[ "${target}" == *freebsd* ]]; then
+    # On clang-based platforms we need to override the check for ffs because it doesn't work with `clang`.
+    export ac_cv_have_decl___builtin_ffs=yes
+
+    # We don't use X-ray on BSD systems
+    CMAKE_FLAGS+=(-DCOMPILER_RT_BUILD_XRAY=OFF)
+fi
+
+if [[ "${target}" == *mingw* ]]; then
+    CMAKE_CPP_FLAGS="${CMAKE_CPP_FLAGS} -remap -D__USING_SJLJ_EXCEPTIONS__ -D__CRT__NO_INLINE"
+    # Windows is case-insensitive and some dependencies take full advantage of that
+    echo "BaseTsd.h basetsd.h" >> /opt/${target}/${target}/include/header.gcc
+fi
+
+if [[ "${target}" == *musl* ]]; then
+    # Taken from https://git.alpinelinux.org/cgit/aports/tree/main/compiler-rt/APKBUILD
+    CMAKE_FLAGS+=(-DCOMPILER_RT_INCLUDE_TESTS=ON)
+    CMAKE_FLAGS+=(-DCOMPILER_RT_BUILD_SANITIZERS=OFF)
+    CMAKE_FLAGS+=(-DCOMPILER_RT_BUILD_XRAY=OFF)
+fi
+
+if [[ "${target}" == *freebsd* ]]; then
+    # On FreeBSD, we must force even statically-linked code to have -fPIC
+    CMAKE_FLAGS+=(-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE)
+fi
+
+cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]} -DCMAKE_CXX_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS}" -DCMAKE_C_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS}"
+cmake -LA || true
+ninja -j${nproc} -v
+
+# Install!
+ninja install -j${nproc}
+
+# move clang products out of $prefix/bin to $prefix/tools
+mv ${prefix}/bin/clang* ${prefix}/tools/
+mv ${prefix}/bin/scan-* ${prefix}/tools/
+mv ${prefix}/bin/c-index* ${prefix}/tools/
+mv ${prefix}/bin/git-clang* ${prefix}/tools/
+mv ${prefix}/bin/lld* ${prefix}/tools/
+
+# Life is harsh on Windows and dynamic libraries are
+# expected to live alongside the binaries. So we have
+# to copy the *.dll from bin/ to tools/ as well...
+if [[ "${target}" == *mingw* ]]; then
+    cp ${prefix}/bin/*.dll ${prefix}/tools/
+fi
+
+# Work around llvm-config bug by creating versioned symlink to libLLVM
+# https://github.com/JuliaLang/julia/pull/30033
+if [[ "${target}" == *darwin* ]]; then
+    LLVM_VER=$(basename $(echo ${prefix}/tools/clang-*.*))
+    ln -s libLLVM.dylib ${prefix}/lib/libLLVM-${LLVM_VER##*-}.dylib
+fi
+
+# Lit is a python dependency and there is no proper install target
+cp -r ${LLVM_SRCDIR}/utils/lit ${prefix}/tools/
+
+install_license ${WORKSPACE}/srcdir/llvm-project/llvm/LICENSE.TXT
+"""
+
+function configure(version; assert=false)
+    sources = [
+        "https://github.com/llvm/llvm-project.git" =>
+        llvm_tags[version],
+        "./bundled",
+    ]
+
+    config = "LLVM_MAJ_VER=$(version.major)\n"
+    if assert
+        config *= "ASSERTS=1\n"
+    end
+    sources, config * buildscript
+end
+
+
+# Dependencies that must be installed before this package can be built
+# TODO: Zlib, LibXML2
+dependencies = [
+]
+
+products = [
+    LibraryProduct("libclang", :libclang, dont_dlopen=true),
+    LibraryProduct(["LLVM", "libLLVM"], :libllvm, dont_dlopen=true),
+    LibraryProduct(["LTO", "libLTO"], :liblto, dont_dlopen=true),
+    ExecutableProduct("llvm-config", :llvm_config, "tools")
+]
+

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -188,6 +188,11 @@ if [[ "${target}" == *freebsd* ]]; then
     CMAKE_FLAGS+=(-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE)
 fi
 
+if [[ "${target}" == *mingw* ]]; then
+    # On LLVM9 clang dylib is only support on Unix
+    CMAKE_FLAGS+=(-DCLANG_LINK_CLANG_DYLIB=OFF)
+fi
+
 cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]} -DCMAKE_CXX_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS}" -DCMAKE_C_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS}"
 cmake -LA || true
 ninja -j${nproc} -v

--- a/L/LLVM/v6/bundled/clang_patches/7003_clang_musl_gcc_detector.patch
+++ b/L/LLVM/v6/bundled/clang_patches/7003_clang_musl_gcc_detector.patch
@@ -1,0 +1,94 @@
+diff --git a/lib/Driver/ToolChains/Gnu.cpp b/lib/Driver/ToolChains/Gnu.cpp
+index 7845781f12c..055774d9d0b 100644
+--- a/lib/Driver/ToolChains/Gnu.cpp
++++ b/lib/Driver/ToolChains/Gnu.cpp
+@@ -1721,7 +1721,8 @@ bool Generic_GCC::GCCInstallationDetector::getBiarchSibling(Multilib &M) const {
+   static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
+                                              "armv7hl-redhat-linux-gnueabi",
+                                              "armv6hl-suse-linux-gnueabi",
+-                                             "armv7hl-suse-linux-gnueabi"};
++                                             "armv7hl-suse-linux-gnueabi",
++                                             "armv7l-linux-gnueabihf"};
+   static const char *const ARMebLibDirs[] = {"/lib"};
+   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi",
+                                              "armeb-linux-androideabi"};
+@@ -1809,6 +1810,79 @@ bool Generic_GCC::GCCInstallationDetector::getBiarchSibling(Multilib &M) const {
+     return;
+   }
+ 
++  if (TargetTriple.isMusl()) {
++    static const char *const AArch64MuslTriples[] = {"aarch64-linux-musl"};
++    static const char *const ARMHFMuslTriples[] = {
++        "arm-linux-musleabihf", "armv7l-linux-musleabihf"
++    };
++    static const char *const ARMMuslTriples[] = {"arm-linux-musleabi"};
++    static const char *const X86_64MuslTriples[] = {"x86_64-linux-musl"};
++    static const char *const X86MuslTriples[] = {"i686-linux-musl"};
++    static const char *const MIPSMuslTriples[] = {
++        "mips-linux-musl", "mipsel-linux-musl",
++        "mipsel-linux-muslhf", "mips-linux-muslhf"
++    };
++    static const char *const PPCMuslTriples[] = {"powerpc-linux-musl"};
++    static const char *const PPC64MuslTriples[] = {"powerpc64-linux-musl"};
++    static const char *const PPC64LEMuslTriples[] = {"powerpc64le-linux-musl"};
++
++    switch (TargetTriple.getArch()) {
++    case llvm::Triple::aarch64:
++      LibDirs.append(begin(AArch64LibDirs), end(AArch64LibDirs));
++      TripleAliases.append(begin(AArch64MuslTriples), end(AArch64MuslTriples));
++      BiarchLibDirs.append(begin(AArch64LibDirs), end(AArch64LibDirs));
++      BiarchTripleAliases.append(begin(AArch64MuslTriples), end(AArch64MuslTriples));
++      break;
++    case llvm::Triple::arm:
++      LibDirs.append(begin(ARMLibDirs), end(ARMLibDirs));
++      if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++        TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
++      } else {
++        TripleAliases.append(begin(ARMMuslTriples), end(ARMMuslTriples));
++      }
++      break;
++    case llvm::Triple::x86_64:
++      LibDirs.append(begin(X86_64LibDirs), end(X86_64LibDirs));
++      TripleAliases.append(begin(X86_64MuslTriples), end(X86_64MuslTriples));
++      BiarchLibDirs.append(begin(X86LibDirs), end(X86LibDirs));
++      BiarchTripleAliases.append(begin(X86MuslTriples), end(X86MuslTriples));
++      break;
++    case llvm::Triple::x86:
++      LibDirs.append(begin(X86LibDirs), end(X86LibDirs));
++      TripleAliases.append(begin(X86MuslTriples), end(X86MuslTriples));
++      BiarchLibDirs.append(begin(X86_64LibDirs), end(X86_64LibDirs));
++      BiarchTripleAliases.append(begin(X86_64MuslTriples), end(X86_64MuslTriples));
++      break;
++    case llvm::Triple::mips:
++      LibDirs.append(begin(MIPSLibDirs), end(MIPSLibDirs));
++      TripleAliases.append(begin(MIPSMuslTriples), end(MIPSMuslTriples));
++      break;
++    case llvm::Triple::ppc:
++      LibDirs.append(begin(PPCLibDirs), end(PPCLibDirs));
++      TripleAliases.append(begin(PPCMuslTriples), end(PPCMuslTriples));
++      BiarchLibDirs.append(begin(PPC64LibDirs), end(PPC64LibDirs));
++      BiarchTripleAliases.append(begin(PPC64MuslTriples), end(PPC64MuslTriples));
++      break;
++    case llvm::Triple::ppc64:
++      LibDirs.append(begin(PPC64LibDirs), end(PPC64LibDirs));
++      TripleAliases.append(begin(PPC64MuslTriples), end(PPC64MuslTriples));
++      BiarchLibDirs.append(begin(PPCLibDirs), end(PPCLibDirs));
++      BiarchTripleAliases.append(begin(PPCMuslTriples), end(PPCMuslTriples));
++      break;
++    case llvm::Triple::ppc64le:
++      LibDirs.append(begin(PPC64LELibDirs), end(PPC64LELibDirs));
++      TripleAliases.append(begin(PPC64LEMuslTriples), end(PPC64LEMuslTriples));
++      break;
++    default:
++      break;
++    }
++    TripleAliases.push_back(TargetTriple.str());
++    if (TargetTriple.str() != BiarchTriple.str())
++      BiarchTripleAliases.push_back(BiarchTriple.str());
++    return;
++  }
++
++
+   switch (TargetTriple.getArch()) {
+   case llvm::Triple::aarch64:
+     LibDirs.append(begin(AArch64LibDirs), end(AArch64LibDirs));

--- a/L/LLVM/v6/bundled/clang_patches/7004-clang-6.0-analyzer-Add-werror-flag-for-analyzer-warnings.patch
+++ b/L/LLVM/v6/bundled/clang_patches/7004-clang-6.0-analyzer-Add-werror-flag-for-analyzer-warnings.patch
@@ -1,0 +1,164 @@
+From 99590411e45f26b2cb6cdb8df9e7ebd2be181f1a Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliacomputing.com>
+Date: Tue, 4 Jun 2019 19:43:29 -0400
+Subject: [PATCH] [analyzer] Add werror flag for analyzer warnings
+
+Summary:
+We're using the clang static analyzer together with a number of
+custom analyses in our CI system to ensure that certain invariants
+are statiesfied for by the code every commit. Unfortunately, there
+currently doesn't seem to be a good way to determine whether any
+analyzer warnings were emitted, other than parsing clang's output
+(or using scan-build, which then in turn parses clang's output).
+As a simpler mechanism, simply add a `-analyzer-werror` flag to CC1
+that causes the analyzer to emit its warnings as errors instead.
+I briefly tried to have this be `Werror=analyzer` and make it go
+through that machinery instead, but that seemed more trouble than
+it was worth in terms of conflicting with options to the actual build
+and special cases that would be required to circumvent the analyzers
+usual attempts to quiet non-analyzer warnings. This is simple and it
+works well.
+
+Reviewers: NoQ
+
+Subscribers: xazax.hun, baloghadamsoftware, szepet, a.sidorin, mikhail.ramalho, Szelethus, donat.nagy, dkrupp, Charusso, cfe-commits
+
+Tags: #clang
+
+Differential Revision: https://reviews.llvm.org/D62885
+---
+ include/clang/Driver/CC1Options.td               |  3 +++
+ .../clang/StaticAnalyzer/Core/AnalyzerOptions.h  |  4 ++++
+ lib/Frontend/CompilerInvocation.cpp              |  1 +
+ lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp | 16 ++++++++++++----
+ test/Analysis/override-werror.c                  |  9 ++++++---
+ 5 files changed, 26 insertions(+), 7 deletions(-)
+
+diff --git a/include/clang/Driver/CC1Options.td b/include/clang/Driver/CC1Options.td
+index 7dea88b62c..ba7f4acb1e 100644
+--- a/include/clang/Driver/CC1Options.td
++++ b/include/clang/Driver/CC1Options.td
+@@ -132,6 +132,9 @@ def analyzer_list_enabled_checkers : Flag<["-"], "analyzer-list-enabled-checkers
+ def analyzer_config : Separate<["-"], "analyzer-config">,
+   HelpText<"Choose analyzer options to enable">;
+ 
++def analyzer_werror : Flag<["-"], "analyzer-werror">,
++  HelpText<"Emit analyzer results as errors, not warnings">;
++
+ //===----------------------------------------------------------------------===//
+ // Migrator Options
+ //===----------------------------------------------------------------------===//
+diff --git a/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h b/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
+index ce50cc582d..897800f4ca 100644
+--- a/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
++++ b/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
+@@ -177,6 +177,9 @@ public:
+   /// \brief Do not re-analyze paths leading to exhausted nodes with a different
+   /// strategy. We get better code coverage when retry is enabled.
+   unsigned NoRetryExhausted : 1;
++
++  /// Emit analyzer warnings as errors.
++  unsigned AnalyzerWerror : 1;
+   
+   /// \brief The inlining stack depth limit.
+   unsigned InlineMaxStackDepth;
+@@ -604,6 +607,7 @@ public:
+     UnoptimizedCFG(0),
+     PrintStats(0),
+     NoRetryExhausted(0),
++    AnalyzerWerror(0),
+     // Cap the stack depth at 4 calls (5 stack frames, base + 4 calls).
+     InlineMaxStackDepth(5),
+     InliningMode(NoRedundancy),
+diff --git a/lib/Frontend/CompilerInvocation.cpp b/lib/Frontend/CompilerInvocation.cpp
+index 438a48083e..086c9c446c 100644
+--- a/lib/Frontend/CompilerInvocation.cpp
++++ b/lib/Frontend/CompilerInvocation.cpp
+@@ -248,6 +248,7 @@ static bool ParseAnalyzerArgs(AnalyzerOptions &Opts, ArgList &Args,
+   Opts.visualizeExplodedGraphWithUbiGraph =
+     Args.hasArg(OPT_analyzer_viz_egraph_ubigraph);
+   Opts.NoRetryExhausted = Args.hasArg(OPT_analyzer_disable_retry_exhausted);
++  Opts.AnalyzerWerror = Args.hasArg(OPT_analyzer_werror);
+   Opts.AnalyzeAll = Args.hasArg(OPT_analyzer_opt_analyze_headers);
+   Opts.AnalyzerDisplayProgress = Args.hasArg(OPT_analyzer_display_progress);
+   Opts.AnalyzeNestedBlocks =
+diff --git a/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp b/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+index fccea9ee53..64834eb226 100644
+--- a/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
++++ b/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+@@ -83,10 +83,11 @@ void ento::createTextPathDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
+ namespace {
+ class ClangDiagPathDiagConsumer : public PathDiagnosticConsumer {
+   DiagnosticsEngine &Diag;
+-  bool IncludePath;
++  bool IncludePath, Werror;
++
+ public:
+   ClangDiagPathDiagConsumer(DiagnosticsEngine &Diag)
+-    : Diag(Diag), IncludePath(false) {}
++      : Diag(Diag), IncludePath(false), Werror(false) {}
+   ~ClangDiagPathDiagConsumer() override {}
+   StringRef getName() const override { return "ClangDiags"; }
+ 
+@@ -101,9 +102,13 @@ public:
+     IncludePath = true;
+   }
+ 
++  void enableWerror() { Werror = true; }
++
+   void FlushDiagnosticsImpl(std::vector<const PathDiagnostic *> &Diags,
+                             FilesMade *filesMade) override {
+-    unsigned WarnID = Diag.getCustomDiagID(DiagnosticsEngine::Warning, "%0");
++    unsigned WarnID =
++        Werror ? Diag.getCustomDiagID(DiagnosticsEngine::Error, "%0")
++               : Diag.getCustomDiagID(DiagnosticsEngine::Warning, "%0");
+     unsigned NoteID = Diag.getCustomDiagID(DiagnosticsEngine::Note, "%0");
+ 
+     for (std::vector<const PathDiagnostic*>::iterator I = Diags.begin(),
+@@ -219,6 +224,9 @@ public:
+           new ClangDiagPathDiagConsumer(PP.getDiagnostics());
+       PathConsumers.push_back(clangDiags);
+ 
++      if (Opts->AnalyzerWerror)
++        clangDiags->enableWerror();
++
+       if (Opts->AnalysisDiagOpt == PD_TEXT) {
+         clangDiags->enablePaths();
+ 
+@@ -249,7 +257,7 @@ public:
+ #define ANALYSIS_CONSTRAINTS(NAME, CMDFLAG, DESC, CREATEFN)     \
+       case NAME##Model: CreateConstraintMgr = CREATEFN; break;
+ #include "clang/StaticAnalyzer/Core/Analyses.def"
+-    }
++    };
+   }
+ 
+   void DisplayFunction(const Decl *D, AnalysisMode Mode,
+diff --git a/test/Analysis/override-werror.c b/test/Analysis/override-werror.c
+index 7dc09f5186..df80bac84f 100644
+--- a/test/Analysis/override-werror.c
++++ b/test/Analysis/override-werror.c
+@@ -1,14 +1,17 @@
+ // RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core -Werror %s -analyzer-store=region -verify
++// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core -Werror %s -analyzer-store=region -analyzer-werror -verify=werror
+ 
+ // This test case illustrates that using '-analyze' overrides the effect of
+ // -Werror.  This allows basic warnings not to interfere with producing
+ // analyzer results.
+ 
+-char* f(int *p) { 
+-  return p; // expected-warning{{incompatible pointer types}}
++char* f(int *p) {
++  return p; // expected-warning{{incompatible pointer types}} \
++               werror-warning{{incompatible pointer types}}
+ }
+ 
+ void g(int *p) {
+-  if (!p) *p = 0; // expected-warning{{null}}  
++  if (!p) *p = 0; // expected-warning{{null}} \
++                     werror-error{{null}}
+ }
+ 
+-- 
+2.17.1
+

--- a/L/LLVM/v6/bundled/crt_patches/0028-llvm-rL341857-basetsd-case-insensitive-mingw.patch
+++ b/L/LLVM/v6/bundled/crt_patches/0028-llvm-rL341857-basetsd-case-insensitive-mingw.patch
@@ -1,0 +1,63 @@
+--- a/lib/profile/WindowsMMap.h	(revision 341856)
++++ b/lib/profile/WindowsMMap.h	(revision 341857)
+@@ -1,59 +1,59 @@
+ /*===- WindowsMMap.h - Support library for PGO instrumentation ------------===*\
+ |*
+ |*                     The LLVM Compiler Infrastructure
+ |*
+ |* This file is distributed under the University of Illinois Open Source
+ |* License. See LICENSE.TXT for details.
+ |*
+ \*===----------------------------------------------------------------------===*/
+ 
+ #ifndef PROFILE_INSTRPROFILING_WINDOWS_MMAP_H
+ #define PROFILE_INSTRPROFILING_WINDOWS_MMAP_H
+ 
+ #if defined(_WIN32)
+ 
+-#include <BaseTsd.h>
++#include <basetsd.h>
+ #include <io.h>
+ #include <sys/types.h>
+ 
+ /*
+  * mmap() flags
+  */
+ #define PROT_READ     0x1
+ #define PROT_WRITE    0x2
+ #define PROT_EXEC     0x0
+ 
+ #define MAP_FILE      0x00
+ #define MAP_SHARED    0x01
+ #define MAP_PRIVATE   0x02
+ #define MAP_ANONYMOUS 0x20
+ #define MAP_ANON      MAP_ANONYMOUS
+ #define MAP_FAILED    ((void *) -1)
+ 
+ /*
+  * msync() flags
+  */
+ #define MS_ASYNC        0x0001  /* return immediately */
+ #define MS_INVALIDATE   0x0002  /* invalidate all cached data */
+ #define MS_SYNC         0x0010  /* msync synchronously */
+ 
+ /*
+  * flock() operations
+  */
+ #define   LOCK_SH   1    /* shared lock */
+ #define   LOCK_EX   2    /* exclusive lock */
+ #define   LOCK_NB   4    /* don't block when locking */
+ #define   LOCK_UN   8    /* unlock */
+ 
+ void *mmap(void *start, size_t length, int prot, int flags, int fd,
+            off_t offset);
+ 
+ void munmap(void *addr, size_t length);
+ 
+ int msync(void *addr, size_t length, int flags);
+ 
+ int flock(int fd, int operation);
+ 
+ #endif /* _WIN32 */
+ 
+ #endif /* PROFILE_INSTRPROFILING_WINDOWS_MMAP_H */

--- a/L/LLVM/v6/bundled/crt_patches/7000-compiler-rt-codesign.patch
+++ b/L/LLVM/v6/bundled/crt_patches/7000-compiler-rt-codesign.patch
@@ -1,0 +1,155 @@
+From 3dec5f3475a26aeb4678627795c4b67c6b7b4785 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 19 Sep 2017 13:13:06 -0500
+Subject: [PATCH] remove codesign use on Apple, disable ios sim testing that
+ needs it
+
+---
+ cmake/Modules/AddCompilerRT.cmake |  8 ------
+ test/asan/CMakeLists.txt          | 52 ---------------------------------------
+ test/tsan/CMakeLists.txt          | 47 -----------------------------------
+ 3 files changed, 107 deletions(-)
+
+diff --git a/cmake/Modules/AddCompilerRT.cmake b/cmake/Modules/AddCompilerRT.cmake
+index bc5fb9ff7..b64eb4246 100644
+--- a/cmake/Modules/AddCompilerRT.cmake
++++ b/cmake/Modules/AddCompilerRT.cmake
+@@ -210,14 +210,6 @@ function(add_compiler_rt_runtime name type)
+         set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")
+         set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
+       endif()
+-      if(APPLE)
+-        # Ad-hoc sign the dylibs
+-        add_custom_command(TARGET ${libname}
+-          POST_BUILD  
+-          COMMAND codesign --sign - $<TARGET_FILE:${libname}>
+-          WORKING_DIRECTORY ${COMPILER_RT_LIBRARY_OUTPUT_DIR}
+-        )
+-      endif()
+     endif()
+     install(TARGETS ${libname}
+       ARCHIVE DESTINATION ${COMPILER_RT_LIBRARY_INSTALL_DIR}
+diff --git a/test/asan/CMakeLists.txt b/test/asan/CMakeLists.txt
+index 8bfc15b5c..f23d0f71a 100644
+--- a/test/asan/CMakeLists.txt
++++ b/test/asan/CMakeLists.txt
+@@ -83,58 +83,6 @@ foreach(arch ${ASAN_TEST_ARCH})
+   endif()
+ endforeach()
+ 
+-# iOS and iOS simulator test suites
+-# These are not added into "check-all", in order to run these tests, use
+-# "check-asan-iossim-x86_64" and similar. They also require that an extra env
+-# variable to select which iOS device or simulator to use, e.g.:
+-# SANITIZER_IOSSIM_TEST_DEVICE_IDENTIFIER="iPhone 6"
+-if(APPLE)
+-  set(EXCLUDE_FROM_ALL ON)
+-
+-  set(ASAN_TEST_TARGET_CC ${COMPILER_RT_TEST_COMPILER})
+-  set(ASAN_TEST_IOS "1")
+-  pythonize_bool(ASAN_TEST_IOS)
+-  set(ASAN_TEST_DYNAMIC True)
+-
+-  foreach(arch ${DARWIN_iossim_ARCHS})
+-    set(ASAN_TEST_IOSSIM "1")
+-    pythonize_bool(ASAN_TEST_IOSSIM)
+-    set(ASAN_TEST_TARGET_ARCH ${arch})
+-    set(ASAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_iossim_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-    set(ASAN_TEST_CONFIG_SUFFIX "-${arch}-iossim")
+-    get_bits_for_arch(${arch} ASAN_TEST_BITS)
+-    string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-    set(CONFIG_NAME "IOSSim${ARCH_UPPER_CASE}Config")
+-    configure_lit_site_cfg(
+-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-      )
+-    add_lit_testsuite(check-asan-iossim-${arch} "AddressSanitizer iOS Simulator ${arch} tests"
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-      DEPENDS ${ASAN_TEST_DEPS})
+-  endforeach()
+-
+-  foreach (arch ${DARWIN_ios_ARCHS})
+-    set(ASAN_TEST_IOSSIM "0")
+-    pythonize_bool(ASAN_TEST_IOSSIM)
+-    set(ASAN_TEST_TARGET_ARCH ${arch})
+-    set(ASAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_ios_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-    set(ASAN_TEST_CONFIG_SUFFIX "-${arch}-ios")
+-    get_bits_for_arch(${arch} ASAN_TEST_BITS)
+-    string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-    set(CONFIG_NAME "IOS${ARCH_UPPER_CASE}Config")
+-    configure_lit_site_cfg(
+-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-      )
+-    add_lit_testsuite(check-asan-ios-${arch} "AddressSanitizer iOS ${arch} tests"
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-      DEPENDS ${ASAN_TEST_DEPS})
+-  endforeach()
+-
+-  set(EXCLUDE_FROM_ALL OFF)
+-endif()
+-
+ # Add unit tests.
+ if(COMPILER_RT_INCLUDE_TESTS)
+   set(ASAN_TEST_DYNAMIC False)
+diff --git a/test/tsan/CMakeLists.txt b/test/tsan/CMakeLists.txt
+index a68908612..cde0accb5 100644
+--- a/test/tsan/CMakeLists.txt
++++ b/test/tsan/CMakeLists.txt
+@@ -42,53 +42,6 @@ foreach(arch ${TSAN_TEST_ARCH})
+   list(APPEND TSAN_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME})
+ endforeach()
+ 
+-# iOS and iOS simulator test suites
+-# These are not added into "check-all", in order to run these tests, use
+-# "check-tsan-iossim-x86_64" and similar. They also require an extra environment
+-# variable to select which iOS device or simulator to use, e.g.:
+-# SANITIZER_IOSSIM_TEST_DEVICE_IDENTIFIER="iPhone 6"
+-if(APPLE)
+-  set(EXCLUDE_FROM_ALL ON)
+-
+-  set(TSAN_TEST_TARGET_CC ${COMPILER_RT_TEST_COMPILER})
+-  set(TSAN_TEST_IOS "1")
+-  pythonize_bool(TSAN_TEST_IOS)
+-
+-  set(arch "x86_64")
+-  set(TSAN_TEST_IOSSIM "1")
+-  pythonize_bool(TSAN_TEST_IOSSIM)
+-  set(TSAN_TEST_TARGET_ARCH ${arch})
+-  set(TSAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_iossim_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-  set(TSAN_TEST_CONFIG_SUFFIX "-${arch}-iossim")
+-  string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-  set(CONFIG_NAME "IOSSim${ARCH_UPPER_CASE}Config")
+-  configure_lit_site_cfg(
+-    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-    )
+-  add_lit_testsuite(check-tsan-iossim-${arch} "ThreadSanitizer iOS Simulator ${arch} tests"
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-    DEPENDS ${TSAN_TEST_DEPS})
+-
+-  set(arch "arm64")
+-  set(TSAN_TEST_IOSSIM "0")
+-  pythonize_bool(TSAN_TEST_IOSSIM)
+-  set(TSAN_TEST_TARGET_ARCH ${arch})
+-  set(TSAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_ios_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-  set(TSAN_TEST_CONFIG_SUFFIX "-${arch}-ios")
+-  string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-  set(CONFIG_NAME "IOS${ARCH_UPPER_CASE}Config")
+-  configure_lit_site_cfg(
+-    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-    )
+-  add_lit_testsuite(check-tsan-ios-${arch} "ThreadSanitizer iOS Simulator ${arch} tests"
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-    DEPENDS ${TSAN_TEST_DEPS})
+-
+-  set(EXCLUDE_FROM_ALL OFF)
+-endif()
+-
+ if(COMPILER_RT_INCLUDE_TESTS)
+   configure_lit_site_cfg(
+     ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.in
+-- 
+2.14.1
+

--- a/L/LLVM/v6/bundled/crt_patches/7003-compiler-rt-cmake-musl.patch
+++ b/L/LLVM/v6/bundled/crt_patches/7003-compiler-rt-cmake-musl.patch
@@ -1,0 +1,22 @@
+From fd82c5b9856b3876eaf323443e95d638ef625c5f Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 1 Jun 2018 17:02:25 -0400
+Subject: [PATCH] load CompilerRTCompile in fuzzer/test
+
+---
+ projects/compiler-rt/lib/fuzzer/tests/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/fuzzer/tests/CMakeLists.txt b/lib/fuzzer/tests/CMakeLists.txt
+index cc3be7de2..c295b4639 100644
+--- a/lib/fuzzer/tests/CMakeLists.txt
++++ b/lib/fuzzer/tests/CMakeLists.txt
+@@ -1,3 +1,5 @@
++include(CompilerRTCompile)
++
+ set(LIBFUZZER_UNITTEST_CFLAGS
+   ${COMPILER_RT_UNITTEST_CFLAGS}
+   ${COMPILER_RT_GTEST_CFLAGS}
+-- 
+2.17.0
+

--- a/L/LLVM/v6/bundled/crt_patches/7004_compiler_rt_musl.patch
+++ b/L/LLVM/v6/bundled/crt_patches/7004_compiler_rt_musl.patch
@@ -1,0 +1,428 @@
+diff --git a/lib/asan/asan_linux.cc b/lib/asan/asan_linux.cc
+index 625f32d408d..500f9946aed 100644
+--- a/lib/asan/asan_linux.cc
++++ b/lib/asan/asan_linux.cc
+@@ -46,7 +46,7 @@
+ #include <link.h>
+ #endif
+ 
+-#if SANITIZER_ANDROID || SANITIZER_FREEBSD || SANITIZER_SOLARIS
++#if SANITIZER_ANDROID || SANITIZER_FREEBSD || SANITIZER_SOLARIS || SANITIZER_NONGNU
+ #include <ucontext.h>
+ extern "C" void* _DYNAMIC;
+ #elif SANITIZER_NETBSD
+@@ -139,7 +139,7 @@ void AsanApplyToGlobals(globals_op_fptr op, const void *needle) {
+   UNIMPLEMENTED();
+ }
+ 
+-#if SANITIZER_ANDROID
++#if SANITIZER_ANDROID || SANITIZER_NONGNU
+ // FIXME: should we do anything for Android?
+ void AsanCheckDynamicRTPrereqs() {}
+ void AsanCheckIncompatibleRT() {}
+@@ -230,7 +230,7 @@ void AsanCheckIncompatibleRT() {
+     }
+   }
+ }
+-#endif // SANITIZER_ANDROID
++#endif // SANITIZER_ANDROID || SANITIZER_NONGNU
+ 
+ #if !SANITIZER_ANDROID
+ void ReadContextStack(void *context, uptr *stack, uptr *ssize) {
+diff --git a/lib/interception/interception_linux.cc b/lib/interception/interception_linux.cc
+index c991550a4f7..93909134141 100644
+--- a/lib/interception/interception_linux.cc
++++ b/lib/interception/interception_linux.cc
+@@ -42,12 +42,12 @@ bool GetRealFunctionAddress(const char *func_name, uptr *func_addr,
+   return real == wrapper;
+ }
+ 
+-// Android and Solaris do not have dlvsym
+-#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS
++// Android,  Solaris, OpenBSD and musl do not have dlvsym
++#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
+ void *GetFuncAddrVer(const char *func_name, const char *ver) {
+   return dlvsym(RTLD_NEXT, func_name, ver);
+ }
+-#endif  // !SANITIZER_ANDROID
++#endif  // !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
+ 
+ }  // namespace __interception
+ 
+diff --git a/lib/interception/interception_linux.h b/lib/interception/interception_linux.h
+index 98fe51b858f..d2e4fb1c485 100644
+--- a/lib/interception/interception_linux.h
++++ b/lib/interception/interception_linux.h
+@@ -35,15 +35,15 @@ void *GetFuncAddrVer(const char *func_name, const char *ver);
+       (::__interception::uptr) & (func),                                   \
+       (::__interception::uptr) & WRAP(func))
+ 
+-// Android and Solaris do not have dlvsym
+-#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS
++// Android,  Solaris and OpenBSD do not have dlvsym
++#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
+ #define INTERCEPT_FUNCTION_VER_LINUX_OR_FREEBSD(func, symver) \
+   (::__interception::real_##func = (func##_f)(                \
+        unsigned long)::__interception::GetFuncAddrVer(#func, symver))
+ #else
+ #define INTERCEPT_FUNCTION_VER_LINUX_OR_FREEBSD(func, symver) \
+   INTERCEPT_FUNCTION_LINUX_OR_FREEBSD(func)
+-#endif  // !SANITIZER_ANDROID && !SANITIZER_SOLARIS
++#endif  // !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
+ 
+ #endif  // INTERCEPTION_LINUX_H
+ #endif  // SANITIZER_LINUX || SANITIZER_FREEBSD || SANITIZER_NETBSD ||
+diff --git a/lib/msan/msan_interceptors.cc b/lib/msan/msan_interceptors.cc
+index a7fe09b25ff..894f6ec2663 100644
+--- a/lib/msan/msan_interceptors.cc
++++ b/lib/msan/msan_interceptors.cc
+@@ -54,6 +54,9 @@ DECLARE_REAL(SIZE_T, strlen, const char *s)
+ DECLARE_REAL(SIZE_T, strnlen, const char *s, SIZE_T maxlen)
+ DECLARE_REAL(void *, memcpy, void *dest, const void *src, uptr n)
+ DECLARE_REAL(void *, memset, void *dest, int c, uptr n)
++#if SANITIZER_NONGNU
++DECLARE_REAL(int, shmctl, int shmid, int cmd, void *buf)
++#endif
+ 
+ // True if this is a nested interceptor.
+ static THREADLOCAL int in_interceptor_scope;
+diff --git a/lib/msan/msan_linux.cc b/lib/msan/msan_linux.cc
+index 4e6321fcb91..8d176f9d66c 100644
+--- a/lib/msan/msan_linux.cc
++++ b/lib/msan/msan_linux.cc
+@@ -13,7 +13,7 @@
+ //===----------------------------------------------------------------------===//
+ 
+ #include "sanitizer_common/sanitizer_platform.h"
+-#if SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD
++#if SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD && !SANITIZER_NONGNU
+ 
+ #include "msan.h"
+ #include "msan_thread.h"
+@@ -26,7 +26,6 @@
+ #include <signal.h>
+ #include <unistd.h>
+ #include <unwind.h>
+-#include <execinfo.h>
+ #include <sys/time.h>
+ #include <sys/resource.h>
+ 
+@@ -213,4 +212,4 @@ void MsanTSDDtor(void *tsd) {
+ 
+ } // namespace __msan
+ 
+-#endif // SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD
++#endif // SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD && !SANITIZER_NONGNU
+diff --git a/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc b/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+index 24e7548a597..20259b1d6b8 100644
+--- a/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -102,7 +102,7 @@ static void ioctl_table_fill() {
+   _(SIOCGETVIFCNT, WRITE, struct_sioc_vif_req_sz);
+ #endif
+ 
+-#if SANITIZER_LINUX
++#if SANITIZER_LINUX && !SANITIZER_NONGNU
+   // Conflicting request ids.
+   // _(CDROMAUDIOBUFSIZ, NONE, 0);
+   // _(SNDCTL_TMR_CONTINUE, NONE, 0);
+@@ -363,7 +363,7 @@ static void ioctl_table_fill() {
+   _(VT_WAITACTIVE, NONE, 0);
+ #endif
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   // _(SIOCDEVPLIP, WRITE, struct_ifreq_sz); // the same as EQL_ENSLAVE
+   _(CYGETDEFTHRESH, WRITE, sizeof(int));
+   _(CYGETDEFTIMEOUT, WRITE, sizeof(int));
+diff --git a/lib/sanitizer_common/sanitizer_common_syscalls.inc b/lib/sanitizer_common/sanitizer_common_syscalls.inc
+index 469c8eb7e14..24f87867d92 100644
+--- a/lib/sanitizer_common/sanitizer_common_syscalls.inc
++++ b/lib/sanitizer_common/sanitizer_common_syscalls.inc
+@@ -2038,7 +2038,7 @@ POST_SYSCALL(setrlimit)(long res, long resource, void *rlim) {
+   }
+ }
+ 
+-#if !SANITIZER_ANDROID
++#if !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ PRE_SYSCALL(prlimit64)(long pid, long resource, const void *new_rlim,
+                        void *old_rlim) {
+   if (new_rlim) PRE_READ(new_rlim, struct_rlimit64_sz);
+diff --git a/lib/sanitizer_common/sanitizer_linux_libcdep.cc b/lib/sanitizer_common/sanitizer_linux_libcdep.cc
+index 56fdfc8705f..a8cabfd33c2 100644
+--- a/lib/sanitizer_common/sanitizer_linux_libcdep.cc
++++ b/lib/sanitizer_common/sanitizer_linux_libcdep.cc
+@@ -14,8 +14,8 @@
+ 
+ #include "sanitizer_platform.h"
+ 
+-#if SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD || \
+-    SANITIZER_SOLARIS
++#if SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD ||                \
++    SANITIZER_OPENBSD || SANITIZER_SOLARIS || SANITIZER_NONGNU
+ 
+ #include "sanitizer_allocator_internal.h"
+ #include "sanitizer_atomic.h"
+@@ -173,8 +173,8 @@ bool SanitizerGetThreadName(char *name, int max_len) {
+ #endif
+ }
+ 
+-#if !SANITIZER_FREEBSD && !SANITIZER_ANDROID && !SANITIZER_GO && \
+-    !SANITIZER_NETBSD && !SANITIZER_SOLARIS
++#if !SANITIZER_FREEBSD && !SANITIZER_ANDROID && !SANITIZER_GO &&               \
++    !SANITIZER_NETBSD && !SANITIZER_OPENBSD && !SANITIZER_SOLARIS && !SANITIZER_NONGNU
+ static uptr g_tls_size;
+ 
+ #ifdef __i386__
+@@ -203,11 +203,12 @@ void InitTlsSize() {
+ #else
+ void InitTlsSize() { }
+ #endif  // !SANITIZER_FREEBSD && !SANITIZER_ANDROID && !SANITIZER_GO &&
+-        // !SANITIZER_NETBSD && !SANITIZER_SOLARIS
++        // !SANITIZER_NETBSD && !SANITIZER_SOLARIS && !SANITIZER_NONGNU
+ 
+-#if (defined(__x86_64__) || defined(__i386__) || defined(__mips__) \
+-    || defined(__aarch64__) || defined(__powerpc64__) || defined(__s390__) \
+-    || defined(__arm__)) && SANITIZER_LINUX && !SANITIZER_ANDROID
++#if (defined(__x86_64__) || defined(__i386__) || defined(__mips__) ||          \
++     defined(__aarch64__) || defined(__powerpc64__) || defined(__s390__) ||    \
++     defined(__arm__)) &&                                                      \
++    SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ // sizeof(struct pthread) from glibc.
+ static atomic_uintptr_t kThreadDescriptorSize;
+ 
+@@ -391,7 +392,7 @@ int GetSizeFromHdr(struct dl_phdr_info *info, size_t size, void *data) {
+ 
+ #if !SANITIZER_GO
+ static void GetTls(uptr *addr, uptr *size) {
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ # if defined(__x86_64__) || defined(__i386__) || defined(__s390__)
+   *addr = ThreadSelf();
+   *size = GetTlsSize();
+@@ -432,7 +433,10 @@ static void GetTls(uptr *addr, uptr *size) {
+       *addr = (uptr)tcb->tcb_dtv[1];
+     }
+   }
+-#elif SANITIZER_ANDROID
++#elif SANITIZER_OPENBSD
++  *addr = 0;
++  *size = 0;
++#elif SANITIZER_ANDROID || SANITIZER_NONGNU
+   *addr = 0;
+   *size = 0;
+ #elif SANITIZER_SOLARIS
+@@ -447,8 +451,8 @@ static void GetTls(uptr *addr, uptr *size) {
+ 
+ #if !SANITIZER_GO
+ uptr GetTlsSize() {
+-#if SANITIZER_FREEBSD || SANITIZER_ANDROID || SANITIZER_NETBSD || \
+-    SANITIZER_SOLARIS
++#if SANITIZER_FREEBSD || SANITIZER_ANDROID || SANITIZER_NETBSD ||              \
++    SANITIZER_OPENBSD || SANITIZER_SOLARIS || SANITIZER_NONGNU
+   uptr addr, size;
+   GetTls(&addr, &size);
+   return size;
+diff --git a/lib/sanitizer_common/sanitizer_platform.h b/lib/sanitizer_common/sanitizer_platform.h
+index 334903c26f9..af05079d839 100644
+--- a/lib/sanitizer_common/sanitizer_platform.h
++++ b/lib/sanitizer_common/sanitizer_platform.h
+@@ -195,6 +195,19 @@
+ # define SANITIZER_SOLARIS32 0
+ #endif
+ 
++#if defined(__myriad2__)
++# define SANITIZER_MYRIAD2 1
++#else
++# define SANITIZER_MYRIAD2 0
++#endif
++
++
++#if defined(__linux__) && !defined(__GLIBC__)
++# define SANITIZER_NONGNU 1
++#else
++# define SANITIZER_NONGNU 0
++#endif
++
+ // By default we allow to use SizeClassAllocator64 on 64-bit platform.
+ // But in some cases (e.g. AArch64's 39-bit address space) SizeClassAllocator64
+ // does not work well and we need to fallback to SizeClassAllocator32.
+diff --git a/lib/sanitizer_common/sanitizer_platform_interceptors.h b/lib/sanitizer_common/sanitizer_platform_interceptors.h
+index b99ac448058..d90e713d412 100644
+--- a/lib/sanitizer_common/sanitizer_platform_interceptors.h
++++ b/lib/sanitizer_common/sanitizer_platform_interceptors.h
+@@ -38,7 +38,7 @@
+ # include "sanitizer_platform_limits_solaris.h"
+ #endif
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ # define SI_LINUX_NOT_ANDROID 1
+ #else
+ # define SI_LINUX_NOT_ANDROID 0
+diff --git a/lib/sanitizer_common/sanitizer_platform_limits_posix.cc b/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+index feb7bad6f34..88440018ff9 100644
+--- a/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -23,6 +23,11 @@
+ #ifdef _FILE_OFFSET_BITS
+ #undef _FILE_OFFSET_BITS
+ #endif
++
++#ifdef SANITIZER_NONGNU
++#include <stdio.h>
++#endif
++
+ #include <arpa/inet.h>
+ #include <dirent.h>
+ #include <grp.h>
+@@ -54,6 +59,9 @@
+ #endif
+ 
+ #if !SANITIZER_ANDROID
++#if !SANITIZER_NONGNU
++#include <fstab.h>
++#endif
+ #include <sys/mount.h>
+ #include <sys/timeb.h>
+ #include <utmpx.h>
+@@ -138,12 +146,14 @@ typedef struct user_fpregs elf_fpregset_t;
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+ #include <glob.h>
+-#include <obstack.h>
++#  if !SANITIZER_NONGNU
++#    include <obstack.h>
++#  endif
+ #include <mqueue.h>
+-#include <net/if_ppp.h>
+-#include <netax25/ax25.h>
+-#include <netipx/ipx.h>
+-#include <netrom/netrom.h>
++#include <linux/if_ppp.h>
++#include <linux/ax25.h>
++#include <linux/ipx.h>
++#include <linux/netrom.h>
+ #if HAVE_RPC_XDR_H
+ # include <rpc/xdr.h>
+ #elif HAVE_TIRPC_RPC_XDR_H
+@@ -228,6 +238,9 @@ namespace __sanitizer {
+ #endif // SANITIZER_MAC && !SANITIZER_IOS
+ 
+ #if !SANITIZER_ANDROID
++#if !SANITIZER_NONGNU
++  unsigned struct_fstab_sz = sizeof(struct fstab);
++#endif
+   unsigned struct_statfs_sz = sizeof(struct statfs);
+   unsigned struct_sockaddr_sz = sizeof(struct sockaddr);
+   unsigned ucontext_t_sz = sizeof(ucontext_t);
+@@ -322,7 +335,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(ElfW(Phdr));
+ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ #endif
+ 
+-#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID
++#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   int glob_nomatch = GLOB_NOMATCH;
+   int glob_altdirfunc = GLOB_ALTDIRFUNC;
+ #endif
+@@ -416,7 +429,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_termios_sz = sizeof(struct termios);
+   unsigned struct_winsize_sz = sizeof(struct winsize);
+ 
+-#if SANITIZER_LINUX
++#if SANITIZER_LINUX && !SANITIZER_NONGNU
+   unsigned struct_arpreq_sz = sizeof(struct arpreq);
+   unsigned struct_cdrom_msf_sz = sizeof(struct cdrom_msf);
+   unsigned struct_cdrom_multisession_sz = sizeof(struct cdrom_multisession);
+@@ -466,7 +479,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_vt_mode_sz = sizeof(struct vt_mode);
+ #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   unsigned struct_ax25_parms_struct_sz = sizeof(struct ax25_parms_struct);
+   unsigned struct_cyclades_monitor_sz = sizeof(struct cyclades_monitor);
+ #if EV_VERSION > (0x010000)
+@@ -834,7 +847,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned IOCTL_VT_WAITACTIVE = VT_WAITACTIVE;
+ #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   unsigned IOCTL_CYGETDEFTHRESH = CYGETDEFTHRESH;
+   unsigned IOCTL_CYGETDEFTIMEOUT = CYGETDEFTIMEOUT;
+   unsigned IOCTL_CYGETMON = CYGETMON;
+@@ -989,7 +1002,7 @@ CHECK_SIZE_AND_OFFSET(dl_phdr_info, dlpi_phdr);
+ CHECK_SIZE_AND_OFFSET(dl_phdr_info, dlpi_phnum);
+ #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+-#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID
++#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ CHECK_TYPE_SIZE(glob_t);
+ CHECK_SIZE_AND_OFFSET(glob_t, gl_pathc);
+ CHECK_SIZE_AND_OFFSET(glob_t, gl_pathv);
+@@ -1023,6 +1036,7 @@ CHECK_TYPE_SIZE(iovec);
+ CHECK_SIZE_AND_OFFSET(iovec, iov_base);
+ CHECK_SIZE_AND_OFFSET(iovec, iov_len);
+ 
++#if !SANITIZER_NONGNU
+ CHECK_TYPE_SIZE(msghdr);
+ CHECK_SIZE_AND_OFFSET(msghdr, msg_name);
+ CHECK_SIZE_AND_OFFSET(msghdr, msg_namelen);
+@@ -1036,6 +1050,7 @@ CHECK_TYPE_SIZE(cmsghdr);
+ CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_len);
+ CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_level);
+ CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_type);
++#endif
+ 
+ COMPILER_CHECK(sizeof(__sanitizer_dirent) <= sizeof(dirent));
+ CHECK_SIZE_AND_OFFSET(dirent, d_ino);
+@@ -1138,7 +1153,7 @@ CHECK_SIZE_AND_OFFSET(mntent, mnt_passno);
+ 
+ CHECK_TYPE_SIZE(ether_addr);
+ 
+-#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID
++#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ CHECK_TYPE_SIZE(ipc_perm);
+ # if SANITIZER_FREEBSD
+ CHECK_SIZE_AND_OFFSET(ipc_perm, key);
+@@ -1199,7 +1214,7 @@ CHECK_SIZE_AND_OFFSET(ifaddrs, ifa_dstaddr);
+ CHECK_SIZE_AND_OFFSET(ifaddrs, ifa_data);
+ #endif
+ 
+-#if SANITIZER_LINUX
++#if SANITIZER_LINUX && !SANITIZER_NONGNU
+ COMPILER_CHECK(sizeof(__sanitizer_mallinfo) == sizeof(struct mallinfo));
+ #endif
+ 
+@@ -1249,7 +1264,7 @@ COMPILER_CHECK(__sanitizer_XDR_DECODE == XDR_DECODE);
+ COMPILER_CHECK(__sanitizer_XDR_FREE == XDR_FREE);
+ #endif
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ COMPILER_CHECK(sizeof(__sanitizer_FILE) <= sizeof(FILE));
+ CHECK_SIZE_AND_OFFSET(FILE, _flags);
+ CHECK_SIZE_AND_OFFSET(FILE, _IO_read_ptr);
+@@ -1268,7 +1283,7 @@ CHECK_SIZE_AND_OFFSET(FILE, _chain);
+ CHECK_SIZE_AND_OFFSET(FILE, _fileno);
+ #endif
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ COMPILER_CHECK(sizeof(__sanitizer__obstack_chunk) <= sizeof(_obstack_chunk));
+ CHECK_SIZE_AND_OFFSET(_obstack_chunk, limit);
+ CHECK_SIZE_AND_OFFSET(_obstack_chunk, prev);
+diff --git a/lib/tsan/rtl/tsan_platform_linux.cc b/lib/tsan/rtl/tsan_platform_linux.cc
+index e14d5f575a2..389a3bc8831 100644
+--- a/lib/tsan/rtl/tsan_platform_linux.cc
++++ b/lib/tsan/rtl/tsan_platform_linux.cc
+@@ -285,7 +285,7 @@ void InitializePlatform() {
+ // This is required to properly "close" the fds, because we do not see internal
+ // closes within glibc. The code is a pure hack.
+ int ExtractResolvFDs(void *state, int *fds, int nfd) {
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   int cnt = 0;
+   struct __res_state *statp = (struct __res_state*)state;
+   for (int i = 0; i < MAXNS && cnt < nfd; i++) {

--- a/L/LLVM/v6/bundled/libcxx_patches/7001-libcxx-do-not-reexport.patch
+++ b/L/LLVM/v6/bundled/libcxx_patches/7001-libcxx-do-not-reexport.patch
@@ -1,0 +1,31 @@
+From c5b565679d973b85943e88bd6b0e3d9e1e58fd8b Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Mon, 23 Apr 2018 15:08:13 -0400
+Subject: [PATCH] forcefully disable APPLE specific 'feature'
+
+---
+ lib/CMakeLists.txt | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index aa5ebf156..0d3220dea 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -39,10 +39,10 @@ if (LIBCXX_GENERATE_COVERAGE AND NOT LIBCXX_COVERAGE_LIBRARY)
+ endif()
+ add_library_flags_if(LIBCXX_COVERAGE_LIBRARY "${LIBCXX_COVERAGE_LIBRARY}")
+ 
+-if (APPLE AND (LIBCXX_CXX_ABI_LIBNAME STREQUAL "libcxxabi" OR
+-               LIBCXX_CXX_ABI_LIBNAME STREQUAL "default"))
+-  set(LIBCXX_OSX_REEXPORT_SYSTEM_ABI_LIBRARY ON)
+-endif()
++# if (APPLE AND (LIBCXX_CXX_ABI_LIBNAME STREQUAL "libcxxabi" OR
++#                LIBCXX_CXX_ABI_LIBNAME STREQUAL "default"))
++#   set(LIBCXX_OSX_REEXPORT_SYSTEM_ABI_LIBRARY ON)
++# endif()
+ 
+ if (LIBCXX_ENABLE_STATIC_ABI_LIBRARY)
+   add_library_flags("-Wl,--whole-archive" "-Wl,-Bstatic")
+-- 
+2.17.0
+

--- a/L/LLVM/v6/bundled/libcxx_patches/7005_libcxx_musl.patch
+++ b/L/LLVM/v6/bundled/libcxx_patches/7005_libcxx_musl.patch
@@ -1,0 +1,22 @@
+diff --git a/include/locale b/include/locale
+index a86645d2cc4..2efcd824b99 100644
+--- a/include/locale
++++ b/include/locale
+@@ -736,7 +736,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        long long __ll = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        long long __ll = strtoll(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;
+@@ -776,7 +776,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        unsigned long long __ll = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        unsigned long long __ll = strtoull(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;

--- a/L/LLVM/v6/bundled/llvm_patches/0000-llvm-D27629-AArch64-large_model_6.0.1.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0000-llvm-D27629-AArch64-large_model_6.0.1.patch
@@ -1,0 +1,53 @@
+From f76abe65e6d07fea5e838c4f8c9a9421c16debb0 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Thu, 5 Jul 2018 12:37:50 -0400
+Subject: [PATCH] Fix unwind info relocation with large code model on AArch64
+
+---
+ lib/MC/MCObjectFileInfo.cpp                   |  2 ++
+ .../AArch64/ELF_ARM64_large-relocations.s     | 20 +++++++++++++++++++
+ 2 files changed, 22 insertions(+)
+ create mode 100644 test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+
+diff --git a/lib/MC/MCObjectFileInfo.cpp b/lib/MC/MCObjectFileInfo.cpp
+index 328f000f37c..938b35f20d1 100644
+--- a/lib/MC/MCObjectFileInfo.cpp
++++ b/lib/MC/MCObjectFileInfo.cpp
+@@ -291,6 +291,8 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
+     break;
+   case Triple::ppc64:
+   case Triple::ppc64le:
++  case Triple::aarch64:
++  case Triple::aarch64_be:
+   case Triple::x86_64:
+     FDECFIEncoding = dwarf::DW_EH_PE_pcrel |
+                      (Large ? dwarf::DW_EH_PE_sdata8 : dwarf::DW_EH_PE_sdata4);
+diff --git a/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+new file mode 100644
+index 00000000000..66f28dabd79
+--- /dev/null
++++ b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+@@ -0,0 +1,20 @@
++# RUN: llvm-mc -triple=arm64-none-linux-gnu -large-code-model -filetype=obj -o %T/large-reloc.o %s
++# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %T/large-reloc.o
++# RUN-BE: llvm-mc -triple=aarch64_be-none-linux-gnu -large-code-model -filetype=obj -o %T/be-large-reloc.o %s
++# RUN-BE: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -map-section be-large-reloc.o,.eh_frame=0x10000 -map-section be-large-reloc.o,.text=0xffff000000000000 -check=%s %T/be-large-reloc.o
++
++        .text
++        .globl  g
++        .p2align        2
++        .type   g,@function
++g:
++        .cfi_startproc
++        mov      x0, xzr
++        ret
++        .Lfunc_end0:
++        .size   g, .Lfunc_end0-g
++        .cfi_endproc
++
++# Skip the CIE and load the 8 bytes PC begin pointer.
++# Assuming the CIE and the FDE length are both 4 bytes.
++# rtdyld-check: *{8}(section_addr(large-reloc.o, .eh_frame) + (*{4}(section_addr(large-reloc.o, .eh_frame))) + 0xc) = g - (section_addr(large-reloc.o, .eh_frame) + (*{4}(section_addr(large-reloc.o, .eh_frame))) + 0xc)
+-- 
+2.18.0
+

--- a/L/LLVM/v6/bundled/llvm_patches/0001-llvm-D34078-vectorize-fdiv.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0001-llvm-D34078-vectorize-fdiv.patch
@@ -1,0 +1,56 @@
+From f94d12b6108b944199b715f31f25a022f75d2feb Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sat, 10 Jun 2017 08:45:13 -0400
+Subject: [PATCH 4/4] Enable support for floating-point division reductions
+
+Similar to fsub, fdiv can also be vectorized using fmul.
+---
+ lib/Transforms/Utils/LoopUtils.cpp               |  1 +
+ test/Transforms/LoopVectorize/float-reduction.ll | 22 ++++++++++++++++++++++
+ 2 files changed, 23 insertions(+)
+
+diff --git a/lib/Transforms/Utils/LoopUtils.cpp b/lib/Transforms/Utils/LoopUtils.cpp
+index 3c522786641..a4aced53a95 100644
+--- a/lib/Transforms/Utils/LoopUtils.cpp
++++ b/lib/Transforms/Utils/LoopUtils.cpp
+@@ -451,6 +451,7 @@ RecurrenceDescriptor::isRecurrenceInstr(Instruction *I, RecurrenceKind Kind,
+     return InstDesc(Kind == RK_IntegerOr, I);
+   case Instruction::Xor:
+     return InstDesc(Kind == RK_IntegerXor, I);
++  case Instruction::FDiv:
+   case Instruction::FMul:
+     return InstDesc(Kind == RK_FloatMult, I, UAI);
+   case Instruction::FSub:
+diff --git a/test/Transforms/LoopVectorize/float-reduction.ll b/test/Transforms/LoopVectorize/float-reduction.ll
+index f3b95d0ead7..669c54d55a2 100644
+--- a/test/Transforms/LoopVectorize/float-reduction.ll
++++ b/test/Transforms/LoopVectorize/float-reduction.ll
+@@ -44,3 +44,25 @@ for.body:                                         ; preds = %for.body, %entry
+ for.end:                                          ; preds = %for.body
+   ret float %sub
+ }
++
++;CHECK-LABEL: @foodiv(
++;CHECK: fdiv fast <4 x float>
++;CHECK: ret
++define float @foodiv(float* nocapture %A, i32* nocapture %n) nounwind uwtable readonly ssp {
++entry:
++  br label %for.body
++
++for.body:                                         ; preds = %for.body, %entry
++  %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
++  %sum.04 = phi float [ 1.000000e+00, %entry ], [ %sub, %for.body ]
++  %arrayidx = getelementptr inbounds float, float* %A, i64 %indvars.iv
++  %0 = load float, float* %arrayidx, align 4
++  %sub = fdiv fast float %sum.04, %0
++  %indvars.iv.next = add i64 %indvars.iv, 1
++  %lftr.wideiv = trunc i64 %indvars.iv.next to i32
++  %exitcond = icmp eq i32 %lftr.wideiv, 200
++  br i1 %exitcond, label %for.end, label %for.body
++
++for.end:                                          ; preds = %for.body
++  ret float %sub
++}
+-- 
+2.14.1
+

--- a/L/LLVM/v6/bundled/llvm_patches/0002-llvm-6.0-NVPTX-addrspaces.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0002-llvm-6.0-NVPTX-addrspaces.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/Target/NVPTX/NVPTXISelLowering.cpp b/lib/Target/NVPTX/NVPTXISelLowering.cpp
+index f1e4251a44b..73d49f5d7e4 100644
+--- a/lib/Target/NVPTX/NVPTXISelLowering.cpp
++++ b/lib/Target/NVPTX/NVPTXISelLowering.cpp
+@@ -1248,6 +1248,14 @@ SDValue NVPTXTargetLowering::getSqrtEstimate(SDValue Operand, SelectionDAG &DAG,
+   }
+ }
+ 
++bool NVPTXTargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
++                                               unsigned DestAS) const {
++  assert(SrcAS != DestAS && "Expected different address spaces!");
++
++  return (SrcAS  == ADDRESS_SPACE_GENERIC || SrcAS  > ADDRESS_SPACE_LOCAL) &&
++         (DestAS == ADDRESS_SPACE_GENERIC || DestAS > ADDRESS_SPACE_LOCAL);
++}
++
+ SDValue
+ NVPTXTargetLowering::LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const {
+   SDLoc dl(Op);
+diff --git a/lib/Target/NVPTX/NVPTXISelLowering.h b/lib/Target/NVPTX/NVPTXISelLowering.h
+index ef04a8573d4..68a9a7195c4 100644
+--- a/lib/Target/NVPTX/NVPTXISelLowering.h
++++ b/lib/Target/NVPTX/NVPTXISelLowering.h
+@@ -443,6 +443,8 @@ public:
+                                const NVPTXSubtarget &STI);
+   SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
+ 
++  bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override;
++
+   SDValue LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
+ 
+   const char *getTargetNodeName(unsigned Opcode) const override;

--- a/L/LLVM/v6/bundled/llvm_patches/0003-llvm-D42262-jumpthreading-not-i1.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0003-llvm-D42262-jumpthreading-not-i1.patch
@@ -1,0 +1,82 @@
+commit 6a311a7a804831fea43cfb2f61322adcb407a1af
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Thu Jan 18 15:57:05 2018 -0500
+
+    [JumpThreading] Don't restrict cast-traversal to i1
+    
+    Summary:
+    In D17663, JumpThreading learned to look trough simple cast instructions,
+    but only if the source of those cast instructions was a phi/cmp i1
+    (in an effort to limit compile time effects). I think this condition
+    is too restrictive. For switches with limited value range, InstCombine
+    will readily introduce an extra `trunc` instruction to a smaller
+    integer type (e.g. from i8 to i2), leaving us in the somewhat perverse
+    situation that jump-threading would work before running instcombine,
+    but not after. Since instcombine produces this pattern, I think we
+    need to consider it canonical and support it in JumpThreading.
+    In general, for limiting recursion, I think the existing restriction
+    to phi and cmp nodes should be sufficient to avoid looking through
+    unprofitable chains of instructions.
+    
+    Reviewers: haicheng, gberry, bmakam, mcrosier
+    
+    Subscribers: llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D42262
+
+diff --git a/lib/Transforms/Scalar/JumpThreading.cpp b/lib/Transforms/Scalar/JumpThreading.cpp
+index 95c4650..1155e18 100644
+--- a/lib/Transforms/Scalar/JumpThreading.cpp
++++ b/lib/Transforms/Scalar/JumpThreading.cpp
+@@ -647,11 +647,9 @@ bool JumpThreadingPass::ComputeValueKnownInPredecessors(
+   }
+ 
+   // Handle Cast instructions.  Only see through Cast when the source operand is
+-  // PHI or Cmp and the source type is i1 to save the compilation time.
++  // PHI or Cmp to save the compilation time.
+   if (CastInst *CI = dyn_cast<CastInst>(I)) {
+     Value *Source = CI->getOperand(0);
+-    if (!Source->getType()->isIntegerTy(1))
+-      return false;
+     if (!isa<PHINode>(Source) && !isa<CmpInst>(Source))
+       return false;
+     ComputeValueKnownInPredecessors(Source, BB, Result, Preference, CxtI);
+diff --git a/test/Transforms/JumpThreading/basic.ll b/test/Transforms/JumpThreading/basic.ll
+index ce86cba..16e7549 100644
+--- a/test/Transforms/JumpThreading/basic.ll
++++ b/test/Transforms/JumpThreading/basic.ll
+@@ -547,6 +547,34 @@ l5:
+ ; CHECK: }
+ }
+ 
++define i1 @trunc_switch(i1 %arg) {
++; CHECK-LABEL: @trunc_switch
++top:
++; CHECK: br i1 %arg, label %exitA, label %exitB
++  br i1 %arg, label %common, label %B
++
++B:
++  br label %common
++
++common:
++  %phi = phi i8 [ 2, %B ], [ 1, %top ]
++  %trunc = trunc i8 %phi to i2
++; CHECK-NOT: switch
++  switch i2 %trunc, label %unreach [
++    i2 1, label %exitA
++    i2 -2, label %exitB
++  ]
++
++unreach:
++  unreachable
++
++exitA:
++  ret i1 true
++
++exitB:
++  ret i1 false
++}
++
+ ; CHECK-LABEL: define void @h_con(i32 %p) {
+ define void @h_con(i32 %p) {
+   %x = icmp ult i32 %p, 5

--- a/L/LLVM/v6/bundled/llvm_patches/0004-llvm-PPC-addrspaces.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0004-llvm-PPC-addrspaces.patch
@@ -1,0 +1,29 @@
+From 15899eaab58e96bb7bbe7a14099674e255656a50 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 23 Feb 2018 14:41:20 -0500
+Subject: [PATCH] Make AddrSpaceCast noops on PPC
+
+PPC as AArch64 doesn't have address-spaces so we can drop them in the backend
+---
+ lib/Target/PowerPC/PPCISelLowering.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/lib/Target/PowerPC/PPCISelLowering.h b/lib/Target/PowerPC/PPCISelLowering.h
+index e60504507d3..c9b89773968 100644
+--- a/lib/Target/PowerPC/PPCISelLowering.h
++++ b/lib/Target/PowerPC/PPCISelLowering.h
+@@ -761,6 +761,11 @@ namespace llvm {
+       ReuseLoadInfo() : IsInvariant(false), Alignment(0), Ranges(nullptr) {}
+     };
+
++    bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override {
++      // Addrspacecasts are always noops.
++      return true;
++    }
++
+     bool canReuseLoadAddress(SDValue Op, EVT MemVT, ReuseLoadInfo &RLI,
+                              SelectionDAG &DAG,
+                              ISD::LoadExtType ET = ISD::NON_EXTLOAD) const;
+-- 
+2.16.2
+

--- a/L/LLVM/v6/bundled/llvm_patches/0008-llvm-6.0.0_D27296-libssp.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0008-llvm-6.0.0_D27296-libssp.patch
@@ -1,0 +1,35 @@
+Index: llvm/trunk/lib/Target/X86/X86ISelLowering.cpp
+===================================================================
+--- a/lib/Target/X86/X86ISelLowering.cpp
++++ b/lib/Target/X86/X86ISelLowering.cpp
+@@ -2098,7 +2098,8 @@
+ 
+ void X86TargetLowering::insertSSPDeclarations(Module &M) const {
+   // MSVC CRT provides functionalities for stack protection.
+-  if (Subtarget.getTargetTriple().isOSMSVCRT()) {
++  if (Subtarget.getTargetTriple().isWindowsMSVCEnvironment() ||
++      Subtarget.getTargetTriple().isWindowsItaniumEnvironment()) {
+     // MSVC CRT has a global variable holding security cookie.
+     M.getOrInsertGlobal("__security_cookie",
+                         Type::getInt8PtrTy(M.getContext()));
+@@ -2120,15 +2121,19 @@
+ 
+ Value *X86TargetLowering::getSDagStackGuard(const Module &M) const {
+   // MSVC CRT has a global variable holding security cookie.
+-  if (Subtarget.getTargetTriple().isOSMSVCRT())
++  if (Subtarget.getTargetTriple().isWindowsMSVCEnvironment() ||
++      Subtarget.getTargetTriple().isWindowsItaniumEnvironment()) {
+     return M.getGlobalVariable("__security_cookie");
++  }
+   return TargetLowering::getSDagStackGuard(M);
+ }
+ 
+ Value *X86TargetLowering::getSSPStackGuardCheck(const Module &M) const {
+   // MSVC CRT has a function to validate security cookie.
+-  if (Subtarget.getTargetTriple().isOSMSVCRT())
++  if (Subtarget.getTargetTriple().isWindowsMSVCEnvironment() ||
++      Subtarget.getTargetTriple().isWindowsItaniumEnvironment()) {
+     return M.getFunction("__security_check_cookie");
++  }
+   return TargetLowering::getSSPStackGuardCheck(M);
+ }

--- a/L/LLVM/v6/bundled/llvm_patches/0009-llvm-6.0-D44650.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0009-llvm-6.0-D44650.patch
@@ -1,0 +1,13 @@
+Index: tools/llvm-cfi-verify/CMakeLists.txt
+===================================================================
+--- a/tools/llvm-cfi-verify/CMakeLists.txt
++++ b/tools/llvm-cfi-verify/CMakeLists.txt
+@@ -11,7 +11,7 @@
+   Symbolize
+   )
+ 
+-add_llvm_tool(llvm-cfi-verify
++add_llvm_tool(llvm-cfi-verify DISABLE_LLVM_LINK_LLVM_DYLIB
+   llvm-cfi-verify.cpp)
+ 
+ add_subdirectory(lib)

--- a/L/LLVM/v6/bundled/llvm_patches/0013-llvm-D46460.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0013-llvm-D46460.patch
@@ -1,0 +1,26 @@
+Index: lib/Analysis/LoopInfo.cpp
+===================================================================
+--- a/lib/Analysis/LoopInfo.cpp
++++ b/lib/Analysis/LoopInfo.cpp
+@@ -223,15 +223,14 @@
+     BasicBlock *H = getHeader();
+     for (BasicBlock *BB : this->blocks()) {
+       TerminatorInst *TI = BB->getTerminator();
+-      MDNode *MD = nullptr;
+ 
+       // Check if this terminator branches to the loop header.
+-      for (BasicBlock *Successor : TI->successors()) {
+-        if (Successor == H) {
+-          MD = TI->getMetadata(LLVMContext::MD_loop);
+-          break;
+-        }
+-      }
++      bool IsPredecessor = any_of(TI->successors(),
++        [=](BasicBlock *Successor) { return Successor == H; });
++      if (!IsPredecessor)
++        continue;
++
++      MDNode *MD = TI->getMetadata(LLVMContext::MD_loop);
+       if (!MD)
+         return nullptr;
+ 

--- a/L/LLVM/v6/bundled/llvm_patches/0018-llvm-6.0-DISABLE_ABI_CHECKS.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0018-llvm-6.0-DISABLE_ABI_CHECKS.patch
@@ -1,0 +1,39 @@
+From d793ba4bacae51ae25be19c1636fcf38707938fd Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 1 Jun 2018 17:43:55 -0400
+Subject: [PATCH] fix LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+
+---
+ cmake/modules/HandleLLVMOptions.cmake    | 2 +-
+ include/llvm/Config/abi-breaking.h.cmake | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/modules/HandleLLVMOptions.cmake b/cmake/modules/HandleLLVMOptions.cmake
+index 3d2dd48018c..b67ee6a896e 100644
+--- a/cmake/modules/HandleLLVMOptions.cmake
++++ b/cmake/modules/HandleLLVMOptions.cmake
+@@ -572,7 +572,7 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
+ 
+   if (LLVM_ENABLE_PEDANTIC AND LLVM_COMPILER_IS_GCC_COMPATIBLE)
+     append("-pedantic" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+-    append("-Wno-long-long" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
++    append("-Wno-long-long -Wundef" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+   endif()
+ 
+   add_flag_if_supported("-Wcovered-switch-default" COVERED_SWITCH_DEFAULT_FLAG)
+diff --git a/include/llvm/Config/abi-breaking.h.cmake b/include/llvm/Config/abi-breaking.h.cmake
+index 7ae401e5b8a..d52c4609101 100644
+--- a/include/llvm/Config/abi-breaking.h.cmake
++++ b/include/llvm/Config/abi-breaking.h.cmake
+@@ -20,7 +20,7 @@
+ 
+ /* Allow selectively disabling link-time mismatch checking so that header-only
+    ADT content from LLVM can be used without linking libSupport. */
+-#if !LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
++#ifndef LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+ 
+ // ABI_BREAKING_CHECKS protection: provides link-time failure when clients build
+ // mismatch with LLVM
+-- 
+2.17.0
+

--- a/L/LLVM/v6/bundled/llvm_patches/0019-llvm-rL327898.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0019-llvm-rL327898.patch
@@ -1,0 +1,6131 @@
+commit 64c3384f94a1eb3e3510d6f66c3bccdfc9d9050b
+Author: Nirav Dave <niravd@google.com>
+Date:   Thu Feb 1 16:11:59 2018 +0000
+
+    r327898/dependencies roll up
+    
+    This is a squash of 13 commits required in the lead up to r327898,
+    which fixes https://github.com/JuliaLang/julia/issues/27603. The squashed
+    commits are:
+    
+    332d15e981e86b9e058087174bb288ba18a15807
+    b659d3fca5d24c25ee73f979edb382f7f24e05e2
+    c01d1363ea080170fc5143d72f26eecd9270f03b
+    eab8a177a4caef9e42ef1d2aeb4ba15dc788d3f2
+    bedb1391781b009ace95f5586e7fae5f03fe0689
+    11d041a905f82ac78e7ccf2394773e80b93d147c
+    e1ec36c55a0127988f42a3329ca835617b30de09
+    b8d2903300c13d8fd151c8e5dc71017269617539
+    00884fea345f47ab05174a8f314ecd60d1676d02
+    28ab04cec0d9888af9d29946b3a048b8340abe0f
+    3dd52e62ea3087efcca63c3772183d9471abc742
+    bd3649ff6d6b4d18b3c6de253179d987a120518a
+    aea03035b9c633e6d745b6d3fc5b6378699f576c
+    
+    Their commit messages follow below:
+    
+    [SelectionDAG] Fix UpdateChains handling of TokenFactors
+    
+    Summary:
+    In Instruction Selection UpdateChains replaces all matched Nodes'
+    chain references including interior token factors and deletes them.
+    This may allow nodes which depend on these interior nodes but are not
+    part of the set of matched nodes to be left with a dangling dependence.
+    Avoid this by doing the replacement for matched non-TokenFactor nodes.
+    
+    Fixes PR36164.
+    
+    Reviewers: jonpa, RKSimon, bogner
+    
+    Subscribers: llvm-commits, hiraditya
+    
+    Differential Revision: https://reviews.llvm.org/D42754
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@323977 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    Regenerate test result for vastart-defs-eflags.ll. NFC.
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@323596 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    Regenerate test result for testb-je-fusion.ll. NFC.
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@323595 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    [X86] Avoid using high register trick for test instruction
+    
+    Summary:
+    It seems it's main effect is to create addition copies when values are inr register that do not support this trick, which increase register pressure and makes the code bigger.
+    
+    Reviewers: craig.topper, niravd, spatel, hfinkel
+    
+    Subscribers: llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D42646
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@323888 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    Add a regression test for problems caused by D42646 . NFC
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@323868 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    Add test case for truncated and promotion to test. NFC
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@323663 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    [X86] Add test case to ensure testw is generated when optimizing for size. NFC
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@323687 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    [X86] Generate testl instruction through truncates.
+    
+    Summary:
+    This was introduced in D42646 but ended up being reverted because the original implementation was buggy.
+    
+    Depends on D42646
+    
+    Reviewers: craig.topper, niravd, spatel, hfinkel
+    
+    Subscribers: llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D42741
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@323899 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    [X86] Don't look for TEST instruction shrinking opportunities when the root node is a X86ISD::SUB.
+    
+    I don't believe we ever create an X86ISD::SUB with a 0 constant which is what the TEST handling needs. The ternary operator at the end of this code shows up as only going one way in the llvm-cov report from the bots.
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@324865 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    [X86] Teach LowerBUILD_VECTOR to recognize pair-wise splats of 32-bit elements and use a 64-bit broadcast
+    
+    If we are splatting pairs of 32-bit elements, we can use a 64-bit broadcast to get the job done.
+    
+    We could probably could probably do this with other sizes too, for example four 16-bit elements. Or we could broadcast pairs of 16-bit elements using a 32-bit element broadcast. But I've left that as a future improvement.
+    
+    I've also restricted this to AVX2 only because we can only broadcast loads under AVX.
+    
+    Differential Revision: https://reviews.llvm.org/D42086
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@322730 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    [DAG, X86] Revert r327197 "Revert r327170, r327171, r327172"
+    
+    Reland ISel cycle checking improvements after simplifying node id
+    invariant traversal and correcting typo.
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@327898 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    [ Modified for cherry-pick: Dropped Hexagon and SystemZ changes"
+    
+    [DAG, X86] Fix ISel-time node insertion ids
+    
+    As in SystemZ backend, correctly propagate node ids when inserting new
+    unselected nodes into the DAG during instruction Seleciton for X86
+    target.
+    
+    Fixes PR36865.
+    
+    Reviewers: jyknight, craig.topper
+    
+    Subscribers: hiraditya, llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D44797
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@328233 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    [DAG] Fix node id invalidation in Instruction Selection.
+    
+    Invalidation should be bit negation. Add missing negation.
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@328287 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    Remove failing tests
+    
+    This removes tests that are failing due to codegen differences,
+    after the latest set of backports. Fixing thse for the backport
+    branch does not seem worth it.
+
+diff --git a/include/llvm/CodeGen/SelectionDAGISel.h b/include/llvm/CodeGen/SelectionDAGISel.h
+index de6849a1eae..e56eafc437c 100644
+--- a/include/llvm/CodeGen/SelectionDAGISel.h
++++ b/include/llvm/CodeGen/SelectionDAGISel.h
+@@ -110,6 +110,11 @@ public:
+                             CodeGenOpt::Level OptLevel,
+                             bool IgnoreChains = false);
+ 
++  static void InvalidateNodeId(SDNode *N);
++  static int getUninvalidatedNodeId(SDNode *N);
++
++  static void EnforceNodeIdInvariant(SDNode *N);
++
+   // Opcodes used by the DAG state machine:
+   enum BuiltinOpcodes {
+     OPC_Scope,
+@@ -199,23 +204,28 @@ protected:
+   /// of the new node T.
+   void ReplaceUses(SDValue F, SDValue T) {
+     CurDAG->ReplaceAllUsesOfValueWith(F, T);
++    EnforceNodeIdInvariant(T.getNode());
+   }
+ 
+   /// ReplaceUses - replace all uses of the old nodes F with the use
+   /// of the new nodes T.
+   void ReplaceUses(const SDValue *F, const SDValue *T, unsigned Num) {
+     CurDAG->ReplaceAllUsesOfValuesWith(F, T, Num);
++    for (unsigned i = 0; i < Num; ++i)
++      EnforceNodeIdInvariant(T[i].getNode());
+   }
+ 
+   /// ReplaceUses - replace all uses of the old node F with the use
+   /// of the new node T.
+   void ReplaceUses(SDNode *F, SDNode *T) {
+     CurDAG->ReplaceAllUsesWith(F, T);
++    EnforceNodeIdInvariant(T);
+   }
+ 
+   /// Replace all uses of \c F with \c T, then remove \c F from the DAG.
+   void ReplaceNode(SDNode *F, SDNode *T) {
+     CurDAG->ReplaceAllUsesWith(F, T);
++    EnforceNodeIdInvariant(T);
+     CurDAG->RemoveDeadNode(F);
+   }
+ 
+diff --git a/include/llvm/CodeGen/SelectionDAGNodes.h b/include/llvm/CodeGen/SelectionDAGNodes.h
+index 522c2f1b2cb..2d974234abf 100644
+--- a/include/llvm/CodeGen/SelectionDAGNodes.h
++++ b/include/llvm/CodeGen/SelectionDAGNodes.h
+@@ -796,16 +796,44 @@ public:
+   /// searches to be performed in parallel, caching of results across
+   /// queries and incremental addition to Worklist. Stops early if N is
+   /// found but will resume. Remember to clear Visited and Worklists
+-  /// if DAG changes.
++  /// if DAG changes. MaxSteps gives a maximum number of nodes to visit before
++  /// giving up. The TopologicalPrune flag signals that positive NodeIds are
++  /// topologically ordered (Operands have strictly smaller node id) and search
++  /// can be pruned leveraging this.
+   static bool hasPredecessorHelper(const SDNode *N,
+                                    SmallPtrSetImpl<const SDNode *> &Visited,
+                                    SmallVectorImpl<const SDNode *> &Worklist,
+-                                   unsigned int MaxSteps = 0) {
++                                   unsigned int MaxSteps = 0,
++                                   bool TopologicalPrune = false) {
++    SmallVector<const SDNode *, 8> DeferredNodes;
+     if (Visited.count(N))
+       return true;
++
++    // Node Id's are assigned in three places: As a topological
++    // ordering (> 0), during legalization (results in values set to
++    // 0), new nodes (set to -1). If N has a topolgical id then we
++    // know that all nodes with ids smaller than it cannot be
++    // successors and we need not check them. Filter out all node
++    // that can't be matches. We add them to the worklist before exit
++    // in case of multiple calls. Note that during selection the topological id
++    // may be violated if a node's predecessor is selected before it. We mark
++    // this at selection negating the id of unselected successors and
++    // restricting topological pruning to positive ids.
++
++    int NId = N->getNodeId();
++    // If we Invalidated the Id, reconstruct original NId.
++    if (NId < -1)
++      NId = -(NId + 1);
++
++    bool Found = false;
+     while (!Worklist.empty()) {
+       const SDNode *M = Worklist.pop_back_val();
+-      bool Found = false;
++      int MId = M->getNodeId();
++      if (TopologicalPrune && M->getOpcode() != ISD::TokenFactor && (NId > 0) &&
++          (MId > 0) && (MId < NId)) {
++        DeferredNodes.push_back(M);
++        continue;
++      }
+       for (const SDValue &OpV : M->op_values()) {
+         SDNode *Op = OpV.getNode();
+         if (Visited.insert(Op).second)
+@@ -814,11 +842,16 @@ public:
+           Found = true;
+       }
+       if (Found)
+-        return true;
++        break;
+       if (MaxSteps != 0 && Visited.size() >= MaxSteps)
+-        return false;
++        break;
+     }
+-    return false;
++    // Push deferred nodes back on worklist.
++    Worklist.append(DeferredNodes.begin(), DeferredNodes.end());
++    // If we bailed early, conservatively return found.
++    if (MaxSteps != 0 && Visited.size() >= MaxSteps)
++      return true;
++    return Found;
+   }
+ 
+   /// Return true if all the users of N are contained in Nodes.
+diff --git a/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp b/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+index bd9fcfb5c1e..17e42240133 100644
+--- a/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
++++ b/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+@@ -937,6 +937,58 @@ public:
+ 
+ } // end anonymous namespace
+ 
++// This function is used to enforce the topological node id property
++// property leveraged during Instruction selection. Before selection all
++// nodes are given a non-negative id such that all nodes have a larger id than
++// their operands. As this holds transitively we can prune checks that a node N
++// is a predecessor of M another by not recursively checking through M's
++// operands if N's ID is larger than M's ID. This is significantly improves
++// performance of for various legality checks (e.g. IsLegalToFold /
++// UpdateChains).
++
++// However, when we fuse multiple nodes into a single node
++// during selection we may induce a predecessor relationship between inputs and
++// outputs of distinct nodes being merged violating the topological property.
++// Should a fused node have a successor which has yet to be selected, our
++// legality checks would be incorrect. To avoid this we mark all unselected
++// sucessor nodes, i.e. id != -1 as invalid for pruning by bit-negating (x =>
++// (-(x+1))) the ids and modify our pruning check to ignore negative Ids of M.
++// We use bit-negation to more clearly enforce that node id -1 can only be
++// achieved by selected nodes). As the conversion is reversable the original Id,
++// topological pruning can still be leveraged when looking for unselected nodes.
++// This method is call internally in all ISel replacement calls.
++void SelectionDAGISel::EnforceNodeIdInvariant(SDNode *Node) {
++  SmallVector<SDNode *, 4> Nodes;
++  Nodes.push_back(Node);
++
++  while (!Nodes.empty()) {
++    SDNode *N = Nodes.pop_back_val();
++    for (auto *U : N->uses()) {
++      auto UId = U->getNodeId();
++      if (UId > 0) {
++        InvalidateNodeId(U);
++        Nodes.push_back(U);
++      }
++    }
++  }
++}
++
++// InvalidateNodeId - As discusses in EnforceNodeIdInvariant, mark a
++// NodeId with the equivalent node id which is invalid for topological
++// pruning.
++void SelectionDAGISel::InvalidateNodeId(SDNode *N) {
++  int InvalidId = -(N->getNodeId() + 1);
++  N->setNodeId(InvalidId);
++}
++
++// getUninvalidatedNodeId - get original uninvalidated node id.
++int SelectionDAGISel::getUninvalidatedNodeId(SDNode *N) {
++  int Id = N->getNodeId();
++  if (Id < -1)
++    return -(Id + 1);
++  return Id;
++}
++
+ void SelectionDAGISel::DoInstructionSelection() {
+   DEBUG(dbgs() << "===== Instruction selection begins: "
+                << printMBBReference(*FuncInfo->MBB) << " '"
+@@ -972,6 +1024,33 @@ void SelectionDAGISel::DoInstructionSelection() {
+       if (Node->use_empty())
+         continue;
+ 
++#ifndef NDEBUG
++      SmallVector<SDNode *, 4> Nodes;
++      Nodes.push_back(Node);
++
++      while (!Nodes.empty()) {
++        auto N = Nodes.pop_back_val();
++        if (N->getOpcode() == ISD::TokenFactor || N->getNodeId() < 0)
++          continue;
++        for (const SDValue &Op : N->op_values()) {
++          if (Op->getOpcode() == ISD::TokenFactor)
++            Nodes.push_back(Op.getNode());
++          else {
++            // We rely on topological ordering of node ids for checking for
++            // cycles when fusing nodes during selection. All unselected nodes
++            // successors of an already selected node should have a negative id.
++            // This assertion will catch such cases. If this assertion triggers
++            // it is likely you using DAG-level Value/Node replacement functions
++            // (versus equivalent ISEL replacement) in backend-specific
++            // selections. See comment in EnforceNodeIdInvariant for more
++            // details.
++            assert(Op->getNodeId() != -1 &&
++                   "Node has already selected predecessor node");
++          }
++        }
++      }
++#endif
++
+       // When we are using non-default rounding modes or FP exception behavior
+       // FP operations are represented by StrictFP pseudo-operations.  They
+       // need to be simplified here so that the target-specific instruction
+@@ -2134,52 +2213,44 @@ static SDNode *findGlueUse(SDNode *N) {
+   return nullptr;
+ }
+ 
+-/// findNonImmUse - Return true if "Use" is a non-immediate use of "Def".
+-/// This function iteratively traverses up the operand chain, ignoring
+-/// certain nodes.
+-static bool findNonImmUse(SDNode *Use, SDNode* Def, SDNode *ImmedUse,
+-                          SDNode *Root, SmallPtrSetImpl<SDNode*> &Visited,
++/// findNonImmUse - Return true if "Def" is a predecessor of "Root" via a path
++/// beyond "ImmedUse".  We may ignore chains as they are checked separately.
++static bool findNonImmUse(SDNode *Root, SDNode *Def, SDNode *ImmedUse,
+                           bool IgnoreChains) {
+-  // The NodeID's are given uniques ID's where a node ID is guaranteed to be
+-  // greater than all of its (recursive) operands.  If we scan to a point where
+-  // 'use' is smaller than the node we're scanning for, then we know we will
+-  // never find it.
+-  //
+-  // The Use may be -1 (unassigned) if it is a newly allocated node.  This can
+-  // happen because we scan down to newly selected nodes in the case of glue
+-  // uses.
+-  std::vector<SDNode *> WorkList;
+-  WorkList.push_back(Use);
+-
+-  while (!WorkList.empty()) {
+-    Use = WorkList.back();
+-    WorkList.pop_back();
+-    if (Use->getNodeId() < Def->getNodeId() && Use->getNodeId() != -1)
+-      continue;
++  SmallPtrSet<const SDNode *, 16> Visited;
++  SmallVector<const SDNode *, 16> WorkList;
++  // Only check if we have non-immediate uses of Def.
++  if (ImmedUse->isOnlyUserOf(Def))
++    return false;
+ 
+-    // Don't revisit nodes if we already scanned it and didn't fail, we know we
+-    // won't fail if we scan it again.
+-    if (!Visited.insert(Use).second)
++  // We don't care about paths to Def that go through ImmedUse so mark it
++  // visited and mark non-def operands as used.
++  Visited.insert(ImmedUse);
++  for (const SDValue &Op : ImmedUse->op_values()) {
++    SDNode *N = Op.getNode();
++    // Ignore chain deps (they are validated by
++    // HandleMergeInputChains) and immediate uses
++    if ((Op.getValueType() == MVT::Other && IgnoreChains) || N == Def)
+       continue;
++    if (!Visited.insert(N).second)
++      continue;
++    WorkList.push_back(N);
++  }
+ 
+-    for (const SDValue &Op : Use->op_values()) {
+-      // Ignore chain uses, they are validated by HandleMergeInputChains.
+-      if (Op.getValueType() == MVT::Other && IgnoreChains)
+-        continue;
+-
++  // Initialize worklist to operands of Root.
++  if (Root != ImmedUse) {
++    for (const SDValue &Op : Root->op_values()) {
+       SDNode *N = Op.getNode();
+-      if (N == Def) {
+-        if (Use == ImmedUse || Use == Root)
+-          continue;  // We are not looking for immediate use.
+-        assert(N != Root);
+-        return true;
+-      }
+-
+-      // Traverse up the operand chain.
++      // Ignore chains (they are validated by HandleMergeInputChains)
++      if ((Op.getValueType() == MVT::Other && IgnoreChains) || N == Def)
++        continue;
++      if (!Visited.insert(N).second)
++        continue;
+       WorkList.push_back(N);
+     }
+   }
+-  return false;
++
++  return SDNode::hasPredecessorHelper(Def, Visited, WorkList, 0, true);
+ }
+ 
+ /// IsProfitableToFold - Returns true if it's profitable to fold the specific
+@@ -2251,13 +2322,12 @@ bool SelectionDAGISel::IsLegalToFold(SDValue N, SDNode *U, SDNode *Root,
+ 
+     // If our query node has a glue result with a use, we've walked up it.  If
+     // the user (which has already been selected) has a chain or indirectly uses
+-    // the chain, our WalkChainUsers predicate will not consider it.  Because of
++    // the chain, HandleMergeInputChains will not consider it.  Because of
+     // this, we cannot ignore chains in this predicate.
+     IgnoreChains = false;
+   }
+ 
+-  SmallPtrSet<SDNode*, 16> Visited;
+-  return !findNonImmUse(Root, N.getNode(), U, Root, Visited, IgnoreChains);
++  return !findNonImmUse(Root, N.getNode(), U, IgnoreChains);
+ }
+ 
+ void SelectionDAGISel::Select_INLINEASM(SDNode *N) {
+@@ -2360,7 +2430,8 @@ void SelectionDAGISel::UpdateChains(
+             std::replace(ChainNodesMatched.begin(), ChainNodesMatched.end(), N,
+                          static_cast<SDNode *>(nullptr));
+           });
+-      CurDAG->ReplaceAllUsesOfValueWith(ChainVal, InputChain);
++      if (ChainNode->getOpcode() != ISD::TokenFactor)
++        ReplaceUses(ChainVal, InputChain);
+ 
+       // If the node became dead and we haven't already seen it, delete it.
+       if (ChainNode != NodeToMatch && ChainNode->use_empty() &&
+@@ -2375,143 +2446,6 @@ void SelectionDAGISel::UpdateChains(
+   DEBUG(dbgs() << "ISEL: Match complete!\n");
+ }
+ 
+-enum ChainResult {
+-  CR_Simple,
+-  CR_InducesCycle,
+-  CR_LeadsToInteriorNode
+-};
+-
+-/// WalkChainUsers - Walk down the users of the specified chained node that is
+-/// part of the pattern we're matching, looking at all of the users we find.
+-/// This determines whether something is an interior node, whether we have a
+-/// non-pattern node in between two pattern nodes (which prevent folding because
+-/// it would induce a cycle) and whether we have a TokenFactor node sandwiched
+-/// between pattern nodes (in which case the TF becomes part of the pattern).
+-///
+-/// The walk we do here is guaranteed to be small because we quickly get down to
+-/// already selected nodes "below" us.
+-static ChainResult
+-WalkChainUsers(const SDNode *ChainedNode,
+-               SmallVectorImpl<SDNode *> &ChainedNodesInPattern,
+-               DenseMap<const SDNode *, ChainResult> &TokenFactorResult,
+-               SmallVectorImpl<SDNode *> &InteriorChainedNodes) {
+-  ChainResult Result = CR_Simple;
+-
+-  for (SDNode::use_iterator UI = ChainedNode->use_begin(),
+-         E = ChainedNode->use_end(); UI != E; ++UI) {
+-    // Make sure the use is of the chain, not some other value we produce.
+-    if (UI.getUse().getValueType() != MVT::Other) continue;
+-
+-    SDNode *User = *UI;
+-
+-    if (User->getOpcode() == ISD::HANDLENODE)  // Root of the graph.
+-      continue;
+-
+-    // If we see an already-selected machine node, then we've gone beyond the
+-    // pattern that we're selecting down into the already selected chunk of the
+-    // DAG.
+-    unsigned UserOpcode = User->getOpcode();
+-    if (User->isMachineOpcode() ||
+-        UserOpcode == ISD::CopyToReg ||
+-        UserOpcode == ISD::CopyFromReg ||
+-        UserOpcode == ISD::INLINEASM ||
+-        UserOpcode == ISD::EH_LABEL ||
+-        UserOpcode == ISD::LIFETIME_START ||
+-        UserOpcode == ISD::LIFETIME_END) {
+-      // If their node ID got reset to -1 then they've already been selected.
+-      // Treat them like a MachineOpcode.
+-      if (User->getNodeId() == -1)
+-        continue;
+-    }
+-
+-    // If we have a TokenFactor, we handle it specially.
+-    if (User->getOpcode() != ISD::TokenFactor) {
+-      // If the node isn't a token factor and isn't part of our pattern, then it
+-      // must be a random chained node in between two nodes we're selecting.
+-      // This happens when we have something like:
+-      //   x = load ptr
+-      //   call
+-      //   y = x+4
+-      //   store y -> ptr
+-      // Because we structurally match the load/store as a read/modify/write,
+-      // but the call is chained between them.  We cannot fold in this case
+-      // because it would induce a cycle in the graph.
+-      if (!std::count(ChainedNodesInPattern.begin(),
+-                      ChainedNodesInPattern.end(), User))
+-        return CR_InducesCycle;
+-
+-      // Otherwise we found a node that is part of our pattern.  For example in:
+-      //   x = load ptr
+-      //   y = x+4
+-      //   store y -> ptr
+-      // This would happen when we're scanning down from the load and see the
+-      // store as a user.  Record that there is a use of ChainedNode that is
+-      // part of the pattern and keep scanning uses.
+-      Result = CR_LeadsToInteriorNode;
+-      InteriorChainedNodes.push_back(User);
+-      continue;
+-    }
+-
+-    // If we found a TokenFactor, there are two cases to consider: first if the
+-    // TokenFactor is just hanging "below" the pattern we're matching (i.e. no
+-    // uses of the TF are in our pattern) we just want to ignore it.  Second,
+-    // the TokenFactor can be sandwiched in between two chained nodes, like so:
+-    //     [Load chain]
+-    //         ^
+-    //         |
+-    //       [Load]
+-    //       ^    ^
+-    //       |    \                    DAG's like cheese
+-    //      /       \                       do you?
+-    //     /         |
+-    // [TokenFactor] [Op]
+-    //     ^          ^
+-    //     |          |
+-    //      \        /
+-    //       \      /
+-    //       [Store]
+-    //
+-    // In this case, the TokenFactor becomes part of our match and we rewrite it
+-    // as a new TokenFactor.
+-    //
+-    // To distinguish these two cases, do a recursive walk down the uses.
+-    auto MemoizeResult = TokenFactorResult.find(User);
+-    bool Visited = MemoizeResult != TokenFactorResult.end();
+-    // Recursively walk chain users only if the result is not memoized.
+-    if (!Visited) {
+-      auto Res = WalkChainUsers(User, ChainedNodesInPattern, TokenFactorResult,
+-                                InteriorChainedNodes);
+-      MemoizeResult = TokenFactorResult.insert(std::make_pair(User, Res)).first;
+-    }
+-    switch (MemoizeResult->second) {
+-    case CR_Simple:
+-      // If the uses of the TokenFactor are just already-selected nodes, ignore
+-      // it, it is "below" our pattern.
+-      continue;
+-    case CR_InducesCycle:
+-      // If the uses of the TokenFactor lead to nodes that are not part of our
+-      // pattern that are not selected, folding would turn this into a cycle,
+-      // bail out now.
+-      return CR_InducesCycle;
+-    case CR_LeadsToInteriorNode:
+-      break;  // Otherwise, keep processing.
+-    }
+-
+-    // Okay, we know we're in the interesting interior case.  The TokenFactor
+-    // is now going to be considered part of the pattern so that we rewrite its
+-    // uses (it may have uses that are not part of the pattern) with the
+-    // ultimate chain result of the generated code.  We will also add its chain
+-    // inputs as inputs to the ultimate TokenFactor we create.
+-    Result = CR_LeadsToInteriorNode;
+-    if (!Visited) {
+-      ChainedNodesInPattern.push_back(User);
+-      InteriorChainedNodes.push_back(User);
+-    }
+-  }
+-
+-  return Result;
+-}
+-
+ /// HandleMergeInputChains - This implements the OPC_EmitMergeInputChains
+ /// operation for when the pattern matched at least one node with a chains.  The
+ /// input vector contains a list of all of the chained nodes that we match.  We
+@@ -2521,47 +2455,56 @@ WalkChainUsers(const SDNode *ChainedNode,
+ static SDValue
+ HandleMergeInputChains(SmallVectorImpl<SDNode*> &ChainNodesMatched,
+                        SelectionDAG *CurDAG) {
+-  // Used for memoization. Without it WalkChainUsers could take exponential
+-  // time to run.
+-  DenseMap<const SDNode *, ChainResult> TokenFactorResult;
+-  // Walk all of the chained nodes we've matched, recursively scanning down the
+-  // users of the chain result. This adds any TokenFactor nodes that are caught
+-  // in between chained nodes to the chained and interior nodes list.
+-  SmallVector<SDNode*, 3> InteriorChainedNodes;
+-  for (unsigned i = 0, e = ChainNodesMatched.size(); i != e; ++i) {
+-    if (WalkChainUsers(ChainNodesMatched[i], ChainNodesMatched,
+-                       TokenFactorResult,
+-                       InteriorChainedNodes) == CR_InducesCycle)
+-      return SDValue(); // Would induce a cycle.
+-  }
+ 
+-  // Okay, we have walked all the matched nodes and collected TokenFactor nodes
+-  // that we are interested in.  Form our input TokenFactor node.
++  SmallPtrSet<const SDNode *, 16> Visited;
++  SmallVector<const SDNode *, 8> Worklist;
+   SmallVector<SDValue, 3> InputChains;
+-  for (unsigned i = 0, e = ChainNodesMatched.size(); i != e; ++i) {
+-    // Add the input chain of this node to the InputChains list (which will be
+-    // the operands of the generated TokenFactor) if it's not an interior node.
+-    SDNode *N = ChainNodesMatched[i];
+-    if (N->getOpcode() != ISD::TokenFactor) {
+-      if (std::count(InteriorChainedNodes.begin(),InteriorChainedNodes.end(),N))
+-        continue;
++  unsigned int Max = 8192;
+ 
+-      // Otherwise, add the input chain.
+-      SDValue InChain = ChainNodesMatched[i]->getOperand(0);
+-      assert(InChain.getValueType() == MVT::Other && "Not a chain");
+-      InputChains.push_back(InChain);
+-      continue;
+-    }
++  // Quick exit on trivial merge.
++  if (ChainNodesMatched.size() == 1)
++    return ChainNodesMatched[0]->getOperand(0);
+ 
+-    // If we have a token factor, we want to add all inputs of the token factor
+-    // that are not part of the pattern we're matching.
+-    for (const SDValue &Op : N->op_values()) {
+-      if (!std::count(ChainNodesMatched.begin(), ChainNodesMatched.end(),
+-                      Op.getNode()))
+-        InputChains.push_back(Op);
+-    }
++  // Add chains that aren't already added (internal). Peek through
++  // token factors.
++  std::function<void(const SDValue)> AddChains = [&](const SDValue V) {
++    if (V.getValueType() != MVT::Other)
++      return;
++    if (V->getOpcode() == ISD::EntryToken)
++      return;
++    if (!Visited.insert(V.getNode()).second)
++      return;
++    if (V->getOpcode() == ISD::TokenFactor) {
++      for (const SDValue &Op : V->op_values())
++        AddChains(Op);
++    } else
++      InputChains.push_back(V);
++  };
++
++  for (auto *N : ChainNodesMatched) {
++    Worklist.push_back(N);
++    Visited.insert(N);
+   }
+ 
++  while (!Worklist.empty())
++    AddChains(Worklist.pop_back_val()->getOperand(0));
++
++  // Skip the search if there are no chain dependencies.
++  if (InputChains.size() == 0)
++    return CurDAG->getEntryNode();
++
++  // If one of these chains is a successor of input, we must have a
++  // node that is both the predecessor and successor of the
++  // to-be-merged nodes. Fail.
++  Visited.clear();
++  for (SDValue V : InputChains)
++    Worklist.push_back(V.getNode());
++
++  for (auto *N : ChainNodesMatched)
++    if (SDNode::hasPredecessorHelper(N, Visited, Worklist, Max, true))
++      return SDValue();
++
++  // Return merged chain.
+   if (InputChains.size() == 1)
+     return InputChains[0];
+   return CurDAG->getNode(ISD::TokenFactor, SDLoc(ChainNodesMatched[0]),
+@@ -2606,8 +2549,8 @@ MorphNode(SDNode *Node, unsigned TargetOpc, SDVTList VTList,
+   // Move the glue if needed.
+   if ((EmitNodeInfo & OPFL_GlueOutput) && OldGlueResultNo != -1 &&
+       (unsigned)OldGlueResultNo != ResNumResults-1)
+-    CurDAG->ReplaceAllUsesOfValueWith(SDValue(Node, OldGlueResultNo),
+-                                      SDValue(Res, ResNumResults-1));
++    ReplaceUses(SDValue(Node, OldGlueResultNo),
++                SDValue(Res, ResNumResults - 1));
+ 
+   if ((EmitNodeInfo & OPFL_GlueOutput) != 0)
+     --ResNumResults;
+@@ -2615,14 +2558,15 @@ MorphNode(SDNode *Node, unsigned TargetOpc, SDVTList VTList,
+   // Move the chain reference if needed.
+   if ((EmitNodeInfo & OPFL_Chain) && OldChainResultNo != -1 &&
+       (unsigned)OldChainResultNo != ResNumResults-1)
+-    CurDAG->ReplaceAllUsesOfValueWith(SDValue(Node, OldChainResultNo),
+-                                      SDValue(Res, ResNumResults-1));
++    ReplaceUses(SDValue(Node, OldChainResultNo),
++                SDValue(Res, ResNumResults - 1));
+ 
+   // Otherwise, no replacement happened because the node already exists. Replace
+   // Uses of the old node with the new one.
+   if (Res != Node) {
+-    CurDAG->ReplaceAllUsesWith(Node, Res);
+-    CurDAG->RemoveDeadNode(Node);
++    ReplaceNode(Node, Res);
++  } else {
++    EnforceNodeIdInvariant(Res);
+   }
+ 
+   return Res;
+@@ -2939,8 +2883,7 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
+     return;
+   case ISD::AssertSext:
+   case ISD::AssertZext:
+-    CurDAG->ReplaceAllUsesOfValueWith(SDValue(NodeToMatch, 0),
+-                                      NodeToMatch->getOperand(0));
++    ReplaceUses(SDValue(NodeToMatch, 0), NodeToMatch->getOperand(0));
+     CurDAG->RemoveDeadNode(NodeToMatch);
+     return;
+   case ISD::INLINEASM:
+@@ -3702,7 +3645,7 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
+                 NodeToMatch->getValueType(i).getSizeInBits() ==
+                     Res.getValueSizeInBits()) &&
+                "invalid replacement");
+-        CurDAG->ReplaceAllUsesOfValueWith(SDValue(NodeToMatch, i), Res);
++        ReplaceUses(SDValue(NodeToMatch, i), Res);
+       }
+ 
+       // Update chain uses.
+@@ -3715,8 +3658,8 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
+       if (NodeToMatch->getValueType(NodeToMatch->getNumValues() - 1) ==
+               MVT::Glue &&
+           InputGlue.getNode())
+-        CurDAG->ReplaceAllUsesOfValueWith(
+-            SDValue(NodeToMatch, NodeToMatch->getNumValues() - 1), InputGlue);
++        ReplaceUses(SDValue(NodeToMatch, NodeToMatch->getNumValues() - 1),
++                    InputGlue);
+ 
+       assert(NodeToMatch->use_empty() &&
+              "Didn't replace all uses of the node?");
+diff --git a/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp b/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+index f4776adb069..be5345e422d 100644
+--- a/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
++++ b/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+@@ -759,12 +759,11 @@ void AMDGPUDAGToDAGISel::SelectADD_SUB_I64(SDNode *N) {
+ 
+   if (ProduceCarry) {
+     // Replace the carry-use
+-    CurDAG->ReplaceAllUsesOfValueWith(SDValue(N, 1), SDValue(AddHi, 1));
++    ReplaceUses(SDValue(N, 1), SDValue(AddHi, 1));
+   }
+ 
+   // Replace the remaining uses.
+-  CurDAG->ReplaceAllUsesWith(N, RegSequence);
+-  CurDAG->RemoveDeadNode(N);
++  ReplaceNode(N, RegSequence);
+ }
+ 
+ void AMDGPUDAGToDAGISel::SelectUADDO_USUBO(SDNode *N) {
+diff --git a/lib/Target/ARM/ARMISelDAGToDAG.cpp b/lib/Target/ARM/ARMISelDAGToDAG.cpp
+index 8d32510e200..0f504718f28 100644
+--- a/lib/Target/ARM/ARMISelDAGToDAG.cpp
++++ b/lib/Target/ARM/ARMISelDAGToDAG.cpp
+@@ -498,7 +498,7 @@ bool ARMDAGToDAGISel::canExtractShiftFromMul(const SDValue &N,
+ 
+ void ARMDAGToDAGISel::replaceDAGValue(const SDValue &N, SDValue M) {
+   CurDAG->RepositionNode(N.getNode()->getIterator(), M.getNode());
+-  CurDAG->ReplaceAllUsesWith(N, M);
++  ReplaceUses(N, M);
+ }
+ 
+ bool ARMDAGToDAGISel::SelectImmShifterOperand(SDValue N,
+diff --git a/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp b/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
+index a6ac4e3df74..3721856ff45 100644
+--- a/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
++++ b/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
+@@ -777,7 +777,7 @@ void HexagonDAGToDAGISel::SelectBitcast(SDNode *N) {
+     return;
+   }
+ 
+-  CurDAG->ReplaceAllUsesOfValueWith(SDValue(N,0), N->getOperand(0));
++  ReplaceUses(SDValue(N, 0), N->getOperand(0));
+   CurDAG->RemoveDeadNode(N);
+ }
+ 
+@@ -2182,4 +2182,3 @@ void HexagonDAGToDAGISel::rebalanceAddressTrees() {
+   RootHeights.clear();
+   RootWeights.clear();
+ }
+-
+diff --git a/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp b/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
+index f08c5054065..0608f06ef7e 100644
+--- a/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
++++ b/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
+@@ -1914,7 +1914,6 @@ void HvxSelector::selectShuffle(SDNode *N) {
+   // If the mask is all -1's, generate "undef".
+   if (!UseLeft && !UseRight) {
+     ISel.ReplaceNode(N, ISel.selectUndef(SDLoc(SN), ResTy).getNode());
+-    DAG.RemoveDeadNode(N);
+     return;
+   }
+ 
+@@ -1970,7 +1969,6 @@ void HvxSelector::selectRor(SDNode *N) {
+     NewN = DAG.getMachineNode(Hexagon::V6_vror, dl, Ty, {VecV, RotV});
+ 
+   ISel.ReplaceNode(N, NewN);
+-  DAG.RemoveDeadNode(N);
+ }
+ 
+ void HexagonDAGToDAGISel::SelectHvxShuffle(SDNode *N) {
+@@ -2017,8 +2015,7 @@ void HexagonDAGToDAGISel::SelectV65GatherPred(SDNode *N) {
+   MemOp[0] = cast<MemIntrinsicSDNode>(N)->getMemOperand();
+   cast<MachineSDNode>(Result)->setMemRefs(MemOp, MemOp + 1);
+ 
+-  ReplaceUses(N, Result);
+-  CurDAG->RemoveDeadNode(N);
++  ReplaceNode(N, Result);
+ }
+ 
+ void HexagonDAGToDAGISel::SelectV65Gather(SDNode *N) {
+@@ -2056,8 +2053,7 @@ void HexagonDAGToDAGISel::SelectV65Gather(SDNode *N) {
+   MemOp[0] = cast<MemIntrinsicSDNode>(N)->getMemOperand();
+   cast<MachineSDNode>(Result)->setMemRefs(MemOp, MemOp + 1);
+ 
+-  ReplaceUses(N, Result);
+-  CurDAG->RemoveDeadNode(N);
++  ReplaceNode(N, Result);
+ }
+ 
+ void HexagonDAGToDAGISel::SelectHVXDualOutput(SDNode *N) {
+@@ -2100,5 +2096,3 @@ void HexagonDAGToDAGISel::SelectHVXDualOutput(SDNode *N) {
+   ReplaceUses(SDValue(N, 1), SDValue(Result, 1));
+   CurDAG->RemoveDeadNode(N);
+ }
+-
+-
+diff --git a/lib/Target/SystemZ/SystemZISelDAGToDAG.cpp b/lib/Target/SystemZ/SystemZISelDAGToDAG.cpp
+index ce6f3d37f5c..fe59d820c88 100644
+--- a/lib/Target/SystemZ/SystemZISelDAGToDAG.cpp
++++ b/lib/Target/SystemZ/SystemZISelDAGToDAG.cpp
+@@ -589,10 +589,16 @@ bool SystemZDAGToDAGISel::selectAddress(SDValue Addr,
+ // The selection DAG must no longer depend on their uniqueness when this
+ // function is used.
+ static void insertDAGNode(SelectionDAG *DAG, SDNode *Pos, SDValue N) {
+-  if (N.getNode()->getNodeId() == -1 ||
+-      N.getNode()->getNodeId() > Pos->getNodeId()) {
++  if (N->getNodeId() == -1 ||
++      (SelectionDAGISel::getUninvalidatedNodeId(N.getNode()) >
++       SelectionDAGISel::getUninvalidatedNodeId(Pos))) {
+     DAG->RepositionNode(Pos->getIterator(), N.getNode());
+-    N.getNode()->setNodeId(Pos->getNodeId());
++    // Mark Node as invalid for pruning as after this it may be a successor to a
++    // selected node but otherwise be in the same position of Pos.
++    // Conservatively mark it with the same -abs(Id) to assure node id
++    // invariant is preserved.
++    N->setNodeId(Pos->getNodeId());
++    SelectionDAGISel::InvalidateNodeId(N.getNode());
+   }
+ }
+ 
+@@ -1022,8 +1028,7 @@ bool SystemZDAGToDAGISel::tryRISBGZero(SDNode *N) {
+   };
+   SDValue New = convertTo(
+       DL, VT, SDValue(CurDAG->getMachineNode(Opcode, DL, OpcodeVT, Ops), 0));
+-  ReplaceUses(N, New.getNode());
+-  CurDAG->RemoveDeadNode(N);
++  ReplaceNode(N, New.getNode());
+   return true;
+ }
+ 
+@@ -1114,8 +1119,7 @@ void SystemZDAGToDAGISel::splitLargeImmediate(unsigned Opcode, SDNode *Node,
+   SDValue Lower = CurDAG->getConstant(LowerVal, DL, VT);
+   SDValue Or = CurDAG->getNode(Opcode, DL, VT, Upper, Lower);
+ 
+-  ReplaceUses(Node, Or.getNode());
+-  CurDAG->RemoveDeadNode(Node);
++  ReplaceNode(Node, Or.getNode());
+ 
+   SelectCode(Or.getNode());
+ }
+diff --git a/lib/Target/X86/X86ISelDAGToDAG.cpp b/lib/Target/X86/X86ISelDAGToDAG.cpp
+index d79fd0ca4da..ee2d221e31c 100644
+--- a/lib/Target/X86/X86ISelDAGToDAG.cpp
++++ b/lib/Target/X86/X86ISelDAGToDAG.cpp
+@@ -988,10 +988,16 @@ bool X86DAGToDAGISel::matchAdd(SDValue N, X86ISelAddressMode &AM,
+ // IDs! The selection DAG must no longer depend on their uniqueness when this
+ // is used.
+ static void insertDAGNode(SelectionDAG &DAG, SDValue Pos, SDValue N) {
+-  if (N.getNode()->getNodeId() == -1 ||
+-      N.getNode()->getNodeId() > Pos.getNode()->getNodeId()) {
+-    DAG.RepositionNode(Pos.getNode()->getIterator(), N.getNode());
+-    N.getNode()->setNodeId(Pos.getNode()->getNodeId());
++  if (N->getNodeId() == -1 ||
++      (SelectionDAGISel::getUninvalidatedNodeId(N.getNode()) >
++       SelectionDAGISel::getUninvalidatedNodeId(Pos.getNode()))) {
++    DAG.RepositionNode(Pos->getIterator(), N.getNode());
++    // Mark Node as invalid for pruning as after this it may be a successor to a
++    // selected node but otherwise be in the same position of Pos.
++    // Conservatively mark it with the same -abs(Id) to assure node id
++    // invariant is preserved.
++    N->setNodeId(Pos->getNodeId());
++    SelectionDAGISel::InvalidateNodeId(N.getNode());
+   }
+ }
+ 
+@@ -2092,50 +2098,84 @@ static bool isFusableLoadOpStorePattern(StoreSDNode *StoreNode,
+       LoadNode->getOffset() != StoreNode->getOffset())
+     return false;
+ 
+-  // Check if the chain is produced by the load or is a TokenFactor with
+-  // the load output chain as an operand. Return InputChain by reference.
++  bool FoundLoad = false;
++  SmallVector<SDValue, 4> ChainOps;
++  SmallVector<const SDNode *, 4> LoopWorklist;
++  SmallPtrSet<const SDNode *, 16> Visited;
++  const unsigned int Max = 1024;
++
++  //  Visualization of Load-Op-Store fusion:
++  // -------------------------
++  // Legend:
++  //    *-lines = Chain operand dependencies.
++  //    |-lines = Normal operand dependencies.
++  //    Dependencies flow down and right. n-suffix references multiple nodes.
++  //
++  //        C                        Xn  C
++  //        *                         *  *
++  //        *                          * *
++  //  Xn  A-LD    Yn                    TF         Yn
++  //   *    * \   |                       *        |
++  //    *   *  \  |                        *       |
++  //     *  *   \ |             =>       A--LD_OP_ST
++  //      * *    \|                                 \
++  //       TF    OP                                  \
++  //         *   | \                                  Zn
++  //          *  |  \
++  //         A-ST    Zn
++  //
++
++  // This merge induced dependences from: #1: Xn -> LD, OP, Zn
++  //                                      #2: Yn -> LD
++  //                                      #3: ST -> Zn
++
++  // Ensure the transform is safe by checking for the dual
++  // dependencies to make sure we do not induce a loop.
++
++  // As LD is a predecessor to both OP and ST we can do this by checking:
++  //  a). if LD is a predecessor to a member of Xn or Yn.
++  //  b). if a Zn is a predecessor to ST.
++
++  // However, (b) can only occur through being a chain predecessor to
++  // ST, which is the same as Zn being a member or predecessor of Xn,
++  // which is a subset of LD being a predecessor of Xn. So it's
++  // subsumed by check (a).
++
+   SDValue Chain = StoreNode->getChain();
+ 
+-  bool ChainCheck = false;
++  // Gather X elements in ChainOps.
+   if (Chain == Load.getValue(1)) {
+-    ChainCheck = true;
+-    InputChain = LoadNode->getChain();
++    FoundLoad = true;
++    ChainOps.push_back(Load.getOperand(0));
+   } else if (Chain.getOpcode() == ISD::TokenFactor) {
+-    SmallVector<SDValue, 4> ChainOps;
+     for (unsigned i = 0, e = Chain.getNumOperands(); i != e; ++i) {
+       SDValue Op = Chain.getOperand(i);
+       if (Op == Load.getValue(1)) {
+-        ChainCheck = true;
++        FoundLoad = true;
+         // Drop Load, but keep its chain. No cycle check necessary.
+         ChainOps.push_back(Load.getOperand(0));
+         continue;
+       }
+-
+-      // Make sure using Op as part of the chain would not cause a cycle here.
+-      // In theory, we could check whether the chain node is a predecessor of
+-      // the load. But that can be very expensive. Instead visit the uses and
+-      // make sure they all have smaller node id than the load.
+-      int LoadId = LoadNode->getNodeId();
+-      for (SDNode::use_iterator UI = Op.getNode()->use_begin(),
+-             UE = UI->use_end(); UI != UE; ++UI) {
+-        if (UI.getUse().getResNo() != 0)
+-          continue;
+-        if (UI->getNodeId() > LoadId)
+-          return false;
+-      }
+-
++      LoopWorklist.push_back(Op.getNode());
+       ChainOps.push_back(Op);
+     }
+-
+-    if (ChainCheck)
+-      // Make a new TokenFactor with all the other input chains except
+-      // for the load.
+-      InputChain = CurDAG->getNode(ISD::TokenFactor, SDLoc(Chain),
+-                                   MVT::Other, ChainOps);
+   }
+-  if (!ChainCheck)
++
++  if (!FoundLoad)
++    return false;
++
++  // Worklist is currently Xn. Add Yn to worklist.
++  for (SDValue Op : StoredVal->ops())
++    if (Op.getNode() != LoadNode)
++      LoopWorklist.push_back(Op.getNode());
++
++  // Check (a) if Load is a predecessor to Xn + Yn
++  if (SDNode::hasPredecessorHelper(Load.getNode(), Visited, LoopWorklist, Max,
++                                   true))
+     return false;
+ 
++  InputChain =
++      CurDAG->getNode(ISD::TokenFactor, SDLoc(Chain), MVT::Other, ChainOps);
+   return true;
+ }
+ 
+@@ -2335,6 +2375,8 @@ bool X86DAGToDAGISel::foldLoadStoreIntoMemOperand(SDNode *Node) {
+   MemOp[1] = LoadNode->getMemOperand();
+   Result->setMemRefs(MemOp, MemOp + 2);
+ 
++  // Update Load Chain uses as well.
++  ReplaceUses(SDValue(LoadNode, 1), SDValue(Result, 1));
+   ReplaceUses(SDValue(StoreNode, 0), SDValue(Result, 1));
+   ReplaceUses(SDValue(StoredVal.getNode(), 1), SDValue(Result, 0));
+   CurDAG->RemoveDeadNode(Node);
+@@ -2946,12 +2988,7 @@ void X86DAGToDAGISel::Select(SDNode *Node) {
+     return;
+   }
+ 
+-  case X86ISD::CMP:
+-  case X86ISD::SUB: {
+-    // Sometimes a SUB is used to perform comparison.
+-    if (Opcode == X86ISD::SUB && Node->hasAnyUseOfValue(0))
+-      // This node is not a CMP.
+-      break;
++  case X86ISD::CMP: {
+     SDValue N0 = Node->getOperand(0);
+     SDValue N1 = Node->getOperand(1);
+ 
+@@ -2971,95 +3008,52 @@ void X86DAGToDAGISel::Select(SDNode *Node) {
+       if (!C) break;
+       uint64_t Mask = C->getZExtValue();
+ 
+-      // For example, convert "testl %eax, $8" to "testb %al, $8"
++      MVT VT;
++      int SubRegOp;
++      unsigned Op;
++
+       if (isUInt<8>(Mask) &&
+           (!(Mask & 0x80) || hasNoSignedComparisonUses(Node))) {
+-        SDValue Imm = CurDAG->getTargetConstant(Mask, dl, MVT::i8);
+-        SDValue Reg = N0.getOperand(0);
+-
+-        // Extract the l-register.
+-        SDValue Subreg = CurDAG->getTargetExtractSubreg(X86::sub_8bit, dl,
+-                                                        MVT::i8, Reg);
+-
+-        // Emit a testb.
+-        SDNode *NewNode = CurDAG->getMachineNode(X86::TEST8ri, dl, MVT::i32,
+-                                                 Subreg, Imm);
+-        // Replace SUB|CMP with TEST, since SUB has two outputs while TEST has
+-        // one, do not call ReplaceAllUsesWith.
+-        ReplaceUses(SDValue(Node, (Opcode == X86ISD::SUB ? 1 : 0)),
+-                    SDValue(NewNode, 0));
+-        CurDAG->RemoveDeadNode(Node);
+-        return;
++        // For example, convert "testl %eax, $8" to "testb %al, $8"
++        VT = MVT::i8;
++        SubRegOp = X86::sub_8bit;
++        Op = X86::TEST8ri;
++      } else if (OptForMinSize && isUInt<16>(Mask) &&
++                 (!(Mask & 0x8000) || hasNoSignedComparisonUses(Node))) {
++        // For example, "testl %eax, $32776" to "testw %ax, $32776".
++        // NOTE: We only want to form TESTW instructions if optimizing for
++        // min size. Otherwise we only save one byte and possibly get a length
++        // changing prefix penalty in the decoders.
++        VT = MVT::i16;
++        SubRegOp = X86::sub_16bit;
++        Op = X86::TEST16ri;
++      } else if (isUInt<32>(Mask) && N0.getValueType() != MVT::i16 &&
++                 (!(Mask & 0x80000000) || hasNoSignedComparisonUses(Node))) {
++        // For example, "testq %rax, $268468232" to "testl %eax, $268468232".
++        // NOTE: We only want to run that transform if N0 is 32 or 64 bits.
++        // Otherwize, we find ourselves in a position where we have to do
++        // promotion. If previous passes did not promote the and, we assume
++        // they had a good reason not to and do not promote here.
++        VT = MVT::i32;
++        SubRegOp = X86::sub_32bit;
++        Op = X86::TEST32ri;
++      } else {
++        // No eligible transformation was found.
++        break;
+       }
+ 
+-      // For example, "testl %eax, $2048" to "testb %ah, $8".
+-      if (isShiftedUInt<8, 8>(Mask) &&
+-          (!(Mask & 0x8000) || hasNoSignedComparisonUses(Node))) {
+-        // Shift the immediate right by 8 bits.
+-        SDValue ShiftedImm = CurDAG->getTargetConstant(Mask >> 8, dl, MVT::i8);
+-        SDValue Reg = N0.getOperand(0);
+-
+-        // Extract the h-register.
+-        SDValue Subreg = CurDAG->getTargetExtractSubreg(X86::sub_8bit_hi, dl,
+-                                                        MVT::i8, Reg);
+-
+-        // Emit a testb.  The EXTRACT_SUBREG becomes a COPY that can only
+-        // target GR8_NOREX registers, so make sure the register class is
+-        // forced.
+-        SDNode *NewNode = CurDAG->getMachineNode(X86::TEST8ri_NOREX, dl,
+-                                                 MVT::i32, Subreg, ShiftedImm);
+-        // Replace SUB|CMP with TEST, since SUB has two outputs while TEST has
+-        // one, do not call ReplaceAllUsesWith.
+-        ReplaceUses(SDValue(Node, (Opcode == X86ISD::SUB ? 1 : 0)),
+-                    SDValue(NewNode, 0));
+-        CurDAG->RemoveDeadNode(Node);
+-        return;
+-      }
++      SDValue Imm = CurDAG->getTargetConstant(Mask, dl, VT);
++      SDValue Reg = N0.getOperand(0);
+ 
+-      // For example, "testl %eax, $32776" to "testw %ax, $32776".
+-      // NOTE: We only want to form TESTW instructions if optimizing for
+-      // min size. Otherwise we only save one byte and possibly get a length
+-      // changing prefix penalty in the decoders.
+-      if (OptForMinSize && isUInt<16>(Mask) && N0.getValueType() != MVT::i16 &&
+-          (!(Mask & 0x8000) || hasNoSignedComparisonUses(Node))) {
+-        SDValue Imm = CurDAG->getTargetConstant(Mask, dl, MVT::i16);
+-        SDValue Reg = N0.getOperand(0);
+-
+-        // Extract the 16-bit subregister.
+-        SDValue Subreg = CurDAG->getTargetExtractSubreg(X86::sub_16bit, dl,
+-                                                        MVT::i16, Reg);
+-
+-        // Emit a testw.
+-        SDNode *NewNode = CurDAG->getMachineNode(X86::TEST16ri, dl, MVT::i32,
+-                                                 Subreg, Imm);
+-        // Replace SUB|CMP with TEST, since SUB has two outputs while TEST has
+-        // one, do not call ReplaceAllUsesWith.
+-        ReplaceUses(SDValue(Node, (Opcode == X86ISD::SUB ? 1 : 0)),
+-                    SDValue(NewNode, 0));
+-        CurDAG->RemoveDeadNode(Node);
+-        return;
+-      }
++      // Extract the subregister if necessary.
++      if (N0.getValueType() != VT)
++        Reg = CurDAG->getTargetExtractSubreg(SubRegOp, dl, VT, Reg);
+ 
+-      // For example, "testq %rax, $268468232" to "testl %eax, $268468232".
+-      if (isUInt<32>(Mask) && N0.getValueType() == MVT::i64 &&
+-          (!(Mask & 0x80000000) || hasNoSignedComparisonUses(Node))) {
+-        SDValue Imm = CurDAG->getTargetConstant(Mask, dl, MVT::i32);
+-        SDValue Reg = N0.getOperand(0);
+-
+-        // Extract the 32-bit subregister.
+-        SDValue Subreg = CurDAG->getTargetExtractSubreg(X86::sub_32bit, dl,
+-                                                        MVT::i32, Reg);
+-
+-        // Emit a testl.
+-        SDNode *NewNode = CurDAG->getMachineNode(X86::TEST32ri, dl, MVT::i32,
+-                                                 Subreg, Imm);
+-        // Replace SUB|CMP with TEST, since SUB has two outputs while TEST has
+-        // one, do not call ReplaceAllUsesWith.
+-        ReplaceUses(SDValue(Node, (Opcode == X86ISD::SUB ? 1 : 0)),
+-                    SDValue(NewNode, 0));
+-        CurDAG->RemoveDeadNode(Node);
+-        return;
+-      }
++      // Emit a testl or testw.
++      SDNode *NewNode = CurDAG->getMachineNode(Op, dl, MVT::i32, Reg, Imm);
++      // Replace CMP with TEST.
++      ReplaceNode(Node, NewNode);
++      return;
+     }
+     break;
+   }
+diff --git a/lib/Target/X86/X86ISelLowering.cpp b/lib/Target/X86/X86ISelLowering.cpp
+index c1ddb771e2f..86e71cba87b 100644
+--- a/lib/Target/X86/X86ISelLowering.cpp
++++ b/lib/Target/X86/X86ISelLowering.cpp
+@@ -8131,6 +8131,32 @@ X86TargetLowering::LowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG) const {
+       return LD;
+   }
+ 
++  // If this is a splat of pairs of 32-bit elements, we can use a narrower
++  // build_vector and broadcast it.
++  // TODO: We could probably generalize this more.
++  if (Subtarget.hasAVX2() && EVTBits == 32 && Values.size() == 2) {
++    SDValue Ops[4] = { Op.getOperand(0), Op.getOperand(1),
++                       DAG.getUNDEF(ExtVT), DAG.getUNDEF(ExtVT) };
++    auto CanSplat = [](SDValue Op, unsigned NumElems, ArrayRef<SDValue> Ops) {
++      // Make sure all the even/odd operands match.
++      for (unsigned i = 2; i != NumElems; ++i)
++        if (Ops[i % 2] != Op.getOperand(i))
++          return false;
++      return true;
++    };
++    if (CanSplat(Op, NumElems, Ops)) {
++      MVT WideEltVT = VT.isFloatingPoint() ? MVT::f64 : MVT::i64;
++      MVT NarrowVT = MVT::getVectorVT(ExtVT, 4);
++      // Create a new build vector and cast to v2i64/v2f64.
++      SDValue NewBV = DAG.getBitcast(MVT::getVectorVT(WideEltVT, 2),
++                                     DAG.getBuildVector(NarrowVT, dl, Ops));
++      // Broadcast from v2i64/v2f64 and cast to final VT.
++      MVT BcastVT = MVT::getVectorVT(WideEltVT, NumElems/2);
++      return DAG.getBitcast(VT, DAG.getNode(X86ISD::VBROADCAST, dl, BcastVT,
++                                            NewBV));
++    }
++  }
++
+   // For AVX-length vectors, build the individual 128-bit pieces and use
+   // shuffles to put them in place.
+   if (VT.is256BitVector() || VT.is512BitVector()) {
+diff --git a/lib/Target/X86/X86InstrArithmetic.td b/lib/Target/X86/X86InstrArithmetic.td
+index 98cc8fb7439..3d5de637da2 100644
+--- a/lib/Target/X86/X86InstrArithmetic.td
++++ b/lib/Target/X86/X86InstrArithmetic.td
+@@ -1257,14 +1257,6 @@ let isCompare = 1 in {
+     def TEST32mi   : BinOpMI_F<0xF6, "test", Xi32, X86testpat, MRM0m>;
+     let Predicates = [In64BitMode] in
+     def TEST64mi32 : BinOpMI_F<0xF6, "test", Xi64, X86testpat, MRM0m>;
+-
+-    // When testing the result of EXTRACT_SUBREG sub_8bit_hi, make sure the
+-    // register class is constrained to GR8_NOREX. This pseudo is explicitly
+-    // marked side-effect free, since it doesn't have an isel pattern like
+-    // other test instructions.
+-    let isPseudo = 1, hasSideEffects = 0 in
+-    def TEST8ri_NOREX : I<0, Pseudo, (outs), (ins GR8_NOREX:$src, i8imm:$mask),
+-                          "", [], IIC_BIN_NONMEM>, Sched<[WriteALU]>;
+   } // Defs = [EFLAGS]
+ 
+   def TEST8i8    : BinOpAI_F<0xA8, "test", Xi8 , AL,
+diff --git a/lib/Target/X86/X86InstrInfo.cpp b/lib/Target/X86/X86InstrInfo.cpp
+index 11ada51a870..84a9200a0ef 100644
+--- a/lib/Target/X86/X86InstrInfo.cpp
++++ b/lib/Target/X86/X86InstrInfo.cpp
+@@ -7854,9 +7854,6 @@ bool X86InstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
+   case X86::VMOVUPSZ256mr_NOVLX:
+     return expandNOVLXStore(MIB, &getRegisterInfo(), get(X86::VMOVUPSYmr),
+                             get(X86::VEXTRACTF64x4Zmr), X86::sub_ymm);
+-  case X86::TEST8ri_NOREX:
+-    MI.setDesc(get(X86::TEST8ri));
+-    return true;
+   case X86::MOV32ri64:
+     MI.setDesc(get(X86::MOV32ri));
+     return true;
+diff --git a/lib/Target/X86/X86MacroFusion.cpp b/lib/Target/X86/X86MacroFusion.cpp
+index 67d95c2233d..4e11397dec4 100644
+--- a/lib/Target/X86/X86MacroFusion.cpp
++++ b/lib/Target/X86/X86MacroFusion.cpp
+@@ -86,7 +86,6 @@ static bool shouldScheduleAdjacent(const TargetInstrInfo &TII,
+   case X86::TEST16mr:
+   case X86::TEST32mr:
+   case X86::TEST64mr:
+-  case X86::TEST8ri_NOREX:
+   case X86::AND16i16:
+   case X86::AND16ri:
+   case X86::AND16ri8:
+diff --git a/test/CodeGen/SystemZ/pr36164.ll b/test/CodeGen/SystemZ/pr36164.ll
+new file mode 100644
+index 00000000000..0c850091d31
+--- /dev/null
++++ b/test/CodeGen/SystemZ/pr36164.ll
+@@ -0,0 +1,113 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
++; RUN: llc %s -o - -mtriple=s390x-linux-gnu -mcpu=z13 -disable-basicaa | FileCheck %s
++
++; This test checks that we do not a reference to a deleted node.
++
++%0 = type { i32 }
++
++@g_11 = external dso_local unnamed_addr global i1, align 4
++@g_69 = external dso_local global i32, align 4
++@g_73 = external dso_local unnamed_addr global i32, align 4
++@g_832 = external dso_local constant %0, align 4
++@g_938 = external dso_local unnamed_addr global i64, align 8
++
++; Function Attrs: nounwind
++define void @main() local_unnamed_addr #0 {
++; CHECK-LABEL: main:
++; CHECK:       # %bb.0:
++; CHECK-NEXT:    stmg %r12, %r15, 96(%r15)
++; CHECK-NEXT:    .cfi_offset %r12, -64
++; CHECK-NEXT:    .cfi_offset %r13, -56
++; CHECK-NEXT:    .cfi_offset %r14, -48
++; CHECK-NEXT:    .cfi_offset %r15, -40
++; CHECK-NEXT:    lhi %r0, 1
++; CHECK-NEXT:    larl %r1, g_938
++; CHECK-NEXT:    lhi %r2, 2
++; CHECK-NEXT:    lhi %r3, 3
++; CHECK-NEXT:    lhi %r4, 0
++; CHECK-NEXT:    lhi %r5, 4
++; CHECK-NEXT:    larl %r14, g_11
++; CHECK-NEXT:  .LBB0_1: # =>This Inner Loop Header: Depth=1
++; CHECK-NEXT:    strl %r0, g_73
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    strl %r0, g_69
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    lghi %r13, 24
++; CHECK-NEXT:    strl %r2, g_69
++; CHECK-NEXT:    ag %r13, 0(%r1)
++; CHECK-NEXT:    lrl %r12, g_832
++; CHECK-NEXT:    strl %r3, g_69
++; CHECK-NEXT:    lrl %r12, g_832
++; CHECK-NEXT:    strl %r4, g_69
++; CHECK-NEXT:    lrl %r12, g_832
++; CHECK-NEXT:    strl %r0, g_69
++; CHECK-NEXT:    lrl %r12, g_832
++; CHECK-NEXT:    strl %r2, g_69
++; CHECK-NEXT:    lrl %r12, g_832
++; CHECK-NEXT:    strl %r3, g_69
++; CHECK-NEXT:    stgrl %r13, g_938
++; CHECK-NEXT:    lrl %r13, g_832
++; CHECK-NEXT:    strl %r5, g_69
++; CHECK-NEXT:    mvi 0(%r14), 1
++; CHECK-NEXT:    j .LBB0_1
++  br label %1
++
++; <label>:1:                                      ; preds = %1, %0
++  store i32 1, i32* @g_73, align 4
++  %2 = load i64, i64* @g_938, align 8
++  store i32 0, i32* @g_69, align 4
++  %3 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  %4 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  %5 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  %6 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 1, i32* @g_69, align 4
++  %7 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  %8 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 3, i32* @g_69, align 4
++  %9 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  %10 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 1, i32* @g_69, align 4
++  %11 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 2, i32* @g_69, align 4
++  %12 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 3, i32* @g_69, align 4
++  %13 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 0, i32* @g_69, align 4
++  %14 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  %15 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  %16 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  %17 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 1, i32* @g_69, align 4
++  %18 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 2, i32* @g_69, align 4
++  %19 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 3, i32* @g_69, align 4
++  %20 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 0, i32* @g_69, align 4
++  %21 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 1, i32* @g_69, align 4
++  %22 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 2, i32* @g_69, align 4
++  %23 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 3, i32* @g_69, align 4
++  %24 = add i64 %2, 24
++  store i64 %24, i64* @g_938, align 8
++  %25 = load volatile i32, i32* getelementptr inbounds (%0, %0* @g_832, i64 0, i32 0), align 4
++  store i32 4, i32* @g_69, align 4
++  store i1 true, i1* @g_11, align 4
++  br label %1
++}
+diff --git a/test/CodeGen/X86/2012-01-16-mfence-nosse-flags.ll b/test/CodeGen/X86/2012-01-16-mfence-nosse-flags.ll
+deleted file mode 100644
+index a6c34b8fffa..00000000000
+--- a/test/CodeGen/X86/2012-01-16-mfence-nosse-flags.ll
++++ /dev/null
+@@ -1,33 +0,0 @@
+-; RUN: llc < %s -verify-machineinstrs -mtriple=i686-linux -mattr=-sse | FileCheck %s
+-; PR11768
+-
+-@ptr = external global i8*
+-
+-define void @baz() nounwind ssp {
+-entry:
+-  %0 = load i8*, i8** @ptr, align 4
+-  %cmp = icmp eq i8* %0, null
+-  fence seq_cst
+-  br i1 %cmp, label %if.then, label %if.else
+-
+-; Make sure the fence comes before the comparison, since it
+-; clobbers EFLAGS.
+-
+-; CHECK: lock orl {{.*}}, (%esp)
+-; CHECK-NEXT: testl [[REG:%e[a-z]+]], [[REG]]
+-
+-if.then:                                          ; preds = %entry
+-  tail call void bitcast (void (...)* @foo to void ()*)() nounwind
+-  br label %if.end
+-
+-if.else:                                          ; preds = %entry
+-  tail call void bitcast (void (...)* @bar to void ()*)() nounwind
+-  br label %if.end
+-
+-if.end:                                           ; preds = %if.else, %if.then
+-  ret void
+-}
+-
+-declare void @foo(...)
+-
+-declare void @bar(...)
+diff --git a/test/CodeGen/X86/avg.ll b/test/CodeGen/X86/avg.ll
+index dd11f6ca293..d2b9984a7fc 100644
+--- a/test/CodeGen/X86/avg.ll
++++ b/test/CodeGen/X86/avg.ll
+@@ -90,12 +90,12 @@ define void @avg_v16i8(<16 x i8>* %a, <16 x i8>* %b) nounwind {
+ define void @avg_v32i8(<32 x i8>* %a, <32 x i8>* %b) nounwind {
+ ; SSE2-LABEL: avg_v32i8:
+ ; SSE2:       # %bb.0:
+-; SSE2-NEXT:    movdqa 16(%rdi), %xmm0
+-; SSE2-NEXT:    movdqa (%rsi), %xmm1
+-; SSE2-NEXT:    pavgb (%rdi), %xmm1
+-; SSE2-NEXT:    pavgb 16(%rsi), %xmm0
+-; SSE2-NEXT:    movdqu %xmm0, (%rax)
++; SSE2-NEXT:    movdqa (%rsi), %xmm0
++; SSE2-NEXT:    movdqa 16(%rsi), %xmm1
++; SSE2-NEXT:    pavgb (%rdi), %xmm0
++; SSE2-NEXT:    pavgb 16(%rdi), %xmm1
+ ; SSE2-NEXT:    movdqu %xmm1, (%rax)
++; SSE2-NEXT:    movdqu %xmm0, (%rax)
+ ; SSE2-NEXT:    retq
+ ;
+ ; AVX1-LABEL: avg_v32i8:
+@@ -545,18 +545,18 @@ define void @avg_v48i8(<48 x i8>* %a, <48 x i8>* %b) nounwind {
+ define void @avg_v64i8(<64 x i8>* %a, <64 x i8>* %b) nounwind {
+ ; SSE2-LABEL: avg_v64i8:
+ ; SSE2:       # %bb.0:
+-; SSE2-NEXT:    movdqa 32(%rdi), %xmm0
+-; SSE2-NEXT:    movdqa (%rsi), %xmm1
+-; SSE2-NEXT:    movdqa 16(%rsi), %xmm2
++; SSE2-NEXT:    movdqa (%rsi), %xmm0
++; SSE2-NEXT:    movdqa 16(%rsi), %xmm1
++; SSE2-NEXT:    movdqa 32(%rsi), %xmm2
+ ; SSE2-NEXT:    movdqa 48(%rsi), %xmm3
+-; SSE2-NEXT:    pavgb (%rdi), %xmm1
+-; SSE2-NEXT:    pavgb 16(%rdi), %xmm2
+-; SSE2-NEXT:    pavgb 32(%rsi), %xmm0
++; SSE2-NEXT:    pavgb (%rdi), %xmm0
++; SSE2-NEXT:    pavgb 16(%rdi), %xmm1
++; SSE2-NEXT:    pavgb 32(%rdi), %xmm2
+ ; SSE2-NEXT:    pavgb 48(%rdi), %xmm3
+ ; SSE2-NEXT:    movdqu %xmm3, (%rax)
+-; SSE2-NEXT:    movdqu %xmm0, (%rax)
+ ; SSE2-NEXT:    movdqu %xmm2, (%rax)
+ ; SSE2-NEXT:    movdqu %xmm1, (%rax)
++; SSE2-NEXT:    movdqu %xmm0, (%rax)
+ ; SSE2-NEXT:    retq
+ ;
+ ; AVX1-LABEL: avg_v64i8:
+@@ -582,23 +582,23 @@ define void @avg_v64i8(<64 x i8>* %a, <64 x i8>* %b) nounwind {
+ ;
+ ; AVX2-LABEL: avg_v64i8:
+ ; AVX2:       # %bb.0:
+-; AVX2-NEXT:    vmovdqa 32(%rdi), %ymm0
+-; AVX2-NEXT:    vmovdqa (%rsi), %ymm1
+-; AVX2-NEXT:    vpavgb (%rdi), %ymm1, %ymm1
+-; AVX2-NEXT:    vpavgb 32(%rsi), %ymm0, %ymm0
+-; AVX2-NEXT:    vmovdqu %ymm0, (%rax)
++; AVX2-NEXT:    vmovdqa (%rsi), %ymm0
++; AVX2-NEXT:    vmovdqa 32(%rsi), %ymm1
++; AVX2-NEXT:    vpavgb (%rdi), %ymm0, %ymm0
++; AVX2-NEXT:    vpavgb 32(%rdi), %ymm1, %ymm1
+ ; AVX2-NEXT:    vmovdqu %ymm1, (%rax)
++; AVX2-NEXT:    vmovdqu %ymm0, (%rax)
+ ; AVX2-NEXT:    vzeroupper
+ ; AVX2-NEXT:    retq
+ ;
+ ; AVX512F-LABEL: avg_v64i8:
+ ; AVX512F:       # %bb.0:
+-; AVX512F-NEXT:    vmovdqa 32(%rdi), %ymm0
+-; AVX512F-NEXT:    vmovdqa (%rsi), %ymm1
+-; AVX512F-NEXT:    vpavgb (%rdi), %ymm1, %ymm1
+-; AVX512F-NEXT:    vpavgb 32(%rsi), %ymm0, %ymm0
+-; AVX512F-NEXT:    vmovdqu %ymm0, (%rax)
++; AVX512F-NEXT:    vmovdqa (%rsi), %ymm0
++; AVX512F-NEXT:    vmovdqa 32(%rsi), %ymm1
++; AVX512F-NEXT:    vpavgb (%rdi), %ymm0, %ymm0
++; AVX512F-NEXT:    vpavgb 32(%rdi), %ymm1, %ymm1
+ ; AVX512F-NEXT:    vmovdqu %ymm1, (%rax)
++; AVX512F-NEXT:    vmovdqu %ymm0, (%rax)
+ ; AVX512F-NEXT:    vzeroupper
+ ; AVX512F-NEXT:    retq
+ ;
+@@ -678,12 +678,12 @@ define void @avg_v8i16(<8 x i16>* %a, <8 x i16>* %b) nounwind {
+ define void @avg_v16i16(<16 x i16>* %a, <16 x i16>* %b) nounwind {
+ ; SSE2-LABEL: avg_v16i16:
+ ; SSE2:       # %bb.0:
+-; SSE2-NEXT:    movdqa 16(%rdi), %xmm0
+-; SSE2-NEXT:    movdqa (%rsi), %xmm1
+-; SSE2-NEXT:    pavgw (%rdi), %xmm1
+-; SSE2-NEXT:    pavgw 16(%rsi), %xmm0
+-; SSE2-NEXT:    movdqu %xmm0, (%rax)
++; SSE2-NEXT:    movdqa (%rsi), %xmm0
++; SSE2-NEXT:    movdqa 16(%rsi), %xmm1
++; SSE2-NEXT:    pavgw (%rdi), %xmm0
++; SSE2-NEXT:    pavgw 16(%rdi), %xmm1
+ ; SSE2-NEXT:    movdqu %xmm1, (%rax)
++; SSE2-NEXT:    movdqu %xmm0, (%rax)
+ ; SSE2-NEXT:    retq
+ ;
+ ; AVX1-LABEL: avg_v16i16:
+@@ -729,18 +729,18 @@ define void @avg_v16i16(<16 x i16>* %a, <16 x i16>* %b) nounwind {
+ define void @avg_v32i16(<32 x i16>* %a, <32 x i16>* %b) nounwind {
+ ; SSE2-LABEL: avg_v32i16:
+ ; SSE2:       # %bb.0:
+-; SSE2-NEXT:    movdqa 32(%rdi), %xmm0
+-; SSE2-NEXT:    movdqa (%rsi), %xmm1
+-; SSE2-NEXT:    movdqa 16(%rsi), %xmm2
++; SSE2-NEXT:    movdqa (%rsi), %xmm0
++; SSE2-NEXT:    movdqa 16(%rsi), %xmm1
++; SSE2-NEXT:    movdqa 32(%rsi), %xmm2
+ ; SSE2-NEXT:    movdqa 48(%rsi), %xmm3
+-; SSE2-NEXT:    pavgw (%rdi), %xmm1
+-; SSE2-NEXT:    pavgw 16(%rdi), %xmm2
+-; SSE2-NEXT:    pavgw 32(%rsi), %xmm0
++; SSE2-NEXT:    pavgw (%rdi), %xmm0
++; SSE2-NEXT:    pavgw 16(%rdi), %xmm1
++; SSE2-NEXT:    pavgw 32(%rdi), %xmm2
+ ; SSE2-NEXT:    pavgw 48(%rdi), %xmm3
+ ; SSE2-NEXT:    movdqu %xmm3, (%rax)
+-; SSE2-NEXT:    movdqu %xmm0, (%rax)
+ ; SSE2-NEXT:    movdqu %xmm2, (%rax)
+ ; SSE2-NEXT:    movdqu %xmm1, (%rax)
++; SSE2-NEXT:    movdqu %xmm0, (%rax)
+ ; SSE2-NEXT:    retq
+ ;
+ ; AVX1-LABEL: avg_v32i16:
+@@ -766,23 +766,23 @@ define void @avg_v32i16(<32 x i16>* %a, <32 x i16>* %b) nounwind {
+ ;
+ ; AVX2-LABEL: avg_v32i16:
+ ; AVX2:       # %bb.0:
+-; AVX2-NEXT:    vmovdqa 32(%rdi), %ymm0
+-; AVX2-NEXT:    vmovdqa (%rsi), %ymm1
+-; AVX2-NEXT:    vpavgw (%rdi), %ymm1, %ymm1
+-; AVX2-NEXT:    vpavgw 32(%rsi), %ymm0, %ymm0
+-; AVX2-NEXT:    vmovdqu %ymm0, (%rax)
++; AVX2-NEXT:    vmovdqa (%rsi), %ymm0
++; AVX2-NEXT:    vmovdqa 32(%rsi), %ymm1
++; AVX2-NEXT:    vpavgw (%rdi), %ymm0, %ymm0
++; AVX2-NEXT:    vpavgw 32(%rdi), %ymm1, %ymm1
+ ; AVX2-NEXT:    vmovdqu %ymm1, (%rax)
++; AVX2-NEXT:    vmovdqu %ymm0, (%rax)
+ ; AVX2-NEXT:    vzeroupper
+ ; AVX2-NEXT:    retq
+ ;
+ ; AVX512F-LABEL: avg_v32i16:
+ ; AVX512F:       # %bb.0:
+-; AVX512F-NEXT:    vmovdqa 32(%rdi), %ymm0
+-; AVX512F-NEXT:    vmovdqa (%rsi), %ymm1
+-; AVX512F-NEXT:    vpavgw (%rdi), %ymm1, %ymm1
+-; AVX512F-NEXT:    vpavgw 32(%rsi), %ymm0, %ymm0
+-; AVX512F-NEXT:    vmovdqu %ymm0, (%rax)
++; AVX512F-NEXT:    vmovdqa (%rsi), %ymm0
++; AVX512F-NEXT:    vmovdqa 32(%rsi), %ymm1
++; AVX512F-NEXT:    vpavgw (%rdi), %ymm0, %ymm0
++; AVX512F-NEXT:    vpavgw 32(%rdi), %ymm1, %ymm1
+ ; AVX512F-NEXT:    vmovdqu %ymm1, (%rax)
++; AVX512F-NEXT:    vmovdqu %ymm0, (%rax)
+ ; AVX512F-NEXT:    vzeroupper
+ ; AVX512F-NEXT:    retq
+ ;
+@@ -891,9 +891,9 @@ define void @avg_v32i8_2(<32 x i8>* %a, <32 x i8>* %b) nounwind {
+ ; SSE2-LABEL: avg_v32i8_2:
+ ; SSE2:       # %bb.0:
+ ; SSE2-NEXT:    movdqa (%rdi), %xmm0
+-; SSE2-NEXT:    movdqa 16(%rsi), %xmm1
++; SSE2-NEXT:    movdqa 16(%rdi), %xmm1
+ ; SSE2-NEXT:    pavgb (%rsi), %xmm0
+-; SSE2-NEXT:    pavgb 16(%rdi), %xmm1
++; SSE2-NEXT:    pavgb 16(%rsi), %xmm1
+ ; SSE2-NEXT:    movdqu %xmm1, (%rax)
+ ; SSE2-NEXT:    movdqu %xmm0, (%rax)
+ ; SSE2-NEXT:    retq
+@@ -1072,9 +1072,9 @@ define void @avg_v16i16_2(<16 x i16>* %a, <16 x i16>* %b) nounwind {
+ ; SSE2-LABEL: avg_v16i16_2:
+ ; SSE2:       # %bb.0:
+ ; SSE2-NEXT:    movdqa (%rdi), %xmm0
+-; SSE2-NEXT:    movdqa 16(%rsi), %xmm1
++; SSE2-NEXT:    movdqa 16(%rdi), %xmm1
+ ; SSE2-NEXT:    pavgw (%rsi), %xmm0
+-; SSE2-NEXT:    pavgw 16(%rdi), %xmm1
++; SSE2-NEXT:    pavgw 16(%rsi), %xmm1
+ ; SSE2-NEXT:    movdqu %xmm1, (%rax)
+ ; SSE2-NEXT:    movdqu %xmm0, (%rax)
+ ; SSE2-NEXT:    retq
+@@ -1124,14 +1124,14 @@ define void @avg_v32i16_2(<32 x i16>* %a, <32 x i16>* %b) nounwind {
+ ; SSE2:       # %bb.0:
+ ; SSE2-NEXT:    movdqa (%rdi), %xmm0
+ ; SSE2-NEXT:    movdqa 16(%rdi), %xmm1
+-; SSE2-NEXT:    movdqa 48(%rdi), %xmm2
+-; SSE2-NEXT:    movdqa 32(%rsi), %xmm3
++; SSE2-NEXT:    movdqa 32(%rdi), %xmm2
++; SSE2-NEXT:    movdqa 48(%rdi), %xmm3
+ ; SSE2-NEXT:    pavgw (%rsi), %xmm0
+ ; SSE2-NEXT:    pavgw 16(%rsi), %xmm1
+-; SSE2-NEXT:    pavgw 32(%rdi), %xmm3
+-; SSE2-NEXT:    pavgw 48(%rsi), %xmm2
+-; SSE2-NEXT:    movdqu %xmm2, (%rax)
++; SSE2-NEXT:    pavgw 32(%rsi), %xmm2
++; SSE2-NEXT:    pavgw 48(%rsi), %xmm3
+ ; SSE2-NEXT:    movdqu %xmm3, (%rax)
++; SSE2-NEXT:    movdqu %xmm2, (%rax)
+ ; SSE2-NEXT:    movdqu %xmm1, (%rax)
+ ; SSE2-NEXT:    movdqu %xmm0, (%rax)
+ ; SSE2-NEXT:    retq
+@@ -1160,9 +1160,9 @@ define void @avg_v32i16_2(<32 x i16>* %a, <32 x i16>* %b) nounwind {
+ ; AVX2-LABEL: avg_v32i16_2:
+ ; AVX2:       # %bb.0:
+ ; AVX2-NEXT:    vmovdqa (%rdi), %ymm0
+-; AVX2-NEXT:    vmovdqa 32(%rsi), %ymm1
++; AVX2-NEXT:    vmovdqa 32(%rdi), %ymm1
+ ; AVX2-NEXT:    vpavgw (%rsi), %ymm0, %ymm0
+-; AVX2-NEXT:    vpavgw 32(%rdi), %ymm1, %ymm1
++; AVX2-NEXT:    vpavgw 32(%rsi), %ymm1, %ymm1
+ ; AVX2-NEXT:    vmovdqu %ymm1, (%rax)
+ ; AVX2-NEXT:    vmovdqu %ymm0, (%rax)
+ ; AVX2-NEXT:    vzeroupper
+@@ -1171,9 +1171,9 @@ define void @avg_v32i16_2(<32 x i16>* %a, <32 x i16>* %b) nounwind {
+ ; AVX512F-LABEL: avg_v32i16_2:
+ ; AVX512F:       # %bb.0:
+ ; AVX512F-NEXT:    vmovdqa (%rdi), %ymm0
+-; AVX512F-NEXT:    vmovdqa 32(%rsi), %ymm1
++; AVX512F-NEXT:    vmovdqa 32(%rdi), %ymm1
+ ; AVX512F-NEXT:    vpavgw (%rsi), %ymm0, %ymm0
+-; AVX512F-NEXT:    vpavgw 32(%rdi), %ymm1, %ymm1
++; AVX512F-NEXT:    vpavgw 32(%rsi), %ymm1, %ymm1
+ ; AVX512F-NEXT:    vmovdqu %ymm1, (%rax)
+ ; AVX512F-NEXT:    vmovdqu %ymm0, (%rax)
+ ; AVX512F-NEXT:    vzeroupper
+diff --git a/test/CodeGen/X86/avx-vbroadcastf128.ll b/test/CodeGen/X86/avx-vbroadcastf128.ll
+index 7fdbf31a993..b5026437153 100644
+--- a/test/CodeGen/X86/avx-vbroadcastf128.ll
++++ b/test/CodeGen/X86/avx-vbroadcastf128.ll
+@@ -235,18 +235,16 @@ define <8 x i32> @PR29088(<4 x i32>* %p0, <8 x float>* %p1) {
+ ; X32:       # %bb.0:
+ ; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+ ; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    vmovaps (%ecx), %xmm0
+ ; X32-NEXT:    vxorps %xmm1, %xmm1, %xmm1
++; X32-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+ ; X32-NEXT:    vmovaps %ymm1, (%eax)
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+ ; X32-NEXT:    retl
+ ;
+ ; X64-LABEL: PR29088:
+ ; X64:       # %bb.0:
+-; X64-NEXT:    vmovaps (%rdi), %xmm0
+ ; X64-NEXT:    vxorps %xmm1, %xmm1, %xmm1
++; X64-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+ ; X64-NEXT:    vmovaps %ymm1, (%rsi)
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+ ; X64-NEXT:    retq
+   %ld = load <4 x i32>, <4 x i32>* %p0
+   store <8 x float> zeroinitializer, <8 x float>* %p1
+diff --git a/test/CodeGen/X86/avx2-vbroadcast.ll b/test/CodeGen/X86/avx2-vbroadcast.ll
+index e5506257e4c..3ae6c0b9d81 100644
+--- a/test/CodeGen/X86/avx2-vbroadcast.ll
++++ b/test/CodeGen/X86/avx2-vbroadcast.ll
+@@ -189,12 +189,7 @@ define <2 x i64> @Q64(i64* %ptr) nounwind uwtable readnone ssp {
+ ; X32-LABEL: Q64:
+ ; X32:       ## %bb.0: ## %entry
+ ; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl (%eax), %ecx
+-; X32-NEXT:    movl 4(%eax), %eax
+-; X32-NEXT:    vmovd %ecx, %xmm0
+-; X32-NEXT:    vpinsrd $1, %eax, %xmm0, %xmm0
+-; X32-NEXT:    vpinsrd $2, %ecx, %xmm0, %xmm0
+-; X32-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
++; X32-NEXT:    vpbroadcastq (%eax), %xmm0
+ ; X32-NEXT:    retl
+ ;
+ ; X64-LABEL: Q64:
+@@ -212,13 +207,8 @@ define <4 x i64> @QQ64(i64* %ptr) nounwind uwtable readnone ssp {
+ ; X32-LABEL: QQ64:
+ ; X32:       ## %bb.0: ## %entry
+ ; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl (%eax), %ecx
+-; X32-NEXT:    movl 4(%eax), %eax
+-; X32-NEXT:    vmovd %ecx, %xmm0
+-; X32-NEXT:    vpinsrd $1, %eax, %xmm0, %xmm0
+-; X32-NEXT:    vpinsrd $2, %ecx, %xmm0, %xmm0
+-; X32-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
+-; X32-NEXT:    vinserti128 $1, %xmm0, %ymm0, %ymm0
++; X32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
++; X32-NEXT:    vbroadcastsd %xmm0, %ymm0
+ ; X32-NEXT:    retl
+ ;
+ ; X64-LABEL: QQ64:
+@@ -1075,9 +1065,7 @@ define void @isel_crash_16b(i8* %cV_R.addr) {
+ ; X64:       ## %bb.0: ## %eintry
+ ; X64-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+ ; X64-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-NEXT:    movb (%rdi), %al
+-; X64-NEXT:    vmovd %eax, %xmm1
+-; X64-NEXT:    vpbroadcastb %xmm1, %xmm1
++; X64-NEXT:    vpbroadcastb (%rdi), %xmm1
+ ; X64-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+ ; X64-NEXT:    vmovdqa %xmm1, -{{[0-9]+}}(%rsp)
+ ; X64-NEXT:    retq
+@@ -1128,9 +1116,7 @@ define void @isel_crash_32b(i8* %cV_R.addr) {
+ ; X64-NEXT:    subq $128, %rsp
+ ; X64-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+ ; X64-NEXT:    vmovaps %ymm0, (%rsp)
+-; X64-NEXT:    movb (%rdi), %al
+-; X64-NEXT:    vmovd %eax, %xmm1
+-; X64-NEXT:    vpbroadcastb %xmm1, %ymm1
++; X64-NEXT:    vpbroadcastb (%rdi), %ymm1
+ ; X64-NEXT:    vmovaps %ymm0, {{[0-9]+}}(%rsp)
+ ; X64-NEXT:    vmovdqa %ymm1, {{[0-9]+}}(%rsp)
+ ; X64-NEXT:    movq %rbp, %rsp
+@@ -1170,9 +1156,7 @@ define void @isel_crash_8w(i16* %cV_R.addr) {
+ ; X64:       ## %bb.0: ## %entry
+ ; X64-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+ ; X64-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-NEXT:    movzwl (%rdi), %eax
+-; X64-NEXT:    vmovd %eax, %xmm1
+-; X64-NEXT:    vpbroadcastw %xmm1, %xmm1
++; X64-NEXT:    vpbroadcastw (%rdi), %xmm1
+ ; X64-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+ ; X64-NEXT:    vmovdqa %xmm1, -{{[0-9]+}}(%rsp)
+ ; X64-NEXT:    retq
+@@ -1223,9 +1207,7 @@ define void @isel_crash_16w(i16* %cV_R.addr) {
+ ; X64-NEXT:    subq $128, %rsp
+ ; X64-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+ ; X64-NEXT:    vmovaps %ymm0, (%rsp)
+-; X64-NEXT:    movzwl (%rdi), %eax
+-; X64-NEXT:    vmovd %eax, %xmm1
+-; X64-NEXT:    vpbroadcastw %xmm1, %ymm1
++; X64-NEXT:    vpbroadcastw (%rdi), %ymm1
+ ; X64-NEXT:    vmovaps %ymm0, {{[0-9]+}}(%rsp)
+ ; X64-NEXT:    vmovdqa %ymm1, {{[0-9]+}}(%rsp)
+ ; X64-NEXT:    movq %rbp, %rsp
+@@ -1261,26 +1243,14 @@ define void @isel_crash_4d(i32* %cV_R.addr) {
+ ; X32-NEXT:    addl $60, %esp
+ ; X32-NEXT:    retl
+ ;
+-; X64-AVX2-LABEL: isel_crash_4d:
+-; X64-AVX2:       ## %bb.0: ## %entry
+-; X64-AVX2-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+-; X64-AVX2-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    movl (%rdi), %eax
+-; X64-AVX2-NEXT:    vmovd %eax, %xmm1
+-; X64-AVX2-NEXT:    vpbroadcastd %xmm1, %xmm1
+-; X64-AVX2-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    vmovdqa %xmm1, -{{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    retq
+-;
+-; X64-AVX512VL-LABEL: isel_crash_4d:
+-; X64-AVX512VL:       ## %bb.0: ## %entry
+-; X64-AVX512VL-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+-; X64-AVX512VL-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    movl (%rdi), %eax
+-; X64-AVX512VL-NEXT:    vpbroadcastd %eax, %xmm1
+-; X64-AVX512VL-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    vmovdqa %xmm1, -{{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    retq
++; X64-LABEL: isel_crash_4d:
++; X64:       ## %bb.0: ## %entry
++; X64-NEXT:    vxorps %xmm0, %xmm0, %xmm0
++; X64-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
++; X64-NEXT:    vbroadcastss (%rdi), %xmm1
++; X64-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
++; X64-NEXT:    vmovaps %xmm1, -{{[0-9]+}}(%rsp)
++; X64-NEXT:    retq
+ entry:
+   %__a.addr.i = alloca <2 x i64>, align 16
+   %__b.addr.i = alloca <2 x i64>, align 16
+@@ -1317,46 +1287,24 @@ define void @isel_crash_8d(i32* %cV_R.addr) {
+ ; X32-NEXT:    vzeroupper
+ ; X32-NEXT:    retl
+ ;
+-; X64-AVX2-LABEL: isel_crash_8d:
+-; X64-AVX2:       ## %bb.0: ## %eintry
+-; X64-AVX2-NEXT:    pushq %rbp
+-; X64-AVX2-NEXT:    .cfi_def_cfa_offset 16
+-; X64-AVX2-NEXT:    .cfi_offset %rbp, -16
+-; X64-AVX2-NEXT:    movq %rsp, %rbp
+-; X64-AVX2-NEXT:    .cfi_def_cfa_register %rbp
+-; X64-AVX2-NEXT:    andq $-32, %rsp
+-; X64-AVX2-NEXT:    subq $128, %rsp
+-; X64-AVX2-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+-; X64-AVX2-NEXT:    vmovaps %ymm0, (%rsp)
+-; X64-AVX2-NEXT:    movl (%rdi), %eax
+-; X64-AVX2-NEXT:    vmovd %eax, %xmm1
+-; X64-AVX2-NEXT:    vpbroadcastd %xmm1, %ymm1
+-; X64-AVX2-NEXT:    vmovaps %ymm0, {{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    vmovdqa %ymm1, {{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    movq %rbp, %rsp
+-; X64-AVX2-NEXT:    popq %rbp
+-; X64-AVX2-NEXT:    vzeroupper
+-; X64-AVX2-NEXT:    retq
+-;
+-; X64-AVX512VL-LABEL: isel_crash_8d:
+-; X64-AVX512VL:       ## %bb.0: ## %eintry
+-; X64-AVX512VL-NEXT:    pushq %rbp
+-; X64-AVX512VL-NEXT:    .cfi_def_cfa_offset 16
+-; X64-AVX512VL-NEXT:    .cfi_offset %rbp, -16
+-; X64-AVX512VL-NEXT:    movq %rsp, %rbp
+-; X64-AVX512VL-NEXT:    .cfi_def_cfa_register %rbp
+-; X64-AVX512VL-NEXT:    andq $-32, %rsp
+-; X64-AVX512VL-NEXT:    subq $128, %rsp
+-; X64-AVX512VL-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+-; X64-AVX512VL-NEXT:    vmovaps %ymm0, (%rsp)
+-; X64-AVX512VL-NEXT:    movl (%rdi), %eax
+-; X64-AVX512VL-NEXT:    vpbroadcastd %eax, %ymm1
+-; X64-AVX512VL-NEXT:    vmovaps %ymm0, {{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    vmovdqa %ymm1, {{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    movq %rbp, %rsp
+-; X64-AVX512VL-NEXT:    popq %rbp
+-; X64-AVX512VL-NEXT:    vzeroupper
+-; X64-AVX512VL-NEXT:    retq
++; X64-LABEL: isel_crash_8d:
++; X64:       ## %bb.0: ## %eintry
++; X64-NEXT:    pushq %rbp
++; X64-NEXT:    .cfi_def_cfa_offset 16
++; X64-NEXT:    .cfi_offset %rbp, -16
++; X64-NEXT:    movq %rsp, %rbp
++; X64-NEXT:    .cfi_def_cfa_register %rbp
++; X64-NEXT:    andq $-32, %rsp
++; X64-NEXT:    subq $128, %rsp
++; X64-NEXT:    vxorps %xmm0, %xmm0, %xmm0
++; X64-NEXT:    vmovaps %ymm0, (%rsp)
++; X64-NEXT:    vbroadcastss (%rdi), %ymm1
++; X64-NEXT:    vmovaps %ymm0, {{[0-9]+}}(%rsp)
++; X64-NEXT:    vmovaps %ymm1, {{[0-9]+}}(%rsp)
++; X64-NEXT:    movq %rbp, %rsp
++; X64-NEXT:    popq %rbp
++; X64-NEXT:    vzeroupper
++; X64-NEXT:    retq
+ eintry:
+   %__a.addr.i = alloca <4 x i64>, align 16
+   %__b.addr.i = alloca <4 x i64>, align 16
+@@ -1380,37 +1328,20 @@ define void @isel_crash_2q(i64* %cV_R.addr) {
+ ; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+ ; X32-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+ ; X32-NEXT:    vmovaps %xmm0, (%esp)
+-; X32-NEXT:    movl (%eax), %ecx
+-; X32-NEXT:    movl 4(%eax), %eax
+-; X32-NEXT:    vmovd %ecx, %xmm1
+-; X32-NEXT:    vpinsrd $1, %eax, %xmm1, %xmm1
+-; X32-NEXT:    vpinsrd $2, %ecx, %xmm1, %xmm1
+-; X32-NEXT:    vpinsrd $3, %eax, %xmm1, %xmm1
++; X32-NEXT:    vpbroadcastq (%eax), %xmm1
+ ; X32-NEXT:    vmovaps %xmm0, {{[0-9]+}}(%esp)
+ ; X32-NEXT:    vmovdqa %xmm1, {{[0-9]+}}(%esp)
+ ; X32-NEXT:    addl $60, %esp
+ ; X32-NEXT:    retl
+ ;
+-; X64-AVX2-LABEL: isel_crash_2q:
+-; X64-AVX2:       ## %bb.0: ## %entry
+-; X64-AVX2-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+-; X64-AVX2-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    movq (%rdi), %rax
+-; X64-AVX2-NEXT:    vmovq %rax, %xmm1
+-; X64-AVX2-NEXT:    vpbroadcastq %xmm1, %xmm1
+-; X64-AVX2-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    vmovdqa %xmm1, -{{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    retq
+-;
+-; X64-AVX512VL-LABEL: isel_crash_2q:
+-; X64-AVX512VL:       ## %bb.0: ## %entry
+-; X64-AVX512VL-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+-; X64-AVX512VL-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    movq (%rdi), %rax
+-; X64-AVX512VL-NEXT:    vpbroadcastq %rax, %xmm1
+-; X64-AVX512VL-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    vmovdqa %xmm1, -{{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    retq
++; X64-LABEL: isel_crash_2q:
++; X64:       ## %bb.0: ## %entry
++; X64-NEXT:    vxorps %xmm0, %xmm0, %xmm0
++; X64-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
++; X64-NEXT:    vpbroadcastq (%rdi), %xmm1
++; X64-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
++; X64-NEXT:    vmovdqa %xmm1, -{{[0-9]+}}(%rsp)
++; X64-NEXT:    retq
+ entry:
+   %__a.addr.i = alloca <2 x i64>, align 16
+   %__b.addr.i = alloca <2 x i64>, align 16
+@@ -1438,60 +1369,33 @@ define void @isel_crash_4q(i64* %cV_R.addr) {
+ ; X32-NEXT:    movl 8(%ebp), %eax
+ ; X32-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+ ; X32-NEXT:    vmovaps %ymm0, (%esp)
+-; X32-NEXT:    movl (%eax), %ecx
+-; X32-NEXT:    movl 4(%eax), %eax
+-; X32-NEXT:    vmovd %ecx, %xmm1
+-; X32-NEXT:    vpinsrd $1, %eax, %xmm1, %xmm1
+-; X32-NEXT:    vpinsrd $2, %ecx, %xmm1, %xmm1
+-; X32-NEXT:    vpinsrd $3, %eax, %xmm1, %xmm1
+-; X32-NEXT:    vinserti128 $1, %xmm1, %ymm1, %ymm1
++; X32-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
++; X32-NEXT:    vbroadcastsd %xmm1, %ymm1
+ ; X32-NEXT:    vmovaps %ymm0, {{[0-9]+}}(%esp)
+-; X32-NEXT:    vmovdqa %ymm1, {{[0-9]+}}(%esp)
++; X32-NEXT:    vmovaps %ymm1, {{[0-9]+}}(%esp)
+ ; X32-NEXT:    movl %ebp, %esp
+ ; X32-NEXT:    popl %ebp
+ ; X32-NEXT:    vzeroupper
+ ; X32-NEXT:    retl
+ ;
+-; X64-AVX2-LABEL: isel_crash_4q:
+-; X64-AVX2:       ## %bb.0: ## %eintry
+-; X64-AVX2-NEXT:    pushq %rbp
+-; X64-AVX2-NEXT:    .cfi_def_cfa_offset 16
+-; X64-AVX2-NEXT:    .cfi_offset %rbp, -16
+-; X64-AVX2-NEXT:    movq %rsp, %rbp
+-; X64-AVX2-NEXT:    .cfi_def_cfa_register %rbp
+-; X64-AVX2-NEXT:    andq $-32, %rsp
+-; X64-AVX2-NEXT:    subq $128, %rsp
+-; X64-AVX2-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+-; X64-AVX2-NEXT:    vmovaps %ymm0, (%rsp)
+-; X64-AVX2-NEXT:    movq (%rdi), %rax
+-; X64-AVX2-NEXT:    vmovq %rax, %xmm1
+-; X64-AVX2-NEXT:    vpbroadcastq %xmm1, %ymm1
+-; X64-AVX2-NEXT:    vmovaps %ymm0, {{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    vmovdqa %ymm1, {{[0-9]+}}(%rsp)
+-; X64-AVX2-NEXT:    movq %rbp, %rsp
+-; X64-AVX2-NEXT:    popq %rbp
+-; X64-AVX2-NEXT:    vzeroupper
+-; X64-AVX2-NEXT:    retq
+-;
+-; X64-AVX512VL-LABEL: isel_crash_4q:
+-; X64-AVX512VL:       ## %bb.0: ## %eintry
+-; X64-AVX512VL-NEXT:    pushq %rbp
+-; X64-AVX512VL-NEXT:    .cfi_def_cfa_offset 16
+-; X64-AVX512VL-NEXT:    .cfi_offset %rbp, -16
+-; X64-AVX512VL-NEXT:    movq %rsp, %rbp
+-; X64-AVX512VL-NEXT:    .cfi_def_cfa_register %rbp
+-; X64-AVX512VL-NEXT:    andq $-32, %rsp
+-; X64-AVX512VL-NEXT:    subq $128, %rsp
+-; X64-AVX512VL-NEXT:    vxorps %xmm0, %xmm0, %xmm0
+-; X64-AVX512VL-NEXT:    vmovaps %ymm0, (%rsp)
+-; X64-AVX512VL-NEXT:    movq (%rdi), %rax
+-; X64-AVX512VL-NEXT:    vpbroadcastq %rax, %ymm1
+-; X64-AVX512VL-NEXT:    vmovaps %ymm0, {{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    vmovdqa %ymm1, {{[0-9]+}}(%rsp)
+-; X64-AVX512VL-NEXT:    movq %rbp, %rsp
+-; X64-AVX512VL-NEXT:    popq %rbp
+-; X64-AVX512VL-NEXT:    vzeroupper
+-; X64-AVX512VL-NEXT:    retq
++; X64-LABEL: isel_crash_4q:
++; X64:       ## %bb.0: ## %eintry
++; X64-NEXT:    pushq %rbp
++; X64-NEXT:    .cfi_def_cfa_offset 16
++; X64-NEXT:    .cfi_offset %rbp, -16
++; X64-NEXT:    movq %rsp, %rbp
++; X64-NEXT:    .cfi_def_cfa_register %rbp
++; X64-NEXT:    andq $-32, %rsp
++; X64-NEXT:    subq $128, %rsp
++; X64-NEXT:    vxorps %xmm0, %xmm0, %xmm0
++; X64-NEXT:    vmovaps %ymm0, (%rsp)
++; X64-NEXT:    vbroadcastsd (%rdi), %ymm1
++; X64-NEXT:    vmovaps %ymm0, {{[0-9]+}}(%rsp)
++; X64-NEXT:    vmovaps %ymm1, {{[0-9]+}}(%rsp)
++; X64-NEXT:    movq %rbp, %rsp
++; X64-NEXT:    popq %rbp
++; X64-NEXT:    vzeroupper
++; X64-NEXT:    retq
+ eintry:
+   %__a.addr.i = alloca <4 x i64>, align 16
+   %__b.addr.i = alloca <4 x i64>, align 16
+diff --git a/test/CodeGen/X86/avx2-vbroadcasti128.ll b/test/CodeGen/X86/avx2-vbroadcasti128.ll
+index 254cdfdd8cb..996e6796616 100644
+--- a/test/CodeGen/X86/avx2-vbroadcasti128.ll
++++ b/test/CodeGen/X86/avx2-vbroadcasti128.ll
+@@ -271,18 +271,16 @@ define <8 x i32> @PR29088(<4 x i32>* %p0, <8 x float>* %p1) {
+ ; X32:       # %bb.0:
+ ; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+ ; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    vmovaps (%ecx), %xmm0
+ ; X32-NEXT:    vxorps %xmm1, %xmm1, %xmm1
++; X32-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+ ; X32-NEXT:    vmovaps %ymm1, (%eax)
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+ ; X32-NEXT:    retl
+ ;
+ ; X64-LABEL: PR29088:
+ ; X64:       # %bb.0:
+-; X64-NEXT:    vmovaps (%rdi), %xmm0
+ ; X64-NEXT:    vxorps %xmm1, %xmm1, %xmm1
++; X64-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+ ; X64-NEXT:    vmovaps %ymm1, (%rsi)
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+ ; X64-NEXT:    retq
+   %ld = load <4 x i32>, <4 x i32>* %p0
+   store <8 x float> zeroinitializer, <8 x float>* %p1
+diff --git a/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll b/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll
+index 80127f66bdf..8ebbbd4b49f 100644
+--- a/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll
++++ b/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll
+@@ -435,16 +435,11 @@ entry:
+ define <8 x i64> @test_mm512_mask_set1_epi64(<8 x i64> %__O, i8 zeroext %__M, i64 %__A) {
+ ; X32-LABEL: test_mm512_mask_set1_epi64:
+ ; X32:       # %bb.0: # %entry
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %edx
+ ; X32-NEXT:    movb {{[0-9]+}}(%esp), %al
+-; X32-NEXT:    vmovd %edx, %xmm1
+-; X32-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm1
+-; X32-NEXT:    vpinsrd $2, %edx, %xmm1, %xmm1
+-; X32-NEXT:    vpinsrd $3, %ecx, %xmm1, %xmm1
+-; X32-NEXT:    vinserti128 $1, %xmm1, %ymm1, %ymm1
++; X32-NEXT:    vmovd {{.*#+}} xmm1 = mem[0],zero,zero,zero
++; X32-NEXT:    vpinsrd $1, {{[0-9]+}}(%esp), %xmm1, %xmm1
+ ; X32-NEXT:    kmovw %eax, %k1
+-; X32-NEXT:    vinserti64x4 $1, %ymm1, %zmm1, %zmm0 {%k1}
++; X32-NEXT:    vpbroadcastq %xmm1, %zmm0 {%k1}
+ ; X32-NEXT:    retl
+ ;
+ ; X64-LABEL: test_mm512_mask_set1_epi64:
+@@ -463,16 +458,11 @@ entry:
+ define <8 x i64> @test_mm512_maskz_set1_epi64(i8 zeroext %__M, i64 %__A)  {
+ ; X32-LABEL: test_mm512_maskz_set1_epi64:
+ ; X32:       # %bb.0: # %entry
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %edx
+ ; X32-NEXT:    movb {{[0-9]+}}(%esp), %al
+-; X32-NEXT:    vmovd %edx, %xmm0
+-; X32-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
+-; X32-NEXT:    vpinsrd $2, %edx, %xmm0, %xmm0
+-; X32-NEXT:    vpinsrd $3, %ecx, %xmm0, %xmm0
+-; X32-NEXT:    vinserti128 $1, %xmm0, %ymm0, %ymm0
++; X32-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
++; X32-NEXT:    vpinsrd $1, {{[0-9]+}}(%esp), %xmm0, %xmm0
+ ; X32-NEXT:    kmovw %eax, %k1
+-; X32-NEXT:    vinserti64x4 $1, %ymm0, %zmm0, %zmm0 {%k1} {z}
++; X32-NEXT:    vpbroadcastq %xmm0, %zmm0 {%k1} {z}
+ ; X32-NEXT:    retl
+ ;
+ ; X64-LABEL: test_mm512_maskz_set1_epi64:
+diff --git a/test/CodeGen/X86/avx512-vbroadcasti128.ll b/test/CodeGen/X86/avx512-vbroadcasti128.ll
+index c5ecb1559b4..2bf69cfadcf 100644
+--- a/test/CodeGen/X86/avx512-vbroadcasti128.ll
++++ b/test/CodeGen/X86/avx512-vbroadcasti128.ll
+@@ -186,26 +186,23 @@ define <64 x i8> @test_broadcast_16i8_64i8(<16 x i8> *%p) nounwind {
+ define <8 x i32> @PR29088(<4 x i32>* %p0, <8 x float>* %p1) {
+ ; X64-AVX512VL-LABEL: PR29088:
+ ; X64-AVX512VL:       ## %bb.0:
+-; X64-AVX512VL-NEXT:    vmovaps (%rdi), %xmm0
+ ; X64-AVX512VL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
++; X64-AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+ ; X64-AVX512VL-NEXT:    vmovdqa %ymm1, (%rsi)
+-; X64-AVX512VL-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+ ; X64-AVX512VL-NEXT:    retq
+ ;
+ ; X64-AVX512BWVL-LABEL: PR29088:
+ ; X64-AVX512BWVL:       ## %bb.0:
+-; X64-AVX512BWVL-NEXT:    vmovaps (%rdi), %xmm0
+ ; X64-AVX512BWVL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
++; X64-AVX512BWVL-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+ ; X64-AVX512BWVL-NEXT:    vmovdqa %ymm1, (%rsi)
+-; X64-AVX512BWVL-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+ ; X64-AVX512BWVL-NEXT:    retq
+ ;
+ ; X64-AVX512DQVL-LABEL: PR29088:
+ ; X64-AVX512DQVL:       ## %bb.0:
+-; X64-AVX512DQVL-NEXT:    vmovaps (%rdi), %xmm0
+ ; X64-AVX512DQVL-NEXT:    vxorps %xmm1, %xmm1, %xmm1
++; X64-AVX512DQVL-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+ ; X64-AVX512DQVL-NEXT:    vmovaps %ymm1, (%rsi)
+-; X64-AVX512DQVL-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+ ; X64-AVX512DQVL-NEXT:    retq
+   %ld = load <4 x i32>, <4 x i32>* %p0
+   store <8 x float> zeroinitializer, <8 x float>* %p1
+diff --git a/test/CodeGen/X86/avx512vl-intrinsics-fast-isel.ll b/test/CodeGen/X86/avx512vl-intrinsics-fast-isel.ll
+index 8c13d4b842f..a2d275c1109 100644
+--- a/test/CodeGen/X86/avx512vl-intrinsics-fast-isel.ll
++++ b/test/CodeGen/X86/avx512vl-intrinsics-fast-isel.ll
+@@ -797,16 +797,11 @@ entry:
+ define <4 x i64> @test_mm256_mask_set1_epi64(<4 x i64> %__O, i8 zeroext %__M, i64 %__A) {
+ ; X32-LABEL: test_mm256_mask_set1_epi64:
+ ; X32:       # %bb.0: # %entry
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    movb {{[0-9]+}}(%esp), %dl
+-; X32-NEXT:    vmovd %ecx, %xmm1
+-; X32-NEXT:    vpinsrd $1, %eax, %xmm1, %xmm1
+-; X32-NEXT:    vpinsrd $2, %ecx, %xmm1, %xmm1
+-; X32-NEXT:    vpinsrd $3, %eax, %xmm1, %xmm1
+-; X32-NEXT:    vinserti128 $1, %xmm1, %ymm1, %ymm1
+-; X32-NEXT:    kmovw %edx, %k1
+-; X32-NEXT:    vmovdqa64 %ymm1, %ymm0 {%k1}
++; X32-NEXT:    movb {{[0-9]+}}(%esp), %al
++; X32-NEXT:    vmovd {{.*#+}} xmm1 = mem[0],zero,zero,zero
++; X32-NEXT:    vpinsrd $1, {{[0-9]+}}(%esp), %xmm1, %xmm1
++; X32-NEXT:    kmovw %eax, %k1
++; X32-NEXT:    vpbroadcastq %xmm1, %ymm0 {%k1}
+ ; X32-NEXT:    retl
+ ;
+ ; X64-LABEL: test_mm256_mask_set1_epi64:
+@@ -826,16 +821,11 @@ entry:
+ define <4 x i64> @test_mm256_maskz_set1_epi64(i8 zeroext %__M, i64 %__A)  {
+ ; X32-LABEL: test_mm256_maskz_set1_epi64:
+ ; X32:       # %bb.0: # %entry
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    movb {{[0-9]+}}(%esp), %dl
+-; X32-NEXT:    vmovd %ecx, %xmm0
+-; X32-NEXT:    vpinsrd $1, %eax, %xmm0, %xmm0
+-; X32-NEXT:    vpinsrd $2, %ecx, %xmm0, %xmm0
+-; X32-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
+-; X32-NEXT:    vinserti128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    kmovw %edx, %k1
+-; X32-NEXT:    vmovdqa64 %ymm0, %ymm0 {%k1} {z}
++; X32-NEXT:    movb {{[0-9]+}}(%esp), %al
++; X32-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
++; X32-NEXT:    vpinsrd $1, {{[0-9]+}}(%esp), %xmm0, %xmm0
++; X32-NEXT:    kmovw %eax, %k1
++; X32-NEXT:    vpbroadcastq %xmm0, %ymm0 {%k1} {z}
+ ; X32-NEXT:    retl
+ ;
+ ; X64-LABEL: test_mm256_maskz_set1_epi64:
+diff --git a/test/CodeGen/X86/broadcastm-lowering.ll b/test/CodeGen/X86/broadcastm-lowering.ll
+index 428eaa19497..664f3b2eba6 100644
+--- a/test/CodeGen/X86/broadcastm-lowering.ll
++++ b/test/CodeGen/X86/broadcastm-lowering.ll
+@@ -122,9 +122,7 @@ define <8 x i64> @test_mm512_epi64(<8 x i32> %a, <8 x i32> %b) {
+ ; X86-AVX512VLCDBW-NEXT:    kmovd %k0, %eax
+ ; X86-AVX512VLCDBW-NEXT:    movzbl %al, %eax
+ ; X86-AVX512VLCDBW-NEXT:    vmovd %eax, %xmm0
+-; X86-AVX512VLCDBW-NEXT:    vpbroadcastq %xmm0, %xmm0
+-; X86-AVX512VLCDBW-NEXT:    vinserti128 $1, %xmm0, %ymm0, %ymm0
+-; X86-AVX512VLCDBW-NEXT:    vinserti64x4 $1, %ymm0, %zmm0, %zmm0
++; X86-AVX512VLCDBW-NEXT:    vpbroadcastq %xmm0, %zmm0
+ ; X86-AVX512VLCDBW-NEXT:    retl
+ entry:
+   %0 = icmp eq <8 x i32> %a, %b
+@@ -160,8 +158,7 @@ define <4 x i64> @test_mm256_epi64(<8 x i32> %a, <8 x i32> %b) {
+ ; X86-AVX512VLCDBW-NEXT:    kmovd %k0, %eax
+ ; X86-AVX512VLCDBW-NEXT:    movzbl %al, %eax
+ ; X86-AVX512VLCDBW-NEXT:    vmovd %eax, %xmm0
+-; X86-AVX512VLCDBW-NEXT:    vpbroadcastq %xmm0, %xmm0
+-; X86-AVX512VLCDBW-NEXT:    vinserti128 $1, %xmm0, %ymm0, %ymm0
++; X86-AVX512VLCDBW-NEXT:    vpbroadcastq %xmm0, %ymm0
+ ; X86-AVX512VLCDBW-NEXT:    retl
+ entry:
+   %0 = icmp eq <8 x i32> %a, %b
+diff --git a/test/CodeGen/X86/i256-add.ll b/test/CodeGen/X86/i256-add.ll
+deleted file mode 100644
+index 36d838a68cb..00000000000
+--- a/test/CodeGen/X86/i256-add.ll
++++ /dev/null
+@@ -1,135 +0,0 @@
+-; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
+-; RUN: llc < %s -mtriple=i386-unknown | FileCheck %s --check-prefix=X32
+-; RUN: llc < %s -mtriple=x86_64-unknown | FileCheck %s --check-prefix=X64
+-
+-define void @add(i256* %p, i256* %q) nounwind {
+-; X32-LABEL: add:
+-; X32:       # %bb.0:
+-; X32-NEXT:    pushl %ebp
+-; X32-NEXT:    pushl %ebx
+-; X32-NEXT:    pushl %edi
+-; X32-NEXT:    pushl %esi
+-; X32-NEXT:    subl $12, %esp
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    movl 8(%ecx), %edi
+-; X32-NEXT:    movl (%ecx), %edx
+-; X32-NEXT:    movl 4(%ecx), %ebx
+-; X32-NEXT:    movl 28(%eax), %esi
+-; X32-NEXT:    movl %esi, {{[0-9]+}}(%esp) # 4-byte Spill
+-; X32-NEXT:    movl 24(%eax), %ebp
+-; X32-NEXT:    addl (%eax), %edx
+-; X32-NEXT:    movl %edx, {{[0-9]+}}(%esp) # 4-byte Spill
+-; X32-NEXT:    adcl 4(%eax), %ebx
+-; X32-NEXT:    adcl 8(%eax), %edi
+-; X32-NEXT:    movl %edi, (%esp) # 4-byte Spill
+-; X32-NEXT:    movl 20(%eax), %edi
+-; X32-NEXT:    movl 12(%eax), %edx
+-; X32-NEXT:    movl 16(%eax), %esi
+-; X32-NEXT:    adcl 12(%ecx), %edx
+-; X32-NEXT:    adcl 16(%ecx), %esi
+-; X32-NEXT:    adcl 20(%ecx), %edi
+-; X32-NEXT:    movl %ebp, %eax
+-; X32-NEXT:    adcl 24(%ecx), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ebp # 4-byte Reload
+-; X32-NEXT:    adcl %ebp, 28(%ecx)
+-; X32-NEXT:    movl (%esp), %ebp # 4-byte Reload
+-; X32-NEXT:    movl %ebp, 8(%ecx)
+-; X32-NEXT:    movl %ebx, 4(%ecx)
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ebx # 4-byte Reload
+-; X32-NEXT:    movl %ebx, (%ecx)
+-; X32-NEXT:    movl %edx, 12(%ecx)
+-; X32-NEXT:    movl %esi, 16(%ecx)
+-; X32-NEXT:    movl %edi, 20(%ecx)
+-; X32-NEXT:    movl %eax, 24(%ecx)
+-; X32-NEXT:    addl $12, %esp
+-; X32-NEXT:    popl %esi
+-; X32-NEXT:    popl %edi
+-; X32-NEXT:    popl %ebx
+-; X32-NEXT:    popl %ebp
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: add:
+-; X64:       # %bb.0:
+-; X64-NEXT:    movq 16(%rdi), %rax
+-; X64-NEXT:    movq (%rdi), %rcx
+-; X64-NEXT:    movq 8(%rdi), %rdx
+-; X64-NEXT:    movq 24(%rsi), %r8
+-; X64-NEXT:    addq (%rsi), %rcx
+-; X64-NEXT:    adcq 8(%rsi), %rdx
+-; X64-NEXT:    adcq 16(%rsi), %rax
+-; X64-NEXT:    adcq %r8, 24(%rdi)
+-; X64-NEXT:    movq %rax, 16(%rdi)
+-; X64-NEXT:    movq %rdx, 8(%rdi)
+-; X64-NEXT:    movq %rcx, (%rdi)
+-; X64-NEXT:    retq
+-  %a = load i256, i256* %p
+-  %b = load i256, i256* %q
+-  %c = add i256 %a, %b
+-  store i256 %c, i256* %p
+-  ret void
+-}
+-define void @sub(i256* %p, i256* %q) nounwind {
+-; X32-LABEL: sub:
+-; X32:       # %bb.0:
+-; X32-NEXT:    pushl %ebp
+-; X32-NEXT:    pushl %ebx
+-; X32-NEXT:    pushl %edi
+-; X32-NEXT:    pushl %esi
+-; X32-NEXT:    subl $8, %esp
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %esi
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    movl 16(%ecx), %eax
+-; X32-NEXT:    movl 12(%ecx), %edx
+-; X32-NEXT:    movl 8(%ecx), %edi
+-; X32-NEXT:    movl (%ecx), %ebx
+-; X32-NEXT:    movl 4(%ecx), %ebp
+-; X32-NEXT:    subl (%esi), %ebx
+-; X32-NEXT:    sbbl 4(%esi), %ebp
+-; X32-NEXT:    sbbl 8(%esi), %edi
+-; X32-NEXT:    sbbl 12(%esi), %edx
+-; X32-NEXT:    movl %edx, {{[0-9]+}}(%esp) # 4-byte Spill
+-; X32-NEXT:    sbbl 16(%esi), %eax
+-; X32-NEXT:    movl %eax, (%esp) # 4-byte Spill
+-; X32-NEXT:    movl 20(%ecx), %edx
+-; X32-NEXT:    sbbl 20(%esi), %edx
+-; X32-NEXT:    movl 24(%ecx), %eax
+-; X32-NEXT:    sbbl 24(%esi), %eax
+-; X32-NEXT:    movl 28(%esi), %esi
+-; X32-NEXT:    sbbl %esi, 28(%ecx)
+-; X32-NEXT:    movl %edi, 8(%ecx)
+-; X32-NEXT:    movl %ebp, 4(%ecx)
+-; X32-NEXT:    movl %ebx, (%ecx)
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %esi # 4-byte Reload
+-; X32-NEXT:    movl %esi, 12(%ecx)
+-; X32-NEXT:    movl (%esp), %esi # 4-byte Reload
+-; X32-NEXT:    movl %esi, 16(%ecx)
+-; X32-NEXT:    movl %edx, 20(%ecx)
+-; X32-NEXT:    movl %eax, 24(%ecx)
+-; X32-NEXT:    addl $8, %esp
+-; X32-NEXT:    popl %esi
+-; X32-NEXT:    popl %edi
+-; X32-NEXT:    popl %ebx
+-; X32-NEXT:    popl %ebp
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: sub:
+-; X64:       # %bb.0:
+-; X64-NEXT:    movq 16(%rdi), %rax
+-; X64-NEXT:    movq (%rdi), %rcx
+-; X64-NEXT:    movq 8(%rdi), %rdx
+-; X64-NEXT:    movq 24(%rsi), %r8
+-; X64-NEXT:    subq (%rsi), %rcx
+-; X64-NEXT:    sbbq 8(%rsi), %rdx
+-; X64-NEXT:    sbbq 16(%rsi), %rax
+-; X64-NEXT:    sbbq %r8, 24(%rdi)
+-; X64-NEXT:    movq %rax, 16(%rdi)
+-; X64-NEXT:    movq %rdx, 8(%rdi)
+-; X64-NEXT:    movq %rcx, (%rdi)
+-; X64-NEXT:    retq
+-  %a = load i256, i256* %p
+-  %b = load i256, i256* %q
+-  %c = sub i256 %a, %b
+-  store i256 %c, i256* %p
+-  ret void
+-}
+diff --git a/test/CodeGen/X86/insertelement-shuffle.ll b/test/CodeGen/X86/insertelement-shuffle.ll
+index 705ceba9487..c0177ad7a9a 100644
+--- a/test/CodeGen/X86/insertelement-shuffle.ll
++++ b/test/CodeGen/X86/insertelement-shuffle.ll
+@@ -103,14 +103,9 @@ define <8 x i64> @insert_subvector_into_undef(i32 %x0, i32 %x1) nounwind {
+ ; X32_AVX256-NEXT:    subl $8, %esp
+ ; X32_AVX256-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; X32_AVX256-NEXT:    vmovlps %xmm0, (%esp)
+-; X32_AVX256-NEXT:    movl (%esp), %eax
+-; X32_AVX256-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32_AVX256-NEXT:    vmovd %eax, %xmm0
+-; X32_AVX256-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
+-; X32_AVX256-NEXT:    vpinsrd $2, %eax, %xmm0, %xmm0
+-; X32_AVX256-NEXT:    vpinsrd $3, %ecx, %xmm0, %xmm0
+-; X32_AVX256-NEXT:    vinserti128 $1, %xmm0, %ymm0, %ymm0
+-; X32_AVX256-NEXT:    vmovdqa %ymm0, %ymm1
++; X32_AVX256-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
++; X32_AVX256-NEXT:    vbroadcastsd %xmm0, %ymm0
++; X32_AVX256-NEXT:    vmovaps %ymm0, %ymm1
+ ; X32_AVX256-NEXT:    movl %ebp, %esp
+ ; X32_AVX256-NEXT:    popl %ebp
+ ; X32_AVX256-NEXT:    retl
+diff --git a/test/CodeGen/X86/masked_memop.ll b/test/CodeGen/X86/masked_memop.ll
+index 82f097e4e0f..33cb5e2f235 100644
+--- a/test/CodeGen/X86/masked_memop.ll
++++ b/test/CodeGen/X86/masked_memop.ll
+@@ -1199,8 +1199,7 @@ define <8 x double> @load_one_mask_bit_set5(<8 x double>* %addr, <8 x double> %v
+ ; AVX-LABEL: load_one_mask_bit_set5:
+ ; AVX:       ## %bb.0:
+ ; AVX-NEXT:    vextractf128 $1, %ymm1, %xmm2
+-; AVX-NEXT:    vmovsd {{.*#+}} xmm3 = mem[0],zero
+-; AVX-NEXT:    vmovlhps {{.*#+}} xmm2 = xmm2[0],xmm3[0]
++; AVX-NEXT:    vmovhpd {{.*#+}} xmm2 = xmm2[0],mem[0]
+ ; AVX-NEXT:    vinsertf128 $1, %xmm2, %ymm1, %ymm1
+ ; AVX-NEXT:    retq
+ ;
+diff --git a/test/CodeGen/X86/merge-consecutive-stores.ll b/test/CodeGen/X86/merge-consecutive-stores.ll
+index af5fb478e52..4f511ef99e5 100644
+--- a/test/CodeGen/X86/merge-consecutive-stores.ll
++++ b/test/CodeGen/X86/merge-consecutive-stores.ll
+@@ -10,12 +10,11 @@ define i32 @foo (i64* %so) nounwind uwtable ssp {
+ ; CHECK-NEXT:    movl {{[0-9]+}}(%esp), %eax
+ ; CHECK-NEXT:    movl $0, 28(%eax)
+ ; CHECK-NEXT:    movl $0, 24(%eax)
+-; CHECK-NEXT:    movl 20(%eax), %ecx
+-; CHECK-NEXT:    movl $0, 20(%eax)
+-; CHECK-NEXT:    xorl %edx, %edx
+-; CHECK-NEXT:    cmpl 16(%eax), %edx
++; CHECK-NEXT:    xorl %ecx, %ecx
++; CHECK-NEXT:    cmpl 16(%eax), %ecx
+ ; CHECK-NEXT:    movl $0, 16(%eax)
+-; CHECK-NEXT:    sbbl %ecx, %edx
++; CHECK-NEXT:    sbbl 20(%eax), %ecx
++; CHECK-NEXT:    movl $0, 20(%eax)
+ ; CHECK-NEXT:    setl %al
+ ; CHECK-NEXT:    movzbl %al, %eax
+ ; CHECK-NEXT:    negl %eax
+diff --git a/test/CodeGen/X86/nontemporal.ll b/test/CodeGen/X86/nontemporal.ll
+index f53982a8542..472c3e4774c 100644
+--- a/test/CodeGen/X86/nontemporal.ll
++++ b/test/CodeGen/X86/nontemporal.ll
+@@ -13,36 +13,35 @@ define i32 @f(<4 x float> %A, i8* %B, <2 x double> %C, i32 %D, <2 x i64> %E, <4
+ ; X32-SSE-NEXT:    andl $-16, %esp
+ ; X32-SSE-NEXT:    subl $16, %esp
+ ; X32-SSE-NEXT:    movsd {{.*#+}} xmm3 = mem[0],zero
+-; X32-SSE-NEXT:    movl 12(%ebp), %eax
++; X32-SSE-NEXT:    movl 12(%ebp), %ecx
+ ; X32-SSE-NEXT:    movdqa 56(%ebp), %xmm4
+ ; X32-SSE-NEXT:    movdqa 40(%ebp), %xmm5
+ ; X32-SSE-NEXT:    movdqa 24(%ebp), %xmm6
+-; X32-SSE-NEXT:    movl 8(%ebp), %edx
+-; X32-SSE-NEXT:    movl 80(%ebp), %ecx
+-; X32-SSE-NEXT:    movl (%ecx), %esi
++; X32-SSE-NEXT:    movl 8(%ebp), %esi
++; X32-SSE-NEXT:    movl 80(%ebp), %edx
++; X32-SSE-NEXT:    movl (%edx), %eax
+ ; X32-SSE-NEXT:    addps {{\.LCPI.*}}, %xmm0
+-; X32-SSE-NEXT:    movntps %xmm0, (%edx)
++; X32-SSE-NEXT:    movntps %xmm0, (%esi)
+ ; X32-SSE-NEXT:    paddq {{\.LCPI.*}}, %xmm2
+-; X32-SSE-NEXT:    addl (%ecx), %esi
+-; X32-SSE-NEXT:    movntdq %xmm2, (%edx)
++; X32-SSE-NEXT:    addl (%edx), %eax
++; X32-SSE-NEXT:    movntdq %xmm2, (%esi)
+ ; X32-SSE-NEXT:    addpd {{\.LCPI.*}}, %xmm1
+-; X32-SSE-NEXT:    addl (%ecx), %esi
+-; X32-SSE-NEXT:    movntpd %xmm1, (%edx)
++; X32-SSE-NEXT:    addl (%edx), %eax
++; X32-SSE-NEXT:    movntpd %xmm1, (%esi)
+ ; X32-SSE-NEXT:    paddd {{\.LCPI.*}}, %xmm6
+-; X32-SSE-NEXT:    addl (%ecx), %esi
+-; X32-SSE-NEXT:    movntdq %xmm6, (%edx)
++; X32-SSE-NEXT:    addl (%edx), %eax
++; X32-SSE-NEXT:    movntdq %xmm6, (%esi)
+ ; X32-SSE-NEXT:    paddw {{\.LCPI.*}}, %xmm5
+-; X32-SSE-NEXT:    addl (%ecx), %esi
+-; X32-SSE-NEXT:    movntdq %xmm5, (%edx)
++; X32-SSE-NEXT:    addl (%edx), %eax
++; X32-SSE-NEXT:    movntdq %xmm5, (%esi)
+ ; X32-SSE-NEXT:    paddb {{\.LCPI.*}}, %xmm4
+-; X32-SSE-NEXT:    addl (%ecx), %esi
+-; X32-SSE-NEXT:    movntdq %xmm4, (%edx)
+-; X32-SSE-NEXT:    addl (%ecx), %esi
+-; X32-SSE-NEXT:    movntil %eax, (%edx)
+-; X32-SSE-NEXT:    movl (%ecx), %eax
+-; X32-SSE-NEXT:    addl %esi, %eax
+-; X32-SSE-NEXT:    movsd %xmm3, (%edx)
+-; X32-SSE-NEXT:    addl (%ecx), %eax
++; X32-SSE-NEXT:    addl (%edx), %eax
++; X32-SSE-NEXT:    movntdq %xmm4, (%esi)
++; X32-SSE-NEXT:    addl (%edx), %eax
++; X32-SSE-NEXT:    movntil %ecx, (%esi)
++; X32-SSE-NEXT:    addl (%edx), %eax
++; X32-SSE-NEXT:    movsd %xmm3, (%esi)
++; X32-SSE-NEXT:    addl (%edx), %eax
+ ; X32-SSE-NEXT:    leal -4(%ebp), %esp
+ ; X32-SSE-NEXT:    popl %esi
+ ; X32-SSE-NEXT:    popl %ebp
+@@ -56,36 +55,35 @@ define i32 @f(<4 x float> %A, i8* %B, <2 x double> %C, i32 %D, <2 x i64> %E, <4
+ ; X32-AVX-NEXT:    andl $-16, %esp
+ ; X32-AVX-NEXT:    subl $16, %esp
+ ; X32-AVX-NEXT:    vmovsd {{.*#+}} xmm3 = mem[0],zero
+-; X32-AVX-NEXT:    movl 12(%ebp), %eax
++; X32-AVX-NEXT:    movl 12(%ebp), %ecx
+ ; X32-AVX-NEXT:    vmovdqa 56(%ebp), %xmm4
+ ; X32-AVX-NEXT:    vmovdqa 40(%ebp), %xmm5
+ ; X32-AVX-NEXT:    vmovdqa 24(%ebp), %xmm6
+-; X32-AVX-NEXT:    movl 8(%ebp), %ecx
+-; X32-AVX-NEXT:    movl 80(%ebp), %edx
+-; X32-AVX-NEXT:    movl (%edx), %esi
++; X32-AVX-NEXT:    movl 8(%ebp), %edx
++; X32-AVX-NEXT:    movl 80(%ebp), %esi
++; X32-AVX-NEXT:    movl (%esi), %eax
+ ; X32-AVX-NEXT:    vaddps {{\.LCPI.*}}, %xmm0, %xmm0
+-; X32-AVX-NEXT:    vmovntps %xmm0, (%ecx)
++; X32-AVX-NEXT:    vmovntps %xmm0, (%edx)
+ ; X32-AVX-NEXT:    vpaddq {{\.LCPI.*}}, %xmm2, %xmm0
+-; X32-AVX-NEXT:    addl (%edx), %esi
+-; X32-AVX-NEXT:    vmovntdq %xmm0, (%ecx)
++; X32-AVX-NEXT:    addl (%esi), %eax
++; X32-AVX-NEXT:    vmovntdq %xmm0, (%edx)
+ ; X32-AVX-NEXT:    vaddpd {{\.LCPI.*}}, %xmm1, %xmm0
+-; X32-AVX-NEXT:    addl (%edx), %esi
+-; X32-AVX-NEXT:    vmovntpd %xmm0, (%ecx)
++; X32-AVX-NEXT:    addl (%esi), %eax
++; X32-AVX-NEXT:    vmovntpd %xmm0, (%edx)
+ ; X32-AVX-NEXT:    vpaddd {{\.LCPI.*}}, %xmm6, %xmm0
+-; X32-AVX-NEXT:    addl (%edx), %esi
+-; X32-AVX-NEXT:    vmovntdq %xmm0, (%ecx)
++; X32-AVX-NEXT:    addl (%esi), %eax
++; X32-AVX-NEXT:    vmovntdq %xmm0, (%edx)
+ ; X32-AVX-NEXT:    vpaddw {{\.LCPI.*}}, %xmm5, %xmm0
+-; X32-AVX-NEXT:    addl (%edx), %esi
+-; X32-AVX-NEXT:    vmovntdq %xmm0, (%ecx)
++; X32-AVX-NEXT:    addl (%esi), %eax
++; X32-AVX-NEXT:    vmovntdq %xmm0, (%edx)
+ ; X32-AVX-NEXT:    vpaddb {{\.LCPI.*}}, %xmm4, %xmm0
+-; X32-AVX-NEXT:    addl (%edx), %esi
+-; X32-AVX-NEXT:    vmovntdq %xmm0, (%ecx)
+-; X32-AVX-NEXT:    addl (%edx), %esi
+-; X32-AVX-NEXT:    movntil %eax, (%ecx)
+-; X32-AVX-NEXT:    movl (%edx), %eax
+-; X32-AVX-NEXT:    addl %esi, %eax
+-; X32-AVX-NEXT:    vmovsd %xmm3, (%ecx)
+-; X32-AVX-NEXT:    addl (%edx), %eax
++; X32-AVX-NEXT:    addl (%esi), %eax
++; X32-AVX-NEXT:    vmovntdq %xmm0, (%edx)
++; X32-AVX-NEXT:    addl (%esi), %eax
++; X32-AVX-NEXT:    movntil %ecx, (%edx)
++; X32-AVX-NEXT:    addl (%esi), %eax
++; X32-AVX-NEXT:    vmovsd %xmm3, (%edx)
++; X32-AVX-NEXT:    addl (%esi), %eax
+ ; X32-AVX-NEXT:    leal -4(%ebp), %esp
+ ; X32-AVX-NEXT:    popl %esi
+ ; X32-AVX-NEXT:    popl %ebp
+diff --git a/test/CodeGen/X86/pr36274.ll b/test/CodeGen/X86/pr36274.ll
+new file mode 100644
+index 00000000000..97b958c6b68
+--- /dev/null
++++ b/test/CodeGen/X86/pr36274.ll
+@@ -0,0 +1,33 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
++; RUN: llc < %s -mtriple=i386-unknown-linux-gnu | FileCheck %s
++
++; This tests is checking for a case where the x86 load-op-store fusion
++; misses a dependence between the fused load and a non-fused operand
++; to the load causing a cycle. Here the dependence in question comes
++; from the carry in input of the adcl.
++
++@vx = external local_unnamed_addr global <2 x i32>, align 8
++
++define void @pr36274(i32* %somewhere) {
++; CHECK-LABEL: pr36274:
++; CHECK:       # %bb.0:
++; CHECK-NEXT:    movl vx+4, %eax
++; CHECK-NEXT:    addl $1, vx
++; CHECK-NEXT:    adcl $0, %eax
++; CHECK-NEXT:    movl %eax, vx+4
++; CHECK-NEXT:    retl
++  %a0  = getelementptr <2 x i32>, <2 x i32>* @vx, i32 0, i32 0
++  %a1  = getelementptr <2 x i32>, <2 x i32>* @vx, i32 0, i32 1
++  %x1  = load volatile i32, i32* %a1, align 4
++  %x0  = load volatile i32, i32* %a0, align 8
++  %vx0 = insertelement <2 x i32> undef, i32 %x0, i32 0
++  %vx1 = insertelement <2 x i32> %vx0, i32 %x1, i32 1
++  %x = bitcast <2 x i32> %vx1 to i64
++  %add = add i64 %x, 1
++  %vadd = bitcast i64 %add to <2 x i32>
++  %vx1_0 = extractelement <2 x i32> %vadd, i32 0
++  %vx1_1 = extractelement <2 x i32> %vadd, i32 1
++  store i32 %vx1_0, i32* %a0, align 8
++  store i32 %vx1_1, i32* %a1, align 4
++  ret void
++}
+diff --git a/test/CodeGen/X86/pr36312.ll b/test/CodeGen/X86/pr36312.ll
+new file mode 100644
+index 00000000000..64048511ac7
+--- /dev/null
++++ b/test/CodeGen/X86/pr36312.ll
+@@ -0,0 +1,35 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
++; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu | FileCheck %s
++
++%struct.anon = type { i32, i32 }
++
++@c = common  global %struct.anon zeroinitializer, align 4
++@d =  local_unnamed_addr global %struct.anon* @c, align 8
++@a = common  local_unnamed_addr global i32 0, align 4
++@b = common  local_unnamed_addr global i32 0, align 4
++
++; Function Attrs: norecurse nounwind uwtable
++define  void @g() local_unnamed_addr #0 {
++; CHECK-LABEL: g:
++; CHECK:       # %bb.0: # %entry
++; CHECK-NEXT:    movq {{.*}}(%rip), %rax
++; CHECK-NEXT:    movl 4(%rax), %eax
++; CHECK-NEXT:    xorl %ecx, %ecx
++; CHECK-NEXT:    incl {{.*}}(%rip)
++; CHECK-NEXT:    setne %cl
++; CHECK-NEXT:    addl %eax, %ecx
++; CHECK-NEXT:    movl %ecx, {{.*}}(%rip)
++; CHECK-NEXT:    retq
++entry:
++  %0 = load %struct.anon*, %struct.anon** @d, align 8
++  %y = getelementptr inbounds %struct.anon, %struct.anon* %0, i64 0, i32 1
++  %1 = load i32, i32* %y, align 4
++  %2 = load i32, i32* @b, align 4
++  %inc = add nsw i32 %2, 1
++  store i32 %inc, i32* @b, align 4
++  %tobool = icmp ne i32 %inc, 0
++  %land.ext = zext i1 %tobool to i32
++  %add = add nsw i32 %1, %land.ext
++  store i32 %add, i32* @a, align 4
++  ret void
++}
+diff --git a/test/CodeGen/X86/store_op_load_fold2.ll b/test/CodeGen/X86/store_op_load_fold2.ll
+index f47d87f4bb8..674b8d8f938 100644
+--- a/test/CodeGen/X86/store_op_load_fold2.ll
++++ b/test/CodeGen/X86/store_op_load_fold2.ll
+@@ -17,14 +17,14 @@ cond_true2732.preheader:                ; preds = %entry
+         store i64 %tmp2676.us.us, i64* %tmp2666
+         ret i32 0
+ 
+-; INTEL: 	and	{{e..}}, dword ptr [360]
+-; INTEL:	and	dword ptr [356], {{e..}}
+-; FIXME:	mov	dword ptr [360], {{e..}}
++; INTEL: 	and	{{e..}}, dword ptr [356]
++; INTEL:	and	dword ptr [360], {{e..}}
++; FIXME:	mov	dword ptr [356], {{e..}}
+ ; The above line comes out as 'mov 360, eax', but when the register is ecx it works?
+ 
+-; ATT: 	andl	360, %{{e..}}
+-; ATT:	andl	%{{e..}}, 356
+-; ATT:	movl	%{{e..}}, 360
++; ATT: 	andl	356, %{{e..}}
++; ATT:	andl	%{{e..}}, 360
++; ATT:	movl	%{{e..}}, 356
+ 
+ }
+ 
+diff --git a/test/CodeGen/X86/subvector-broadcast.ll b/test/CodeGen/X86/subvector-broadcast.ll
+deleted file mode 100644
+index 33cf2f453ba..00000000000
+--- a/test/CodeGen/X86/subvector-broadcast.ll
++++ /dev/null
+@@ -1,1683 +0,0 @@
+-; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
+-; RUN: llc < %s -mtriple=i686-unknown-unknown -mattr=+avx | FileCheck %s --check-prefix=X32 --check-prefix=X32-AVX --check-prefix=X32-AVX1
+-; RUN: llc < %s -mtriple=i686-unknown-unknown -mattr=+avx2 | FileCheck %s --check-prefix=X32 --check-prefix=X32-AVX --check-prefix=X32-AVX2
+-; RUN: llc < %s -mtriple=i686-unknown-unknown -mattr=+avx512vl | FileCheck %s --check-prefix=X32 --check-prefix=X32-AVX512 --check-prefix=X32-AVX512F
+-; RUN: llc < %s -mtriple=i686-unknown-unknown -mattr=+avx512bw,+avx512vl | FileCheck %s --check-prefix=X32 --check-prefix=X32-AVX512 --check-prefix=X32-AVX512BW
+-; RUN: llc < %s -mtriple=i686-unknown-unknown -mattr=+avx512dq,+avx512vl | FileCheck %s --check-prefix=X32 --check-prefix=X32-AVX512 --check-prefix=X32-AVX512DQ
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx | FileCheck %s --check-prefix=X64 --check-prefix=X64-AVX --check-prefix=X64-AVX1
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx2 | FileCheck %s --check-prefix=X64 --check-prefix=X64-AVX --check-prefix=X64-AVX2
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx512vl | FileCheck %s --check-prefix=X64 --check-prefix=X64-AVX512 --check-prefix=X64-AVX512F
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx512bw,+avx512vl | FileCheck %s --check-prefix=X64 --check-prefix=X64-AVX512 --check-prefix=X64-AVX512BW
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx512dq,+avx512vl | FileCheck %s --check-prefix=X64 --check-prefix=X64-AVX512 --check-prefix=X64-AVX512DQ
+-
+-;
+-; Subvector Load + Broadcast
+-;
+-
+-define <4 x double> @test_broadcast_2f64_4f64(<2 x double> *%p) nounwind {
+-; X32-LABEL: test_broadcast_2f64_4f64:
+-; X32:       # %bb.0:
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: test_broadcast_2f64_4f64:
+-; X64:       # %bb.0:
+-; X64-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-NEXT:    retq
+- %1 = load <2 x double>, <2 x double> *%p
+- %2 = shufflevector <2 x double> %1, <2 x double> undef, <4 x i32> <i32 0, i32 1, i32 0, i32 1>
+- ret <4 x double> %2
+-}
+-
+-define <8 x double> @test_broadcast_2f64_8f64(<2 x double> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_2f64_8f64:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_2f64_8f64:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcastf32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_2f64_8f64:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_2f64_8f64:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcastf32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <2 x double>, <2 x double> *%p
+- %2 = shufflevector <2 x double> %1, <2 x double> undef, <8 x i32> <i32 0, i32 1, i32 0, i32 1, i32 0, i32 1, i32 0, i32 1>
+- ret <8 x double> %2
+-}
+-
+-define <8 x double> @test_broadcast_4f64_8f64(<4 x double> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_4f64_8f64:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_4f64_8f64:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcastf64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_4f64_8f64:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_4f64_8f64:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcastf64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <4 x double>, <4 x double> *%p
+- %2 = shufflevector <4 x double> %1, <4 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x double> %2
+-}
+-
+-define <4 x i64> @test_broadcast_2i64_4i64(<2 x i64> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_2i64_4i64:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_2i64_4i64:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_2i64_4i64:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_2i64_4i64:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <2 x i64>, <2 x i64> *%p
+- %2 = shufflevector <2 x i64> %1, <2 x i64> undef, <4 x i32> <i32 0, i32 1, i32 0, i32 1>
+- ret <4 x i64> %2
+-}
+-
+-define <8 x i64> @test_broadcast_2i64_8i64(<2 x i64> *%p) nounwind {
+-; X32-AVX1-LABEL: test_broadcast_2i64_8i64:
+-; X32-AVX1:       # %bb.0:
+-; X32-AVX1-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX1-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX1-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX1-NEXT:    retl
+-;
+-; X32-AVX2-LABEL: test_broadcast_2i64_8i64:
+-; X32-AVX2:       # %bb.0:
+-; X32-AVX2-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX2-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX2-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX2-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_2i64_8i64:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcasti32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX1-LABEL: test_broadcast_2i64_8i64:
+-; X64-AVX1:       # %bb.0:
+-; X64-AVX1-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX1-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX1-NEXT:    retq
+-;
+-; X64-AVX2-LABEL: test_broadcast_2i64_8i64:
+-; X64-AVX2:       # %bb.0:
+-; X64-AVX2-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX2-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX2-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_2i64_8i64:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcasti32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <2 x i64>, <2 x i64> *%p
+- %2 = shufflevector <2 x i64> %1, <2 x i64> undef, <8 x i32> <i32 0, i32 1, i32 0, i32 1, i32 0, i32 1, i32 0, i32 1>
+- ret <8 x i64> %2
+-}
+-
+-define <8 x i64> @test_broadcast_4i64_8i64(<4 x i64> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_4i64_8i64:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_4i64_8i64:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcasti64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_4i64_8i64:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_4i64_8i64:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcasti64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <4 x i64>, <4 x i64> *%p
+- %2 = shufflevector <4 x i64> %1, <4 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x i64> %2
+-}
+-
+-define <8 x float> @test_broadcast_4f32_8f32(<4 x float> *%p) nounwind {
+-; X32-LABEL: test_broadcast_4f32_8f32:
+-; X32:       # %bb.0:
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: test_broadcast_4f32_8f32:
+-; X64:       # %bb.0:
+-; X64-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-NEXT:    retq
+- %1 = load <4 x float>, <4 x float> *%p
+- %2 = shufflevector <4 x float> %1, <4 x float> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x float> %2
+-}
+-
+-define <16 x float> @test_broadcast_4f32_16f32(<4 x float> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_4f32_16f32:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_4f32_16f32:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcastf32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_4f32_16f32:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_4f32_16f32:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcastf32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <4 x float>, <4 x float> *%p
+- %2 = shufflevector <4 x float> %1, <4 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <16 x float> %2
+-}
+-
+-define <16 x float> @test_broadcast_8f32_16f32(<8 x float> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_8f32_16f32:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_8f32_16f32:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcastf64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_8f32_16f32:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_8f32_16f32:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcastf64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <8 x float>, <8 x float> *%p
+- %2 = shufflevector <8 x float> %1, <8 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+- ret <16 x float> %2
+-}
+-
+-define <8 x i32> @test_broadcast_4i32_8i32(<4 x i32> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_4i32_8i32:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_4i32_8i32:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_4i32_8i32:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_4i32_8i32:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <4 x i32>, <4 x i32> *%p
+- %2 = shufflevector <4 x i32> %1, <4 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x i32> %2
+-}
+-
+-define <16 x i32> @test_broadcast_4i32_16i32(<4 x i32> *%p) nounwind {
+-; X32-AVX1-LABEL: test_broadcast_4i32_16i32:
+-; X32-AVX1:       # %bb.0:
+-; X32-AVX1-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX1-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX1-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX1-NEXT:    retl
+-;
+-; X32-AVX2-LABEL: test_broadcast_4i32_16i32:
+-; X32-AVX2:       # %bb.0:
+-; X32-AVX2-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX2-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX2-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX2-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_4i32_16i32:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcasti32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX1-LABEL: test_broadcast_4i32_16i32:
+-; X64-AVX1:       # %bb.0:
+-; X64-AVX1-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX1-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX1-NEXT:    retq
+-;
+-; X64-AVX2-LABEL: test_broadcast_4i32_16i32:
+-; X64-AVX2:       # %bb.0:
+-; X64-AVX2-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX2-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX2-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_4i32_16i32:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcasti32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <4 x i32>, <4 x i32> *%p
+- %2 = shufflevector <4 x i32> %1, <4 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <16 x i32> %2
+-}
+-
+-define <16 x i32> @test_broadcast_8i32_16i32(<8 x i32> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_8i32_16i32:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_8i32_16i32:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcasti64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_8i32_16i32:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_8i32_16i32:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcasti64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <8 x i32>, <8 x i32> *%p
+- %2 = shufflevector <8 x i32> %1, <8 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+- ret <16 x i32> %2
+-}
+-
+-define <16 x i16> @test_broadcast_8i16_16i16(<8 x i16> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_8i16_16i16:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_8i16_16i16:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_8i16_16i16:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_8i16_16i16:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <8 x i16>, <8 x i16> *%p
+- %2 = shufflevector <8 x i16> %1, <8 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+- ret <16 x i16> %2
+-}
+-
+-define <32 x i16> @test_broadcast_8i16_32i16(<8 x i16> *%p) nounwind {
+-; X32-AVX1-LABEL: test_broadcast_8i16_32i16:
+-; X32-AVX1:       # %bb.0:
+-; X32-AVX1-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX1-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX1-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX1-NEXT:    retl
+-;
+-; X32-AVX2-LABEL: test_broadcast_8i16_32i16:
+-; X32-AVX2:       # %bb.0:
+-; X32-AVX2-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX2-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX2-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX2-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: test_broadcast_8i16_32i16:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX512F-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: test_broadcast_8i16_32i16:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: test_broadcast_8i16_32i16:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512DQ-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX512DQ-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX1-LABEL: test_broadcast_8i16_32i16:
+-; X64-AVX1:       # %bb.0:
+-; X64-AVX1-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX1-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX1-NEXT:    retq
+-;
+-; X64-AVX2-LABEL: test_broadcast_8i16_32i16:
+-; X64-AVX2:       # %bb.0:
+-; X64-AVX2-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX2-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX2-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: test_broadcast_8i16_32i16:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX512F-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: test_broadcast_8i16_32i16:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: test_broadcast_8i16_32i16:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX512DQ-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX512DQ-NEXT:    retq
+- %1 = load <8 x i16>, <8 x i16> *%p
+- %2 = shufflevector <8 x i16> %1, <8 x i16> undef, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+- ret <32 x i16> %2
+-}
+-
+-define <32 x i16> @test_broadcast_16i16_32i16(<16 x i16> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_16i16_32i16:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: test_broadcast_16i16_32i16:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512F-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: test_broadcast_16i16_32i16:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512BW-NEXT:    vbroadcasti64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: test_broadcast_16i16_32i16:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512DQ-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_16i16_32i16:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: test_broadcast_16i16_32i16:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: test_broadcast_16i16_32i16:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    vbroadcasti64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: test_broadcast_16i16_32i16:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512DQ-NEXT:    retq
+- %1 = load <16 x i16>, <16 x i16> *%p
+- %2 = shufflevector <16 x i16> %1, <16 x i16> undef, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+- ret <32 x i16> %2
+-}
+-
+-define <32 x i8> @test_broadcast_16i8_32i8(<16 x i8> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_16i8_32i8:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: test_broadcast_16i8_32i8:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_16i8_32i8:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: test_broadcast_16i8_32i8:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX512-NEXT:    retq
+- %1 = load <16 x i8>, <16 x i8> *%p
+- %2 = shufflevector <16 x i8> %1, <16 x i8> undef, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+- ret <32 x i8> %2
+-}
+-
+-define <64 x i8> @test_broadcast_16i8_64i8(<16 x i8> *%p) nounwind {
+-; X32-AVX1-LABEL: test_broadcast_16i8_64i8:
+-; X32-AVX1:       # %bb.0:
+-; X32-AVX1-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX1-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX1-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX1-NEXT:    retl
+-;
+-; X32-AVX2-LABEL: test_broadcast_16i8_64i8:
+-; X32-AVX2:       # %bb.0:
+-; X32-AVX2-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX2-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX2-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX2-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: test_broadcast_16i8_64i8:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX512F-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: test_broadcast_16i8_64i8:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: test_broadcast_16i8_64i8:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512DQ-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X32-AVX512DQ-NEXT:    vmovdqa %ymm0, %ymm1
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX1-LABEL: test_broadcast_16i8_64i8:
+-; X64-AVX1:       # %bb.0:
+-; X64-AVX1-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX1-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX1-NEXT:    retq
+-;
+-; X64-AVX2-LABEL: test_broadcast_16i8_64i8:
+-; X64-AVX2:       # %bb.0:
+-; X64-AVX2-NEXT:    vbroadcastf128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX2-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX2-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: test_broadcast_16i8_64i8:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX512F-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: test_broadcast_16i8_64i8:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: test_broadcast_16i8_64i8:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = mem[0,1,0,1]
+-; X64-AVX512DQ-NEXT:    vmovdqa %ymm0, %ymm1
+-; X64-AVX512DQ-NEXT:    retq
+- %1 = load <16 x i8>, <16 x i8> *%p
+- %2 = shufflevector <16 x i8> %1, <16 x i8> undef, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+- ret <64 x i8> %2
+-}
+-
+-define <64 x i8> @test_broadcast_32i8_64i8(<32 x i8> *%p) nounwind {
+-; X32-AVX-LABEL: test_broadcast_32i8_64i8:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: test_broadcast_32i8_64i8:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512F-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: test_broadcast_32i8_64i8:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512BW-NEXT:    vbroadcasti64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: test_broadcast_32i8_64i8:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512DQ-NEXT:    vmovaps (%eax), %ymm0
+-; X32-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_32i8_64i8:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: test_broadcast_32i8_64i8:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: test_broadcast_32i8_64i8:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    vbroadcasti64x4 {{.*#+}} zmm0 = mem[0,1,2,3,0,1,2,3]
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: test_broadcast_32i8_64i8:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    vmovaps (%rdi), %ymm0
+-; X64-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512DQ-NEXT:    retq
+- %1 = load <32 x i8>, <32 x i8> *%p
+- %2 = shufflevector <32 x i8> %1, <32 x i8> undef, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+- ret <64 x i8> %2
+-}
+-
+-;
+-; Subvector Load + Broadcast + Store
+-;
+-
+-define <4 x double> @test_broadcast_2f64_4f64_reuse(<2 x double>* %p0, <2 x double>* %p1) {
+-; X32-LABEL: test_broadcast_2f64_4f64_reuse:
+-; X32:       # %bb.0:
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-NEXT:    vmovaps %xmm0, (%eax)
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: test_broadcast_2f64_4f64_reuse:
+-; X64:       # %bb.0:
+-; X64-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-NEXT:    vmovaps %xmm0, (%rsi)
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = load <2 x double>, <2 x double>* %p0
+- store <2 x double> %1, <2 x double>* %p1
+- %2 = shufflevector <2 x double> %1, <2 x double> undef, <4 x i32> <i32 0, i32 1, i32 0, i32 1>
+- ret <4 x double> %2
+-}
+-
+-define <4 x i64> @test_broadcast_2i64_4i64_reuse(<2 x i64>* %p0, <2 x i64>* %p1) {
+-; X32-LABEL: test_broadcast_2i64_4i64_reuse:
+-; X32:       # %bb.0:
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-NEXT:    vmovaps %xmm0, (%eax)
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: test_broadcast_2i64_4i64_reuse:
+-; X64:       # %bb.0:
+-; X64-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-NEXT:    vmovaps %xmm0, (%rsi)
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = load <2 x i64>, <2 x i64>* %p0
+- store <2 x i64> %1, <2 x i64>* %p1
+- %2 = shufflevector <2 x i64> %1, <2 x i64> undef, <4 x i32> <i32 0, i32 1, i32 0, i32 1>
+- ret <4 x i64> %2
+-}
+-
+-define <8 x float> @test_broadcast_4f32_8f32_reuse(<4 x float>* %p0, <4 x float>* %p1) {
+-; X32-LABEL: test_broadcast_4f32_8f32_reuse:
+-; X32:       # %bb.0:
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-NEXT:    vmovaps %xmm0, (%eax)
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: test_broadcast_4f32_8f32_reuse:
+-; X64:       # %bb.0:
+-; X64-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-NEXT:    vmovaps %xmm0, (%rsi)
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = load <4 x float>, <4 x float>* %p0
+- store <4 x float> %1, <4 x float>* %p1
+- %2 = shufflevector <4 x float> %1, <4 x float> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x float> %2
+-}
+-
+-define <8 x i32> @test_broadcast_4i32_8i32_reuse(<4 x i32>* %p0, <4 x i32>* %p1) {
+-; X32-LABEL: test_broadcast_4i32_8i32_reuse:
+-; X32:       # %bb.0:
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-NEXT:    vmovaps %xmm0, (%eax)
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: test_broadcast_4i32_8i32_reuse:
+-; X64:       # %bb.0:
+-; X64-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-NEXT:    vmovaps %xmm0, (%rsi)
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = load <4 x i32>, <4 x i32>* %p0
+- store <4 x i32> %1, <4 x i32>* %p1
+- %2 = shufflevector <4 x i32> %1, <4 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x i32> %2
+-}
+-
+-define <16 x i16> @test_broadcast_8i16_16i16_reuse(<8 x i16> *%p0, <8 x i16> *%p1) nounwind {
+-; X32-LABEL: test_broadcast_8i16_16i16_reuse:
+-; X32:       # %bb.0:
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-NEXT:    vmovaps %xmm0, (%eax)
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: test_broadcast_8i16_16i16_reuse:
+-; X64:       # %bb.0:
+-; X64-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-NEXT:    vmovaps %xmm0, (%rsi)
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = load <8 x i16>, <8 x i16> *%p0
+- store <8 x i16> %1, <8 x i16>* %p1
+- %2 = shufflevector <8 x i16> %1, <8 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+- ret <16 x i16> %2
+-}
+-
+-define <32 x i8> @test_broadcast_16i8_32i8_reuse(<16 x i8> *%p0, <16 x i8> *%p1) nounwind {
+-; X32-LABEL: test_broadcast_16i8_32i8_reuse:
+-; X32:       # %bb.0:
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-NEXT:    vmovaps %xmm0, (%eax)
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: test_broadcast_16i8_32i8_reuse:
+-; X64:       # %bb.0:
+-; X64-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-NEXT:    vmovaps %xmm0, (%rsi)
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = load <16 x i8>, <16 x i8> *%p0
+- store <16 x i8> %1, <16 x i8>* %p1
+- %2 = shufflevector <16 x i8> %1, <16 x i8> undef, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+- ret <32 x i8> %2
+-}
+-
+-;
+-; Subvector Load + Broadcast with Separate Store
+-;
+-
+-define <8 x i32> @test_broadcast_4i32_8i32_chain(<4 x i32>* %p0, <4 x float>* %p1) {
+-; X32-AVX-LABEL: test_broadcast_4i32_8i32_chain:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-AVX-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-AVX-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+-; X32-AVX-NEXT:    vmovaps %xmm1, (%eax)
+-; X32-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: test_broadcast_4i32_8i32_chain:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-AVX512F-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-AVX512F-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+-; X32-AVX512F-NEXT:    vmovdqa %xmm1, (%eax)
+-; X32-AVX512F-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: test_broadcast_4i32_8i32_chain:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512BW-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-AVX512BW-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-AVX512BW-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+-; X32-AVX512BW-NEXT:    vmovdqa %xmm1, (%eax)
+-; X32-AVX512BW-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: test_broadcast_4i32_8i32_chain:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512DQ-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-AVX512DQ-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-AVX512DQ-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+-; X32-AVX512DQ-NEXT:    vmovaps %xmm1, (%eax)
+-; X32-AVX512DQ-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_4i32_8i32_chain:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-AVX-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+-; X64-AVX-NEXT:    vmovaps %xmm1, (%rsi)
+-; X64-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: test_broadcast_4i32_8i32_chain:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-AVX512F-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+-; X64-AVX512F-NEXT:    vmovdqa %xmm1, (%rsi)
+-; X64-AVX512F-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: test_broadcast_4i32_8i32_chain:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-AVX512BW-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+-; X64-AVX512BW-NEXT:    vmovdqa %xmm1, (%rsi)
+-; X64-AVX512BW-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: test_broadcast_4i32_8i32_chain:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-AVX512DQ-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+-; X64-AVX512DQ-NEXT:    vmovaps %xmm1, (%rsi)
+-; X64-AVX512DQ-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512DQ-NEXT:    retq
+-  %1 = load <4 x i32>, <4 x i32>* %p0
+-  store <4 x float> zeroinitializer, <4 x float>* %p1
+-  %2 = shufflevector <4 x i32> %1, <4 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+-  ret <8 x i32> %2
+-}
+-
+-define <16 x i32> @test_broadcast_4i32_16i32_chain(<4 x i32>* %p0, <4 x float>* %p1) {
+-; X32-AVX-LABEL: test_broadcast_4i32_16i32_chain:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-AVX-NEXT:    vmovaps (%ecx), %xmm0
+-; X32-AVX-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+-; X32-AVX-NEXT:    vmovaps %xmm1, (%eax)
+-; X32-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: test_broadcast_4i32_16i32_chain:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-AVX512F-NEXT:    vmovdqa (%ecx), %xmm0
+-; X32-AVX512F-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+-; X32-AVX512F-NEXT:    vmovdqa %xmm1, (%eax)
+-; X32-AVX512F-NEXT:    vshufi32x4 {{.*#+}} zmm0 = zmm0[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: test_broadcast_4i32_16i32_chain:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512BW-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-AVX512BW-NEXT:    vmovdqa (%ecx), %xmm0
+-; X32-AVX512BW-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+-; X32-AVX512BW-NEXT:    vmovdqa %xmm1, (%eax)
+-; X32-AVX512BW-NEXT:    vshufi32x4 {{.*#+}} zmm0 = zmm0[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: test_broadcast_4i32_16i32_chain:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512DQ-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+-; X32-AVX512DQ-NEXT:    vmovdqa (%ecx), %xmm0
+-; X32-AVX512DQ-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+-; X32-AVX512DQ-NEXT:    vmovaps %xmm1, (%eax)
+-; X32-AVX512DQ-NEXT:    vshufi32x4 {{.*#+}} zmm0 = zmm0[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX-LABEL: test_broadcast_4i32_16i32_chain:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps (%rdi), %xmm0
+-; X64-AVX-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+-; X64-AVX-NEXT:    vmovaps %xmm1, (%rsi)
+-; X64-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: test_broadcast_4i32_16i32_chain:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    vmovdqa (%rdi), %xmm0
+-; X64-AVX512F-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+-; X64-AVX512F-NEXT:    vmovdqa %xmm1, (%rsi)
+-; X64-AVX512F-NEXT:    vshufi32x4 {{.*#+}} zmm0 = zmm0[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: test_broadcast_4i32_16i32_chain:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    vmovdqa (%rdi), %xmm0
+-; X64-AVX512BW-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+-; X64-AVX512BW-NEXT:    vmovdqa %xmm1, (%rsi)
+-; X64-AVX512BW-NEXT:    vshufi32x4 {{.*#+}} zmm0 = zmm0[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: test_broadcast_4i32_16i32_chain:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    vmovdqa (%rdi), %xmm0
+-; X64-AVX512DQ-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+-; X64-AVX512DQ-NEXT:    vmovaps %xmm1, (%rsi)
+-; X64-AVX512DQ-NEXT:    vshufi32x4 {{.*#+}} zmm0 = zmm0[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+-; X64-AVX512DQ-NEXT:    retq
+-  %1 = load <4 x i32>, <4 x i32>* %p0
+-  store <4 x float> zeroinitializer, <4 x float>* %p1
+-  %2 = shufflevector <4 x i32> %1, <4 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+-  ret <16 x i32> %2
+-}
+-
+-;
+-; subvector Load with multiple uses + broadcast
+-; Fallback to the broadcast should be done
+-;
+-
+-@ga4 = global <4 x i64> zeroinitializer, align 8
+-@gb4 = global <8 x i64> zeroinitializer, align 8
+-
+-define void @fallback_broadcast_v4i64_to_v8i64(<4 x i64> %a, <8 x i64> %b) {
+-; X32-AVX1-LABEL: fallback_broadcast_v4i64_to_v8i64:
+-; X32-AVX1:       # %bb.0: # %entry
+-; X32-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm3
+-; X32-AVX1-NEXT:    vmovdqa {{.*#+}} ymm4 = [1,0,2,0,3,0,4,0]
+-; X32-AVX1-NEXT:    vextractf128 $1, %ymm4, %xmm5
+-; X32-AVX1-NEXT:    vpaddq %xmm5, %xmm3, %xmm3
+-; X32-AVX1-NEXT:    vpaddq %xmm4, %xmm0, %xmm0
+-; X32-AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm0, %ymm0
+-; X32-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm3
+-; X32-AVX1-NEXT:    vpaddq %xmm5, %xmm3, %xmm3
+-; X32-AVX1-NEXT:    vpaddq %xmm4, %xmm2, %xmm2
+-; X32-AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm2, %ymm2
+-; X32-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm3
+-; X32-AVX1-NEXT:    vpaddq %xmm5, %xmm3, %xmm3
+-; X32-AVX1-NEXT:    vpaddq %xmm4, %xmm1, %xmm1
+-; X32-AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm1, %ymm1
+-; X32-AVX1-NEXT:    vandps %ymm4, %ymm1, %ymm1
+-; X32-AVX1-NEXT:    vandps %ymm4, %ymm2, %ymm2
+-; X32-AVX1-NEXT:    vmovups %ymm0, ga4
+-; X32-AVX1-NEXT:    vmovups %ymm2, gb4+32
+-; X32-AVX1-NEXT:    vmovups %ymm1, gb4
+-; X32-AVX1-NEXT:    vzeroupper
+-; X32-AVX1-NEXT:    retl
+-;
+-; X32-AVX2-LABEL: fallback_broadcast_v4i64_to_v8i64:
+-; X32-AVX2:       # %bb.0: # %entry
+-; X32-AVX2-NEXT:    vmovdqa {{.*#+}} ymm3 = [1,0,2,0,3,0,4,0]
+-; X32-AVX2-NEXT:    vpaddq %ymm3, %ymm0, %ymm0
+-; X32-AVX2-NEXT:    vpaddq %ymm3, %ymm2, %ymm2
+-; X32-AVX2-NEXT:    vpaddq %ymm3, %ymm1, %ymm1
+-; X32-AVX2-NEXT:    vpand %ymm3, %ymm1, %ymm1
+-; X32-AVX2-NEXT:    vpand %ymm3, %ymm2, %ymm2
+-; X32-AVX2-NEXT:    vmovdqu %ymm0, ga4
+-; X32-AVX2-NEXT:    vmovdqu %ymm2, gb4+32
+-; X32-AVX2-NEXT:    vmovdqu %ymm1, gb4
+-; X32-AVX2-NEXT:    vzeroupper
+-; X32-AVX2-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: fallback_broadcast_v4i64_to_v8i64:
+-; X32-AVX512:       # %bb.0: # %entry
+-; X32-AVX512-NEXT:    vpaddq {{\.LCPI.*}}, %ymm0, %ymm0
+-; X32-AVX512-NEXT:    vmovdqa64 {{.*#+}} zmm2 = [1,0,2,0,3,0,4,0,1,0,2,0,3,0,4,0]
+-; X32-AVX512-NEXT:    vpaddq %zmm2, %zmm1, %zmm1
+-; X32-AVX512-NEXT:    vpandq %zmm2, %zmm1, %zmm1
+-; X32-AVX512-NEXT:    vmovdqu %ymm0, ga4
+-; X32-AVX512-NEXT:    vmovdqu64 %zmm1, gb4
+-; X32-AVX512-NEXT:    vzeroupper
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX1-LABEL: fallback_broadcast_v4i64_to_v8i64:
+-; X64-AVX1:       # %bb.0: # %entry
+-; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm3
+-; X64-AVX1-NEXT:    vmovdqa {{.*#+}} xmm4 = [3,4]
+-; X64-AVX1-NEXT:    vpaddq %xmm4, %xmm3, %xmm3
+-; X64-AVX1-NEXT:    vmovdqa {{.*#+}} xmm5 = [1,2]
+-; X64-AVX1-NEXT:    vpaddq %xmm5, %xmm0, %xmm0
+-; X64-AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm0, %ymm0
+-; X64-AVX1-NEXT:    vmovaps {{.*#+}} ymm3 = [1,2,3,4]
+-; X64-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm6
+-; X64-AVX1-NEXT:    vpaddq %xmm4, %xmm6, %xmm6
+-; X64-AVX1-NEXT:    vpaddq %xmm5, %xmm2, %xmm2
+-; X64-AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm2, %ymm2
+-; X64-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm6
+-; X64-AVX1-NEXT:    vpaddq %xmm4, %xmm6, %xmm4
+-; X64-AVX1-NEXT:    vpaddq %xmm5, %xmm1, %xmm1
+-; X64-AVX1-NEXT:    vinsertf128 $1, %xmm4, %ymm1, %ymm1
+-; X64-AVX1-NEXT:    vandps %ymm3, %ymm1, %ymm1
+-; X64-AVX1-NEXT:    vandps %ymm3, %ymm2, %ymm2
+-; X64-AVX1-NEXT:    vmovups %ymm0, {{.*}}(%rip)
+-; X64-AVX1-NEXT:    vmovups %ymm2, gb4+{{.*}}(%rip)
+-; X64-AVX1-NEXT:    vmovups %ymm1, {{.*}}(%rip)
+-; X64-AVX1-NEXT:    vzeroupper
+-; X64-AVX1-NEXT:    retq
+-;
+-; X64-AVX2-LABEL: fallback_broadcast_v4i64_to_v8i64:
+-; X64-AVX2:       # %bb.0: # %entry
+-; X64-AVX2-NEXT:    vmovdqa {{.*#+}} ymm3 = [1,2,3,4]
+-; X64-AVX2-NEXT:    vpaddq %ymm3, %ymm0, %ymm0
+-; X64-AVX2-NEXT:    vpaddq %ymm3, %ymm2, %ymm2
+-; X64-AVX2-NEXT:    vpaddq %ymm3, %ymm1, %ymm1
+-; X64-AVX2-NEXT:    vpand %ymm3, %ymm1, %ymm1
+-; X64-AVX2-NEXT:    vpand %ymm3, %ymm2, %ymm2
+-; X64-AVX2-NEXT:    vmovdqu %ymm0, {{.*}}(%rip)
+-; X64-AVX2-NEXT:    vmovdqu %ymm2, gb4+{{.*}}(%rip)
+-; X64-AVX2-NEXT:    vmovdqu %ymm1, {{.*}}(%rip)
+-; X64-AVX2-NEXT:    vzeroupper
+-; X64-AVX2-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: fallback_broadcast_v4i64_to_v8i64:
+-; X64-AVX512:       # %bb.0: # %entry
+-; X64-AVX512-NEXT:    vmovdqa {{.*#+}} ymm2 = [1,2,3,4]
+-; X64-AVX512-NEXT:    vpaddq %ymm2, %ymm0, %ymm0
+-; X64-AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm2, %zmm2
+-; X64-AVX512-NEXT:    vpaddq %zmm2, %zmm1, %zmm1
+-; X64-AVX512-NEXT:    vpandq %zmm2, %zmm1, %zmm1
+-; X64-AVX512-NEXT:    vmovdqu %ymm0, {{.*}}(%rip)
+-; X64-AVX512-NEXT:    vmovdqu64 %zmm1, {{.*}}(%rip)
+-; X64-AVX512-NEXT:    vzeroupper
+-; X64-AVX512-NEXT:    retq
+-entry:
+-  %0 = add <4 x i64> %a, <i64 1, i64 2, i64 3, i64 4>
+-  %1 = add <8 x i64> %b, <i64 1, i64 2, i64 3, i64 4, i64 1, i64 2, i64 3, i64 4>
+-  %2 = and <8 x i64> %1, <i64 1, i64 2, i64 3, i64 4, i64 1, i64 2, i64 3, i64 4>
+-  store <4 x i64> %0, <4 x i64>* @ga4, align 8
+-  store <8 x i64> %2, <8 x i64>* @gb4, align 8
+-  ret void
+-}
+-
+-
+-@ga2 = global <4 x double> zeroinitializer, align 8
+-@gb2 = global <8 x double> zeroinitializer, align 8
+-
+-define void @fallback_broadcast_v4f64_to_v8f64(<4 x double> %a, <8 x double> %b) {
+-; X32-AVX-LABEL: fallback_broadcast_v4f64_to_v8f64:
+-; X32-AVX:       # %bb.0: # %entry
+-; X32-AVX-NEXT:    vmovapd {{.*#+}} ymm3 = [1.000000e+00,2.000000e+00,3.000000e+00,4.000000e+00]
+-; X32-AVX-NEXT:    vaddpd %ymm3, %ymm0, %ymm0
+-; X32-AVX-NEXT:    vaddpd %ymm3, %ymm2, %ymm2
+-; X32-AVX-NEXT:    vaddpd %ymm3, %ymm1, %ymm1
+-; X32-AVX-NEXT:    vdivpd %ymm3, %ymm1, %ymm1
+-; X32-AVX-NEXT:    vdivpd %ymm3, %ymm2, %ymm2
+-; X32-AVX-NEXT:    vmovupd %ymm0, ga2
+-; X32-AVX-NEXT:    vmovupd %ymm2, gb2+32
+-; X32-AVX-NEXT:    vmovupd %ymm1, gb2
+-; X32-AVX-NEXT:    vzeroupper
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: fallback_broadcast_v4f64_to_v8f64:
+-; X32-AVX512:       # %bb.0: # %entry
+-; X32-AVX512-NEXT:    vmovapd {{.*#+}} ymm2 = [1.000000e+00,2.000000e+00,3.000000e+00,4.000000e+00]
+-; X32-AVX512-NEXT:    vaddpd %ymm2, %ymm0, %ymm0
+-; X32-AVX512-NEXT:    vinsertf64x4 $1, %ymm2, %zmm2, %zmm2
+-; X32-AVX512-NEXT:    vaddpd %zmm2, %zmm1, %zmm1
+-; X32-AVX512-NEXT:    vdivpd %zmm2, %zmm1, %zmm1
+-; X32-AVX512-NEXT:    vmovupd %ymm0, ga2
+-; X32-AVX512-NEXT:    vmovupd %zmm1, gb2
+-; X32-AVX512-NEXT:    vzeroupper
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: fallback_broadcast_v4f64_to_v8f64:
+-; X64-AVX:       # %bb.0: # %entry
+-; X64-AVX-NEXT:    vmovapd {{.*#+}} ymm3 = [1.000000e+00,2.000000e+00,3.000000e+00,4.000000e+00]
+-; X64-AVX-NEXT:    vaddpd %ymm3, %ymm0, %ymm0
+-; X64-AVX-NEXT:    vaddpd %ymm3, %ymm2, %ymm2
+-; X64-AVX-NEXT:    vaddpd %ymm3, %ymm1, %ymm1
+-; X64-AVX-NEXT:    vdivpd %ymm3, %ymm1, %ymm1
+-; X64-AVX-NEXT:    vdivpd %ymm3, %ymm2, %ymm2
+-; X64-AVX-NEXT:    vmovupd %ymm0, {{.*}}(%rip)
+-; X64-AVX-NEXT:    vmovupd %ymm2, gb2+{{.*}}(%rip)
+-; X64-AVX-NEXT:    vmovupd %ymm1, {{.*}}(%rip)
+-; X64-AVX-NEXT:    vzeroupper
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: fallback_broadcast_v4f64_to_v8f64:
+-; X64-AVX512:       # %bb.0: # %entry
+-; X64-AVX512-NEXT:    vmovapd {{.*#+}} ymm2 = [1.000000e+00,2.000000e+00,3.000000e+00,4.000000e+00]
+-; X64-AVX512-NEXT:    vaddpd %ymm2, %ymm0, %ymm0
+-; X64-AVX512-NEXT:    vinsertf64x4 $1, %ymm2, %zmm2, %zmm2
+-; X64-AVX512-NEXT:    vaddpd %zmm2, %zmm1, %zmm1
+-; X64-AVX512-NEXT:    vdivpd %zmm2, %zmm1, %zmm1
+-; X64-AVX512-NEXT:    vmovupd %ymm0, {{.*}}(%rip)
+-; X64-AVX512-NEXT:    vmovupd %zmm1, {{.*}}(%rip)
+-; X64-AVX512-NEXT:    vzeroupper
+-; X64-AVX512-NEXT:    retq
+-entry:
+-  %0 = fadd <4 x double> %a, <double 1.0, double 2.0, double 3.0, double 4.0>
+-  %1 = fadd <8 x double> %b, <double 1.0, double 2.0, double 3.0, double 4.0, double 1.0, double 2.0, double 3.0, double 4.0>
+-  %2 = fdiv <8 x double> %1, <double 1.0, double 2.0, double 3.0, double 4.0, double 1.0, double 2.0, double 3.0, double 4.0>
+-  store <4 x double> %0, <4 x double>* @ga2, align 8
+-  store <8 x double> %2, <8 x double>* @gb2, align 8
+-  ret void
+-}
+-
+-;
+-; Subvector Broadcast from register
+-;
+-
+-define <4 x double> @reg_broadcast_2f64_4f64(<2 x double> %a0) nounwind {
+-; X32-LABEL: reg_broadcast_2f64_4f64:
+-; X32:       # %bb.0:
+-; X32-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: reg_broadcast_2f64_4f64:
+-; X64:       # %bb.0:
+-; X64-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = shufflevector <2 x double> %a0, <2 x double> undef, <4 x i32> <i32 0, i32 1, i32 0, i32 1>
+- ret <4 x double> %1
+-}
+-
+-define <8 x double> @reg_broadcast_2f64_8f64(<2 x double> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_2f64_8f64:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: reg_broadcast_2f64_8f64:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_2f64_8f64:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: reg_broadcast_2f64_8f64:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512-NEXT:    retq
+- %1 = shufflevector <2 x double> %a0, <2 x double> undef, <8 x i32> <i32 0, i32 1, i32 0, i32 1, i32 0, i32 1, i32 0, i32 1>
+- ret <8 x double> %1
+-}
+-
+-define <8 x double> @reg_broadcast_4f64_8f64(<4 x double> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_4f64_8f64:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: reg_broadcast_4f64_8f64:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X32-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_4f64_8f64:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: reg_broadcast_4f64_8f64:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X64-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512-NEXT:    retq
+- %1 = shufflevector <4 x double> %a0, <4 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x double> %1
+-}
+-
+-define <4 x i64> @reg_broadcast_2i64_4i64(<2 x i64> %a0) nounwind {
+-; X32-LABEL: reg_broadcast_2i64_4i64:
+-; X32:       # %bb.0:
+-; X32-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: reg_broadcast_2i64_4i64:
+-; X64:       # %bb.0:
+-; X64-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = shufflevector <2 x i64> %a0, <2 x i64> undef, <4 x i32> <i32 0, i32 1, i32 0, i32 1>
+- ret <4 x i64> %1
+-}
+-
+-define <8 x i64> @reg_broadcast_2i64_8i64(<2 x i64> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_2i64_8i64:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: reg_broadcast_2i64_8i64:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_2i64_8i64:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: reg_broadcast_2i64_8i64:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512-NEXT:    retq
+- %1 = shufflevector <2 x i64> %a0, <2 x i64> undef, <8 x i32> <i32 0, i32 1, i32 0, i32 1, i32 0, i32 1, i32 0, i32 1>
+- ret <8 x i64> %1
+-}
+-
+-define <8 x i64> @reg_broadcast_4i64_8i64(<4 x i64> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_4i64_8i64:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: reg_broadcast_4i64_8i64:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X32-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_4i64_8i64:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: reg_broadcast_4i64_8i64:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X64-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512-NEXT:    retq
+- %1 = shufflevector <4 x i64> %a0, <4 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x i64> %1
+-}
+-
+-define <8 x float> @reg_broadcast_4f32_8f32(<4 x float> %a0) nounwind {
+-; X32-LABEL: reg_broadcast_4f32_8f32:
+-; X32:       # %bb.0:
+-; X32-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: reg_broadcast_4f32_8f32:
+-; X64:       # %bb.0:
+-; X64-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = shufflevector <4 x float> %a0, <4 x float> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x float> %1
+-}
+-
+-define <16 x float> @reg_broadcast_4f32_16f32(<4 x float> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_4f32_16f32:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: reg_broadcast_4f32_16f32:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_4f32_16f32:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: reg_broadcast_4f32_16f32:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512-NEXT:    retq
+- %1 = shufflevector <4 x float> %a0, <4 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <16 x float> %1
+-}
+-
+-define <16 x float> @reg_broadcast_8f32_16f32(<8 x float> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_8f32_16f32:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: reg_broadcast_8f32_16f32:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X32-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_8f32_16f32:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: reg_broadcast_8f32_16f32:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X64-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512-NEXT:    retq
+- %1 = shufflevector <8 x float> %a0, <8 x float> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+- ret <16 x float> %1
+-}
+-
+-define <8 x i32> @reg_broadcast_4i32_8i32(<4 x i32> %a0) nounwind {
+-; X32-LABEL: reg_broadcast_4i32_8i32:
+-; X32:       # %bb.0:
+-; X32-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: reg_broadcast_4i32_8i32:
+-; X64:       # %bb.0:
+-; X64-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = shufflevector <4 x i32> %a0, <4 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <8 x i32> %1
+-}
+-
+-define <16 x i32> @reg_broadcast_4i32_16i32(<4 x i32> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_4i32_16i32:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: reg_broadcast_4i32_16i32:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_4i32_16i32:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: reg_broadcast_4i32_16i32:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512-NEXT:    retq
+- %1 = shufflevector <4 x i32> %a0, <4 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+- ret <16 x i32> %1
+-}
+-
+-define <16 x i32> @reg_broadcast_8i32_16i32(<8 x i32> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_8i32_16i32:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512-LABEL: reg_broadcast_8i32_16i32:
+-; X32-AVX512:       # %bb.0:
+-; X32-AVX512-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X32-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_8i32_16i32:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512-LABEL: reg_broadcast_8i32_16i32:
+-; X64-AVX512:       # %bb.0:
+-; X64-AVX512-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X64-AVX512-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512-NEXT:    retq
+- %1 = shufflevector <8 x i32> %a0, <8 x i32> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+- ret <16 x i32> %1
+-}
+-
+-define <16 x i16> @reg_broadcast_8i16_16i16(<8 x i16> %a0) nounwind {
+-; X32-LABEL: reg_broadcast_8i16_16i16:
+-; X32:       # %bb.0:
+-; X32-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: reg_broadcast_8i16_16i16:
+-; X64:       # %bb.0:
+-; X64-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = shufflevector <8 x i16> %a0, <8 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+- ret <16 x i16> %1
+-}
+-
+-define <32 x i16> @reg_broadcast_8i16_32i16(<8 x i16> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_8i16_32i16:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: reg_broadcast_8i16_32i16:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512F-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: reg_broadcast_8i16_32i16:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512BW-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512BW-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: reg_broadcast_8i16_32i16:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512DQ-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_8i16_32i16:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: reg_broadcast_8i16_32i16:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512F-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: reg_broadcast_8i16_32i16:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512BW-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512BW-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: reg_broadcast_8i16_32i16:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512DQ-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512DQ-NEXT:    retq
+- %1 = shufflevector <8 x i16> %a0, <8 x i16> undef, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+- ret <32 x i16> %1
+-}
+-
+-define <32 x i16> @reg_broadcast_16i16_32i16(<16 x i16> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_16i16_32i16:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: reg_broadcast_16i16_32i16:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: reg_broadcast_16i16_32i16:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X32-AVX512BW-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: reg_broadcast_16i16_32i16:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_16i16_32i16:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: reg_broadcast_16i16_32i16:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: reg_broadcast_16i16_32i16:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X64-AVX512BW-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: reg_broadcast_16i16_32i16:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512DQ-NEXT:    retq
+- %1 = shufflevector <16 x i16> %a0, <16 x i16> undef, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+- ret <32 x i16> %1
+-}
+-
+-define <32 x i8> @reg_broadcast_16i8_32i8(<16 x i8> %a0) nounwind {
+-; X32-LABEL: reg_broadcast_16i8_32i8:
+-; X32:       # %bb.0:
+-; X32-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-NEXT:    retl
+-;
+-; X64-LABEL: reg_broadcast_16i8_32i8:
+-; X64:       # %bb.0:
+-; X64-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-NEXT:    retq
+- %1 = shufflevector <16 x i8> %a0, <16 x i8> undef, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+- ret <32 x i8> %1
+-}
+-
+-define <64 x i8> @reg_broadcast_16i8_64i8(<16 x i8> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_16i8_64i8:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: reg_broadcast_16i8_64i8:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512F-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: reg_broadcast_16i8_64i8:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512BW-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512BW-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: reg_broadcast_16i8_64i8:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X32-AVX512DQ-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X32-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_16i8_64i8:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: reg_broadcast_16i8_64i8:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512F-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: reg_broadcast_16i8_64i8:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512BW-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512BW-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: reg_broadcast_16i8_64i8:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; X64-AVX512DQ-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+-; X64-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512DQ-NEXT:    retq
+- %1 = shufflevector <16 x i8> %a0, <16 x i8> undef, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+- ret <64 x i8> %1
+-}
+-
+-define <64 x i8> @reg_broadcast_32i8_64i8(<32 x i8> %a0) nounwind {
+-; X32-AVX-LABEL: reg_broadcast_32i8_64i8:
+-; X32-AVX:       # %bb.0:
+-; X32-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX-NEXT:    retl
+-;
+-; X32-AVX512F-LABEL: reg_broadcast_32i8_64i8:
+-; X32-AVX512F:       # %bb.0:
+-; X32-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512F-NEXT:    retl
+-;
+-; X32-AVX512BW-LABEL: reg_broadcast_32i8_64i8:
+-; X32-AVX512BW:       # %bb.0:
+-; X32-AVX512BW-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X32-AVX512BW-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X32-AVX512BW-NEXT:    retl
+-;
+-; X32-AVX512DQ-LABEL: reg_broadcast_32i8_64i8:
+-; X32-AVX512DQ:       # %bb.0:
+-; X32-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X32-AVX512DQ-NEXT:    retl
+-;
+-; X64-AVX-LABEL: reg_broadcast_32i8_64i8:
+-; X64-AVX:       # %bb.0:
+-; X64-AVX-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX-NEXT:    retq
+-;
+-; X64-AVX512F-LABEL: reg_broadcast_32i8_64i8:
+-; X64-AVX512F:       # %bb.0:
+-; X64-AVX512F-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512F-NEXT:    retq
+-;
+-; X64-AVX512BW-LABEL: reg_broadcast_32i8_64i8:
+-; X64-AVX512BW:       # %bb.0:
+-; X64-AVX512BW-NEXT:    # kill: def %ymm0 killed %ymm0 def %zmm0
+-; X64-AVX512BW-NEXT:    vinsertf64x4 $1, %ymm0, %zmm0, %zmm0
+-; X64-AVX512BW-NEXT:    retq
+-;
+-; X64-AVX512DQ-LABEL: reg_broadcast_32i8_64i8:
+-; X64-AVX512DQ:       # %bb.0:
+-; X64-AVX512DQ-NEXT:    vmovaps %ymm0, %ymm1
+-; X64-AVX512DQ-NEXT:    retq
+- %1 = shufflevector <32 x i8> %a0, <32 x i8> undef, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+- ret <64 x i8> %1
+-}
+diff --git a/test/CodeGen/X86/test-shrink-bug.ll b/test/CodeGen/X86/test-shrink-bug.ll
+index 814e07f718b..a79bb0a8c21 100644
+--- a/test/CodeGen/X86/test-shrink-bug.ll
++++ b/test/CodeGen/X86/test-shrink-bug.ll
+@@ -1,18 +1,39 @@
+-; RUN: llc < %s | FileCheck %s
+-
+-; Codegen shouldn't reduce the comparison down to testb $-1, %al
+-; because that changes the result of the signed test.
+-; PR5132
+-; CHECK: testl  $255, %eax
+-
+-target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:128:128"
+-target triple = "i386-apple-darwin10.0"
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
++; RUN: llc < %s -mtriple=i386-apple-darwin10.0 | FileCheck %s --check-prefix=CHECK-X86
++; RUN: llc < %s -mtriple=x86_64-grtev4-linux-gnu | FileCheck %s --check-prefix=CHECK-X64
+ 
+ @g_14 = global i8 -6, align 1                     ; <i8*> [#uses=1]
+ 
+ declare i32 @func_16(i8 signext %p_19, i32 %p_20) nounwind
+ 
+ define i32 @func_35(i64 %p_38) nounwind ssp {
++; CHECK-X86-LABEL: func_35:
++; CHECK-X86:       ## %bb.0: ## %entry
++; CHECK-X86-NEXT:    subl $12, %esp
++; CHECK-X86-NEXT:    movsbl _g_14, %eax
++; CHECK-X86-NEXT:    xorl %ecx, %ecx
++; CHECK-X86-NEXT:    testl $255, %eax
++; CHECK-X86-NEXT:    setg %cl
++; CHECK-X86-NEXT:    subl $8, %esp
++; CHECK-X86-NEXT:    pushl %ecx
++; CHECK-X86-NEXT:    pushl %eax
++; CHECK-X86-NEXT:    calll _func_16
++; CHECK-X86-NEXT:    addl $16, %esp
++; CHECK-X86-NEXT:    movl $1, %eax
++; CHECK-X86-NEXT:    addl $12, %esp
++; CHECK-X86-NEXT:    retl
++;
++; CHECK-X64-LABEL: func_35:
++; CHECK-X64:       # %bb.0: # %entry
++; CHECK-X64-NEXT:    pushq %rax
++; CHECK-X64-NEXT:    movsbl {{.*}}(%rip), %edi
++; CHECK-X64-NEXT:    xorl %esi, %esi
++; CHECK-X64-NEXT:    testl $255, %edi
++; CHECK-X64-NEXT:    setg %sil
++; CHECK-X64-NEXT:    callq func_16
++; CHECK-X64-NEXT:    movl $1, %eax
++; CHECK-X64-NEXT:    popq %rcx
++; CHECK-X64-NEXT:    retq
+ entry:
+   %tmp = load i8, i8* @g_14                           ; <i8> [#uses=2]
+   %conv = zext i8 %tmp to i32                     ; <i32> [#uses=1]
+@@ -21,3 +42,62 @@ entry:
+   %call = call i32 @func_16(i8 signext %tmp, i32 %conv2) ssp ; <i32> [#uses=1]
+   ret i32 1
+ }
++
++define void @fail(i16 %a, <2 x i8> %b) {
++; CHECK-X86-LABEL: fail:
++; CHECK-X86:       ## %bb.0:
++; CHECK-X86-NEXT:    subl $12, %esp
++; CHECK-X86-NEXT:    .cfi_def_cfa_offset 16
++; CHECK-X86-NEXT:    movzwl {{[0-9]+}}(%esp), %ecx
++; CHECK-X86-NEXT:    cmpb $123, {{[0-9]+}}(%esp)
++; CHECK-X86-NEXT:    sete %al
++; CHECK-X86-NEXT:    testl $263, %ecx ## imm = 0x107
++; CHECK-X86-NEXT:    je LBB1_2
++; CHECK-X86-NEXT:  ## %bb.1:
++; CHECK-X86-NEXT:    testb %al, %al
++; CHECK-X86-NEXT:    jne LBB1_2
++; CHECK-X86-NEXT:  ## %bb.3: ## %no
++; CHECK-X86-NEXT:    calll _bar
++; CHECK-X86-NEXT:    addl $12, %esp
++; CHECK-X86-NEXT:    retl
++; CHECK-X86-NEXT:  LBB1_2: ## %yes
++; CHECK-X86-NEXT:    addl $12, %esp
++; CHECK-X86-NEXT:    retl
++;
++; CHECK-X64-LABEL: fail:
++; CHECK-X64:       # %bb.0:
++; CHECK-X64-NEXT:    pushq %rax
++; CHECK-X64-NEXT:    .cfi_def_cfa_offset 16
++; CHECK-X64-NEXT:    andw $263, %di # imm = 0x107
++; CHECK-X64-NEXT:    je .LBB1_2
++; CHECK-X64-NEXT:  # %bb.1:
++; CHECK-X64-NEXT:    pand {{.*}}(%rip), %xmm0
++; CHECK-X64-NEXT:    pcmpeqd {{.*}}(%rip), %xmm0
++; CHECK-X64-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,0,3,2]
++; CHECK-X64-NEXT:    pand %xmm0, %xmm1
++; CHECK-X64-NEXT:    pextrw $4, %xmm1, %eax
++; CHECK-X64-NEXT:    testb $1, %al
++; CHECK-X64-NEXT:    jne .LBB1_2
++; CHECK-X64-NEXT:  # %bb.3: # %no
++; CHECK-X64-NEXT:    callq bar
++; CHECK-X64-NEXT:    popq %rax
++; CHECK-X64-NEXT:    retq
++; CHECK-X64-NEXT:  .LBB1_2: # %yes
++; CHECK-X64-NEXT:    popq %rax
++; CHECK-X64-NEXT:    retq
++  %1 = icmp eq <2 x i8> %b, <i8 40, i8 123>
++  %2 = extractelement <2 x i1> %1, i32 1
++  %3 = and i16 %a, 263
++  %4 = icmp eq i16 %3, 0
++  %merge = or i1 %4, %2
++  br i1 %merge, label %yes, label %no
++
++yes:                                              ; preds = %0
++  ret void
++
++no:                                               ; preds = %0
++  call void @bar()
++  ret void
++}
++
++declare void @bar()
+diff --git a/test/CodeGen/X86/test-shrink.ll b/test/CodeGen/X86/test-shrink.ll
+index 9e59f9a2faa..0cc7849e8e4 100644
+--- a/test/CodeGen/X86/test-shrink.ll
++++ b/test/CodeGen/X86/test-shrink.ll
+@@ -481,4 +481,94 @@ no:
+   ret void
+ }
+ 
++define void @truncand32(i16 inreg %x) nounwind {
++; CHECK-LINUX64-LABEL: truncand32:
++; CHECK-LINUX64:       # %bb.0:
++; CHECK-LINUX64-NEXT:    testl $2049, %edi # imm = 0x801
++; CHECK-LINUX64-NEXT:    je .LBB11_1
++; CHECK-LINUX64-NEXT:  # %bb.2: # %no
++; CHECK-LINUX64-NEXT:    retq
++; CHECK-LINUX64-NEXT:  .LBB11_1: # %yes
++; CHECK-LINUX64-NEXT:    pushq %rax
++; CHECK-LINUX64-NEXT:    callq bar
++; CHECK-LINUX64-NEXT:    popq %rax
++; CHECK-LINUX64-NEXT:    retq
++;
++; CHECK-WIN32-64-LABEL: truncand32:
++; CHECK-WIN32-64:       # %bb.0:
++; CHECK-WIN32-64-NEXT:    subq $40, %rsp
++; CHECK-WIN32-64-NEXT:    testl $2049, %ecx # imm = 0x801
++; CHECK-WIN32-64-NEXT:    je .LBB11_1
++; CHECK-WIN32-64-NEXT:  # %bb.2: # %no
++; CHECK-WIN32-64-NEXT:    addq $40, %rsp
++; CHECK-WIN32-64-NEXT:    retq
++; CHECK-WIN32-64-NEXT:  .LBB11_1: # %yes
++; CHECK-WIN32-64-NEXT:    callq bar
++; CHECK-WIN32-64-NEXT:    addq $40, %rsp
++; CHECK-WIN32-64-NEXT:    retq
++;
++; CHECK-X86-LABEL: truncand32:
++; CHECK-X86:       # %bb.0:
++; CHECK-X86-NEXT:    testl $2049, %eax # imm = 0x801
++; CHECK-X86-NEXT:    je .LBB11_1
++; CHECK-X86-NEXT:  # %bb.2: # %no
++; CHECK-X86-NEXT:    retl
++; CHECK-X86-NEXT:  .LBB11_1: # %yes
++; CHECK-X86-NEXT:    calll bar
++; CHECK-X86-NEXT:    retl
++  %t = and i16 %x, 2049
++  %s = icmp eq i16 %t, 0
++  br i1 %s, label %yes, label %no
++
++yes:
++  call void @bar()
++  ret void
++no:
++  ret void
++}
++
++define void @testw(i16 inreg %x) nounwind minsize {
++; CHECK-LINUX64-LABEL: testw:
++; CHECK-LINUX64:       # %bb.0:
++; CHECK-LINUX64-NEXT:    testw $2049, %di # imm = 0x801
++; CHECK-LINUX64-NEXT:    je .LBB12_1
++; CHECK-LINUX64-NEXT:  # %bb.2: # %no
++; CHECK-LINUX64-NEXT:    retq
++; CHECK-LINUX64-NEXT:  .LBB12_1: # %yes
++; CHECK-LINUX64-NEXT:    pushq %rax
++; CHECK-LINUX64-NEXT:    callq bar
++; CHECK-LINUX64-NEXT:    popq %rax
++; CHECK-LINUX64-NEXT:    retq
++;
++; CHECK-WIN32-64-LABEL: testw:
++; CHECK-WIN32-64:       # %bb.0:
++; CHECK-WIN32-64-NEXT:    subq $40, %rsp
++; CHECK-WIN32-64-NEXT:    testw $2049, %cx # imm = 0x801
++; CHECK-WIN32-64-NEXT:    jne .LBB12_2
++; CHECK-WIN32-64-NEXT:  # %bb.1: # %yes
++; CHECK-WIN32-64-NEXT:    callq bar
++; CHECK-WIN32-64-NEXT:  .LBB12_2: # %no
++; CHECK-WIN32-64-NEXT:    addq $40, %rsp
++; CHECK-WIN32-64-NEXT:    retq
++;
++; CHECK-X86-LABEL: testw:
++; CHECK-X86:       # %bb.0:
++; CHECK-X86-NEXT:    testw $2049, %ax # imm = 0x801
++; CHECK-X86-NEXT:    je .LBB12_1
++; CHECK-X86-NEXT:  # %bb.2: # %no
++; CHECK-X86-NEXT:    retl
++; CHECK-X86-NEXT:  .LBB12_1: # %yes
++; CHECK-X86-NEXT:    calll bar
++; CHECK-X86-NEXT:    retl
++  %t = and i16 %x, 2049
++  %s = icmp eq i16 %t, 0
++  br i1 %s, label %yes, label %no
++
++yes:
++  call void @bar()
++  ret void
++no:
++  ret void
++}
++
+ declare void @bar()
+diff --git a/test/CodeGen/X86/testb-je-fusion.ll b/test/CodeGen/X86/testb-je-fusion.ll
+index c085a422295..47453ca6791 100644
+--- a/test/CodeGen/X86/testb-je-fusion.ll
++++ b/test/CodeGen/X86/testb-je-fusion.ll
+@@ -1,11 +1,18 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
+ ; RUN: llc < %s -mtriple=x86_64-- -mcpu=corei7-avx | FileCheck %s
+ 
+ ; testb should be scheduled right before je to enable macro-fusion.
+ 
+-; CHECK: testb $2, %{{[abcd]}}h
+-; CHECK-NEXT: je
+-
+ define i32 @check_flag(i32 %flags, ...) nounwind {
++; CHECK-LABEL: check_flag:
++; CHECK:       # %bb.0: # %entry
++; CHECK-NEXT:    xorl %eax, %eax
++; CHECK-NEXT:    testl $512, %edi # imm = 0x200
++; CHECK-NEXT:    je .LBB0_2
++; CHECK-NEXT:  # %bb.1: # %if.then
++; CHECK-NEXT:    movl $1, %eax
++; CHECK-NEXT:  .LBB0_2: # %if.end
++; CHECK-NEXT:    retq
+ entry:
+   %and = and i32 %flags, 512
+   %tobool = icmp eq i32 %and, 0
+diff --git a/test/CodeGen/X86/var-permute-256.ll b/test/CodeGen/X86/var-permute-256.ll
+deleted file mode 100644
+index b624fb08719..00000000000
+--- a/test/CodeGen/X86/var-permute-256.ll
++++ /dev/null
+@@ -1,1459 +0,0 @@
+-; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx | FileCheck %s --check-prefixes=AVX,AVXNOVLBW,AVX1
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx2 | FileCheck %s --check-prefixes=AVX,AVXNOVLBW,INT256,AVX2
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx512f | FileCheck %s --check-prefixes=AVX,AVXNOVLBW,INT256,AVX512,AVX512F
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx512f,+avx512vl | FileCheck %s --check-prefixes=AVX,AVXNOVLBW,INT256,AVX512,AVX512VL
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx512bw,+avx512vl | FileCheck %s --check-prefixes=AVX,INT256,AVX512,AVX512VLBW
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx512bw,+avx512vl,+avx512vbmi | FileCheck %s --check-prefixes=AVX,INT256,AVX512,AVX512VLBW,VBMI
+-
+-define <4 x i64> @var_shuffle_v4i64(<4 x i64> %v, <4 x i64> %indices) nounwind {
+-; AVX1-LABEL: var_shuffle_v4i64:
+-; AVX1:       # %bb.0:
+-; AVX1-NEXT:    pushq %rbp
+-; AVX1-NEXT:    movq %rsp, %rbp
+-; AVX1-NEXT:    andq $-32, %rsp
+-; AVX1-NEXT:    subq $64, %rsp
+-; AVX1-NEXT:    vmovq %xmm1, %rax
+-; AVX1-NEXT:    andl $3, %eax
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %rcx
+-; AVX1-NEXT:    andl $3, %ecx
+-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+-; AVX1-NEXT:    vmovq %xmm1, %rdx
+-; AVX1-NEXT:    andl $3, %edx
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %rsi
+-; AVX1-NEXT:    andl $3, %esi
+-; AVX1-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX1-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+-; AVX1-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+-; AVX1-NEXT:    vmovlhps {{.*#+}} xmm0 = xmm1[0],xmm0[0]
+-; AVX1-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+-; AVX1-NEXT:    vmovsd {{.*#+}} xmm2 = mem[0],zero
+-; AVX1-NEXT:    vmovlhps {{.*#+}} xmm1 = xmm2[0],xmm1[0]
+-; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX1-NEXT:    movq %rbp, %rsp
+-; AVX1-NEXT:    popq %rbp
+-; AVX1-NEXT:    retq
+-;
+-; AVX2-LABEL: var_shuffle_v4i64:
+-; AVX2:       # %bb.0:
+-; AVX2-NEXT:    pushq %rbp
+-; AVX2-NEXT:    movq %rsp, %rbp
+-; AVX2-NEXT:    andq $-32, %rsp
+-; AVX2-NEXT:    subq $64, %rsp
+-; AVX2-NEXT:    vmovq %xmm1, %rax
+-; AVX2-NEXT:    andl $3, %eax
+-; AVX2-NEXT:    vpextrq $1, %xmm1, %rcx
+-; AVX2-NEXT:    andl $3, %ecx
+-; AVX2-NEXT:    vextracti128 $1, %ymm1, %xmm1
+-; AVX2-NEXT:    vmovq %xmm1, %rdx
+-; AVX2-NEXT:    andl $3, %edx
+-; AVX2-NEXT:    vpextrq $1, %xmm1, %rsi
+-; AVX2-NEXT:    andl $3, %esi
+-; AVX2-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX2-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+-; AVX2-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+-; AVX2-NEXT:    vmovlhps {{.*#+}} xmm0 = xmm1[0],xmm0[0]
+-; AVX2-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+-; AVX2-NEXT:    vmovsd {{.*#+}} xmm2 = mem[0],zero
+-; AVX2-NEXT:    vmovlhps {{.*#+}} xmm1 = xmm2[0],xmm1[0]
+-; AVX2-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX2-NEXT:    movq %rbp, %rsp
+-; AVX2-NEXT:    popq %rbp
+-; AVX2-NEXT:    retq
+-;
+-; AVX512F-LABEL: var_shuffle_v4i64:
+-; AVX512F:       # %bb.0:
+-; AVX512F-NEXT:    pushq %rbp
+-; AVX512F-NEXT:    movq %rsp, %rbp
+-; AVX512F-NEXT:    andq $-32, %rsp
+-; AVX512F-NEXT:    subq $64, %rsp
+-; AVX512F-NEXT:    vmovq %xmm1, %rax
+-; AVX512F-NEXT:    andl $3, %eax
+-; AVX512F-NEXT:    vpextrq $1, %xmm1, %rcx
+-; AVX512F-NEXT:    andl $3, %ecx
+-; AVX512F-NEXT:    vextracti128 $1, %ymm1, %xmm1
+-; AVX512F-NEXT:    vmovq %xmm1, %rdx
+-; AVX512F-NEXT:    andl $3, %edx
+-; AVX512F-NEXT:    vpextrq $1, %xmm1, %rsi
+-; AVX512F-NEXT:    andl $3, %esi
+-; AVX512F-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX512F-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+-; AVX512F-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+-; AVX512F-NEXT:    vmovlhps {{.*#+}} xmm0 = xmm1[0],xmm0[0]
+-; AVX512F-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+-; AVX512F-NEXT:    vmovsd {{.*#+}} xmm2 = mem[0],zero
+-; AVX512F-NEXT:    vmovlhps {{.*#+}} xmm1 = xmm2[0],xmm1[0]
+-; AVX512F-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX512F-NEXT:    movq %rbp, %rsp
+-; AVX512F-NEXT:    popq %rbp
+-; AVX512F-NEXT:    retq
+-;
+-; AVX512VL-LABEL: var_shuffle_v4i64:
+-; AVX512VL:       # %bb.0:
+-; AVX512VL-NEXT:    vpermpd %ymm0, %ymm1, %ymm0
+-; AVX512VL-NEXT:    retq
+-;
+-; AVX512VLBW-LABEL: var_shuffle_v4i64:
+-; AVX512VLBW:       # %bb.0:
+-; AVX512VLBW-NEXT:    vpermpd %ymm0, %ymm1, %ymm0
+-; AVX512VLBW-NEXT:    retq
+-  %index0 = extractelement <4 x i64> %indices, i32 0
+-  %index1 = extractelement <4 x i64> %indices, i32 1
+-  %index2 = extractelement <4 x i64> %indices, i32 2
+-  %index3 = extractelement <4 x i64> %indices, i32 3
+-  %v0 = extractelement <4 x i64> %v, i64 %index0
+-  %v1 = extractelement <4 x i64> %v, i64 %index1
+-  %v2 = extractelement <4 x i64> %v, i64 %index2
+-  %v3 = extractelement <4 x i64> %v, i64 %index3
+-  %ret0 = insertelement <4 x i64> undef, i64 %v0, i32 0
+-  %ret1 = insertelement <4 x i64> %ret0, i64 %v1, i32 1
+-  %ret2 = insertelement <4 x i64> %ret1, i64 %v2, i32 2
+-  %ret3 = insertelement <4 x i64> %ret2, i64 %v3, i32 3
+-  ret <4 x i64> %ret3
+-}
+-
+-define <8 x i32> @var_shuffle_v8i32(<8 x i32> %v, <8 x i32> %indices) nounwind {
+-; AVX1-LABEL: var_shuffle_v8i32:
+-; AVX1:       # %bb.0:
+-; AVX1-NEXT:    pushq %rbp
+-; AVX1-NEXT:    movq %rsp, %rbp
+-; AVX1-NEXT:    andq $-32, %rsp
+-; AVX1-NEXT:    subq $64, %rsp
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %r8
+-; AVX1-NEXT:    movq %r8, %rcx
+-; AVX1-NEXT:    shrq $30, %rcx
+-; AVX1-NEXT:    vmovq %xmm1, %r9
+-; AVX1-NEXT:    movq %r9, %rsi
+-; AVX1-NEXT:    shrq $30, %rsi
+-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %r10
+-; AVX1-NEXT:    movq %r10, %rdi
+-; AVX1-NEXT:    shrq $30, %rdi
+-; AVX1-NEXT:    vmovq %xmm1, %rax
+-; AVX1-NEXT:    movq %rax, %rdx
+-; AVX1-NEXT:    shrq $30, %rdx
+-; AVX1-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX1-NEXT:    andl $7, %r9d
+-; AVX1-NEXT:    andl $28, %esi
+-; AVX1-NEXT:    andl $7, %r8d
+-; AVX1-NEXT:    andl $28, %ecx
+-; AVX1-NEXT:    andl $7, %eax
+-; AVX1-NEXT:    andl $28, %edx
+-; AVX1-NEXT:    andl $7, %r10d
+-; AVX1-NEXT:    andl $28, %edi
+-; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+-; AVX1-NEXT:    vpinsrd $1, (%rsp,%rdx), %xmm0, %xmm0
+-; AVX1-NEXT:    vpinsrd $2, (%rsp,%r10,4), %xmm0, %xmm0
+-; AVX1-NEXT:    vpinsrd $3, (%rsp,%rdi), %xmm0, %xmm0
+-; AVX1-NEXT:    vmovd {{.*#+}} xmm1 = mem[0],zero,zero,zero
+-; AVX1-NEXT:    vpinsrd $1, (%rsp,%rsi), %xmm1, %xmm1
+-; AVX1-NEXT:    vpinsrd $2, (%rsp,%r8,4), %xmm1, %xmm1
+-; AVX1-NEXT:    vpinsrd $3, (%rsp,%rcx), %xmm1, %xmm1
+-; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX1-NEXT:    movq %rbp, %rsp
+-; AVX1-NEXT:    popq %rbp
+-; AVX1-NEXT:    retq
+-;
+-; INT256-LABEL: var_shuffle_v8i32:
+-; INT256:       # %bb.0:
+-; INT256-NEXT:    vpermps %ymm0, %ymm1, %ymm0
+-; INT256-NEXT:    retq
+-  %index0 = extractelement <8 x i32> %indices, i32 0
+-  %index1 = extractelement <8 x i32> %indices, i32 1
+-  %index2 = extractelement <8 x i32> %indices, i32 2
+-  %index3 = extractelement <8 x i32> %indices, i32 3
+-  %index4 = extractelement <8 x i32> %indices, i32 4
+-  %index5 = extractelement <8 x i32> %indices, i32 5
+-  %index6 = extractelement <8 x i32> %indices, i32 6
+-  %index7 = extractelement <8 x i32> %indices, i32 7
+-  %v0 = extractelement <8 x i32> %v, i32 %index0
+-  %v1 = extractelement <8 x i32> %v, i32 %index1
+-  %v2 = extractelement <8 x i32> %v, i32 %index2
+-  %v3 = extractelement <8 x i32> %v, i32 %index3
+-  %v4 = extractelement <8 x i32> %v, i32 %index4
+-  %v5 = extractelement <8 x i32> %v, i32 %index5
+-  %v6 = extractelement <8 x i32> %v, i32 %index6
+-  %v7 = extractelement <8 x i32> %v, i32 %index7
+-  %ret0 = insertelement <8 x i32> undef, i32 %v0, i32 0
+-  %ret1 = insertelement <8 x i32> %ret0, i32 %v1, i32 1
+-  %ret2 = insertelement <8 x i32> %ret1, i32 %v2, i32 2
+-  %ret3 = insertelement <8 x i32> %ret2, i32 %v3, i32 3
+-  %ret4 = insertelement <8 x i32> %ret3, i32 %v4, i32 4
+-  %ret5 = insertelement <8 x i32> %ret4, i32 %v5, i32 5
+-  %ret6 = insertelement <8 x i32> %ret5, i32 %v6, i32 6
+-  %ret7 = insertelement <8 x i32> %ret6, i32 %v7, i32 7
+-  ret <8 x i32> %ret7
+-}
+-
+-define <16 x i16> @var_shuffle_v16i16(<16 x i16> %v, <16 x i16> %indices) nounwind {
+-; AVX1-LABEL: var_shuffle_v16i16:
+-; AVX1:       # %bb.0:
+-; AVX1-NEXT:    pushq %rbp
+-; AVX1-NEXT:    movq %rsp, %rbp
+-; AVX1-NEXT:    andq $-32, %rsp
+-; AVX1-NEXT:    subq $64, %rsp
+-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm2
+-; AVX1-NEXT:    vmovd %xmm2, %eax
+-; AVX1-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    movzwl (%rsp,%rax,2), %eax
+-; AVX1-NEXT:    vmovd %eax, %xmm0
+-; AVX1-NEXT:    vpextrw $1, %xmm2, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $1, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrw $2, %xmm2, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $2, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrw $3, %xmm2, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $3, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrw $4, %xmm2, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $4, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrw $5, %xmm2, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $5, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrw $6, %xmm2, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $6, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrw $7, %xmm2, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $7, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX1-NEXT:    vmovd %xmm1, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    movzwl (%rsp,%rax,2), %eax
+-; AVX1-NEXT:    vmovd %eax, %xmm2
+-; AVX1-NEXT:    vpextrw $1, %xmm1, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $1, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrw $2, %xmm1, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $2, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrw $3, %xmm1, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $3, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrw $4, %xmm1, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $4, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrw $5, %xmm1, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $5, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrw $6, %xmm1, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $6, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrw $7, %xmm1, %eax
+-; AVX1-NEXT:    andl $15, %eax
+-; AVX1-NEXT:    vpinsrw $7, (%rsp,%rax,2), %xmm2, %xmm1
+-; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX1-NEXT:    movq %rbp, %rsp
+-; AVX1-NEXT:    popq %rbp
+-; AVX1-NEXT:    retq
+-;
+-; AVX2-LABEL: var_shuffle_v16i16:
+-; AVX2:       # %bb.0:
+-; AVX2-NEXT:    pushq %rbp
+-; AVX2-NEXT:    movq %rsp, %rbp
+-; AVX2-NEXT:    andq $-32, %rsp
+-; AVX2-NEXT:    subq $64, %rsp
+-; AVX2-NEXT:    vextracti128 $1, %ymm1, %xmm2
+-; AVX2-NEXT:    vmovd %xmm2, %eax
+-; AVX2-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    movzwl (%rsp,%rax,2), %eax
+-; AVX2-NEXT:    vmovd %eax, %xmm0
+-; AVX2-NEXT:    vpextrw $1, %xmm2, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $1, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrw $2, %xmm2, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $2, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrw $3, %xmm2, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $3, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrw $4, %xmm2, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $4, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrw $5, %xmm2, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $5, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrw $6, %xmm2, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $6, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrw $7, %xmm2, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $7, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX2-NEXT:    vmovd %xmm1, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    movzwl (%rsp,%rax,2), %eax
+-; AVX2-NEXT:    vmovd %eax, %xmm2
+-; AVX2-NEXT:    vpextrw $1, %xmm1, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $1, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrw $2, %xmm1, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $2, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrw $3, %xmm1, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $3, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrw $4, %xmm1, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $4, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrw $5, %xmm1, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $5, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrw $6, %xmm1, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $6, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrw $7, %xmm1, %eax
+-; AVX2-NEXT:    andl $15, %eax
+-; AVX2-NEXT:    vpinsrw $7, (%rsp,%rax,2), %xmm2, %xmm1
+-; AVX2-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
+-; AVX2-NEXT:    movq %rbp, %rsp
+-; AVX2-NEXT:    popq %rbp
+-; AVX2-NEXT:    retq
+-;
+-; AVX512F-LABEL: var_shuffle_v16i16:
+-; AVX512F:       # %bb.0:
+-; AVX512F-NEXT:    pushq %rbp
+-; AVX512F-NEXT:    movq %rsp, %rbp
+-; AVX512F-NEXT:    andq $-32, %rsp
+-; AVX512F-NEXT:    subq $64, %rsp
+-; AVX512F-NEXT:    vextracti128 $1, %ymm1, %xmm2
+-; AVX512F-NEXT:    vmovd %xmm2, %eax
+-; AVX512F-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    movzwl (%rsp,%rax,2), %eax
+-; AVX512F-NEXT:    vmovd %eax, %xmm0
+-; AVX512F-NEXT:    vpextrw $1, %xmm2, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $1, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrw $2, %xmm2, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $2, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrw $3, %xmm2, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $3, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrw $4, %xmm2, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $4, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrw $5, %xmm2, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $5, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrw $6, %xmm2, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $6, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrw $7, %xmm2, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $7, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512F-NEXT:    vmovd %xmm1, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    movzwl (%rsp,%rax,2), %eax
+-; AVX512F-NEXT:    vmovd %eax, %xmm2
+-; AVX512F-NEXT:    vpextrw $1, %xmm1, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $1, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrw $2, %xmm1, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $2, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrw $3, %xmm1, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $3, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrw $4, %xmm1, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $4, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrw $5, %xmm1, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $5, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrw $6, %xmm1, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $6, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrw $7, %xmm1, %eax
+-; AVX512F-NEXT:    andl $15, %eax
+-; AVX512F-NEXT:    vpinsrw $7, (%rsp,%rax,2), %xmm2, %xmm1
+-; AVX512F-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
+-; AVX512F-NEXT:    movq %rbp, %rsp
+-; AVX512F-NEXT:    popq %rbp
+-; AVX512F-NEXT:    retq
+-;
+-; AVX512VL-LABEL: var_shuffle_v16i16:
+-; AVX512VL:       # %bb.0:
+-; AVX512VL-NEXT:    pushq %rbp
+-; AVX512VL-NEXT:    movq %rsp, %rbp
+-; AVX512VL-NEXT:    andq $-32, %rsp
+-; AVX512VL-NEXT:    subq $64, %rsp
+-; AVX512VL-NEXT:    vextracti128 $1, %ymm1, %xmm2
+-; AVX512VL-NEXT:    vmovd %xmm2, %eax
+-; AVX512VL-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    movzwl (%rsp,%rax,2), %eax
+-; AVX512VL-NEXT:    vmovd %eax, %xmm0
+-; AVX512VL-NEXT:    vpextrw $1, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $1, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrw $2, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $2, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrw $3, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $3, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrw $4, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $4, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrw $5, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $5, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrw $6, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $6, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrw $7, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $7, (%rsp,%rax,2), %xmm0, %xmm0
+-; AVX512VL-NEXT:    vmovd %xmm1, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    movzwl (%rsp,%rax,2), %eax
+-; AVX512VL-NEXT:    vmovd %eax, %xmm2
+-; AVX512VL-NEXT:    vpextrw $1, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $1, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrw $2, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $2, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrw $3, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $3, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrw $4, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $4, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrw $5, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $5, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrw $6, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $6, (%rsp,%rax,2), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrw $7, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $15, %eax
+-; AVX512VL-NEXT:    vpinsrw $7, (%rsp,%rax,2), %xmm2, %xmm1
+-; AVX512VL-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
+-; AVX512VL-NEXT:    movq %rbp, %rsp
+-; AVX512VL-NEXT:    popq %rbp
+-; AVX512VL-NEXT:    retq
+-;
+-; AVX512VLBW-LABEL: var_shuffle_v16i16:
+-; AVX512VLBW:       # %bb.0:
+-; AVX512VLBW-NEXT:    vpermw %ymm0, %ymm1, %ymm0
+-; AVX512VLBW-NEXT:    retq
+-  %index0 = extractelement <16 x i16> %indices, i32 0
+-  %index1 = extractelement <16 x i16> %indices, i32 1
+-  %index2 = extractelement <16 x i16> %indices, i32 2
+-  %index3 = extractelement <16 x i16> %indices, i32 3
+-  %index4 = extractelement <16 x i16> %indices, i32 4
+-  %index5 = extractelement <16 x i16> %indices, i32 5
+-  %index6 = extractelement <16 x i16> %indices, i32 6
+-  %index7 = extractelement <16 x i16> %indices, i32 7
+-  %index8 = extractelement <16 x i16> %indices, i32 8
+-  %index9 = extractelement <16 x i16> %indices, i32 9
+-  %index10 = extractelement <16 x i16> %indices, i32 10
+-  %index11 = extractelement <16 x i16> %indices, i32 11
+-  %index12 = extractelement <16 x i16> %indices, i32 12
+-  %index13 = extractelement <16 x i16> %indices, i32 13
+-  %index14 = extractelement <16 x i16> %indices, i32 14
+-  %index15 = extractelement <16 x i16> %indices, i32 15
+-  %v0 = extractelement <16 x i16> %v, i16 %index0
+-  %v1 = extractelement <16 x i16> %v, i16 %index1
+-  %v2 = extractelement <16 x i16> %v, i16 %index2
+-  %v3 = extractelement <16 x i16> %v, i16 %index3
+-  %v4 = extractelement <16 x i16> %v, i16 %index4
+-  %v5 = extractelement <16 x i16> %v, i16 %index5
+-  %v6 = extractelement <16 x i16> %v, i16 %index6
+-  %v7 = extractelement <16 x i16> %v, i16 %index7
+-  %v8 = extractelement <16 x i16> %v, i16 %index8
+-  %v9 = extractelement <16 x i16> %v, i16 %index9
+-  %v10 = extractelement <16 x i16> %v, i16 %index10
+-  %v11 = extractelement <16 x i16> %v, i16 %index11
+-  %v12 = extractelement <16 x i16> %v, i16 %index12
+-  %v13 = extractelement <16 x i16> %v, i16 %index13
+-  %v14 = extractelement <16 x i16> %v, i16 %index14
+-  %v15 = extractelement <16 x i16> %v, i16 %index15
+-  %ret0 = insertelement <16 x i16> undef, i16 %v0, i32 0
+-  %ret1 = insertelement <16 x i16> %ret0, i16 %v1, i32 1
+-  %ret2 = insertelement <16 x i16> %ret1, i16 %v2, i32 2
+-  %ret3 = insertelement <16 x i16> %ret2, i16 %v3, i32 3
+-  %ret4 = insertelement <16 x i16> %ret3, i16 %v4, i32 4
+-  %ret5 = insertelement <16 x i16> %ret4, i16 %v5, i32 5
+-  %ret6 = insertelement <16 x i16> %ret5, i16 %v6, i32 6
+-  %ret7 = insertelement <16 x i16> %ret6, i16 %v7, i32 7
+-  %ret8 = insertelement <16 x i16> %ret7, i16 %v8, i32 8
+-  %ret9 = insertelement <16 x i16> %ret8, i16 %v9, i32 9
+-  %ret10 = insertelement <16 x i16> %ret9, i16 %v10, i32 10
+-  %ret11 = insertelement <16 x i16> %ret10, i16 %v11, i32 11
+-  %ret12 = insertelement <16 x i16> %ret11, i16 %v12, i32 12
+-  %ret13 = insertelement <16 x i16> %ret12, i16 %v13, i32 13
+-  %ret14 = insertelement <16 x i16> %ret13, i16 %v14, i32 14
+-  %ret15 = insertelement <16 x i16> %ret14, i16 %v15, i32 15
+-  ret <16 x i16> %ret15
+-}
+-
+-define <32 x i8> @var_shuffle_v32i8(<32 x i8> %v, <32 x i8> %indices) nounwind {
+-; AVX1-LABEL: var_shuffle_v32i8:
+-; AVX1:       # %bb.0:
+-; AVX1-NEXT:    pushq %rbp
+-; AVX1-NEXT:    movq %rsp, %rbp
+-; AVX1-NEXT:    andq $-32, %rsp
+-; AVX1-NEXT:    subq $64, %rsp
+-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm2
+-; AVX1-NEXT:    vpextrb $0, %xmm2, %eax
+-; AVX1-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vmovd %eax, %xmm0
+-; AVX1-NEXT:    vpextrb $1, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $1, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $2, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $2, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $3, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $3, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $4, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $4, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $5, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $5, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $6, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $6, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $7, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $7, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $8, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $8, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $9, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $9, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $10, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $10, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $11, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $11, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $12, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $12, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $13, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $13, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $14, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $14, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $15, %xmm2, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $15, %eax, %xmm0, %xmm0
+-; AVX1-NEXT:    vpextrb $0, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vmovd %eax, %xmm2
+-; AVX1-NEXT:    vpextrb $1, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $1, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $2, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $2, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $3, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $3, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $4, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $4, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $5, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $5, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $6, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $6, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $7, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $7, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $8, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $8, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $9, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $9, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $10, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $10, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $11, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $11, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $12, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $12, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $13, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $13, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $14, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    vpinsrb $14, (%rsp,%rax), %xmm2, %xmm2
+-; AVX1-NEXT:    vpextrb $15, %xmm1, %eax
+-; AVX1-NEXT:    andl $31, %eax
+-; AVX1-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX1-NEXT:    vpinsrb $15, %eax, %xmm2, %xmm1
+-; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX1-NEXT:    movq %rbp, %rsp
+-; AVX1-NEXT:    popq %rbp
+-; AVX1-NEXT:    retq
+-;
+-; AVX2-LABEL: var_shuffle_v32i8:
+-; AVX2:       # %bb.0:
+-; AVX2-NEXT:    pushq %rbp
+-; AVX2-NEXT:    movq %rsp, %rbp
+-; AVX2-NEXT:    andq $-32, %rsp
+-; AVX2-NEXT:    subq $64, %rsp
+-; AVX2-NEXT:    vextracti128 $1, %ymm1, %xmm2
+-; AVX2-NEXT:    vpextrb $0, %xmm2, %eax
+-; AVX2-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vmovd %eax, %xmm0
+-; AVX2-NEXT:    vpextrb $1, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $1, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $2, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $2, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $3, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $3, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $4, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $4, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $5, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $5, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $6, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $6, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $7, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $7, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $8, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $8, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $9, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $9, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $10, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $10, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $11, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $11, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $12, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $12, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $13, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $13, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $14, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $14, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $15, %xmm2, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $15, %eax, %xmm0, %xmm0
+-; AVX2-NEXT:    vpextrb $0, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vmovd %eax, %xmm2
+-; AVX2-NEXT:    vpextrb $1, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $1, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $2, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $2, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $3, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $3, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $4, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $4, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $5, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $5, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $6, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $6, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $7, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $7, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $8, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $8, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $9, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $9, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $10, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $10, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $11, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $11, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $12, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $12, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $13, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $13, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $14, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    vpinsrb $14, (%rsp,%rax), %xmm2, %xmm2
+-; AVX2-NEXT:    vpextrb $15, %xmm1, %eax
+-; AVX2-NEXT:    andl $31, %eax
+-; AVX2-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX2-NEXT:    vpinsrb $15, %eax, %xmm2, %xmm1
+-; AVX2-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
+-; AVX2-NEXT:    movq %rbp, %rsp
+-; AVX2-NEXT:    popq %rbp
+-; AVX2-NEXT:    retq
+-;
+-; AVX512F-LABEL: var_shuffle_v32i8:
+-; AVX512F:       # %bb.0:
+-; AVX512F-NEXT:    pushq %rbp
+-; AVX512F-NEXT:    movq %rsp, %rbp
+-; AVX512F-NEXT:    andq $-32, %rsp
+-; AVX512F-NEXT:    subq $64, %rsp
+-; AVX512F-NEXT:    vextracti128 $1, %ymm1, %xmm2
+-; AVX512F-NEXT:    vpextrb $0, %xmm2, %eax
+-; AVX512F-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vmovd %eax, %xmm0
+-; AVX512F-NEXT:    vpextrb $1, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $1, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $2, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $2, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $3, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $3, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $4, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $4, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $5, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $5, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $6, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $6, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $7, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $7, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $8, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $8, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $9, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $9, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $10, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $10, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $11, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $11, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $12, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $12, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $13, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $13, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $14, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $14, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $15, %xmm2, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $15, %eax, %xmm0, %xmm0
+-; AVX512F-NEXT:    vpextrb $0, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vmovd %eax, %xmm2
+-; AVX512F-NEXT:    vpextrb $1, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $1, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $2, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $2, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $3, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $3, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $4, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $4, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $5, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $5, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $6, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $6, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $7, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $7, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $8, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $8, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $9, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $9, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $10, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $10, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $11, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $11, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $12, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $12, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $13, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $13, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $14, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    vpinsrb $14, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512F-NEXT:    vpextrb $15, %xmm1, %eax
+-; AVX512F-NEXT:    andl $31, %eax
+-; AVX512F-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512F-NEXT:    vpinsrb $15, %eax, %xmm2, %xmm1
+-; AVX512F-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
+-; AVX512F-NEXT:    movq %rbp, %rsp
+-; AVX512F-NEXT:    popq %rbp
+-; AVX512F-NEXT:    retq
+-;
+-; AVX512VL-LABEL: var_shuffle_v32i8:
+-; AVX512VL:       # %bb.0:
+-; AVX512VL-NEXT:    pushq %rbp
+-; AVX512VL-NEXT:    movq %rsp, %rbp
+-; AVX512VL-NEXT:    andq $-32, %rsp
+-; AVX512VL-NEXT:    subq $64, %rsp
+-; AVX512VL-NEXT:    vextracti128 $1, %ymm1, %xmm2
+-; AVX512VL-NEXT:    vpextrb $0, %xmm2, %eax
+-; AVX512VL-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vmovd %eax, %xmm0
+-; AVX512VL-NEXT:    vpextrb $1, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $1, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $2, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $2, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $3, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $3, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $4, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $4, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $5, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $5, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $6, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $6, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $7, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $7, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $8, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $8, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $9, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $9, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $10, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $10, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $11, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $11, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $12, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $12, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $13, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $13, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $14, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $14, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $15, %xmm2, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $15, %eax, %xmm0, %xmm0
+-; AVX512VL-NEXT:    vpextrb $0, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vmovd %eax, %xmm2
+-; AVX512VL-NEXT:    vpextrb $1, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $1, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $2, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $2, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $3, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $3, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $4, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $4, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $5, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $5, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $6, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $6, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $7, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $7, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $8, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $8, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $9, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $9, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $10, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $10, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $11, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $11, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $12, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $12, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $13, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $13, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $14, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    vpinsrb $14, (%rsp,%rax), %xmm2, %xmm2
+-; AVX512VL-NEXT:    vpextrb $15, %xmm1, %eax
+-; AVX512VL-NEXT:    andl $31, %eax
+-; AVX512VL-NEXT:    movzbl (%rsp,%rax), %eax
+-; AVX512VL-NEXT:    vpinsrb $15, %eax, %xmm2, %xmm1
+-; AVX512VL-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
+-; AVX512VL-NEXT:    movq %rbp, %rsp
+-; AVX512VL-NEXT:    popq %rbp
+-; AVX512VL-NEXT:    retq
+-;
+-; VBMI-LABEL: var_shuffle_v32i8:
+-; VBMI:       # %bb.0:
+-; VBMI-NEXT:    vpermb %ymm0, %ymm1, %ymm0
+-; VBMI-NEXT:    retq
+-  %index0 = extractelement <32 x i8> %indices, i32 0
+-  %index1 = extractelement <32 x i8> %indices, i32 1
+-  %index2 = extractelement <32 x i8> %indices, i32 2
+-  %index3 = extractelement <32 x i8> %indices, i32 3
+-  %index4 = extractelement <32 x i8> %indices, i32 4
+-  %index5 = extractelement <32 x i8> %indices, i32 5
+-  %index6 = extractelement <32 x i8> %indices, i32 6
+-  %index7 = extractelement <32 x i8> %indices, i32 7
+-  %index8 = extractelement <32 x i8> %indices, i32 8
+-  %index9 = extractelement <32 x i8> %indices, i32 9
+-  %index10 = extractelement <32 x i8> %indices, i32 10
+-  %index11 = extractelement <32 x i8> %indices, i32 11
+-  %index12 = extractelement <32 x i8> %indices, i32 12
+-  %index13 = extractelement <32 x i8> %indices, i32 13
+-  %index14 = extractelement <32 x i8> %indices, i32 14
+-  %index15 = extractelement <32 x i8> %indices, i32 15
+-  %index16 = extractelement <32 x i8> %indices, i32 16
+-  %index17 = extractelement <32 x i8> %indices, i32 17
+-  %index18 = extractelement <32 x i8> %indices, i32 18
+-  %index19 = extractelement <32 x i8> %indices, i32 19
+-  %index20 = extractelement <32 x i8> %indices, i32 20
+-  %index21 = extractelement <32 x i8> %indices, i32 21
+-  %index22 = extractelement <32 x i8> %indices, i32 22
+-  %index23 = extractelement <32 x i8> %indices, i32 23
+-  %index24 = extractelement <32 x i8> %indices, i32 24
+-  %index25 = extractelement <32 x i8> %indices, i32 25
+-  %index26 = extractelement <32 x i8> %indices, i32 26
+-  %index27 = extractelement <32 x i8> %indices, i32 27
+-  %index28 = extractelement <32 x i8> %indices, i32 28
+-  %index29 = extractelement <32 x i8> %indices, i32 29
+-  %index30 = extractelement <32 x i8> %indices, i32 30
+-  %index31 = extractelement <32 x i8> %indices, i32 31
+-  %v0 = extractelement <32 x i8> %v, i8 %index0
+-  %v1 = extractelement <32 x i8> %v, i8 %index1
+-  %v2 = extractelement <32 x i8> %v, i8 %index2
+-  %v3 = extractelement <32 x i8> %v, i8 %index3
+-  %v4 = extractelement <32 x i8> %v, i8 %index4
+-  %v5 = extractelement <32 x i8> %v, i8 %index5
+-  %v6 = extractelement <32 x i8> %v, i8 %index6
+-  %v7 = extractelement <32 x i8> %v, i8 %index7
+-  %v8 = extractelement <32 x i8> %v, i8 %index8
+-  %v9 = extractelement <32 x i8> %v, i8 %index9
+-  %v10 = extractelement <32 x i8> %v, i8 %index10
+-  %v11 = extractelement <32 x i8> %v, i8 %index11
+-  %v12 = extractelement <32 x i8> %v, i8 %index12
+-  %v13 = extractelement <32 x i8> %v, i8 %index13
+-  %v14 = extractelement <32 x i8> %v, i8 %index14
+-  %v15 = extractelement <32 x i8> %v, i8 %index15
+-  %v16 = extractelement <32 x i8> %v, i8 %index16
+-  %v17 = extractelement <32 x i8> %v, i8 %index17
+-  %v18 = extractelement <32 x i8> %v, i8 %index18
+-  %v19 = extractelement <32 x i8> %v, i8 %index19
+-  %v20 = extractelement <32 x i8> %v, i8 %index20
+-  %v21 = extractelement <32 x i8> %v, i8 %index21
+-  %v22 = extractelement <32 x i8> %v, i8 %index22
+-  %v23 = extractelement <32 x i8> %v, i8 %index23
+-  %v24 = extractelement <32 x i8> %v, i8 %index24
+-  %v25 = extractelement <32 x i8> %v, i8 %index25
+-  %v26 = extractelement <32 x i8> %v, i8 %index26
+-  %v27 = extractelement <32 x i8> %v, i8 %index27
+-  %v28 = extractelement <32 x i8> %v, i8 %index28
+-  %v29 = extractelement <32 x i8> %v, i8 %index29
+-  %v30 = extractelement <32 x i8> %v, i8 %index30
+-  %v31 = extractelement <32 x i8> %v, i8 %index31
+-  %ret0 = insertelement <32 x i8> undef, i8 %v0, i32 0
+-  %ret1 = insertelement <32 x i8> %ret0, i8 %v1, i32 1
+-  %ret2 = insertelement <32 x i8> %ret1, i8 %v2, i32 2
+-  %ret3 = insertelement <32 x i8> %ret2, i8 %v3, i32 3
+-  %ret4 = insertelement <32 x i8> %ret3, i8 %v4, i32 4
+-  %ret5 = insertelement <32 x i8> %ret4, i8 %v5, i32 5
+-  %ret6 = insertelement <32 x i8> %ret5, i8 %v6, i32 6
+-  %ret7 = insertelement <32 x i8> %ret6, i8 %v7, i32 7
+-  %ret8 = insertelement <32 x i8> %ret7, i8 %v8, i32 8
+-  %ret9 = insertelement <32 x i8> %ret8, i8 %v9, i32 9
+-  %ret10 = insertelement <32 x i8> %ret9, i8 %v10, i32 10
+-  %ret11 = insertelement <32 x i8> %ret10, i8 %v11, i32 11
+-  %ret12 = insertelement <32 x i8> %ret11, i8 %v12, i32 12
+-  %ret13 = insertelement <32 x i8> %ret12, i8 %v13, i32 13
+-  %ret14 = insertelement <32 x i8> %ret13, i8 %v14, i32 14
+-  %ret15 = insertelement <32 x i8> %ret14, i8 %v15, i32 15
+-  %ret16 = insertelement <32 x i8> %ret15, i8 %v16, i32 16
+-  %ret17 = insertelement <32 x i8> %ret16, i8 %v17, i32 17
+-  %ret18 = insertelement <32 x i8> %ret17, i8 %v18, i32 18
+-  %ret19 = insertelement <32 x i8> %ret18, i8 %v19, i32 19
+-  %ret20 = insertelement <32 x i8> %ret19, i8 %v20, i32 20
+-  %ret21 = insertelement <32 x i8> %ret20, i8 %v21, i32 21
+-  %ret22 = insertelement <32 x i8> %ret21, i8 %v22, i32 22
+-  %ret23 = insertelement <32 x i8> %ret22, i8 %v23, i32 23
+-  %ret24 = insertelement <32 x i8> %ret23, i8 %v24, i32 24
+-  %ret25 = insertelement <32 x i8> %ret24, i8 %v25, i32 25
+-  %ret26 = insertelement <32 x i8> %ret25, i8 %v26, i32 26
+-  %ret27 = insertelement <32 x i8> %ret26, i8 %v27, i32 27
+-  %ret28 = insertelement <32 x i8> %ret27, i8 %v28, i32 28
+-  %ret29 = insertelement <32 x i8> %ret28, i8 %v29, i32 29
+-  %ret30 = insertelement <32 x i8> %ret29, i8 %v30, i32 30
+-  %ret31 = insertelement <32 x i8> %ret30, i8 %v31, i32 31
+-  ret <32 x i8> %ret31
+-}
+-
+-define <4 x double> @var_shuffle_v4f64(<4 x double> %v, <4 x i64> %indices) nounwind {
+-; AVX1-LABEL: var_shuffle_v4f64:
+-; AVX1:       # %bb.0:
+-; AVX1-NEXT:    pushq %rbp
+-; AVX1-NEXT:    movq %rsp, %rbp
+-; AVX1-NEXT:    andq $-32, %rsp
+-; AVX1-NEXT:    subq $64, %rsp
+-; AVX1-NEXT:    vmovq %xmm1, %rax
+-; AVX1-NEXT:    andl $3, %eax
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %rcx
+-; AVX1-NEXT:    andl $3, %ecx
+-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+-; AVX1-NEXT:    vmovq %xmm1, %rdx
+-; AVX1-NEXT:    andl $3, %edx
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %rsi
+-; AVX1-NEXT:    andl $3, %esi
+-; AVX1-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX1-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+-; AVX1-NEXT:    vmovhpd {{.*#+}} xmm0 = xmm0[0],mem[0]
+-; AVX1-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+-; AVX1-NEXT:    vmovhpd {{.*#+}} xmm1 = xmm1[0],mem[0]
+-; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX1-NEXT:    movq %rbp, %rsp
+-; AVX1-NEXT:    popq %rbp
+-; AVX1-NEXT:    retq
+-;
+-; AVX2-LABEL: var_shuffle_v4f64:
+-; AVX2:       # %bb.0:
+-; AVX2-NEXT:    pushq %rbp
+-; AVX2-NEXT:    movq %rsp, %rbp
+-; AVX2-NEXT:    andq $-32, %rsp
+-; AVX2-NEXT:    subq $64, %rsp
+-; AVX2-NEXT:    vmovq %xmm1, %rax
+-; AVX2-NEXT:    andl $3, %eax
+-; AVX2-NEXT:    vpextrq $1, %xmm1, %rcx
+-; AVX2-NEXT:    andl $3, %ecx
+-; AVX2-NEXT:    vextracti128 $1, %ymm1, %xmm1
+-; AVX2-NEXT:    vmovq %xmm1, %rdx
+-; AVX2-NEXT:    andl $3, %edx
+-; AVX2-NEXT:    vpextrq $1, %xmm1, %rsi
+-; AVX2-NEXT:    andl $3, %esi
+-; AVX2-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX2-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+-; AVX2-NEXT:    vmovhpd {{.*#+}} xmm0 = xmm0[0],mem[0]
+-; AVX2-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+-; AVX2-NEXT:    vmovhpd {{.*#+}} xmm1 = xmm1[0],mem[0]
+-; AVX2-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX2-NEXT:    movq %rbp, %rsp
+-; AVX2-NEXT:    popq %rbp
+-; AVX2-NEXT:    retq
+-;
+-; AVX512F-LABEL: var_shuffle_v4f64:
+-; AVX512F:       # %bb.0:
+-; AVX512F-NEXT:    pushq %rbp
+-; AVX512F-NEXT:    movq %rsp, %rbp
+-; AVX512F-NEXT:    andq $-32, %rsp
+-; AVX512F-NEXT:    subq $64, %rsp
+-; AVX512F-NEXT:    vmovq %xmm1, %rax
+-; AVX512F-NEXT:    andl $3, %eax
+-; AVX512F-NEXT:    vpextrq $1, %xmm1, %rcx
+-; AVX512F-NEXT:    andl $3, %ecx
+-; AVX512F-NEXT:    vextracti128 $1, %ymm1, %xmm1
+-; AVX512F-NEXT:    vmovq %xmm1, %rdx
+-; AVX512F-NEXT:    andl $3, %edx
+-; AVX512F-NEXT:    vpextrq $1, %xmm1, %rsi
+-; AVX512F-NEXT:    andl $3, %esi
+-; AVX512F-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX512F-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+-; AVX512F-NEXT:    vmovhpd {{.*#+}} xmm0 = xmm0[0],mem[0]
+-; AVX512F-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+-; AVX512F-NEXT:    vmovhpd {{.*#+}} xmm1 = xmm1[0],mem[0]
+-; AVX512F-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX512F-NEXT:    movq %rbp, %rsp
+-; AVX512F-NEXT:    popq %rbp
+-; AVX512F-NEXT:    retq
+-;
+-; AVX512VL-LABEL: var_shuffle_v4f64:
+-; AVX512VL:       # %bb.0:
+-; AVX512VL-NEXT:    vpermpd %ymm0, %ymm1, %ymm0
+-; AVX512VL-NEXT:    retq
+-;
+-; AVX512VLBW-LABEL: var_shuffle_v4f64:
+-; AVX512VLBW:       # %bb.0:
+-; AVX512VLBW-NEXT:    vpermpd %ymm0, %ymm1, %ymm0
+-; AVX512VLBW-NEXT:    retq
+-  %index0 = extractelement <4 x i64> %indices, i32 0
+-  %index1 = extractelement <4 x i64> %indices, i32 1
+-  %index2 = extractelement <4 x i64> %indices, i32 2
+-  %index3 = extractelement <4 x i64> %indices, i32 3
+-  %v0 = extractelement <4 x double> %v, i64 %index0
+-  %v1 = extractelement <4 x double> %v, i64 %index1
+-  %v2 = extractelement <4 x double> %v, i64 %index2
+-  %v3 = extractelement <4 x double> %v, i64 %index3
+-  %ret0 = insertelement <4 x double> undef, double %v0, i32 0
+-  %ret1 = insertelement <4 x double> %ret0, double %v1, i32 1
+-  %ret2 = insertelement <4 x double> %ret1, double %v2, i32 2
+-  %ret3 = insertelement <4 x double> %ret2, double %v3, i32 3
+-  ret <4 x double> %ret3
+-}
+-
+-define <8 x float> @var_shuffle_v8f32(<8 x float> %v, <8 x i32> %indices) nounwind {
+-; AVX1-LABEL: var_shuffle_v8f32:
+-; AVX1:       # %bb.0:
+-; AVX1-NEXT:    pushq %rbp
+-; AVX1-NEXT:    movq %rsp, %rbp
+-; AVX1-NEXT:    andq $-32, %rsp
+-; AVX1-NEXT:    subq $64, %rsp
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %r8
+-; AVX1-NEXT:    movq %r8, %rcx
+-; AVX1-NEXT:    shrq $30, %rcx
+-; AVX1-NEXT:    vmovq %xmm1, %r9
+-; AVX1-NEXT:    movq %r9, %rdx
+-; AVX1-NEXT:    shrq $30, %rdx
+-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %r10
+-; AVX1-NEXT:    movq %r10, %rdi
+-; AVX1-NEXT:    shrq $30, %rdi
+-; AVX1-NEXT:    vmovq %xmm1, %rax
+-; AVX1-NEXT:    movq %rax, %rsi
+-; AVX1-NEXT:    shrq $30, %rsi
+-; AVX1-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX1-NEXT:    andl $7, %r9d
+-; AVX1-NEXT:    andl $28, %edx
+-; AVX1-NEXT:    andl $7, %r8d
+-; AVX1-NEXT:    andl $28, %ecx
+-; AVX1-NEXT:    andl $7, %eax
+-; AVX1-NEXT:    andl $28, %esi
+-; AVX1-NEXT:    andl $7, %r10d
+-; AVX1-NEXT:    andl $28, %edi
+-; AVX1-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0],mem[0],xmm0[2,3]
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0,1],mem[0],xmm0[3]
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0,1,2],mem[0]
+-; AVX1-NEXT:    vmovss {{.*#+}} xmm1 = mem[0],zero,zero,zero
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm1 = xmm1[0],mem[0],xmm1[2,3]
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm1 = xmm1[0,1],mem[0],xmm1[3]
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm1 = xmm1[0,1,2],mem[0]
+-; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX1-NEXT:    movq %rbp, %rsp
+-; AVX1-NEXT:    popq %rbp
+-; AVX1-NEXT:    retq
+-;
+-; INT256-LABEL: var_shuffle_v8f32:
+-; INT256:       # %bb.0:
+-; INT256-NEXT:    vpermps %ymm0, %ymm1, %ymm0
+-; INT256-NEXT:    retq
+-  %index0 = extractelement <8 x i32> %indices, i32 0
+-  %index1 = extractelement <8 x i32> %indices, i32 1
+-  %index2 = extractelement <8 x i32> %indices, i32 2
+-  %index3 = extractelement <8 x i32> %indices, i32 3
+-  %index4 = extractelement <8 x i32> %indices, i32 4
+-  %index5 = extractelement <8 x i32> %indices, i32 5
+-  %index6 = extractelement <8 x i32> %indices, i32 6
+-  %index7 = extractelement <8 x i32> %indices, i32 7
+-  %v0 = extractelement <8 x float> %v, i32 %index0
+-  %v1 = extractelement <8 x float> %v, i32 %index1
+-  %v2 = extractelement <8 x float> %v, i32 %index2
+-  %v3 = extractelement <8 x float> %v, i32 %index3
+-  %v4 = extractelement <8 x float> %v, i32 %index4
+-  %v5 = extractelement <8 x float> %v, i32 %index5
+-  %v6 = extractelement <8 x float> %v, i32 %index6
+-  %v7 = extractelement <8 x float> %v, i32 %index7
+-  %ret0 = insertelement <8 x float> undef, float %v0, i32 0
+-  %ret1 = insertelement <8 x float> %ret0, float %v1, i32 1
+-  %ret2 = insertelement <8 x float> %ret1, float %v2, i32 2
+-  %ret3 = insertelement <8 x float> %ret2, float %v3, i32 3
+-  %ret4 = insertelement <8 x float> %ret3, float %v4, i32 4
+-  %ret5 = insertelement <8 x float> %ret4, float %v5, i32 5
+-  %ret6 = insertelement <8 x float> %ret5, float %v6, i32 6
+-  %ret7 = insertelement <8 x float> %ret6, float %v7, i32 7
+-  ret <8 x float> %ret7
+-}
+-
+-define <8 x i32> @pr35820(<4 x i32> %v, <8 x i32> %indices) unnamed_addr nounwind {
+-; AVX1-LABEL: pr35820:
+-; AVX1:       # %bb.0: # %entry
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %r8
+-; AVX1-NEXT:    movq %r8, %r10
+-; AVX1-NEXT:    shrq $30, %r10
+-; AVX1-NEXT:    vmovq %xmm1, %r9
+-; AVX1-NEXT:    movq %r9, %rsi
+-; AVX1-NEXT:    shrq $30, %rsi
+-; AVX1-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; AVX1-NEXT:    andl $3, %r9d
+-; AVX1-NEXT:    andl $12, %esi
+-; AVX1-NEXT:    andl $3, %r8d
+-; AVX1-NEXT:    andl $12, %r10d
+-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm0
+-; AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+-; AVX1-NEXT:    movq %rax, %rdi
+-; AVX1-NEXT:    shrq $30, %rdi
+-; AVX1-NEXT:    vmovq %xmm0, %rcx
+-; AVX1-NEXT:    movq %rcx, %rdx
+-; AVX1-NEXT:    shrq $30, %rdx
+-; AVX1-NEXT:    andl $3, %ecx
+-; AVX1-NEXT:    andl $12, %edx
+-; AVX1-NEXT:    andl $3, %eax
+-; AVX1-NEXT:    andl $12, %edi
+-; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+-; AVX1-NEXT:    vpinsrd $1, -24(%rsp,%rdx), %xmm0, %xmm0
+-; AVX1-NEXT:    vpinsrd $2, -24(%rsp,%rax,4), %xmm0, %xmm0
+-; AVX1-NEXT:    vpinsrd $3, -24(%rsp,%rdi), %xmm0, %xmm0
+-; AVX1-NEXT:    vmovd {{.*#+}} xmm1 = mem[0],zero,zero,zero
+-; AVX1-NEXT:    vpinsrd $1, -24(%rsp,%rsi), %xmm1, %xmm1
+-; AVX1-NEXT:    vpinsrd $2, -24(%rsp,%r8,4), %xmm1, %xmm1
+-; AVX1-NEXT:    vpinsrd $3, -24(%rsp,%r10), %xmm1, %xmm1
+-; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX1-NEXT:    retq
+-;
+-; INT256-LABEL: pr35820:
+-; INT256:       # %bb.0: # %entry
+-; INT256-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; INT256-NEXT:    vpermps %ymm0, %ymm1, %ymm0
+-; INT256-NEXT:    retq
+-entry:
+-  %tmp1 = extractelement <8 x i32> %indices, i32 0
+-  %vecext2.8 = extractelement <4 x i32> %v, i32 %tmp1
+-  %tmp2 = extractelement <8 x i32> %indices, i32 1
+-  %vecext2.9 = extractelement <4 x i32> %v, i32 %tmp2
+-  %tmp3 = extractelement <8 x i32> %indices, i32 2
+-  %vecext2.10 = extractelement <4 x i32> %v, i32 %tmp3
+-  %tmp4 = extractelement <8 x i32> %indices, i32 3
+-  %vecext2.11 = extractelement <4 x i32> %v, i32 %tmp4
+-  %tmp5 = extractelement <8 x i32> %indices, i32 4
+-  %vecext2.12 = extractelement <4 x i32> %v, i32 %tmp5
+-  %tmp6 = extractelement <8 x i32> %indices, i32 5
+-  %vecext2.13 = extractelement <4 x i32> %v, i32 %tmp6
+-  %tmp7 = extractelement <8 x i32> %indices, i32 6
+-  %vecext2.14 = extractelement <4 x i32> %v, i32 %tmp7
+-  %tmp8 = extractelement <8 x i32> %indices, i32 7
+-  %vecext2.15 = extractelement <4 x i32> %v, i32 %tmp8
+-  %tmp9 = insertelement <8 x i32> undef, i32 %vecext2.8, i32 0
+-  %tmp10 = insertelement <8 x i32> %tmp9, i32 %vecext2.9, i32 1
+-  %tmp11 = insertelement <8 x i32> %tmp10, i32 %vecext2.10, i32 2
+-  %tmp12 = insertelement <8 x i32> %tmp11, i32 %vecext2.11, i32 3
+-  %tmp13 = insertelement <8 x i32> %tmp12, i32 %vecext2.12, i32 4
+-  %tmp14 = insertelement <8 x i32> %tmp13, i32 %vecext2.13, i32 5
+-  %tmp15 = insertelement <8 x i32> %tmp14, i32 %vecext2.14, i32 6
+-  %tmp16 = insertelement <8 x i32> %tmp15, i32 %vecext2.15, i32 7
+-  ret <8 x i32> %tmp16
+-}
+-
+-define <8 x float> @pr35820_float(<4 x float> %v, <8 x i32> %indices) unnamed_addr nounwind {
+-; AVX1-LABEL: pr35820_float:
+-; AVX1:       # %bb.0: # %entry
+-; AVX1-NEXT:    vpextrq $1, %xmm1, %r8
+-; AVX1-NEXT:    movq %r8, %r10
+-; AVX1-NEXT:    shrq $30, %r10
+-; AVX1-NEXT:    vmovq %xmm1, %r9
+-; AVX1-NEXT:    movq %r9, %rdx
+-; AVX1-NEXT:    shrq $30, %rdx
+-; AVX1-NEXT:    vmovaps %xmm0, -{{[0-9]+}}(%rsp)
+-; AVX1-NEXT:    andl $3, %r9d
+-; AVX1-NEXT:    andl $12, %edx
+-; AVX1-NEXT:    andl $3, %r8d
+-; AVX1-NEXT:    andl $12, %r10d
+-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm0
+-; AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+-; AVX1-NEXT:    movq %rax, %rdi
+-; AVX1-NEXT:    shrq $30, %rdi
+-; AVX1-NEXT:    vmovq %xmm0, %rcx
+-; AVX1-NEXT:    movq %rcx, %rsi
+-; AVX1-NEXT:    shrq $30, %rsi
+-; AVX1-NEXT:    andl $3, %ecx
+-; AVX1-NEXT:    andl $12, %esi
+-; AVX1-NEXT:    andl $3, %eax
+-; AVX1-NEXT:    andl $12, %edi
+-; AVX1-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0],mem[0],xmm0[2,3]
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0,1],mem[0],xmm0[3]
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0,1,2],mem[0]
+-; AVX1-NEXT:    vmovss {{.*#+}} xmm1 = mem[0],zero,zero,zero
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm1 = xmm1[0],mem[0],xmm1[2,3]
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm1 = xmm1[0,1],mem[0],xmm1[3]
+-; AVX1-NEXT:    vinsertps {{.*#+}} xmm1 = xmm1[0,1,2],mem[0]
+-; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+-; AVX1-NEXT:    retq
+-;
+-; INT256-LABEL: pr35820_float:
+-; INT256:       # %bb.0: # %entry
+-; INT256-NEXT:    # kill: def %xmm0 killed %xmm0 def %ymm0
+-; INT256-NEXT:    vpermps %ymm0, %ymm1, %ymm0
+-; INT256-NEXT:    retq
+-entry:
+-  %tmp1 = extractelement <8 x i32> %indices, i32 0
+-  %vecext2.8 = extractelement <4 x float> %v, i32 %tmp1
+-  %tmp2 = extractelement <8 x i32> %indices, i32 1
+-  %vecext2.9 = extractelement <4 x float> %v, i32 %tmp2
+-  %tmp3 = extractelement <8 x i32> %indices, i32 2
+-  %vecext2.10 = extractelement <4 x float> %v, i32 %tmp3
+-  %tmp4 = extractelement <8 x i32> %indices, i32 3
+-  %vecext2.11 = extractelement <4 x float> %v, i32 %tmp4
+-  %tmp5 = extractelement <8 x i32> %indices, i32 4
+-  %vecext2.12 = extractelement <4 x float> %v, i32 %tmp5
+-  %tmp6 = extractelement <8 x i32> %indices, i32 5
+-  %vecext2.13 = extractelement <4 x float> %v, i32 %tmp6
+-  %tmp7 = extractelement <8 x i32> %indices, i32 6
+-  %vecext2.14 = extractelement <4 x float> %v, i32 %tmp7
+-  %tmp8 = extractelement <8 x i32> %indices, i32 7
+-  %vecext2.15 = extractelement <4 x float> %v, i32 %tmp8
+-  %tmp9 = insertelement <8 x float> undef, float %vecext2.8, i32 0
+-  %tmp10 = insertelement <8 x float> %tmp9, float %vecext2.9, i32 1
+-  %tmp11 = insertelement <8 x float> %tmp10, float %vecext2.10, i32 2
+-  %tmp12 = insertelement <8 x float> %tmp11, float %vecext2.11, i32 3
+-  %tmp13 = insertelement <8 x float> %tmp12, float %vecext2.12, i32 4
+-  %tmp14 = insertelement <8 x float> %tmp13, float %vecext2.13, i32 5
+-  %tmp15 = insertelement <8 x float> %tmp14, float %vecext2.14, i32 6
+-  %tmp16 = insertelement <8 x float> %tmp15, float %vecext2.15, i32 7
+-  ret <8 x float> %tmp16
+-}
+-
+-define <4 x i32> @big_source(<8 x i32> %v, <4 x i32> %indices) unnamed_addr nounwind {
+-; AVX-LABEL: big_source:
+-; AVX:       # %bb.0: # %entry
+-; AVX-NEXT:    pushq %rbp
+-; AVX-NEXT:    movq %rsp, %rbp
+-; AVX-NEXT:    andq $-32, %rsp
+-; AVX-NEXT:    subq $64, %rsp
+-; AVX-NEXT:    vmovq %xmm1, %rax
+-; AVX-NEXT:    movq %rax, %rcx
+-; AVX-NEXT:    shrq $30, %rcx
+-; AVX-NEXT:    andl $28, %ecx
+-; AVX-NEXT:    vpextrq $1, %xmm1, %rdx
+-; AVX-NEXT:    movq %rdx, %rsi
+-; AVX-NEXT:    sarq $32, %rsi
+-; AVX-NEXT:    andl $7, %eax
+-; AVX-NEXT:    andl $7, %edx
+-; AVX-NEXT:    vmovaps %ymm0, (%rsp)
+-; AVX-NEXT:    andl $7, %esi
+-; AVX-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+-; AVX-NEXT:    vpinsrd $1, (%rsp,%rcx), %xmm0, %xmm0
+-; AVX-NEXT:    vpinsrd $2, (%rsp,%rdx,4), %xmm0, %xmm0
+-; AVX-NEXT:    vpinsrd $3, (%rsp,%rsi,4), %xmm0, %xmm0
+-; AVX-NEXT:    movq %rbp, %rsp
+-; AVX-NEXT:    popq %rbp
+-; AVX-NEXT:    vzeroupper
+-; AVX-NEXT:    retq
+-entry:
+-  %tmp1 = extractelement <4 x i32> %indices, i32 0
+-  %vecext2.8 = extractelement <8 x i32> %v, i32 %tmp1
+-  %tmp2 = extractelement <4 x i32> %indices, i32 1
+-  %vecext2.9 = extractelement <8 x i32> %v, i32 %tmp2
+-  %tmp3 = extractelement <4 x i32> %indices, i32 2
+-  %vecext2.10 = extractelement <8 x i32> %v, i32 %tmp3
+-  %tmp4 = extractelement <4 x i32> %indices, i32 3
+-  %vecext2.11 = extractelement <8 x i32> %v, i32 %tmp4
+-  %tmp9 = insertelement <4 x i32> undef, i32 %vecext2.8, i32 0
+-  %tmp10 = insertelement <4 x i32> %tmp9, i32 %vecext2.9, i32 1
+-  %tmp11 = insertelement <4 x i32> %tmp10, i32 %vecext2.10, i32 2
+-  %tmp12 = insertelement <4 x i32> %tmp11, i32 %vecext2.11, i32 3
+-  ret <4 x i32> %tmp12
+-}
+diff --git a/test/CodeGen/X86/vastart-defs-eflags.ll b/test/CodeGen/X86/vastart-defs-eflags.ll
+index d0c515089f4..6ef691552aa 100644
+--- a/test/CodeGen/X86/vastart-defs-eflags.ll
++++ b/test/CodeGen/X86/vastart-defs-eflags.ll
+@@ -1,3 +1,4 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
+ ; RUN: llc %s -o - | FileCheck %s
+ 
+ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+@@ -5,10 +6,41 @@ target triple = "x86_64-apple-macosx10.10.0"
+ 
+ ; Check that vastart handling doesn't get between testb and je for the branch.
+ define i32 @check_flag(i32 %flags, ...) nounwind {
++; CHECK-LABEL: check_flag:
++; CHECK:       ## %bb.0: ## %entry
++; CHECK-NEXT:    subq $56, %rsp
++; CHECK-NEXT:    testb %al, %al
++; CHECK-NEXT:    je LBB0_2
++; CHECK-NEXT:  ## %bb.1: ## %entry
++; CHECK-NEXT:    movaps %xmm0, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movaps %xmm1, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movaps %xmm2, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movaps %xmm3, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movaps %xmm4, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movaps %xmm5, (%rsp)
++; CHECK-NEXT:    movaps %xmm6, {{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movaps %xmm7, {{[0-9]+}}(%rsp)
++; CHECK-NEXT:  LBB0_2: ## %entry
++; CHECK-NEXT:    movq %r9, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movq %r8, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movq %rcx, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movq %rdx, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    movq %rsi, -{{[0-9]+}}(%rsp)
++; CHECK-NEXT:    xorl %eax, %eax
++; CHECK-NEXT:    testl $512, %edi ## imm = 0x200
++; CHECK-NEXT:    je LBB0_4
++; CHECK-NEXT:  ## %bb.3: ## %if.then
++; CHECK-NEXT:    leaq -{{[0-9]+}}(%rsp), %rax
++; CHECK-NEXT:    movq %rax, 16
++; CHECK-NEXT:    leaq {{[0-9]+}}(%rsp), %rax
++; CHECK-NEXT:    movq %rax, 8
++; CHECK-NEXT:    movl $48, 4
++; CHECK-NEXT:    movl $8, 0
++; CHECK-NEXT:    movl $1, %eax
++; CHECK-NEXT:  LBB0_4: ## %if.end
++; CHECK-NEXT:    addq $56, %rsp
++; CHECK-NEXT:    retq
+ entry:
+-; CHECK: {{^}} testb $2, %bh
+-; CHECK-NOT: test
+-; CHECK: {{^}} je
+   %and = and i32 %flags, 512
+   %tobool = icmp eq i32 %and, 0
+   br i1 %tobool, label %if.end, label %if.then
+diff --git a/test/CodeGen/X86/vector-shuffle-combining-xop.ll b/test/CodeGen/X86/vector-shuffle-combining-xop.ll
+index 83001cf5fb9..dc08ad8a3de 100644
+--- a/test/CodeGen/X86/vector-shuffle-combining-xop.ll
++++ b/test/CodeGen/X86/vector-shuffle-combining-xop.ll
+@@ -1,8 +1,8 @@
+ ; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
+-; RUN: llc < %s -mtriple=i686-unknown-unknown -mattr=+avx,+xop | FileCheck %s --check-prefix=X32
+-; RUN: llc < %s -mtriple=i686-unknown-unknown -mattr=+avx2,+xop | FileCheck %s --check-prefix=X32
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx,+xop | FileCheck %s --check-prefix=X64
+-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx2,+xop | FileCheck %s --check-prefix=X64
++; RUN: llc < %s -mtriple=i686-unknown-unknown -mattr=+avx,+xop | FileCheck %s --check-prefix=X32 --check-prefix=X86AVX
++; RUN: llc < %s -mtriple=i686-unknown-unknown -mattr=+avx2,+xop | FileCheck %s --check-prefix=X32 --check-prefix=X86AVX2
++; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx,+xop | FileCheck %s --check-prefix=X64 --check-prefix=X64AVX
++; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+avx2,+xop | FileCheck %s --check-prefix=X64 --check-prefix=X64AVX2
+ 
+ declare <2 x double> @llvm.x86.xop.vpermil2pd(<2 x double>, <2 x double>, <2 x i64>, i8) nounwind readnone
+ declare <4 x double> @llvm.x86.xop.vpermil2pd.256(<4 x double>, <4 x double>, <4 x i64>, i8) nounwind readnone
+@@ -320,20 +320,35 @@ define <4 x i32> @combine_vpperm_10zz32BA(<4 x i32> %a0, <4 x i32> %a1) {
+ 
+ ; FIXME: Duplicated load in i686
+ define void @buildvector_v4f32_0404(float %a, float %b, <4 x float>* %ptr) {
+-; X32-LABEL: buildvector_v4f32_0404:
+-; X32:       # %bb.0:
+-; X32-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+-; X32-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0,1],mem[0],xmm0[3]
+-; X32-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0,1,2],mem[0]
+-; X32-NEXT:    vmovaps %xmm0, (%eax)
+-; X32-NEXT:    retl
++; X86AVX-LABEL: buildvector_v4f32_0404:
++; X86AVX:       # %bb.0:
++; X86AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
++; X86AVX-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
++; X86AVX-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0,1],mem[0],xmm0[3]
++; X86AVX-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0,1,2],mem[0]
++; X86AVX-NEXT:    vmovaps %xmm0, (%eax)
++; X86AVX-NEXT:    retl
+ ;
+-; X64-LABEL: buildvector_v4f32_0404:
+-; X64:       # %bb.0:
+-; X64-NEXT:    vpermil2ps {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[0],xmm1[0]
+-; X64-NEXT:    vmovaps %xmm0, (%rdi)
+-; X64-NEXT:    retq
++; X86AVX2-LABEL: buildvector_v4f32_0404:
++; X86AVX2:       # %bb.0:
++; X86AVX2-NEXT:    movl {{[0-9]+}}(%esp), %eax
++; X86AVX2-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
++; X86AVX2-NEXT:    vmovddup {{.*#+}} xmm0 = xmm0[0,0]
++; X86AVX2-NEXT:    vmovapd %xmm0, (%eax)
++; X86AVX2-NEXT:    retl
++;
++; X64AVX-LABEL: buildvector_v4f32_0404:
++; X64AVX:       # %bb.0:
++; X64AVX-NEXT:    vpermil2ps {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[0],xmm1[0]
++; X64AVX-NEXT:    vmovaps %xmm0, (%rdi)
++; X64AVX-NEXT:    retq
++;
++; X64AVX2-LABEL: buildvector_v4f32_0404:
++; X64AVX2:       # %bb.0:
++; X64AVX2-NEXT:    vinsertps {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[2,3]
++; X64AVX2-NEXT:    vmovddup {{.*#+}} xmm0 = xmm0[0,0]
++; X64AVX2-NEXT:    vmovapd %xmm0, (%rdi)
++; X64AVX2-NEXT:    retq
+   %v0 = insertelement <4 x float> undef, float %a, i32 0
+   %v1 = insertelement <4 x float> %v0,   float %b, i32 1
+   %v2 = insertelement <4 x float> %v1,   float %a, i32 2
+diff --git a/test/CodeGen/X86/vector-shuffle-variable-256.ll b/test/CodeGen/X86/vector-shuffle-variable-256.ll
+index 91672d07b05..0c806d76273 100644
+--- a/test/CodeGen/X86/vector-shuffle-variable-256.ll
++++ b/test/CodeGen/X86/vector-shuffle-variable-256.ll
+@@ -47,8 +47,7 @@ define <4 x double> @var_shuffle_v4f64_v4f64_uxx0_i64(<4 x double> %x, i64 %i0,
+ ; ALL-NEXT:    andl $3, %edx
+ ; ALL-NEXT:    andl $3, %esi
+ ; ALL-NEXT:    vmovaps %ymm0, (%rsp)
+-; ALL-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+-; ALL-NEXT:    vmovddup {{.*#+}} xmm0 = xmm0[0,0]
++; ALL-NEXT:    vmovddup {{.*#+}} xmm0 = mem[0,0]
+ ; ALL-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+ ; ALL-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
+ ; ALL-NEXT:    movq %rbp, %rsp

--- a/L/LLVM/v6/bundled/llvm_patches/0020-llvm-D49832-SCEVPred.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0020-llvm-D49832-SCEVPred.patch
@@ -1,0 +1,187 @@
+commit 98592fcc61307968f7df1362771534595a1e1c21
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Wed Jul 25 19:29:02 2018 -0400
+
+    [SCEV] Don't expand Wrap predicate using inttoptr in ni addrspaces
+    
+    Summary:
+    In non-integral address spaces, we're not allowed to introduce inttoptr/ptrtoint
+    intrinsics. Instead, we need to expand any pointer arithmetic as geps on the
+    base pointer. Luckily this is a common task for SCEV, so all we have to do here
+    is hook up the corresponding helper function and add test case.
+    
+    Fixes PR38290
+    
+    Reviewers: reames, sanjoy
+    
+    Subscribers: javed.absar, llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D49832
+
+diff --git a/lib/Analysis/ScalarEvolutionExpander.cpp b/lib/Analysis/ScalarEvolutionExpander.cpp
+index 7f76f057216..f441a3647fb 100644
+--- a/lib/Analysis/ScalarEvolutionExpander.cpp
++++ b/lib/Analysis/ScalarEvolutionExpander.cpp
+@@ -2157,8 +2157,9 @@ Value *SCEVExpander::generateOverflowCheck(const SCEVAddRecExpr *AR,
+   const SCEV *Step = AR->getStepRecurrence(SE);
+   const SCEV *Start = AR->getStart();
+ 
++  Type *ARTy = AR->getType();
+   unsigned SrcBits = SE.getTypeSizeInBits(ExitCount->getType());
+-  unsigned DstBits = SE.getTypeSizeInBits(AR->getType());
++  unsigned DstBits = SE.getTypeSizeInBits(ARTy);
+ 
+   // The expression {Start,+,Step} has nusw/nssw if
+   //   Step < 0, Start - |Step| * Backedge <= Start
+@@ -2170,11 +2171,12 @@ Value *SCEVExpander::generateOverflowCheck(const SCEVAddRecExpr *AR,
+   Value *TripCountVal = expandCodeFor(ExitCount, CountTy, Loc);
+ 
+   IntegerType *Ty =
+-      IntegerType::get(Loc->getContext(), SE.getTypeSizeInBits(AR->getType()));
++      IntegerType::get(Loc->getContext(), SE.getTypeSizeInBits(ARTy));
++  Type *ARExpandTy = DL.isNonIntegralPointerType(ARTy) ? ARTy : Ty;
+ 
+   Value *StepValue = expandCodeFor(Step, Ty, Loc);
+   Value *NegStepValue = expandCodeFor(SE.getNegativeSCEV(Step), Ty, Loc);
+-  Value *StartValue = expandCodeFor(Start, Ty, Loc);
++  Value *StartValue = expandCodeFor(Start, ARExpandTy, Loc);
+ 
+   ConstantInt *Zero =
+       ConstantInt::get(Loc->getContext(), APInt::getNullValue(DstBits));
+@@ -2197,8 +2199,21 @@ Value *SCEVExpander::generateOverflowCheck(const SCEVAddRecExpr *AR,
+   // Compute:
+   //   Start + |Step| * Backedge < Start
+   //   Start - |Step| * Backedge > Start
+-  Value *Add = Builder.CreateAdd(StartValue, MulV);
+-  Value *Sub = Builder.CreateSub(StartValue, MulV);
++  Value *Add = nullptr, *Sub = nullptr;
++  if (ARExpandTy->isPointerTy()) {
++    PointerType *ARPtrTy = cast<PointerType>(ARExpandTy);
++    const SCEV *MulS = SE.getSCEV(MulV);
++    const SCEV *const StepArray[2] = {MulS, SE.getNegativeSCEV(MulS)};
++    Add = Builder.CreateBitCast(
++        expandAddToGEP(&StepArray[0], &StepArray[1], ARPtrTy, Ty, StartValue),
++        ARPtrTy);
++    Sub = Builder.CreateBitCast(
++        expandAddToGEP(&StepArray[1], &StepArray[2], ARPtrTy, Ty, StartValue),
++        ARPtrTy);
++  } else {
++    Add = Builder.CreateAdd(StartValue, MulV);
++    Sub = Builder.CreateSub(StartValue, MulV);
++  }
+ 
+   Value *EndCompareGT = Builder.CreateICmp(
+       Signed ? ICmpInst::ICMP_SGT : ICmpInst::ICMP_UGT, Sub, StartValue);
+diff --git a/test/Analysis/LoopAccessAnalysis/wrapping-pointer-ni.ll b/test/Analysis/LoopAccessAnalysis/wrapping-pointer-ni.ll
+new file mode 100644
+index 00000000000..ddcf5e1a195
+--- /dev/null
++++ b/test/Analysis/LoopAccessAnalysis/wrapping-pointer-ni.ll
+@@ -0,0 +1,73 @@
++; RUN: opt -loop-versioning -S < %s | FileCheck %s -check-prefix=LV
++
++; NB: addrspaces 10-13 are non-integral
++target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
++
++; This matches the test case from PR38290
++; Check that we expand the SCEV predicate check using GEP, rather
++; than ptrtoint.
++
++%jl_value_t = type opaque
++%jl_array_t = type { i8 addrspace(13)*, i64, i16, i16, i32 }
++
++declare i64 @julia_steprange_last_4949()
++
++define void @"japi1_align!_9477"(%jl_value_t addrspace(10)**) #0 {
++; LV-LAVEL: L26.lver.check
++; LV: [[OFMul:%[^ ]*]]  = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 4, i64 [[Step:%[^ ]*]])
++; LV-NEXT: [[OFMulResult:%[^ ]*]] = extractvalue { i64, i1 } [[OFMul]], 0
++; LV-NEXT: [[OFMulOverflow:%[^ ]*]] = extractvalue { i64, i1 } [[OFMul]], 1
++; LV-NEXT: [[PosGEP:%[^ ]*]] = getelementptr i32, i32 addrspace(13)* [[Base:%[^ ]*]], i64 [[Step]]
++; LV-NEXT: [[NegGEP:%[^ ]*]] = getelementptr i32, i32 addrspace(13)* [[Base]], i64 [[NegStep:%[^ ]*]]
++; LV-NEXT: icmp ugt i32 addrspace(13)* [[NegGEP]], [[Base]]
++; LV-NEXT: icmp ult i32 addrspace(13)* [[PosGEP]], [[Base]]
++; LV-NOT: inttoptr
++; LV-NOT: ptrtoint
++top:
++  %1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %0, align 8, !nonnull !1, !dereferenceable !2, !align !3
++  %2 = load i32, i32* inttoptr (i64 12 to i32*), align 4, !tbaa !4
++  %3 = sub i32 0, %2
++  %4 = call i64 @julia_steprange_last_4949()
++  %5 = addrspacecast %jl_value_t addrspace(10)* %1 to %jl_value_t addrspace(11)*
++  %6 = bitcast %jl_value_t addrspace(11)* %5 to %jl_value_t addrspace(10)* addrspace(11)*
++  %7 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(11)* %6, align 8, !tbaa !4, !nonnull !1, !dereferenceable !9, !align !2
++  %8 = addrspacecast %jl_value_t addrspace(10)* %7 to %jl_value_t addrspace(11)*
++  %9 = bitcast %jl_value_t addrspace(11)* %8 to i32 addrspace(13)* addrspace(11)*
++  %10 = load i32 addrspace(13)*, i32 addrspace(13)* addrspace(11)* %9, align 8, !tbaa !10, !nonnull !1
++  %11 = sext i32 %3 to i64
++  br label %L26
++
++L26:                                              ; preds = %L26, %top
++  %value_phi3 = phi i64 [ 0, %top ], [ %12, %L26 ]
++  %12 = add i64 %value_phi3, -1
++  %13 = getelementptr inbounds i32, i32 addrspace(13)* %10, i64 %12
++  %14 = load i32, i32 addrspace(13)* %13, align 4, !tbaa !13
++  %15 = add i64 %12, %11
++  %16 = getelementptr inbounds i32, i32 addrspace(13)* %10, i64 %15
++  store i32 %14, i32 addrspace(13)* %16, align 4, !tbaa !13
++  %17 = icmp eq i64 %value_phi3, %4
++  br i1 %17, label %L45, label %L26
++
++L45:                                              ; preds = %L26
++  ret void
++}
++
++attributes #0 = { "thunk" }
++
++!llvm.module.flags = !{!0}
++
++!0 = !{i32 1, !"Debug Info Version", i32 3}
++!1 = !{}
++!2 = !{i64 16}
++!3 = !{i64 8}
++!4 = !{!5, !5, i64 0}
++!5 = !{!"jtbaa_mutab", !6, i64 0}
++!6 = !{!"jtbaa_value", !7, i64 0}
++!7 = !{!"jtbaa_data", !8, i64 0}
++!8 = !{!"jtbaa"}
++!9 = !{i64 40}
++!10 = !{!11, !11, i64 0}
++!11 = !{!"jtbaa_arrayptr", !12, i64 0}
++!12 = !{!"jtbaa_array", !8, i64 0}
++!13 = !{!14, !14, i64 0}
++!14 = !{!"jtbaa_arraybuf", !7, i64 0}
+diff --git a/test/Analysis/LoopAccessAnalysis/wrapping-pointer-versioning.ll b/test/Analysis/LoopAccessAnalysis/wrapping-pointer-versioning.ll
+index a7e5bce7445..fa6fccecbf1 100644
+--- a/test/Analysis/LoopAccessAnalysis/wrapping-pointer-versioning.ll
++++ b/test/Analysis/LoopAccessAnalysis/wrapping-pointer-versioning.ll
+@@ -58,10 +58,10 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+ ; LV-NEXT: [[OFMul1:%[^ ]*]] = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 4, i64 [[BE]])
+ ; LV-NEXT: [[OFMulResult1:%[^ ]*]] = extractvalue { i64, i1 } [[OFMul1]], 0
+ ; LV-NEXT: [[OFMulOverflow1:%[^ ]*]] = extractvalue { i64, i1 } [[OFMul1]], 1
+-; LV-NEXT: [[AddEnd1:%[^ ]*]] = add i64 %a2, [[OFMulResult1]]
+-; LV-NEXT: [[SubEnd1:%[^ ]*]] = sub i64 %a2, [[OFMulResult1]]
+-; LV-NEXT: [[CmpNeg1:%[^ ]*]] = icmp ugt i64 [[SubEnd1]], %a2
+-; LV-NEXT: [[CmpPos1:%[^ ]*]] = icmp ult i64 [[AddEnd1]], %a2
++; LV-NEXT: [[AddEnd1:%[^ ]*]] = add i64 [[A0:%[^ ]*]], [[OFMulResult1]]
++; LV-NEXT: [[SubEnd1:%[^ ]*]] = sub i64 [[A0]], [[OFMulResult1]]
++; LV-NEXT: [[CmpNeg1:%[^ ]*]] = icmp ugt i64 [[SubEnd1]], [[A0]]
++; LV-NEXT: [[CmpPos1:%[^ ]*]] = icmp ult i64 [[AddEnd1]], [[A0]]
+ ; LV-NEXT: [[Cmp:%[^ ]*]] = select i1 false, i1 [[CmpNeg1]], i1 [[CmpPos1]]
+ ; LV-NEXT: [[PredCheck1:%[^ ]*]] = or i1 [[Cmp]], [[OFMulOverflow1]]
+ 
+@@ -233,10 +233,10 @@ for.end:                                          ; preds = %for.body
+ ; LV: [[OFMul1:%[^ ]*]] = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 4, i64 [[BE:%[^ ]*]])
+ ; LV-NEXT: [[OFMulResult1:%[^ ]*]] = extractvalue { i64, i1 } [[OFMul1]], 0
+ ; LV-NEXT: [[OFMulOverflow1:%[^ ]*]] = extractvalue { i64, i1 } [[OFMul1]], 1
+-; LV-NEXT: [[AddEnd1:%[^ ]*]] = add i64 %a2, [[OFMulResult1]]
+-; LV-NEXT: [[SubEnd1:%[^ ]*]] = sub i64 %a2, [[OFMulResult1]]
+-; LV-NEXT: [[CmpNeg1:%[^ ]*]] = icmp ugt i64 [[SubEnd1]], %a2
+-; LV-NEXT: [[CmpPos1:%[^ ]*]] = icmp ult i64 [[AddEnd1]], %a2
++; LV-NEXT: [[AddEnd1:%[^ ]*]] = add i64 [[A0:%[^ ]*]], [[OFMulResult1]]
++; LV-NEXT: [[SubEnd1:%[^ ]*]] = sub i64 [[A0]], [[OFMulResult1]]
++; LV-NEXT: [[CmpNeg1:%[^ ]*]] = icmp ugt i64 [[SubEnd1]], [[A0]]
++; LV-NEXT: [[CmpPos1:%[^ ]*]] = icmp ult i64 [[AddEnd1]], [[A0]]
+ ; LV-NEXT: [[Cmp:%[^ ]*]] = select i1 false, i1 [[CmpNeg1]], i1 [[CmpPos1]]
+ ; LV-NEXT: [[PredCheck1:%[^ ]*]] = or i1 [[Cmp]], [[OFMulOverflow1]]
+ 

--- a/L/LLVM/v6/bundled/llvm_patches/0021-llvm-rL323946-LSRTy.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0021-llvm-rL323946-LSRTy.patch
@@ -1,0 +1,45 @@
+commit ab60b05a472e8651cbe53c19513b7e62b9ff32df
+Author: Mikael Holmen <mikael.holmen@ericsson.com>
+Date:   Thu Feb 1 06:38:34 2018 +0000
+
+    [LSR] Don't force bases of foldable formulae to the final type.
+    
+    Summary:
+    Before emitting code for scaled registers, we prevent
+    SCEVExpander from hoisting any scaled addressing mode
+    by emitting all the bases first. However, these bases
+    are being forced to the final type, resulting in some
+    odd code.
+    
+    For example, if the type of the base is an integer and
+    the final type is a pointer, we will emit an inttoptr
+    for the base, a ptrtoint for the scale, and then a
+    'reverse' GEP where the GEP pointer is actually the base
+    integer and the index is the pointer. It's more intuitive
+    to use the pointer as a pointer and the integer as index.
+    
+    Patch by: Bevin Hansson
+    
+    Reviewers: atrick, qcolombet, sanjoy
+    
+    Reviewed By: qcolombet
+    
+    Subscribers: llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D42103
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@323946 91177308-0d34-0410-b5e6-96231b3b80d8
+
+diff --git a/lib/Transforms/Scalar/LoopStrengthReduce.cpp b/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+index 332c074a1df..4b8e2286ed9 100644
+--- a/lib/Transforms/Scalar/LoopStrengthReduce.cpp
++++ b/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+@@ -4993,7 +4993,7 @@ Value *LSRInstance::Expand(const LSRUse &LU, const LSRFixup &LF,
+       // Unless the addressing mode will not be folded.
+       if (!Ops.empty() && LU.Kind == LSRUse::Address &&
+           isAMCompletelyFolded(TTI, LU, F)) {
+-        Value *FullV = Rewriter.expandCodeFor(SE.getAddExpr(Ops), Ty);
++        Value *FullV = Rewriter.expandCodeFor(SE.getAddExpr(Ops), nullptr);
+         Ops.clear();
+         Ops.push_back(SE.getUnknown(FullV));
+       }

--- a/L/LLVM/v6/bundled/llvm_patches/0022-llvm-OProfile-line-num.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0022-llvm-OProfile-line-num.patch
@@ -1,0 +1,48 @@
+commit 4840cf7299bb312125d41fc84733c15c2370f18e
+Author: DokFaust <rodia@autistici.org>
+Date:   Fri Jun 8 19:23:01 2018 +0200
+
+    Add debug line-level code information to OProfile module
+
+diff --git a/lib/ExecutionEngine/OProfileJIT/LLVMBuild.txt b/lib/ExecutionEngine/OProfileJIT/LLVMBuild.txt
+index 7d5550046a5..ea100286318 100644
+--- a/lib/ExecutionEngine/OProfileJIT/LLVMBuild.txt
++++ b/lib/ExecutionEngine/OProfileJIT/LLVMBuild.txt
+@@ -24 +24 @@ parent = ExecutionEngine
+-required_libraries = Support Object ExecutionEngine
++required_libraries = DebugInfoDWARF Support Object ExecutionEngine
+diff --git a/lib/ExecutionEngine/OProfileJIT/OProfileJITEventListener.cpp b/lib/ExecutionEngine/OProfileJIT/OProfileJITEventListener.cpp
+index 3581d645839..045ecb82853 100644
+--- a/lib/ExecutionEngine/OProfileJIT/OProfileJITEventListener.cpp
++++ b/lib/ExecutionEngine/OProfileJIT/OProfileJITEventListener.cpp
+@@ -26,0 +27,2 @@
++#include "llvm/DebugInfo/DIContext.h"
++#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+@@ -86,0 +89,2 @@ void OProfileJITEventListener::NotifyObjectEmitted(
++  std::unique_ptr<DIContext> Context = DWARFContext::create(DebugObj);
++  std::string SourceFileName;
+@@ -111 +115,23 @@ void OProfileJITEventListener::NotifyObjectEmitted(
+-    // TODO: support line number info (similar to IntelJITEventListener.cpp)
++    DILineInfoTable Lines = Context->getLineInfoForAddressRange(Addr, Size);
++    DILineInfoTable::iterator Begin = Lines.begin();
++    DILineInfoTable::iterator End = Lines.end();
++    size_t i = 0;
++
++    size_t num_entries = std::distance(Begin, End);
++    static struct debug_line_info* debug_line;
++    debug_line = (struct debug_line_info * )calloc(num_entries, sizeof(struct debug_line_info));
++
++    for(DILineInfoTable::iterator It=Begin; It != End; ++It){
++        i = std::distance(Begin,It);
++        debug_line[i].vma = (unsigned long) It->first;
++        debug_line[i].lineno = It->second.Line;
++        SourceFileName = Lines.front().second.FileName;
++        debug_line[i].filename = const_cast<char *>(SourceFileName.c_str());
++    }
++
++    if(Wrapper->op_write_debug_line_info((void*) Addr, num_entries, debug_line) == -1) {
++        DEBUG(dbgs() << "Failed to tell OProfiler about debug object at ["
++                     << (void*) Addr << "-" << ((char *) Addr + Size)
++                     <<  "]\n");
++        continue;
++    }

--- a/L/LLVM/v6/bundled/llvm_patches/0023-llvm-D44892-Perf-integration.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0023-llvm-D44892-Perf-integration.patch
@@ -1,0 +1,677 @@
+From 45bc0f0badbdbabaed7d204757c2aad7ab49a3fe Mon Sep 17 00:00:00 2001
+From: DokFaust <rodia@autistici.org>
+Date: Mon, 11 Jun 2018 12:59:42 +0200
+Subject: [PATCH] PerfJITEventListener integration, requires compile flag
+ LLVM_USE_PERF
+
+---
+ CMakeLists.txt                                |  13 +
+ include/llvm/Config/config.h.cmake            |   3 +
+ include/llvm/Config/llvm-config.h.cmake       |   3 +
+ .../llvm/ExecutionEngine/JITEventListener.h   |   9 +
+ lib/ExecutionEngine/CMakeLists.txt            |   4 +
+ lib/ExecutionEngine/LLVMBuild.txt             |   2 +-
+ lib/ExecutionEngine/Orc/LLVMBuild.txt         |   2 +-
+ .../PerfJITEvents/CMakeLists.txt              |   5 +
+ .../PerfJITEvents/LLVMBuild.txt               |  23 +
+ .../PerfJITEvents/PerfJITEventListener.cpp    | 492 ++++++++++++++++++
+ 10 files changed, 554 insertions(+), 2 deletions(-)
+ create mode 100644 lib/ExecutionEngine/PerfJITEvents/CMakeLists.txt
+ create mode 100644 lib/ExecutionEngine/PerfJITEvents/LLVMBuild.txt
+ create mode 100644 lib/ExecutionEngine/PerfJITEvents/PerfJITEventListener.cpp
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f8da6cf9211..fb92c825a46 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -426,6 +426,16 @@ if( LLVM_USE_OPROFILE )
+   endif( NOT CMAKE_SYSTEM_NAME MATCHES "Linux" )
+ endif( LLVM_USE_OPROFILE )
+
++option(LLVM_USE_PERF
++  "Use perf JIT interface to inform perf about JIT code" OFF)
++
++# If enabled, verify we are on a platform that supports perf.
++if( LLVM_USE_PERF )
++  if( NOT CMAKE_SYSTEM_NAME MATCHES "Linux" )
++    message(FATAL_ERROR "perf support is available on Linux only.")
++  endif( NOT CMAKE_SYSTEM_NAME MATCHES "Linux" )
++endif( LLVM_USE_PERF )
++
+ set(LLVM_USE_SANITIZER "" CACHE STRING
+   "Define the sanitizer used to build binaries and tests.")
+ set(LLVM_LIB_FUZZING_ENGINE "" CACHE PATH
+@@ -634,6 +644,9 @@ endif (LLVM_USE_INTEL_JITEVENTS)
+ if (LLVM_USE_OPROFILE)
+   set(LLVMOPTIONALCOMPONENTS ${LLVMOPTIONALCOMPONENTS} OProfileJIT)
+ endif (LLVM_USE_OPROFILE)
++if (LLVM_USE_PERF)
++    set(LLVMOPTIONALCOMPONENTS ${LLVMOPTIONALCOMPONENTS} PerfJITEvents)
++endif (LLVM_USE_PERF)
+
+ message(STATUS "Constructing LLVMBuild project information")
+ execute_process(
+diff --git a/include/llvm/Config/config.h.cmake b/include/llvm/Config/config.h.cmake
+index 940f8420304..17787ed779b 100644
+--- a/include/llvm/Config/config.h.cmake
++++ b/include/llvm/Config/config.h.cmake
+@@ -377,6 +377,9 @@
+ /* Define if we have the oprofile JIT-support library */
+ #cmakedefine01 LLVM_USE_OPROFILE
+
++/* Define if we have the perf JIT-support library */
++#cmakedefine01 LLVM_USE_PERF
++
+ /* LLVM version information */
+ #cmakedefine LLVM_VERSION_INFO "${LLVM_VERSION_INFO}"
+
+diff --git a/include/llvm/Config/llvm-config.h.cmake b/include/llvm/Config/llvm-config.h.cmake
+index 4daa00f3bc4..8d9c3b24d52 100644
+--- a/include/llvm/Config/llvm-config.h.cmake
++++ b/include/llvm/Config/llvm-config.h.cmake
+@@ -65,6 +65,9 @@
+ /* Define if we have the oprofile JIT-support library */
+ #cmakedefine01 LLVM_USE_OPROFILE
+
++/* Define if we have the perf JIT-support library */
++#cmakedefine01 LLVM_USE_PERF
++
+ /* Major version of the LLVM API */
+ #define LLVM_VERSION_MAJOR ${LLVM_VERSION_MAJOR}
+
+diff --git a/include/llvm/ExecutionEngine/JITEventListener.h b/include/llvm/ExecutionEngine/JITEventListener.h
+index ff7840f00a4..1cc2c423a8b 100644
+--- a/include/llvm/ExecutionEngine/JITEventListener.h
++++ b/include/llvm/ExecutionEngine/JITEventListener.h
+@@ -115,6 +115,15 @@ public:
+   }
+ #endif // USE_OPROFILE
+
++#ifdef LLVM_USE_PERF
++  static JITEventListener *createPerfJITEventListener();
++#else
++  static JITEventListener *createPerfJITEventListener()
++  {
++    return nullptr;
++  }
++#endif //USE_PERF
++
+ private:
+   virtual void anchor();
+ };
+diff --git a/lib/ExecutionEngine/CMakeLists.txt b/lib/ExecutionEngine/CMakeLists.txt
+index 84b34919e44..893d113a685 100644
+--- a/lib/ExecutionEngine/CMakeLists.txt
++++ b/lib/ExecutionEngine/CMakeLists.txt
+@@ -30,3 +30,7 @@ endif( LLVM_USE_OPROFILE )
+ if( LLVM_USE_INTEL_JITEVENTS )
+   add_subdirectory(IntelJITEvents)
+ endif( LLVM_USE_INTEL_JITEVENTS )
++
++if( LLVM_USE_PERF )
++    add_subdirectory(PerfJITEvents)
++endif( LLVM_USE_PERF )
+diff --git a/lib/ExecutionEngine/LLVMBuild.txt b/lib/ExecutionEngine/LLVMBuild.txt
+index 9d29a41f504..b6e1bda6a51 100644
+--- a/lib/ExecutionEngine/LLVMBuild.txt
++++ b/lib/ExecutionEngine/LLVMBuild.txt
+@@ -16,7 +16,7 @@
+ ;===------------------------------------------------------------------------===;
+
+ [common]
+-subdirectories = Interpreter MCJIT RuntimeDyld IntelJITEvents OProfileJIT Orc
++subdirectories = Interpreter MCJIT RuntimeDyld IntelJITEvents OProfileJIT Orc PerfJITEvents
+
+ [component_0]
+ type = Library
+diff --git a/lib/ExecutionEngine/Orc/LLVMBuild.txt b/lib/ExecutionEngine/Orc/LLVMBuild.txt
+index 8f05172e77a..ef4ae64e823 100644
+--- a/lib/ExecutionEngine/Orc/LLVMBuild.txt
++++ b/lib/ExecutionEngine/Orc/LLVMBuild.txt
+@@ -19,4 +19,4 @@
+ type = Library
+ name = OrcJIT
+ parent = ExecutionEngine
+-required_libraries = Core ExecutionEngine Object RuntimeDyld Support TransformUtils
++required_libraries = Core ExecutionEngine Object RuntimeDyld Support TransformUtils
+diff --git a/lib/ExecutionEngine/PerfJITEvents/CMakeLists.txt b/lib/ExecutionEngine/PerfJITEvents/CMakeLists.txt
+new file mode 100644
+index 00000000000..136cc429d02
+--- /dev/null
++++ b/lib/ExecutionEngine/PerfJITEvents/CMakeLists.txt
+@@ -0,0 +1,5 @@
++add_llvm_library(LLVMPerfJITEvents
++  PerfJITEventListener.cpp
++  )
++
++add_dependencies(LLVMPerfJITEvents LLVMCodeGen)
+diff --git a/lib/ExecutionEngine/PerfJITEvents/LLVMBuild.txt b/lib/ExecutionEngine/PerfJITEvents/LLVMBuild.txt
+new file mode 100644
+index 00000000000..b1958a69260
+--- /dev/null
++++ b/lib/ExecutionEngine/PerfJITEvents/LLVMBuild.txt
+@@ -0,0 +1,23 @@
++;===- ./lib/ExecutionEngine/PerfJITEvents/LLVMBuild.txt ----------------*- Conf -*--===;
++;
++;                     The LLVM Compiler Infrastructure
++;
++; This file is distributed under the University of Illinois Open Source
++; License. See LICENSE.TXT for details.
++;
++;===------------------------------------------------------------------------===;
++;
++; This is an LLVMBuild description file for the components in this subdirectory.
++;
++; For more information on the LLVMBuild system, please see:
++;
++;   http://llvm.org/docs/LLVMBuild.html
++;
++;===------------------------------------------------------------------------===;
++
++[component_0]
++type = OptionalLibrary
++name = PerfJITEvents
++parent = ExecutionEngine
++required_libraries = CodeGen Core DebugInfoDWARF ExecutionEngine Object Support TransformUtils
++
+diff --git a/lib/ExecutionEngine/PerfJITEvents/PerfJITEventListener.cpp b/lib/ExecutionEngine/PerfJITEvents/PerfJITEventListener.cpp
+new file mode 100644
+index 00000000000..c2b97dd59f3
+--- /dev/null
++++ b/lib/ExecutionEngine/PerfJITEvents/PerfJITEventListener.cpp
+@@ -0,0 +1,492 @@
++//===-- PerfJITEventListener.cpp - Tell Linux's perf about JITted code ----===//
++//
++//                     The LLVM Compiler Infrastructure
++//
++// This file is distributed under the University of Illinois Open Source
++// License. See LICENSE.TXT for details.
++//
++//===----------------------------------------------------------------------===//
++//
++// This file defines a JITEventListener object that tells perf about JITted
++// functions, including source line information.
++//
++// Documentation for perf jit integration is available at:
++// https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/jitdump-specification.txt
++// https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/jit-interface.txt
++//
++//===----------------------------------------------------------------------===//
++
++#include "llvm/ADT/Twine.h"
++#include "llvm/Config/config.h"
++#include "llvm/DebugInfo/DWARF/DWARFContext.h"
++#include "llvm/ExecutionEngine/JITEventListener.h"
++#include "llvm/Object/ObjectFile.h"
++#include "llvm/Object/SymbolSize.h"
++#include "llvm/Support/Debug.h"
++#include "llvm/Support/Errno.h"
++#include "llvm/Support/FileSystem.h"
++#include "llvm/Support/MemoryBuffer.h"
++#include "llvm/Support/Mutex.h"
++#include "llvm/Support/MutexGuard.h"
++#include "llvm/Support/Path.h"
++#include "llvm/Support/Process.h"
++#include "llvm/Support/Threading.h"
++#include "llvm/Support/raw_ostream.h"
++
++#include <sys/mman.h>  // mmap()
++#include <sys/types.h> // getpid()
++#include <time.h>      // clock_gettime(), time(), localtime_r() */
++#include <unistd.h>    // for getpid(), read(), close()
++
++using namespace llvm;
++using namespace llvm::object;
++typedef DILineInfoSpecifier::FileLineInfoKind FileLineInfoKind;
++
++namespace {
++
++// language identifier (XXX: should we generate something better from debug
++// info?)
++#define JIT_LANG "llvm-IR"
++#define LLVM_PERF_JIT_MAGIC                                                    \
++  ((uint32_t)'J' << 24 | (uint32_t)'i' << 16 | (uint32_t)'T' << 8 |            \
++   (uint32_t)'D')
++#define LLVM_PERF_JIT_VERSION 1
++
++// bit 0: set if the jitdump file is using an architecture-specific timestamp
++// clock source
++#define JITDUMP_FLAGS_ARCH_TIMESTAMP (1ULL << 0)
++
++struct LLVMPerfJitHeader;
++
++class PerfJITEventListener : public JITEventListener {
++public:
++  PerfJITEventListener();
++  ~PerfJITEventListener() {
++    if (MarkerAddr)
++      CloseMarker();
++  }
++
++  void NotifyObjectEmitted(const ObjectFile &Obj,
++                           const RuntimeDyld::LoadedObjectInfo &L) override;
++  void NotifyFreeingObject(const ObjectFile &Obj) override;
++
++private:
++  bool InitDebuggingDir();
++  bool OpenMarker();
++  void CloseMarker();
++  static bool FillMachine(LLVMPerfJitHeader &hdr);
++
++  void NotifyCode(Expected<llvm::StringRef> &Symbol, uint64_t CodeAddr,
++                  uint64_t CodeSize);
++  void NotifyDebug(uint64_t CodeAddr, DILineInfoTable Lines);
++
++  // cache lookups
++  pid_t Pid;
++
++  // base directory for output data
++  std::string JitPath;
++
++  // output data stream, closed via Dumpstream
++  int DumpFd = -1;
++
++  // output data stream
++  std::unique_ptr<raw_fd_ostream> Dumpstream;
++
++  // prevent concurrent dumps from messing up the output file
++  sys::Mutex Mutex;
++
++  // perf mmap marker
++  void *MarkerAddr = NULL;
++
++  // perf support ready
++  bool SuccessfullyInitialized = false;
++
++  // identifier for functions, primarily to identify when moving them around
++  uint64_t CodeGeneration = 1;
++};
++
++// The following are POD struct definitions from the perf jit specification
++
++enum LLVMPerfJitRecordType {
++  JIT_CODE_LOAD = 0,
++  JIT_CODE_MOVE = 1, // not emitted, code isn't moved
++  JIT_CODE_DEBUG_INFO = 2,
++  JIT_CODE_CLOSE = 3,          // not emitted, unnecessary
++  JIT_CODE_UNWINDING_INFO = 4, // not emitted
++
++  JIT_CODE_MAX
++};
++
++struct LLVMPerfJitHeader {
++  uint32_t Magic;     // characters "JiTD"
++  uint32_t Version;   // header version
++  uint32_t TotalSize; // total size of header
++  uint32_t ElfMach;   // elf mach target
++  uint32_t Pad1;      // reserved
++  uint32_t Pid;
++  uint64_t Timestamp; // timestamp
++  uint64_t Flags;     // flags
++};
++
++// record prefix (mandatory in each record)
++struct LLVMPerfJitRecordPrefix {
++  uint32_t Id; // record type identifier
++  uint32_t TotalSize;
++  uint64_t Timestamp;
++};
++
++struct LLVMPerfJitRecordCodeLoad {
++  LLVMPerfJitRecordPrefix Prefix;
++
++  uint32_t Pid;
++  uint32_t Tid;
++  uint64_t Vma;
++  uint64_t CodeAddr;
++  uint64_t CodeSize;
++  uint64_t CodeIndex;
++};
++
++struct LLVMPerfJitDebugEntry {
++  uint64_t Addr;
++  int Lineno;  // source line number starting at 1
++  int Discrim; // column discriminator, 0 is default
++  // followed by null terminated filename, \xff\0 if same as previous entry
++};
++
++struct LLVMPerfJitRecordDebugInfo {
++  LLVMPerfJitRecordPrefix Prefix;
++
++  uint64_t CodeAddr;
++  uint64_t NrEntry;
++  // followed by NrEntry LLVMPerfJitDebugEntry records
++};
++
++static inline uint64_t timespec_to_ns(const struct timespec *ts) {
++  const uint64_t NanoSecPerSec = 1000000000;
++  return ((uint64_t)ts->tv_sec * NanoSecPerSec) + ts->tv_nsec;
++}
++
++static inline uint64_t perf_get_timestamp(void) {
++  struct timespec ts;
++  int ret;
++
++  ret = clock_gettime(CLOCK_MONOTONIC, &ts);
++  if (ret)
++    return 0;
++
++  return timespec_to_ns(&ts);
++}
++
++PerfJITEventListener::PerfJITEventListener() : Pid(::getpid()) {
++  // check if clock-source is supported
++  if (!perf_get_timestamp()) {
++    errs() << "kernel does not support CLOCK_MONOTONIC\n";
++    return;
++  }
++
++  if (!InitDebuggingDir()) {
++    errs() << "could not initialize debugging directory\n";
++    return;
++  }
++
++  std::string Filename;
++  raw_string_ostream FilenameBuf(Filename);
++  FilenameBuf << JitPath << "/jit-" << Pid << ".dump";
++
++  // Need to open ourselves, because we need to hand the FD to OpenMarker() and
++  // raw_fd_ostream doesn't expose the FD.
++  using sys::fs::openFileForWrite;
++  if (auto EC =
++          openFileForWrite(FilenameBuf.str(), DumpFd, sys::fs::F_RW, 0666)) {
++    errs() << "could not open JIT dump file " << FilenameBuf.str() << ": "
++           << EC.message() << "\n";
++    return;
++  }
++
++  Dumpstream = make_unique<raw_fd_ostream>(DumpFd, true);
++
++  LLVMPerfJitHeader Header = {0};
++  if (!FillMachine(Header))
++    return;
++
++  // signal this process emits JIT information
++  if (!OpenMarker())
++    return;
++
++  // emit dumpstream header
++  Header.Magic = LLVM_PERF_JIT_MAGIC;
++  Header.Version = LLVM_PERF_JIT_VERSION;
++  Header.TotalSize = sizeof(Header);
++  Header.Pid = Pid;
++  Header.Timestamp = perf_get_timestamp();
++  Dumpstream->write(reinterpret_cast<const char *>(&Header), sizeof(Header));
++
++  // Everything initialized, can do profiling now.
++  if (!Dumpstream->has_error())
++    SuccessfullyInitialized = true;
++}
++
++void PerfJITEventListener::NotifyObjectEmitted(
++    const ObjectFile &Obj, const RuntimeDyld::LoadedObjectInfo &L) {
++
++  if (!SuccessfullyInitialized)
++    return;
++
++  OwningBinary<ObjectFile> DebugObjOwner = L.getObjectForDebug(Obj);
++  const ObjectFile &DebugObj = *DebugObjOwner.getBinary();
++
++  // Get the address of the object image for use as a unique identifier
++  std::unique_ptr<DIContext> Context = DWARFContext::create(DebugObj);
++
++  // Use symbol info to iterate over functions in the object.
++  for (const std::pair<SymbolRef, uint64_t> &P : computeSymbolSizes(DebugObj)) {
++    SymbolRef Sym = P.first;
++    std::string SourceFileName;
++
++    Expected<SymbolRef::Type> SymTypeOrErr = Sym.getType();
++    if (!SymTypeOrErr) {
++      // There's not much we can with errors here
++      consumeError(SymTypeOrErr.takeError());
++      continue;
++    }
++    SymbolRef::Type SymType = *SymTypeOrErr;
++    if (SymType != SymbolRef::ST_Function)
++      continue;
++
++    Expected<StringRef> Name = Sym.getName();
++    if (!Name) {
++      consumeError(Name.takeError());
++      continue;
++    }
++
++    Expected<uint64_t> AddrOrErr = Sym.getAddress();
++    if (!AddrOrErr) {
++      consumeError(AddrOrErr.takeError());
++      continue;
++    }
++    uint64_t Addr = *AddrOrErr;
++    uint64_t Size = P.second;
++
++    // According to spec debugging info has to come before loading the
++    // corresonding code load.
++    DILineInfoTable Lines = Context->getLineInfoForAddressRange(
++        Addr, Size, FileLineInfoKind::AbsoluteFilePath);
++
++    NotifyDebug(Addr, Lines);
++    NotifyCode(Name, Addr, Size);
++  }
++
++  Dumpstream->flush();
++}
++
++void PerfJITEventListener::NotifyFreeingObject(const ObjectFile &Obj) {
++  // perf currently doesn't have an interface for unloading. But munmap()ing the
++  // code section does, so that's ok.
++}
++
++bool PerfJITEventListener::InitDebuggingDir() {
++  time_t Time;
++  struct tm LocalTime;
++  char TimeBuffer[sizeof("YYYYMMDD")];
++  SmallString<64> Path;
++
++  // search for location to dump data to
++  if (const char *BaseDir = getenv("JITDUMPDIR"))
++    Path.append(BaseDir);
++  else if (!sys::path::home_directory(Path))
++    Path = ".";
++
++  // create debug directory
++  Path += "/.debug/jit/";
++  if (auto EC = sys::fs::create_directories(Path)) {
++    errs() << "could not create jit cache directory " << Path << ": "
++           << EC.message() << "\n";
++    return false;
++  }
++
++  // create unique directory for dump data related to this process
++  time(&Time);
++  localtime_r(&Time, &LocalTime);
++  strftime(TimeBuffer, sizeof(TimeBuffer), "%Y%m%d", &LocalTime);
++  Path += JIT_LANG "-jit-";
++  Path += TimeBuffer;
++
++  SmallString<128> UniqueDebugDir;
++
++  using sys::fs::createUniqueDirectory;
++  if (auto EC = createUniqueDirectory(Path, UniqueDebugDir)) {
++    errs() << "could not create unique jit cache directory " << UniqueDebugDir
++           << ": " << EC.message() << "\n";
++    return false;
++  }
++
++  JitPath = UniqueDebugDir.str();
++
++  return true;
++}
++
++bool PerfJITEventListener::OpenMarker() {
++  // We mmap the jitdump to create an MMAP RECORD in perf.data file.  The mmap
++  // is captured either live (perf record running when we mmap) or in deferred
++  // mode, via /proc/PID/maps. The MMAP record is used as a marker of a jitdump
++  // file for more meta data info about the jitted code. Perf report/annotate
++  // detect this special filename and process the jitdump file.
++  //
++  // Mapping must be PROT_EXEC to ensure it is captured by perf record
++  // even when not using -d option.
++  MarkerAddr = ::mmap(NULL, sys::Process::getPageSize(), PROT_READ | PROT_EXEC,
++                      MAP_PRIVATE, DumpFd, 0);
++
++  if (MarkerAddr == MAP_FAILED) {
++    errs() << "could not mmap JIT marker\n";
++    return false;
++  }
++  return true;
++}
++
++void PerfJITEventListener::CloseMarker() {
++  if (!MarkerAddr)
++    return;
++
++  munmap(MarkerAddr, sys::Process::getPageSize());
++  MarkerAddr = nullptr;
++}
++
++bool PerfJITEventListener::FillMachine(LLVMPerfJitHeader &hdr) {
++  char id[16];
++  struct {
++    uint16_t e_type;
++    uint16_t e_machine;
++  } info;
++
++  size_t RequiredMemory = sizeof(id) + sizeof(info);
++
++  ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
++    MemoryBuffer::getFileSlice("/proc/self/exe",
++			       RequiredMemory,
++			       0);
++
++  // This'll not guarantee that enough data was actually read from the
++  // underlying file. Instead the trailing part of the buffer would be
++  // zeroed. Given the ELF signature check below that seems ok though,
++  // it's unlikely that the file ends just after that, and the
++  // consequence would just be that perf wouldn't recognize the
++  // signature.
++  if (auto EC = MB.getError()) {
++    errs() << "could not open /proc/self/exe: " << EC.message() << "\n";
++    return false;
++  }
++
++  memcpy(&id, (*MB)->getBufferStart(), sizeof(id));
++  memcpy(&info, (*MB)->getBufferStart() + sizeof(id), sizeof(info));
++
++  // check ELF signature
++  if (id[0] != 0x7f || id[1] != 'E' || id[2] != 'L' || id[3] != 'F') {
++    errs() << "invalid elf signature\n";
++    return false;
++  }
++
++  hdr.ElfMach = info.e_machine;
++
++  return true;
++}
++
++void PerfJITEventListener::NotifyCode(Expected<llvm::StringRef> &Symbol,
++                                      uint64_t CodeAddr, uint64_t CodeSize) {
++  assert(SuccessfullyInitialized);
++
++  // 0 length functions can't have samples.
++  if (CodeSize == 0)
++    return;
++
++  LLVMPerfJitRecordCodeLoad rec;
++  rec.Prefix.Id = JIT_CODE_LOAD;
++  rec.Prefix.TotalSize = sizeof(rec) +        // debug record itself
++                         Symbol->size() + 1 + // symbol name
++                         CodeSize;            // and code
++  rec.Prefix.Timestamp = perf_get_timestamp();
++
++  rec.CodeSize = CodeSize;
++  rec.Vma = 0;
++  rec.CodeAddr = CodeAddr;
++  rec.Pid = Pid;
++  rec.Tid = get_threadid();
++
++  // avoid interspersing output
++  MutexGuard Guard(Mutex);
++
++  rec.CodeIndex = CodeGeneration++; // under lock!
++
++  Dumpstream->write(reinterpret_cast<const char *>(&rec), sizeof(rec));
++  Dumpstream->write(Symbol->data(), Symbol->size() + 1);
++  Dumpstream->write(reinterpret_cast<const char *>(CodeAddr), CodeSize);
++}
++
++void PerfJITEventListener::NotifyDebug(uint64_t CodeAddr,
++                                       DILineInfoTable Lines) {
++  assert(SuccessfullyInitialized);
++
++  // Didn't get useful debug info.
++  if (Lines.empty())
++    return;
++
++  LLVMPerfJitRecordDebugInfo rec;
++  rec.Prefix.Id = JIT_CODE_DEBUG_INFO;
++  rec.Prefix.TotalSize = sizeof(rec); // will be increased further
++  rec.Prefix.Timestamp = perf_get_timestamp();
++  rec.CodeAddr = CodeAddr;
++  rec.NrEntry = Lines.size();
++
++  // compute total size size of record (variable due to filenames)
++  DILineInfoTable::iterator Begin = Lines.begin();
++  DILineInfoTable::iterator End = Lines.end();
++  for (DILineInfoTable::iterator It = Begin; It != End; ++It) {
++    DILineInfo &line = It->second;
++    rec.Prefix.TotalSize += sizeof(LLVMPerfJitDebugEntry);
++    rec.Prefix.TotalSize += line.FileName.size() + 1;
++  }
++
++  // The debug_entry describes the source line information. It is defined as
++  // follows in order:
++  // * uint64_t code_addr: address of function for which the debug information
++  // is generated
++  // * uint32_t line     : source file line number (starting at 1)
++  // * uint32_t discrim  : column discriminator, 0 is default
++  // * char name[n]      : source file name in ASCII, including null termination
++
++  // avoid interspersing output
++  MutexGuard Guard(Mutex);
++
++  Dumpstream->write(reinterpret_cast<const char *>(&rec), sizeof(rec));
++
++  for (DILineInfoTable::iterator It = Begin; It != End; ++It) {
++    LLVMPerfJitDebugEntry LineInfo;
++    DILineInfo &Line = It->second;
++
++    LineInfo.Addr = It->first;
++    // The function re-created by perf is preceded by a elf
++    // header. Need to adjust for that, otherwise the results are
++    // wrong.
++    LineInfo.Addr += 0x40;
++    LineInfo.Lineno = Line.Line;
++    LineInfo.Discrim = Line.Discriminator;
++
++    Dumpstream->write(reinterpret_cast<const char *>(&LineInfo),
++                      sizeof(LineInfo));
++    Dumpstream->write(Line.FileName.c_str(), Line.FileName.size() + 1);
++  }
++}
++
++// There should be only a single event listener per process, otherwise perf gets
++// confused.
++llvm::ManagedStatic<PerfJITEventListener> PerfListener;
++
++} // end anonymous namespace
++
++namespace llvm {
++JITEventListener *JITEventListener::createPerfJITEventListener() {
++  return &*PerfListener;
++}
++
++} // namespace llvm
++
+--
+2.17.1
+

--- a/L/LLVM/v6/bundled/llvm_patches/0024-llvm-D50010-VNCoercion-ni.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0024-llvm-D50010-VNCoercion-ni.patch
@@ -1,0 +1,89 @@
+commit 8eb2b102a203d83fb713f3bf79acf235dabdd8cd
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Mon Jul 30 16:59:08 2018 -0400
+
+    [VNCoercion] Disallow coercion between different ni addrspaces
+    
+    Summary:
+    I'm not sure if it would be legal by the IR reference to introduce
+    an addrspacecast here, since the IR reference is a bit vague on
+    the exact semantics, but at least for our usage of it (and I
+    suspect for many other's usage) it is not. For us, addrspacecasts
+    between non-integral address spaces carry frontend information that the
+    optimizer cannot deduce afterwards in a generic way (though we
+    have frontend specific passes in our pipline that do propagate
+    these). In any case, I'm sure nobody is using it this way at
+    the moment, since it would have introduced inttoptrs, which
+    are definitely illegal.
+    
+    Fixes PR38375
+    
+    Reviewers: sanjoy, reames, dberlin
+    
+    Subscribers: llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D50010
+
+diff --git a/lib/Transforms/Utils/VNCoercion.cpp b/lib/Transforms/Utils/VNCoercion.cpp
+index c3feea6a0a4..735d1e7b792 100644
+--- a/lib/Transforms/Utils/VNCoercion.cpp
++++ b/lib/Transforms/Utils/VNCoercion.cpp
+@@ -20,14 +20,21 @@ bool canCoerceMustAliasedValueToLoad(Value *StoredVal, Type *LoadTy,
+       StoredVal->getType()->isStructTy() || StoredVal->getType()->isArrayTy())
+     return false;
+ 
++  Type *StoredValTy = StoredVal->getType();
++
+   // The store has to be at least as big as the load.
+   if (DL.getTypeSizeInBits(StoredVal->getType()) < DL.getTypeSizeInBits(LoadTy))
+     return false;
+ 
+-  // Don't coerce non-integral pointers to integers or vice versa.
+-  if (DL.isNonIntegralPointerType(StoredVal->getType()) !=
+-      DL.isNonIntegralPointerType(LoadTy))
++  bool StoredNI = DL.isNonIntegralPointerType(StoredValTy);
++  bool LoadNI = DL.isNonIntegralPointerType(LoadTy);
++  if (StoredNI != LoadNI) {
+     return false;
++  } else if (StoredNI && LoadNI &&
++             cast<PointerType>(StoredValTy)->getAddressSpace() !=
++                 cast<PointerType>(LoadTy)->getAddressSpace()) {
++    return false;
++  }
+ 
+   return true;
+ }
+diff --git a/test/Transforms/GVN/non-integral-pointers.ll b/test/Transforms/GVN/non-integral-pointers.ll
+index 9ae4132231d..5217fc1a06a 100644
+--- a/test/Transforms/GVN/non-integral-pointers.ll
++++ b/test/Transforms/GVN/non-integral-pointers.ll
+@@ -1,6 +1,6 @@
+ ; RUN: opt -gvn -S < %s | FileCheck %s
+ 
+-target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128-ni:4"
++target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128-ni:4:5"
+ target triple = "x86_64-unknown-linux-gnu"
+ 
+ define void @f0(i1 %alwaysFalse, i64 %val, i64* %loc) {
+@@ -37,3 +37,21 @@ define i64 @f1(i1 %alwaysFalse, i8 addrspace(4)* %val, i8 addrspace(4)** %loc) {
+  alwaysTaken:
+   ret i64 42
+ }
++
++ define i8 addrspace(5)* @multini(i1 %alwaysFalse, i8 addrspace(4)* %val, i8 addrspace(4)** %loc) {
++ ; CHECK-LABEL: @multini(
++ ; CHECK-NOT: inttoptr
++ ; CHECK-NOT: ptrtoint
++ ; CHECK-NOT: addrspacecast
++  entry:
++   store i8 addrspace(4)* %val, i8 addrspace(4)** %loc
++   br i1 %alwaysFalse, label %neverTaken, label %alwaysTaken
++
++  neverTaken:
++   %loc.bc = bitcast i8 addrspace(4)** %loc to i8 addrspace(5)**
++   %differentas = load i8 addrspace(5)*, i8 addrspace(5)** %loc.bc
++   ret i8 addrspace(5)* %differentas
++
++  alwaysTaken:
++   ret i8 addrspace(5)* null
++ }

--- a/L/LLVM/v6/bundled/llvm_patches/0025-llvm-D50167-scev-umin.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0025-llvm-D50167-scev-umin.patch
@@ -1,0 +1,1153 @@
+commit 556c30af1c797be294edde0ce621884f5acf11f0
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Wed Aug 1 20:45:11 2018 -0400
+
+    RFC: [SCEV] Add explicit representations of umin/smin
+    
+    Summary:
+    Currently we express umin as `~umax(~x, ~y)`. However, this becomes
+    a problem for operands in non-integral pointer spaces, because `~x`
+    is not something we can compute for `x` non-integral. However, since
+    comparisons are generally still allowed, we are actually able to
+    express `umin(x, y)` directly as long as we don't try to express is
+    as a umax. Support this by adding an explicit umin/smin representation
+    to SCEV. We do this by factoring the existing getUMax/getSMax functions
+    into a new function that does all four. The previous two functions
+    were largely identical, except that the SMax variant used `isKnownPredicate`
+    while the UMax variant used `isKnownViaNonRecursiveReasoning`.
+    
+    Trying to make the UMax variant also use `isKnownPredicate` yields to
+    an infinite recursion, while trying to make the `SMax` variant use
+    `isKnownViaNonRecursiveReasoning` causes
+    `Transforms/IndVarSimplify/backedge-on-min-max.ll` to fail.
+    
+    I would appreciate any insight into which predicate is correct here.
+    
+    Reviewers: reames, sanjoy
+    
+    Subscribers: javed.absar, llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D50167
+
+diff --git a/include/llvm/Analysis/ScalarEvolution.h b/include/llvm/Analysis/ScalarEvolution.h
+index 21b72f3e13c..9fd6794395c 100644
+--- a/include/llvm/Analysis/ScalarEvolution.h
++++ b/include/llvm/Analysis/ScalarEvolution.h
+@@ -582,12 +582,15 @@ public:
+   /// \p IndexExprs The expressions for the indices.
+   const SCEV *getGEPExpr(GEPOperator *GEP,
+                          const SmallVectorImpl<const SCEV *> &IndexExprs);
++  const SCEV *getUSMinMaxExpr(unsigned Kind, SmallVectorImpl<const SCEV *> &Operands);
+   const SCEV *getSMaxExpr(const SCEV *LHS, const SCEV *RHS);
+   const SCEV *getSMaxExpr(SmallVectorImpl<const SCEV *> &Operands);
+   const SCEV *getUMaxExpr(const SCEV *LHS, const SCEV *RHS);
+   const SCEV *getUMaxExpr(SmallVectorImpl<const SCEV *> &Operands);
+   const SCEV *getSMinExpr(const SCEV *LHS, const SCEV *RHS);
++  const SCEV *getSMinExpr(SmallVectorImpl<const SCEV *> &Operands);
+   const SCEV *getUMinExpr(const SCEV *LHS, const SCEV *RHS);
++  const SCEV *getUMinExpr(SmallVectorImpl<const SCEV *> &Operands);
+   const SCEV *getUnknown(Value *V);
+   const SCEV *getCouldNotCompute();
+ 
+diff --git a/include/llvm/Analysis/ScalarEvolutionExpander.h b/include/llvm/Analysis/ScalarEvolutionExpander.h
+index 3df04e98bd2..9e407c63abc 100644
+--- a/include/llvm/Analysis/ScalarEvolutionExpander.h
++++ b/include/llvm/Analysis/ScalarEvolutionExpander.h
+@@ -367,6 +367,10 @@ namespace llvm {
+ 
+     Value *visitUMaxExpr(const SCEVUMaxExpr *S);
+ 
++    Value *visitSMinExpr(const SCEVSMinExpr *S);
++
++    Value *visitUMinExpr(const SCEVUMinExpr *S);
++
+     Value *visitUnknown(const SCEVUnknown *S) {
+       return S->getValue();
+     }
+diff --git a/include/llvm/Analysis/ScalarEvolutionExpressions.h b/include/llvm/Analysis/ScalarEvolutionExpressions.h
+index acf83455cdc..0d20a1bcdcc 100644
+--- a/include/llvm/Analysis/ScalarEvolutionExpressions.h
++++ b/include/llvm/Analysis/ScalarEvolutionExpressions.h
+@@ -40,7 +40,7 @@ class Type;
+     // These should be ordered in terms of increasing complexity to make the
+     // folders simpler.
+     scConstant, scTruncate, scZeroExtend, scSignExtend, scAddExpr, scMulExpr,
+-    scUDivExpr, scAddRecExpr, scUMaxExpr, scSMaxExpr,
++    scUDivExpr, scAddRecExpr, scUMaxExpr, scSMaxExpr, scUMinExpr, scSMinExpr,
+     scUnknown, scCouldNotCompute
+   };
+ 
+@@ -187,6 +187,8 @@ class Type;
+              S->getSCEVType() == scMulExpr ||
+              S->getSCEVType() == scSMaxExpr ||
+              S->getSCEVType() == scUMaxExpr ||
++             S->getSCEVType() == scSMinExpr ||
++             S->getSCEVType() == scUMinExpr ||
+              S->getSCEVType() == scAddRecExpr;
+     }
+   };
+@@ -204,7 +206,9 @@ class Type;
+       return S->getSCEVType() == scAddExpr ||
+              S->getSCEVType() == scMulExpr ||
+              S->getSCEVType() == scSMaxExpr ||
+-             S->getSCEVType() == scUMaxExpr;
++             S->getSCEVType() == scUMaxExpr ||
++             S->getSCEVType() == scSMinExpr ||
++             S->getSCEVType() == scUMinExpr;
+     }
+ 
+     /// Set flags for a non-recurrence without clearing previously set flags.
+@@ -396,6 +400,42 @@ class Type;
+     }
+   };
+ 
++  /// This class represents a signed minimum selection.
++  class SCEVSMinExpr : public SCEVCommutativeExpr {
++    friend class ScalarEvolution;
++
++    SCEVSMinExpr(const FoldingSetNodeIDRef ID,
++                 const SCEV *const *O, size_t N)
++      : SCEVCommutativeExpr(ID, scSMinExpr, O, N) {
++      // Min never overflows.
++      setNoWrapFlags((NoWrapFlags)(FlagNUW | FlagNSW));
++    }
++
++  public:
++    /// Methods for support type inquiry through isa, cast, and dyn_cast:
++    static bool classof(const SCEV *S) {
++      return S->getSCEVType() == scSMinExpr;
++    }
++  };
++
++  /// This class represents an unsigned minimum selection.
++  class SCEVUMinExpr : public SCEVCommutativeExpr {
++    friend class ScalarEvolution;
++
++    SCEVUMinExpr(const FoldingSetNodeIDRef ID,
++                 const SCEV *const *O, size_t N)
++      : SCEVCommutativeExpr(ID, scUMinExpr, O, N) {
++      // Min never overflows.
++      setNoWrapFlags((NoWrapFlags)(FlagNUW | FlagNSW));
++    }
++
++  public:
++    /// Methods for support type inquiry through isa, cast, and dyn_cast:
++    static bool classof(const SCEV *S) {
++      return S->getSCEVType() == scUMinExpr;
++    }
++  };
++
+   /// This means that we are dealing with an entirely unknown SCEV
+   /// value, and only represent it as its LLVM Value.  This is the
+   /// "bottom" value for the analysis.
+@@ -468,6 +508,10 @@ class Type;
+         return ((SC*)this)->visitSMaxExpr((const SCEVSMaxExpr*)S);
+       case scUMaxExpr:
+         return ((SC*)this)->visitUMaxExpr((const SCEVUMaxExpr*)S);
++      case scSMinExpr:
++        return ((SC*)this)->visitSMinExpr((const SCEVSMinExpr*)S);
++      case scUMinExpr:
++        return ((SC*)this)->visitUMinExpr((const SCEVUMinExpr*)S);
+       case scUnknown:
+         return ((SC*)this)->visitUnknown((const SCEVUnknown*)S);
+       case scCouldNotCompute:
+@@ -521,6 +565,8 @@ class Type;
+         case scMulExpr:
+         case scSMaxExpr:
+         case scUMaxExpr:
++        case scSMinExpr:
++        case scUMinExpr:
+         case scAddRecExpr:
+           for (const auto *Op : cast<SCEVNAryExpr>(S)->operands())
+             push(Op);
+@@ -683,6 +729,26 @@ class Type;
+       return !Changed ? Expr : SE.getUMaxExpr(Operands);
+     }
+ 
++    const SCEV *visitSMinExpr(const SCEVSMinExpr *Expr) {
++      SmallVector<const SCEV *, 2> Operands;
++      bool Changed = false;
++      for (auto *Op : Expr->operands()) {
++        Operands.push_back(((SC *)this)->visit(Op));
++        Changed |= Op != Operands.back();
++      }
++      return !Changed ? Expr : SE.getSMinExpr(Operands);
++    }
++
++    const SCEV *visitUMinExpr(const SCEVUMinExpr *Expr) {
++      SmallVector<const SCEV *, 2> Operands;
++      bool Changed = false;
++      for (auto *Op : Expr->operands()) {
++        Operands.push_back(((SC*)this)->visit(Op));
++        Changed |= Op != Operands.back();
++      }
++      return !Changed ? Expr : SE.getUMinExpr(Operands);
++    }
++
+     const SCEV *visitUnknown(const SCEVUnknown *Expr) {
+       return Expr;
+     }
+diff --git a/lib/Analysis/ScalarEvolution.cpp b/lib/Analysis/ScalarEvolution.cpp
+index bfff7afb5b4..750c1fdfdfb 100644
+--- a/lib/Analysis/ScalarEvolution.cpp
++++ b/lib/Analysis/ScalarEvolution.cpp
+@@ -271,7 +271,9 @@ void SCEV::print(raw_ostream &OS) const {
+   case scAddExpr:
+   case scMulExpr:
+   case scUMaxExpr:
+-  case scSMaxExpr: {
++  case scSMaxExpr:
++  case scUMinExpr:
++  case scSMinExpr: {
+     const SCEVNAryExpr *NAry = cast<SCEVNAryExpr>(this);
+     const char *OpStr = nullptr;
+     switch (NAry->getSCEVType()) {
+@@ -279,6 +281,8 @@ void SCEV::print(raw_ostream &OS) const {
+     case scMulExpr: OpStr = " * "; break;
+     case scUMaxExpr: OpStr = " umax "; break;
+     case scSMaxExpr: OpStr = " smax "; break;
++    case scUMinExpr: OpStr = " umin "; break;
++    case scSMinExpr: OpStr = " smin "; break;
+     }
+     OS << "(";
+     for (SCEVNAryExpr::op_iterator I = NAry->op_begin(), E = NAry->op_end();
+@@ -347,6 +351,8 @@ Type *SCEV::getType() const {
+   case scMulExpr:
+   case scUMaxExpr:
+   case scSMaxExpr:
++  case scUMinExpr:
++  case scSMinExpr:
+     return cast<SCEVNAryExpr>(this)->getType();
+   case scAddExpr:
+     return cast<SCEVAddExpr>(this)->getType();
+@@ -718,7 +724,9 @@ static int CompareSCEVComplexity(
+   case scAddExpr:
+   case scMulExpr:
+   case scSMaxExpr:
+-  case scUMaxExpr: {
++  case scUMaxExpr:
++  case scSMinExpr:
++  case scUMinExpr: {
+     const SCEVNAryExpr *LC = cast<SCEVNAryExpr>(LHS);
+     const SCEVNAryExpr *RC = cast<SCEVNAryExpr>(RHS);
+ 
+@@ -922,6 +930,8 @@ public:
+   void visitUDivExpr(const SCEVUDivExpr *Numerator) {}
+   void visitSMaxExpr(const SCEVSMaxExpr *Numerator) {}
+   void visitUMaxExpr(const SCEVUMaxExpr *Numerator) {}
++  void visitSMinExpr(const SCEVSMinExpr *Numerator) {}
++  void visitUMinExpr(const SCEVUMinExpr *Numerator) {}
+   void visitUnknown(const SCEVUnknown *Numerator) {}
+   void visitCouldNotCompute(const SCEVCouldNotCompute *Numerator) {}
+ 
+@@ -2276,6 +2286,8 @@ bool ScalarEvolution::isAvailableAtLoopEntry(const SCEV *S, const Loop *L) {
+       case scMulExpr:
+       case scUMaxExpr:
+       case scSMaxExpr:
++      case scUMinExpr:
++      case scSMinExpr:
+       case scUDivExpr:
+         return true;
+       case scUnknown:
+@@ -3405,23 +3417,20 @@ ScalarEvolution::getGEPExpr(GEPOperator *GEP,
+   return getAddExpr(BaseExpr, TotalOffset, Wrap);
+ }
+ 
+-const SCEV *ScalarEvolution::getSMaxExpr(const SCEV *LHS,
+-                                         const SCEV *RHS) {
+-  SmallVector<const SCEV *, 2> Ops = {LHS, RHS};
+-  return getSMaxExpr(Ops);
+-}
+-
+ const SCEV *
+-ScalarEvolution::getSMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
+-  assert(!Ops.empty() && "Cannot get empty smax!");
++ScalarEvolution::getUSMinMaxExpr(unsigned Kind, SmallVectorImpl<const SCEV *> &Ops) {
++  assert(!Ops.empty() && "Cannot get empty (u|s)(min|max)!");
+   if (Ops.size() == 1) return Ops[0];
+ #ifndef NDEBUG
+   Type *ETy = getEffectiveSCEVType(Ops[0]->getType());
+   for (unsigned i = 1, e = Ops.size(); i != e; ++i)
+     assert(getEffectiveSCEVType(Ops[i]->getType()) == ETy &&
+-           "SCEVSMaxExpr operand types don't match!");
++           "Operand types don't match!");
+ #endif
+ 
++  bool IsSigned = Kind == scSMaxExpr || Kind == scSMinExpr;
++  bool IsMax = Kind == scSMaxExpr || Kind == scUMaxExpr;
++
+   // Sort by complexity, this groups all similar expression types together.
+   GroupByComplexity(Ops, &LI, DT);
+ 
+@@ -3430,61 +3439,85 @@ ScalarEvolution::getSMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
+   if (const SCEVConstant *LHSC = dyn_cast<SCEVConstant>(Ops[0])) {
+     ++Idx;
+     assert(Idx < Ops.size());
++    auto &FoldOp =
++        Kind == scSMaxExpr ? APIntOps::smax :
++        Kind == scSMinExpr ? APIntOps::smin :
++        Kind == scUMaxExpr ? APIntOps::umax :
++                             APIntOps::umin;
+     while (const SCEVConstant *RHSC = dyn_cast<SCEVConstant>(Ops[Idx])) {
+       // We found two constants, fold them together!
+       ConstantInt *Fold = ConstantInt::get(
+-          getContext(), APIntOps::smax(LHSC->getAPInt(), RHSC->getAPInt()));
++          getContext(), FoldOp(LHSC->getAPInt(), RHSC->getAPInt()));
+       Ops[0] = getConstant(Fold);
+       Ops.erase(Ops.begin()+1);  // Erase the folded element
+       if (Ops.size() == 1) return Ops[0];
+       LHSC = cast<SCEVConstant>(Ops[0]);
+     }
+ 
+-    // If we are left with a constant minimum-int, strip it off.
+-    if (cast<SCEVConstant>(Ops[0])->getValue()->isMinValue(true)) {
+-      Ops.erase(Ops.begin());
+-      --Idx;
+-    } else if (cast<SCEVConstant>(Ops[0])->getValue()->isMaxValue(true)) {
+-      // If we have an smax with a constant maximum-int, it will always be
+-      // maximum-int.
+-      return Ops[0];
++    if (IsMax) {
++      // If we are left with a constant minimum-int, strip it off.
++      if (cast<SCEVConstant>(Ops[0])->getValue()->isMinValue(IsSigned)) {
++        Ops.erase(Ops.begin());
++        --Idx;
++      } else if (cast<SCEVConstant>(Ops[0])->getValue()->isMaxValue(IsSigned)) {
++        // If we have an smax with a constant maximum-int, it will always be
++        // maximum-int.
++        return Ops[0];
++      }
++    } else {
++      // If we are left with a constant maximum-int, strip it off.
++      if (cast<SCEVConstant>(Ops[0])->getValue()->isMaxValue(IsSigned)) {
++        Ops.erase(Ops.begin());
++        --Idx;
++      } else if (cast<SCEVConstant>(Ops[0])->getValue()->isMinValue(IsSigned)) {
++        // If we have an smax with a constant minimum-int, it will always be
++        // maximum-int.
++        return Ops[0];
++      }
+     }
+ 
+     if (Ops.size() == 1) return Ops[0];
+   }
+ 
+-  // Find the first SMax
+-  while (Idx < Ops.size() && Ops[Idx]->getSCEVType() < scSMaxExpr)
++  // Find the first operation of the same kind
++  while (Idx < Ops.size() && Ops[Idx]->getSCEVType() != Kind)
+     ++Idx;
+ 
+   // Check to see if one of the operands is an SMax. If so, expand its operands
+   // onto our operand list, and recurse to simplify.
+   if (Idx < Ops.size()) {
+-    bool DeletedSMax = false;
+-    while (const SCEVSMaxExpr *SMax = dyn_cast<SCEVSMaxExpr>(Ops[Idx])) {
++    bool DeletedAny = false;
++    while (Ops[Idx]->getSCEVType() == Kind) {
++      const SCEVCommutativeExpr *SCE = cast<SCEVCommutativeExpr>(Ops[Idx]);
+       Ops.erase(Ops.begin()+Idx);
+-      Ops.append(SMax->op_begin(), SMax->op_end());
+-      DeletedSMax = true;
++      Ops.append(SCE->op_begin(), SCE->op_end());
++      DeletedAny = true;
+     }
+ 
+-    if (DeletedSMax)
+-      return getSMaxExpr(Ops);
++    if (DeletedAny)
++      return getUSMinMaxExpr(Kind, Ops);
+   }
+ 
+   // Okay, check to see if the same value occurs in the operand list twice.  If
+   // so, delete one.  Since we sorted the list, these values are required to
+   // be adjacent.
+-  for (unsigned i = 0, e = Ops.size()-1; i != e; ++i)
+-    //  X smax Y smax Y  -->  X smax Y
+-    //  X smax Y         -->  X, if X is always greater than Y
+-    if (Ops[i] == Ops[i+1] ||
+-        isKnownPredicate(ICmpInst::ICMP_SGE, Ops[i], Ops[i+1])) {
+-      Ops.erase(Ops.begin()+i+1, Ops.begin()+i+2);
+-      --i; --e;
+-    } else if (isKnownPredicate(ICmpInst::ICMP_SLE, Ops[i], Ops[i+1])) {
+-      Ops.erase(Ops.begin()+i, Ops.begin()+i+1);
+-      --i; --e;
+-    }
++  llvm::CmpInst::Predicate GEPred = IsSigned ? ICmpInst::ICMP_SGE : ICmpInst::ICMP_UGE;
++  llvm::CmpInst::Predicate LEPred = IsSigned ? ICmpInst::ICMP_SLE : ICmpInst::ICMP_ULE;
++  llvm::CmpInst::Predicate FirstPred = IsMax ? GEPred : LEPred;
++  llvm::CmpInst::Predicate SecondPred = IsMax ? LEPred : GEPred;
++  for (unsigned i = 0, e = Ops.size()-1; i != e; ++i) {
++      if (Ops[i] == Ops[i+1] ||
++          isKnownPredicate(FirstPred, Ops[i], Ops[i+1])) {
++        //  X op Y op Y  -->  X op Y
++        //  X op Y       -->  X, if we know X, Y are ordered appropriately
++        Ops.erase(Ops.begin()+i+1, Ops.begin()+i+2);
++        --i; --e;
++      } else if (isKnownPredicate(SecondPred, Ops[i], Ops[i+1])) {
++        //  X op Y       -->  Y, if we know X, Y are ordered appropriately
++        Ops.erase(Ops.begin()+i, Ops.begin()+i+1);
++        --i; --e;
++      }
++  }
+ 
+   if (Ops.size() == 1) return Ops[0];
+ 
+@@ -3493,132 +3526,73 @@ ScalarEvolution::getSMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
+   // Okay, it looks like we really DO need an smax expr.  Check to see if we
+   // already have one, otherwise create a new one.
+   FoldingSetNodeID ID;
+-  ID.AddInteger(scSMaxExpr);
++  ID.AddInteger(Kind);
+   for (unsigned i = 0, e = Ops.size(); i != e; ++i)
+     ID.AddPointer(Ops[i]);
+   void *IP = nullptr;
+   if (const SCEV *S = UniqueSCEVs.FindNodeOrInsertPos(ID, IP)) return S;
+   const SCEV **O = SCEVAllocator.Allocate<const SCEV *>(Ops.size());
+   std::uninitialized_copy(Ops.begin(), Ops.end(), O);
+-  SCEV *S = new (SCEVAllocator) SCEVSMaxExpr(ID.Intern(SCEVAllocator),
+-                                             O, Ops.size());
++  SCEV *S = nullptr;
++
++  if (Kind == scSMaxExpr) {
++    S = new (SCEVAllocator) SCEVSMaxExpr(ID.Intern(SCEVAllocator),
++                                         O, Ops.size());
++  } else if (Kind == scUMaxExpr) {
++    S = new (SCEVAllocator) SCEVUMaxExpr(ID.Intern(SCEVAllocator),
++                                         O, Ops.size());
++  } else if (Kind == scSMinExpr) {
++    S = new (SCEVAllocator) SCEVSMinExpr(ID.Intern(SCEVAllocator),
++                                         O, Ops.size());
++  } else {
++    assert(Kind == scUMinExpr);
++    S = new (SCEVAllocator) SCEVUMinExpr(ID.Intern(SCEVAllocator),
++                                         O, Ops.size());
++  }
++
+   UniqueSCEVs.InsertNode(S, IP);
+   addToLoopUseLists(S);
+   return S;
+ }
+ 
+-const SCEV *ScalarEvolution::getUMaxExpr(const SCEV *LHS,
++const SCEV *ScalarEvolution::getSMaxExpr(const SCEV *LHS,
+                                          const SCEV *RHS) {
+   SmallVector<const SCEV *, 2> Ops = {LHS, RHS};
+-  return getUMaxExpr(Ops);
++  return getSMaxExpr(Ops);
+ }
+ 
+-const SCEV *
+-ScalarEvolution::getUMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
+-  assert(!Ops.empty() && "Cannot get empty umax!");
+-  if (Ops.size() == 1) return Ops[0];
+-#ifndef NDEBUG
+-  Type *ETy = getEffectiveSCEVType(Ops[0]->getType());
+-  for (unsigned i = 1, e = Ops.size(); i != e; ++i)
+-    assert(getEffectiveSCEVType(Ops[i]->getType()) == ETy &&
+-           "SCEVUMaxExpr operand types don't match!");
+-#endif
+-
+-  // Sort by complexity, this groups all similar expression types together.
+-  GroupByComplexity(Ops, &LI, DT);
+-
+-  // If there are any constants, fold them together.
+-  unsigned Idx = 0;
+-  if (const SCEVConstant *LHSC = dyn_cast<SCEVConstant>(Ops[0])) {
+-    ++Idx;
+-    assert(Idx < Ops.size());
+-    while (const SCEVConstant *RHSC = dyn_cast<SCEVConstant>(Ops[Idx])) {
+-      // We found two constants, fold them together!
+-      ConstantInt *Fold = ConstantInt::get(
+-          getContext(), APIntOps::umax(LHSC->getAPInt(), RHSC->getAPInt()));
+-      Ops[0] = getConstant(Fold);
+-      Ops.erase(Ops.begin()+1);  // Erase the folded element
+-      if (Ops.size() == 1) return Ops[0];
+-      LHSC = cast<SCEVConstant>(Ops[0]);
+-    }
+-
+-    // If we are left with a constant minimum-int, strip it off.
+-    if (cast<SCEVConstant>(Ops[0])->getValue()->isMinValue(false)) {
+-      Ops.erase(Ops.begin());
+-      --Idx;
+-    } else if (cast<SCEVConstant>(Ops[0])->getValue()->isMaxValue(false)) {
+-      // If we have an umax with a constant maximum-int, it will always be
+-      // maximum-int.
+-      return Ops[0];
+-    }
+-
+-    if (Ops.size() == 1) return Ops[0];
+-  }
+-
+-  // Find the first UMax
+-  while (Idx < Ops.size() && Ops[Idx]->getSCEVType() < scUMaxExpr)
+-    ++Idx;
+-
+-  // Check to see if one of the operands is a UMax. If so, expand its operands
+-  // onto our operand list, and recurse to simplify.
+-  if (Idx < Ops.size()) {
+-    bool DeletedUMax = false;
+-    while (const SCEVUMaxExpr *UMax = dyn_cast<SCEVUMaxExpr>(Ops[Idx])) {
+-      Ops.erase(Ops.begin()+Idx);
+-      Ops.append(UMax->op_begin(), UMax->op_end());
+-      DeletedUMax = true;
+-    }
+-
+-    if (DeletedUMax)
+-      return getUMaxExpr(Ops);
+-  }
+-
+-  // Okay, check to see if the same value occurs in the operand list twice.  If
+-  // so, delete one.  Since we sorted the list, these values are required to
+-  // be adjacent.
+-  for (unsigned i = 0, e = Ops.size()-1; i != e; ++i)
+-    //  X umax Y umax Y  -->  X umax Y
+-    //  X umax Y         -->  X, if X is always greater than Y
+-    if (Ops[i] == Ops[i+1] ||
+-        isKnownPredicate(ICmpInst::ICMP_UGE, Ops[i], Ops[i+1])) {
+-      Ops.erase(Ops.begin()+i+1, Ops.begin()+i+2);
+-      --i; --e;
+-    } else if (isKnownPredicate(ICmpInst::ICMP_ULE, Ops[i], Ops[i+1])) {
+-      Ops.erase(Ops.begin()+i, Ops.begin()+i+1);
+-      --i; --e;
+-    }
+-
+-  if (Ops.size() == 1) return Ops[0];
++const SCEV *ScalarEvolution::getSMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
++  return getUSMinMaxExpr(scSMaxExpr, Ops);
++}
+ 
+-  assert(!Ops.empty() && "Reduced umax down to nothing!");
++const SCEV *ScalarEvolution::getUMaxExpr(const SCEV *LHS,
++                                         const SCEV *RHS) {
++  SmallVector<const SCEV *, 2> Ops = {LHS, RHS};
++  return getUMaxExpr(Ops);
++}
+ 
+-  // Okay, it looks like we really DO need a umax expr.  Check to see if we
+-  // already have one, otherwise create a new one.
+-  FoldingSetNodeID ID;
+-  ID.AddInteger(scUMaxExpr);
+-  for (unsigned i = 0, e = Ops.size(); i != e; ++i)
+-    ID.AddPointer(Ops[i]);
+-  void *IP = nullptr;
+-  if (const SCEV *S = UniqueSCEVs.FindNodeOrInsertPos(ID, IP)) return S;
+-  const SCEV **O = SCEVAllocator.Allocate<const SCEV *>(Ops.size());
+-  std::uninitialized_copy(Ops.begin(), Ops.end(), O);
+-  SCEV *S = new (SCEVAllocator) SCEVUMaxExpr(ID.Intern(SCEVAllocator),
+-                                             O, Ops.size());
+-  UniqueSCEVs.InsertNode(S, IP);
+-  addToLoopUseLists(S);
+-  return S;
++const SCEV *ScalarEvolution::getUMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
++  return getUSMinMaxExpr(scUMaxExpr, Ops);
+ }
+ 
+ const SCEV *ScalarEvolution::getSMinExpr(const SCEV *LHS,
+                                          const SCEV *RHS) {
+-  // ~smax(~x, ~y) == smin(x, y).
+-  return getNotSCEV(getSMaxExpr(getNotSCEV(LHS), getNotSCEV(RHS)));
++  SmallVector<const SCEV *, 2> Ops = { LHS, RHS };
++  return getSMinExpr(Ops);
++}
++
++const SCEV *ScalarEvolution::getSMinExpr(SmallVectorImpl<const SCEV *> &Ops) {
++  return getUSMinMaxExpr(scSMinExpr, Ops);
+ }
+ 
+ const SCEV *ScalarEvolution::getUMinExpr(const SCEV *LHS,
+                                          const SCEV *RHS) {
+-  // ~umax(~x, ~y) == umin(x, y)
+-  return getNotSCEV(getUMaxExpr(getNotSCEV(LHS), getNotSCEV(RHS)));
++  SmallVector<const SCEV *, 2> Ops = { LHS, RHS };
++  return getUMinExpr(Ops);
++}
++
++const SCEV *ScalarEvolution::getUMinExpr(SmallVectorImpl<const SCEV *> &Ops) {
++  return getUSMinMaxExpr(scUMinExpr, Ops);
+ }
+ 
+ const SCEV *ScalarEvolution::getSizeOfExpr(Type *IntTy, Type *AllocTy) {
+@@ -5002,6 +4976,7 @@ static bool IsAvailableOnEntry(const Loop *L, DominatorTree &DT, const SCEV *S,
+       switch (S->getSCEVType()) {
+       case scConstant: case scTruncate: case scZeroExtend: case scSignExtend:
+       case scAddExpr: case scMulExpr: case scUMaxExpr: case scSMaxExpr:
++      case scUMinExpr: case scSMinExpr:
+         // These expressions are available if their operand(s) is/are.
+         return true;
+ 
+@@ -7885,7 +7860,9 @@ static Constant *BuildConstantFromSCEV(const SCEV *V) {
+     }
+     case scSMaxExpr:
+     case scUMaxExpr:
+-      break; // TODO: smax, umax.
++    case scSMinExpr:
++    case scUMinExpr:
++      break; // TODO: smax, umax, smin, umax.
+   }
+   return nullptr;
+ }
+@@ -8015,6 +7992,10 @@ const SCEV *ScalarEvolution::computeSCEVAtScope(const SCEV *V, const Loop *L) {
+           return getSMaxExpr(NewOps);
+         if (isa<SCEVUMaxExpr>(Comm))
+           return getUMaxExpr(NewOps);
++        if (isa<SCEVSMinExpr>(Comm))
++          return getSMinExpr(NewOps);
++        if (isa<SCEVUMinExpr>(Comm))
++          return getUMinExpr(NewOps);
+         llvm_unreachable("Unknown commutative SCEV type!");
+       }
+     }
+@@ -10998,7 +10979,9 @@ ScalarEvolution::computeLoopDisposition(const SCEV *S, const Loop *L) {
+   case scAddExpr:
+   case scMulExpr:
+   case scUMaxExpr:
+-  case scSMaxExpr: {
++  case scSMaxExpr:
++  case scUMinExpr:
++  case scSMinExpr: {
+     bool HasVarying = false;
+     for (auto *Op : cast<SCEVNAryExpr>(S)->operands()) {
+       LoopDisposition D = getLoopDisposition(Op, L);
+@@ -11085,7 +11068,9 @@ ScalarEvolution::computeBlockDisposition(const SCEV *S, const BasicBlock *BB) {
+   case scAddExpr:
+   case scMulExpr:
+   case scUMaxExpr:
+-  case scSMaxExpr: {
++  case scSMaxExpr:
++  case scUMinExpr:
++  case scSMinExpr: {
+     const SCEVNAryExpr *NAry = cast<SCEVNAryExpr>(S);
+     bool Proper = true;
+     for (const SCEV *NAryOp : NAry->operands()) {
+diff --git a/lib/Analysis/ScalarEvolutionExpander.cpp b/lib/Analysis/ScalarEvolutionExpander.cpp
+index 01a8732b0b8..8160a1eaa0b 100644
+--- a/lib/Analysis/ScalarEvolutionExpander.cpp
++++ b/lib/Analysis/ScalarEvolutionExpander.cpp
+@@ -1634,14 +1634,15 @@ Value *SCEVExpander::visitSMaxExpr(const SCEVSMaxExpr *S) {
+   for (int i = S->getNumOperands()-2; i >= 0; --i) {
+     // In the case of mixed integer and pointer types, do the
+     // rest of the comparisons as integer.
+-    if (S->getOperand(i)->getType() != Ty) {
++    Type *OpTy = S->getOperand(i)->getType();
++    if (OpTy->isIntegerTy() != Ty->isIntegerTy()) {
+       Ty = SE.getEffectiveSCEVType(Ty);
+       LHS = InsertNoopCastOfTo(LHS, Ty);
+     }
+     Value *RHS = expandCodeFor(S->getOperand(i), Ty);
+     Value *ICmp = Builder.CreateICmpSGT(LHS, RHS);
+     rememberInstruction(ICmp);
+-    Value *Sel = Builder.CreateSelect(ICmp, LHS, RHS, "smax");
++    Value *Sel = Builder.CreateSelect(ICmp, LHS, RHS, "smin");
+     rememberInstruction(Sel);
+     LHS = Sel;
+   }
+@@ -1658,14 +1659,15 @@ Value *SCEVExpander::visitUMaxExpr(const SCEVUMaxExpr *S) {
+   for (int i = S->getNumOperands()-2; i >= 0; --i) {
+     // In the case of mixed integer and pointer types, do the
+     // rest of the comparisons as integer.
+-    if (S->getOperand(i)->getType() != Ty) {
++    Type *OpTy = S->getOperand(i)->getType();
++    if (OpTy->isIntegerTy() != Ty->isIntegerTy()) {
+       Ty = SE.getEffectiveSCEVType(Ty);
+       LHS = InsertNoopCastOfTo(LHS, Ty);
+     }
+     Value *RHS = expandCodeFor(S->getOperand(i), Ty);
+     Value *ICmp = Builder.CreateICmpUGT(LHS, RHS);
+     rememberInstruction(ICmp);
+-    Value *Sel = Builder.CreateSelect(ICmp, LHS, RHS, "umax");
++    Value *Sel = Builder.CreateSelect(ICmp, LHS, RHS, "umin");
+     rememberInstruction(Sel);
+     LHS = Sel;
+   }
+@@ -1671,6 +1671,56 @@ Value *SCEVExpander::visitUMaxExpr(const SCEVUMaxExpr *S) {
+   return LHS;
+ }
+ 
++Value *SCEVExpander::visitSMinExpr(const SCEVSMinExpr *S) {
++  Value *LHS = expand(S->getOperand(S->getNumOperands()-1));
++  Type *Ty = LHS->getType();
++  for (int i = S->getNumOperands()-2; i >= 0; --i) {
++    // In the case of mixed integer and pointer types, do the
++    // rest of the comparisons as integer.
++    Type *OpTy = S->getOperand(i)->getType();
++    if (OpTy->isIntegerTy() != Ty->isIntegerTy()) {
++      Ty = SE.getEffectiveSCEVType(Ty);
++      LHS = InsertNoopCastOfTo(LHS, Ty);
++    }
++    Value *RHS = expandCodeFor(S->getOperand(i), Ty);
++    Value *ICmp = Builder.CreateICmpSLT(LHS, RHS);
++    rememberInstruction(ICmp);
++    Value *Sel = Builder.CreateSelect(ICmp, LHS, RHS, "smax");
++    rememberInstruction(Sel);
++    LHS = Sel;
++  }
++  // In the case of mixed integer and pointer types, cast the
++  // final result back to the pointer type.
++  if (LHS->getType() != S->getType())
++    LHS = InsertNoopCastOfTo(LHS, S->getType());
++  return LHS;
++}
++
++Value *SCEVExpander::visitUMinExpr(const SCEVUMinExpr *S) {
++  Value *LHS = expand(S->getOperand(S->getNumOperands()-1));
++  Type *Ty = LHS->getType();
++  for (int i = S->getNumOperands()-2; i >= 0; --i) {
++    // In the case of mixed integer and pointer types, do the
++    // rest of the comparisons as integer.
++    Type *OpTy = S->getOperand(i)->getType();
++    if (OpTy->isIntegerTy() != Ty->isIntegerTy()) {
++      Ty = SE.getEffectiveSCEVType(Ty);
++      LHS = InsertNoopCastOfTo(LHS, Ty);
++    }
++    Value *RHS = expandCodeFor(S->getOperand(i), Ty);
++    Value *ICmp = Builder.CreateICmpULT(LHS, RHS);
++    rememberInstruction(ICmp);
++    Value *Sel = Builder.CreateSelect(ICmp, LHS, RHS, "umax");
++    rememberInstruction(Sel);
++    LHS = Sel;
++  }
++  // In the case of mixed integer and pointer types, cast the
++  // final result back to the pointer type.
++  if (LHS->getType() != S->getType())
++    LHS = InsertNoopCastOfTo(LHS, S->getType());
++  return LHS;
++}
++
+ Value *SCEVExpander::expandCodeFor(const SCEV *SH, Type *Ty,
+                                    Instruction *IP) {
+   setInsertPoint(IP);
+diff --git a/test/Analysis/LoopAccessAnalysis/memcheck-ni.ll b/test/Analysis/LoopAccessAnalysis/memcheck-ni.ll
+new file mode 100644
+index 00000000000..a08632f38d1
+--- /dev/null
++++ b/test/Analysis/LoopAccessAnalysis/memcheck-ni.ll
+@@ -0,0 +1,50 @@
++; RUN: opt -loop-versioning -S < %s | FileCheck %s
++
++; NB: addrspaces 10-13 are non-integral
++target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
++
++%jl_value_t = type opaque
++%jl_array_t = type { i8 addrspace(13)*, i64, i16, i16, i32 }
++
++define void @"japi1_permutedims!_33509"(%jl_value_t addrspace(10)**) {
++; CHECK: [[CMP:%[^ ]*]] = icmp ult double addrspace(13)* [[A:%[^ ]*]], [[B:%[^ ]*]]
++; CHECK: [[SELECT:%[^ ]*]] = select i1 %18, double addrspace(13)* [[A]], double addrspace(13)* [[B]]
++top:
++  %1 = alloca [3 x i64], align 8 
++  %2 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %0, align 8
++  %3 = getelementptr inbounds %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %0, i64 1
++  %4 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %3, align 8
++  %5 = getelementptr inbounds [3 x i64], [3 x i64]* %1, i64 0, i64 0
++  store i64 1, i64* %5, align 8
++  %6 = getelementptr inbounds [3 x i64], [3 x i64]* %1, i64 0, i64 1
++  %7 = load i64, i64* inttoptr (i64 24 to i64*), align 8
++  %8 = addrspacecast %jl_value_t addrspace(10)* %4 to %jl_value_t addrspace(11)*
++  %9 = bitcast %jl_value_t addrspace(11)* %8 to double addrspace(13)* addrspace(11)*
++  %10 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %9, align 8
++  %11 = addrspacecast %jl_value_t addrspace(10)* %2 to %jl_value_t addrspace(11)*
++  %12 = bitcast %jl_value_t addrspace(11)* %11 to double addrspace(13)* addrspace(11)*
++  %13 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %12, align 8
++  %14 = load i64, i64* %6, align 8
++  br label %L74
++
++L74:
++  %value_phi20 = phi i64 [ 1, %top ], [ %22, %L74 ]
++  %value_phi21 = phi i64 [ 1, %top ], [ %23, %L74 ]
++  %value_phi22 = phi i64 [ 1, %top ], [ %25, %L74 ]
++  %15 = add i64 %value_phi21, -1
++  %16 = getelementptr inbounds double, double addrspace(13)* %10, i64 %15
++  %17 = bitcast double addrspace(13)* %16 to i64 addrspace(13)*
++  %18 = load i64, i64 addrspace(13)* %17, align 8
++  %19 = add i64 %value_phi20, -1
++  %20 = getelementptr inbounds double, double addrspace(13)* %13, i64 %19
++  %21 = bitcast double addrspace(13)* %20 to i64 addrspace(13)*
++  store i64 %18, i64 addrspace(13)* %21, align 8
++  %22 = add i64 %value_phi20, 1
++  %23 = add i64 %14, %value_phi21
++  %24 = icmp eq i64 %value_phi22, %7
++  %25 = add i64 %value_phi22, 1
++  br i1 %24, label %L94, label %L74
++
++L94:
++  ret void 
++}
+diff --git a/test/Analysis/LoopAccessAnalysis/reverse-memcheck-bounds.ll b/test/Analysis/LoopAccessAnalysis/reverse-memcheck-bounds.ll
+index 405a47554e4..4285ef0f117 100644
+--- a/test/Analysis/LoopAccessAnalysis/reverse-memcheck-bounds.ll
++++ b/test/Analysis/LoopAccessAnalysis/reverse-memcheck-bounds.ll
+@@ -58,7 +58,7 @@ for.end:                                          ; preds = %for.body
+ 
+ ; Here it is not obvious what the limits are, since 'step' could be negative.
+ 
+-; CHECK: Low: (-1 + (-1 * ((-60001 + (-1 * %a)) umax (-60001 + (40000 * %step) + (-1 * %a)))))
++; CHECK: Low: ((60000 + %a)<nsw> umin (60000 + (-40000 * %step) + %a)) 
+ ; CHECK: High: (4 + ((60000 + %a)<nsw> umax (60000 + (-40000 * %step) + %a)))
+ 
+ define void @g(i64 %step) {
+diff --git a/test/Analysis/ScalarEvolution/2008-07-29-SMinExpr.ll b/test/Analysis/ScalarEvolution/2008-07-29-SMinExpr.ll
+index 3542ad2a41e..53e024a68fb 100644
+--- a/test/Analysis/ScalarEvolution/2008-07-29-SMinExpr.ll
++++ b/test/Analysis/ScalarEvolution/2008-07-29-SMinExpr.ll
+@@ -22,5 +22,5 @@ afterfor:		; preds = %forinc, %entry
+ 	ret i32 %j.0.lcssa
+ }
+ 
+-; CHECK: backedge-taken count is (-2147483632 + ((-1 + (-1 * %{{[xy]}})) smax (-1 + (-1 * %{{[xy]}}))))
++; CHECK: backedge-taken count is (-2147483633 + (-1 * (%x smin %y)))
+ 
+diff --git a/test/Analysis/ScalarEvolution/min-max-exprs.ll b/test/Analysis/ScalarEvolution/min-max-exprs.ll
+index e8c1e33e095..51f72c643cc 100644
+--- a/test/Analysis/ScalarEvolution/min-max-exprs.ll
++++ b/test/Analysis/ScalarEvolution/min-max-exprs.ll
+@@ -33,7 +33,7 @@ bb2:                                              ; preds = %bb1
+   %tmp9 = select i1 %tmp4, i64 %tmp5, i64 %tmp6
+ ;                  min(N, i+3)
+ ; CHECK:           select i1 %tmp4, i64 %tmp5, i64 %tmp6
+-; CHECK-NEXT:  --> (-1 + (-1 * ((-1 + (-1 * (sext i32 {3,+,1}<nuw><%bb1> to i64))<nsw>)<nsw> smax (-1 + (-1 * (sext i32 %N to i64))<nsw>)<nsw>))<nsw>)<nsw>
++; CHECK-NEXT:  --> ((sext i32 {3,+,1}<nuw><%bb1> to i64) smin (sext i32 %N to i64))
+   %tmp11 = getelementptr inbounds i32, i32* %A, i64 %tmp9
+   %tmp12 = load i32, i32* %tmp11, align 4
+   %tmp13 = shl nsw i32 %tmp12, 1
+diff --git a/test/Analysis/ScalarEvolution/pr28705.ll b/test/Analysis/ScalarEvolution/pr28705.ll
+index 8fbc08e3ca6..7d797a15bd5 100644
+--- a/test/Analysis/ScalarEvolution/pr28705.ll
++++ b/test/Analysis/ScalarEvolution/pr28705.ll
+@@ -5,7 +5,7 @@
+ ; with "%.sroa.speculated + 1".
+ ;
+ ; CHECK-LABEL: @foo(
+-; CHECK: %[[EXIT:.+]] = sub i32 %.sroa.speculated, -1
++; CHECK: %[[EXIT:.+]] = add i32 %.sroa.speculated, 1
+ ; CHECK: %DB.sroa.9.0.lcssa = phi i32 [ 1, %entry ], [ %[[EXIT]], %loopexit ]
+ ;
+ define void @foo(i32 %sub.ptr.div.i, i8* %ref.i1174) local_unnamed_addr {
+diff --git a/test/Analysis/ScalarEvolution/predicated-trip-count.ll b/test/Analysis/ScalarEvolution/predicated-trip-count.ll
+index 2db0a8b5777..b07662ed95f 100644
+--- a/test/Analysis/ScalarEvolution/predicated-trip-count.ll
++++ b/test/Analysis/ScalarEvolution/predicated-trip-count.ll
+@@ -80,7 +80,7 @@ return:         ; preds = %bb5
+ ; CHECK-NEXT:    -->  (sext i16 {%Start,+,-1}<%bb3> to i32)
+ ; CHECK:       Loop %bb3: Unpredictable backedge-taken count.
+ ; CHECK-NEXT:  Loop %bb3: Unpredictable max backedge-taken count.
+-; CHECK-NEXT:  Loop %bb3: Predicated backedge-taken count is (2 + (sext i16 %Start to i32) + ((-2 + (-1 * (sext i16 %Start to i32))) smax (-1 + (-1 * %M))))
++; CHECK-NEXT:  Loop %bb3: Predicated backedge-taken count is (1 + (sext i16 %Start to i32) + (-1 * ((1 + (sext i16 %Start to i32))<nsw> smin %M)))
+ ; CHECK-NEXT:  Predicates:
+ ; CHECK-NEXT:    {%Start,+,-1}<%bb3> Added Flags: <nssw>
+ 
+diff --git a/test/Analysis/ScalarEvolution/trip-count3.ll b/test/Analysis/ScalarEvolution/trip-count3.ll
+index cce0182d649..7f20b4e71be 100644
+--- a/test/Analysis/ScalarEvolution/trip-count3.ll
++++ b/test/Analysis/ScalarEvolution/trip-count3.ll
+@@ -4,7 +4,7 @@
+ ; dividing by the stride will have a remainder. This could theoretically
+ ; be teaching it how to use a more elaborate trip count computation.
+ 
+-; CHECK: Loop %bb3.i: backedge-taken count is ((64 + (-64 smax (-1 + (-1 * %0))) + %0) /u 64)
++; CHECK: Loop %bb3.i: backedge-taken count is ((63 + (-1 * (63 smin %0)) + %0) /u 64)
+ ; CHECK: Loop %bb3.i: max backedge-taken count is 33554431
+ 
+ %struct.FILE = type { i32, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, %struct._IO_marker*, %struct.FILE*, i32, i32, i64, i16, i8, [1 x i8], i8*, i64, i8*, i8*, i8*, i8*, i64, i32, [20 x i8] }
+diff --git a/test/Transforms/IRCE/conjunctive-checks.ll b/test/Transforms/IRCE/conjunctive-checks.ll
+index f6a909e432c..d9bf485df3a 100644
+--- a/test/Transforms/IRCE/conjunctive-checks.ll
++++ b/test/Transforms/IRCE/conjunctive-checks.ll
+@@ -4,16 +4,6 @@ define void @f_0(i32 *%arr, i32 *%a_len_ptr, i32 %n, i1* %cond_buf) {
+ ; CHECK-LABEL: @f_0(
+ 
+ ; CHECK: loop.preheader:
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_safe_range_end:[^ ]+]] = sub i32 3, %len
+-; CHECK: [[not_exit_main_loop_at_hiclamp_cmp:[^ ]+]] = icmp sgt i32 [[not_n]], [[not_safe_range_end]]
+-; CHECK: [[not_exit_main_loop_at_hiclamp:[^ ]+]] = select i1 [[not_exit_main_loop_at_hiclamp_cmp]], i32 [[not_n]], i32 [[not_safe_range_end]]
+-; CHECK: [[exit_main_loop_at_hiclamp:[^ ]+]] = sub i32 -1, [[not_exit_main_loop_at_hiclamp]]
+-; CHECK: [[exit_main_loop_at_loclamp_cmp:[^ ]+]] = icmp sgt i32 [[exit_main_loop_at_hiclamp]], 0
+-; CHECK: [[exit_main_loop_at_loclamp:[^ ]+]] = select i1 [[exit_main_loop_at_loclamp_cmp]], i32 [[exit_main_loop_at_hiclamp]], i32 0
+-; CHECK: [[enter_main_loop:[^ ]+]] = icmp slt i32 0, [[exit_main_loop_at_loclamp]]
+-; CHECK: br i1 [[enter_main_loop]], label %loop.preheader2, label %main.pseudo.exit
+-
+ ; CHECK: loop.preheader2:
+ ; CHECK: br label %loop
+ 
+@@ -57,14 +47,10 @@ define void @f_1(
+ ; CHECK-LABEL: @f_1(
+ 
+ ; CHECK: loop.preheader:
+-; CHECK: [[not_len_b:[^ ]+]] = sub i32 -1, %len.b
+-; CHECK: [[not_len_a:[^ ]+]] = sub i32 -1, %len.a
+-; CHECK: [[smax_not_len_cond:[^ ]+]] = icmp sgt i32 [[not_len_b]], [[not_len_a]]
+-; CHECK: [[smax_not_len:[^ ]+]] = select i1 [[smax_not_len_cond]], i32 [[not_len_b]], i32 [[not_len_a]]
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_upper_limit_cond_loclamp:[^ ]+]] = icmp sgt i32 [[smax_not_len]], [[not_n]]
+-; CHECK: [[not_upper_limit_loclamp:[^ ]+]] = select i1 [[not_upper_limit_cond_loclamp]], i32 [[smax_not_len]], i32 [[not_n]]
+-; CHECK: [[upper_limit_loclamp:[^ ]+]] = sub i32 -1, [[not_upper_limit_loclamp]]
++; CHECK: [[smax_len_cond:[^ ]+]] = icmp slt i32 %len.b, %len.a
++; CHECK: [[smax_len:[^ ]+]] = select i1 [[smax_len_cond]], i32 %len.b, i32 %len.a
++; CHECK: [[upper_limit_cond_loclamp:[^ ]+]] = icmp slt i32 [[smax_len]], %n 
++; CHECK: [[upper_limit_loclamp:[^ ]+]] = select i1 [[upper_limit_cond_loclamp]], i32 [[smax_len]], i32 %n
+ ; CHECK: [[upper_limit_cmp:[^ ]+]] = icmp sgt i32 [[upper_limit_loclamp]], 0
+ ; CHECK: [[upper_limit:[^ ]+]] = select i1 [[upper_limit_cmp]], i32 [[upper_limit_loclamp]], i32 0
+ 
+diff --git a/test/Transforms/IRCE/decrementing-loop.ll b/test/Transforms/IRCE/decrementing-loop.ll
+index fac873b4a24..30663da9e9f 100644
+--- a/test/Transforms/IRCE/decrementing-loop.ll
++++ b/test/Transforms/IRCE/decrementing-loop.ll
+@@ -28,11 +28,8 @@ define void @decrementing_loop(i32 *%arr, i32 *%a_len_ptr, i32 %n) {
+   ret void
+ 
+ ; CHECK: loop.preheader:
+-; CHECK:   [[not_len:[^ ]+]] = sub i32 -1, %len
+-; CHECK:   [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK:   [[not_len_hiclamp_cmp:[^ ]+]] = icmp sgt i32 [[not_len]], [[not_n]]
+-; CHECK:   [[not_len_hiclamp:[^ ]+]] = select i1 [[not_len_hiclamp_cmp]], i32 [[not_len]], i32 [[not_n]]
+-; CHECK:   [[len_hiclamp:[^ ]+]] = sub i32 -1, [[not_len_hiclamp]]
++; CHECK:   [[len_hiclamp_cmp:[^ ]+]] = icmp slt i32 %len, %n
++; CHECK:   [[len_hiclamp:[^ ]+]] = select i1 [[len_hiclamp_cmp]], i32 %len, i32 %n
+ ; CHECK:   [[not_exit_preloop_at_cmp:[^ ]+]] = icmp sgt i32 [[len_hiclamp]], 0
+ ; CHECK:   [[not_exit_preloop_at:[^ ]+]] = select i1 [[not_exit_preloop_at_cmp]], i32 [[len_hiclamp]], i32 0
+ ; CHECK:   %exit.preloop.at = add i32 [[not_exit_preloop_at]], -1
+diff --git a/test/Transforms/IRCE/multiple-access-no-preloop.ll b/test/Transforms/IRCE/multiple-access-no-preloop.ll
+index 31bfe7881b6..e693b1b8ef4 100644
+--- a/test/Transforms/IRCE/multiple-access-no-preloop.ll
++++ b/test/Transforms/IRCE/multiple-access-no-preloop.ll
+@@ -37,14 +37,10 @@ define void @multiple_access_no_preloop(
+ ; CHECK-LABEL: @multiple_access_no_preloop(
+ 
+ ; CHECK: loop.preheader:
+-; CHECK: [[not_len_b:[^ ]+]] = sub i32 -1, %len.b
+-; CHECK: [[not_len_a:[^ ]+]] = sub i32 -1, %len.a
+-; CHECK: [[smax_not_len_cond:[^ ]+]] = icmp sgt i32 [[not_len_b]], [[not_len_a]]
+-; CHECK: [[smax_not_len:[^ ]+]] = select i1 [[smax_not_len_cond]], i32 [[not_len_b]], i32 [[not_len_a]]
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_upper_limit_cond_loclamp:[^ ]+]] = icmp sgt i32 [[smax_not_len]], [[not_n]]
+-; CHECK: [[not_upper_limit_loclamp:[^ ]+]] = select i1 [[not_upper_limit_cond_loclamp]], i32 [[smax_not_len]], i32 [[not_n]]
+-; CHECK: [[upper_limit_loclamp:[^ ]+]] = sub i32 -1, [[not_upper_limit_loclamp]]
++; CHECK: [[smax_len_cond:[^ ]+]] = icmp slt i32 %len.b, %len.a
++; CHECK: [[smax_len:[^ ]+]] = select i1 [[smax_len_cond]], i32 %len.b, i32 %len.a
++; CHECK: [[upper_limit_cond_loclamp:[^ ]+]] = icmp slt i32 [[smax_len]], %n
++; CHECK: [[upper_limit_loclamp:[^ ]+]] = select i1 [[upper_limit_cond_loclamp]], i32 [[smax_len]], i32 %n
+ ; CHECK: [[upper_limit_cmp:[^ ]+]] = icmp sgt i32 [[upper_limit_loclamp]], 0
+ ; CHECK: [[upper_limit:[^ ]+]] = select i1 [[upper_limit_cmp]], i32 [[upper_limit_loclamp]], i32 0
+ 
+diff --git a/test/Transforms/IRCE/ranges_of_different_types.ll b/test/Transforms/IRCE/ranges_of_different_types.ll
+index c38ef24bc18..5694906a4c5 100644
+--- a/test/Transforms/IRCE/ranges_of_different_types.ll
++++ b/test/Transforms/IRCE/ranges_of_different_types.ll
+@@ -22,12 +22,11 @@ define void @test_01(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NOT:     preloop
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 12, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[SMAX:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, [[SMAX]]
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SUB2]], 0
+-; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SUB2]], i32 0
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = add i32 %len, -13
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp slt i32 [[SUB1]], 101
++; CHECK-NEXT:      [[SMAX:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 101
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SMAX]], 0
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SMAX]], i32 0
+ ; CHECK-NEXT:      [[GOTO_LOOP:%[^ ]+]] = icmp slt i32 0, %exit.mainloop.at
+ ; CHECK-NEXT:      br i1 [[GOTO_LOOP]], label %loop.preheader, label %main.pseudo.exit
+ ; CHECK:         loop
+@@ -82,13 +81,11 @@ define void @test_02(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NEXT:      [[LEN_MINUS_SMAX:%[^ ]+]] = add i32 %len, -2147483647
+ ; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[LEN_MINUS_SMAX]], -13
+ ; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[LEN_MINUS_SMAX]], i32 -13
+-; CHECK-NEXT:      [[ADD1:%[^ ]+]] = add i32 [[SMAX1]], -1
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 [[ADD1]], %len
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[SMAX2:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, [[SMAX2]]
+-; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp sgt i32 [[SUB2]], 0
+-; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP3]], i32 [[SUB2]], i32 0
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 %len, [[SMAX1]]
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp slt i32 [[SUB1]], 101
++; CHECK-NEXT:      [[SMAX2:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB1]], i32 101
++; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp sgt i32 [[SMAX2]], 0
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP3]], i32 [[SMAX2]], i32 0
+ ; CHECK-NEXT:      br i1 true, label %loop.preloop.preheader
+ ; CHECK:         loop.preloop:
+ ; CHECK-NEXT:      %idx.preloop = phi i32 [ %idx.next.preloop, %in.bounds.preloop ], [ 0, %loop.preloop.preheader ]
+@@ -150,14 +147,11 @@ define void @test_03(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NOT:     preloop
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 -2, %len
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[SUB2]], -14
+-; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB2]], i32 -14
+-; CHECK-NEXT:      [[SUB3:%[^ ]+]] = sub i32 [[SUB1]], [[SMAX1]]
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp ugt i32 [[SUB3]], -102
+-; CHECK-NEXT:      [[UMAX1:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB3]], i32 -102
+-; CHECK-NEXT:      %exit.mainloop.at = sub i32 -1, [[UMAX1]]
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp slt i32 %len, 13
++; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 %len, i32 13
++; CHECK-NEXT:      [[SUB3:%[^ ]+]] = sub i32 %len, [[SMAX1]]
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp ult i32 [[SUB3]], 101
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SUB3]], i32 101
+ ; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp ult i32 0, %exit.mainloop.at
+ ; CHECK-NEXT:      br i1 [[CMP3]], label %loop.preheader, label %main.pseudo.exit
+ ; CHECK:         postloop:
+@@ -207,10 +201,9 @@ define void @test_04(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-LABEL: test_04(
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 -14, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp ugt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[UMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      %exit.mainloop.at = sub i32 -1, [[UMAX1]]
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = add i32 %len, 13
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp ult i32 [[SUB1]], 101
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP1]], i32 [[SUB1]], i32 101
+ ; CHECK-NEXT:      br i1 true, label %loop.preloop.preheader
+ ; CHECK:         in.bounds.preloop:
+ ; CHECK-NEXT:      %addr.preloop = getelementptr i32, i32* %arr, i32 %idx.preloop
+@@ -251,12 +244,11 @@ define void @test_05(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NOT:     preloop
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 12, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[SMAX:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, [[SMAX]]
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SUB2]], 0
+-; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SUB2]], i32 0
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = add i32 %len, -13
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp slt i32 [[SUB1]], 101
++; CHECK-NEXT:      [[SMAX:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 101
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SMAX]], 0
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SMAX]], i32 0
+ ; CHECK-NEXT:      [[GOTO_LOOP:%[^ ]+]] = icmp slt i32 0, %exit.mainloop.at
+ ; CHECK-NEXT:      br i1 [[GOTO_LOOP]], label %loop.preheader, label %main.pseudo.exit
+ ; CHECK:         loop
+@@ -296,13 +288,11 @@ define void @test_06(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NEXT:      [[LEN_MINUS_SMAX:%[^ ]+]] = add i32 %len, -2147483647
+ ; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[LEN_MINUS_SMAX]], -13
+ ; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[LEN_MINUS_SMAX]], i32 -13
+-; CHECK-NEXT:      [[ADD1:%[^ ]+]] = add i32 [[SMAX1]], -1
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 [[ADD1]], %len
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[SMAX2:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, [[SMAX2]]
+-; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp sgt i32 [[SUB2]], 0
+-; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP3]], i32 [[SUB2]], i32 0
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 %len, [[SMAX1]]
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp slt i32 [[SUB1]], 101
++; CHECK-NEXT:      [[SMAX2:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB1]], i32 101
++; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp sgt i32 [[SMAX2]], 0
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP3]], i32 [[SMAX2]], i32 0
+ ; CHECK-NEXT:      br i1 true, label %loop.preloop.preheader
+ ; CHECK:         in.bounds.preloop:
+ ; CHECK-NEXT:      %addr.preloop = getelementptr i32, i32* %arr, i32 %idx.preloop
+@@ -343,14 +333,11 @@ define void @test_07(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NOT:     preloop
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 -2, %len
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[SUB2]], -14
+-; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB2]], i32 -14
+-; CHECK-NEXT:      [[SUB3:%[^ ]+]] = sub i32 [[SUB1]], [[SMAX1]]
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp ugt i32 [[SUB3]], -102
+-; CHECK-NEXT:      [[UMAX1:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB3]], i32 -102
+-; CHECK-NEXT:      %exit.mainloop.at = sub i32 -1, [[UMAX1]]
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp slt i32 %len, 13
++; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 %len, i32 13
++; CHECK-NEXT:      [[SUB3:%[^ ]+]] = sub i32 %len, [[SMAX1]]
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp ult i32 [[SUB3]], 101
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SUB3]], i32 101
+ ; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp ult i32 0, %exit.mainloop.at
+ ; CHECK-NEXT:      br i1 [[CMP3]], label %loop.preheader, label %main.pseudo.exit
+ ; CHECK:         loop
+@@ -387,10 +374,9 @@ define void @test_08(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-LABEL: test_08(
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 -14, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp ugt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[UMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      %exit.mainloop.at = sub i32 -1, [[UMAX1]]
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = add i32 %len, 13
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp ult i32 [[SUB1]], 101
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP1]], i32 [[SUB1]], i32 101
+ ; CHECK-NEXT:      br i1 true, label %loop.preloop.preheader
+ ; CHECK:         in.bounds.preloop:
+ ; CHECK-NEXT:      %addr.preloop = getelementptr i32, i32* %arr, i32 %idx.preloop
+diff --git a/test/Transforms/IRCE/single-access-no-preloop.ll b/test/Transforms/IRCE/single-access-no-preloop.ll
+index 53f430d0ba3..cbbdf81d46c 100644
+--- a/test/Transforms/IRCE/single-access-no-preloop.ll
++++ b/test/Transforms/IRCE/single-access-no-preloop.ll
+@@ -85,11 +85,9 @@ define void @single_access_no_preloop_with_offset(i32 *%arr, i32 *%a_len_ptr, i3
+ ; CHECK-LABEL: @single_access_no_preloop_with_offset(
+ 
+ ; CHECK: loop.preheader:
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_safe_range_end:[^ ]+]] = sub i32 3, %len
+-; CHECK: [[not_exit_main_loop_at_hiclamp_cmp:[^ ]+]] = icmp sgt i32 [[not_n]], [[not_safe_range_end]]
+-; CHECK: [[not_exit_main_loop_at_hiclamp:[^ ]+]] = select i1 [[not_exit_main_loop_at_hiclamp_cmp]], i32 [[not_n]], i32 [[not_safe_range_end]]
+-; CHECK: [[exit_main_loop_at_hiclamp:[^ ]+]] = sub i32 -1, [[not_exit_main_loop_at_hiclamp]]
++; CHECK: [[safe_range_end:[^ ]+]] = add i32 %len, -4
++; CHECK: [[exit_main_loop_at_hiclamp_cmp:[^ ]+]] = icmp slt i32 %n, [[safe_range_end]]
++; CHECK: [[exit_main_loop_at_hiclamp:[^ ]+]] = select i1 [[exit_main_loop_at_hiclamp_cmp]], i32 %n, i32 [[safe_range_end]]
+ ; CHECK: [[exit_main_loop_at_loclamp_cmp:[^ ]+]] = icmp sgt i32 [[exit_main_loop_at_hiclamp]], 0
+ ; CHECK: [[exit_main_loop_at_loclamp:[^ ]+]] = select i1 [[exit_main_loop_at_loclamp_cmp]], i32 [[exit_main_loop_at_hiclamp]], i32 0
+ ; CHECK: [[enter_main_loop:[^ ]+]] = icmp slt i32 0, [[exit_main_loop_at_loclamp]]
+diff --git a/test/Transforms/IRCE/single-access-with-preloop.ll b/test/Transforms/IRCE/single-access-with-preloop.ll
+index 4b93122b6e7..3e2395dd100 100644
+--- a/test/Transforms/IRCE/single-access-with-preloop.ll
++++ b/test/Transforms/IRCE/single-access-with-preloop.ll
+@@ -33,11 +33,9 @@ define void @single_access_with_preloop(i32 *%arr, i32 *%a_len_ptr, i32 %n, i32
+ ; CHECK: [[check_min_sint_offset:[^ ]+]] = icmp sgt i32 %offset, -2147483647
+ ; CHECK: [[safe_offset_preloop:[^ ]+]] = select i1 [[check_min_sint_offset]], i32 %offset, i32 -2147483647
+ ; If Offset was a SINT_MIN, we could have an overflow here. That is why we calculated its safe version.
+-; CHECK: [[not_safe_start:[^ ]+]] = add i32 [[safe_offset_preloop]], -1
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_exit_preloop_at_cond_loclamp:[^ ]+]] = icmp sgt i32 [[not_safe_start]], [[not_n]]
+-; CHECK: [[not_exit_preloop_at_loclamp:[^ ]+]] = select i1 [[not_exit_preloop_at_cond_loclamp]], i32 [[not_safe_start]], i32 [[not_n]]
+-; CHECK: [[exit_preloop_at_loclamp:[^ ]+]] = sub i32 -1, [[not_exit_preloop_at_loclamp]]
++; CHECK: [[safe_start:[^ ]+]] = sub i32 0, [[safe_offset_preloop]]
++; CHECK: [[exit_preloop_at_cond_loclamp:[^ ]+]] = icmp slt i32 %n, [[safe_start]]
++; CHECK: [[exit_preloop_at_loclamp:[^ ]+]] = select i1 [[exit_preloop_at_cond_loclamp]], i32 %n, i32 [[safe_start]]
+ ; CHECK: [[exit_preloop_at_cond:[^ ]+]] = icmp sgt i32 [[exit_preloop_at_loclamp]], 0
+ ; CHECK: [[exit_preloop_at:[^ ]+]] = select i1 [[exit_preloop_at_cond]], i32 [[exit_preloop_at_loclamp]], i32 0
+ 
+@@ -45,17 +43,15 @@ define void @single_access_with_preloop(i32 *%arr, i32 *%a_len_ptr, i32 %n, i32
+ ; CHECK: [[len_minus_sint_max:[^ ]+]] = add i32 %len, -2147483647
+ ; CHECK: [[check_len_min_sint_offset:[^ ]+]] = icmp sgt i32 %offset, [[len_minus_sint_max]]
+ ; CHECK: [[safe_offset_mainloop:[^ ]+]] = select i1 [[check_len_min_sint_offset]], i32 %offset, i32 [[len_minus_sint_max]]
+-; CHECK: [[not_safe_start_2:[^ ]+]] = add i32 [[safe_offset_mainloop]], -1
+ ; If Offset was a SINT_MIN, we could have an overflow here. That is why we calculated its safe version.
+-; CHECK: [[not_safe_upper_end:[^ ]+]] = sub i32 [[not_safe_start_2]], %len
+-; CHECK: [[not_exit_mainloop_at_cond_loclamp:[^ ]+]] = icmp sgt i32 [[not_safe_upper_end]], [[not_n]]
+-; CHECK: [[not_exit_mainloop_at_loclamp:[^ ]+]] = select i1 [[not_exit_mainloop_at_cond_loclamp]], i32 [[not_safe_upper_end]], i32 [[not_n]]
++; CHECK: [[safe_upper_end:[^ ]+]] = sub i32 %len, [[safe_offset_mainloop]]
++; CHECK: [[exit_mainloop_at_cond_loclamp:[^ ]+]] = icmp slt i32 %n, [[safe_upper_end]]
++; CHECK: [[exit_mainloop_at_loclamp:[^ ]+]] = select i1 [[exit_mainloop_at_cond_loclamp]], i32 %n, i32 [[safe_upper_end]]
+ ; CHECK: [[check_offset_mainloop_2:[^ ]+]] = icmp sgt i32 %offset, 0
+ ; CHECK: [[safe_offset_mainloop_2:[^ ]+]] = select i1 [[check_offset_mainloop_2]], i32 %offset, i32 0
+-; CHECK: [[not_safe_lower_end:[^ ]+]] = add i32 [[safe_offset_mainloop_2]], -2147483648
+-; CHECK: [[not_exit_mainloop_at_cond_hiclamp:[^ ]+]] = icmp sgt i32 [[not_exit_mainloop_at_loclamp]], [[not_safe_lower_end]]
+-; CHECK: [[not_exit_mainloop_at_hiclamp:[^ ]+]] = select i1 [[not_exit_mainloop_at_cond_hiclamp]], i32 [[not_exit_mainloop_at_loclamp]], i32 [[not_safe_lower_end]]
+-; CHECK: [[exit_mainloop_at_hiclamp:[^ ]+]] = sub i32 -1, [[not_exit_mainloop_at_hiclamp]]
++; CHECK: [[safe_lower_end:[^ ]+]] = sub i32 2147483647, [[safe_offset_mainloop_2]]
++; CHECK: [[exit_mainloop_at_cond_hiclamp:[^ ]+]] = icmp slt i32 [[exit_mainloop_at_loclamp]], [[safe_lower_end]]
++; CHECK: [[exit_mainloop_at_hiclamp:[^ ]+]] = select i1 [[exit_mainloop_at_cond_hiclamp]], i32 [[exit_mainloop_at_loclamp]], i32 [[safe_lower_end]]
+ ; CHECK: [[exit_mainloop_at_cmp:[^ ]+]] = icmp sgt i32 [[exit_mainloop_at_hiclamp]], 0
+ ; CHECK: [[exit_mainloop_at:[^ ]+]] = select i1 [[exit_mainloop_at_cmp]], i32 [[exit_mainloop_at_hiclamp]], i32 0
+ 
+diff --git a/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll b/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll
+index ea3f6077231..d5232e1874c 100644
+--- a/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll
++++ b/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll
+@@ -14,8 +14,6 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
+ ; current LSR cost model.
+ ; CHECK-NOT: = ptrtoint i8* undef to i64
+ ; CHECK: .lr.ph
+-; CHECK: [[TMP:%[^ ]+]] = add i64 %tmp{{[0-9]+}}, -1
+-; CHECK: sub i64 [[TMP]], %tmp{{[0-9]+}}
+ ; CHECK: ret void
+ define void @VerifyDiagnosticConsumerTest() unnamed_addr nounwind uwtable align 2 {
+ bb:

--- a/L/LLVM/v6/bundled/llvm_patches/0026-llvm-rL326967-aligned-load.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0026-llvm-rL326967-aligned-load.patch
@@ -1,0 +1,301 @@
+commit b398d8e1fa5a5a914957fa22d0a64db97f6c265e
+Author: Craig Topper <craig.topper@intel.com>
+Date:   Thu Mar 8 00:21:17 2018 +0000
+
+    [X86] Fix some isel patterns that used aligned vector load instructions with unaligned predicates.
+    
+    These patterns weren't checking the alignment of the load, but were using the aligned instructions. This will cause a GP fault if the data isn't aligned.
+    
+    I believe these were introduced in r312450.
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@326967 91177308-0d34-0410-b5e6-96231b3b80d8
+
+diff --git a/lib/Target/X86/X86InstrVecCompiler.td b/lib/Target/X86/X86InstrVecCompiler.td
+index db3dfe56531..50c7763a2c3 100644
+--- a/lib/Target/X86/X86InstrVecCompiler.td
++++ b/lib/Target/X86/X86InstrVecCompiler.td
+@@ -261,10 +261,10 @@ let Predicates = [HasVLX] in {
+ // will zero the upper bits.
+ // TODO: Is there a safe way to detect whether the producing instruction
+ // already zeroed the upper bits?
+-multiclass subvector_zero_lowering<string MoveStr, RegisterClass RC,
+-                                   ValueType DstTy, ValueType SrcTy,
+-                                   ValueType ZeroTy, PatFrag memop,
+-                                   SubRegIndex SubIdx> {
++multiclass subvector_zero_lowering<string MoveStr, string LoadStr,
++                                   RegisterClass RC, ValueType DstTy,
++                                   ValueType SrcTy, ValueType ZeroTy,
++                                   PatFrag memop, SubRegIndex SubIdx> {
+   def : Pat<(DstTy (insert_subvector (bitconvert (ZeroTy immAllZerosV)),
+                                      (SrcTy RC:$src), (iPTR 0))),
+             (SUBREG_TO_REG (i64 0),
+@@ -274,91 +274,91 @@ multiclass subvector_zero_lowering<string MoveStr, RegisterClass RC,
+                                      (SrcTy (bitconvert (memop addr:$src))),
+                                      (iPTR 0))),
+             (SUBREG_TO_REG (i64 0),
+-             (!cast<Instruction>("VMOV"#MoveStr#"rm") addr:$src), SubIdx)>;
++             (!cast<Instruction>("VMOV"#LoadStr#"rm") addr:$src), SubIdx)>;
+ }
+ 
+ let Predicates = [HasAVX, NoVLX] in {
+-  defm : subvector_zero_lowering<"APD", VR128, v4f64, v2f64, v8i32, loadv2f64,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"APS", VR128, v8f32, v4f32, v8i32, loadv4f32,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA", VR128, v4i64, v2i64, v8i32, loadv2i64,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA", VR128, v8i32, v4i32, v8i32, loadv2i64,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA", VR128, v16i16, v8i16, v8i32, loadv2i64,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA", VR128, v32i8, v16i8, v8i32, loadv2i64,
+-                                 sub_xmm>;
+-}
+-
+-let Predicates = [HasVLX] in {
+-  defm : subvector_zero_lowering<"APDZ128", VR128X, v4f64, v2f64, v8i32,
++  defm : subvector_zero_lowering<"APD", "UPD", VR128, v4f64, v2f64, v8i32,
+                                  loadv2f64, sub_xmm>;
+-  defm : subvector_zero_lowering<"APSZ128", VR128X, v8f32, v4f32, v8i32,
++  defm : subvector_zero_lowering<"APS", "UPS", VR128, v8f32, v4f32, v8i32,
+                                  loadv4f32, sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA64Z128", VR128X, v4i64, v2i64, v8i32,
++  defm : subvector_zero_lowering<"DQA", "DQU", VR128, v4i64, v2i64, v8i32,
+                                  loadv2i64, sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA64Z128", VR128X, v8i32, v4i32, v8i32,
++  defm : subvector_zero_lowering<"DQA", "DQU", VR128, v8i32, v4i32, v8i32,
+                                  loadv2i64, sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA64Z128", VR128X, v16i16, v8i16, v8i32,
++  defm : subvector_zero_lowering<"DQA", "DQU", VR128, v16i16, v8i16, v8i32,
+                                  loadv2i64, sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA64Z128", VR128X, v32i8, v16i8, v8i32,
+-                                 loadv2i64, sub_xmm>;
+-
+-  defm : subvector_zero_lowering<"APDZ128", VR128X, v8f64, v2f64, v16i32,
+-                                 loadv2f64, sub_xmm>;
+-  defm : subvector_zero_lowering<"APSZ128", VR128X, v16f32, v4f32, v16i32,
+-                                 loadv4f32, sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA64Z128", VR128X, v8i64, v2i64, v16i32,
+-                                 loadv2i64, sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA64Z128", VR128X, v16i32, v4i32, v16i32,
+-                                 loadv2i64, sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA64Z128", VR128X, v32i16, v8i16, v16i32,
+-                                 loadv2i64, sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA64Z128", VR128X, v64i8, v16i8, v16i32,
++  defm : subvector_zero_lowering<"DQA", "DQU", VR128, v32i8, v16i8, v8i32,
+                                  loadv2i64, sub_xmm>;
++}
+ 
+-  defm : subvector_zero_lowering<"APDZ256", VR256X, v8f64, v4f64, v16i32,
+-                                 loadv4f64, sub_ymm>;
+-  defm : subvector_zero_lowering<"APSZ256", VR256X, v16f32, v8f32, v16i32,
+-                                 loadv8f32, sub_ymm>;
+-  defm : subvector_zero_lowering<"DQA64Z256", VR256X, v8i64, v4i64, v16i32,
+-                                 loadv4i64, sub_ymm>;
+-  defm : subvector_zero_lowering<"DQA64Z256", VR256X, v16i32, v8i32, v16i32,
+-                                 loadv4i64, sub_ymm>;
+-  defm : subvector_zero_lowering<"DQA64Z256", VR256X, v32i16, v16i16, v16i32,
+-                                 loadv4i64, sub_ymm>;
+-  defm : subvector_zero_lowering<"DQA64Z256", VR256X, v64i8, v32i8, v16i32,
+-                                 loadv4i64, sub_ymm>;
++let Predicates = [HasVLX] in {
++  defm : subvector_zero_lowering<"APDZ128", "UPDZ128", VR128X, v4f64,
++                                 v2f64, v8i32, loadv2f64, sub_xmm>;
++  defm : subvector_zero_lowering<"APSZ128", "UPSZ128", VR128X, v8f32,
++                                 v4f32, v8i32, loadv4f32, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA64Z128", "DQU64Z128", VR128X, v4i64,
++                                 v2i64, v8i32, loadv2i64, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA64Z128", "DQU64Z128", VR128X, v8i32,
++                                 v4i32, v8i32, loadv2i64, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA64Z128", "DQU64Z128", VR128X, v16i16,
++                                 v8i16, v8i32, loadv2i64, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA64Z128", "DQU64Z128", VR128X, v32i8,
++                                 v16i8, v8i32, loadv2i64, sub_xmm>;
++
++  defm : subvector_zero_lowering<"APDZ128", "UPDZ128", VR128X, v8f64,
++                                 v2f64, v16i32, loadv2f64, sub_xmm>;
++  defm : subvector_zero_lowering<"APSZ128", "UPSZ128", VR128X, v16f32,
++                                 v4f32, v16i32, loadv4f32, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA64Z128", "DQU64Z128", VR128X, v8i64,
++                                 v2i64, v16i32, loadv2i64, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA64Z128", "DQU64Z128", VR128X, v16i32,
++                                 v4i32, v16i32, loadv2i64, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA64Z128", "DQU64Z128", VR128X, v32i16,
++                                 v8i16, v16i32, loadv2i64, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA64Z128", "DQU64Z128", VR128X, v64i8,
++                                 v16i8, v16i32, loadv2i64, sub_xmm>;
++
++  defm : subvector_zero_lowering<"APDZ256", "UPDZ256", VR256X, v8f64,
++                                 v4f64, v16i32, loadv4f64, sub_ymm>;
++  defm : subvector_zero_lowering<"APSZ256", "UPDZ256", VR256X, v16f32,
++                                 v8f32, v16i32, loadv8f32, sub_ymm>;
++  defm : subvector_zero_lowering<"DQA64Z256", "DQU64Z256", VR256X, v8i64,
++                                 v4i64, v16i32, loadv4i64, sub_ymm>;
++  defm : subvector_zero_lowering<"DQA64Z256", "DQU64Z256", VR256X, v16i32,
++                                 v8i32, v16i32, loadv4i64, sub_ymm>;
++  defm : subvector_zero_lowering<"DQA64Z256", "DQU64Z256", VR256X, v32i16,
++                                 v16i16, v16i32, loadv4i64, sub_ymm>;
++  defm : subvector_zero_lowering<"DQA64Z256", "DQU64Z256", VR256X, v64i8,
++                                 v32i8, v16i32, loadv4i64, sub_ymm>;
+ }
+ 
+ let Predicates = [HasAVX512, NoVLX] in {
+-  defm : subvector_zero_lowering<"APD", VR128, v8f64, v2f64, v16i32, loadv2f64,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"APS", VR128, v16f32, v4f32, v16i32, loadv4f32,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA", VR128, v8i64, v2i64, v16i32, loadv2i64,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA", VR128, v16i32, v4i32, v16i32, loadv2i64,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA", VR128, v32i16, v8i16, v16i32, loadv2i64,
+-                                 sub_xmm>;
+-  defm : subvector_zero_lowering<"DQA", VR128, v64i8, v16i8, v16i32, loadv2i64,
+-                                 sub_xmm>;
+-
+-  defm : subvector_zero_lowering<"APDY", VR256, v8f64, v4f64, v16i32,
+-                                 loadv4f64, sub_ymm>;
+-  defm : subvector_zero_lowering<"APSY", VR256, v16f32, v8f32, v16i32,
+-                                 loadv8f32, sub_ymm>;
+-  defm : subvector_zero_lowering<"DQAY", VR256, v8i64, v4i64, v16i32,
+-                                 loadv4i64, sub_ymm>;
+-  defm : subvector_zero_lowering<"DQAY", VR256, v16i32, v8i32, v16i32,
+-                                 loadv4i64, sub_ymm>;
+-  defm : subvector_zero_lowering<"DQAY", VR256, v32i16, v16i16, v16i32,
+-                                 loadv4i64, sub_ymm>;
+-  defm : subvector_zero_lowering<"DQAY", VR256, v64i8, v32i8, v16i32,
+-                                 loadv4i64, sub_ymm>;
++  defm : subvector_zero_lowering<"APD", "UPD", VR128, v8f64, v2f64,
++                                 v16i32,loadv2f64, sub_xmm>;
++  defm : subvector_zero_lowering<"APS", "UPS", VR128, v16f32, v4f32,
++                                 v16i32, loadv4f32, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA", "DQU", VR128, v8i64, v2i64,
++                                 v16i32, loadv2i64, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA", "DQU", VR128, v16i32, v4i32,
++                                 v16i32, loadv2i64, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA", "DQU", VR128, v32i16, v8i16,
++                                 v16i32, loadv2i64, sub_xmm>;
++  defm : subvector_zero_lowering<"DQA", "DQU", VR128, v64i8, v16i8,
++                                 v16i32, loadv2i64, sub_xmm>;
++
++  defm : subvector_zero_lowering<"APDY", "UPDY", VR256, v8f64, v4f64,
++                                 v16i32, loadv4f64, sub_ymm>;
++  defm : subvector_zero_lowering<"APSY", "UPSY", VR256, v16f32, v8f32,
++                                 v16i32, loadv8f32, sub_ymm>;
++  defm : subvector_zero_lowering<"DQAY", "DQUY", VR256, v8i64, v4i64,
++                                 v16i32, loadv4i64, sub_ymm>;
++  defm : subvector_zero_lowering<"DQAY", "DQUY", VR256, v16i32, v8i32,
++                                 v16i32, loadv4i64, sub_ymm>;
++  defm : subvector_zero_lowering<"DQAY", "DQUY", VR256, v32i16, v16i16,
++                                 v16i32, loadv4i64, sub_ymm>;
++  defm : subvector_zero_lowering<"DQAY", "DQUY", VR256, v64i8, v32i8,
++                                 v16i32, loadv4i64, sub_ymm>;
+ }
+ 
+ // List of opcodes that guaranteed to zero the upper elements of vector regs.
+diff --git a/test/CodeGen/X86/merge-consecutive-loads-256.ll b/test/CodeGen/X86/merge-consecutive-loads-256.ll
+index 6ecd8116443..0f2cf594b1c 100644
+--- a/test/CodeGen/X86/merge-consecutive-loads-256.ll
++++ b/test/CodeGen/X86/merge-consecutive-loads-256.ll
+@@ -28,13 +28,13 @@ define <4 x double> @merge_4f64_2f64_23(<2 x double>* %ptr) nounwind uwtable noi
+ define <4 x double> @merge_4f64_2f64_2z(<2 x double>* %ptr) nounwind uwtable noinline ssp {
+ ; AVX-LABEL: merge_4f64_2f64_2z:
+ ; AVX:       # %bb.0:
+-; AVX-NEXT:    vmovaps 32(%rdi), %xmm0
++; AVX-NEXT:    vmovups 32(%rdi), %xmm0
+ ; AVX-NEXT:    retq
+ ;
+ ; X32-AVX-LABEL: merge_4f64_2f64_2z:
+ ; X32-AVX:       # %bb.0:
+ ; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps 32(%eax), %xmm0
++; X32-AVX-NEXT:    vmovups 32(%eax), %xmm0
+ ; X32-AVX-NEXT:    retl
+   %ptr0 = getelementptr inbounds <2 x double>, <2 x double>* %ptr, i64 2
+   %val0 = load <2 x double>, <2 x double>* %ptr0
+@@ -109,13 +109,13 @@ define <4 x double> @merge_4f64_f64_34uu(double* %ptr) nounwind uwtable noinline
+ define <4 x double> @merge_4f64_f64_45zz(double* %ptr) nounwind uwtable noinline ssp {
+ ; AVX-LABEL: merge_4f64_f64_45zz:
+ ; AVX:       # %bb.0:
+-; AVX-NEXT:    vmovaps 32(%rdi), %xmm0
++; AVX-NEXT:    vmovups 32(%rdi), %xmm0
+ ; AVX-NEXT:    retq
+ ;
+ ; X32-AVX-LABEL: merge_4f64_f64_45zz:
+ ; X32-AVX:       # %bb.0:
+ ; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps 32(%eax), %xmm0
++; X32-AVX-NEXT:    vmovups 32(%eax), %xmm0
+ ; X32-AVX-NEXT:    retl
+   %ptr0 = getelementptr inbounds double, double* %ptr, i64 4
+   %ptr1 = getelementptr inbounds double, double* %ptr, i64 5
+@@ -155,13 +155,13 @@ define <4 x double> @merge_4f64_f64_34z6(double* %ptr) nounwind uwtable noinline
+ define <4 x i64> @merge_4i64_2i64_3z(<2 x i64>* %ptr) nounwind uwtable noinline ssp {
+ ; AVX-LABEL: merge_4i64_2i64_3z:
+ ; AVX:       # %bb.0:
+-; AVX-NEXT:    vmovaps 48(%rdi), %xmm0
++; AVX-NEXT:    vmovups 48(%rdi), %xmm0
+ ; AVX-NEXT:    retq
+ ;
+ ; X32-AVX-LABEL: merge_4i64_2i64_3z:
+ ; X32-AVX:       # %bb.0:
+ ; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps 48(%eax), %xmm0
++; X32-AVX-NEXT:    vmovups 48(%eax), %xmm0
+ ; X32-AVX-NEXT:    retl
+   %ptr0 = getelementptr inbounds <2 x i64>, <2 x i64>* %ptr, i64 3
+   %val0 = load <2 x i64>, <2 x i64>* %ptr0
+@@ -217,13 +217,13 @@ define <4 x i64> @merge_4i64_i64_1zzu(i64* %ptr) nounwind uwtable noinline ssp {
+ define <4 x i64> @merge_4i64_i64_23zz(i64* %ptr) nounwind uwtable noinline ssp {
+ ; AVX-LABEL: merge_4i64_i64_23zz:
+ ; AVX:       # %bb.0:
+-; AVX-NEXT:    vmovaps 16(%rdi), %xmm0
++; AVX-NEXT:    vmovups 16(%rdi), %xmm0
+ ; AVX-NEXT:    retq
+ ;
+ ; X32-AVX-LABEL: merge_4i64_i64_23zz:
+ ; X32-AVX:       # %bb.0:
+ ; X32-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX-NEXT:    vmovaps 16(%eax), %xmm0
++; X32-AVX-NEXT:    vmovups 16(%eax), %xmm0
+ ; X32-AVX-NEXT:    retl
+   %ptr0 = getelementptr inbounds i64, i64* %ptr, i64 2
+   %ptr1 = getelementptr inbounds i64, i64* %ptr, i64 3
+diff --git a/test/CodeGen/X86/merge-consecutive-loads-512.ll b/test/CodeGen/X86/merge-consecutive-loads-512.ll
+index 62102eb382c..3c6eaf65292 100644
+--- a/test/CodeGen/X86/merge-consecutive-loads-512.ll
++++ b/test/CodeGen/X86/merge-consecutive-loads-512.ll
+@@ -106,13 +106,13 @@ define <8 x double> @merge_8f64_f64_23uuuuu9(double* %ptr) nounwind uwtable noin
+ define <8 x double> @merge_8f64_f64_12zzuuzz(double* %ptr) nounwind uwtable noinline ssp {
+ ; ALL-LABEL: merge_8f64_f64_12zzuuzz:
+ ; ALL:       # %bb.0:
+-; ALL-NEXT:    vmovaps 8(%rdi), %xmm0
++; ALL-NEXT:    vmovups 8(%rdi), %xmm0
+ ; ALL-NEXT:    retq
+ ;
+ ; X32-AVX512F-LABEL: merge_8f64_f64_12zzuuzz:
+ ; X32-AVX512F:       # %bb.0:
+ ; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512F-NEXT:    vmovaps 8(%eax), %xmm0
++; X32-AVX512F-NEXT:    vmovups 8(%eax), %xmm0
+ ; X32-AVX512F-NEXT:    retl
+   %ptr0 = getelementptr inbounds double, double* %ptr, i64 1
+   %ptr1 = getelementptr inbounds double, double* %ptr, i64 2
+@@ -190,7 +190,7 @@ define <8 x i64> @merge_8i64_4i64_z3(<4 x i64>* %ptr) nounwind uwtable noinline
+ define <8 x i64> @merge_8i64_i64_56zz9uzz(i64* %ptr) nounwind uwtable noinline ssp {
+ ; ALL-LABEL: merge_8i64_i64_56zz9uzz:
+ ; ALL:       # %bb.0:
+-; ALL-NEXT:    vmovaps 40(%rdi), %xmm0
++; ALL-NEXT:    vmovups 40(%rdi), %xmm0
+ ; ALL-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+ ; ALL-NEXT:    vinsertf64x4 $1, %ymm1, %zmm0, %zmm0
+ ; ALL-NEXT:    retq
+@@ -198,7 +198,7 @@ define <8 x i64> @merge_8i64_i64_56zz9uzz(i64* %ptr) nounwind uwtable noinline s
+ ; X32-AVX512F-LABEL: merge_8i64_i64_56zz9uzz:
+ ; X32-AVX512F:       # %bb.0:
+ ; X32-AVX512F-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; X32-AVX512F-NEXT:    vmovaps 40(%eax), %xmm0
++; X32-AVX512F-NEXT:    vmovups 40(%eax), %xmm0
+ ; X32-AVX512F-NEXT:    vmovsd {{.*#+}} xmm1 = mem[0],zero
+ ; X32-AVX512F-NEXT:    vinsertf64x4 $1, %ymm1, %zmm0, %zmm0
+ ; X32-AVX512F-NEXT:    retl

--- a/L/LLVM/v6/bundled/llvm_patches/0027-llvm-D51842-win64-byval-cc.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0027-llvm-D51842-win64-byval-cc.patch
@@ -1,0 +1,164 @@
+commit 11e52448390e0d8a80565ccd1ca4865df7787f21
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Sun Sep 9 16:45:35 2018 -0400
+
+    [X86ISel] Implement byval lowering for Win64 calling convention
+    
+    Summary:
+    The IR reference for the `byval` attribute states:
+    
+    ```
+    This indicates that the pointer parameter should really be passed by value
+    to the function. The attribute implies that a hidden copy of the pointee is
+    made between the caller and the callee, so the callee is unable to modify
+    the value in the caller. This attribute is only valid on LLVM pointer arguments.
+    ```
+    
+    However, on Win64, this attribute is unimplemented and the raw pointer is
+    passed to the callee instead. This is problematic, because frontend authors
+    relying on the implicit hidden copy (as happens for every other calling
+    convention) will see the passed value silently (if mutable memory) or
+    loudly (by means of a crash) modified because the callee treats the
+    location as scratch memory space it is allowed to mutate.
+    
+    At this point, it's worth taking a step back to understand the context.
+    In most calling conventions, aggregates that are too large to be passed
+    in registers, instead get *copied* to the stack at a fixed (computable
+    from the signature) offset of the stack pointer. At the LLVM, we hide
+    this hidden copy behind the byval attribute. The caller passes a pointer
+    to the desired data and the callee receives a pointer, but these pointers
+    are not the same. In particular, the pointer that the callee receives
+    points to temporary stack memory allocated as part of the call lowering.
+    In most calling conventions, this pointer is never realized in registers
+    or memory. The temporary memory is simply defined by an implicit
+    offset from the stack pointer at function entry.
+    
+    Win64, uniquely, works differently. The structure is still passed in
+    memory, but instead of being stored at an implicit memory offset, the
+    caller computes a pointer to the temporary memory and passes it to
+    the callee as a regular pointer (taking up a register, or if all
+    registers are taken up, an additional stack slot). Presumably, this
+    was done to allow eliding the copy when passing aggregates through
+    several functions on the stack.
+    
+    This explains why ignoring the `byval` attribute mostly works on Win64.
+    The argument simply gets passed as a pointer and as long as we're ok
+    with the callee trampling all over that memory, there are no ill effects.
+    However, it does contradict the documentation of the `byval` attribute
+    which specifies that there is to be an implicit copy.
+    
+    Frontends can of course work around this by never emitting the `byval`
+    attribute for Win64 and creating `alloca`s for the requisite temporary
+    stack slots (and that does appear to be what frontends are doing).
+    However, the presence of the `byval` attribute is not a trap for
+    frontend authors, since it seems to work, but silently modifies the
+    passed memory contrary to documentation.
+    
+    I see two solutions:
+    - Disallow the `byval` attribute in the verifier if using the Win64
+      calling convention.
+    - Make it work by simply emitting a temporary stack copy as we would
+      with any other calling convention (frontends can of course always
+      not use the attribute if they want to elide the copy).
+    
+    This patch implements the second option (make it work), though I would
+    be fine with the first also.
+    
+    Ref: https://github.com/JuliaLang/julia/issues/28338
+    
+    Reviewers: rnk
+    
+    Subscribers: llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D51842
+
+diff --git a/lib/Target/X86/X86CallingConv.td b/lib/Target/X86/X86CallingConv.td
+index 5d806fe60b8..7a82b299301 100644
+--- a/lib/Target/X86/X86CallingConv.td
++++ b/lib/Target/X86/X86CallingConv.td
+@@ -583,9 +583,11 @@ def CC_X86_64_HHVM_C : CallingConv<[
+ 
+ // Calling convention used on Win64
+ def CC_X86_Win64_C : CallingConv<[
+-  // FIXME: Handle byval stuff.
+   // FIXME: Handle varargs.
+ 
++  // Byval aggregates are passed by pointer
++  CCIfByVal<CCPassIndirect<i64>>,
++
+   // Promote i1/i8/i16/v1i1 arguments to i32.
+   CCIfType<[i1, i8, i16, v1i1], CCPromoteToType<i32>>,
+ 
+diff --git a/lib/Target/X86/X86ISelLowering.cpp b/lib/Target/X86/X86ISelLowering.cpp
+index 86e71cba87b..412d015824b 100644
+--- a/lib/Target/X86/X86ISelLowering.cpp
++++ b/lib/Target/X86/X86ISelLowering.cpp
+@@ -3062,7 +3062,8 @@ SDValue X86TargetLowering::LowerFormalArguments(
+     }
+ 
+     // If value is passed via pointer - do a load.
+-    if (VA.getLocInfo() == CCValAssign::Indirect)
++    if (VA.getLocInfo() == CCValAssign::Indirect &&
++        !Ins[I].Flags.isByVal())
+       ArgValue =
+           DAG.getLoad(VA.getValVT(), dl, Chain, ArgValue, MachinePointerInfo());
+ 
+@@ -3540,13 +3541,27 @@ X86TargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
+       Arg = DAG.getBitcast(RegVT, Arg);
+       break;
+     case CCValAssign::Indirect: {
+-      // Store the argument.
+-      SDValue SpillSlot = DAG.CreateStackTemporary(VA.getValVT());
+-      int FI = cast<FrameIndexSDNode>(SpillSlot)->getIndex();
+-      Chain = DAG.getStore(
+-          Chain, dl, Arg, SpillSlot,
+-          MachinePointerInfo::getFixedStack(DAG.getMachineFunction(), FI));
+-      Arg = SpillSlot;
++      if (isByVal) {
++        // Copy the argument into a temportary spill slot
++        int FrameIdx = MF.getFrameInfo().CreateStackObject(
++            Flags.getByValSize(), std::max(16, (int)Flags.getByValAlign()),
++            false);
++        SDValue SpillSlot =
++            DAG.getFrameIndex(FrameIdx, getPointerTy(DAG.getDataLayout()));
++        Chain =
++            CreateCopyOfByValArgument(Arg, SpillSlot, Chain, Flags, DAG, dl);
++        // From now on treat this as a regular pointer
++        Arg = SpillSlot;
++        isByVal = false;
++      } else {
++        // Store the argument.
++        SDValue SpillSlot = DAG.CreateStackTemporary(VA.getValVT());
++        int FI = cast<FrameIndexSDNode>(SpillSlot)->getIndex();
++        Chain = DAG.getStore(
++            Chain, dl, Arg, SpillSlot,
++            MachinePointerInfo::getFixedStack(DAG.getMachineFunction(), FI));
++        Arg = SpillSlot;
++      }
+       break;
+     }
+     }
+diff --git a/test/CodeGen/X86/win64-byval.ll b/test/CodeGen/X86/win64-byval.ll
+new file mode 100644
+index 00000000000..0b762cd3cea
+--- /dev/null
++++ b/test/CodeGen/X86/win64-byval.ll
+@@ -0,0 +1,18 @@
++; RUN: llc -mtriple x86_64-w64-mingw32 %s -o - | FileCheck %s
++
++declare void @foo({ float, double }* byval); 
++@G = external constant { float, double }
++
++define void @bar()
++{
++; Make sure we're creating a temporary stack slot, rather than just passing
++; the pointer through unmodified.
++; CHECK-LABEL: @bar
++; CHECK: movq    G+8(%rip), %rax
++; CHECK: movq    %rax, 40(%rsp)
++; CHECK: movq    G(%rip), %rax
++; CHECK: movq    %rax, 32(%rsp)
++; CHECK: leaq    32(%rsp), %rcx
++    call void @foo({ float, double }* byval @G)
++    ret void
++}

--- a/L/LLVM/v6/bundled/llvm_patches/0029-llvm-r355582-avxminmax.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0029-llvm-r355582-avxminmax.patch
@@ -1,0 +1,48 @@
+From 7f82bf14c02915ff1bf0e931465fc208287d24c6 Mon Sep 17 00:00:00 2001
+From: nic <nwerneck@gmail.com>
+Date: Thu, 7 Mar 2019 22:01:01 +0100
+Subject: [PATCH] Backporting r355582 on release/6.x
+
+---
+ lib/Target/X86/X86ISelLowering.cpp | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/lib/Target/X86/X86ISelLowering.cpp b/lib/Target/X86/X86ISelLowering.cpp
+index c1ddb771e2f..2a96373ed10 100644
+--- a/lib/Target/X86/X86ISelLowering.cpp
++++ b/lib/Target/X86/X86ISelLowering.cpp
+@@ -35751,15 +35751,17 @@ static SDValue combineFMinNumFMaxNum(SDNode *N, SelectionDAG &DAG,
+   if (Subtarget.useSoftFloat())
+     return SDValue();
+
++  const TargetLowering &TLI = DAG.getTargetLoweringInfo();
++
+   // TODO: Check for global or instruction-level "nnan". In that case, we
+   //       should be able to lower to FMAX/FMIN alone.
+   // TODO: If an operand is already known to be a NaN or not a NaN, this
+   //       should be an optional swap and FMAX/FMIN.
+
+   EVT VT = N->getValueType(0);
+-  if (!((Subtarget.hasSSE1() && (VT == MVT::f32 || VT == MVT::v4f32)) ||
+-        (Subtarget.hasSSE2() && (VT == MVT::f64 || VT == MVT::v2f64)) ||
+-        (Subtarget.hasAVX() && (VT == MVT::v8f32 || VT == MVT::v4f64))))
++  if (!((Subtarget.hasSSE1() && VT == MVT::f32) ||
++	(Subtarget.hasSSE2() && VT == MVT::f64) ||
++	(VT.isVector() && TLI.isTypeLegal(VT))))
+     return SDValue();
+
+   // This takes at least 3 instructions, so favor a library call when operating
+@@ -35770,9 +35772,8 @@ static SDValue combineFMinNumFMaxNum(SDNode *N, SelectionDAG &DAG,
+   SDValue Op0 = N->getOperand(0);
+   SDValue Op1 = N->getOperand(1);
+   SDLoc DL(N);
+-  EVT SetCCType = DAG.getTargetLoweringInfo().getSetCCResultType(
+-      DAG.getDataLayout(), *DAG.getContext(), VT);
+-
++  EVT SetCCType = TLI.getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(),
++					 VT);
+   // There are 4 possibilities involving NaN inputs, and these are the required
+   // outputs:
+   //                   Op1
+--
+2.14.1

--- a/L/LLVM/v6/bundled/llvm_patches/0100-llvm-config-sysroot.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/0100-llvm-config-sysroot.patch
@@ -1,0 +1,15 @@
+diff --git a/tools/llvm-config/CMakeLists.txt b/tools/llvm-config/CMakeLists.txt
+index fc3dbaa9639..860fec06207 100644
+--- a/tools/llvm-config/CMakeLists.txt
++++ b/tools/llvm-config/CMakeLists.txt
+@@ -49,6 +49,10 @@ set(LLVM_HAS_RTTI ${LLVM_CONFIG_HAS_RTTI})
+ set(LLVM_DYLIB_VERSION "${LLVM_VERSION_MAJOR}${LLVM_VERSION_SUFFIX}")
+ set(LLVM_HAS_GLOBAL_ISEL "ON")
+ 
++# Do not embed --sysroot as it's non-portable
++string(REGEX REPLACE "--sysroot /[^ ]+" "" LLVM_CFLAGS ${LLVM_CFLAGS})
++string(REGEX REPLACE "--sysroot /[^ ]+" "" LLVM_CXXFLAGS ${LLVM_CXXFLAGS})
++
+ # Use the C++ link flags, since they should be a superset of C link flags.
+ set(LLVM_LDFLAGS "${CMAKE_CXX_LINK_FLAGS}")
+ set(LLVM_BUILDMODE ${CMAKE_BUILD_TYPE})

--- a/L/LLVM/v6/bundled/llvm_patches/9999-llvm-symver-jlprefix.patch
+++ b/L/LLVM/v6/bundled/llvm_patches/9999-llvm-symver-jlprefix.patch
@@ -1,0 +1,19 @@
+From f23277bb91a4925ba8763337137a3123a7600557 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Tue, 16 Jan 2018 17:29:05 -0500
+Subject: [PATCH] add JL prefix to all LLVM version suffixes
+
+---
+ tools/llvm-shlib/simple_version_script.map.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/llvm-shlib/simple_version_script.map.in b/tools/llvm-shlib/simple_version_script.map.in
+index e9515fe7862..af082581627 100644
+--- a/tools/llvm-shlib/simple_version_script.map.in
++++ b/tools/llvm-shlib/simple_version_script.map.in
+@@ -1 +1 @@
+-LLVM_@LLVM_VERSION_MAJOR@.@LLVM_VERSION_MINOR@ { global: *; };
++JL_LLVM_@LLVM_VERSION_MAJOR@.@LLVM_VERSION_MINOR@ { global: *; };
+-- 
+2.15.1
+

--- a/L/LLVM/v8/bundled/clang_patches/7002-clang-analyzer-Add-werror-flag-for-analyzer-warnings.patch
+++ b/L/LLVM/v8/bundled/clang_patches/7002-clang-analyzer-Add-werror-flag-for-analyzer-warnings.patch
@@ -1,0 +1,119 @@
+diff --git a/include/clang/Driver/CC1Options.td b/include/clang/Driver/CC1Options.td
+index 07c76884063..cff6280bb4a 100644
+--- a/include/clang/Driver/CC1Options.td
++++ b/include/clang/Driver/CC1Options.td
+@@ -146,6 +146,9 @@ def analyzer_config_compatibility_mode : Separate<["-"], "analyzer-config-compat
+ def analyzer_config_compatibility_mode_EQ : Joined<["-"], "analyzer-config-compatibility-mode=">,
+   Alias<analyzer_config_compatibility_mode>;
+ 
++def analyzer_werror : Flag<["-"], "analyzer-werror">,
++  HelpText<"Emit analyzer results as errors rather than warnings">;
++
+ //===----------------------------------------------------------------------===//
+ // Migrator Options
+ //===----------------------------------------------------------------------===//
+diff --git a/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h b/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
+index 7745e459e19..ea59779fda8 100644
+--- a/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
++++ b/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
+@@ -216,6 +216,9 @@ public:
+   /// strategy. We get better code coverage when retry is enabled.
+   unsigned NoRetryExhausted : 1;
+ 
++  /// Emit analyzer warnings as errors.
++  unsigned AnalyzerWerror : 1;
++
+   /// The inlining stack depth limit.
+   // Cap the stack depth at 4 calls (5 stack frames, base + 4 calls).
+   unsigned InlineMaxStackDepth = 5;
+@@ -265,7 +268,8 @@ public:
+         AnalyzeAll(false), AnalyzerDisplayProgress(false),
+         AnalyzeNestedBlocks(false), eagerlyAssumeBinOpBifurcation(false),
+         TrimGraph(false), visualizeExplodedGraphWithGraphViz(false),
+-        UnoptimizedCFG(false), PrintStats(false), NoRetryExhausted(false) {
++        UnoptimizedCFG(false), PrintStats(false), NoRetryExhausted(false),
++        AnalyzerWerror(false) {
+     llvm::sort(AnalyzerConfigCmdFlags);
+   }
+ 
+diff --git a/clang/lib/Frontend/CompilerInvocation.cpp b/lib/Frontend/CompilerInvocation.cpp
+index 3e6528c2598..74c3e57eb99 100644
+--- a/lib/Frontend/CompilerInvocation.cpp
++++ b/lib/Frontend/CompilerInvocation.cpp
+@@ -299,6 +299,7 @@ static bool ParseAnalyzerArgs(AnalyzerOptions &Opts, ArgList &Args,
+     Args.hasArg(OPT_analyzer_viz_egraph_graphviz);
+   Opts.DumpExplodedGraphTo = Args.getLastArgValue(OPT_analyzer_dump_egraph);
+   Opts.NoRetryExhausted = Args.hasArg(OPT_analyzer_disable_retry_exhausted);
++  Opts.AnalyzerWerror = Args.hasArg(OPT_analyzer_werror);
+   Opts.AnalyzeAll = Args.hasArg(OPT_analyzer_opt_analyze_headers);
+   Opts.AnalyzerDisplayProgress = Args.hasArg(OPT_analyzer_display_progress);
+   Opts.AnalyzeNestedBlocks =
+diff --git a/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp b/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+index d87937d9b63..9415d7ed8a9 100644
+--- a/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
++++ b/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+@@ -84,10 +84,11 @@ void ento::createTextPathDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
+ namespace {
+ class ClangDiagPathDiagConsumer : public PathDiagnosticConsumer {
+   DiagnosticsEngine &Diag;
+-  bool IncludePath;
++  bool IncludePath, ShouldEmitAsError;
++
+ public:
+   ClangDiagPathDiagConsumer(DiagnosticsEngine &Diag)
+-    : Diag(Diag), IncludePath(false) {}
++      : Diag(Diag), IncludePath(false), ShouldEmitAsError(false) {}
+   ~ClangDiagPathDiagConsumer() override {}
+   StringRef getName() const override { return "ClangDiags"; }
+ 
+@@ -102,9 +103,14 @@ public:
+     IncludePath = true;
+   }
+ 
++  void enableWerror() { ShouldEmitAsError = true; }
++
+   void FlushDiagnosticsImpl(std::vector<const PathDiagnostic *> &Diags,
+                             FilesMade *filesMade) override {
+-    unsigned WarnID = Diag.getCustomDiagID(DiagnosticsEngine::Warning, "%0");
++    unsigned WarnID =
++        ShouldEmitAsError
++            ? Diag.getCustomDiagID(DiagnosticsEngine::Error, "%0")
++            : Diag.getCustomDiagID(DiagnosticsEngine::Warning, "%0");
+     unsigned NoteID = Diag.getCustomDiagID(DiagnosticsEngine::Note, "%0");
+ 
+     for (std::vector<const PathDiagnostic*>::iterator I = Diags.begin(),
+@@ -226,6 +232,9 @@ public:
+           new ClangDiagPathDiagConsumer(PP.getDiagnostics());
+       PathConsumers.push_back(clangDiags);
+ 
++      if (Opts->AnalyzerWerror)
++        clangDiags->enableWerror();
++
+       if (Opts->AnalysisDiagOpt == PD_TEXT) {
+         clangDiags->enablePaths();
+ 
+diff --git a/test/Analysis/override-werror.c b/test/Analysis/override-werror.c
+index 7dc09f51862..df80bac84f4 100644
+--- a/test/Analysis/override-werror.c
++++ b/test/Analysis/override-werror.c
+@@ -1,14 +1,17 @@
+ // RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core -Werror %s -analyzer-store=region -verify
++// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core -Werror %s -analyzer-store=region -analyzer-werror -verify=werror
+ 
+ // This test case illustrates that using '-analyze' overrides the effect of
+ // -Werror.  This allows basic warnings not to interfere with producing
+ // analyzer results.
+ 
+-char* f(int *p) { 
+-  return p; // expected-warning{{incompatible pointer types}}
++char* f(int *p) {
++  return p; // expected-warning{{incompatible pointer types}} \
++               werror-warning{{incompatible pointer types}}
+ }
+ 
+ void g(int *p) {
+-  if (!p) *p = 0; // expected-warning{{null}}  
++  if (!p) *p = 0; // expected-warning{{null}} \
++                     werror-error{{null}}
+ }
+ 

--- a/L/LLVM/v8/bundled/clang_patches/7003_clang_musl_gcc_detector.patch
+++ b/L/LLVM/v8/bundled/clang_patches/7003_clang_musl_gcc_detector.patch
@@ -1,0 +1,94 @@
+diff --git a/lib/Driver/ToolChains/Gnu.cpp b/lib/Driver/ToolChains/Gnu.cpp
+index 2ad45097dce..17b1d76028a 100644
+--- a/lib/Driver/ToolChains/Gnu.cpp
++++ b/lib/Driver/ToolChains/Gnu.cpp
+@@ -1882,7 +1882,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
+                                              "armv7hl-redhat-linux-gnueabi",
+                                              "armv6hl-suse-linux-gnueabi",
+-                                             "armv7hl-suse-linux-gnueabi"};
++                                             "armv7hl-suse-linux-gnueabi",
++                                             "armv7l-linux-gnueabihf"};
+   static const char *const ARMebLibDirs[] = {"/lib"};
+   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi",
+                                              "armeb-linux-androideabi"};
+@@ -2074,6 +2075,79 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     return;
+   }
+ 
++  if (TargetTriple.isMusl()) {
++    static const char *const AArch64MuslTriples[] = {"aarch64-linux-musl"};
++    static const char *const ARMHFMuslTriples[] = {
++        "arm-linux-musleabihf", "armv7l-linux-musleabihf"
++    };
++    static const char *const ARMMuslTriples[] = {"arm-linux-musleabi"};
++    static const char *const X86_64MuslTriples[] = {"x86_64-linux-musl"};
++    static const char *const X86MuslTriples[] = {"i686-linux-musl"};
++    static const char *const MIPSMuslTriples[] = {
++        "mips-linux-musl", "mipsel-linux-musl",
++        "mipsel-linux-muslhf", "mips-linux-muslhf"
++    };
++    static const char *const PPCMuslTriples[] = {"powerpc-linux-musl"};
++    static const char *const PPC64MuslTriples[] = {"powerpc64-linux-musl"};
++    static const char *const PPC64LEMuslTriples[] = {"powerpc64le-linux-musl"};
++
++    switch (TargetTriple.getArch()) {
++    case llvm::Triple::aarch64:
++      LibDirs.append(begin(AArch64LibDirs), end(AArch64LibDirs));
++      TripleAliases.append(begin(AArch64MuslTriples), end(AArch64MuslTriples));
++      BiarchLibDirs.append(begin(AArch64LibDirs), end(AArch64LibDirs));
++      BiarchTripleAliases.append(begin(AArch64MuslTriples), end(AArch64MuslTriples));
++      break;
++    case llvm::Triple::arm:
++      LibDirs.append(begin(ARMLibDirs), end(ARMLibDirs));
++      if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++        TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
++      } else {
++        TripleAliases.append(begin(ARMMuslTriples), end(ARMMuslTriples));
++      }
++      break;
++    case llvm::Triple::x86_64:
++      LibDirs.append(begin(X86_64LibDirs), end(X86_64LibDirs));
++      TripleAliases.append(begin(X86_64MuslTriples), end(X86_64MuslTriples));
++      BiarchLibDirs.append(begin(X86LibDirs), end(X86LibDirs));
++      BiarchTripleAliases.append(begin(X86MuslTriples), end(X86MuslTriples));
++      break;
++    case llvm::Triple::x86:
++      LibDirs.append(begin(X86LibDirs), end(X86LibDirs));
++      TripleAliases.append(begin(X86MuslTriples), end(X86MuslTriples));
++      BiarchLibDirs.append(begin(X86_64LibDirs), end(X86_64LibDirs));
++      BiarchTripleAliases.append(begin(X86_64MuslTriples), end(X86_64MuslTriples));
++      break;
++    case llvm::Triple::mips:
++      LibDirs.append(begin(MIPSLibDirs), end(MIPSLibDirs));
++      TripleAliases.append(begin(MIPSMuslTriples), end(MIPSMuslTriples));
++      break;
++    case llvm::Triple::ppc:
++      LibDirs.append(begin(PPCLibDirs), end(PPCLibDirs));
++      TripleAliases.append(begin(PPCMuslTriples), end(PPCMuslTriples));
++      BiarchLibDirs.append(begin(PPC64LibDirs), end(PPC64LibDirs));
++      BiarchTripleAliases.append(begin(PPC64MuslTriples), end(PPC64MuslTriples));
++      break;
++    case llvm::Triple::ppc64:
++      LibDirs.append(begin(PPC64LibDirs), end(PPC64LibDirs));
++      TripleAliases.append(begin(PPC64MuslTriples), end(PPC64MuslTriples));
++      BiarchLibDirs.append(begin(PPCLibDirs), end(PPCLibDirs));
++      BiarchTripleAliases.append(begin(PPCMuslTriples), end(PPCMuslTriples));
++      break;
++    case llvm::Triple::ppc64le:
++      LibDirs.append(begin(PPC64LELibDirs), end(PPC64LELibDirs));
++      TripleAliases.append(begin(PPC64LEMuslTriples), end(PPC64LEMuslTriples));
++      break;
++    default:
++      break;
++    }
++    TripleAliases.push_back(TargetTriple.str());
++    if (TargetTriple.str() != BiarchTriple.str())
++      BiarchTripleAliases.push_back(BiarchTriple.str());
++    return;
++  }
++
++
+   switch (TargetTriple.getArch()) {
+   case llvm::Triple::aarch64:
+     LibDirs.append(begin(AArch64LibDirs), end(AArch64LibDirs));

--- a/L/LLVM/v8/bundled/crt_patches/7000-compiler-rt-codesign.patch
+++ b/L/LLVM/v8/bundled/crt_patches/7000-compiler-rt-codesign.patch
@@ -1,0 +1,34 @@
+From 3dec5f3475a26aeb4678627795c4b67c6b7b4785 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 19 Sep 2017 13:13:06 -0500
+Subject: [PATCH] remove codesign use on Apple, disable ios sim testing that
+ needs it
+
+---
+ cmake/Modules/AddCompilerRT.cmake |  8 ------
+ test/asan/CMakeLists.txt          | 52 ---------------------------------------
+ test/tsan/CMakeLists.txt          | 47 -----------------------------------
+ 3 files changed, 107 deletions(-)
+
+diff --git a/cmake/Modules/AddCompilerRT.cmake b/cmake/Modules/AddCompilerRT.cmake
+index bc5fb9ff7..b64eb4246 100644
+--- a/cmake/Modules/AddCompilerRT.cmake
++++ b/cmake/Modules/AddCompilerRT.cmake
+@@ -210,14 +210,6 @@ function(add_compiler_rt_runtime name type)
+         set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")
+         set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
+       endif()
+-      if(APPLE)
+-        # Ad-hoc sign the dylibs
+-        add_custom_command(TARGET ${libname}
+-          POST_BUILD  
+-          COMMAND codesign --sign - $<TARGET_FILE:${libname}>
+-          WORKING_DIRECTORY ${COMPILER_RT_LIBRARY_OUTPUT_DIR}
+-        )
+-      endif()
+     endif()
+     install(TARGETS ${libname}
+       ARCHIVE DESTINATION ${COMPILER_RT_LIBRARY_INSTALL_DIR}
+-- 
+2.14.1
+

--- a/L/LLVM/v8/bundled/crt_patches/7004_compiler_rt_musl.patch
+++ b/L/LLVM/v8/bundled/crt_patches/7004_compiler_rt_musl.patch
@@ -1,0 +1,409 @@
+diff --git a/lib/asan/asan_linux.cc b/lib/asan/asan_linux.cc
+index a150b1955d6..56874522b0e 100644
+--- a/lib/asan/asan_linux.cc
++++ b/lib/asan/asan_linux.cc
+@@ -46,7 +46,7 @@
+ #include <link.h>
+ #endif
+ 
+-#if SANITIZER_ANDROID || SANITIZER_FREEBSD || SANITIZER_SOLARIS
++#if SANITIZER_ANDROID || SANITIZER_FREEBSD || SANITIZER_SOLARIS || SANITIZER_NONGNU
+ #include <ucontext.h>
+ extern "C" void* _DYNAMIC;
+ #elif SANITIZER_NETBSD
+@@ -139,7 +139,7 @@ void AsanApplyToGlobals(globals_op_fptr op, const void *needle) {
+   UNIMPLEMENTED();
+ }
+ 
+-#if SANITIZER_ANDROID
++#if SANITIZER_ANDROID || SANITIZER_NONGNU
+ // FIXME: should we do anything for Android?
+ void AsanCheckDynamicRTPrereqs() {}
+ void AsanCheckIncompatibleRT() {}
+@@ -230,7 +230,7 @@ void AsanCheckIncompatibleRT() {
+     }
+   }
+ }
+-#endif // SANITIZER_ANDROID
++#endif // SANITIZER_ANDROID || SANITIZER_NONGNU
+ 
+ #if !SANITIZER_ANDROID
+ void ReadContextStack(void *context, uptr *stack, uptr *ssize) {
+diff --git a/lib/interception/interception_linux.cc b/lib/interception/interception_linux.cc
+index 26bfcd8f679..12d7fe13f47 100644
+--- a/lib/interception/interception_linux.cc
++++ b/lib/interception/interception_linux.cc
+@@ -42,12 +42,12 @@ bool GetRealFunctionAddress(const char *func_name, uptr *func_addr,
+   return real == wrapper;
+ }
+ 
+-// Android and Solaris do not have dlvsym
+-#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD
++// Android,  Solaris, OpenBSD and musl do not have dlvsym
++#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
+ void *GetFuncAddrVer(const char *func_name, const char *ver) {
+   return dlvsym(RTLD_NEXT, func_name, ver);
+ }
+-#endif  // !SANITIZER_ANDROID
++#endif  // !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
+ 
+ }  // namespace __interception
+ 
+diff --git a/lib/interception/interception_linux.h b/lib/interception/interception_linux.h
+index 765a186e582..7382c0813ee 100644
+--- a/lib/interception/interception_linux.h
++++ b/lib/interception/interception_linux.h
+@@ -36,14 +36,14 @@ void *GetFuncAddrVer(const char *func_name, const char *ver);
+       (::__interception::uptr) & WRAP(func))
+ 
+ // Android,  Solaris and OpenBSD do not have dlvsym
+-#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD
++#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
+ #define INTERCEPT_FUNCTION_VER_LINUX_OR_FREEBSD(func, symver) \
+   (::__interception::real_##func = (func##_type)(                \
+        unsigned long)::__interception::GetFuncAddrVer(#func, symver))
+ #else
+ #define INTERCEPT_FUNCTION_VER_LINUX_OR_FREEBSD(func, symver) \
+   INTERCEPT_FUNCTION_LINUX_OR_FREEBSD(func)
+-#endif  // !SANITIZER_ANDROID && !SANITIZER_SOLARIS
++#endif  // !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
+ 
+ #endif  // INTERCEPTION_LINUX_H
+ #endif  // SANITIZER_LINUX || SANITIZER_FREEBSD || SANITIZER_NETBSD ||
+diff --git a/lib/msan/msan_interceptors.cc b/lib/msan/msan_interceptors.cc
+index 497f943a8a0..60ce1f6e106 100644
+--- a/lib/msan/msan_interceptors.cc
++++ b/lib/msan/msan_interceptors.cc
+@@ -58,6 +58,9 @@ DECLARE_REAL(SIZE_T, strlen, const char *s)
+ DECLARE_REAL(SIZE_T, strnlen, const char *s, SIZE_T maxlen)
+ DECLARE_REAL(void *, memcpy, void *dest, const void *src, uptr n)
+ DECLARE_REAL(void *, memset, void *dest, int c, uptr n)
++#if SANITIZER_NONGNU
++DECLARE_REAL(int, shmctl, int shmid, int cmd, void *buf)
++#endif
+ 
+ // True if this is a nested interceptor.
+ static THREADLOCAL int in_interceptor_scope;
+diff --git a/lib/msan/msan_linux.cc b/lib/msan/msan_linux.cc
+index 0b0208884d2..087c8f585e7 100644
+--- a/lib/msan/msan_linux.cc
++++ b/lib/msan/msan_linux.cc
+@@ -13,7 +13,7 @@
+ //===----------------------------------------------------------------------===//
+ 
+ #include "sanitizer_common/sanitizer_platform.h"
+-#if SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD
++#if SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD && !SANITIZER_NONGNU
+ 
+ #include "msan.h"
+ #include "msan_report.h"
+@@ -27,7 +27,6 @@
+ #include <signal.h>
+ #include <unistd.h>
+ #include <unwind.h>
+-#include <execinfo.h>
+ #include <sys/time.h>
+ #include <sys/resource.h>
+ 
+@@ -260,4 +259,4 @@ void MsanTSDDtor(void *tsd) {
+ 
+ } // namespace __msan
+ 
+-#endif // SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD
++#endif // SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD && !SANITIZER_NONGNU
+diff --git a/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc b/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+index 2d633c17389..b6eb23116d5 100644
+--- a/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -104,7 +104,7 @@ static void ioctl_table_fill() {
+   _(SIOCGETVIFCNT, WRITE, struct_sioc_vif_req_sz);
+ #endif
+ 
+-#if SANITIZER_LINUX
++#if SANITIZER_LINUX && !SANITIZER_NONGNU
+   // Conflicting request ids.
+   // _(CDROMAUDIOBUFSIZ, NONE, 0);
+   // _(SNDCTL_TMR_CONTINUE, NONE, 0);
+@@ -365,7 +365,7 @@ static void ioctl_table_fill() {
+   _(VT_WAITACTIVE, NONE, 0);
+ #endif
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   // _(SIOCDEVPLIP, WRITE, struct_ifreq_sz); // the same as EQL_ENSLAVE
+   _(CYGETDEFTHRESH, WRITE, sizeof(int));
+   _(CYGETDEFTIMEOUT, WRITE, sizeof(int));
+diff --git a/lib/sanitizer_common/sanitizer_common_syscalls.inc b/lib/sanitizer_common/sanitizer_common_syscalls.inc
+index 469c8eb7e14..24f87867d92 100644
+--- a/lib/sanitizer_common/sanitizer_common_syscalls.inc
++++ b/lib/sanitizer_common/sanitizer_common_syscalls.inc
+@@ -2038,7 +2038,7 @@ POST_SYSCALL(setrlimit)(long res, long resource, void *rlim) {
+   }
+ }
+ 
+-#if !SANITIZER_ANDROID
++#if !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ PRE_SYSCALL(prlimit64)(long pid, long resource, const void *new_rlim,
+                        void *old_rlim) {
+   if (new_rlim) PRE_READ(new_rlim, struct_rlimit64_sz);
+diff --git a/lib/sanitizer_common/sanitizer_linux_libcdep.cc b/lib/sanitizer_common/sanitizer_linux_libcdep.cc
+index 6ce47ec620d..0f810d9edbd 100644
+--- a/lib/sanitizer_common/sanitizer_linux_libcdep.cc
++++ b/lib/sanitizer_common/sanitizer_linux_libcdep.cc
+@@ -15,7 +15,7 @@
+ #include "sanitizer_platform.h"
+ 
+ #if SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD ||                \
+-    SANITIZER_OPENBSD || SANITIZER_SOLARIS
++    SANITIZER_OPENBSD || SANITIZER_SOLARIS || SANITIZER_NONGNU
+ 
+ #include "sanitizer_allocator_internal.h"
+ #include "sanitizer_atomic.h"
+@@ -184,7 +184,7 @@ __attribute__((unused)) static bool GetLibcVersion(int *major, int *minor,
+ }
+ 
+ #if !SANITIZER_FREEBSD && !SANITIZER_ANDROID && !SANITIZER_GO &&               \
+-    !SANITIZER_NETBSD && !SANITIZER_OPENBSD && !SANITIZER_SOLARIS
++    !SANITIZER_NETBSD && !SANITIZER_OPENBSD && !SANITIZER_SOLARIS && !SANITIZER_NONGNU
+ static uptr g_tls_size;
+ 
+ #ifdef __i386__
+@@ -261,12 +261,12 @@ void InitTlsSize() {
+ #else
+ void InitTlsSize() { }
+ #endif  // !SANITIZER_FREEBSD && !SANITIZER_ANDROID && !SANITIZER_GO &&
+-        // !SANITIZER_NETBSD && !SANITIZER_SOLARIS
++        // !SANITIZER_NETBSD && !SANITIZER_SOLARIS && !SANITIZER_NONGNU
+ 
+ #if (defined(__x86_64__) || defined(__i386__) || defined(__mips__) ||          \
+      defined(__aarch64__) || defined(__powerpc64__) || defined(__s390__) ||    \
+      defined(__arm__)) &&                                                      \
+-    SANITIZER_LINUX && !SANITIZER_ANDROID
++    SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ // sizeof(struct pthread) from glibc.
+ static atomic_uintptr_t thread_descriptor_size;
+ 
+@@ -431,7 +431,7 @@ int GetSizeFromHdr(struct dl_phdr_info *info, size_t size, void *data) {
+ 
+ #if !SANITIZER_GO
+ static void GetTls(uptr *addr, uptr *size) {
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ # if defined(__x86_64__) || defined(__i386__) || defined(__s390__)
+   *addr = ThreadSelf();
+   *size = GetTlsSize();
+@@ -475,7 +475,7 @@ static void GetTls(uptr *addr, uptr *size) {
+ #elif SANITIZER_OPENBSD
+   *addr = 0;
+   *size = 0;
+-#elif SANITIZER_ANDROID
++#elif SANITIZER_ANDROID || SANITIZER_NONGNU
+   *addr = 0;
+   *size = 0;
+ #elif SANITIZER_SOLARIS
+@@ -491,7 +491,7 @@ static void GetTls(uptr *addr, uptr *size) {
+ #if !SANITIZER_GO
+ uptr GetTlsSize() {
+ #if SANITIZER_FREEBSD || SANITIZER_ANDROID || SANITIZER_NETBSD ||              \
+-    SANITIZER_OPENBSD || SANITIZER_SOLARIS
++    SANITIZER_OPENBSD || SANITIZER_SOLARIS || SANITIZER_NONGNU
+   uptr addr, size;
+   GetTls(&addr, &size);
+   return size;
+diff --git a/lib/sanitizer_common/sanitizer_platform.h b/lib/sanitizer_common/sanitizer_platform.h
+index 82bb1af7746..b9431eaab8b 100644
+--- a/lib/sanitizer_common/sanitizer_platform.h
++++ b/lib/sanitizer_common/sanitizer_platform.h
+@@ -214,6 +214,13 @@
+ # define SANITIZER_MYRIAD2 0
+ #endif
+ 
++
++#if defined(__linux__) && !defined(__GLIBC__)
++# define SANITIZER_NONGNU 1
++#else
++# define SANITIZER_NONGNU 0
++#endif
++
+ // By default we allow to use SizeClassAllocator64 on 64-bit platform.
+ // But in some cases (e.g. AArch64's 39-bit address space) SizeClassAllocator64
+ // does not work well and we need to fallback to SizeClassAllocator32.
+diff --git a/lib/sanitizer_common/sanitizer_platform_interceptors.h b/lib/sanitizer_common/sanitizer_platform_interceptors.h
+index 4d146651b78..e91bf973889 100644
+--- a/lib/sanitizer_common/sanitizer_platform_interceptors.h
++++ b/lib/sanitizer_common/sanitizer_platform_interceptors.h
+@@ -40,7 +40,7 @@
+ # include "sanitizer_platform_limits_solaris.h"
+ #endif
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ # define SI_LINUX_NOT_ANDROID 1
+ #else
+ # define SI_LINUX_NOT_ANDROID 0
+diff --git a/lib/sanitizer_common/sanitizer_platform_limits_posix.cc b/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+index ecc69bcea79..0cca90b9fc1 100644
+--- a/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -23,6 +23,11 @@
+ #ifdef _FILE_OFFSET_BITS
+ #undef _FILE_OFFSET_BITS
+ #endif
++
++#ifdef SANITIZER_NONGNU
++#include <stdio.h>
++#endif
++
+ #include <arpa/inet.h>
+ #include <dirent.h>
+ #include <grp.h>
+@@ -55,7 +60,9 @@
+ #endif
+ 
+ #if !SANITIZER_ANDROID
++#if !SANITIZER_NONGNU
+ #include <fstab.h>
++#endif
+ #include <sys/mount.h>
+ #include <sys/timeb.h>
+ #include <utmpx.h>
+@@ -108,12 +115,14 @@ typedef struct user_fpregs elf_fpregset_t;
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+ #include <glob.h>
+-#include <obstack.h>
++#  if !SANITIZER_NONGNU
++#    include <obstack.h>
++#  endif
+ #include <mqueue.h>
+-#include <net/if_ppp.h>
+-#include <netax25/ax25.h>
+-#include <netipx/ipx.h>
+-#include <netrom/netrom.h>
++#include <linux/if_ppp.h>
++#include <linux/ax25.h>
++#include <linux/ipx.h>
++#include <linux/netrom.h>
+ #if HAVE_RPC_XDR_H
+ # include <rpc/xdr.h>
+ #endif
+@@ -197,7 +206,9 @@ namespace __sanitizer {
+ #endif // SANITIZER_MAC && !SANITIZER_IOS
+ 
+ #if !SANITIZER_ANDROID
++#if !SANITIZER_NONGNU
+   unsigned struct_fstab_sz = sizeof(struct fstab);
++#endif
+   unsigned struct_statfs_sz = sizeof(struct statfs);
+   unsigned struct_sockaddr_sz = sizeof(struct sockaddr);
+   unsigned ucontext_t_sz = sizeof(ucontext_t);
+@@ -292,7 +303,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(ElfW(Phdr));
+ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ #endif
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   int glob_nomatch = GLOB_NOMATCH;
+   int glob_altdirfunc = GLOB_ALTDIRFUNC;
+ #endif
+@@ -386,7 +397,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_termios_sz = sizeof(struct termios);
+   unsigned struct_winsize_sz = sizeof(struct winsize);
+ 
+-#if SANITIZER_LINUX
++#if SANITIZER_LINUX && !SANITIZER_NONGNU
+   unsigned struct_arpreq_sz = sizeof(struct arpreq);
+   unsigned struct_cdrom_msf_sz = sizeof(struct cdrom_msf);
+   unsigned struct_cdrom_multisession_sz = sizeof(struct cdrom_multisession);
+@@ -436,7 +447,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_vt_mode_sz = sizeof(struct vt_mode);
+ #endif // SANITIZER_LINUX
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   unsigned struct_ax25_parms_struct_sz = sizeof(struct ax25_parms_struct);
+   unsigned struct_cyclades_monitor_sz = sizeof(struct cyclades_monitor);
+ #if EV_VERSION > (0x010000)
+@@ -803,7 +814,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned IOCTL_VT_WAITACTIVE = VT_WAITACTIVE;
+ #endif // SANITIZER_LINUX
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   unsigned IOCTL_CYGETDEFTHRESH = CYGETDEFTHRESH;
+   unsigned IOCTL_CYGETDEFTIMEOUT = CYGETDEFTIMEOUT;
+   unsigned IOCTL_CYGETMON = CYGETMON;
+@@ -958,7 +969,7 @@ CHECK_SIZE_AND_OFFSET(dl_phdr_info, dlpi_phdr);
+ CHECK_SIZE_AND_OFFSET(dl_phdr_info, dlpi_phnum);
+ #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+-#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID
++#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ CHECK_TYPE_SIZE(glob_t);
+ CHECK_SIZE_AND_OFFSET(glob_t, gl_pathc);
+ CHECK_SIZE_AND_OFFSET(glob_t, gl_pathv);
+@@ -992,6 +1003,7 @@ CHECK_TYPE_SIZE(iovec);
+ CHECK_SIZE_AND_OFFSET(iovec, iov_base);
+ CHECK_SIZE_AND_OFFSET(iovec, iov_len);
+ 
++#if !SANITIZER_NONGNU
+ CHECK_TYPE_SIZE(msghdr);
+ CHECK_SIZE_AND_OFFSET(msghdr, msg_name);
+ CHECK_SIZE_AND_OFFSET(msghdr, msg_namelen);
+@@ -1005,6 +1017,7 @@ CHECK_TYPE_SIZE(cmsghdr);
+ CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_len);
+ CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_level);
+ CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_type);
++#endif
+ 
+ #ifndef __GLIBC_PREREQ
+ #define __GLIBC_PREREQ(x, y) 0
+@@ -1114,7 +1127,7 @@ CHECK_SIZE_AND_OFFSET(mntent, mnt_passno);
+ 
+ CHECK_TYPE_SIZE(ether_addr);
+ 
+-#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID
++#if (SANITIZER_LINUX || SANITIZER_FREEBSD) && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ CHECK_TYPE_SIZE(ipc_perm);
+ # if SANITIZER_FREEBSD
+ CHECK_SIZE_AND_OFFSET(ipc_perm, key);
+@@ -1175,7 +1188,7 @@ CHECK_SIZE_AND_OFFSET(ifaddrs, ifa_dstaddr);
+ CHECK_SIZE_AND_OFFSET(ifaddrs, ifa_data);
+ #endif
+ 
+-#if SANITIZER_LINUX
++#if SANITIZER_LINUX && !SANITIZER_NONGNU
+ COMPILER_CHECK(sizeof(__sanitizer_struct_mallinfo) == sizeof(struct mallinfo));
+ #endif
+ 
+@@ -1225,7 +1238,7 @@ COMPILER_CHECK(__sanitizer_XDR_DECODE == XDR_DECODE);
+ COMPILER_CHECK(__sanitizer_XDR_FREE == XDR_FREE);
+ #endif
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ COMPILER_CHECK(sizeof(__sanitizer_FILE) <= sizeof(FILE));
+ CHECK_SIZE_AND_OFFSET(FILE, _flags);
+ CHECK_SIZE_AND_OFFSET(FILE, _IO_read_ptr);
+@@ -1244,7 +1257,7 @@ CHECK_SIZE_AND_OFFSET(FILE, _chain);
+ CHECK_SIZE_AND_OFFSET(FILE, _fileno);
+ #endif
+ 
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+ COMPILER_CHECK(sizeof(__sanitizer__obstack_chunk) <= sizeof(_obstack_chunk));
+ CHECK_SIZE_AND_OFFSET(_obstack_chunk, limit);
+ CHECK_SIZE_AND_OFFSET(_obstack_chunk, prev);
+diff --git a/lib/tsan/rtl/tsan_platform_linux.cc b/lib/tsan/rtl/tsan_platform_linux.cc
+index d2ce6070906..b57e95cf6d1 100644
+--- a/lib/tsan/rtl/tsan_platform_linux.cc
++++ b/lib/tsan/rtl/tsan_platform_linux.cc
+@@ -302,7 +302,7 @@ void InitializePlatform() {
+ // This is required to properly "close" the fds, because we do not see internal
+ // closes within glibc. The code is a pure hack.
+ int ExtractResolvFDs(void *state, int *fds, int nfd) {
+-#if SANITIZER_LINUX && !SANITIZER_ANDROID
++#if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+   int cnt = 0;
+   struct __res_state *statp = (struct __res_state*)state;
+   for (int i = 0; i < MAXNS && cnt < nfd; i++) {

--- a/L/LLVM/v8/bundled/libcxx_patches/7005_libcxx_musl.patch
+++ b/L/LLVM/v8/bundled/libcxx_patches/7005_libcxx_musl.patch
@@ -1,0 +1,22 @@
+diff --git a/include/locale b/include/locale
+index 2043892fa2d..4af51464208 100644
+--- a/include/locale
++++ b/include/locale
+@@ -737,7 +737,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        long long __ll = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        long long __ll = strtoll(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;
+@@ -777,7 +777,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        unsigned long long __ll = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        unsigned long long __ll = strtoull(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;

--- a/L/LLVM/v8/bundled/llvm_patches/0001-llvm-D27629-AArch64-large_model_6.0.1.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0001-llvm-D27629-AArch64-large_model_6.0.1.patch
@@ -1,0 +1,53 @@
+From f76abe65e6d07fea5e838c4f8c9a9421c16debb0 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Thu, 5 Jul 2018 12:37:50 -0400
+Subject: [PATCH] Fix unwind info relocation with large code model on AArch64
+
+---
+ lib/MC/MCObjectFileInfo.cpp                   |  2 ++
+ .../AArch64/ELF_ARM64_large-relocations.s     | 20 +++++++++++++++++++
+ 2 files changed, 22 insertions(+)
+ create mode 100644 test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+
+diff --git a/lib/MC/MCObjectFileInfo.cpp b/lib/MC/MCObjectFileInfo.cpp
+index 328f000f37c..938b35f20d1 100644
+--- a/lib/MC/MCObjectFileInfo.cpp
++++ b/lib/MC/MCObjectFileInfo.cpp
+@@ -291,6 +291,8 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
+     break;
+   case Triple::ppc64:
+   case Triple::ppc64le:
++  case Triple::aarch64:
++  case Triple::aarch64_be:
+   case Triple::x86_64:
+     FDECFIEncoding = dwarf::DW_EH_PE_pcrel |
+                      (Large ? dwarf::DW_EH_PE_sdata8 : dwarf::DW_EH_PE_sdata4);
+diff --git a/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+new file mode 100644
+index 00000000000..66f28dabd79
+--- /dev/null
++++ b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+@@ -0,0 +1,20 @@
++# RUN: llvm-mc -triple=arm64-none-linux-gnu -large-code-model -filetype=obj -o %T/large-reloc.o %s
++# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %T/large-reloc.o
++# RUN-BE: llvm-mc -triple=aarch64_be-none-linux-gnu -large-code-model -filetype=obj -o %T/be-large-reloc.o %s
++# RUN-BE: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -map-section be-large-reloc.o,.eh_frame=0x10000 -map-section be-large-reloc.o,.text=0xffff000000000000 -check=%s %T/be-large-reloc.o
++
++        .text
++        .globl  g
++        .p2align        2
++        .type   g,@function
++g:
++        .cfi_startproc
++        mov      x0, xzr
++        ret
++        .Lfunc_end0:
++        .size   g, .Lfunc_end0-g
++        .cfi_endproc
++
++# Skip the CIE and load the 8 bytes PC begin pointer.
++# Assuming the CIE and the FDE length are both 4 bytes.
++# rtdyld-check: *{8}(section_addr(large-reloc.o, .eh_frame) + (*{4}(section_addr(large-reloc.o, .eh_frame))) + 0xc) = g - (section_addr(large-reloc.o, .eh_frame) + (*{4}(section_addr(large-reloc.o, .eh_frame))) + 0xc)
+-- 
+2.18.0
+

--- a/L/LLVM/v8/bundled/llvm_patches/0002-llvm8-D34078-vectorize-fdiv.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0002-llvm8-D34078-vectorize-fdiv.patch
@@ -1,0 +1,42 @@
+diff --git a/lib/Analysis/IVDescriptors.cpp b/lib/Analysis/IVDescriptors.cpp
+index aaebc4a481e..91fe4c0003c 100644
+--- a/lib/Analysis/IVDescriptors.cpp
++++ b/lib/Analysis/IVDescriptors.cpp
+@@ -571,6 +571,7 @@ RecurrenceDescriptor::isRecurrenceInstr(Instruction *I, RecurrenceKind Kind,
+     return InstDesc(Kind == RK_IntegerOr, I);
+   case Instruction::Xor:
+     return InstDesc(Kind == RK_IntegerXor, I);
++  case Instruction::FDiv:
+   case Instruction::FMul:
+     return InstDesc(Kind == RK_FloatMult, I, UAI);
+   case Instruction::FSub:
+diff --git a/test/Transforms/LoopVectorize/float-reduction.ll b/test/Transforms/LoopVectorize/float-reduction.ll
+index f3b95d0ead7..669c54d55a2 100644
+--- a/test/Transforms/LoopVectorize/float-reduction.ll
++++ b/test/Transforms/LoopVectorize/float-reduction.ll
+@@ -44,3 +44,25 @@ for.body:                                         ; preds = %for.body, %entry
+ for.end:                                          ; preds = %for.body
+   ret float %sub
+ }
++
++;CHECK-LABEL: @foodiv(
++;CHECK: fdiv fast <4 x float>
++;CHECK: ret
++define float @foodiv(float* nocapture %A, i32* nocapture %n) nounwind uwtable readonly ssp {
++entry:
++  br label %for.body
++
++for.body:                                         ; preds = %for.body, %entry
++  %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
++  %sum.04 = phi float [ 1.000000e+00, %entry ], [ %sub, %for.body ]
++  %arrayidx = getelementptr inbounds float, float* %A, i64 %indvars.iv
++  %0 = load float, float* %arrayidx, align 4
++  %sub = fdiv fast float %sum.04, %0
++  %indvars.iv.next = add i64 %indvars.iv, 1
++  %lftr.wideiv = trunc i64 %indvars.iv.next to i32
++  %exitcond = icmp eq i32 %lftr.wideiv, 200
++  br i1 %exitcond, label %for.end, label %for.body
++
++for.end:                                          ; preds = %for.body
++  ret float %sub
++}

--- a/L/LLVM/v8/bundled/llvm_patches/0003-llvm-6.0-NVPTX-addrspaces.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0003-llvm-6.0-NVPTX-addrspaces.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/Target/NVPTX/NVPTXISelLowering.cpp b/lib/Target/NVPTX/NVPTXISelLowering.cpp
+index f1e4251a44b..73d49f5d7e4 100644
+--- a/lib/Target/NVPTX/NVPTXISelLowering.cpp
++++ b/lib/Target/NVPTX/NVPTXISelLowering.cpp
+@@ -1248,6 +1248,14 @@ SDValue NVPTXTargetLowering::getSqrtEstimate(SDValue Operand, SelectionDAG &DAG,
+   }
+ }
+ 
++bool NVPTXTargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
++                                               unsigned DestAS) const {
++  assert(SrcAS != DestAS && "Expected different address spaces!");
++
++  return (SrcAS  == ADDRESS_SPACE_GENERIC || SrcAS  > ADDRESS_SPACE_LOCAL) &&
++         (DestAS == ADDRESS_SPACE_GENERIC || DestAS > ADDRESS_SPACE_LOCAL);
++}
++
+ SDValue
+ NVPTXTargetLowering::LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const {
+   SDLoc dl(Op);
+diff --git a/lib/Target/NVPTX/NVPTXISelLowering.h b/lib/Target/NVPTX/NVPTXISelLowering.h
+index ef04a8573d4..68a9a7195c4 100644
+--- a/lib/Target/NVPTX/NVPTXISelLowering.h
++++ b/lib/Target/NVPTX/NVPTXISelLowering.h
+@@ -443,6 +443,8 @@ public:
+                                const NVPTXSubtarget &STI);
+   SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
+ 
++  bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override;
++
+   SDValue LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
+ 
+   const char *getTargetNodeName(unsigned Opcode) const override;

--- a/L/LLVM/v8/bundled/llvm_patches/0004-llvm-7.0-D44650.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0004-llvm-7.0-D44650.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/llvm-cfi-verify/CMakeLists.txt b/tools/llvm-cfi-verify/CMakeLists.txt
+index ae12bec5e80..9ffbe4e070d 100644
+--- a/tools/llvm-cfi-verify/CMakeLists.txt
++++ b/tools/llvm-cfi-verify/CMakeLists.txt
+@@ -11,7 +11,7 @@ set(LLVM_LINK_COMPONENTS
+   Symbolize
+   )
+ 
+-add_llvm_tool(llvm-cfi-verify
++add_llvm_tool(llvm-cfi-verify DISABLE_LLVM_LINK_LLVM_DYLIB
+   llvm-cfi-verify.cpp
+   )
+ 

--- a/L/LLVM/v8/bundled/llvm_patches/0005-llvm-6.0-DISABLE_ABI_CHECKS.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0005-llvm-6.0-DISABLE_ABI_CHECKS.patch
@@ -1,0 +1,39 @@
+From d793ba4bacae51ae25be19c1636fcf38707938fd Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 1 Jun 2018 17:43:55 -0400
+Subject: [PATCH] fix LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+
+---
+ cmake/modules/HandleLLVMOptions.cmake    | 2 +-
+ include/llvm/Config/abi-breaking.h.cmake | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/modules/HandleLLVMOptions.cmake b/cmake/modules/HandleLLVMOptions.cmake
+index 3d2dd48018c..b67ee6a896e 100644
+--- a/cmake/modules/HandleLLVMOptions.cmake
++++ b/cmake/modules/HandleLLVMOptions.cmake
+@@ -572,7 +572,7 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
+ 
+   if (LLVM_ENABLE_PEDANTIC AND LLVM_COMPILER_IS_GCC_COMPATIBLE)
+     append("-pedantic" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+-    append("-Wno-long-long" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
++    append("-Wno-long-long -Wundef" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+   endif()
+ 
+   add_flag_if_supported("-Wcovered-switch-default" COVERED_SWITCH_DEFAULT_FLAG)
+diff --git a/include/llvm/Config/abi-breaking.h.cmake b/include/llvm/Config/abi-breaking.h.cmake
+index 7ae401e5b8a..d52c4609101 100644
+--- a/include/llvm/Config/abi-breaking.h.cmake
++++ b/include/llvm/Config/abi-breaking.h.cmake
+@@ -20,7 +20,7 @@
+ 
+ /* Allow selectively disabling link-time mismatch checking so that header-only
+    ADT content from LLVM can be used without linking libSupport. */
+-#if !LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
++#ifndef LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+ 
+ // ABI_BREAKING_CHECKS protection: provides link-time failure when clients build
+ // mismatch with LLVM
+-- 
+2.17.0
+

--- a/L/LLVM/v8/bundled/llvm_patches/0006-llvm7-D50010-VNCoercion-ni.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0006-llvm7-D50010-VNCoercion-ni.patch
@@ -1,0 +1,67 @@
+diff --git a/lib/Transforms/Utils/VNCoercion.cpp b/lib/Transforms/Utils/VNCoercion.cpp
+index 948d9bd5baa..fbd5b9bb3be 100644
+--- a/lib/Transforms/Utils/VNCoercion.cpp
++++ b/lib/Transforms/Utils/VNCoercion.cpp
+@@ -20,7 +20,8 @@ bool canCoerceMustAliasedValueToLoad(Value *StoredVal, Type *LoadTy,
+       StoredVal->getType()->isStructTy() || StoredVal->getType()->isArrayTy())
+     return false;
+ 
+-  uint64_t StoreSize = DL.getTypeSizeInBits(StoredVal->getType());
++  Type *StoredValTy = StoredVal->getType();
++  uint64_t StoreSize = DL.getTypeSizeInBits(StoredValTy);
+ 
+   // The store size must be byte-aligned to support future type casts.
+   if (llvm::alignTo(StoreSize, 8) != StoreSize)
+@@ -30,10 +31,15 @@ bool canCoerceMustAliasedValueToLoad(Value *StoredVal, Type *LoadTy,
+   if (StoreSize < DL.getTypeSizeInBits(LoadTy))
+     return false;
+ 
+-  // Don't coerce non-integral pointers to integers or vice versa.
+-  if (DL.isNonIntegralPointerType(StoredVal->getType()) !=
+-      DL.isNonIntegralPointerType(LoadTy))
++  bool StoredNI = DL.isNonIntegralPointerType(StoredValTy);
++  bool LoadNI = DL.isNonIntegralPointerType(LoadTy);
++  if (StoredNI != LoadNI) {
++    return false;
++  } else if (StoredNI && LoadNI &&
++             cast<PointerType>(StoredValTy)->getAddressSpace() !=
++                 cast<PointerType>(LoadTy)->getAddressSpace()) {
+     return false;
++  }
+ 
+   return true;
+ }
+diff --git a/test/Transforms/GVN/non-integral-pointers.ll b/test/Transforms/GVN/non-integral-pointers.ll
+index 9ae4132231d..5217fc1a06a 100644
+--- a/test/Transforms/GVN/non-integral-pointers.ll
++++ b/test/Transforms/GVN/non-integral-pointers.ll
+@@ -1,6 +1,6 @@
+ ; RUN: opt -gvn -S < %s | FileCheck %s
+ 
+-target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128-ni:4"
++target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128-ni:4:5"
+ target triple = "x86_64-unknown-linux-gnu"
+ 
+ define void @f0(i1 %alwaysFalse, i64 %val, i64* %loc) {
+@@ -37,3 +37,21 @@ define i64 @f1(i1 %alwaysFalse, i8 addrspace(4)* %val, i8 addrspace(4)** %loc) {
+  alwaysTaken:
+   ret i64 42
+ }
++
++ define i8 addrspace(5)* @multini(i1 %alwaysFalse, i8 addrspace(4)* %val, i8 addrspace(4)** %loc) {
++ ; CHECK-LABEL: @multini(
++ ; CHECK-NOT: inttoptr
++ ; CHECK-NOT: ptrtoint
++ ; CHECK-NOT: addrspacecast
++  entry:
++   store i8 addrspace(4)* %val, i8 addrspace(4)** %loc
++   br i1 %alwaysFalse, label %neverTaken, label %alwaysTaken
++
++  neverTaken:
++   %loc.bc = bitcast i8 addrspace(4)** %loc to i8 addrspace(5)**
++   %differentas = load i8 addrspace(5)*, i8 addrspace(5)** %loc.bc
++   ret i8 addrspace(5)* %differentas
++
++  alwaysTaken:
++   ret i8 addrspace(5)* null
++ }

--- a/L/LLVM/v8/bundled/llvm_patches/0007-llvm-8.0-D50167-scev-umin.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0007-llvm-8.0-D50167-scev-umin.patch
@@ -1,0 +1,1870 @@
+commit 18e563f695dd561c32393512fbdb8ce8771d7e5f
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Thu May 2 08:35:22 2019 -0400
+
+    [SCEV] Add explicit representations of umin/smin
+    
+    Summary:
+    Currently we express umin as `~umax(~x, ~y)`. However, this becomes
+    a problem for operands in non-integral pointer spaces, because `~x`
+    is not something we can compute for `x` non-integral. However, since
+    comparisons are generally still allowed, we are actually able to
+    express `umin(x, y)` directly as long as we don't try to express is
+    as a umax. Support this by adding an explicit umin/smin representation
+    to SCEV. We do this by factoring the existing getUMax/getSMax functions
+    into a new function that does all four. The previous two functions were
+    largely identical.
+    
+    Reviewers: reames, sanjoy, mkazantsev
+    
+    Reviewed By: sanjoy
+    
+    Subscribers: tvvikram, dmgreen, vchuravy, javed.absar, llvm-commits
+    
+    Tags: #llvm
+    
+    Differential Revision: https://reviews.llvm.org/D50167
+
+diff --git a/include/llvm/Analysis/ScalarEvolution.h b/include/llvm/Analysis/ScalarEvolution.h
+index 8f4200b07e5..6b76a16a2b4 100644
+--- a/include/llvm/Analysis/ScalarEvolution.h
++++ b/include/llvm/Analysis/ScalarEvolution.h
+@@ -582,6 +582,8 @@ public:
+   /// \p IndexExprs The expressions for the indices.
+   const SCEV *getGEPExpr(GEPOperator *GEP,
+                          const SmallVectorImpl<const SCEV *> &IndexExprs);
++  const SCEV *getMinMaxExpr(unsigned Kind,
++                            SmallVectorImpl<const SCEV *> &Operands);
+   const SCEV *getSMaxExpr(const SCEV *LHS, const SCEV *RHS);
+   const SCEV *getSMaxExpr(SmallVectorImpl<const SCEV *> &Operands);
+   const SCEV *getUMaxExpr(const SCEV *LHS, const SCEV *RHS);
+diff --git a/include/llvm/Analysis/ScalarEvolutionExpander.h b/include/llvm/Analysis/ScalarEvolutionExpander.h
+index 58d42680d6b..57d658b157d 100644
+--- a/include/llvm/Analysis/ScalarEvolutionExpander.h
++++ b/include/llvm/Analysis/ScalarEvolutionExpander.h
+@@ -368,6 +368,10 @@ namespace llvm {
+ 
+     Value *visitUMaxExpr(const SCEVUMaxExpr *S);
+ 
++    Value *visitSMinExpr(const SCEVSMinExpr *S);
++
++    Value *visitUMinExpr(const SCEVUMinExpr *S);
++
+     Value *visitUnknown(const SCEVUnknown *S) {
+       return S->getValue();
+     }
+diff --git a/include/llvm/Analysis/ScalarEvolutionExpressions.h b/include/llvm/Analysis/ScalarEvolutionExpressions.h
+index 42e76094eb2..99e39d484c5 100644
+--- a/include/llvm/Analysis/ScalarEvolutionExpressions.h
++++ b/include/llvm/Analysis/ScalarEvolutionExpressions.h
+@@ -40,7 +40,7 @@ class Type;
+     // These should be ordered in terms of increasing complexity to make the
+     // folders simpler.
+     scConstant, scTruncate, scZeroExtend, scSignExtend, scAddExpr, scMulExpr,
+-    scUDivExpr, scAddRecExpr, scUMaxExpr, scSMaxExpr,
++    scUDivExpr, scAddRecExpr, scUMaxExpr, scSMaxExpr, scUMinExpr, scSMinExpr,
+     scUnknown, scCouldNotCompute
+   };
+ 
+@@ -183,10 +183,9 @@ class Type;
+ 
+     /// Methods for support type inquiry through isa, cast, and dyn_cast:
+     static bool classof(const SCEV *S) {
+-      return S->getSCEVType() == scAddExpr ||
+-             S->getSCEVType() == scMulExpr ||
+-             S->getSCEVType() == scSMaxExpr ||
+-             S->getSCEVType() == scUMaxExpr ||
++      return S->getSCEVType() == scAddExpr || S->getSCEVType() == scMulExpr ||
++             S->getSCEVType() == scSMaxExpr || S->getSCEVType() == scUMaxExpr ||
++             S->getSCEVType() == scSMinExpr || S->getSCEVType() == scUMinExpr ||
+              S->getSCEVType() == scAddRecExpr;
+     }
+   };
+@@ -201,10 +200,9 @@ class Type;
+   public:
+     /// Methods for support type inquiry through isa, cast, and dyn_cast:
+     static bool classof(const SCEV *S) {
+-      return S->getSCEVType() == scAddExpr ||
+-             S->getSCEVType() == scMulExpr ||
+-             S->getSCEVType() == scSMaxExpr ||
+-             S->getSCEVType() == scUMaxExpr;
++      return S->getSCEVType() == scAddExpr || S->getSCEVType() == scMulExpr ||
++             S->getSCEVType() == scSMaxExpr || S->getSCEVType() == scUMaxExpr ||
++             S->getSCEVType() == scSMinExpr || S->getSCEVType() == scUMinExpr;
+     }
+ 
+     /// Set flags for a non-recurrence without clearing previously set flags.
+@@ -358,17 +356,53 @@ class Type;
+     }
+   };
+ 
+-  /// This class represents a signed maximum selection.
+-  class SCEVSMaxExpr : public SCEVCommutativeExpr {
++  /// This node is the base class min/max selections.
++  class SCEVMinMaxExpr : public SCEVCommutativeExpr {
+     friend class ScalarEvolution;
+ 
+-    SCEVSMaxExpr(const FoldingSetNodeIDRef ID,
+-                 const SCEV *const *O, size_t N)
+-      : SCEVCommutativeExpr(ID, scSMaxExpr, O, N) {
+-      // Max never overflows.
++    static bool isMinMaxType(enum SCEVTypes T) {
++      return T == scSMaxExpr || T == scUMaxExpr || T == scSMinExpr ||
++             T == scUMinExpr;
++    }
++
++  protected:
++    /// Note: Constructing subclasses via this constructor is allowed
++    SCEVMinMaxExpr(const FoldingSetNodeIDRef ID, enum SCEVTypes T,
++                   const SCEV *const *O, size_t N)
++        : SCEVCommutativeExpr(ID, T, O, N) {
++      assert(isMinMaxType(T));
++      // Min and max nenver overflow
+       setNoWrapFlags((NoWrapFlags)(FlagNUW | FlagNSW));
+     }
+ 
++  public:
++    static bool classof(const SCEV *S) {
++      return isMinMaxType(static_cast<SCEVTypes>(S->getSCEVType()));
++    }
++
++    static enum SCEVTypes negate(enum SCEVTypes T) {
++      switch (T) {
++      case scSMaxExpr:
++        return scSMinExpr;
++      case scSMinExpr:
++        return scSMaxExpr;
++      case scUMaxExpr:
++        return scUMaxExpr;
++      case scUMinExpr:
++        return scUMinExpr;
++      default:
++        llvm_unreachable("Not a min or max SCEV type!");
++      }
++    }
++  };
++
++  /// This class represents a signed maximum selection.
++  class SCEVSMaxExpr : public SCEVMinMaxExpr {
++    friend class ScalarEvolution;
++
++    SCEVSMaxExpr(const FoldingSetNodeIDRef ID, const SCEV *const *O, size_t N)
++        : SCEVMinMaxExpr(ID, scSMaxExpr, O, N) {}
++
+   public:
+     /// Methods for support type inquiry through isa, cast, and dyn_cast:
+     static bool classof(const SCEV *S) {
+@@ -377,15 +411,11 @@ class Type;
+   };
+ 
+   /// This class represents an unsigned maximum selection.
+-  class SCEVUMaxExpr : public SCEVCommutativeExpr {
++  class SCEVUMaxExpr : public SCEVMinMaxExpr {
+     friend class ScalarEvolution;
+ 
+-    SCEVUMaxExpr(const FoldingSetNodeIDRef ID,
+-                 const SCEV *const *O, size_t N)
+-      : SCEVCommutativeExpr(ID, scUMaxExpr, O, N) {
+-      // Max never overflows.
+-      setNoWrapFlags((NoWrapFlags)(FlagNUW | FlagNSW));
+-    }
++    SCEVUMaxExpr(const FoldingSetNodeIDRef ID, const SCEV *const *O, size_t N)
++        : SCEVMinMaxExpr(ID, scUMaxExpr, O, N) {}
+ 
+   public:
+     /// Methods for support type inquiry through isa, cast, and dyn_cast:
+@@ -394,6 +424,34 @@ class Type;
+     }
+   };
+ 
++  /// This class represents a signed minimum selection.
++  class SCEVSMinExpr : public SCEVMinMaxExpr {
++    friend class ScalarEvolution;
++
++    SCEVSMinExpr(const FoldingSetNodeIDRef ID, const SCEV *const *O, size_t N)
++        : SCEVMinMaxExpr(ID, scSMinExpr, O, N) {}
++
++  public:
++    /// Methods for support type inquiry through isa, cast, and dyn_cast:
++    static bool classof(const SCEV *S) {
++      return S->getSCEVType() == scSMinExpr;
++    }
++  };
++
++  /// This class represents an unsigned minimum selection.
++  class SCEVUMinExpr : public SCEVMinMaxExpr {
++    friend class ScalarEvolution;
++
++    SCEVUMinExpr(const FoldingSetNodeIDRef ID, const SCEV *const *O, size_t N)
++        : SCEVMinMaxExpr(ID, scUMinExpr, O, N) {}
++
++  public:
++    /// Methods for support type inquiry through isa, cast, and dyn_cast:
++    static bool classof(const SCEV *S) {
++      return S->getSCEVType() == scUMinExpr;
++    }
++  };
++
+   /// This means that we are dealing with an entirely unknown SCEV
+   /// value, and only represent it as its LLVM Value.  This is the
+   /// "bottom" value for the analysis.
+@@ -466,6 +524,10 @@ class Type;
+         return ((SC*)this)->visitSMaxExpr((const SCEVSMaxExpr*)S);
+       case scUMaxExpr:
+         return ((SC*)this)->visitUMaxExpr((const SCEVUMaxExpr*)S);
++      case scSMinExpr:
++        return ((SC *)this)->visitSMinExpr((const SCEVSMinExpr *)S);
++      case scUMinExpr:
++        return ((SC *)this)->visitUMinExpr((const SCEVUMinExpr *)S);
+       case scUnknown:
+         return ((SC*)this)->visitUnknown((const SCEVUnknown*)S);
+       case scCouldNotCompute:
+@@ -519,6 +581,8 @@ class Type;
+         case scMulExpr:
+         case scSMaxExpr:
+         case scUMaxExpr:
++        case scSMinExpr:
++        case scUMinExpr:
+         case scAddRecExpr:
+           for (const auto *Op : cast<SCEVNAryExpr>(S)->operands())
+             push(Op);
+@@ -681,6 +745,26 @@ class Type;
+       return !Changed ? Expr : SE.getUMaxExpr(Operands);
+     }
+ 
++    const SCEV *visitSMinExpr(const SCEVSMinExpr *Expr) {
++      SmallVector<const SCEV *, 2> Operands;
++      bool Changed = false;
++      for (auto *Op : Expr->operands()) {
++        Operands.push_back(((SC *)this)->visit(Op));
++        Changed |= Op != Operands.back();
++      }
++      return !Changed ? Expr : SE.getSMinExpr(Operands);
++    }
++
++    const SCEV *visitUMinExpr(const SCEVUMinExpr *Expr) {
++      SmallVector<const SCEV *, 2> Operands;
++      bool Changed = false;
++      for (auto *Op : Expr->operands()) {
++        Operands.push_back(((SC *)this)->visit(Op));
++        Changed |= Op != Operands.back();
++      }
++      return !Changed ? Expr : SE.getUMinExpr(Operands);
++    }
++
+     const SCEV *visitUnknown(const SCEVUnknown *Expr) {
+       return Expr;
+     }
+diff --git a/lib/Analysis/ScalarEvolution.cpp b/lib/Analysis/ScalarEvolution.cpp
+index e5134f2eeda..f2553de0af1 100644
+--- a/lib/Analysis/ScalarEvolution.cpp
++++ b/lib/Analysis/ScalarEvolution.cpp
+@@ -273,7 +273,9 @@ void SCEV::print(raw_ostream &OS) const {
+   case scAddExpr:
+   case scMulExpr:
+   case scUMaxExpr:
+-  case scSMaxExpr: {
++  case scSMaxExpr:
++  case scUMinExpr:
++  case scSMinExpr: {
+     const SCEVNAryExpr *NAry = cast<SCEVNAryExpr>(this);
+     const char *OpStr = nullptr;
+     switch (NAry->getSCEVType()) {
+@@ -281,6 +283,12 @@ void SCEV::print(raw_ostream &OS) const {
+     case scMulExpr: OpStr = " * "; break;
+     case scUMaxExpr: OpStr = " umax "; break;
+     case scSMaxExpr: OpStr = " smax "; break;
++    case scUMinExpr:
++      OpStr = " umin ";
++      break;
++    case scSMinExpr:
++      OpStr = " smin ";
++      break;
+     }
+     OS << "(";
+     for (SCEVNAryExpr::op_iterator I = NAry->op_begin(), E = NAry->op_end();
+@@ -349,6 +357,8 @@ Type *SCEV::getType() const {
+   case scMulExpr:
+   case scUMaxExpr:
+   case scSMaxExpr:
++  case scUMinExpr:
++  case scSMinExpr:
+     return cast<SCEVNAryExpr>(this)->getType();
+   case scAddExpr:
+     return cast<SCEVAddExpr>(this)->getType();
+@@ -713,7 +723,9 @@ static int CompareSCEVComplexity(
+   case scAddExpr:
+   case scMulExpr:
+   case scSMaxExpr:
+-  case scUMaxExpr: {
++  case scUMaxExpr:
++  case scSMinExpr:
++  case scUMinExpr: {
+     const SCEVNAryExpr *LC = cast<SCEVNAryExpr>(LHS);
+     const SCEVNAryExpr *RC = cast<SCEVNAryExpr>(RHS);
+ 
+@@ -913,6 +925,8 @@ public:
+   void visitUDivExpr(const SCEVUDivExpr *Numerator) {}
+   void visitSMaxExpr(const SCEVSMaxExpr *Numerator) {}
+   void visitUMaxExpr(const SCEVUMaxExpr *Numerator) {}
++  void visitSMinExpr(const SCEVSMinExpr *Numerator) {}
++  void visitUMinExpr(const SCEVUMinExpr *Numerator) {}
+   void visitUnknown(const SCEVUnknown *Numerator) {}
+   void visitCouldNotCompute(const SCEVCouldNotCompute *Numerator) {}
+ 
+@@ -3493,209 +3507,153 @@ ScalarEvolution::getGEPExpr(GEPOperator *GEP,
+   return getAddExpr(BaseExpr, TotalOffset, Wrap);
+ }
+ 
+-const SCEV *ScalarEvolution::getSMaxExpr(const SCEV *LHS,
+-                                         const SCEV *RHS) {
+-  SmallVector<const SCEV *, 2> Ops = {LHS, RHS};
+-  return getSMaxExpr(Ops);
+-}
+-
+-const SCEV *
+-ScalarEvolution::getSMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
+-  assert(!Ops.empty() && "Cannot get empty smax!");
++const SCEV *ScalarEvolution::getMinMaxExpr(unsigned Kind,
++                                           SmallVectorImpl<const SCEV *> &Ops) {
++  assert(!Ops.empty() && "Cannot get empty (u|s)(min|max)!");
+   if (Ops.size() == 1) return Ops[0];
+ #ifndef NDEBUG
+   Type *ETy = getEffectiveSCEVType(Ops[0]->getType());
+   for (unsigned i = 1, e = Ops.size(); i != e; ++i)
+     assert(getEffectiveSCEVType(Ops[i]->getType()) == ETy &&
+-           "SCEVSMaxExpr operand types don't match!");
++           "Operand types don't match!");
+ #endif
+ 
++  bool IsSigned = Kind == scSMaxExpr || Kind == scSMinExpr;
++  bool IsMax = Kind == scSMaxExpr || Kind == scUMaxExpr;
++
+   // Sort by complexity, this groups all similar expression types together.
+   GroupByComplexity(Ops, &LI, DT);
+ 
++
++
++
++
++
+   // If there are any constants, fold them together.
+   unsigned Idx = 0;
+   if (const SCEVConstant *LHSC = dyn_cast<SCEVConstant>(Ops[0])) {
+     ++Idx;
+     assert(Idx < Ops.size());
++    auto FoldOp = [&](const APInt &LHS, const APInt &RHS) {
++      if (Kind == scSMaxExpr)
++        return APIntOps::smax(LHS, RHS);
++      else if (Kind == scSMinExpr)
++        return APIntOps::smin(LHS, RHS);
++      else if (Kind == scUMaxExpr)
++        return APIntOps::umax(LHS, RHS);
++      else if (Kind == scUMinExpr)
++        return APIntOps::umin(LHS, RHS);
++      llvm_unreachable("Unknown SCEV min/max opcode");
++    };
++
+     while (const SCEVConstant *RHSC = dyn_cast<SCEVConstant>(Ops[Idx])) {
+       // We found two constants, fold them together!
+       ConstantInt *Fold = ConstantInt::get(
+-          getContext(), APIntOps::smax(LHSC->getAPInt(), RHSC->getAPInt()));
++          getContext(), FoldOp(LHSC->getAPInt(), RHSC->getAPInt()));
+       Ops[0] = getConstant(Fold);
+       Ops.erase(Ops.begin()+1);  // Erase the folded element
+       if (Ops.size() == 1) return Ops[0];
+       LHSC = cast<SCEVConstant>(Ops[0]);
+     }
+ 
+-    // If we are left with a constant minimum-int, strip it off.
+-    if (cast<SCEVConstant>(Ops[0])->getValue()->isMinValue(true)) {
++    bool IsMinV = LHSC->getValue()->isMinValue(IsSigned);
++    bool IsMaxV = LHSC->getValue()->isMaxValue(IsSigned);
++
++    if (IsMax ? IsMinV : IsMaxV) {
++      // If we are left with a constant minimum(/maximum)-int, strip it off.
+       Ops.erase(Ops.begin());
+       --Idx;
+-    } else if (cast<SCEVConstant>(Ops[0])->getValue()->isMaxValue(true)) {
+-      // If we have an smax with a constant maximum-int, it will always be
+-      // maximum-int.
+-      return Ops[0];
++    } else if (IsMax ? IsMaxV : IsMinV) {
++      // If we have a max(/min) with a constant maximum(/minimum)-int,
++      // it will always be the extremum.
++      return LHSC;
+     }
+ 
+     if (Ops.size() == 1) return Ops[0];
+   }
+ 
+-  // Find the first SMax
+-  while (Idx < Ops.size() && Ops[Idx]->getSCEVType() < scSMaxExpr)
++  // Find the first operation of the same kind
++  while (Idx < Ops.size() && Ops[Idx]->getSCEVType() < Kind)
+     ++Idx;
+ 
+-  // Check to see if one of the operands is an SMax. If so, expand its operands
+-  // onto our operand list, and recurse to simplify.
++  // Check to see if one of the operands is of the same kind. If so, expand its
++  // operands onto our operand list, and recurse to simplify.
+   if (Idx < Ops.size()) {
+-    bool DeletedSMax = false;
+-    while (const SCEVSMaxExpr *SMax = dyn_cast<SCEVSMaxExpr>(Ops[Idx])) {
++    bool DeletedAny = false;
++    while (Ops[Idx]->getSCEVType() == Kind) {
++      const SCEVMinMaxExpr *SMME = cast<SCEVMinMaxExpr>(Ops[Idx]);
+       Ops.erase(Ops.begin()+Idx);
+-      Ops.append(SMax->op_begin(), SMax->op_end());
+-      DeletedSMax = true;
++      Ops.append(SMME->op_begin(), SMME->op_end());
++      DeletedAny = true;
+     }
+ 
+-    if (DeletedSMax)
+-      return getSMaxExpr(Ops);
++    if (DeletedAny)
++      return getMinMaxExpr(Kind, Ops);
+   }
+ 
+   // Okay, check to see if the same value occurs in the operand list twice.  If
+   // so, delete one.  Since we sorted the list, these values are required to
+   // be adjacent.
+-  for (unsigned i = 0, e = Ops.size()-1; i != e; ++i)
+-    //  X smax Y smax Y  -->  X smax Y
+-    //  X smax Y         -->  X, if X is always greater than Y
+-    if (Ops[i] == Ops[i+1] ||
+-        isKnownPredicate(ICmpInst::ICMP_SGE, Ops[i], Ops[i+1])) {
+-      Ops.erase(Ops.begin()+i+1, Ops.begin()+i+2);
+-      --i; --e;
+-    } else if (isKnownPredicate(ICmpInst::ICMP_SLE, Ops[i], Ops[i+1])) {
+-      Ops.erase(Ops.begin()+i, Ops.begin()+i+1);
+-      --i; --e;
++  llvm::CmpInst::Predicate GEPred =
++      IsSigned ? ICmpInst::ICMP_SGE : ICmpInst::ICMP_UGE;
++  llvm::CmpInst::Predicate LEPred =
++      IsSigned ? ICmpInst::ICMP_SLE : ICmpInst::ICMP_ULE;
++  llvm::CmpInst::Predicate FirstPred = IsMax ? GEPred : LEPred;
++  llvm::CmpInst::Predicate SecondPred = IsMax ? LEPred : GEPred;
++  for (unsigned i = 0, e = Ops.size() - 1; i != e; ++i) {
++    if (Ops[i] == Ops[i + 1] ||
++        isKnownViaNonRecursiveReasoning(FirstPred, Ops[i], Ops[i + 1])) {
++      //  X op Y op Y  -->  X op Y
++      //  X op Y       -->  X, if we know X, Y are ordered appropriately
++      Ops.erase(Ops.begin() + i + 1, Ops.begin() + i + 2);
++      --i;
++      --e;
++    } else if (isKnownViaNonRecursiveReasoning(SecondPred, Ops[i],
++                                               Ops[i + 1])) {
++      //  X op Y       -->  Y, if we know X, Y are ordered appropriately
++      Ops.erase(Ops.begin() + i, Ops.begin() + i + 1);
++      --i;
++      --e;
+     }
++  }
+ 
+   if (Ops.size() == 1) return Ops[0];
+ 
+   assert(!Ops.empty() && "Reduced smax down to nothing!");
+ 
+-  // Okay, it looks like we really DO need an smax expr.  Check to see if we
++  // Okay, it looks like we really DO need an expr.  Check to see if we
+   // already have one, otherwise create a new one.
+   FoldingSetNodeID ID;
+-  ID.AddInteger(scSMaxExpr);
++  ID.AddInteger(Kind);
+   for (unsigned i = 0, e = Ops.size(); i != e; ++i)
+     ID.AddPointer(Ops[i]);
+   void *IP = nullptr;
+   if (const SCEV *S = UniqueSCEVs.FindNodeOrInsertPos(ID, IP)) return S;
+   const SCEV **O = SCEVAllocator.Allocate<const SCEV *>(Ops.size());
+   std::uninitialized_copy(Ops.begin(), Ops.end(), O);
+-  SCEV *S = new (SCEVAllocator) SCEVSMaxExpr(ID.Intern(SCEVAllocator),
+-                                             O, Ops.size());
++  SCEV *S = new (SCEVAllocator) SCEVMinMaxExpr(
++      ID.Intern(SCEVAllocator), static_cast<SCEVTypes>(Kind), O, Ops.size());
+   UniqueSCEVs.InsertNode(S, IP);
+   addToLoopUseLists(S);
+   return S;
+ }
+ 
+-const SCEV *ScalarEvolution::getUMaxExpr(const SCEV *LHS,
+-                                         const SCEV *RHS) {
++const SCEV *ScalarEvolution::getSMaxExpr(const SCEV *LHS, const SCEV *RHS) {
+   SmallVector<const SCEV *, 2> Ops = {LHS, RHS};
+-  return getUMaxExpr(Ops);
++  return getSMaxExpr(Ops);
+ }
+ 
+-const SCEV *
+-ScalarEvolution::getUMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
+-  assert(!Ops.empty() && "Cannot get empty umax!");
+-  if (Ops.size() == 1) return Ops[0];
+-#ifndef NDEBUG
+-  Type *ETy = getEffectiveSCEVType(Ops[0]->getType());
+-  for (unsigned i = 1, e = Ops.size(); i != e; ++i)
+-    assert(getEffectiveSCEVType(Ops[i]->getType()) == ETy &&
+-           "SCEVUMaxExpr operand types don't match!");
+-#endif
+-
+-  // Sort by complexity, this groups all similar expression types together.
+-  GroupByComplexity(Ops, &LI, DT);
+-
+-  // If there are any constants, fold them together.
+-  unsigned Idx = 0;
+-  if (const SCEVConstant *LHSC = dyn_cast<SCEVConstant>(Ops[0])) {
+-    ++Idx;
+-    assert(Idx < Ops.size());
+-    while (const SCEVConstant *RHSC = dyn_cast<SCEVConstant>(Ops[Idx])) {
+-      // We found two constants, fold them together!
+-      ConstantInt *Fold = ConstantInt::get(
+-          getContext(), APIntOps::umax(LHSC->getAPInt(), RHSC->getAPInt()));
+-      Ops[0] = getConstant(Fold);
+-      Ops.erase(Ops.begin()+1);  // Erase the folded element
+-      if (Ops.size() == 1) return Ops[0];
+-      LHSC = cast<SCEVConstant>(Ops[0]);
+-    }
+-
+-    // If we are left with a constant minimum-int, strip it off.
+-    if (cast<SCEVConstant>(Ops[0])->getValue()->isMinValue(false)) {
+-      Ops.erase(Ops.begin());
+-      --Idx;
+-    } else if (cast<SCEVConstant>(Ops[0])->getValue()->isMaxValue(false)) {
+-      // If we have an umax with a constant maximum-int, it will always be
+-      // maximum-int.
+-      return Ops[0];
+-    }
+-
+-    if (Ops.size() == 1) return Ops[0];
+-  }
+-
+-  // Find the first UMax
+-  while (Idx < Ops.size() && Ops[Idx]->getSCEVType() < scUMaxExpr)
+-    ++Idx;
+-
+-  // Check to see if one of the operands is a UMax. If so, expand its operands
+-  // onto our operand list, and recurse to simplify.
+-  if (Idx < Ops.size()) {
+-    bool DeletedUMax = false;
+-    while (const SCEVUMaxExpr *UMax = dyn_cast<SCEVUMaxExpr>(Ops[Idx])) {
+-      Ops.erase(Ops.begin()+Idx);
+-      Ops.append(UMax->op_begin(), UMax->op_end());
+-      DeletedUMax = true;
+-    }
+-
+-    if (DeletedUMax)
+-      return getUMaxExpr(Ops);
+-  }
+-
+-  // Okay, check to see if the same value occurs in the operand list twice.  If
+-  // so, delete one.  Since we sorted the list, these values are required to
+-  // be adjacent.
+-  for (unsigned i = 0, e = Ops.size()-1; i != e; ++i)
+-    //  X umax Y umax Y  -->  X umax Y
+-    //  X umax Y         -->  X, if X is always greater than Y
+-    if (Ops[i] == Ops[i + 1] || isKnownViaNonRecursiveReasoning(
+-                                    ICmpInst::ICMP_UGE, Ops[i], Ops[i + 1])) {
+-      Ops.erase(Ops.begin() + i + 1, Ops.begin() + i + 2);
+-      --i; --e;
+-    } else if (isKnownViaNonRecursiveReasoning(ICmpInst::ICMP_ULE, Ops[i],
+-                                               Ops[i + 1])) {
+-      Ops.erase(Ops.begin() + i, Ops.begin() + i + 1);
+-      --i; --e;
+-    }
+-
+-  if (Ops.size() == 1) return Ops[0];
++const SCEV *ScalarEvolution::getSMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
++  return getMinMaxExpr(scSMaxExpr, Ops);
++}
+ 
+-  assert(!Ops.empty() && "Reduced umax down to nothing!");
++const SCEV *ScalarEvolution::getUMaxExpr(const SCEV *LHS, const SCEV *RHS) {
++  SmallVector<const SCEV *, 2> Ops = {LHS, RHS};
++  return getUMaxExpr(Ops);
++}
+ 
+-  // Okay, it looks like we really DO need a umax expr.  Check to see if we
+-  // already have one, otherwise create a new one.
+-  FoldingSetNodeID ID;
+-  ID.AddInteger(scUMaxExpr);
+-  for (unsigned i = 0, e = Ops.size(); i != e; ++i)
+-    ID.AddPointer(Ops[i]);
+-  void *IP = nullptr;
+-  if (const SCEV *S = UniqueSCEVs.FindNodeOrInsertPos(ID, IP)) return S;
+-  const SCEV **O = SCEVAllocator.Allocate<const SCEV *>(Ops.size());
+-  std::uninitialized_copy(Ops.begin(), Ops.end(), O);
+-  SCEV *S = new (SCEVAllocator) SCEVUMaxExpr(ID.Intern(SCEVAllocator),
+-                                             O, Ops.size());
+-  UniqueSCEVs.InsertNode(S, IP);
+-  addToLoopUseLists(S);
+-  return S;
++const SCEV *ScalarEvolution::getUMaxExpr(SmallVectorImpl<const SCEV *> &Ops) {
++  return getMinMaxExpr(scUMaxExpr, Ops);
+ }
+ 
+ const SCEV *ScalarEvolution::getSMinExpr(const SCEV *LHS,
+@@ -3705,11 +3663,7 @@ const SCEV *ScalarEvolution::getSMinExpr(const SCEV *LHS,
+ }
+ 
+ const SCEV *ScalarEvolution::getSMinExpr(SmallVectorImpl<const SCEV *> &Ops) {
+-  // ~smax(~x, ~y, ~z) == smin(x, y, z).
+-  SmallVector<const SCEV *, 2> NotOps;
+-  for (auto *S : Ops)
+-    NotOps.push_back(getNotSCEV(S));
+-  return getNotSCEV(getSMaxExpr(NotOps));
++  return getMinMaxExpr(scSMinExpr, Ops);
+ }
+ 
+ const SCEV *ScalarEvolution::getUMinExpr(const SCEV *LHS,
+@@ -3719,16 +3673,7 @@ const SCEV *ScalarEvolution::getUMinExpr(const SCEV *LHS,
+ }
+ 
+ const SCEV *ScalarEvolution::getUMinExpr(SmallVectorImpl<const SCEV *> &Ops) {
+-  assert(!Ops.empty() && "At least one operand must be!");
+-  // Trivial case.
+-  if (Ops.size() == 1)
+-    return Ops[0];
+-
+-  // ~umax(~x, ~y, ~z) == umin(x, y, z).
+-  SmallVector<const SCEV *, 2> NotOps;
+-  for (auto *S : Ops)
+-    NotOps.push_back(getNotSCEV(S));
+-  return getNotSCEV(getUMaxExpr(NotOps));
++  return getMinMaxExpr(scUMinExpr, Ops);
+ }
+ 
+ const SCEV *ScalarEvolution::getSizeOfExpr(Type *IntTy, Type *AllocTy) {
+@@ -3970,12 +3915,45 @@ const SCEV *ScalarEvolution::getNegativeSCEV(const SCEV *V,
+       V, getConstant(cast<ConstantInt>(Constant::getAllOnesValue(Ty))), Flags);
+ }
+ 
++/// If Expr computes ~A, return A else return nullptr
++static const SCEV *MatchNotExpr(const SCEV *Expr) {
++  const SCEVAddExpr *Add = dyn_cast<SCEVAddExpr>(Expr);
++  if (!Add || Add->getNumOperands() != 2 ||
++      !Add->getOperand(0)->isAllOnesValue())
++    return nullptr;
++
++  const SCEVMulExpr *AddRHS = dyn_cast<SCEVMulExpr>(Add->getOperand(1));
++  if (!AddRHS || AddRHS->getNumOperands() != 2 ||
++      !AddRHS->getOperand(0)->isAllOnesValue())
++    return nullptr;
++
++  return AddRHS->getOperand(1);
++}
++
+ /// Return a SCEV corresponding to ~V = -1-V
+ const SCEV *ScalarEvolution::getNotSCEV(const SCEV *V) {
+   if (const SCEVConstant *VC = dyn_cast<SCEVConstant>(V))
+     return getConstant(
+                 cast<ConstantInt>(ConstantExpr::getNot(VC->getValue())));
+ 
++  // Fold ~(u|s)(min|max)(~x, ~y) to (u|s)(max|min)(x, y)
++  if (const SCEVMinMaxExpr *MME = dyn_cast<SCEVMinMaxExpr>(V)) {
++    auto MatchMinMaxNegation = [&](const SCEVMinMaxExpr *MME) {
++      SmallVector<const SCEV *, 2> MatchedOperands;
++      for (const SCEV *Operand : MME->operands()) {
++        const SCEV *Matched = MatchNotExpr(Operand);
++        if (!Matched)
++          return (const SCEV *)nullptr;
++        MatchedOperands.push_back(Matched);
++      }
++      return getMinMaxExpr(
++          SCEVMinMaxExpr::negate(static_cast<SCEVTypes>(MME->getSCEVType())),
++          MatchedOperands);
++    };
++    if (const SCEV *Replaced = MatchMinMaxNegation(MME))
++      return Replaced;
++  }
++
+   Type *Ty = V->getType();
+   Ty = getEffectiveSCEVType(Ty);
+   const SCEV *AllOnes =
+@@ -5196,6 +5174,8 @@ static bool IsAvailableOnEntry(const Loop *L, DominatorTree &DT, const SCEV *S,
+       switch (S->getSCEVType()) {
+       case scConstant: case scTruncate: case scZeroExtend: case scSignExtend:
+       case scAddExpr: case scMulExpr: case scUMaxExpr: case scSMaxExpr:
++      case scUMinExpr:
++      case scSMinExpr:
+         // These expressions are available if their operand(s) is/are.
+         return true;
+ 
+@@ -8075,7 +8055,9 @@ static Constant *BuildConstantFromSCEV(const SCEV *V) {
+     }
+     case scSMaxExpr:
+     case scUMaxExpr:
+-      break; // TODO: smax, umax.
++    case scSMinExpr:
++    case scUMinExpr:
++      break; // TODO: smax, umax, smin, umax.
+   }
+   return nullptr;
+ }
+@@ -8201,10 +8183,8 @@ const SCEV *ScalarEvolution::computeSCEVAtScope(const SCEV *V, const Loop *L) {
+           return getAddExpr(NewOps);
+         if (isa<SCEVMulExpr>(Comm))
+           return getMulExpr(NewOps);
+-        if (isa<SCEVSMaxExpr>(Comm))
+-          return getSMaxExpr(NewOps);
+-        if (isa<SCEVUMaxExpr>(Comm))
+-          return getUMaxExpr(NewOps);
++        if (isa<SCEVMinMaxExpr>(Comm))
++          return getMinMaxExpr(Comm->getSCEVType(), NewOps);
+         llvm_unreachable("Unknown commutative SCEV type!");
+       }
+     }
+@@ -10045,41 +10025,15 @@ bool ScalarEvolution::isImpliedCondOperands(ICmpInst::Predicate Pred,
+                                      getNotSCEV(FoundLHS));
+ }
+ 
+-/// If Expr computes ~A, return A else return nullptr
+-static const SCEV *MatchNotExpr(const SCEV *Expr) {
+-  const SCEVAddExpr *Add = dyn_cast<SCEVAddExpr>(Expr);
+-  if (!Add || Add->getNumOperands() != 2 ||
+-      !Add->getOperand(0)->isAllOnesValue())
+-    return nullptr;
+-
+-  const SCEVMulExpr *AddRHS = dyn_cast<SCEVMulExpr>(Add->getOperand(1));
+-  if (!AddRHS || AddRHS->getNumOperands() != 2 ||
+-      !AddRHS->getOperand(0)->isAllOnesValue())
+-    return nullptr;
+-
+-  return AddRHS->getOperand(1);
+-}
+-
+-/// Is MaybeMaxExpr an SMax or UMax of Candidate and some other values?
+-template<typename MaxExprType>
+-static bool IsMaxConsistingOf(const SCEV *MaybeMaxExpr,
+-                              const SCEV *Candidate) {
+-  const MaxExprType *MaxExpr = dyn_cast<MaxExprType>(MaybeMaxExpr);
+-  if (!MaxExpr) return false;
+-
+-  return find(MaxExpr->operands(), Candidate) != MaxExpr->op_end();
+-}
+-
+-/// Is MaybeMinExpr an SMin or UMin of Candidate and some other values?
+-template<typename MaxExprType>
+-static bool IsMinConsistingOf(ScalarEvolution &SE,
+-                              const SCEV *MaybeMinExpr,
+-                              const SCEV *Candidate) {
+-  const SCEV *MaybeMaxExpr = MatchNotExpr(MaybeMinExpr);
+-  if (!MaybeMaxExpr)
++/// Is MaybeMinMaxExpr an (U|S)(Min|Max) of Candidate and some other values?
++template <typename MinMaxExprType>
++static bool IsMinMaxConsistingOf(const SCEV *MaybeMinMaxExpr,
++                                 const SCEV *Candidate) {
++  const MinMaxExprType *MinMaxExpr = dyn_cast<MinMaxExprType>(MaybeMinMaxExpr);
++  if (!MinMaxExpr)
+     return false;
+ 
+-  return IsMaxConsistingOf<MaxExprType>(MaybeMaxExpr, SE.getNotSCEV(Candidate));
++  return find(MinMaxExpr->operands(), Candidate) != MinMaxExpr->op_end();
+ }
+ 
+ static bool IsKnownPredicateViaAddRecStart(ScalarEvolution &SE,
+@@ -10128,20 +10082,20 @@ static bool IsKnownPredicateViaMinOrMax(ScalarEvolution &SE,
+     LLVM_FALLTHROUGH;
+   case ICmpInst::ICMP_SLE:
+     return
+-      // min(A, ...) <= A
+-      IsMinConsistingOf<SCEVSMaxExpr>(SE, LHS, RHS) ||
+-      // A <= max(A, ...)
+-      IsMaxConsistingOf<SCEVSMaxExpr>(RHS, LHS);
++        // min(A, ...) <= A
++        IsMinMaxConsistingOf<SCEVSMinExpr>(LHS, RHS) ||
++        // A <= max(A, ...)
++        IsMinMaxConsistingOf<SCEVSMaxExpr>(RHS, LHS);
+ 
+   case ICmpInst::ICMP_UGE:
+     std::swap(LHS, RHS);
+     LLVM_FALLTHROUGH;
+   case ICmpInst::ICMP_ULE:
+     return
+-      // min(A, ...) <= A
+-      IsMinConsistingOf<SCEVUMaxExpr>(SE, LHS, RHS) ||
+-      // A <= max(A, ...)
+-      IsMaxConsistingOf<SCEVUMaxExpr>(RHS, LHS);
++        // min(A, ...) <= A
++        IsMinMaxConsistingOf<SCEVUMinExpr>(LHS, RHS) ||
++        // A <= max(A, ...)
++        IsMinMaxConsistingOf<SCEVUMaxExpr>(RHS, LHS);
+   }
+ 
+   llvm_unreachable("covered switch fell through?!");
+@@ -11611,7 +11565,9 @@ ScalarEvolution::computeLoopDisposition(const SCEV *S, const Loop *L) {
+   case scAddExpr:
+   case scMulExpr:
+   case scUMaxExpr:
+-  case scSMaxExpr: {
++  case scSMaxExpr:
++  case scUMinExpr:
++  case scSMinExpr: {
+     bool HasVarying = false;
+     for (auto *Op : cast<SCEVNAryExpr>(S)->operands()) {
+       LoopDisposition D = getLoopDisposition(Op, L);
+@@ -11698,7 +11654,9 @@ ScalarEvolution::computeBlockDisposition(const SCEV *S, const BasicBlock *BB) {
+   case scAddExpr:
+   case scMulExpr:
+   case scUMaxExpr:
+-  case scSMaxExpr: {
++  case scSMaxExpr:
++  case scUMinExpr:
++  case scSMinExpr: {
+     const SCEVNAryExpr *NAry = cast<SCEVNAryExpr>(S);
+     bool Proper = true;
+     for (const SCEV *NAryOp : NAry->operands()) {
+diff --git a/lib/Analysis/ScalarEvolutionExpander.cpp b/lib/Analysis/ScalarEvolutionExpander.cpp
+index ca5cf1663b8..b56ec40ab75 100644
+--- a/lib/Analysis/ScalarEvolutionExpander.cpp
++++ b/lib/Analysis/ScalarEvolutionExpander.cpp
+@@ -1634,7 +1634,8 @@ Value *SCEVExpander::visitSMaxExpr(const SCEVSMaxExpr *S) {
+   for (int i = S->getNumOperands()-2; i >= 0; --i) {
+     // In the case of mixed integer and pointer types, do the
+     // rest of the comparisons as integer.
+-    if (S->getOperand(i)->getType() != Ty) {
++    Type *OpTy = S->getOperand(i)->getType();
++    if (OpTy->isIntegerTy() != Ty->isIntegerTy()) {
+       Ty = SE.getEffectiveSCEVType(Ty);
+       LHS = InsertNoopCastOfTo(LHS, Ty);
+     }
+@@ -1658,7 +1659,8 @@ Value *SCEVExpander::visitUMaxExpr(const SCEVUMaxExpr *S) {
+   for (int i = S->getNumOperands()-2; i >= 0; --i) {
+     // In the case of mixed integer and pointer types, do the
+     // rest of the comparisons as integer.
+-    if (S->getOperand(i)->getType() != Ty) {
++    Type *OpTy = S->getOperand(i)->getType();
++    if (OpTy->isIntegerTy() != Ty->isIntegerTy()) {
+       Ty = SE.getEffectiveSCEVType(Ty);
+       LHS = InsertNoopCastOfTo(LHS, Ty);
+     }
+@@ -1676,6 +1678,56 @@ Value *SCEVExpander::visitUMaxExpr(const SCEVUMaxExpr *S) {
+   return LHS;
+ }
+ 
++Value *SCEVExpander::visitSMinExpr(const SCEVSMinExpr *S) {
++  Value *LHS = expand(S->getOperand(S->getNumOperands() - 1));
++  Type *Ty = LHS->getType();
++  for (int i = S->getNumOperands() - 2; i >= 0; --i) {
++    // In the case of mixed integer and pointer types, do the
++    // rest of the comparisons as integer.
++    Type *OpTy = S->getOperand(i)->getType();
++    if (OpTy->isIntegerTy() != Ty->isIntegerTy()) {
++      Ty = SE.getEffectiveSCEVType(Ty);
++      LHS = InsertNoopCastOfTo(LHS, Ty);
++    }
++    Value *RHS = expandCodeFor(S->getOperand(i), Ty);
++    Value *ICmp = Builder.CreateICmpSLT(LHS, RHS);
++    rememberInstruction(ICmp);
++    Value *Sel = Builder.CreateSelect(ICmp, LHS, RHS, "smin");
++    rememberInstruction(Sel);
++    LHS = Sel;
++  }
++  // In the case of mixed integer and pointer types, cast the
++  // final result back to the pointer type.
++  if (LHS->getType() != S->getType())
++    LHS = InsertNoopCastOfTo(LHS, S->getType());
++  return LHS;
++}
++
++Value *SCEVExpander::visitUMinExpr(const SCEVUMinExpr *S) {
++  Value *LHS = expand(S->getOperand(S->getNumOperands() - 1));
++  Type *Ty = LHS->getType();
++  for (int i = S->getNumOperands() - 2; i >= 0; --i) {
++    // In the case of mixed integer and pointer types, do the
++    // rest of the comparisons as integer.
++    Type *OpTy = S->getOperand(i)->getType();
++    if (OpTy->isIntegerTy() != Ty->isIntegerTy()) {
++      Ty = SE.getEffectiveSCEVType(Ty);
++      LHS = InsertNoopCastOfTo(LHS, Ty);
++    }
++    Value *RHS = expandCodeFor(S->getOperand(i), Ty);
++    Value *ICmp = Builder.CreateICmpULT(LHS, RHS);
++    rememberInstruction(ICmp);
++    Value *Sel = Builder.CreateSelect(ICmp, LHS, RHS, "umin");
++    rememberInstruction(Sel);
++    LHS = Sel;
++  }
++  // In the case of mixed integer and pointer types, cast the
++  // final result back to the pointer type.
++  if (LHS->getType() != S->getType())
++    LHS = InsertNoopCastOfTo(LHS, S->getType());
++  return LHS;
++}
++
+ Value *SCEVExpander::expandCodeFor(const SCEV *SH, Type *Ty,
+                                    Instruction *IP) {
+   setInsertPoint(IP);
+@@ -2102,7 +2154,7 @@ bool SCEVExpander::isHighCostExpansionHelper(
+ 
+   // HowManyLessThans uses a Max expression whenever the loop is not guarded by
+   // the exit condition.
+-  if (isa<SCEVSMaxExpr>(S) || isa<SCEVUMaxExpr>(S))
++  if (isa<SCEVMinMaxExpr>(S))
+     return true;
+ 
+   // Recurse past nary expressions, which commonly occur in the
+diff --git a/test/Analysis/LoopAccessAnalysis/memcheck-ni.ll b/test/Analysis/LoopAccessAnalysis/memcheck-ni.ll
+new file mode 100644
+index 00000000000..a08632f38d1
+--- /dev/null
++++ b/test/Analysis/LoopAccessAnalysis/memcheck-ni.ll
+@@ -0,0 +1,50 @@
++; RUN: opt -loop-versioning -S < %s | FileCheck %s
++
++; NB: addrspaces 10-13 are non-integral
++target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
++
++%jl_value_t = type opaque
++%jl_array_t = type { i8 addrspace(13)*, i64, i16, i16, i32 }
++
++define void @"japi1_permutedims!_33509"(%jl_value_t addrspace(10)**) {
++; CHECK: [[CMP:%[^ ]*]] = icmp ult double addrspace(13)* [[A:%[^ ]*]], [[B:%[^ ]*]]
++; CHECK: [[SELECT:%[^ ]*]] = select i1 %18, double addrspace(13)* [[A]], double addrspace(13)* [[B]]
++top:
++  %1 = alloca [3 x i64], align 8 
++  %2 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %0, align 8
++  %3 = getelementptr inbounds %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %0, i64 1
++  %4 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %3, align 8
++  %5 = getelementptr inbounds [3 x i64], [3 x i64]* %1, i64 0, i64 0
++  store i64 1, i64* %5, align 8
++  %6 = getelementptr inbounds [3 x i64], [3 x i64]* %1, i64 0, i64 1
++  %7 = load i64, i64* inttoptr (i64 24 to i64*), align 8
++  %8 = addrspacecast %jl_value_t addrspace(10)* %4 to %jl_value_t addrspace(11)*
++  %9 = bitcast %jl_value_t addrspace(11)* %8 to double addrspace(13)* addrspace(11)*
++  %10 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %9, align 8
++  %11 = addrspacecast %jl_value_t addrspace(10)* %2 to %jl_value_t addrspace(11)*
++  %12 = bitcast %jl_value_t addrspace(11)* %11 to double addrspace(13)* addrspace(11)*
++  %13 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %12, align 8
++  %14 = load i64, i64* %6, align 8
++  br label %L74
++
++L74:
++  %value_phi20 = phi i64 [ 1, %top ], [ %22, %L74 ]
++  %value_phi21 = phi i64 [ 1, %top ], [ %23, %L74 ]
++  %value_phi22 = phi i64 [ 1, %top ], [ %25, %L74 ]
++  %15 = add i64 %value_phi21, -1
++  %16 = getelementptr inbounds double, double addrspace(13)* %10, i64 %15
++  %17 = bitcast double addrspace(13)* %16 to i64 addrspace(13)*
++  %18 = load i64, i64 addrspace(13)* %17, align 8
++  %19 = add i64 %value_phi20, -1
++  %20 = getelementptr inbounds double, double addrspace(13)* %13, i64 %19
++  %21 = bitcast double addrspace(13)* %20 to i64 addrspace(13)*
++  store i64 %18, i64 addrspace(13)* %21, align 8
++  %22 = add i64 %value_phi20, 1
++  %23 = add i64 %14, %value_phi21
++  %24 = icmp eq i64 %value_phi22, %7
++  %25 = add i64 %value_phi22, 1
++  br i1 %24, label %L94, label %L74
++
++L94:
++  ret void 
++}
+diff --git a/test/Analysis/LoopAccessAnalysis/reverse-memcheck-bounds.ll b/test/Analysis/LoopAccessAnalysis/reverse-memcheck-bounds.ll
+index 405a47554e4..4285ef0f117 100644
+--- a/test/Analysis/LoopAccessAnalysis/reverse-memcheck-bounds.ll
++++ b/test/Analysis/LoopAccessAnalysis/reverse-memcheck-bounds.ll
+@@ -58,7 +58,7 @@ for.end:                                          ; preds = %for.body
+ 
+ ; Here it is not obvious what the limits are, since 'step' could be negative.
+ 
+-; CHECK: Low: (-1 + (-1 * ((-60001 + (-1 * %a)) umax (-60001 + (40000 * %step) + (-1 * %a)))))
++; CHECK: Low: ((60000 + %a)<nsw> umin (60000 + (-40000 * %step) + %a)) 
+ ; CHECK: High: (4 + ((60000 + %a)<nsw> umax (60000 + (-40000 * %step) + %a)))
+ 
+ define void @g(i64 %step) {
+diff --git a/test/Analysis/ScalarEvolution/2008-07-29-SMinExpr.ll b/test/Analysis/ScalarEvolution/2008-07-29-SMinExpr.ll
+index 3542ad2a41e..d930706d7d2 100644
+--- a/test/Analysis/ScalarEvolution/2008-07-29-SMinExpr.ll
++++ b/test/Analysis/ScalarEvolution/2008-07-29-SMinExpr.ll
+@@ -22,5 +22,5 @@ afterfor:		; preds = %forinc, %entry
+ 	ret i32 %j.0.lcssa
+ }
+ 
+-; CHECK: backedge-taken count is (-2147483632 + ((-1 + (-1 * %{{[xy]}})) smax (-1 + (-1 * %{{[xy]}}))))
++; CHECK: backedge-taken count is (-2147483633 + (-1 * (%{{[xy]}} smin %{{[xy]}})))
+ 
+diff --git a/test/Analysis/ScalarEvolution/min-max-exprs.ll b/test/Analysis/ScalarEvolution/min-max-exprs.ll
+index e8c1e33e095..51f72c643cc 100644
+--- a/test/Analysis/ScalarEvolution/min-max-exprs.ll
++++ b/test/Analysis/ScalarEvolution/min-max-exprs.ll
+@@ -33,7 +33,7 @@ bb2:                                              ; preds = %bb1
+   %tmp9 = select i1 %tmp4, i64 %tmp5, i64 %tmp6
+ ;                  min(N, i+3)
+ ; CHECK:           select i1 %tmp4, i64 %tmp5, i64 %tmp6
+-; CHECK-NEXT:  --> (-1 + (-1 * ((-1 + (-1 * (sext i32 {3,+,1}<nuw><%bb1> to i64))<nsw>)<nsw> smax (-1 + (-1 * (sext i32 %N to i64))<nsw>)<nsw>))<nsw>)<nsw>
++; CHECK-NEXT:  --> ((sext i32 {3,+,1}<nuw><%bb1> to i64) smin (sext i32 %N to i64))
+   %tmp11 = getelementptr inbounds i32, i32* %A, i64 %tmp9
+   %tmp12 = load i32, i32* %tmp11, align 4
+   %tmp13 = shl nsw i32 %tmp12, 1
+diff --git a/test/Analysis/ScalarEvolution/predicated-trip-count.ll b/test/Analysis/ScalarEvolution/predicated-trip-count.ll
+index a0afcf457d2..b07662ed95f 100644
+--- a/test/Analysis/ScalarEvolution/predicated-trip-count.ll
++++ b/test/Analysis/ScalarEvolution/predicated-trip-count.ll
+@@ -80,7 +80,7 @@ return:         ; preds = %bb5
+ ; CHECK-NEXT:    -->  (sext i16 {%Start,+,-1}<%bb3> to i32)
+ ; CHECK:       Loop %bb3: Unpredictable backedge-taken count.
+ ; CHECK-NEXT:  Loop %bb3: Unpredictable max backedge-taken count.
+-; CHECK-NEXT:  Loop %bb3: Predicated backedge-taken count is (2 + (sext i16 %Start to i32) + ((-2 + (-1 * (sext i16 %Start to i32))<nsw>) smax (-1 + (-1 * %M))))
++; CHECK-NEXT:  Loop %bb3: Predicated backedge-taken count is (1 + (sext i16 %Start to i32) + (-1 * ((1 + (sext i16 %Start to i32))<nsw> smin %M)))
+ ; CHECK-NEXT:  Predicates:
+ ; CHECK-NEXT:    {%Start,+,-1}<%bb3> Added Flags: <nssw>
+ 
+diff --git a/test/Analysis/ScalarEvolution/trip-count14.ll b/test/Analysis/ScalarEvolution/trip-count14.ll
+index 5e6cfe85101..15080613881 100644
+--- a/test/Analysis/ScalarEvolution/trip-count14.ll
++++ b/test/Analysis/ScalarEvolution/trip-count14.ll
+@@ -81,7 +81,7 @@ if.end:
+   br i1 %cmp1, label %do.body, label %do.end ; taken either 0 or 2 times
+ 
+ ; CHECK-LABEL: Determining loop execution counts for: @s32_max2_unpredictable_exit
+-; CHECK-NEXT: Loop %do.body: <multiple exits> backedge-taken count is (-1 + (-1 * ((-1 + (-1 * ((2 + %n) smax %n)) + %n) umax (-1 + (-1 * %x) + %n))))
++; CHECK-NEXT: Loop %do.body: <multiple exits> backedge-taken count is (((-1 * %n) + ((2 + %n) smax %n)) umin ((-1 * %n) + %x))
+ ; CHECK-NEXT: Loop %do.body: max backedge-taken count is 2{{$}}
+ 
+ do.end:
+@@ -169,7 +169,7 @@ if.end:
+   br i1 %cmp1, label %do.body, label %do.end ; taken either 0 or 2 times
+ 
+ ; CHECK-LABEL: Determining loop execution counts for: @u32_max2_unpredictable_exit
+-; CHECK-NEXT: Loop %do.body: <multiple exits> backedge-taken count is (-1 + (-1 * ((-1 + (-1 * ((2 + %n) umax %n)) + %n) umax (-1 + (-1 * %x) + %n))))
++; CHECK-NEXT: Loop %do.body: <multiple exits> backedge-taken count is (((-1 * %n) + ((2 + %n) umax %n)) umin ((-1 * %n) + %x))
+ ; CHECK-NEXT: Loop %do.body: max backedge-taken count is 2{{$}}
+ 
+ do.end:
+diff --git a/test/Analysis/ScalarEvolution/trip-count3.ll b/test/Analysis/ScalarEvolution/trip-count3.ll
+index df6637a4ced..e10012c0c32 100644
+--- a/test/Analysis/ScalarEvolution/trip-count3.ll
++++ b/test/Analysis/ScalarEvolution/trip-count3.ll
+@@ -4,7 +4,7 @@
+ ; dividing by the stride will have a remainder. This could theoretically
+ ; be teaching it how to use a more elaborate trip count computation.
+ 
+-; CHECK: Loop %bb3.i: backedge-taken count is ((64 + (-64 smax (-1 + (-1 * %0))) + %0) /u 64)
++; CHECK: Loop %bb3.i: backedge-taken count is ((63 + (-1 * (63 smin %0)) + %0) /u 64)
+ ; CHECK: Loop %bb3.i: max backedge-taken count is 33554431
+ 
+ %struct.FILE = type { i32, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, %struct._IO_marker*, %struct.FILE*, i32, i32, i64, i16, i8, [1 x i8], i8*, i64, i8*, i8*, i8*, i8*, i64, i32, [20 x i8] }
+diff --git a/test/Transforms/IRCE/conjunctive-checks.ll b/test/Transforms/IRCE/conjunctive-checks.ll
+index 60a0af83174..8711c1b00e8 100644
+--- a/test/Transforms/IRCE/conjunctive-checks.ll
++++ b/test/Transforms/IRCE/conjunctive-checks.ll
+@@ -5,17 +5,15 @@ define void @f_0(i32 *%arr, i32 *%a_len_ptr, i32 %n, i1* %cond_buf) {
+ ; CHECK-LABEL: @f_0(
+ 
+ ; CHECK: loop.preheader:
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_safe_range_end:[^ ]+]] = sub i32 3, %len
+-; CHECK: [[not_exit_main_loop_at_hiclamp_cmp:[^ ]+]] = icmp sgt i32 [[not_n]], [[not_safe_range_end]]
+-; CHECK: [[not_exit_main_loop_at_hiclamp:[^ ]+]] = select i1 [[not_exit_main_loop_at_hiclamp_cmp]], i32 [[not_n]], i32 [[not_safe_range_end]]
+-; CHECK: [[exit_main_loop_at_hiclamp:[^ ]+]] = sub i32 -1, [[not_exit_main_loop_at_hiclamp]]
++; CHECK: [[len_sub:[^ ]+]] = add i32 %len, -4
++; CHECK: [[exit_main_loop_at_hiclamp_cmp:[^ ]+]] = icmp slt i32 %n, [[len_sub]]
++; CHECK: [[exit_main_loop_at_hiclamp:[^ ]+]] = select i1 [[exit_main_loop_at_hiclamp_cmp]], i32 %n, i32 [[len_sub]]
+ ; CHECK: [[exit_main_loop_at_loclamp_cmp:[^ ]+]] = icmp sgt i32 [[exit_main_loop_at_hiclamp]], 0
+ ; CHECK: [[exit_main_loop_at_loclamp:[^ ]+]] = select i1 [[exit_main_loop_at_loclamp_cmp]], i32 [[exit_main_loop_at_hiclamp]], i32 0
+ ; CHECK: [[enter_main_loop:[^ ]+]] = icmp slt i32 0, [[exit_main_loop_at_loclamp]]
+-; CHECK: br i1 [[enter_main_loop]], label %loop.preheader2, label %main.pseudo.exit
++; CHECK: br i1 [[enter_main_loop]], label %[[loop_preheader2:[^ ,]+]], label %main.pseudo.exit
+ 
+-; CHECK: loop.preheader2:
++; CHECK: [[loop_preheader2]]:
+ ; CHECK: br label %loop
+ 
+  entry:
+@@ -35,9 +33,9 @@ define void @f_0(i32 *%arr, i32 *%a_len_ptr, i32 %n, i1* %cond_buf) {
+ ; CHECK: loop:
+ ; CHECK:  %cond = load volatile i1, i1* %cond_buf
+ ; CHECK:  %abc = and i1 %cond, true
+-; CHECK:  br i1 %abc, label %in.bounds, label %out.of.bounds.loopexit3, !prof !1
++; CHECK:  br i1 %abc, label %in.bounds, label %[[loop_exit:[^ ,]+]], !prof !1
+ 
+-; CHECK: out.of.bounds.loopexit:
++; CHECK: [[loop_exit]]:
+ ; CHECK:  br label %out.of.bounds
+ 
+  in.bounds:
+@@ -58,14 +56,10 @@ define void @f_1(
+ ; CHECK-LABEL: @f_1(
+ 
+ ; CHECK: loop.preheader:
+-; CHECK: [[not_len_b:[^ ]+]] = sub i32 -1, %len.b
+-; CHECK: [[not_len_a:[^ ]+]] = sub i32 -1, %len.a
+-; CHECK: [[smax_not_len_cond:[^ ]+]] = icmp sgt i32 [[not_len_b]], [[not_len_a]]
+-; CHECK: [[smax_not_len:[^ ]+]] = select i1 [[smax_not_len_cond]], i32 [[not_len_b]], i32 [[not_len_a]]
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_upper_limit_cond_loclamp:[^ ]+]] = icmp sgt i32 [[smax_not_len]], [[not_n]]
+-; CHECK: [[not_upper_limit_loclamp:[^ ]+]] = select i1 [[not_upper_limit_cond_loclamp]], i32 [[smax_not_len]], i32 [[not_n]]
+-; CHECK: [[upper_limit_loclamp:[^ ]+]] = sub i32 -1, [[not_upper_limit_loclamp]]
++; CHECK: [[smax_len_cond:[^ ]+]] = icmp slt i32 %len.b, %len.a
++; CHECK: [[smax_len:[^ ]+]] = select i1 [[smax_len_cond]], i32 %len.b, i32 %len.a
++; CHECK: [[upper_limit_cond_loclamp:[^ ]+]] = icmp slt i32 [[smax_len]], %n 
++; CHECK: [[upper_limit_loclamp:[^ ]+]] = select i1 [[upper_limit_cond_loclamp]], i32 [[smax_len]], i32 %n
+ ; CHECK: [[upper_limit_cmp:[^ ]+]] = icmp sgt i32 [[upper_limit_loclamp]], 0
+ ; CHECK: [[upper_limit:[^ ]+]] = select i1 [[upper_limit_cmp]], i32 [[upper_limit_loclamp]], i32 0
+ 
+@@ -85,9 +79,9 @@ define void @f_1(
+ 
+ ; CHECK: loop:
+ ; CHECK:   %abc = and i1 true, true
+-; CHECK:   br i1 %abc, label %in.bounds, label %out.of.bounds.loopexit4, !prof !1
++; CHECK:   br i1 %abc, label %in.bounds, label %[[oob_loopexit:[^ ,]+]], !prof !1
+ 
+-; CHECK: out.of.bounds.loopexit:
++; CHECK: [[oob_loopexit]]:
+ ; CHECK-NEXT:  br label %out.of.bounds
+ 
+ 
+diff --git a/test/Transforms/IRCE/decrementing-loop.ll b/test/Transforms/IRCE/decrementing-loop.ll
+index 4c82cd3e341..2994a432a71 100644
+--- a/test/Transforms/IRCE/decrementing-loop.ll
++++ b/test/Transforms/IRCE/decrementing-loop.ll
+@@ -29,11 +29,8 @@ define void @decrementing_loop(i32 *%arr, i32 *%a_len_ptr, i32 %n) {
+   ret void
+ 
+ ; CHECK: loop.preheader:
+-; CHECK:   [[not_len:[^ ]+]] = sub i32 -1, %len
+-; CHECK:   [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK:   [[not_len_hiclamp_cmp:[^ ]+]] = icmp sgt i32 [[not_len]], [[not_n]]
+-; CHECK:   [[not_len_hiclamp:[^ ]+]] = select i1 [[not_len_hiclamp_cmp]], i32 [[not_len]], i32 [[not_n]]
+-; CHECK:   [[len_hiclamp:[^ ]+]] = sub i32 -1, [[not_len_hiclamp]]
++; CHECK:   [[len_hiclamp_cmp:[^ ]+]] = icmp slt i32 %len, %n
++; CHECK:   [[len_hiclamp:[^ ]+]] = select i1 [[len_hiclamp_cmp]], i32 %len, i32 %n
+ ; CHECK:   [[not_exit_preloop_at_cmp:[^ ]+]] = icmp sgt i32 [[len_hiclamp]], 0
+ ; CHECK:   [[not_exit_preloop_at:[^ ]+]] = select i1 [[not_exit_preloop_at_cmp]], i32 [[len_hiclamp]], i32 0
+ ; CHECK:   %exit.preloop.at = add i32 [[not_exit_preloop_at]], -1
+diff --git a/test/Transforms/IRCE/multiple-access-no-preloop.ll b/test/Transforms/IRCE/multiple-access-no-preloop.ll
+index 000d1ab36f2..3bde9bd8668 100644
+--- a/test/Transforms/IRCE/multiple-access-no-preloop.ll
++++ b/test/Transforms/IRCE/multiple-access-no-preloop.ll
+@@ -38,14 +38,10 @@ define void @multiple_access_no_preloop(
+ ; CHECK-LABEL: @multiple_access_no_preloop(
+ 
+ ; CHECK: loop.preheader:
+-; CHECK: [[not_len_b:[^ ]+]] = sub i32 -1, %len.b
+-; CHECK: [[not_len_a:[^ ]+]] = sub i32 -1, %len.a
+-; CHECK: [[smax_not_len_cond:[^ ]+]] = icmp sgt i32 [[not_len_b]], [[not_len_a]]
+-; CHECK: [[smax_not_len:[^ ]+]] = select i1 [[smax_not_len_cond]], i32 [[not_len_b]], i32 [[not_len_a]]
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_upper_limit_cond_loclamp:[^ ]+]] = icmp sgt i32 [[smax_not_len]], [[not_n]]
+-; CHECK: [[not_upper_limit_loclamp:[^ ]+]] = select i1 [[not_upper_limit_cond_loclamp]], i32 [[smax_not_len]], i32 [[not_n]]
+-; CHECK: [[upper_limit_loclamp:[^ ]+]] = sub i32 -1, [[not_upper_limit_loclamp]]
++; CHECK: [[smax_len_cond:[^ ]+]] = icmp slt i32 %len.b, %len.a
++; CHECK: [[smax_len:[^ ]+]] = select i1 [[smax_len_cond]], i32 %len.b, i32 %len.a
++; CHECK: [[upper_limit_cond_loclamp:[^ ]+]] = icmp slt i32 [[smax_len]], %n
++; CHECK: [[upper_limit_loclamp:[^ ]+]] = select i1 [[upper_limit_cond_loclamp]], i32 [[smax_len]], i32 %n
+ ; CHECK: [[upper_limit_cmp:[^ ]+]] = icmp sgt i32 [[upper_limit_loclamp]], 0
+ ; CHECK: [[upper_limit:[^ ]+]] = select i1 [[upper_limit_cmp]], i32 [[upper_limit_loclamp]], i32 0
+ 
+diff --git a/test/Transforms/IRCE/ranges_of_different_types.ll b/test/Transforms/IRCE/ranges_of_different_types.ll
+index 5c8161369f2..46bd94ce687 100644
+--- a/test/Transforms/IRCE/ranges_of_different_types.ll
++++ b/test/Transforms/IRCE/ranges_of_different_types.ll
+@@ -23,12 +23,11 @@ define void @test_01(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NOT:     preloop
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 12, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[SMAX:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, [[SMAX]]
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SUB2]], 0
+-; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SUB2]], i32 0
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = add i32 %len, -13
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp slt i32 [[SUB1]], 101
++; CHECK-NEXT:      [[SMAX:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 101
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SMAX]], 0
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SMAX]], i32 0
+ ; CHECK-NEXT:      [[GOTO_LOOP:%[^ ]+]] = icmp slt i32 0, %exit.mainloop.at
+ ; CHECK-NEXT:      br i1 [[GOTO_LOOP]], label %loop.preheader, label %main.pseudo.exit
+ ; CHECK:         loop
+@@ -83,13 +82,11 @@ define void @test_02(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NEXT:      [[LEN_MINUS_SMAX:%[^ ]+]] = add i32 %len, -2147483647
+ ; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[LEN_MINUS_SMAX]], -13
+ ; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[LEN_MINUS_SMAX]], i32 -13
+-; CHECK-NEXT:      [[ADD1:%[^ ]+]] = add i32 [[SMAX1]], -1
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 [[ADD1]], %len
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[SMAX2:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, [[SMAX2]]
+-; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp sgt i32 [[SUB2]], 0
+-; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP3]], i32 [[SUB2]], i32 0
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 %len, [[SMAX1]]
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp slt i32 [[SUB1]], 101
++; CHECK-NEXT:      [[SMAX2:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB1]], i32 101
++; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp sgt i32 [[SMAX2]], 0
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP3]], i32 [[SMAX2]], i32 0
+ ; CHECK-NEXT:      br i1 true, label %loop.preloop.preheader
+ ; CHECK:         loop.preloop:
+ ; CHECK-NEXT:      %idx.preloop = phi i32 [ %idx.next.preloop, %in.bounds.preloop ], [ 0, %loop.preloop.preheader ]
+@@ -151,14 +148,11 @@ define void @test_03(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NOT:     preloop
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 -2, %len
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[SUB2]], -14
+-; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB2]], i32 -14
+-; CHECK-NEXT:      [[SUB3:%[^ ]+]] = sub i32 [[SUB1]], [[SMAX1]]
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp ugt i32 [[SUB3]], -102
+-; CHECK-NEXT:      [[UMAX1:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB3]], i32 -102
+-; CHECK-NEXT:      %exit.mainloop.at = sub i32 -1, [[UMAX1]]
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp slt i32 %len, 13
++; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 %len, i32 13
++; CHECK-NEXT:      [[SUB3:%[^ ]+]] = sub i32 %len, [[SMAX1]]
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp ult i32 [[SUB3]], 101
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SUB3]], i32 101
+ ; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp ult i32 0, %exit.mainloop.at
+ ; CHECK-NEXT:      br i1 [[CMP3]], label %loop.preheader, label %main.pseudo.exit
+ ; CHECK:         postloop:
+@@ -208,10 +202,9 @@ define void @test_04(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-LABEL: test_04(
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 -14, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp ugt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[UMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      %exit.mainloop.at = sub i32 -1, [[UMAX1]]
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = add i32 %len, 13
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp ult i32 [[SUB1]], 101
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP1]], i32 [[SUB1]], i32 101
+ ; CHECK-NEXT:      br i1 true, label %loop.preloop.preheader
+ ; CHECK:         in.bounds.preloop:
+ ; CHECK-NEXT:      %addr.preloop = getelementptr i32, i32* %arr, i32 %idx.preloop
+@@ -252,12 +245,11 @@ define void @test_05(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NOT:     preloop
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 12, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[SMAX:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, [[SMAX]]
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SUB2]], 0
+-; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SUB2]], i32 0
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = add i32 %len, -13
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp slt i32 [[SUB1]], 101
++; CHECK-NEXT:      [[SMAX:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 101
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SMAX]], 0
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SMAX]], i32 0
+ ; CHECK-NEXT:      [[GOTO_LOOP:%[^ ]+]] = icmp slt i32 0, %exit.mainloop.at
+ ; CHECK-NEXT:      br i1 [[GOTO_LOOP]], label %loop.preheader, label %main.pseudo.exit
+ ; CHECK:         loop
+@@ -297,13 +289,11 @@ define void @test_06(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NEXT:      [[LEN_MINUS_SMAX:%[^ ]+]] = add i32 %len, -2147483647
+ ; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[LEN_MINUS_SMAX]], -13
+ ; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[LEN_MINUS_SMAX]], i32 -13
+-; CHECK-NEXT:      [[ADD1:%[^ ]+]] = add i32 [[SMAX1]], -1
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 [[ADD1]], %len
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp sgt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[SMAX2:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, [[SMAX2]]
+-; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp sgt i32 [[SUB2]], 0
+-; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP3]], i32 [[SUB2]], i32 0
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 %len, [[SMAX1]]
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp slt i32 [[SUB1]], 101
++; CHECK-NEXT:      [[SMAX2:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB1]], i32 101
++; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp sgt i32 [[SMAX2]], 0
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP3]], i32 [[SMAX2]], i32 0
+ ; CHECK-NEXT:      br i1 true, label %loop.preloop.preheader
+ ; CHECK:         in.bounds.preloop:
+ ; CHECK-NEXT:      %addr.preloop = getelementptr i32, i32* %arr, i32 %idx.preloop
+@@ -344,14 +334,11 @@ define void @test_07(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-NOT:     preloop
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 -2, %len
+-; CHECK-NEXT:      [[SUB2:%[^ ]+]] = sub i32 -1, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp sgt i32 [[SUB2]], -14
+-; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB2]], i32 -14
+-; CHECK-NEXT:      [[SUB3:%[^ ]+]] = sub i32 [[SUB1]], [[SMAX1]]
+-; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp ugt i32 [[SUB3]], -102
+-; CHECK-NEXT:      [[UMAX1:%[^ ]+]] = select i1 [[CMP2]], i32 [[SUB3]], i32 -102
+-; CHECK-NEXT:      %exit.mainloop.at = sub i32 -1, [[UMAX1]]
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp slt i32 %len, 13
++; CHECK-NEXT:      [[SMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 %len, i32 13
++; CHECK-NEXT:      [[SUB3:%[^ ]+]] = sub i32 %len, [[SMAX1]]
++; CHECK-NEXT:      [[CMP2:%[^ ]+]] = icmp ult i32 [[SUB3]], 101
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP2]], i32 [[SUB3]], i32 101
+ ; CHECK-NEXT:      [[CMP3:%[^ ]+]] = icmp ult i32 0, %exit.mainloop.at
+ ; CHECK-NEXT:      br i1 [[CMP3]], label %loop.preheader, label %main.pseudo.exit
+ ; CHECK:         loop
+@@ -388,10 +375,9 @@ define void @test_08(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK-LABEL: test_08(
+ ; CHECK:         entry:
+ ; CHECK-NEXT:      %len = load i32, i32* %a_len_ptr, !range !0
+-; CHECK-NEXT:      [[SUB1:%[^ ]+]] = sub i32 -14, %len
+-; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp ugt i32 [[SUB1]], -102
+-; CHECK-NEXT:      [[UMAX1:%[^ ]+]] = select i1 [[CMP1]], i32 [[SUB1]], i32 -102
+-; CHECK-NEXT:      %exit.mainloop.at = sub i32 -1, [[UMAX1]]
++; CHECK-NEXT:      [[SUB1:%[^ ]+]] = add i32 %len, 13
++; CHECK-NEXT:      [[CMP1:%[^ ]+]] = icmp ult i32 [[SUB1]], 101
++; CHECK-NEXT:      %exit.mainloop.at = select i1 [[CMP1]], i32 [[SUB1]], i32 101
+ ; CHECK-NEXT:      br i1 true, label %loop.preloop.preheader
+ ; CHECK:         in.bounds.preloop:
+ ; CHECK-NEXT:      %addr.preloop = getelementptr i32, i32* %arr, i32 %idx.preloop
+diff --git a/test/Transforms/IRCE/rc-negative-bound.ll b/test/Transforms/IRCE/rc-negative-bound.ll
+index bfc0cd14778..d226bffeaae 100644
+--- a/test/Transforms/IRCE/rc-negative-bound.ll
++++ b/test/Transforms/IRCE/rc-negative-bound.ll
+@@ -114,49 +114,44 @@ define void @test_03(i32 *%arr, i32 %n, i32 %bound) {
+ ; CHECK:       loop.preheader:
+ ; CHECK-NEXT:    [[TMP0:%.*]] = add i32 [[BOUND:%.*]], -2147483647
+ ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt i32 [[TMP0]], 0
+-; CHECK-NEXT:    [[SMAX:%.*]] = select i1 [[TMP1]], i32 [[TMP0]], i32 0
+-; CHECK-NEXT:    [[TMP2:%.*]] = sub i32 [[BOUND]], [[SMAX]]
+-; CHECK-NEXT:    [[TMP3:%.*]] = sub i32 -1, [[BOUND]]
+-; CHECK-NEXT:    [[TMP4:%.*]] = icmp sgt i32 [[TMP3]], -1
+-; CHECK-NEXT:    [[SMAX1:%.*]] = select i1 [[TMP4]], i32 [[TMP3]], i32 -1
+-; CHECK-NEXT:    [[TMP5:%.*]] = sub i32 -1, [[SMAX1]]
+-; CHECK-NEXT:    [[TMP6:%.*]] = icmp sgt i32 [[TMP5]], -1
+-; CHECK-NEXT:    [[SMAX2:%.*]] = select i1 [[TMP6]], i32 [[TMP5]], i32 -1
+-; CHECK-NEXT:    [[TMP7:%.*]] = add i32 [[SMAX2]], 1
+-; CHECK-NEXT:    [[TMP8:%.*]] = mul i32 [[TMP2]], [[TMP7]]
+-; CHECK-NEXT:    [[TMP9:%.*]] = sub i32 -1, [[TMP8]]
+-; CHECK-NEXT:    [[TMP10:%.*]] = sub i32 -1, [[N]]
+-; CHECK-NEXT:    [[TMP11:%.*]] = icmp sgt i32 [[TMP9]], [[TMP10]]
+-; CHECK-NEXT:    [[SMAX3:%.*]] = select i1 [[TMP11]], i32 [[TMP9]], i32 [[TMP10]]
+-; CHECK-NEXT:    [[TMP12:%.*]] = sub i32 -1, [[SMAX3]]
+-; CHECK-NEXT:    [[TMP13:%.*]] = icmp sgt i32 [[TMP12]], 0
+-; CHECK-NEXT:    [[EXIT_MAINLOOP_AT:%.*]] = select i1 [[TMP13]], i32 [[TMP12]], i32 0
+-; CHECK-NEXT:    [[TMP14:%.*]] = icmp slt i32 0, [[EXIT_MAINLOOP_AT]]
+-; CHECK-NEXT:    br i1 [[TMP14]], label [[LOOP_PREHEADER5:%.*]], label [[MAIN_PSEUDO_EXIT:%.*]]
+-; CHECK:       loop.preheader5:
++; CHECK-NEXT:    [[SMIN:%.*]] = select i1 [[TMP1]], i32 [[TMP0]], i32 0
++; CHECK-NEXT:    [[TMP2:%.*]] = sub i32 [[BOUND]], [[SMIN]]
++; CHECK-NEXT:    [[TMP3:%.*]] = icmp slt i32 [[BOUND]], 0
++; CHECK-NEXT:    [[SMAX:%.*]] = select i1 [[TMP3]], i32 [[BOUND]], i32 0
++; CHECK-NEXT:    [[TMP4:%.*]] = icmp sgt i32 [[SMAX]], -1
++; CHECK-NEXT:    [[SMIN1:%.*]] = select i1 [[TMP4]], i32 [[SMAX]], i32 -1
++; CHECK-NEXT:    [[TMP5:%.*]] = add i32 [[SMIN1]], 1
++; CHECK-NEXT:    [[TMP6:%.*]] = mul i32 [[TMP2]], [[TMP5]]
++; CHECK-NEXT:    [[TMP7:%.*]] = icmp slt i32 [[N]], [[TMP6]]
++; CHECK-NEXT:    [[SMAX2:%.*]] = select i1 [[TMP7]], i32 [[N]], i32 [[TMP6]]
++; CHECK-NEXT:    [[TMP8:%.*]] = icmp sgt i32 [[SMAX2]], 0
++; CHECK-NEXT:    [[EXIT_MAINLOOP_AT:%.*]] = select i1 [[TMP8]], i32 [[SMAX2]], i32 0
++; CHECK-NEXT:    [[TMP9:%.*]] = icmp slt i32 0, [[EXIT_MAINLOOP_AT]]
++; CHECK-NEXT:    br i1 [[TMP9]], label [[LOOP_PREHEADER4:%.*]], label [[MAIN_PSEUDO_EXIT:%.*]]
++; CHECK:       loop.preheader4:
+ ; CHECK-NEXT:    br label [[LOOP:%.*]]
+ ; CHECK:       loop:
+-; CHECK-NEXT:    [[IDX:%.*]] = phi i32 [ [[IDX_NEXT:%.*]], [[IN_BOUNDS:%.*]] ], [ 0, [[LOOP_PREHEADER5]] ]
++; CHECK-NEXT:    [[IDX:%.*]] = phi i32 [ [[IDX_NEXT:%.*]], [[IN_BOUNDS:%.*]] ], [ 0, [[LOOP_PREHEADER4]] ]
+ ; CHECK-NEXT:    [[IDX_NEXT]] = add i32 [[IDX]], 1
+ ; CHECK-NEXT:    [[ABC:%.*]] = icmp slt i32 [[IDX]], [[BOUND]]
+-; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label [[OUT_OF_BOUNDS_LOOPEXIT6:%.*]], !prof !0
++; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label [[OUT_OF_BOUNDS_LOOPEXIT5:%.*]], !prof !0
+ ; CHECK:       in.bounds:
+ ; CHECK-NEXT:    [[ADDR:%.*]] = getelementptr i32, i32* [[ARR:%.*]], i32 [[IDX]]
+ ; CHECK-NEXT:    store i32 0, i32* [[ADDR]]
+ ; CHECK-NEXT:    [[NEXT:%.*]] = icmp slt i32 [[IDX_NEXT]], [[N]]
+-; CHECK-NEXT:    [[TMP15:%.*]] = icmp slt i32 [[IDX_NEXT]], [[EXIT_MAINLOOP_AT]]
+-; CHECK-NEXT:    br i1 [[TMP15]], label [[LOOP]], label [[MAIN_EXIT_SELECTOR:%.*]]
++; CHECK-NEXT:    [[TMP10:%.*]] = icmp slt i32 [[IDX_NEXT]], [[EXIT_MAINLOOP_AT]]
++; CHECK-NEXT:    br i1 [[TMP10]], label [[LOOP]], label [[MAIN_EXIT_SELECTOR:%.*]]
+ ; CHECK:       main.exit.selector:
+ ; CHECK-NEXT:    [[IDX_NEXT_LCSSA:%.*]] = phi i32 [ [[IDX_NEXT]], [[IN_BOUNDS]] ]
+-; CHECK-NEXT:    [[TMP16:%.*]] = icmp slt i32 [[IDX_NEXT_LCSSA]], [[N]]
+-; CHECK-NEXT:    br i1 [[TMP16]], label [[MAIN_PSEUDO_EXIT]], label [[EXIT_LOOPEXIT:%.*]]
++; CHECK-NEXT:    [[TMP11:%.*]] = icmp slt i32 [[IDX_NEXT_LCSSA]], [[N]]
++; CHECK-NEXT:    br i1 [[TMP11]], label [[MAIN_PSEUDO_EXIT]], label [[EXIT_LOOPEXIT:%.*]]
+ ; CHECK:       main.pseudo.exit:
+ ; CHECK-NEXT:    [[IDX_COPY:%.*]] = phi i32 [ 0, [[LOOP_PREHEADER]] ], [ [[IDX_NEXT_LCSSA]], [[MAIN_EXIT_SELECTOR]] ]
+ ; CHECK-NEXT:    [[INDVAR_END:%.*]] = phi i32 [ 0, [[LOOP_PREHEADER]] ], [ [[IDX_NEXT_LCSSA]], [[MAIN_EXIT_SELECTOR]] ]
+ ; CHECK-NEXT:    br label [[POSTLOOP:%.*]]
+ ; CHECK:       out.of.bounds.loopexit:
+ ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS:%.*]]
+-; CHECK:       out.of.bounds.loopexit6:
++; CHECK:       out.of.bounds.loopexit5:
+ ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS]]
+ ; CHECK:       out.of.bounds:
+ ; CHECK-NEXT:    ret void
+@@ -211,47 +206,41 @@ define void @test_04(i32 *%arr, i32 %n, i32 %bound) {
+ ; CHECK-NEXT:    [[FIRST_ITR_CHECK:%.*]] = icmp sgt i32 [[N:%.*]], 0
+ ; CHECK-NEXT:    br i1 [[FIRST_ITR_CHECK]], label [[LOOP_PREHEADER:%.*]], label [[EXIT:%.*]]
+ ; CHECK:       loop.preheader:
+-; CHECK-NEXT:    [[TMP0:%.*]] = sub i32 -1, [[BOUND:%.*]]
+-; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt i32 [[TMP0]], -1
+-; CHECK-NEXT:    [[SMAX:%.*]] = select i1 [[TMP1]], i32 [[TMP0]], i32 -1
+-; CHECK-NEXT:    [[TMP2:%.*]] = add i32 [[BOUND]], [[SMAX]]
+-; CHECK-NEXT:    [[TMP3:%.*]] = add i32 [[TMP2]], 1
+-; CHECK-NEXT:    [[TMP4:%.*]] = sub i32 -1, [[SMAX]]
+-; CHECK-NEXT:    [[TMP5:%.*]] = icmp sgt i32 [[TMP4]], -1
+-; CHECK-NEXT:    [[SMAX1:%.*]] = select i1 [[TMP5]], i32 [[TMP4]], i32 -1
+-; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[SMAX1]], 1
+-; CHECK-NEXT:    [[TMP7:%.*]] = mul i32 [[TMP3]], [[TMP6]]
+-; CHECK-NEXT:    [[TMP8:%.*]] = sub i32 -1, [[TMP7]]
+-; CHECK-NEXT:    [[TMP9:%.*]] = sub i32 -1, [[N]]
+-; CHECK-NEXT:    [[TMP10:%.*]] = icmp ugt i32 [[TMP8]], [[TMP9]]
+-; CHECK-NEXT:    [[UMAX:%.*]] = select i1 [[TMP10]], i32 [[TMP8]], i32 [[TMP9]]
+-; CHECK-NEXT:    [[EXIT_MAINLOOP_AT:%.*]] = sub i32 -1, [[UMAX]]
+-; CHECK-NEXT:    [[TMP11:%.*]] = icmp ult i32 0, [[EXIT_MAINLOOP_AT]]
+-; CHECK-NEXT:    br i1 [[TMP11]], label [[LOOP_PREHEADER2:%.*]], label [[MAIN_PSEUDO_EXIT:%.*]]
+-; CHECK:       loop.preheader2:
++; CHECK-NEXT:    [[TMP0:%.*]] = icmp slt i32 [[BOUND:%.*]], 0
++; CHECK-NEXT:    [[SMAX:%.*]] = select i1 [[TMP0]], i32 [[BOUND]], i32 0
++; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[BOUND]], [[SMAX]]
++; CHECK-NEXT:    [[TMP2:%.*]] = icmp sgt i32 [[SMAX]], -1
++; CHECK-NEXT:    [[SMIN:%.*]] = select i1 [[TMP2]], i32 [[SMAX]], i32 -1
++; CHECK-NEXT:    [[TMP3:%.*]] = add i32 [[SMIN]], 1
++; CHECK-NEXT:    [[TMP4:%.*]] = mul i32 [[TMP1]], [[TMP3]]
++; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult i32 [[N]], [[TMP4]]
++; CHECK-NEXT:    [[EXIT_MAINLOOP_AT:%.*]] = select i1 [[TMP5]], i32 [[N]], i32 [[TMP4]]
++; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 0, [[EXIT_MAINLOOP_AT]]
++; CHECK-NEXT:    br i1 [[TMP6]], label [[LOOP_PREHEADER1:%.*]], label [[MAIN_PSEUDO_EXIT:%.*]]
++; CHECK:       loop.preheader1:
+ ; CHECK-NEXT:    br label [[LOOP:%.*]]
+ ; CHECK:       loop:
+-; CHECK-NEXT:    [[IDX:%.*]] = phi i32 [ [[IDX_NEXT:%.*]], [[IN_BOUNDS:%.*]] ], [ 0, [[LOOP_PREHEADER2]] ]
++; CHECK-NEXT:    [[IDX:%.*]] = phi i32 [ [[IDX_NEXT:%.*]], [[IN_BOUNDS:%.*]] ], [ 0, [[LOOP_PREHEADER1]] ]
+ ; CHECK-NEXT:    [[IDX_NEXT]] = add i32 [[IDX]], 1
+ ; CHECK-NEXT:    [[ABC:%.*]] = icmp slt i32 [[IDX]], [[BOUND]]
+-; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label [[OUT_OF_BOUNDS_LOOPEXIT3:%.*]], !prof !0
++; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label [[OUT_OF_BOUNDS_LOOPEXIT2:%.*]], !prof !0
+ ; CHECK:       in.bounds:
+ ; CHECK-NEXT:    [[ADDR:%.*]] = getelementptr i32, i32* [[ARR:%.*]], i32 [[IDX]]
+ ; CHECK-NEXT:    store i32 0, i32* [[ADDR]]
+ ; CHECK-NEXT:    [[NEXT:%.*]] = icmp ult i32 [[IDX_NEXT]], [[N]]
+-; CHECK-NEXT:    [[TMP12:%.*]] = icmp ult i32 [[IDX_NEXT]], [[EXIT_MAINLOOP_AT]]
+-; CHECK-NEXT:    br i1 [[TMP12]], label [[LOOP]], label [[MAIN_EXIT_SELECTOR:%.*]]
++; CHECK-NEXT:    [[TMP7:%.*]] = icmp ult i32 [[IDX_NEXT]], [[EXIT_MAINLOOP_AT]]
++; CHECK-NEXT:    br i1 [[TMP7]], label [[LOOP]], label [[MAIN_EXIT_SELECTOR:%.*]]
+ ; CHECK:       main.exit.selector:
+ ; CHECK-NEXT:    [[IDX_NEXT_LCSSA:%.*]] = phi i32 [ [[IDX_NEXT]], [[IN_BOUNDS]] ]
+-; CHECK-NEXT:    [[TMP13:%.*]] = icmp ult i32 [[IDX_NEXT_LCSSA]], [[N]]
+-; CHECK-NEXT:    br i1 [[TMP13]], label [[MAIN_PSEUDO_EXIT]], label [[EXIT_LOOPEXIT:%.*]]
++; CHECK-NEXT:    [[TMP8:%.*]] = icmp ult i32 [[IDX_NEXT_LCSSA]], [[N]]
++; CHECK-NEXT:    br i1 [[TMP8]], label [[MAIN_PSEUDO_EXIT]], label [[EXIT_LOOPEXIT:%.*]]
+ ; CHECK:       main.pseudo.exit:
+ ; CHECK-NEXT:    [[IDX_COPY:%.*]] = phi i32 [ 0, [[LOOP_PREHEADER]] ], [ [[IDX_NEXT_LCSSA]], [[MAIN_EXIT_SELECTOR]] ]
+ ; CHECK-NEXT:    [[INDVAR_END:%.*]] = phi i32 [ 0, [[LOOP_PREHEADER]] ], [ [[IDX_NEXT_LCSSA]], [[MAIN_EXIT_SELECTOR]] ]
+ ; CHECK-NEXT:    br label [[POSTLOOP:%.*]]
+ ; CHECK:       out.of.bounds.loopexit:
+ ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS:%.*]]
+-; CHECK:       out.of.bounds.loopexit3:
++; CHECK:       out.of.bounds.loopexit2:
+ ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS]]
+ ; CHECK:       out.of.bounds:
+ ; CHECK-NEXT:    ret void
+@@ -413,49 +402,44 @@ define void @test_07(i32 *%arr, i32 %n, i32 %bound) {
+ ; CHECK:       loop.preheader:
+ ; CHECK-NEXT:    [[TMP0:%.*]] = add i32 [[BOUND:%.*]], -2147483647
+ ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt i32 [[TMP0]], 0
+-; CHECK-NEXT:    [[SMAX:%.*]] = select i1 [[TMP1]], i32 [[TMP0]], i32 0
+-; CHECK-NEXT:    [[TMP2:%.*]] = sub i32 [[BOUND]], [[SMAX]]
+-; CHECK-NEXT:    [[TMP3:%.*]] = sub i32 -1, [[BOUND]]
+-; CHECK-NEXT:    [[TMP4:%.*]] = icmp sgt i32 [[TMP3]], -1
+-; CHECK-NEXT:    [[SMAX1:%.*]] = select i1 [[TMP4]], i32 [[TMP3]], i32 -1
+-; CHECK-NEXT:    [[TMP5:%.*]] = sub i32 -1, [[SMAX1]]
+-; CHECK-NEXT:    [[TMP6:%.*]] = icmp sgt i32 [[TMP5]], -1
+-; CHECK-NEXT:    [[SMAX2:%.*]] = select i1 [[TMP6]], i32 [[TMP5]], i32 -1
+-; CHECK-NEXT:    [[TMP7:%.*]] = add i32 [[SMAX2]], 1
+-; CHECK-NEXT:    [[TMP8:%.*]] = mul i32 [[TMP2]], [[TMP7]]
+-; CHECK-NEXT:    [[TMP9:%.*]] = sub i32 -1, [[TMP8]]
+-; CHECK-NEXT:    [[TMP10:%.*]] = sub i32 -1, [[N]]
+-; CHECK-NEXT:    [[TMP11:%.*]] = icmp sgt i32 [[TMP9]], [[TMP10]]
+-; CHECK-NEXT:    [[SMAX3:%.*]] = select i1 [[TMP11]], i32 [[TMP9]], i32 [[TMP10]]
+-; CHECK-NEXT:    [[TMP12:%.*]] = sub i32 -1, [[SMAX3]]
+-; CHECK-NEXT:    [[TMP13:%.*]] = icmp sgt i32 [[TMP12]], 0
+-; CHECK-NEXT:    [[EXIT_MAINLOOP_AT:%.*]] = select i1 [[TMP13]], i32 [[TMP12]], i32 0
+-; CHECK-NEXT:    [[TMP14:%.*]] = icmp slt i32 0, [[EXIT_MAINLOOP_AT]]
+-; CHECK-NEXT:    br i1 [[TMP14]], label [[LOOP_PREHEADER5:%.*]], label [[MAIN_PSEUDO_EXIT:%.*]]
+-; CHECK:       loop.preheader5:
++; CHECK-NEXT:    [[SMIN:%.*]] = select i1 [[TMP1]], i32 [[TMP0]], i32 0
++; CHECK-NEXT:    [[TMP2:%.*]] = sub i32 [[BOUND]], [[SMIN]]
++; CHECK-NEXT:    [[TMP3:%.*]] = icmp slt i32 [[BOUND]], 0
++; CHECK-NEXT:    [[SMAX:%.*]] = select i1 [[TMP3]], i32 [[BOUND]], i32 0
++; CHECK-NEXT:    [[TMP4:%.*]] = icmp sgt i32 [[SMAX]], -1
++; CHECK-NEXT:    [[SMIN1:%.*]] = select i1 [[TMP4]], i32 [[SMAX]], i32 -1
++; CHECK-NEXT:    [[TMP5:%.*]] = add i32 [[SMIN1]], 1
++; CHECK-NEXT:    [[TMP6:%.*]] = mul i32 [[TMP2]], [[TMP5]]
++; CHECK-NEXT:    [[TMP7:%.*]] = icmp slt i32 [[N]], [[TMP6]]
++; CHECK-NEXT:    [[SMAX2:%.*]] = select i1 [[TMP7]], i32 [[N]], i32 [[TMP6]]
++; CHECK-NEXT:    [[TMP8:%.*]] = icmp sgt i32 [[SMAX2]], 0
++; CHECK-NEXT:    [[EXIT_MAINLOOP_AT:%.*]] = select i1 [[TMP8]], i32 [[SMAX2]], i32 0
++; CHECK-NEXT:    [[TMP9:%.*]] = icmp slt i32 0, [[EXIT_MAINLOOP_AT]]
++; CHECK-NEXT:    br i1 [[TMP9]], label [[LOOP_PREHEADER4:%.*]], label [[MAIN_PSEUDO_EXIT:%.*]]
++; CHECK:       loop.preheader4:
+ ; CHECK-NEXT:    br label [[LOOP:%.*]]
+ ; CHECK:       loop:
+-; CHECK-NEXT:    [[IDX:%.*]] = phi i32 [ [[IDX_NEXT:%.*]], [[IN_BOUNDS:%.*]] ], [ 0, [[LOOP_PREHEADER5]] ]
++; CHECK-NEXT:    [[IDX:%.*]] = phi i32 [ [[IDX_NEXT:%.*]], [[IN_BOUNDS:%.*]] ], [ 0, [[LOOP_PREHEADER4]] ]
+ ; CHECK-NEXT:    [[IDX_NEXT]] = add i32 [[IDX]], 1
+ ; CHECK-NEXT:    [[ABC:%.*]] = icmp ult i32 [[IDX]], [[BOUND]]
+-; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label [[OUT_OF_BOUNDS_LOOPEXIT6:%.*]], !prof !0
++; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label [[OUT_OF_BOUNDS_LOOPEXIT5:%.*]], !prof !0
+ ; CHECK:       in.bounds:
+ ; CHECK-NEXT:    [[ADDR:%.*]] = getelementptr i32, i32* [[ARR:%.*]], i32 [[IDX]]
+ ; CHECK-NEXT:    store i32 0, i32* [[ADDR]]
+ ; CHECK-NEXT:    [[NEXT:%.*]] = icmp slt i32 [[IDX_NEXT]], [[N]]
+-; CHECK-NEXT:    [[TMP15:%.*]] = icmp slt i32 [[IDX_NEXT]], [[EXIT_MAINLOOP_AT]]
+-; CHECK-NEXT:    br i1 [[TMP15]], label [[LOOP]], label [[MAIN_EXIT_SELECTOR:%.*]]
++; CHECK-NEXT:    [[TMP10:%.*]] = icmp slt i32 [[IDX_NEXT]], [[EXIT_MAINLOOP_AT]]
++; CHECK-NEXT:    br i1 [[TMP10]], label [[LOOP]], label [[MAIN_EXIT_SELECTOR:%.*]]
+ ; CHECK:       main.exit.selector:
+ ; CHECK-NEXT:    [[IDX_NEXT_LCSSA:%.*]] = phi i32 [ [[IDX_NEXT]], [[IN_BOUNDS]] ]
+-; CHECK-NEXT:    [[TMP16:%.*]] = icmp slt i32 [[IDX_NEXT_LCSSA]], [[N]]
+-; CHECK-NEXT:    br i1 [[TMP16]], label [[MAIN_PSEUDO_EXIT]], label [[EXIT_LOOPEXIT:%.*]]
++; CHECK-NEXT:    [[TMP11:%.*]] = icmp slt i32 [[IDX_NEXT_LCSSA]], [[N]]
++; CHECK-NEXT:    br i1 [[TMP11]], label [[MAIN_PSEUDO_EXIT]], label [[EXIT_LOOPEXIT:%.*]]
+ ; CHECK:       main.pseudo.exit:
+ ; CHECK-NEXT:    [[IDX_COPY:%.*]] = phi i32 [ 0, [[LOOP_PREHEADER]] ], [ [[IDX_NEXT_LCSSA]], [[MAIN_EXIT_SELECTOR]] ]
+ ; CHECK-NEXT:    [[INDVAR_END:%.*]] = phi i32 [ 0, [[LOOP_PREHEADER]] ], [ [[IDX_NEXT_LCSSA]], [[MAIN_EXIT_SELECTOR]] ]
+ ; CHECK-NEXT:    br label [[POSTLOOP:%.*]]
+ ; CHECK:       out.of.bounds.loopexit:
+ ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS:%.*]]
+-; CHECK:       out.of.bounds.loopexit6:
++; CHECK:       out.of.bounds.loopexit5:
+ ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS]]
+ ; CHECK:       out.of.bounds:
+ ; CHECK-NEXT:    ret void
+@@ -512,47 +496,41 @@ define void @test_08(i32 *%arr, i32 %n, i32 %bound) {
+ ; CHECK-NEXT:    [[FIRST_ITR_CHECK:%.*]] = icmp sgt i32 [[N:%.*]], 0
+ ; CHECK-NEXT:    br i1 [[FIRST_ITR_CHECK]], label [[LOOP_PREHEADER:%.*]], label [[EXIT:%.*]]
+ ; CHECK:       loop.preheader:
+-; CHECK-NEXT:    [[TMP0:%.*]] = sub i32 -1, [[BOUND:%.*]]
+-; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt i32 [[TMP0]], -1
+-; CHECK-NEXT:    [[SMAX:%.*]] = select i1 [[TMP1]], i32 [[TMP0]], i32 -1
+-; CHECK-NEXT:    [[TMP2:%.*]] = add i32 [[BOUND]], [[SMAX]]
+-; CHECK-NEXT:    [[TMP3:%.*]] = add i32 [[TMP2]], 1
+-; CHECK-NEXT:    [[TMP4:%.*]] = sub i32 -1, [[SMAX]]
+-; CHECK-NEXT:    [[TMP5:%.*]] = icmp sgt i32 [[TMP4]], -1
+-; CHECK-NEXT:    [[SMAX1:%.*]] = select i1 [[TMP5]], i32 [[TMP4]], i32 -1
+-; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[SMAX1]], 1
+-; CHECK-NEXT:    [[TMP7:%.*]] = mul i32 [[TMP3]], [[TMP6]]
+-; CHECK-NEXT:    [[TMP8:%.*]] = sub i32 -1, [[TMP7]]
+-; CHECK-NEXT:    [[TMP9:%.*]] = sub i32 -1, [[N]]
+-; CHECK-NEXT:    [[TMP10:%.*]] = icmp ugt i32 [[TMP8]], [[TMP9]]
+-; CHECK-NEXT:    [[UMAX:%.*]] = select i1 [[TMP10]], i32 [[TMP8]], i32 [[TMP9]]
+-; CHECK-NEXT:    [[EXIT_MAINLOOP_AT:%.*]] = sub i32 -1, [[UMAX]]
+-; CHECK-NEXT:    [[TMP11:%.*]] = icmp ult i32 0, [[EXIT_MAINLOOP_AT]]
+-; CHECK-NEXT:    br i1 [[TMP11]], label [[LOOP_PREHEADER2:%.*]], label [[MAIN_PSEUDO_EXIT:%.*]]
+-; CHECK:       loop.preheader2:
++; CHECK-NEXT:    [[TMP0:%.*]] = icmp slt i32 [[BOUND:%.*]], 0
++; CHECK-NEXT:    [[SMAX:%.*]] = select i1 [[TMP0]], i32 [[BOUND]], i32 0
++; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[BOUND]], [[SMAX]]
++; CHECK-NEXT:    [[TMP2:%.*]] = icmp sgt i32 [[SMAX]], -1
++; CHECK-NEXT:    [[SMIN:%.*]] = select i1 [[TMP2]], i32 [[SMAX]], i32 -1
++; CHECK-NEXT:    [[TMP3:%.*]] = add i32 [[SMIN]], 1
++; CHECK-NEXT:    [[TMP4:%.*]] = mul i32 [[TMP1]], [[TMP3]]
++; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult i32 [[N]], [[TMP4]]
++; CHECK-NEXT:    [[EXIT_MAINLOOP_AT:%.*]] = select i1 [[TMP5]], i32 [[N]], i32 [[TMP4]]
++; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 0, [[EXIT_MAINLOOP_AT]]
++; CHECK-NEXT:    br i1 [[TMP6]], label [[LOOP_PREHEADER1:%.*]], label [[MAIN_PSEUDO_EXIT:%.*]]
++; CHECK:       loop.preheader1:
+ ; CHECK-NEXT:    br label [[LOOP:%.*]]
+ ; CHECK:       loop:
+-; CHECK-NEXT:    [[IDX:%.*]] = phi i32 [ [[IDX_NEXT:%.*]], [[IN_BOUNDS:%.*]] ], [ 0, [[LOOP_PREHEADER2]] ]
++; CHECK-NEXT:    [[IDX:%.*]] = phi i32 [ [[IDX_NEXT:%.*]], [[IN_BOUNDS:%.*]] ], [ 0, [[LOOP_PREHEADER1]] ]
+ ; CHECK-NEXT:    [[IDX_NEXT]] = add i32 [[IDX]], 1
+ ; CHECK-NEXT:    [[ABC:%.*]] = icmp ult i32 [[IDX]], [[BOUND]]
+-; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label [[OUT_OF_BOUNDS_LOOPEXIT3:%.*]], !prof !0
++; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label [[OUT_OF_BOUNDS_LOOPEXIT2:%.*]], !prof !0
+ ; CHECK:       in.bounds:
+ ; CHECK-NEXT:    [[ADDR:%.*]] = getelementptr i32, i32* [[ARR:%.*]], i32 [[IDX]]
+ ; CHECK-NEXT:    store i32 0, i32* [[ADDR]]
+ ; CHECK-NEXT:    [[NEXT:%.*]] = icmp ult i32 [[IDX_NEXT]], [[N]]
+-; CHECK-NEXT:    [[TMP12:%.*]] = icmp ult i32 [[IDX_NEXT]], [[EXIT_MAINLOOP_AT]]
+-; CHECK-NEXT:    br i1 [[TMP12]], label [[LOOP]], label [[MAIN_EXIT_SELECTOR:%.*]]
++; CHECK-NEXT:    [[TMP7:%.*]] = icmp ult i32 [[IDX_NEXT]], [[EXIT_MAINLOOP_AT]]
++; CHECK-NEXT:    br i1 [[TMP7]], label [[LOOP]], label [[MAIN_EXIT_SELECTOR:%.*]]
+ ; CHECK:       main.exit.selector:
+ ; CHECK-NEXT:    [[IDX_NEXT_LCSSA:%.*]] = phi i32 [ [[IDX_NEXT]], [[IN_BOUNDS]] ]
+-; CHECK-NEXT:    [[TMP13:%.*]] = icmp ult i32 [[IDX_NEXT_LCSSA]], [[N]]
+-; CHECK-NEXT:    br i1 [[TMP13]], label [[MAIN_PSEUDO_EXIT]], label [[EXIT_LOOPEXIT:%.*]]
++; CHECK-NEXT:    [[TMP8:%.*]] = icmp ult i32 [[IDX_NEXT_LCSSA]], [[N]]
++; CHECK-NEXT:    br i1 [[TMP8]], label [[MAIN_PSEUDO_EXIT]], label [[EXIT_LOOPEXIT:%.*]]
+ ; CHECK:       main.pseudo.exit:
+ ; CHECK-NEXT:    [[IDX_COPY:%.*]] = phi i32 [ 0, [[LOOP_PREHEADER]] ], [ [[IDX_NEXT_LCSSA]], [[MAIN_EXIT_SELECTOR]] ]
+ ; CHECK-NEXT:    [[INDVAR_END:%.*]] = phi i32 [ 0, [[LOOP_PREHEADER]] ], [ [[IDX_NEXT_LCSSA]], [[MAIN_EXIT_SELECTOR]] ]
+ ; CHECK-NEXT:    br label [[POSTLOOP:%.*]]
+ ; CHECK:       out.of.bounds.loopexit:
+ ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS:%.*]]
+-; CHECK:       out.of.bounds.loopexit3:
++; CHECK:       out.of.bounds.loopexit2:
+ ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS]]
+ ; CHECK:       out.of.bounds:
+ ; CHECK-NEXT:    ret void
+diff --git a/test/Transforms/IRCE/single-access-no-preloop.ll b/test/Transforms/IRCE/single-access-no-preloop.ll
+index fb643139c6d..7bf36f7c254 100644
+--- a/test/Transforms/IRCE/single-access-no-preloop.ll
++++ b/test/Transforms/IRCE/single-access-no-preloop.ll
+@@ -86,15 +86,13 @@ define void @single_access_no_preloop_with_offset(i32 *%arr, i32 *%a_len_ptr, i3
+ ; CHECK-LABEL: @single_access_no_preloop_with_offset(
+ 
+ ; CHECK: loop.preheader:
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_safe_range_end:[^ ]+]] = sub i32 3, %len
+-; CHECK: [[not_exit_main_loop_at_hiclamp_cmp:[^ ]+]] = icmp sgt i32 [[not_n]], [[not_safe_range_end]]
+-; CHECK: [[not_exit_main_loop_at_hiclamp:[^ ]+]] = select i1 [[not_exit_main_loop_at_hiclamp_cmp]], i32 [[not_n]], i32 [[not_safe_range_end]]
+-; CHECK: [[exit_main_loop_at_hiclamp:[^ ]+]] = sub i32 -1, [[not_exit_main_loop_at_hiclamp]]
++; CHECK: [[safe_range_end:[^ ]+]] = add i32 %len, -4
++; CHECK: [[exit_main_loop_at_hiclamp_cmp:[^ ]+]] = icmp slt i32 %n, [[safe_range_end]]
++; CHECK: [[exit_main_loop_at_hiclamp:[^ ]+]] = select i1 [[exit_main_loop_at_hiclamp_cmp]], i32 %n, i32 [[safe_range_end]]
+ ; CHECK: [[exit_main_loop_at_loclamp_cmp:[^ ]+]] = icmp sgt i32 [[exit_main_loop_at_hiclamp]], 0
+ ; CHECK: [[exit_main_loop_at_loclamp:[^ ]+]] = select i1 [[exit_main_loop_at_loclamp_cmp]], i32 [[exit_main_loop_at_hiclamp]], i32 0
+ ; CHECK: [[enter_main_loop:[^ ]+]] = icmp slt i32 0, [[exit_main_loop_at_loclamp]]
+-; CHECK: br i1 [[enter_main_loop]], label %loop.preheader2, label %main.pseudo.exit
++; CHECK: br i1 [[enter_main_loop]], label %[[loop_preheader:[^ ,]+]], label %main.pseudo.exit
+ 
+ ; CHECK: loop:
+ ; CHECK: br i1 true, label %in.bounds, label %out.of.bounds
+diff --git a/test/Transforms/IRCE/single-access-with-preloop.ll b/test/Transforms/IRCE/single-access-with-preloop.ll
+index 6f3b0324e39..bd235aa4a73 100644
+--- a/test/Transforms/IRCE/single-access-with-preloop.ll
++++ b/test/Transforms/IRCE/single-access-with-preloop.ll
+@@ -34,11 +34,9 @@ define void @single_access_with_preloop(i32 *%arr, i32 *%a_len_ptr, i32 %n, i32
+ ; CHECK: [[check_min_sint_offset:[^ ]+]] = icmp sgt i32 %offset, -2147483647
+ ; CHECK: [[safe_offset_preloop:[^ ]+]] = select i1 [[check_min_sint_offset]], i32 %offset, i32 -2147483647
+ ; If Offset was a SINT_MIN, we could have an overflow here. That is why we calculated its safe version.
+-; CHECK: [[not_safe_start:[^ ]+]] = add i32 [[safe_offset_preloop]], -1
+-; CHECK: [[not_n:[^ ]+]] = sub i32 -1, %n
+-; CHECK: [[not_exit_preloop_at_cond_loclamp:[^ ]+]] = icmp sgt i32 [[not_safe_start]], [[not_n]]
+-; CHECK: [[not_exit_preloop_at_loclamp:[^ ]+]] = select i1 [[not_exit_preloop_at_cond_loclamp]], i32 [[not_safe_start]], i32 [[not_n]]
+-; CHECK: [[exit_preloop_at_loclamp:[^ ]+]] = sub i32 -1, [[not_exit_preloop_at_loclamp]]
++; CHECK: [[safe_start:[^ ]+]] = sub i32 0, [[safe_offset_preloop]]
++; CHECK: [[exit_preloop_at_cond_loclamp:[^ ]+]] = icmp slt i32 %n, [[safe_start]]
++; CHECK: [[exit_preloop_at_loclamp:[^ ]+]] = select i1 [[exit_preloop_at_cond_loclamp]], i32 %n, i32 [[safe_start]]
+ ; CHECK: [[exit_preloop_at_cond:[^ ]+]] = icmp sgt i32 [[exit_preloop_at_loclamp]], 0
+ ; CHECK: [[exit_preloop_at:[^ ]+]] = select i1 [[exit_preloop_at_cond]], i32 [[exit_preloop_at_loclamp]], i32 0
+ 
+@@ -46,17 +44,15 @@ define void @single_access_with_preloop(i32 *%arr, i32 *%a_len_ptr, i32 %n, i32
+ ; CHECK: [[len_minus_sint_max:[^ ]+]] = add i32 %len, -2147483647
+ ; CHECK: [[check_len_min_sint_offset:[^ ]+]] = icmp sgt i32 %offset, [[len_minus_sint_max]]
+ ; CHECK: [[safe_offset_mainloop:[^ ]+]] = select i1 [[check_len_min_sint_offset]], i32 %offset, i32 [[len_minus_sint_max]]
+-; CHECK: [[not_safe_start_2:[^ ]+]] = add i32 [[safe_offset_mainloop]], -1
+ ; If Offset was a SINT_MIN, we could have an overflow here. That is why we calculated its safe version.
+-; CHECK: [[not_safe_upper_end:[^ ]+]] = sub i32 [[not_safe_start_2]], %len
+-; CHECK: [[not_exit_mainloop_at_cond_loclamp:[^ ]+]] = icmp sgt i32 [[not_safe_upper_end]], [[not_n]]
+-; CHECK: [[not_exit_mainloop_at_loclamp:[^ ]+]] = select i1 [[not_exit_mainloop_at_cond_loclamp]], i32 [[not_safe_upper_end]], i32 [[not_n]]
++; CHECK: [[safe_upper_end:[^ ]+]] = sub i32 %len, [[safe_offset_mainloop]]
++; CHECK: [[exit_mainloop_at_cond_loclamp:[^ ]+]] = icmp slt i32 %n, [[safe_upper_end]]
++; CHECK: [[exit_mainloop_at_loclamp:[^ ]+]] = select i1 [[exit_mainloop_at_cond_loclamp]], i32 %n, i32 [[safe_upper_end]]
+ ; CHECK: [[check_offset_mainloop_2:[^ ]+]] = icmp sgt i32 %offset, 0
+ ; CHECK: [[safe_offset_mainloop_2:[^ ]+]] = select i1 [[check_offset_mainloop_2]], i32 %offset, i32 0
+-; CHECK: [[not_safe_lower_end:[^ ]+]] = add i32 [[safe_offset_mainloop_2]], -2147483648
+-; CHECK: [[not_exit_mainloop_at_cond_hiclamp:[^ ]+]] = icmp sgt i32 [[not_exit_mainloop_at_loclamp]], [[not_safe_lower_end]]
+-; CHECK: [[not_exit_mainloop_at_hiclamp:[^ ]+]] = select i1 [[not_exit_mainloop_at_cond_hiclamp]], i32 [[not_exit_mainloop_at_loclamp]], i32 [[not_safe_lower_end]]
+-; CHECK: [[exit_mainloop_at_hiclamp:[^ ]+]] = sub i32 -1, [[not_exit_mainloop_at_hiclamp]]
++; CHECK: [[safe_lower_end:[^ ]+]] = sub i32 2147483647, [[safe_offset_mainloop_2]]
++; CHECK: [[exit_mainloop_at_cond_hiclamp:[^ ]+]] = icmp slt i32 [[exit_mainloop_at_loclamp]], [[safe_lower_end]]
++; CHECK: [[exit_mainloop_at_hiclamp:[^ ]+]] = select i1 [[exit_mainloop_at_cond_hiclamp]], i32 [[exit_mainloop_at_loclamp]], i32 [[safe_lower_end]]
+ ; CHECK: [[exit_mainloop_at_cmp:[^ ]+]] = icmp sgt i32 [[exit_mainloop_at_hiclamp]], 0
+ ; CHECK: [[exit_mainloop_at:[^ ]+]] = select i1 [[exit_mainloop_at_cmp]], i32 [[exit_mainloop_at_hiclamp]], i32 0
+ 
+@@ -67,7 +63,7 @@ define void @single_access_with_preloop(i32 *%arr, i32 *%a_len_ptr, i32 %n, i32
+ ; CHECK: %abc.high = icmp slt i32 %array.idx, %len
+ ; CHECK: %abc.low = icmp sge i32 %array.idx, 0
+ ; CHECK: %abc = and i1 true, true
+-; CHECK: br i1 %abc, label %in.bounds, label %out.of.bounds.loopexit11
++; CHECK: br i1 %abc, label %in.bounds, label %[[loopexit:[^ ,]+]]
+ 
+ ; CHECK: in.bounds:
+ ; CHECK: [[continue_mainloop_cond:[^ ]+]] = icmp slt i32 %idx.next, [[exit_mainloop_at]]
+diff --git a/test/Transforms/IRCE/unsigned_comparisons_ugt.ll b/test/Transforms/IRCE/unsigned_comparisons_ugt.ll
+index 8f00c733569..3451d65c7bb 100644
+--- a/test/Transforms/IRCE/unsigned_comparisons_ugt.ll
++++ b/test/Transforms/IRCE/unsigned_comparisons_ugt.ll
+@@ -58,8 +58,8 @@ define void @test_02(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK:        entry:
+ ; CHECK-NEXT:     %len = load i32, i32* %a_len_ptr, !range !0
+ ; CHECK-NEXT:     [[COND1:%[^ ]+]] = icmp ugt i32 %len, 1
+-; CHECK-NEXT:     %umax = select i1 [[COND1]], i32 %len, i32 1
+-; CHECK-NEXT:     %exit.preloop.at = add i32 %umax, -1
++; CHECK-NEXT:     [[UMIN:%[^ ]+]] = select i1 [[COND1]], i32 %len, i32 1
++; CHECK-NEXT:     %exit.preloop.at = add i32 [[UMIN]], -1
+ ; CHECK-NEXT:     [[COND2:%[^ ]+]] = icmp ugt i32 100, %exit.preloop.at
+ ; CHECK-NEXT:     br i1 [[COND2]], label %loop.preloop.preheader, label %preloop.pseudo.exit
+ ; CHECK:        mainloop:
+@@ -149,8 +149,8 @@ define void @test_04(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK:        entry:
+ ; CHECK-NEXT:     %len = load i32, i32* %a_len_ptr, !range !0
+ ; CHECK-NEXT:     [[COND1:%[^ ]+]] = icmp ugt i32 %len, 1
+-; CHECK-NEXT:     %umax = select i1 [[COND1]], i32 %len, i32 1
+-; CHECK-NEXT:     %exit.preloop.at = add i32 %umax, -1
++; CHECK-NEXT:     [[UMIN:%[^ ]+]] = select i1 [[COND1]], i32 %len, i32 1
++; CHECK-NEXT:     %exit.preloop.at = add i32 [[UMIN]], -1
+ ; CHECK-NEXT:     [[COND2:%[^ ]+]] = icmp ugt i32 -2147483648, %exit.preloop.at
+ ; CHECK-NEXT:     br i1 [[COND2]], label %loop.preloop.preheader, label %preloop.pseudo.exit
+ ; CHECK:        mainloop:
+diff --git a/test/Transforms/IRCE/unsigned_comparisons_ult.ll b/test/Transforms/IRCE/unsigned_comparisons_ult.ll
+index dc59c11df1b..aca3c3d192e 100644
+--- a/test/Transforms/IRCE/unsigned_comparisons_ult.ll
++++ b/test/Transforms/IRCE/unsigned_comparisons_ult.ll
+@@ -61,8 +61,8 @@ define void @test_02(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK:        entry:
+ ; CHECK-NEXT:     %len = load i32, i32* %a_len_ptr, !range !0
+ ; CHECK-NEXT:     [[COND1:%[^ ]+]] = icmp ugt i32 %len, 1
+-; CHECK-NEXT:     %umax = select i1 [[COND1]], i32 %len, i32 1
+-; CHECK-NEXT:     %exit.preloop.at = add i32 %umax, -1
++; CHECK-NEXT:     [[UMIN:%[^ ]+]] = select i1 [[COND1]], i32 %len, i32 1
++; CHECK-NEXT:     %exit.preloop.at = add i32 [[UMIN]], -1
+ ; CHECK-NEXT:     [[COND2:%[^ ]+]] = icmp ugt i32 100, %exit.preloop.at
+ ; CHECK-NEXT:     br i1 [[COND2]], label %loop.preloop.preheader, label %preloop.pseudo.exit
+ ; CHECK:        mainloop:
+@@ -194,8 +194,8 @@ define void @test_05(i32* %arr, i32* %a_len_ptr) #0 {
+ ; CHECK:        entry:
+ ; CHECK-NEXT:     %len = load i32, i32* %a_len_ptr, !range !0
+ ; CHECK-NEXT:     [[COND1:%[^ ]+]] = icmp ugt i32 %len, 1
+-; CHECK-NEXT:     %umax = select i1 [[COND1]], i32 %len, i32 1
+-; CHECK-NEXT:     %exit.preloop.at = add i32 %umax, -1
++; CHECK-NEXT:     [[UMIN:%[^ ]+]] = select i1 [[COND1]], i32 %len, i32 1
++; CHECK-NEXT:     %exit.preloop.at = add i32 [[UMIN]], -1
+ ; CHECK-NEXT:     [[COND2:%[^ ]+]] = icmp ugt i32 -2147483648, %exit.preloop.at
+ ; CHECK-NEXT:     br i1 [[COND2]], label %loop.preloop.preheader, label %preloop.pseudo.exit
+ ; CHECK:        mainloop:
+diff --git a/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll b/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll
+index ea3f6077231..d5232e1874c 100644
+--- a/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll
++++ b/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll
+@@ -14,8 +14,6 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
+ ; current LSR cost model.
+ ; CHECK-NOT: = ptrtoint i8* undef to i64
+ ; CHECK: .lr.ph
+-; CHECK: [[TMP:%[^ ]+]] = add i64 %tmp{{[0-9]+}}, -1
+-; CHECK: sub i64 [[TMP]], %tmp{{[0-9]+}}
+ ; CHECK: ret void
+ define void @VerifyDiagnosticConsumerTest() unnamed_addr nounwind uwtable align 2 {
+ bb:
+diff --git a/test/Transforms/LoopVectorize/X86/pr35432.ll b/test/Transforms/LoopVectorize/X86/pr35432.ll
+index 1f2a2061586..6aaa13c183a 100644
+--- a/test/Transforms/LoopVectorize/X86/pr35432.ll
++++ b/test/Transforms/LoopVectorize/X86/pr35432.ll
+@@ -27,7 +27,6 @@ define i32 @main() local_unnamed_addr #0 {
+ ; CHECK-NEXT:    [[CMP8:%.*]] = icmp eq i32 [[CONV17]], 0
+ ; CHECK-NEXT:    br i1 [[CMP8]], label [[FOR_BODY_LR_PH:%.*]], label [[FOR_END12:%.*]]
+ ; CHECK:       for.body.lr.ph:
+-; CHECK-NEXT:    [[TMP3:%.*]] = sub i32 -1, [[TMP2]]
+ ; CHECK-NEXT:    br label [[FOR_BODY:%.*]]
+ ; CHECK:       for.body:
+ ; CHECK-NEXT:    [[STOREMERGE_IN9:%.*]] = phi i32 [ [[TMP2]], [[FOR_BODY_LR_PH]] ], [ [[ADD:%.*]], [[FOR_INC9:%.*]] ]
+@@ -37,77 +36,74 @@ define i32 @main() local_unnamed_addr #0 {
+ ; CHECK:       for.body8.lr.ph:
+ ; CHECK-NEXT:    [[CONV3:%.*]] = trunc i32 [[STOREMERGE_IN9]] to i8
+ ; CHECK-NEXT:    [[DOTPROMOTED:%.*]] = load i32, i32* getelementptr inbounds ([192 x [192 x i32]], [192 x [192 x i32]]* @a, i64 0, i64 0, i64 0), align 16
+-; CHECK-NEXT:    [[TMP4:%.*]] = add i8 [[CONV3]], -1
+-; CHECK-NEXT:    [[TMP5:%.*]] = zext i8 [[TMP4]] to i32
+-; CHECK-NEXT:    [[TMP6:%.*]] = sub i32 -1, [[TMP5]]
+-; CHECK-NEXT:    [[TMP7:%.*]] = icmp ugt i32 [[TMP3]], [[TMP6]]
+-; CHECK-NEXT:    [[UMAX:%.*]] = select i1 [[TMP7]], i32 [[TMP3]], i32 [[TMP6]]
+-; CHECK-NEXT:    [[TMP8:%.*]] = add i32 [[UMAX]], 2
+-; CHECK-NEXT:    [[TMP9:%.*]] = add i32 [[TMP8]], [[TMP5]]
+-; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i32 [[TMP9]], 8
++; CHECK-NEXT:    [[TMP3:%.*]] = add i8 [[CONV3]], -1
++; CHECK-NEXT:    [[TMP4:%.*]] = zext i8 [[TMP3]] to i32
++; CHECK-NEXT:    [[TMP5:%.*]] = add i32 [[TMP4]], 1
++; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 [[TMP2]], [[TMP4]]
++; CHECK-NEXT:    [[UMAX:%.*]] = select i1 [[TMP6]], i32 [[TMP2]], i32 [[TMP4]]
++; CHECK-NEXT:    [[TMP7:%.*]] = sub i32 [[TMP5]], [[UMAX]]
++; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i32 [[TMP7]], 8
+ ; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label [[SCALAR_PH:%.*]], label [[VECTOR_SCEVCHECK:%.*]]
+ ; CHECK:       vector.scevcheck:
+-; CHECK-NEXT:    [[TMP10:%.*]] = add i8 [[CONV3]], -1
+-; CHECK-NEXT:    [[TMP11:%.*]] = zext i8 [[TMP10]] to i32
+-; CHECK-NEXT:    [[TMP12:%.*]] = sub i32 -1, [[TMP11]]
+-; CHECK-NEXT:    [[TMP13:%.*]] = icmp ugt i32 [[TMP3]], [[TMP12]]
+-; CHECK-NEXT:    [[UMAX1:%.*]] = select i1 [[TMP13]], i32 [[TMP3]], i32 [[TMP12]]
+-; CHECK-NEXT:    [[TMP14:%.*]] = add i32 [[UMAX1]], 1
+-; CHECK-NEXT:    [[TMP15:%.*]] = add i32 [[TMP14]], [[TMP11]]
+-; CHECK-NEXT:    [[TMP16:%.*]] = trunc i32 [[TMP15]] to i8
+-; CHECK-NEXT:    [[MUL:%.*]] = call { i8, i1 } @llvm.umul.with.overflow.i8(i8 1, i8 [[TMP16]])
++; CHECK-NEXT:    [[TMP8:%.*]] = add i8 [[CONV3]], -1
++; CHECK-NEXT:    [[TMP9:%.*]] = zext i8 [[TMP8]] to i32
++; CHECK-NEXT:    [[TMP10:%.*]] = icmp ult i32 [[TMP2]], [[TMP9]]
++; CHECK-NEXT:    [[UMAX1:%.*]] = select i1 [[TMP10]], i32 [[TMP2]], i32 [[TMP9]]
++; CHECK-NEXT:    [[TMP11:%.*]] = sub i32 [[TMP9]], [[UMAX1]]
++; CHECK-NEXT:    [[TMP12:%.*]] = trunc i32 [[TMP11]] to i8
++; CHECK-NEXT:    [[MUL:%.*]] = call { i8, i1 } @llvm.umul.with.overflow.i8(i8 1, i8 [[TMP12]])
+ ; CHECK-NEXT:    [[MUL_RESULT:%.*]] = extractvalue { i8, i1 } [[MUL]], 0
+ ; CHECK-NEXT:    [[MUL_OVERFLOW:%.*]] = extractvalue { i8, i1 } [[MUL]], 1
+-; CHECK-NEXT:    [[TMP17:%.*]] = add i8 [[TMP10]], [[MUL_RESULT]]
+-; CHECK-NEXT:    [[TMP18:%.*]] = sub i8 [[TMP10]], [[MUL_RESULT]]
+-; CHECK-NEXT:    [[TMP19:%.*]] = icmp ugt i8 [[TMP18]], [[TMP10]]
+-; CHECK-NEXT:    [[TMP20:%.*]] = icmp ult i8 [[TMP17]], [[TMP10]]
+-; CHECK-NEXT:    [[TMP21:%.*]] = select i1 true, i1 [[TMP19]], i1 [[TMP20]]
+-; CHECK-NEXT:    [[TMP22:%.*]] = icmp ugt i32 [[TMP15]], 255
+-; CHECK-NEXT:    [[TMP23:%.*]] = or i1 [[TMP21]], [[TMP22]]
+-; CHECK-NEXT:    [[TMP24:%.*]] = or i1 [[TMP23]], [[MUL_OVERFLOW]]
+-; CHECK-NEXT:    [[TMP25:%.*]] = or i1 false, [[TMP24]]
+-; CHECK-NEXT:    br i1 [[TMP25]], label [[SCALAR_PH]], label [[VECTOR_PH:%.*]]
++; CHECK-NEXT:    [[TMP13:%.*]] = add i8 [[TMP8]], [[MUL_RESULT]]
++; CHECK-NEXT:    [[TMP14:%.*]] = sub i8 [[TMP8]], [[MUL_RESULT]]
++; CHECK-NEXT:    [[TMP15:%.*]] = icmp ugt i8 [[TMP14]], [[TMP8]]
++; CHECK-NEXT:    [[TMP16:%.*]] = icmp ult i8 [[TMP13]], [[TMP8]]
++; CHECK-NEXT:    [[TMP17:%.*]] = select i1 true, i1 [[TMP15]], i1 [[TMP16]]
++; CHECK-NEXT:    [[TMP18:%.*]] = icmp ugt i32 [[TMP11]], 255
++; CHECK-NEXT:    [[TMP19:%.*]] = or i1 [[TMP17]], [[TMP18]]
++; CHECK-NEXT:    [[TMP20:%.*]] = or i1 [[TMP19]], [[MUL_OVERFLOW]]
++; CHECK-NEXT:    [[TMP21:%.*]] = or i1 false, [[TMP20]]
++; CHECK-NEXT:    br i1 [[TMP21]], label [[SCALAR_PH]], label [[VECTOR_PH:%.*]]
+ ; CHECK:       vector.ph:
+-; CHECK-NEXT:    [[N_MOD_VF:%.*]] = urem i32 [[TMP9]], 8
+-; CHECK-NEXT:    [[N_VEC:%.*]] = sub i32 [[TMP9]], [[N_MOD_VF]]
++; CHECK-NEXT:    [[N_MOD_VF:%.*]] = urem i32 [[TMP7]], 8
++; CHECK-NEXT:    [[N_VEC:%.*]] = sub i32 [[TMP7]], [[N_MOD_VF]]
+ ; CHECK-NEXT:    [[CAST_CRD:%.*]] = trunc i32 [[N_VEC]] to i8
+ ; CHECK-NEXT:    [[IND_END:%.*]] = sub i8 [[CONV3]], [[CAST_CRD]]
+-; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <4 x i32> zeroinitializer, i32 [[DOTPROMOTED]], i32 0
++; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <4 x i32> zeroinitializer, i32 [[DOTPROMOTED]], i32 0
+ ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
+ ; CHECK:       vector.body:
+ ; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
+-; CHECK-NEXT:    [[VEC_PHI:%.*]] = phi <4 x i32> [ [[TMP26]], [[VECTOR_PH]] ], [ [[TMP30:%.*]], [[VECTOR_BODY]] ]
+-; CHECK-NEXT:    [[VEC_PHI2:%.*]] = phi <4 x i32> [ zeroinitializer, [[VECTOR_PH]] ], [ [[TMP31:%.*]], [[VECTOR_BODY]] ]
+-; CHECK-NEXT:    [[TMP27:%.*]] = trunc i32 [[INDEX]] to i8
+-; CHECK-NEXT:    [[OFFSET_IDX:%.*]] = sub i8 [[CONV3]], [[TMP27]]
++; CHECK-NEXT:    [[VEC_PHI:%.*]] = phi <4 x i32> [ [[TMP22]], [[VECTOR_PH]] ], [ [[TMP26:%.*]], [[VECTOR_BODY]] ]
++; CHECK-NEXT:    [[VEC_PHI2:%.*]] = phi <4 x i32> [ zeroinitializer, [[VECTOR_PH]] ], [ [[TMP27:%.*]], [[VECTOR_BODY]] ]
++; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[INDEX]] to i8
++; CHECK-NEXT:    [[OFFSET_IDX:%.*]] = sub i8 [[CONV3]], [[TMP23]]
+ ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i8> undef, i8 [[OFFSET_IDX]], i32 0
+ ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i8> [[BROADCAST_SPLATINSERT]], <4 x i8> undef, <4 x i32> zeroinitializer
+ ; CHECK-NEXT:    [[INDUCTION:%.*]] = add <4 x i8> [[BROADCAST_SPLAT]], <i8 0, i8 -1, i8 -2, i8 -3>
+ ; CHECK-NEXT:    [[INDUCTION3:%.*]] = add <4 x i8> [[BROADCAST_SPLAT]], <i8 -4, i8 -5, i8 -6, i8 -7>
+-; CHECK-NEXT:    [[TMP28:%.*]] = add i8 [[OFFSET_IDX]], 0
+-; CHECK-NEXT:    [[TMP29:%.*]] = add i8 [[OFFSET_IDX]], -4
+-; CHECK-NEXT:    [[TMP30]] = add <4 x i32> [[VEC_PHI]], <i32 1, i32 1, i32 1, i32 1>
+-; CHECK-NEXT:    [[TMP31]] = add <4 x i32> [[VEC_PHI2]], <i32 1, i32 1, i32 1, i32 1>
+-; CHECK-NEXT:    [[TMP32:%.*]] = add i8 [[TMP28]], -1
+-; CHECK-NEXT:    [[TMP33:%.*]] = add i8 [[TMP29]], -1
+-; CHECK-NEXT:    [[TMP34:%.*]] = zext i8 [[TMP32]] to i32
+-; CHECK-NEXT:    [[TMP35:%.*]] = zext i8 [[TMP33]] to i32
++; CHECK-NEXT:    [[TMP24:%.*]] = add i8 [[OFFSET_IDX]], 0
++; CHECK-NEXT:    [[TMP25:%.*]] = add i8 [[OFFSET_IDX]], -4
++; CHECK-NEXT:    [[TMP26]] = add <4 x i32> [[VEC_PHI]], <i32 1, i32 1, i32 1, i32 1>
++; CHECK-NEXT:    [[TMP27]] = add <4 x i32> [[VEC_PHI2]], <i32 1, i32 1, i32 1, i32 1>
++; CHECK-NEXT:    [[TMP28:%.*]] = add i8 [[TMP24]], -1
++; CHECK-NEXT:    [[TMP29:%.*]] = add i8 [[TMP25]], -1
++; CHECK-NEXT:    [[TMP30:%.*]] = zext i8 [[TMP28]] to i32
++; CHECK-NEXT:    [[TMP31:%.*]] = zext i8 [[TMP29]] to i32
+ ; CHECK-NEXT:    [[INDEX_NEXT]] = add i32 [[INDEX]], 8
+-; CHECK-NEXT:    [[TMP36:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
+-; CHECK-NEXT:    br i1 [[TMP36]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop !0
++; CHECK-NEXT:    [[TMP32:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
++; CHECK-NEXT:    br i1 [[TMP32]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop !0
+ ; CHECK:       middle.block:
+-; CHECK-NEXT:    [[BIN_RDX:%.*]] = add <4 x i32> [[TMP31]], [[TMP30]]
++; CHECK-NEXT:    [[BIN_RDX:%.*]] = add <4 x i32> [[TMP27]], [[TMP26]]
+ ; CHECK-NEXT:    [[RDX_SHUF:%.*]] = shufflevector <4 x i32> [[BIN_RDX]], <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+ ; CHECK-NEXT:    [[BIN_RDX4:%.*]] = add <4 x i32> [[BIN_RDX]], [[RDX_SHUF]]
+ ; CHECK-NEXT:    [[RDX_SHUF5:%.*]] = shufflevector <4 x i32> [[BIN_RDX4]], <4 x i32> undef, <4 x i32> <i32 1, i32 undef, i32 undef, i32 undef>
+ ; CHECK-NEXT:    [[BIN_RDX6:%.*]] = add <4 x i32> [[BIN_RDX4]], [[RDX_SHUF5]]
+-; CHECK-NEXT:    [[TMP37:%.*]] = extractelement <4 x i32> [[BIN_RDX6]], i32 0
+-; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i32 [[TMP9]], [[N_VEC]]
++; CHECK-NEXT:    [[TMP33:%.*]] = extractelement <4 x i32> [[BIN_RDX6]], i32 0
++; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i32 [[TMP7]], [[N_VEC]]
+ ; CHECK-NEXT:    br i1 [[CMP_N]], label [[FOR_COND4_FOR_INC9_CRIT_EDGE:%.*]], label [[SCALAR_PH]]
+ ; CHECK:       scalar.ph:
+ ; CHECK-NEXT:    [[BC_RESUME_VAL:%.*]] = phi i8 [ [[IND_END]], [[MIDDLE_BLOCK]] ], [ [[CONV3]], [[FOR_BODY8_LR_PH]] ], [ [[CONV3]], [[VECTOR_SCEVCHECK]] ]
+-; CHECK-NEXT:    [[BC_MERGE_RDX:%.*]] = phi i32 [ [[DOTPROMOTED]], [[FOR_BODY8_LR_PH]] ], [ [[DOTPROMOTED]], [[VECTOR_SCEVCHECK]] ], [ [[TMP37]], [[MIDDLE_BLOCK]] ]
++; CHECK-NEXT:    [[BC_MERGE_RDX:%.*]] = phi i32 [ [[DOTPROMOTED]], [[FOR_BODY8_LR_PH]] ], [ [[DOTPROMOTED]], [[VECTOR_SCEVCHECK]] ], [ [[TMP33]], [[MIDDLE_BLOCK]] ]
+ ; CHECK-NEXT:    br label [[FOR_BODY8:%.*]]
+ ; CHECK:       for.body8:
+ ; CHECK-NEXT:    [[INC5:%.*]] = phi i32 [ [[BC_MERGE_RDX]], [[SCALAR_PH]] ], [ [[INC:%.*]], [[FOR_BODY8]] ]
+@@ -118,7 +114,7 @@ define i32 @main() local_unnamed_addr #0 {
+ ; CHECK-NEXT:    [[CMP6:%.*]] = icmp ult i32 [[TMP2]], [[CONV5]]
+ ; CHECK-NEXT:    br i1 [[CMP6]], label [[FOR_BODY8]], label [[FOR_COND4_FOR_INC9_CRIT_EDGE]], !llvm.loop !2
+ ; CHECK:       for.cond4.for.inc9_crit_edge:
+-; CHECK-NEXT:    [[INC_LCSSA:%.*]] = phi i32 [ [[INC]], [[FOR_BODY8]] ], [ [[TMP37]], [[MIDDLE_BLOCK]] ]
++; CHECK-NEXT:    [[INC_LCSSA:%.*]] = phi i32 [ [[INC]], [[FOR_BODY8]] ], [ [[TMP33]], [[MIDDLE_BLOCK]] ]
+ ; CHECK-NEXT:    store i32 [[INC_LCSSA]], i32* getelementptr inbounds ([192 x [192 x i32]], [192 x [192 x i32]]* @a, i64 0, i64 0, i64 0), align 16
+ ; CHECK-NEXT:    br label [[FOR_INC9]]
+ ; CHECK:       for.inc9:

--- a/L/LLVM/v8/bundled/llvm_patches/0008-llvm7-windows-race.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0008-llvm7-windows-race.patch
@@ -1,0 +1,15 @@
+diff --git a/tools/llvm-config/CMakeLists.txt b/tools/llvm-config/CMakeLists.txt
+index f59402ac4b0..5de4c6febe7 100644
+--- a/tools/llvm-config/CMakeLists.txt
++++ b/tools/llvm-config/CMakeLists.txt
+@@ -77,5 +77,10 @@ if(CMAKE_CROSSCOMPILING AND NOT LLVM_CONFIG_PATH)
+   add_custom_target(NativeLLVMConfig DEPENDS ${LLVM_CONFIG_PATH})
+   add_dependencies(NativeLLVMConfig CONFIGURE_LLVM_NATIVE)
+ 
++  # Add a dependency on the host tblgen, which uses the same working
++  # directory and with which we're otherwise racing to build some
++  # of the utility libraries.
++  add_dependencies(NativeLLVMConfig LLVM-tablegen-host)
++
+   add_dependencies(llvm-config NativeLLVMConfig)
+ endif()

--- a/L/LLVM/v8/bundled/llvm_patches/0009-llvm-D57118-powerpc.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0009-llvm-D57118-powerpc.patch
@@ -1,0 +1,30 @@
+commit 812db527538f30ac77a19d755e24109a6db7e569
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Wed Jan 23 16:46:59 2019 -0500
+
+    [CMake][PowerPC] Recognize LLVM_NATIVE_TARGET="ppc64le" as PowerPC
+    
+    Summary:
+    This value is derived from the host triple, which on the machine
+    I'm currently using is `ppc64le-linux-redhat`. This change makes
+    LLVM compile.
+    
+    Reviewers: hfinkel
+    
+    Subscribers: nemanjai, mgorny, jsji, llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D57118
+
+diff --git a/cmake/config-ix.cmake b/cmake/config-ix.cmake
+index 900c35ee4f0..b9c9757a4f6 100644
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -386,6 +386,8 @@ elseif (LLVM_NATIVE_ARCH MATCHES "sparc")
+   set(LLVM_NATIVE_ARCH Sparc)
+ elseif (LLVM_NATIVE_ARCH MATCHES "powerpc")
+   set(LLVM_NATIVE_ARCH PowerPC)
++elseif (LLVM_NATIVE_ARCH MATCHES "ppc64le")
++  set(LLVM_NATIVE_ARCH PowerPC)
+ elseif (LLVM_NATIVE_ARCH MATCHES "aarch64")
+   set(LLVM_NATIVE_ARCH AArch64)
+ elseif (LLVM_NATIVE_ARCH MATCHES "arm64")

--- a/L/LLVM/v8/bundled/llvm_patches/0010-llvm-exegesis-mingw.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0010-llvm-exegesis-mingw.patch
@@ -1,0 +1,24 @@
+From 9ba86352649a39b03adce98670714c4c8eb5341d Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Wed, 24 Jul 2019 21:19:20 -0400
+Subject: [PATCH] Fix build of llvm-exegis on mingw32
+
+---
+ llvm/tools/llvm-exegesis/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/llvm-exegesis/CMakeLists.txt b/tools/llvm-exegesis/CMakeLists.txt
+index a59e1b74024..7a30e0ea98f 100644
+--- a/tools/llvm-exegesis/CMakeLists.txt
++++ b/tools/llvm-exegesis/CMakeLists.txt
+@@ -4,7 +4,7 @@ set(LLVM_LINK_COMPONENTS
+   native
+   )
+ 
+-add_llvm_tool(llvm-exegesis
++add_llvm_tool(llvm-exegesis DISABLE_LLVM_LINK_LLVM_DYLIB
+   llvm-exegesis.cpp
+   )
+ 
+-- 
+2.22.0

--- a/L/LLVM/v8/bundled/llvm_patches/0011-llvm-test-plugin-mingw.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0011-llvm-test-plugin-mingw.patch
@@ -1,0 +1,24 @@
+From 9bd3774db73533c8df475639805ff1516aea274c Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Wed, 24 Jul 2019 21:45:33 -0400
+Subject: [PATCH] add missing components to TestPlugin
+
+---
+ llvm/unittests/Passes/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/unittests/Passes/CMakeLists.txt b/unittests/Passes/CMakeLists.txt
+index 3e83b527958..4b09f47c234 100644
+--- a/unittests/Passes/CMakeLists.txt
++++ b/unittests/Passes/CMakeLists.txt
+@@ -14,7 +14,7 @@ add_llvm_unittest(PluginsTests
+ export_executable_symbols(PluginsTests)
+ target_link_libraries(PluginsTests PRIVATE LLVMTestingSupport)
+ 
+-set(LLVM_LINK_COMPONENTS)
++set(LLVM_LINK_COMPONENTS Support Passes Core)
+ add_llvm_library(TestPlugin MODULE BUILDTREE_ONLY
+   TestPlugin.cpp
+   )
+-- 
+2.22.0

--- a/L/LLVM/v8/bundled/llvm_patches/0012-llvm-6.0-D63688-wasm-isLocal.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0012-llvm-6.0-D63688-wasm-isLocal.patch
@@ -1,0 +1,36 @@
+commit e5f9df1ac59925e12588c6edf4a371175090d203
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Sat Jun 22 19:42:28 2019 -0400
+
+    [Support] Fix build under Emscripten
+    
+    Summary:
+    Emscripten's libc doesn't define MNT_LOCAL, thus causing a build
+    failure in the fallback path. However, to the best of my knowledge,
+    it also doesn't support remote file system mounts, so we may simply
+    return `true` here (as we do for e.g. Fuchsia). With this fix, the
+    core LLVM libraries build correctly under emscripten (though some
+    of the tools and utils do not).
+    
+    Reviewers: kripken
+    
+    Subscribers: kristina, llvm-commits
+    
+    Tags: #llvm
+    
+    Differential Revision: https://reviews.llvm.org/D63688
+
+diff --git a/lib/Support/Unix/Path.inc b/lib/Support/Unix/Path.inc
+index 2ecb97316c8..ea4c8b9db47 100644
+--- a/lib/Support/Unix/Path.inc
++++ b/lib/Support/Unix/Path.inc
+@@ -380,6 +380,9 @@ static bool is_local_impl(struct STATVFS &Vfs) {
+ #elif defined(__CYGWIN__)
+   // Cygwin doesn't expose this information; would need to use Win32 API.
+   return false;
++#elif defined(__EMSCRIPTEN__)
++  // Emscripten doesn't currently support remote filesystem mounts.
++  return true;
+ #elif defined(__sun)
+   // statvfs::f_basetype contains a null-terminated FSType name of the mounted target
+   StringRef fstype(Vfs.f_basetype);

--- a/L/LLVM/v8/bundled/llvm_patches/0013-llvm-6.0-D64032-cmake-cross.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0013-llvm-6.0-D64032-cmake-cross.patch
@@ -1,0 +1,69 @@
+commit e83088cbec5e5798651f02e2ff6b11969994cc86
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Mon Jul 1 16:43:53 2019 -0400
+
+    With utils disabled, don't build tblgen in cross mode
+    
+    Summary:
+    In cross mode, we build a separate NATIVE tblgen that runs on the
+    host and is used during the build. Separately, we have a flag that
+    disables building all executables in utils/. Of course generally,
+    this doesn't turn off tblgen, since we need that during the build.
+    In cross mode, however, that tblegen is useless since we never
+    actually use it. Furthermore, it can be actively problematic if the
+    cross toolchain doesn't like building executables for whatever reason.
+    And even if building executables works fine, we can at least save
+    compile time by omitting it from the target build. There's two changes
+    needed to make this happen:
+    - Stop creating a dependency from the native tool to the target tool.
+      No such dependency is required for a correct build, so I'm not entirely
+      sure why it was there in the first place.
+    - If utils were disabled on the CMake command line and we're in cross mode,
+      respect that by excluding it from the install target (using EXCLUDE_FROM_ALL).
+    
+    Reviewers: smeenai, compnerd, aganea, pzheng
+    
+    Subscribers: mgorny, llvm-commits
+    
+    Tags: #llvm
+    
+    Differential Revision: https://reviews.llvm.org/D64032
+
+diff --git a/cmake/modules/TableGen.cmake b/cmake/modules/TableGen.cmake
+index d1afcb42f9d..095b316d627 100644
+--- a/cmake/modules/TableGen.cmake
++++ b/cmake/modules/TableGen.cmake
+@@ -127,9 +127,6 @@ macro(add_tablegen target project)
+     set(LLVM_ENABLE_OBJLIB ON)
+   endif()
+ 
+-  add_llvm_executable(${target} DISABLE_LLVM_LINK_LLVM_DYLIB ${ARGN})
+-  set(LLVM_LINK_COMPONENTS ${${target}_OLD_LLVM_LINK_COMPONENTS})
+-
+   set(${project}_TABLEGEN "${target}" CACHE
+       STRING "Native TableGen executable. Saves building one when cross-compiling.")
+ 
+@@ -160,15 +157,22 @@ macro(add_tablegen target project)
+                                     CONFIGURATION Release)
+       add_custom_command(OUTPUT ${${project}_TABLEGEN_EXE}
+         COMMAND ${tblgen_build_cmd}
+-        DEPENDS CONFIGURE_LLVM_NATIVE ${target}
++        DEPENDS CONFIGURE_LLVM_NATIVE
+         WORKING_DIRECTORY ${LLVM_NATIVE_BUILD}
+         COMMENT "Building native TableGen..."
+         USES_TERMINAL)
+       add_custom_target(${project}-tablegen-host DEPENDS ${${project}_TABLEGEN_EXE})
+       set(${project}_TABLEGEN_TARGET ${project}-tablegen-host PARENT_SCOPE)
++
++      if ( NOT LLVM_BUILD_UTILS )
++        set(EXCLUDE_FROM_ALL ON)
++      endif()
+     endif()
+   endif()
+ 
++  add_llvm_executable(${target} DISABLE_LLVM_LINK_LLVM_DYLIB ${ARGN})
++  set(LLVM_LINK_COMPONENTS ${${target}_OLD_LLVM_LINK_COMPONENTS})
++
+   if (${project} STREQUAL LLVM AND NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+     if(${target} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+         NOT LLVM_DISTRIBUTION_COMPONENTS)

--- a/L/LLVM/v8/bundled/llvm_patches/0014-llvm-6.0-D64225-cmake-cross2.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0014-llvm-6.0-D64225-cmake-cross2.patch
@@ -1,0 +1,37 @@
+commit 4e47c3ca1fd460a3000a58cd2c37ee0a91f77247
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Thu Jul 4 19:33:56 2019 -0400
+
+    [cmake] Don't set install rules for tblgen if building utils is disabled
+    
+    Summary:
+    This is a follow up to D64032. Afterwards if building utils is disabled
+    and cross compilation is attempted, CMake will complain that adding
+    `install()` directives to targets with EXCLUDE_FROM_ALL set is "undefined".
+    Indeed, it appears depending on the CMake version and the selected
+    Generator, the install rule will error because the underlying target isn't
+    built. Fix that by not adding the install rule if building utils is not
+    requested. Note that this doesn't prevent building tblgen as a
+    dependency in not cross-build, even if building tools is disabled.
+    
+    Reviewers: smeenai
+    
+    Subscribers: mgorny, llvm-commits
+    
+    Tags: #llvm
+    
+    Differential Revision: https://reviews.llvm.org/D64225
+
+diff --git a/cmake/modules/TableGen.cmake b/cmake/modules/TableGen.cmake
+index 095b316d627..75985ba905e 100644
+--- a/cmake/modules/TableGen.cmake
++++ b/cmake/modules/TableGen.cmake
+@@ -173,7 +173,7 @@ macro(add_tablegen target project)
+   add_llvm_executable(${target} DISABLE_LLVM_LINK_LLVM_DYLIB ${ARGN})
+   set(LLVM_LINK_COMPONENTS ${${target}_OLD_LLVM_LINK_COMPONENTS})
+
+-  if (${project} STREQUAL LLVM AND NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
++  if (${project} STREQUAL LLVM AND NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND LLVM_BUILD_UTILS)
+     if(${target} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+         NOT LLVM_DISTRIBUTION_COMPONENTS)
+       set(export_to_llvmexports EXPORT LLVMExports)

--- a/L/LLVM/v8/bundled/llvm_patches/0015-llvm-8.0-D66401-mingw-reloc.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0015-llvm-8.0-D66401-mingw-reloc.patch
@@ -1,0 +1,69 @@
+diff --git a/test/CodeGen/X86/mingw-refptr.ll b/test/CodeGen/X86/mingw-refptr.ll
+--- a/test/CodeGen/X86/mingw-refptr.ll
++++ b/test/CodeGen/X86/mingw-refptr.ll
+@@ -1,5 +1,6 @@
+ ; RUN: llc < %s -mtriple=x86_64-w64-mingw32 | FileCheck %s -check-prefix=CHECK-X64
+ ; RUN: llc < %s -mtriple=i686-w64-mingw32 | FileCheck %s -check-prefix=CHECK-X86
++; RUN: llc < %s -mtriple=i686-w64-mingw32-none-elf | FileCheck %s -check-prefix=CHECK-X86-ELF
+ 
+ @var = external local_unnamed_addr global i32, align 4
+ @dsolocalvar = external dso_local local_unnamed_addr global i32, align 4
+@@ -16,6 +17,9 @@
+ ; CHECK-X86:    movl .refptr._var, %eax
+ ; CHECK-X86:    movl (%eax), %eax
+ ; CHECK-X86:    retl
++; CHECK-X86-ELF-LABEL: getVar:
++; CHECK-X86-ELF:    movl var, %eax
++; CHECK-X86-ELF:    retl
+ entry:
+   %0 = load i32, i32* @var, align 4
+   ret i32 %0
+@@ -66,6 +70,9 @@
+ ; CHECK-X86:    movl __imp__extvar, %eax
+ ; CHECK-X86:    movl (%eax), %eax
+ ; CHECK-X86:    retl
++; CHECK-X86-ELF-LABEL: getExtVar:
++; CHECK-X86-ELF:    movl extvar, %eax
++; CHECK-X86-ELF:    retl
+ entry:
+   %0 = load i32, i32* @extvar, align 4
+   ret i32 %0
+diff --git a/lib/Target/X86/X86Subtarget.cpp b/lib/Target/X86/X86Subtarget.cpp
+--- a/lib/Target/X86/X86Subtarget.cpp
++++ b/lib/Target/X86/X86Subtarget.cpp
+@@ -146,6 +146,9 @@
+       return X86II::MO_DLLIMPORT;
+     return X86II::MO_COFFSTUB;
+   }
++  // Some JIT users use *-win32-elf triples; these shouldn't use GOT tables.
++  if (isOSWindows())
++    return X86II::MO_NO_FLAG;
+ 
+   if (is64Bit()) {
+     // ELF supports a large, truly PIC code model with non-PC relative GOT
+diff --git a/lib/Target/TargetMachine.cpp b/lib/Target/TargetMachine.cpp
+--- a/lib/Target/TargetMachine.cpp
++++ b/lib/Target/TargetMachine.cpp
+@@ -128,8 +128,8 @@
+   // don't assume the variables to be DSO local unless we actually know
+   // that for sure. This only has to be done for variables; for functions
+   // the linker can insert thunks for calling functions from another DLL.
+-  if (TT.isWindowsGNUEnvironment() && GV && GV->isDeclarationForLinker() &&
+-      isa<GlobalVariable>(GV))
++  if (TT.isWindowsGNUEnvironment() && TT.isOSBinFormatCOFF() && GV &&
++      GV->isDeclarationForLinker() && isa<GlobalVariable>(GV))
+     return false;
+ 
+   // On COFF, don't mark 'extern_weak' symbols as DSO local. If these symbols
+@@ -142,7 +142,9 @@
+   // Make an exception for windows OS in the triple: Some firmware builds use
+   // *-win32-macho triples. This (accidentally?) produced windows relocations
+   // without GOT tables in older clang versions; Keep this behaviour.
+-  if (TT.isOSBinFormatCOFF() || (TT.isOSWindows() && TT.isOSBinFormatMachO()))
++  // Some JIT users use *-win32-elf triples; these shouldn't use GOT tables
++  // either.
++  if (TT.isOSBinFormatCOFF() || TT.isOSWindows())
+     return true;
+ 
+   // Most PIC code sequences that assume that a symbol is local cannot
+

--- a/L/LLVM/v8/bundled/llvm_patches/0016-llvm7-revert-D44485.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0016-llvm7-revert-D44485.patch
@@ -1,0 +1,94 @@
+From 4370214628487ac8495f963ae05960b5ecc31103 Mon Sep 17 00:00:00 2001
+From: Jameson Nash <vtjnash@gmail.com>
+Date: Thu, 12 Sep 2019 11:45:07 -0400
+Subject: [PATCH] Revert "[MC] Always emit relocations for same-section
+ function references"
+
+This reverts commit 9232972575cafac29c3e4817c8714c9aca0e8585.
+---
+ lib/MC/WinCOFFObjectWriter.cpp | 12 +++++-------
+ test/MC/COFF/diff.s            | 25 ++++++++-----------------
+ 2 files changed, 13 insertions(+), 24 deletions(-)
+
+diff --git a/lib/MC/WinCOFFObjectWriter.cpp b/lib/MC/WinCOFFObjectWriter.cpp
+index 9ffecd99df6..0214161e03c 100644
+--- a/lib/MC/WinCOFFObjectWriter.cpp
++++ b/lib/MC/WinCOFFObjectWriter.cpp
+@@ -690,14 +690,12 @@ void WinCOFFObjectWriter::executePostLayoutBinding(MCAssembler &Asm,
+ bool WinCOFFObjectWriter::isSymbolRefDifferenceFullyResolvedImpl(
+     const MCAssembler &Asm, const MCSymbol &SymA, const MCFragment &FB,
+     bool InSet, bool IsPCRel) const {
+-  // Don't drop relocations between functions, even if they are in the same text
+-  // section. Multiple Visual C++ linker features depend on having the
+-  // relocations present. The /INCREMENTAL flag will cause these relocations to
+-  // point to thunks, and the /GUARD:CF flag assumes that it can use relocations
+-  // to approximate the set of all address taken functions. LLD's implementation
+-  // of /GUARD:CF also relies on the existance of these relocations.
++  // MS LINK expects to be able to replace all references to a function with a
++  // thunk to implement their /INCREMENTAL feature.  Make sure we don't optimize
++  // away any relocations to functions.
+   uint16_t Type = cast<MCSymbolCOFF>(SymA).getType();
+-  if ((Type >> COFF::SCT_COMPLEX_TYPE_SHIFT) == COFF::IMAGE_SYM_DTYPE_FUNCTION)
++  if (Asm.isIncrementalLinkerCompatible() &&
++      (Type >> COFF::SCT_COMPLEX_TYPE_SHIFT) == COFF::IMAGE_SYM_DTYPE_FUNCTION)
+     return false;
+   return MCObjectWriter::isSymbolRefDifferenceFullyResolvedImpl(Asm, SymA, FB,
+                                                                 InSet, IsPCRel);
+diff --git a/test/MC/COFF/diff.s b/test/MC/COFF/diff.s
+index f89e4ed8901..d68e628577b 100644
+--- a/test/MC/COFF/diff.s
++++ b/test/MC/COFF/diff.s
+@@ -1,14 +1,19 @@
+ // RUN: llvm-mc -filetype=obj -triple i686-pc-mingw32 %s | llvm-readobj -s -sr -sd | FileCheck %s
+ 
+-// COFF resolves differences between labels in the same section, unless that
+-// label is declared with function type.
+-
+ .section baz, "xr"
++	.def	X
++	.scl	2;
++	.type	32;
++	.endef
+ 	.globl	X
+ X:
+ 	mov	Y-X+42,	%eax
+ 	retl
+ 
++	.def	Y
++	.scl	2;
++	.type	32;
++	.endef
+ 	.globl	Y
+ Y:
+ 	retl
+@@ -25,11 +30,6 @@ _foobar:                                # @foobar
+ # %bb.0:
+ 	ret
+ 
+-	.globl	_baz
+-_baz:
+-	calll	_foobar
+-	retl
+-
+ 	.data
+ 	.globl	_rust_crate             # @rust_crate
+ 	.align	4
+@@ -39,15 +39,6 @@ _rust_crate:
+ 	.long	_foobar-_rust_crate
+ 	.long	_foobar-_rust_crate
+ 
+-// Even though _baz and _foobar are in the same .text section, we keep the
+-// relocation for compatibility with the VC linker's /guard:cf and /incremental
+-// flags, even on mingw.
+-
+-// CHECK:        Name: .text
+-// CHECK:        Relocations [
+-// CHECK-NEXT:     0x12 IMAGE_REL_I386_REL32 _foobar
+-// CHECK-NEXT:   ]
+-
+ // CHECK:        Name: .data
+ // CHECK:        Relocations [
+ // CHECK-NEXT:     0x4 IMAGE_REL_I386_DIR32 _foobar
+-- 
+2.17.1
+

--- a/L/LLVM/v8/bundled/llvm_patches/0017-llvm-8.0-D55758-tablegen-cond.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0017-llvm-8.0-D55758-tablegen-cond.patch
@@ -1,0 +1,794 @@
+From 95135c5a18ee14ca091d3513cc7801521d4eb204 Mon Sep 17 00:00:00 2001
+From: Javed Absar <javed.absar@arm.com>
+Date: Fri, 25 Jan 2019 10:25:25 +0000
+Subject: [PATCH] [TblGen] Extend !if semantics through new feature !cond
+
+This patch extends TableGen language with !cond operator.
+Instead of embedding !if inside !if which can get cumbersome,
+one can now use !cond.
+Below is an example to convert an integer 'x' into a string:
+
+    !cond(!lt(x,0) : "Negative",
+          !eq(x,0) : "Zero",
+          !eq(x,1) : "One,
+          1        : "MoreThanOne")
+
+Reviewed By: hfinkel, simon_tatham, greened
+Differential Revision: https://reviews.llvm.org/D55758
+
+llvm-svn: 352185
+---
+ docs/TableGen/LangIntro.rst          |  14 +++
+ docs/TableGen/LangRef.rst            |  10 +-
+ include/llvm/TableGen/Record.h       |  78 ++++++++++++++++
+ lib/TableGen/Record.cpp              | 131 +++++++++++++++++++++++++++
+ lib/TableGen/TGLexer.cpp             |   1 +
+ lib/TableGen/TGLexer.h               |   2 +-
+ lib/TableGen/TGParser.cpp            |  90 ++++++++++++++++++
+ lib/TableGen/TGParser.h              |   1 +
+ test/TableGen/cond-bitlist.td        |  27 ++++++
+ test/TableGen/cond-default.td        |  11 +++
+ test/TableGen/cond-empty-list-arg.td |   8 ++
+ test/TableGen/cond-inheritance.td    |  22 +++++
+ test/TableGen/cond-let.td            |  36 ++++++++
+ test/TableGen/cond-list.td           |  38 ++++++++
+ test/TableGen/cond-subclass.td       |  27 ++++++
+ test/TableGen/cond-type.td           |  11 +++
+ test/TableGen/cond-usage.td          |  29 ++++++
+ test/TableGen/condsbit.td            |  15 +++
+ 18 files changed, 549 insertions(+), 2 deletions(-)
+ create mode 100644 llvm/test/TableGen/cond-bitlist.td
+ create mode 100644 llvm/test/TableGen/cond-default.td
+ create mode 100644 llvm/test/TableGen/cond-empty-list-arg.td
+ create mode 100644 llvm/test/TableGen/cond-inheritance.td
+ create mode 100644 llvm/test/TableGen/cond-let.td
+ create mode 100644 llvm/test/TableGen/cond-list.td
+ create mode 100644 llvm/test/TableGen/cond-subclass.td
+ create mode 100644 llvm/test/TableGen/cond-type.td
+ create mode 100644 llvm/test/TableGen/cond-usage.td
+ create mode 100644 llvm/test/TableGen/condsbit.td
+
+diff --git a/docs/TableGen/LangIntro.rst b/docs/TableGen/LangIntro.rst
+index ea46550ffc0..390f941f0ca 100644
+--- a/docs/TableGen/LangIntro.rst
++++ b/docs/TableGen/LangIntro.rst
+@@ -258,6 +258,20 @@ supported include:
+ ``!if(a,b,c)``
+   'b' if the result of 'int' or 'bit' operator 'a' is nonzero, 'c' otherwise.
+ 
++``!cond(condition_1 : val1, condition_2 : val2, ..., condition_n : valn)``
++    Instead of embedding !if inside !if which can get cumbersome,
++    one can use !cond. !cond returns 'val1' if the result of 'int' or 'bit'
++    operator 'condition1' is nonzero. Otherwise, it checks 'condition2'.
++    If 'condition2' is nonzero, returns 'val2', and so on.
++    If all conditions are zero, it reports an error.
++
++    Below is an example to convert an integer 'x' into a string:
++
++    !cond(!lt(x,0) : "Negative",
++          !eq(x,0) : "Zero",
++          !eq(x,1) : "One,
++          1        : "MoreThanOne")
++
+ ``!eq(a,b)``
+     'bit 1' if string a is equal to string b, 0 otherwise.  This only operates
+     on string, int and bit objects.  Use !cast<string> to compare other types of
+diff --git a/docs/TableGen/LangRef.rst b/docs/TableGen/LangRef.rst
+index 2efee12ec9d..a3dbf363151 100644
+--- a/docs/TableGen/LangRef.rst
++++ b/docs/TableGen/LangRef.rst
+@@ -102,6 +102,12 @@ wide variety of meanings:
+                :!isa    !dag     !le      !lt        !ge
+                :!gt     !ne
+ 
++TableGen also has !cond operator that needs a slightly different
++syntax compared to other "bang operators":
++
++.. productionlist::
++   CondOperator: !cond
++
+ 
+ Syntax
+ ======
+@@ -140,7 +146,7 @@ considered to define the class if any of the following is true:
+ #. The :token:`Body` in the :token:`ObjectBody` is present and is not empty.
+ #. The :token:`BaseClassList` in the :token:`ObjectBody` is present.
+ 
+-You can declare an empty class by giving and empty :token:`TemplateArgList`
++You can declare an empty class by giving an empty :token:`TemplateArgList`
+ and an empty :token:`ObjectBody`. This can serve as a restricted form of
+ forward declaration: note that records deriving from the forward-declared
+ class will inherit no fields from it since the record expansion is done
+@@ -315,6 +321,8 @@ The initial :token:`DagArg` is called the "operator" of the dag.
+ 
+ .. productionlist::
+    SimpleValue: `BangOperator` ["<" `Type` ">"] "(" `ValueListNE` ")"
++              :| `CondOperator` "(" `CondVal` ("," `CondVal`)* ")"
++   CondVal: `Value` ":" `Value`
+ 
+ Bodies
+ ------
+diff --git a/include/llvm/TableGen/Record.h b/include/llvm/TableGen/Record.h
+index e022bc82b4e..3ca67ec72bd 100644
+--- a/include/llvm/TableGen/Record.h
++++ b/include/llvm/TableGen/Record.h
+@@ -316,6 +316,7 @@ protected:
+     IK_TernOpInit,
+     IK_UnOpInit,
+     IK_LastOpInit,
++    IK_CondOpInit,
+     IK_FoldOpInit,
+     IK_IsAOpInit,
+     IK_StringInit,
+@@ -912,6 +913,83 @@ public:
+   std::string getAsString() const override;
+ };
+ 
++/// !cond(condition_1: value1, ... , condition_n: value)
++/// Selects the first value for which condition is true.
++/// Otherwise reports an error.
++class CondOpInit final : public TypedInit, public FoldingSetNode,
++                      public TrailingObjects<CondOpInit, Init *> {
++  unsigned NumConds;
++  RecTy *ValType;
++
++  CondOpInit(unsigned NC, RecTy *Type)
++    : TypedInit(IK_CondOpInit, Type),
++      NumConds(NC), ValType(Type) {}
++
++  size_t numTrailingObjects(OverloadToken<Init *>) const {
++    return 2*NumConds;
++  }
++
++public:
++  CondOpInit(const CondOpInit &) = delete;
++  CondOpInit &operator=(const CondOpInit &) = delete;
++
++  static bool classof(const Init *I) {
++    return I->getKind() == IK_CondOpInit;
++  }
++
++  static CondOpInit *get(ArrayRef<Init*> C, ArrayRef<Init*> V,
++                        RecTy *Type);
++
++  void Profile(FoldingSetNodeID &ID) const;
++
++  RecTy *getValType() const { return ValType; }
++
++  unsigned getNumConds() const { return NumConds; }
++
++  Init *getCond(unsigned Num) const {
++    assert(Num < NumConds && "Condition number out of range!");
++    return getTrailingObjects<Init *>()[Num];
++  }
++
++  Init *getVal(unsigned Num) const {
++    assert(Num < NumConds && "Val number out of range!");
++    return getTrailingObjects<Init *>()[Num+NumConds];
++  }
++
++  ArrayRef<Init *> getConds() const {
++    return makeArrayRef(getTrailingObjects<Init *>(), NumConds);
++  }
++
++  ArrayRef<Init *> getVals() const {
++    return makeArrayRef(getTrailingObjects<Init *>()+NumConds, NumConds);
++  }
++
++  Init *Fold(Record *CurRec) const;
++
++  Init *resolveReferences(Resolver &R) const override;
++
++  bool isConcrete() const override;
++  bool isComplete() const override;
++  std::string getAsString() const override;
++
++  using const_case_iterator = SmallVectorImpl<Init*>::const_iterator;
++  using const_val_iterator = SmallVectorImpl<Init*>::const_iterator;
++
++  inline const_case_iterator  arg_begin() const { return getConds().begin(); }
++  inline const_case_iterator  arg_end  () const { return getConds().end(); }
++
++  inline size_t              case_size () const { return NumConds; }
++  inline bool                case_empty() const { return NumConds == 0; }
++
++  inline const_val_iterator name_begin() const { return getVals().begin();}
++  inline const_val_iterator name_end  () const { return getVals().end(); }
++
++  inline size_t              val_size () const { return NumConds; }
++  inline bool                val_empty() const { return NumConds == 0; }
++
++  Init *getBit(unsigned Bit) const override;
++};
++
+ /// !foldl (a, b, expr, start, lst) - Fold over a list.
+ class FoldOpInit : public TypedInit, public FoldingSetNode {
+ private:
+diff --git a/lib/TableGen/Record.cpp b/lib/TableGen/Record.cpp
+index cf1685a2e8c..26ffe761b66 100644
+--- a/lib/TableGen/Record.cpp
++++ b/lib/TableGen/Record.cpp
+@@ -1694,6 +1694,137 @@ Init *FieldInit::Fold(Record *CurRec) const {
+   return const_cast<FieldInit *>(this);
+ }
+ 
++static void ProfileCondOpInit(FoldingSetNodeID &ID,
++                             ArrayRef<Init *> CondRange,
++                             ArrayRef<Init *> ValRange,
++                             const RecTy *ValType) {
++  assert(CondRange.size() == ValRange.size() &&
++         "Number of conditions and values must match!");
++  ID.AddPointer(ValType);
++  ArrayRef<Init *>::iterator Case = CondRange.begin();
++  ArrayRef<Init *>::iterator Val = ValRange.begin();
++
++  while (Case != CondRange.end()) {
++    ID.AddPointer(*Case++);
++    ID.AddPointer(*Val++);
++  }
++}
++
++void CondOpInit::Profile(FoldingSetNodeID &ID) const {
++  ProfileCondOpInit(ID,
++      makeArrayRef(getTrailingObjects<Init *>(), NumConds),
++      makeArrayRef(getTrailingObjects<Init *>() + NumConds, NumConds),
++      ValType);
++}
++
++CondOpInit *
++CondOpInit::get(ArrayRef<Init *> CondRange,
++                ArrayRef<Init *> ValRange, RecTy *Ty) {
++  assert(CondRange.size() == ValRange.size() &&
++         "Number of conditions and values must match!");
++
++  static FoldingSet<CondOpInit> ThePool;
++  FoldingSetNodeID ID;
++  ProfileCondOpInit(ID, CondRange, ValRange, Ty);
++
++  void *IP = nullptr;
++  if (CondOpInit *I = ThePool.FindNodeOrInsertPos(ID, IP))
++    return I;
++
++  void *Mem = Allocator.Allocate(totalSizeToAlloc<Init *>(2*CondRange.size()),
++                                 alignof(BitsInit));
++  CondOpInit *I = new(Mem) CondOpInit(CondRange.size(), Ty);
++
++  std::uninitialized_copy(CondRange.begin(), CondRange.end(),
++                          I->getTrailingObjects<Init *>());
++  std::uninitialized_copy(ValRange.begin(), ValRange.end(),
++                          I->getTrailingObjects<Init *>()+CondRange.size());
++  ThePool.InsertNode(I, IP);
++  return I;
++}
++
++Init *CondOpInit::resolveReferences(Resolver &R) const {
++  SmallVector<Init*, 4> NewConds;
++  bool Changed = false;
++  for (const Init *Case : getConds()) {
++    Init *NewCase = Case->resolveReferences(R);
++    NewConds.push_back(NewCase);
++    Changed |= NewCase != Case;
++  }
++
++  SmallVector<Init*, 4> NewVals;
++  for (const Init *Val : getVals()) {
++    Init *NewVal = Val->resolveReferences(R);
++    NewVals.push_back(NewVal);
++    Changed |= NewVal != Val;
++  }
++
++  if (Changed)
++    return (CondOpInit::get(NewConds, NewVals,
++            getValType()))->Fold(R.getCurrentRecord());
++
++  return const_cast<CondOpInit *>(this);
++}
++
++Init *CondOpInit::Fold(Record *CurRec) const {
++  for ( unsigned i = 0; i < NumConds; ++i) {
++    Init *Cond = getCond(i);
++    Init *Val = getVal(i);
++
++    if (IntInit *CondI = dyn_cast_or_null<IntInit>(
++            Cond->convertInitializerTo(IntRecTy::get()))) {
++      if (CondI->getValue())
++        return Val->convertInitializerTo(getValType());
++    } else
++     return const_cast<CondOpInit *>(this);
++  }
++
++  PrintFatalError(CurRec->getLoc(),
++                  CurRec->getName() +
++                  " does not have any true condition in:" +
++                  this->getAsString());
++  return nullptr;
++}
++
++bool CondOpInit::isConcrete() const {
++  for (const Init *Case : getConds())
++    if (!Case->isConcrete())
++      return false;
++
++  for (const Init *Val : getVals())
++    if (!Val->isConcrete())
++      return false;
++
++  return true;
++}
++
++bool CondOpInit::isComplete() const {
++  for (const Init *Case : getConds())
++    if (!Case->isComplete())
++      return false;
++
++  for (const Init *Val : getVals())
++    if (!Val->isConcrete())
++      return false;
++
++  return true;
++}
++
++std::string CondOpInit::getAsString() const {
++  std::string Result = "!cond(";
++  for (unsigned i = 0; i < getNumConds(); i++) {
++    Result += getCond(i)->getAsString() + ": ";
++    Result += getVal(i)->getAsString();
++    if (i != getNumConds()-1)
++      Result += ", ";
++  }
++  return Result + ")";
++}
++
++Init *CondOpInit::getBit(unsigned Bit) const {
++  return VarBitInit::get(const_cast<CondOpInit *>(this), Bit);
++}
++
+ static void ProfileDagInit(FoldingSetNodeID &ID, Init *V, StringInit *VN,
+                            ArrayRef<Init *> ArgRange,
+                            ArrayRef<StringInit *> NameRange) {
+diff --git a/lib/TableGen/TGLexer.cpp b/lib/TableGen/TGLexer.cpp
+index 16aeee56107..f733cc3c134 100644
+--- a/lib/TableGen/TGLexer.cpp
++++ b/lib/TableGen/TGLexer.cpp
+@@ -545,6 +545,7 @@ tgtok::TokKind TGLexer::LexExclaim() {
+     .Case("ge", tgtok::XGe)
+     .Case("gt", tgtok::XGt)
+     .Case("if", tgtok::XIf)
++    .Case("cond", tgtok::XCond)
+     .Case("isa", tgtok::XIsA)
+     .Case("head", tgtok::XHead)
+     .Case("tail", tgtok::XTail)
+diff --git a/lib/TableGen/TGLexer.h b/lib/TableGen/TGLexer.h
+index e9980b36b97..9bdb01cf3dd 100644
+--- a/lib/TableGen/TGLexer.h
++++ b/lib/TableGen/TGLexer.h
+@@ -51,7 +51,7 @@ namespace tgtok {
+ 
+     // !keywords.
+     XConcat, XADD, XAND, XOR, XSRA, XSRL, XSHL, XListConcat, XStrConcat, XCast,
+-    XSubst, XForEach, XFoldl, XHead, XTail, XSize, XEmpty, XIf, XEq, XIsA, XDag,
++    XSubst, XForEach, XFoldl, XHead, XTail, XSize, XEmpty, XIf, XCond, XEq, XIsA, XDag,
+     XNe, XLe, XLt, XGe, XGt,
+ 
+     // Integer value.
+diff --git a/lib/TableGen/TGParser.cpp b/lib/TableGen/TGParser.cpp
+index 1d1f3603c83..200190acd59 100644
+--- a/lib/TableGen/TGParser.cpp
++++ b/lib/TableGen/TGParser.cpp
+@@ -1445,6 +1445,9 @@ Init *TGParser::ParseOperation(Record *CurRec, RecTy *ItemType) {
+     return (TernOpInit::get(Code, LHS, MHS, RHS, Type))->Fold(CurRec);
+   }
+ 
++  case tgtok::XCond:
++    return ParseOperationCond(CurRec, ItemType);
++
+   case tgtok::XFoldl: {
+     // Value ::= !foldl '(' Id ',' Id ',' Value ',' Value ',' Value ')'
+     Lex.Lex(); // eat the operation
+@@ -1603,6 +1606,91 @@ RecTy *TGParser::ParseOperatorType() {
+   return Type;
+ }
+ 
++Init *TGParser::ParseOperationCond(Record *CurRec, RecTy *ItemType) {
++  Lex.Lex();  // eat the operation 'cond'
++
++  if (Lex.getCode() != tgtok::l_paren) {
++     TokError("expected '(' after !cond operator");
++     return nullptr;
++  }
++  Lex.Lex();  // eat the '('
++
++  // Parse through '[Case: Val,]+'
++  SmallVector<Init *, 4> Case;
++  SmallVector<Init *, 4> Val;
++  while (true) {
++    if (Lex.getCode() == tgtok::r_paren) {
++      Lex.Lex(); // eat the ')'
++      break;
++    }
++
++    Init *V = ParseValue(CurRec);
++    if (!V)
++      return nullptr;
++    Case.push_back(V);
++
++    if (Lex.getCode() != tgtok::colon) {
++      TokError("expected ':'  following a condition in !cond operator");
++      return nullptr;
++    }
++    Lex.Lex(); // eat the ':'
++
++    V = ParseValue(CurRec, ItemType);
++    if (!V)
++      return nullptr;
++    Val.push_back(V);
++
++    if (Lex.getCode() == tgtok::r_paren) {
++      Lex.Lex(); // eat the ')'
++      break;
++    }
++
++    if (Lex.getCode() != tgtok::comma) {
++      TokError("expected ',' or ')' following a value in !cond operator");
++      return nullptr;
++    }
++    Lex.Lex();  // eat the ','
++  }
++
++  if (Case.size() < 1) {
++    TokError("there should be at least 1 'condition : value' in the !cond operator");
++    return nullptr;
++  }
++
++  // resolve type
++  RecTy *Type = nullptr;
++  for (Init *V : Val) {
++    RecTy *VTy = nullptr;
++    if (TypedInit *Vt = dyn_cast<TypedInit>(V))
++      VTy = Vt->getType();
++    if (BitsInit *Vbits = dyn_cast<BitsInit>(V))
++      VTy = BitsRecTy::get(Vbits->getNumBits());
++    if (isa<BitInit>(V))
++      VTy = BitRecTy::get();
++
++    if (Type == nullptr) {
++      if (!isa<UnsetInit>(V))
++        Type = VTy;
++    } else {
++      if (!isa<UnsetInit>(V)) {
++        RecTy *RType = resolveTypes(Type, VTy);
++        if (!RType) {
++          TokError(Twine("inconsistent types '") + Type->getAsString() +
++                         "' and '" + VTy->getAsString() + "' for !cond");
++          return nullptr;
++        }
++        Type = RType;
++      }
++    }
++  }
++
++  if (!Type) {
++    TokError("could not determine type for !cond from its arguments");
++    return nullptr;
++  }
++  return CondOpInit::get(Case, Val, Type)->Fold(CurRec);
++}
++
+ /// ParseSimpleValue - Parse a tblgen value.  This returns null on error.
+ ///
+ ///   SimpleValue ::= IDValue
+@@ -1621,6 +1709,7 @@ RecTy *TGParser::ParseOperatorType() {
+ ///   SimpleValue ::= SRLTOK '(' Value ',' Value ')'
+ ///   SimpleValue ::= LISTCONCATTOK '(' Value ',' Value ')'
+ ///   SimpleValue ::= STRCONCATTOK '(' Value ',' Value ')'
++///   SimpleValue ::= COND '(' [Value ':' Value,]+ ')'
+ ///
+ Init *TGParser::ParseSimpleValue(Record *CurRec, RecTy *ItemType,
+                                  IDParseMode Mode) {
+@@ -1933,6 +2022,7 @@ Init *TGParser::ParseSimpleValue(Record *CurRec, RecTy *ItemType,
+   case tgtok::XListConcat:
+   case tgtok::XStrConcat:   // Value ::= !binop '(' Value ',' Value ')'
+   case tgtok::XIf:
++  case tgtok::XCond:
+   case tgtok::XFoldl:
+   case tgtok::XForEach:
+   case tgtok::XSubst: {  // Value ::= !ternop '(' Value ',' Value ',' Value ')'
+diff --git a/lib/TableGen/TGParser.h b/lib/TableGen/TGParser.h
+index e3849043513..215b9dad770 100644
+--- a/lib/TableGen/TGParser.h
++++ b/lib/TableGen/TGParser.h
+@@ -194,6 +194,7 @@ private:  // Parser methods.
+   bool ParseRangePiece(SmallVectorImpl<unsigned> &Ranges);
+   RecTy *ParseType();
+   Init *ParseOperation(Record *CurRec, RecTy *ItemType);
++  Init *ParseOperationCond(Record *CurRec, RecTy *ItemType);
+   RecTy *ParseOperatorType();
+   Init *ParseObjectName(MultiClass *CurMultiClass);
+   Record *ParseClassID();
+diff --git a/test/TableGen/cond-bitlist.td b/test/TableGen/cond-bitlist.td
+new file mode 100644
+index 00000000000..bce615838df
+--- /dev/null
++++ b/test/TableGen/cond-bitlist.td
+@@ -0,0 +1,27 @@
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++class S<int s> {
++  bits<2> val = !cond(!eq(s, 8):  {0, 0},
++                      !eq(s, 16): 0b01,
++                      !eq(s, 32): 2,
++                      !eq(s, 64): {1, 1},
++                              1 : ?);
++}
++
++def D8  : S<8>;
++def D16 : S<16>;
++def D32 : S<32>;
++def D64 : S<64>;
++def D128: S<128>;
++// CHECK: def D128
++// CHECK-NEXT: bits<2> val = { ?, ? };
++// CHECK: def D16
++// CHECK-NEXT: bits<2> val = { 0, 1 };
++// CHECK: def D32
++// CHECK-NEXT: bits<2> val = { 1, 0 };
++// CHECK: def D64
++// CHECK-NEXT: bits<2> val = { 1, 1 };
++// CHECK: def D8
++// CHECK-NEXT: bits<2> val = { 0, 0 };
++
+diff --git a/test/TableGen/cond-default.td b/test/TableGen/cond-default.td
+new file mode 100644
+index 00000000000..816bf10676f
+--- /dev/null
++++ b/test/TableGen/cond-default.td
+@@ -0,0 +1,11 @@
++// Check that not specifying a valid condition results in error
++
++// RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
++// XFAIL: vg_leak
++
++class C<int x> {
++  string s  = !cond(!lt(x,0) : "negative", !gt(x,0) : "positive");
++}
++
++def Zero : C<0>;
++//CHECK: error: Zero does not have any true condition in:!cond(0: "negative", 0: "positive")
+diff --git a/test/TableGen/cond-empty-list-arg.td b/test/TableGen/cond-empty-list-arg.td
+new file mode 100644
+index 00000000000..5f4ccade169
+--- /dev/null
++++ b/test/TableGen/cond-empty-list-arg.td
+@@ -0,0 +1,8 @@
++// RUN: llvm-tblgen %s
++// XFAIL: vg_leak
++
++class C<bit cond> {
++  bit true = 1;
++  list<int> X = !cond(cond: [1, 2, 3], true : []);
++  list<int> Y = !cond(cond: [], true : [4, 5, 6]);
++}
+diff --git a/test/TableGen/cond-inheritance.td b/test/TableGen/cond-inheritance.td
+new file mode 100644
+index 00000000000..4b4abdf72f3
+--- /dev/null
++++ b/test/TableGen/cond-inheritance.td
+@@ -0,0 +1,22 @@
++// Make sure !cond gets propagated across multiple layers of inheritance.
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++class getInt<int c> {
++  int ret = !cond(c: 0, 1 : 1);
++}
++
++class I1<int c> {
++  int i = getInt<c>.ret;
++}
++
++class I2<int c> : I1<c>;
++
++def DI1: I1<1>;
++// CHECK: def DI1 {     // I1
++// CHECK-NEXT: int i = 0;
++
++// CHECK: def DI2 {     // I1 I2
++// CHECK-NEXT: int i = 0;
++def DI2: I2<1>;
++
+diff --git a/test/TableGen/cond-let.td b/test/TableGen/cond-let.td
+new file mode 100644
+index 00000000000..044878f2ab8
+--- /dev/null
++++ b/test/TableGen/cond-let.td
+@@ -0,0 +1,36 @@
++// Check support for `!cond' operator as part of a `let' statement.
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++
++class C<bits<3> x, bits<4> y, bit z> {
++  bits<16> n;
++
++  let n{11}  = !cond(y{3}: 1,
++                     y{2}: x{0},
++                     y{1}: x{1},
++                     y{0}: x{2},
++                     {1} :?);
++  let n{10-9}= !cond(x{2}: y{3-2},
++                     x{1}: y{2-1},
++                     x{1}: y{1-0},
++                     {1} : ?);
++  let n{8-6} = !cond(x{2}: 0b010,  1 : 0b110);
++  let n{5-4} = !cond(x{1}: y{3-2}, 1 :  {0, 1});
++  let n{3-0} = !cond(x{0}: y{3-0}, 1 : {z, y{2}, y{1}, y{0}});
++}
++
++
++def C1 : C<{1, 0, 1}, {0, 1, 0, 1}, 0>;
++def C2 : C<{0, 1, 0}, {1, 0, 1, 0}, 1>;
++def C3 : C<{0, 0, 0}, {1, 0, 1, 0}, 0>;
++def C4 : C<{0, 0, 0}, {0, 0, 0, 0}, 0>;
++
++// CHECK: def C1
++// CHECK-NEXT: bits<16> n = { ?, ?, ?, ?, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1 };
++// CHECK: def C2
++// CHECK-NEXT: bits<16> n = { ?, ?, ?, ?, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0 };
++// CHECK: def C3
++// CHECK-NEXT: bits<16> n = { ?, ?, ?, ?, 1, ?, ?, 1, 1, 0, 0, 1, 0, 0, 1, 0 };
++// CHECK: def C4
++// CHECK-NEXT: bits<16> n = { ?, ?, ?, ?, ?, ?, ?, 1, 1, 0, 0, 1, 0, 0, 0, 0 };
+diff --git a/test/TableGen/cond-list.td b/test/TableGen/cond-list.td
+new file mode 100644
+index 00000000000..aa013cea4e1
+--- /dev/null
++++ b/test/TableGen/cond-list.td
+@@ -0,0 +1,38 @@
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++
++class A<list<list<int>> vals> {
++  list<int> first = vals[0];
++  list<int> rest  = !cond(!empty(!tail(vals)): vals[0],
++                          1                 : vals[1]);
++}
++
++def A_OneEl : A<[[1,2,3]]>;
++// CHECK:      def A_OneEl {  // A
++// CHECK-NEXT: list<int> first = [1, 2, 3];
++// CHECK-NEXT: list<int> rest = [1, 2, 3];
++// CHECK-NEXT: }
++
++def A_TwoEl : A<[[1,2,3], [4,5,6]]>;
++// CHECK:      def A_TwoEl { // A
++// CHECK-NEXT: list<int> first = [1, 2, 3];
++// CHECK-NEXT: list<int> rest = [4, 5, 6];
++// CHECK-NEXT: }
++
++
++class B<list<int> v> {
++  list<int> vals = v;
++}
++class BB<list<list<int>> vals> : B<!cond(!empty(!tail(vals)): vals[0],  1 : vals[1])>;
++class BBB<list<list<int>> vals> : BB<vals>;
++
++def B_OneEl : BBB<[[1,2,3]]>;
++// CHECK:      def B_OneEl { //  B BB BBB
++// CHECK-NEXT: list<int> vals = [1, 2, 3];
++// CHECK-NEXT: }
++
++def B_TwoEl : BBB<[[1,2,3],[4,5,6]]>;
++// CHECK:      def B_TwoEl { // B BB BBB
++// CHECK-NEXT: list<int> vals = [4, 5, 6];
++// CHECK-NEXT: }
+diff --git a/test/TableGen/cond-subclass.td b/test/TableGen/cond-subclass.td
+new file mode 100644
+index 00000000000..9f6f6e2cb8c
+--- /dev/null
++++ b/test/TableGen/cond-subclass.td
+@@ -0,0 +1,27 @@
++// Check that !cond with operands of different subtypes can
++// initialize a supertype variable.
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++class E<int dummy> {}
++class E1<int dummy> : E<dummy> {}
++class E2<int dummy> : E<dummy> {}
++
++class EX<int cc, E1 b, E2 c> {
++  E x = !cond(cc: b, 1 : c);
++}
++
++def E1d : E1<0>;
++def E2d : E2<0>;
++
++def EXd1 : EX<1, E1d, E2d>;
++def EXd2 : EX<0, E1d, E2d>;
++
++// CHECK: def EXd1 {
++// CHECK:   E x = E1d;
++// CHECK: }
++//
++// CHECK: def EXd2 {
++// CHECK:   E x = E2d;
++// CHECK: }
++
+diff --git a/test/TableGen/cond-type.td b/test/TableGen/cond-type.td
+new file mode 100644
+index 00000000000..fd2a3cc52b7
+--- /dev/null
++++ b/test/TableGen/cond-type.td
+@@ -0,0 +1,11 @@
++// RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
++// XFAIL: vg_leak
++
++class A<int dummy> {}
++class B<int dummy> : A<dummy> {}
++class C<int dummy> : A<dummy> {}
++
++// CHECK: Value 'x' of type 'C' is incompatible with initializer '{{.*}}' of type 'A'
++class X<int cc, B b, C c> {
++  C x = !cond(cc: b, 1 : c);
++}
+diff --git a/test/TableGen/cond-usage.td b/test/TableGen/cond-usage.td
+new file mode 100644
+index 00000000000..055fd6d7c69
+--- /dev/null
++++ b/test/TableGen/cond-usage.td
+@@ -0,0 +1,29 @@
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++// Check that !cond picks the first true value
++// CHECK:       class A
++// CHECK-NEXT:  string S = !cond(!eq(A:x, 10): "ten", !eq(A:x, 11): "eleven", !eq(A:x, 10): "TEN", !gt(A:x, 9): "MoreThanNine", 1: "unknown"); 
++// CHECK: B1
++// CHECK-NEXT: string S = "unknown"
++// CHECK: B10
++// CHECK-NEXT: string S = "ten";
++// CHECK: def B11
++// CHECK-NEXT: string S = "eleven";
++// CHECK: def B12
++// CHECK-NEXT:  string S = "MoreThanNine";
++// CHECK: def B9
++// CHECK-NEXT: string S = "unknown"
++
++class A<int x> {
++  string S = !cond(!eq(x,10) : "ten",
++                   !eq(x,11) : "eleven",
++                   !eq(x,10) : "TEN",
++                   !gt(x,9) : "MoreThanNine",
++                   !eq(1,1) : "unknown");
++}
++def B1  : A<1>;
++def B9  : A<9>;
++def B10 : A<10>;
++def B11 : A<11>;
++def B12 : A<12>;
+diff --git a/test/TableGen/condsbit.td b/test/TableGen/condsbit.td
+new file mode 100644
+index 00000000000..e08ac97f68b
+--- /dev/null
++++ b/test/TableGen/condsbit.td
+@@ -0,0 +1,15 @@
++// check that !cond works well with bit conditional values
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++// CHECK: a = 6
++// CHECK: a = 5
++
++class A<bit b = 1> {
++  bit true = 1;
++  int a = !cond(b: 5, true : 6);
++  bit c = !cond(b: 0, true : 1);
++  bits<1> d = !cond(b: 0, true : 1);
++}
++
++def X : A<0>;
++def Y : A;
+-- 
+2.17.1
+

--- a/L/LLVM/v8/bundled/llvm_patches/0018-llvm-8.0-D59389-refactor-wmma.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0018-llvm-8.0-D59389-refactor-wmma.patch
@@ -1,0 +1,899 @@
+From e9737bf498597707d084398b9485676dc7421644 Mon Sep 17 00:00:00 2001
+From: Artem Belevich <tra@google.com>
+Date: Thu, 25 Apr 2019 22:27:35 +0000
+Subject: [PATCH] [NVPTX] Refactor generation of MMA intrinsics and
+ instructions. NFC.
+
+Generalized constructions of 'fragments' of MMA operations to provide
+common primitives for construction of the ops. This will make it easier
+to add new variants of the instructions that operate on integer types.
+
+Use nested foreach loops which makes it possible to better control
+naming of the intrinsics.
+
+This patch does not affect LLVM's output, so there are no test changes.
+
+Differential Revision: https://reviews.llvm.org/D59389
+
+llvm-svn: 359245
+---
+ include/llvm/IR/IntrinsicsNVVM.td   | 258 ++++++--------
+ lib/Target/NVPTX/NVPTXIntrinsics.td | 512 ++++++++++------------------
+ 2 files changed, 295 insertions(+), 475 deletions(-)
+
+diff --git a/include/llvm/IR/IntrinsicsNVVM.td b/include/llvm/IR/IntrinsicsNVVM.td
+index 7f694f68969..e30a27613a6 100644
+--- a/include/llvm/IR/IntrinsicsNVVM.td
++++ b/include/llvm/IR/IntrinsicsNVVM.td
+@@ -38,6 +38,69 @@ def llvm_anyi64ptr_ty     : LLVMAnyPointerType<llvm_i64_ty>;     // (space)i64*
+ // MISC
+ //
+ 
++// Helper class for construction of n-element list<LLVMtype> [t,t,...,t]
++class RepLLVMType<int N, LLVMType T> {
++  list<LLVMType> ret = !if(N, !listconcat(RepLLVMType<!add(N,-1), T>.ret, [T]), []);
++}
++
++// Helper class that represents a 'fragment' of an NVPTX *MMA instruction.
++// Geom: m<M>n<N>k<K>. E.g. m8n32k16
++// Frag: [abcd]
++// PtxEltType: PTX type for the element.
++class WMMA_REGS<string Geom, string Frag, string PtxEltType> {
++  string geom = Geom;
++  string frag = Frag;
++  string ptx_elt_type = PtxEltType;
++  string ft = frag#":"#ptx_elt_type;
++  list<LLVMType> regs = !cond(
++    // fp16 -> fp16/fp32 @  m16n16k16/m8n32k16/m32n8k16
++    // All currently supported geometries use the same fragment format,
++    // so we only need to consider {fragment, type}.
++    !eq(ft,"a:f16") : RepLLVMType<8, llvm_v2f16_ty>.ret,
++    !eq(ft,"b:f16") : RepLLVMType<8, llvm_v2f16_ty>.ret,
++    !eq(ft,"c:f16") : RepLLVMType<4, llvm_v2f16_ty>.ret,
++    !eq(ft,"d:f16") : RepLLVMType<4, llvm_v2f16_ty>.ret,
++    !eq(ft,"c:f32") : RepLLVMType<8, llvm_float_ty>.ret,
++    !eq(ft,"d:f32") : RepLLVMType<8, llvm_float_ty>.ret);
++}
++
++class WMMA_NAME_LDST<string Op, WMMA_REGS Frag, string Layout, int WithStride> {
++  string intr = "llvm.nvvm.wmma."
++                # Frag.geom
++                # "." # Op
++                # "." # Frag.frag
++                # "." # Layout
++                # !if(WithStride, ".stride", "")
++                # "." # Frag.ptx_elt_type
++                ;
++  // TODO(tra): record name should ideally use the same field order as the intrinsic.
++  // E.g. string record = !subst("llvm", "int",
++  //                      !subst(".", "_", llvm));
++  string record = "int_nvvm_wmma_"
++                # Frag.geom
++                # "_" # Op
++                # "_" # Frag.frag
++                # "_" # Frag.ptx_elt_type
++                # "_" # Layout
++                # !if(WithStride, "_stride", "");
++}
++
++class WMMA_NAME_MMA<string ALayout, string BLayout,
++                    WMMA_REGS C, WMMA_REGS D,
++                    int Satfinite> {
++  string llvm = "llvm.nvvm.wmma."
++                # C.geom
++                # ".mma"
++                # "." # ALayout
++                # "." # BLayout
++                # "." # D.ptx_elt_type  // Intrinsic encodes 'd' first.
++                # "." # C.ptx_elt_type
++                # !if(Satfinite, ".satfinite", "");
++
++  string record = !subst(".", "_",
++                  !subst("llvm.", "int_", llvm));
++}
++
+ let TargetPrefix = "nvvm" in {
+   def int_nvvm_prmt : GCCBuiltin<"__nvvm_prmt">,
+       Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
+@@ -3882,166 +3945,69 @@ def int_nvvm_match_all_sync_i64p :
+ //
+ // WMMA instructions
+ //
+-
+ // WMMA.LOAD
+-class NVVM_WMMA_LD_GALSTS<string Geometry, string Abc, string Layout,
+-                          string Type, LLVMType regty, int WithStride>
+-  : Intrinsic<!if(!eq(Abc#Type,"cf16"),
+-                  [regty, regty, regty, regty],
+-                  [regty, regty, regty, regty,
+-                   regty, regty, regty, regty]),
++class NVVM_WMMA_LD<WMMA_REGS Frag, string Layout, int WithStride>
++  : Intrinsic<Frag.regs,
+               !if(WithStride, [llvm_anyptr_ty, llvm_i32_ty], [llvm_anyptr_ty]),
+               [IntrReadMem, IntrArgMemOnly, ReadOnly<0>, NoCapture<0>],
+-              "llvm.nvvm.wmma."
+-                # Geometry
+-                # ".load"
+-                # "." # Abc
+-                # "." # Layout
+-                # !if(WithStride, ".stride", "")
+-                # "." # Type>;
+-
+-multiclass NVVM_WMMA_LD_GALT<string Geometry, string Abc, string Layout,
+-                             string Type, LLVMType regty> {
+-  def _stride: NVVM_WMMA_LD_GALSTS<Geometry, Abc, Layout, Type, regty, 1>;
+-  def NAME   : NVVM_WMMA_LD_GALSTS<Geometry, Abc, Layout, Type, regty, 0>;
+-}
+-
+-multiclass NVVM_WMMA_LD_GAT<string Geometry, string Abc,
+-                           string Type, LLVMType regty> {
+-  defm _row: NVVM_WMMA_LD_GALT<Geometry, Abc, "row", Type, regty>;
+-  defm _col: NVVM_WMMA_LD_GALT<Geometry, Abc, "col", Type, regty>;
+-}
+-
+-multiclass NVVM_WMMA_LD_G<string Geometry> {
+-  defm _a_f16: NVVM_WMMA_LD_GAT<Geometry, "a", "f16", llvm_v2f16_ty>;
+-  defm _b_f16: NVVM_WMMA_LD_GAT<Geometry, "b", "f16", llvm_v2f16_ty>;
+-  defm _c_f16: NVVM_WMMA_LD_GAT<Geometry, "c", "f16", llvm_v2f16_ty>;
+-  defm _c_f32: NVVM_WMMA_LD_GAT<Geometry, "c", "f32", llvm_float_ty>;
+-}
+-
+-multiclass NVVM_WMMA_LD {
+-  defm _m32n8k16_load: NVVM_WMMA_LD_G<"m32n8k16">;
+-  defm _m16n16k16_load: NVVM_WMMA_LD_G<"m16n16k16">;
+-  defm _m8n32k16_load: NVVM_WMMA_LD_G<"m8n32k16">;
+-}
+-
+-defm int_nvvm_wmma: NVVM_WMMA_LD;
++              WMMA_NAME_LDST<"load", Frag, Layout, WithStride>.intr>;
+ 
+ // WMMA.STORE.D
+-class NVVM_WMMA_STD_GLSTS<string Geometry, string Layout,
+-                          string Type, LLVMType regty, int WithStride,
+-                          // This is only used to create a typed empty array we
+-                          // need to pass to !if below.
+-                          list<LLVMType>Empty=[]>
++class NVVM_WMMA_ST<WMMA_REGS Frag, string Layout, int WithStride>
+   : Intrinsic<[],
+               !listconcat(
+                 [llvm_anyptr_ty],
+-                !if(!eq(Type,"f16"),
+-                    [regty, regty, regty, regty],
+-                    [regty, regty, regty, regty,
+-                     regty, regty, regty, regty]),
+-                !if(WithStride, [llvm_i32_ty], Empty)),
++                Frag.regs,
++                !if(WithStride, [llvm_i32_ty], [])),
+               [IntrWriteMem, IntrArgMemOnly, WriteOnly<0>, NoCapture<0>],
+-              "llvm.nvvm.wmma."
+-                   # Geometry
+-                   # ".store.d"
+-                   # "." # Layout
+-                   # !if(WithStride, ".stride", "")
+-                   # "." # Type>;
+-
+-multiclass NVVM_WMMA_STD_GLT<string Geometry, string Layout,
+-                             string Type, LLVMType regty> {
+-  def _stride: NVVM_WMMA_STD_GLSTS<Geometry, Layout, Type, regty, 1>;
+-  def NAME:    NVVM_WMMA_STD_GLSTS<Geometry, Layout, Type, regty, 0>;
+-}
+-
+-multiclass NVVM_WMMA_STD_GT<string Geometry, string Type, LLVMType regty> {
+-  defm _row: NVVM_WMMA_STD_GLT<Geometry, "row", Type, regty>;
+-  defm _col: NVVM_WMMA_STD_GLT<Geometry, "col", Type, regty>;
+-}
+-multiclass NVVM_WMMA_STD_G<string Geometry> {
+-  defm _d_f16: NVVM_WMMA_STD_GT<Geometry, "f16", llvm_v2f16_ty>;
+-  defm _d_f32: NVVM_WMMA_STD_GT<Geometry, "f32", llvm_float_ty>;
+-}
+-
+-multiclass NVVM_WMMA_STD {
+-  defm _m32n8k16_store:  NVVM_WMMA_STD_G<"m32n8k16">;
+-  defm _m16n16k16_store: NVVM_WMMA_STD_G<"m16n16k16">;
+-  defm _m8n32k16_store:  NVVM_WMMA_STD_G<"m8n32k16">;
++              WMMA_NAME_LDST<"store", Frag, Layout, WithStride>.intr>;
++
++// Create all load/store variants 
++foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++  foreach layout = ["row", "col"] in {
++    foreach stride = [0, 1] in {
++      foreach frag = [WMMA_REGS<geom, "a", "f16">,
++                      WMMA_REGS<geom, "b", "f16">,
++                      WMMA_REGS<geom, "c", "f16">,
++                      WMMA_REGS<geom, "c", "f32">] in {
++          def WMMA_NAME_LDST<"load", frag, layout, stride>.record
++             : NVVM_WMMA_LD<frag, layout, stride>;
++      }
++      foreach frag = [WMMA_REGS<geom, "d", "f16">,
++                      WMMA_REGS<geom, "d", "f32">] in {
++          def WMMA_NAME_LDST<"store", frag, layout, stride>.record
++             : NVVM_WMMA_ST<frag, layout, stride>;
++      }
++    }
++  }
+ }
+ 
+-defm int_nvvm_wmma: NVVM_WMMA_STD;
+-
+ // WMMA.MMA
+-class NVVM_WMMA_MMA_GABDCS<string Geometry,
+-                           string ALayout, string BLayout,
+-                           string DType, LLVMType d_regty,
+-                           string CType, LLVMType c_regty,
+-                           string Satfinite = "">
+-  : Intrinsic<!if(!eq(DType,"f16"),
+-                      [d_regty, d_regty, d_regty, d_regty],
+-                      [d_regty, d_regty, d_regty, d_regty,
+-                       d_regty, d_regty, d_regty, d_regty]),
++class NVVM_WMMA_MMA<string ALayout, string BLayout,
++                    WMMA_REGS C, WMMA_REGS D, int Satfinite>
++  : Intrinsic<D.regs,
+               !listconcat(
+-                [// A
+-                llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty,
+-                llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty,
+-                // B
+-                llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty,
+-                llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty],
+-                !if(!eq(CType,"f16"),
+-                      [c_regty, c_regty, c_regty, c_regty],
+-                      [c_regty, c_regty, c_regty, c_regty,
+-                       c_regty, c_regty, c_regty, c_regty])),
++                WMMA_REGS<C.geom, "a", "f16">.regs,
++                WMMA_REGS<C.geom, "b", "f16">.regs,
++                C.regs),
+               [IntrNoMem],
+-              "llvm.nvvm.wmma."
+-                # Geometry
+-                # ".mma"
+-                # "." # ALayout
+-                # "." # BLayout
+-                # "." # DType
+-                # "." # CType
+-                # Satfinite> {
+-}
+-
+-multiclass NVVM_WMMA_MMA_GABDC<string Geometry, string ALayout, string BLayout,
+-                               string DType, LLVMType d_regty,
+-                               string CType, LLVMType c_regty> {
+-  def NAME : NVVM_WMMA_MMA_GABDCS<Geometry, ALayout, BLayout,
+-                                  DType, d_regty, CType, c_regty>;
+-  def _satfinite: NVVM_WMMA_MMA_GABDCS<Geometry, ALayout, BLayout,
+-                                       DType, d_regty, CType, c_regty,".satfinite">;
+-}
+-
+-multiclass NVVM_WMMA_MMA_GABD<string Geometry, string ALayout, string BLayout,
+-                              string DType, LLVMType d_regty> {
+-  defm _f16: NVVM_WMMA_MMA_GABDC<Geometry, ALayout, BLayout, DType, d_regty,
+-                                "f16", llvm_v2f16_ty>;
+-  defm _f32: NVVM_WMMA_MMA_GABDC<Geometry, ALayout, BLayout, DType, d_regty,
+-                                "f32", llvm_float_ty>;
+-}
+-
+-multiclass NVVM_WMMA_MMA_GAB<string Geometry, string ALayout, string BLayout> {
+-  defm _f16: NVVM_WMMA_MMA_GABD<Geometry, ALayout, BLayout, "f16", llvm_v2f16_ty>;
+-  defm _f32: NVVM_WMMA_MMA_GABD<Geometry, ALayout, BLayout, "f32", llvm_float_ty>;
+-}
+-
+-multiclass NVVM_WMMA_MMA_GA<string Geometry, string ALayout> {
+-  defm _col: NVVM_WMMA_MMA_GAB<Geometry, ALayout, "col">;
+-  defm _row: NVVM_WMMA_MMA_GAB<Geometry, ALayout, "row">;
+-}
+-
+-multiclass NVVM_WMMA_MMA_G<string Geometry> {
+-  defm _col: NVVM_WMMA_MMA_GA<Geometry, "col">;
+-  defm _row: NVVM_WMMA_MMA_GA<Geometry, "row">;
+-}
+-
+-multiclass NVVM_WMMA_MMA {
+-  defm _m32n8k16_mma : NVVM_WMMA_MMA_G<"m32n8k16">;
+-  defm _m16n16k16_mma : NVVM_WMMA_MMA_G<"m16n16k16">;
+-  defm _m8n32k16_mma : NVVM_WMMA_MMA_G<"m8n32k16">;
++              WMMA_NAME_MMA<ALayout, BLayout, C, D, Satfinite>.llvm>;
++
++foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++  foreach layout_a = ["row", "col"] in {
++    foreach layout_b = ["row", "col"] in {
++      foreach frag_c = [WMMA_REGS<geom, "c", "f16">,
++                        WMMA_REGS<geom, "c", "f32">] in {
++        foreach frag_d = [WMMA_REGS<geom, "d", "f16">,
++                          WMMA_REGS<geom, "d", "f32">] in {
++          foreach satf = [0, 1] in {
++            def WMMA_NAME_MMA<layout_a, layout_b, frag_c, frag_d, satf>.record
++             : NVVM_WMMA_MMA<layout_a, layout_b, frag_c, frag_d, satf>;
++          }
++        }
++      }
++    }
++  }
+ }
+ 
+-defm int_nvvm_wmma : NVVM_WMMA_MMA;
+-
+ } // let TargetPrefix = "nvvm"
+diff --git a/lib/Target/NVPTX/NVPTXIntrinsics.td b/lib/Target/NVPTX/NVPTXIntrinsics.td
+index 47dcdcf6e0b..b9a67ba5ed3 100644
+--- a/lib/Target/NVPTX/NVPTXIntrinsics.td
++++ b/lib/Target/NVPTX/NVPTXIntrinsics.td
+@@ -27,7 +27,17 @@ def immDouble1 : PatLeaf<(fpimm), [{
+     return (d==1.0);
+ }]>;
+ 
+-
++def AS_match {
++  code generic = [{
++   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GENERIC);
++  }];
++  code shared = [{
++   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_SHARED);
++  }];
++  code global = [{
++   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GLOBAL);
++  }];
++}
+ 
+ //-----------------------------------
+ // Synchronization and shuffle functions
+@@ -1007,17 +1017,11 @@ def INT_FNS_iii : INT_FNS_MBO<(ins    i32imm:$mask,    i32imm:$base,    i32imm:$
+ //-----------------------------------
+ 
+ class ATOMIC_GLOBAL_CHK <dag ops, dag frag>
+- : PatFrag<ops, frag, [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GLOBAL);
+-}]>;
++ : PatFrag<ops, frag, AS_match.global>;
+ class ATOMIC_SHARED_CHK <dag ops, dag frag>
+- : PatFrag<ops, frag, [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_SHARED);
+-}]>;
++ : PatFrag<ops, frag, AS_match.shared>;
+ class ATOMIC_GENERIC_CHK <dag ops, dag frag>
+- : PatFrag<ops, frag, [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GENERIC);
+-}]>;
++ : PatFrag<ops, frag, AS_match.generic>;
+ 
+ multiclass F_ATOMIC_2_imp<NVPTXRegClass ptrclass, NVPTXRegClass regclass,
+   string SpaceStr, string TypeStr, string OpcStr, PatFrag IntOp,
+@@ -7381,36 +7385,60 @@ def INT_PTX_SREG_WARPSIZE :
+     NVPTXInst<(outs Int32Regs:$dst), (ins), "mov.u32 \t$dst, WARP_SZ;",
+               [(set Int32Regs:$dst, (int_nvvm_read_ptx_sreg_warpsize))]>;
+ 
+-//
+-// wmma.load.[a|b|c].sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
+-//
+-
+ class EmptyNVPTXInst : NVPTXInst<(outs), (ins), "?", []>;
++// Generates list of n sequential register names.
++class RegSeq<int n, string prefix> {
++  list<string> ret = !if(n, !listconcat(RegSeq<!add(n,-1), prefix>.ret,
++                                        [prefix # !add(n, -1)]),
++                            []);
++}
+ 
+-class WMMA_LOAD_GALSTOS<string Geometry, string Abc, string Layout,
+-                        string Space, string Type, NVPTXRegClass regclass,
+-                        DAGOperand SrcOp, bit WithStride>
+-  : EmptyNVPTXInst,
+-    Requires<[!if(!eq(Geometry, "m16n16k16"),
+-                  hasPTX60,
+-                  hasPTX61),
+-              hasSM70]> {
+-  // Pattern (created by WMMA_LOAD_INTR_HELPER below) that matches the intrinsic
+-  // for this function.
+-  PatFrag IntrMatcher = !cast<PatFrag>("INT_WMMA_"
+-                                       # Geometry # "_load_"
+-                                       # !subst("c", "c_" # Type, Abc)
+-                                       # "_" # Layout
+-                                       # !subst(".", "_", Space)
+-                                       # !if(WithStride,"_stride", "")
+-                                       # "_Intr");
+-  dag OutsR03 = (outs regclass:$r0, regclass:$r1, regclass:$r2, regclass:$r3);
+-  dag OutsR47 = (outs regclass:$r4, regclass:$r5, regclass:$r6, regclass:$r7);
+-  dag Outs = !if(!eq(Abc#Type,"cf16"), OutsR03, !con(OutsR03, OutsR47));
+-
+-  dag StrideArg = !if(WithStride, (ins Int32Regs:$ldm), (ins));
+-  dag Ins = !con((ins SrcOp:$src), StrideArg);
++// Helper class that represents a 'fragment' of an NVPTX *MMA instruction.
++// In addition to target-independent fields provided by WMMA_REGS, it adds
++// the fields commonly used to implement specific PTX instruction -- register
++// types and names, constraints, parts of assembly, etc.
++class WMMA_REGINFO<string Geom, string Frag, string PtxEltType>
++      : WMMA_REGS<Geom, Frag, PtxEltType> {
++  // NVPTX register types used to carry fragment data.
++  NVPTXRegClass regclass = !cond(
++    !eq(PtxEltType, "f16") : Float16x2Regs,
++    !eq(PtxEltType, "f32") : Float32Regs);
++
++  // Instruction input/output arguments for the fragment.
++  list<NVPTXRegClass> ptx_regs = !foreach(tmp, regs, regclass);
++
++  // List of register names for the fragment -- ["ra0", "ra1",...]
++  list<string> reg_names = RegSeq<!size(ptx_regs), "r"#frag>.ret;
++  // Generates "{{$r0, $r1,.... $rN-1}}" for use in asm string construction.
++  string regstring = "{{$" # !head(reg_names)
++                           # !foldl("", !tail(reg_names), a, b,
++                                    !strconcat(a, ", $", b))
++                     # "}}";
++
++  // Predicates for particular fragment variant. Technically those are
++  // per-instruction predicates, but currently all fragments that can be used in
++  // a given instruction are subject to the same constraints, so an instruction
++  // can use predicates from any of its fragments. If/when this is no
++  // longer the case, we can concat all per-fragment predicates to enforce that
++  // all fragments of the instruction are viable.
++  list<Predicate> Predicates = !cond(
++    // fp16 -> fp16/fp32 @ m16n16k16
++    !and(!eq(Geom, "m16n16k16"),
++         !or(!eq(PtxEltType, "f16"),
++             !eq(PtxEltType, "f32"))) : [hasSM70, hasPTX60],
++
++    // fp16 -> fp16/fp32 @ m8n32k16/m32n8k16
++    !and(!or(!eq(Geom, "m8n32k16"),
++             !eq(Geom, "m32n8k16")),
++         !or(!eq(PtxEltType, "f16"),
++             !eq(PtxEltType, "f32"))) : [hasSM70, hasPTX61]);
++
++  // template DAGs for instruction inputs/output.
++  dag Outs = !dag(outs, ptx_regs, reg_names);
++  dag Ins = !dag(ins, ptx_regs, reg_names);
++}
+ 
++class BuildPattern<dag Outs, PatFrag IntrMatcher, dag Ins> {
+   // Build a dag pattern that matches the intrinsic call.
+   // We want a dag that looks like this:
+   // (set <output args>, (intrinsic <input arguments>)) where input and
+@@ -7431,277 +7459,127 @@ class WMMA_LOAD_GALSTOS<string Geometry, string Abc, string Layout,
+                               !subst(ins, IntrMatcher, tmp)))));
+   // Finally, consatenate both parts together. !con() requires both dags to have
+   // the same operator, so we wrap PatArgs in a (set ...) dag.
+-  let Pattern = [!con(PatOuts, (set PatArgs))];
+-  let OutOperandList = Outs;
+-  let InOperandList = Ins;
+-  let AsmString = "wmma.load."
+-                  # Abc
+-                  # ".sync"
+-                  # "." # Layout
+-                  # "." # Geometry
+-                  # Space
+-                  # "." # Type # " \t"
+-                  # !if(!eq(Abc#Type, "cf16"),
+-                        "{{$r0, $r1, $r2, $r3}}",
+-                        "{{$r0, $r1, $r2, $r3, $r4, $r5, $r6, $r7}}")
+-                  # ", [$src]"
+-                  # !if(WithStride, ", $ldm", "")
+-                  # ";";
++  dag ret = !con(PatOuts, (set PatArgs));
+ }
+ 
+-class WMMA_LOAD_INTR_HELPER<string Geometry, string Abc, string Layout,
+-                            string Space, string Type, bit WithStride>
++//
++// wmma.load.[a|b|c].sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
++//
++
++class WMMA_LOAD_INTR_HELPER<WMMA_REGINFO Frag, string Layout, string Space,
++                            bit WithStride>
+                            : PatFrag <(ops),(ops)> {
+   // Intrinsic that matches this instruction.
+-  Intrinsic Intr = !cast<Intrinsic>("int_nvvm_wmma"
+-                                    # "_" # Geometry # "_load_"
+-                                    # Abc # "_" # Type # "_" # Layout
+-                                    # !if(WithStride,"_stride", ""));
+-  code match_generic = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GENERIC);
+-  }];
+-  code match_shared = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_SHARED);
+-  }];
+-  code match_global = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GLOBAL);
+-  }];
+-
++  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_LDST<"load", Frag, Layout,
++                                                   WithStride>.record);
+   let Operands = !if(WithStride, (ops node:$src, node:$ldm), (ops node:$src));
+   let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
+-  let PredicateCode = !if(!eq(Space, ".shared"), match_shared,
+-                      !if(!eq(Space, ".global"), match_global, match_generic));
+-}
+-
+-multiclass WMMA_LOAD_GALSTS<string Geometry, string Abc, string Layout,
+-                            string Space, string Type, NVPTXRegClass regclass,
+-                            bit WithStride> {
+-  def _avar:  WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                imem, WithStride>;
+-  def _areg: WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                Int32Regs, WithStride>;
+-  def _areg64: WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                Int64Regs, WithStride>;
+-  def _ari: WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                MEMri, WithStride>;
+-  def _ari64: WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                MEMri64, WithStride>;
++  let PredicateCode = !cond(!eq(Space, ".shared"): AS_match.shared,
++                            !eq(Space, ".global"): AS_match.global,
++                            1: AS_match.generic);
+ }
+ 
+-multiclass WMMA_LOAD_GALSTSh<string Geometry, string Abc, string Layout,
+-                             string Space, string Type, NVPTXRegClass regclass,
+-                             bit WithStride> {
+-  // Define a PatFrag that matches appropriate intrinsic that loads from the
+-  // given address space.
+-  def _Intr:  WMMA_LOAD_INTR_HELPER<Geometry, Abc, Layout, Space, Type,
+-                                    WithStride>;
+-  defm NAME:  WMMA_LOAD_GALSTS<Geometry, Abc, Layout, Space, Type, regclass,
+-                               WithStride>;
+-}
+-
+-multiclass WMMA_LOAD_GALST<string Geometry, string Abc, string Layout,
+-                           string Space, string Type, NVPTXRegClass regclass> {
+-  defm _stride: WMMA_LOAD_GALSTSh<Geometry, Abc, Layout, Space, Type, regclass, 1>;
+-  defm NAME:    WMMA_LOAD_GALSTSh<Geometry, Abc, Layout, Space, Type, regclass, 0>;
+-}
+-
+-multiclass WMMA_LOAD_GALT<string Geometry, string Abc, string Layout,
+-                          string Type, NVPTXRegClass regclass> {
+-  defm _global: WMMA_LOAD_GALST<Geometry, Abc, Layout, ".global",
+-                                Type, regclass>;
+-  defm _shared: WMMA_LOAD_GALST<Geometry, Abc, Layout, ".shared",
+-                                Type, regclass>;
+-  defm NAME:    WMMA_LOAD_GALST<Geometry, Abc, Layout,        "",
+-                                Type, regclass>;
+-}
+-
+-multiclass WMMA_LOAD_GAT<string Geometry, string Abc,
+-                         string Type, NVPTXRegClass regclass> {
+-  defm _row: WMMA_LOAD_GALT<Geometry, Abc, "row", Type, regclass>;
+-  defm _col: WMMA_LOAD_GALT<Geometry, Abc, "col", Type, regclass>;
+-}
++class WMMA_LOAD<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
++                DAGOperand SrcOp>
++  : EmptyNVPTXInst,
++    Requires<Frag.Predicates> {
++  // Pattern that matches the intrinsic for this instruction variant.
++  PatFrag IntrMatcher = WMMA_LOAD_INTR_HELPER<Frag, Layout, Space, WithStride>;
++  dag Ins = !con((ins SrcOp:$src), !if(WithStride, (ins Int32Regs:$ldm), (ins)));
+ 
+-multiclass WMMA_LOAD_G<string Geometry> {
+-  defm _load_a: WMMA_LOAD_GAT<Geometry, "a", "f16", Float16x2Regs>;
+-  defm _load_b: WMMA_LOAD_GAT<Geometry, "b", "f16", Float16x2Regs>;
+-  defm _load_c_f16: WMMA_LOAD_GAT<Geometry, "c", "f16", Float16x2Regs>;
+-  defm _load_c_f32: WMMA_LOAD_GAT<Geometry, "c", "f32", Float32Regs>;
++  let Pattern = [BuildPattern<Frag.Outs, IntrMatcher, Ins>.ret];
++  let OutOperandList = Frag.Outs;
++  let InOperandList = Ins;
++  let AsmString = "wmma.load."
++                  # Frag.frag
++                  # ".sync"
++                  # "." # Layout
++                  # "." # Frag.geom
++                  # Space
++                  # "." # Frag.ptx_elt_type # " \t"
++                  # Frag.regstring
++                  # ", [$src]"
++                  # !if(WithStride, ", $ldm", "")
++                  # ";";
+ }
+ 
+-defm INT_WMMA_m32n8k16: WMMA_LOAD_G<"m32n8k16">;
+-defm INT_WMMA_m16n16k16: WMMA_LOAD_G<"m16n16k16">;
+-defm INT_WMMA_m8n32k16: WMMA_LOAD_G<"m8n32k16">;
+-
+ //
+ // wmma.store.d.sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
+ //
+-class WMMA_STORE_D_GLSTSO<string Geometry, string Layout, string Space,
+-                          string Type, NVPTXRegClass regclass,
+-                          bit WithStride, DAGOperand DstOp>
++class WMMA_STORE_INTR_HELPER<WMMA_REGINFO Frag, string Layout, string Space,
++                             bit WithStride>
++                            : PatFrag <(ops),(ops)> {
++  // Intrinsic that matches this instruction.
++  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_LDST<"store", Frag, Layout,
++                                                   WithStride>.record);
++  let Operands = !con((ops node:$dst),
++                      !dag(ops, !foreach(tmp, Frag.regs, node), Frag.reg_names),
++                      !if(WithStride, (ops node:$ldm), (ops)));
++  let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
++  let PredicateCode = !cond(!eq(Space, ".shared"): AS_match.shared,
++                            !eq(Space, ".global"): AS_match.global,
++                            1: AS_match.generic);
++}
++
++class WMMA_STORE<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
++                 DAGOperand DstOp>
+   : EmptyNVPTXInst,
+-    Requires<[!if(!eq(Geometry, "m16n16k16"),
+-                  hasPTX60,
+-                  hasPTX61),
+-              hasSM70]> {
+-  PatFrag IntrMatcher = !cast<PatFrag>("INT_WMMA"
+-                                       # "_" # Geometry # "_store_d"
+-                                       # "_" # Type
+-                                       # "_" # Layout
+-                                       # !subst(".", "_", Space)
+-                                       # !if(WithStride,"_stride", "")
+-                                       # "_Intr");
+-  dag InsR03 = (ins DstOp:$src, regclass:$r0, regclass:$r1,
+-                                regclass:$r2, regclass:$r3);
+-  dag InsR47 = (ins regclass:$r4, regclass:$r5,
+-                    regclass:$r6, regclass:$r7);
+-  dag InsR = !if(!eq(Type,"f16"), InsR03, !con(InsR03, InsR47));
+-  dag StrideArg = !if(WithStride, (ins Int32Regs:$ldm), (ins));
+-  dag Ins = !con(InsR, StrideArg);
+-
+-  // Construct the pattern to match corresponding intrinsic call. See the
+-  // details in the comments in WMMA_LOAD_ALSTOS.
+-  dag PatArgs = !foreach(tmp, Ins,
+-                              !subst(imem, ADDRvar,
+-                              !subst(MEMri64, ADDRri64,
+-                              !subst(MEMri, ADDRri,
+-                              !subst(ins, IntrMatcher, tmp)))));
+-  let Pattern = [PatArgs];
++    Requires<Frag.Predicates> {
++  PatFrag IntrMatcher = WMMA_STORE_INTR_HELPER<Frag, Layout, Space, WithStride>;
++  dag Ins = !con((ins DstOp:$src),
++                 Frag.Ins,
++                 !if(WithStride, (ins Int32Regs:$ldm), (ins)));
++  let Pattern = [BuildPattern<(set), IntrMatcher, Ins>.ret];
+   let OutOperandList = (outs);
+   let InOperandList = Ins;
+   let AsmString = "wmma.store.d.sync."
+                   # Layout
+-                  # "." # Geometry
++                  # "." # Frag.geom
+                   # Space
+-                  # "." # Type
++                  # "." # Frag.ptx_elt_type
+                   # " \t[$src],"
+-                  # !if(!eq(Type,"f16"),
+-                        "{{$r0, $r1, $r2, $r3}}",
+-                        "{{$r0, $r1, $r2, $r3, $r4, $r5, $r6, $r7}}")
++                  # Frag.regstring
+                   # !if(WithStride, ", $ldm", "")
+                   # ";";
+-
+ }
+ 
+-class WMMA_STORE_INTR_HELPER<string Geometry, string Layout, string Space,
+-                             string Type, bit WithStride>
+-                            : PatFrag <(ops),(ops)> {
+-  // Intrinsic that matches this instruction.
+-  Intrinsic Intr = !cast<Intrinsic>("int_nvvm_wmma_"
+-                                    # Geometry
+-                                    # "_store_d"
+-                                    # "_" # Type
+-                                    # "_" # Layout
+-                                    # !if(WithStride, "_stride", ""));
+-  code match_generic = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GENERIC);
+-  }];
+-  code match_shared = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_SHARED);
+-  }];
+-  code match_global = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GLOBAL);
+-  }];
+-
+-  dag Args = !if(!eq(Type,"f16"),
+-                 (ops node:$dst, node:$r0, node:$r1, node:$r2, node:$r3),
+-                 (ops node:$dst, node:$r0, node:$r1, node:$r2, node:$r3,
+-                                 node:$r4, node:$r5, node:$r6, node:$r7));
+-  dag StrideArg = !if(WithStride, (ops node:$ldm), (ops));
+-  let Operands = !con(Args, StrideArg);
+-  let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
+-  let PredicateCode = !if(!eq(Space, ".shared"), match_shared,
+-                      !if(!eq(Space, ".global"), match_global, match_generic));
+-}
+-
+-multiclass WMMA_STORE_D_GLSTS<string Geometry, string Layout, string Space,
+-                              string Type, NVPTXRegClass regclass,
+-                              bit WithStride> {
+-  def _avar:   WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, imem>;
+-  def _areg:   WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, Int32Regs>;
+-  def _areg64: WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, Int64Regs>;
+-  def _ari:    WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, MEMri>;
+-  def _ari64:  WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, MEMri64>;
+-}
+-
+-multiclass WMMA_STORE_D_GLSTSh<string Geometry, string Layout, string Space,
+-                               string Type, NVPTXRegClass regclass,
+-                               bit WithStride> {
+-  // Define a PatFrag that matches appropriate intrinsic that loads from the
+-  // given address space.
+-  def _Intr:    WMMA_STORE_INTR_HELPER<Geometry, Layout, Space, Type,
+-                                       WithStride>;
+-  defm NAME:    WMMA_STORE_D_GLSTS<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride>;
+-}
+-
+-multiclass WMMA_STORE_D_GLST<string Geometry, string Layout, string Space,
+-                             string Type, NVPTXRegClass regclass > {
+-  defm _stride: WMMA_STORE_D_GLSTSh<Geometry, Layout, Space, Type, regclass, 1>;
+-  defm NAME:    WMMA_STORE_D_GLSTSh<Geometry, Layout, Space, Type, regclass, 0>;
+-}
+-
+-multiclass WMMA_STORE_D_GLT<string Geometry, string Layout,
+-                           string Type, NVPTXRegClass regclass> {
+-  defm _global: WMMA_STORE_D_GLST<Geometry, Layout, ".global", Type, regclass>;
+-  defm _shared: WMMA_STORE_D_GLST<Geometry, Layout, ".shared", Type, regclass>;
+-  defm NAME:    WMMA_STORE_D_GLST<Geometry, Layout,        "", Type, regclass>;
+-}
+-
+-multiclass WMMA_STORE_D_GT<string Geometry, string Type,
+-                           NVPTXRegClass regclass> {
+-  defm _row:    WMMA_STORE_D_GLT<Geometry, "row", Type, regclass>;
+-  defm _col:    WMMA_STORE_D_GLT<Geometry, "col", Type, regclass>;
+-}
+-
+-multiclass WMMA_STORE_D_G<string Geometry> {
+-  defm _store_d_f16: WMMA_STORE_D_GT<Geometry, "f16", Float16x2Regs>;
+-  defm _store_d_f32: WMMA_STORE_D_GT<Geometry, "f32", Float32Regs>;
+-}
+-
+-defm INT_WMMA_m32n8k16: WMMA_STORE_D_G<"m32n8k16">;
+-defm INT_WMMA_m16n16k16: WMMA_STORE_D_G<"m16n16k16">;
+-defm INT_WMMA_m8n32k16: WMMA_STORE_D_G<"m8n32k16">;
++// Create all load/store variants
++foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++  foreach layout = ["row", "col"] in {
++    foreach stride = [0, 1] in {
++      foreach space = [".global", ".shared", ""] in {
++        foreach addr = [imem, Int32Regs, Int64Regs, MEMri, MEMri64] in {
++          foreach frag = [WMMA_REGINFO<geom, "a", "f16">,
++                          WMMA_REGINFO<geom, "b", "f16">,
++                          WMMA_REGINFO<geom, "c", "f16">,
++                          WMMA_REGINFO<geom, "c", "f32">] in {
++              def : WMMA_LOAD<frag, layout, space, stride, addr>;
++          }
++          foreach frag = [WMMA_REGINFO<geom, "d", "f16">,
++                          WMMA_REGINFO<geom, "d", "f32">] in {
++              def : WMMA_STORE<frag, layout, space, stride, addr>;
++          }
++        } // addr
++      } // space
++    } // stride
++  } // layout
++} // geom
+ 
+ // WMMA.MMA
+-class WMMA_MMA_GABDCS<string Geometry, string ALayout, string BLayout,
+-                     string DType, NVPTXRegClass d_reg,
+-                     string CType, NVPTXRegClass c_reg,
+-                     NVPTXRegClass ab_reg,
+-                     string Satfinite = "">
++class WMMA_MMA<WMMA_REGINFO FragA, WMMA_REGINFO FragB,
++               WMMA_REGINFO FragC, WMMA_REGINFO FragD,
++               string ALayout, string BLayout, int Satfinite>
+   : EmptyNVPTXInst,
+-    Requires<[!if(!eq(Geometry, "m16n16k16"),
+-                  hasPTX60,
+-                  hasPTX61),
+-              hasSM70]> {
+-  Intrinsic Intr = !cast<Intrinsic>("int_nvvm_wmma_"
+-                                    # Geometry
+-                                    # "_mma"
+-                                    # "_" # ALayout
+-                                    # "_" # BLayout
+-                                    # "_" # DType
+-                                    # "_" # CType
+-                                    # !subst(".", "_", Satfinite));
+-  dag Outs = !if(!eq(DType,"f16"),
+-                 (outs d_reg:$d0, d_reg:$d1, d_reg:$d2, d_reg:$d3),
+-                 (outs d_reg:$d0, d_reg:$d1, d_reg:$d2, d_reg:$d3,
+-                       d_reg:$d4, d_reg:$d5, d_reg:$d6, d_reg:$d7));
+-  dag InsExtraCArgs = !if(!eq(CType,"f16"),
+-                          (ins),
+-                          (ins c_reg:$c4,  c_reg:$c5,  c_reg:$c6,  c_reg:$c7));
+-  dag Ins = !con((ins ab_reg:$a0, ab_reg:$a1, ab_reg:$a2, ab_reg:$a3,
+-                      ab_reg:$a4, ab_reg:$a5, ab_reg:$a6, ab_reg:$a7,
+-                      ab_reg:$b0, ab_reg:$b1, ab_reg:$b2, ab_reg:$b3,
+-                      ab_reg:$b4, ab_reg:$b5, ab_reg:$b6, ab_reg:$b7,
+-                      c_reg:$c0,  c_reg:$c1,  c_reg:$c2,  c_reg:$c3),
+-                  InsExtraCArgs);
+-
+-  // Construct the pattern to match corresponding intrinsic call. See the
+-  // details in the comments in WMMA_LOAD_ALSTOS.
++    Requires<FragC.Predicates> {
++  //Intrinsic Intr = int_nvvm_suld_1d_v4i32_zero;
++  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_MMA<ALayout, BLayout, FragC, FragD, Satfinite>.record);
++  dag Outs = FragD.Outs;
++  dag Ins = !con(FragA.Ins,
++                 FragB.Ins,
++                 FragC.Ins);
++
++  // Construct the pattern to match corresponding intrinsic call.
++  // mma does not load/store anything, so we don't need complex operand matching here.
+   dag PatOuts = !foreach(tmp, Outs, !subst(outs, set, tmp));
+   dag PatArgs = !foreach(tmp, Ins, !subst(ins, Intr, tmp));
+   let Pattern = [!con(PatOuts, (set PatArgs))];
+@@ -7710,54 +7588,30 @@ class WMMA_MMA_GABDCS<string Geometry, string ALayout, string BLayout,
+   let AsmString = "wmma.mma.sync."
+                   # ALayout
+                   # "." # BLayout
+-                  # "." # Geometry
+-                  # "." # DType
+-                  # "." # CType
+-                  # Satfinite # "\n\t\t"
+-                  # !if(!eq(DType,"f16"),
+-                        "{{$d0, $d1, $d2, $d3}}, \n\t\t",
+-                        "{{$d0, $d1, $d2, $d3, $d4, $d5, $d6, $d7}},\n\t\t")
+-                  # "{{$a0, $a1, $a2, $a3, $a4, $a5, $a6, $a7}},\n\t\t"
+-                  # "{{$b0, $b1, $b2, $b3, $b4, $b5, $b6, $b7}},\n\t\t"
+-                  # !if(!eq(CType,"f16"),
+-                        "{{$c0, $c1, $c2, $c3}};",
+-                        "{{$c0, $c1, $c2, $c3, $c4, $c5, $c6, $c7}};");
+-}
+-
+-multiclass WMMA_MMA_GABDC<string Geometry, string ALayout, string BLayout,
+-                         string DType, NVPTXRegClass d_reg,
+-                         string CType, NVPTXRegClass c_reg> {
+-  def _satfinite: WMMA_MMA_GABDCS<Geometry, ALayout, BLayout,
+-                                 DType, d_reg, CType, c_reg,
+-                                 Float16x2Regs, ".satfinite">;
+-  def NAME:       WMMA_MMA_GABDCS<Geometry, ALayout, BLayout,
+-                                 DType, d_reg, CType, c_reg,
+-                                 Float16x2Regs>;
+-}
+-
+-multiclass WMMA_MMA_GABD<string Geometry, string ALayout, string BLayout,
+-                        string DType, NVPTXRegClass d_reg> {
+-  defm _f16: WMMA_MMA_GABDC<Geometry, ALayout, BLayout, DType, d_reg,
+-                            "f16", Float16x2Regs>;
+-  defm _f32: WMMA_MMA_GABDC<Geometry, ALayout, BLayout, DType, d_reg,
+-                            "f32", Float32Regs>;
+-}
+-
+-multiclass WMMA_MMA_GAB<string Geometry, string ALayout, string BLayout> {
+-  defm _f16: WMMA_MMA_GABD<Geometry, ALayout, BLayout, "f16", Float16x2Regs>;
+-  defm _f32: WMMA_MMA_GABD<Geometry, ALayout, BLayout, "f32", Float32Regs>;
+-}
+-
+-multiclass WMMA_MMA_GA<string Geometry, string ALayout> {
+-  defm _col: WMMA_MMA_GAB<Geometry, ALayout, "col">;
+-  defm _row: WMMA_MMA_GAB<Geometry, ALayout, "row">;
+-}
+-
+-multiclass WMMA_MMA_G<string Geometry> {
+-  defm _col: WMMA_MMA_GA<Geometry, "col">;
+-  defm _row: WMMA_MMA_GA<Geometry, "row">;
++                  # "." # FragA.geom
++                  # "." # FragD.ptx_elt_type
++                  # "." # FragC.ptx_elt_type
++                  # !if(Satfinite, ".satfinite", "") # "\n\t\t"
++                  # FragD.regstring # ",\n\t\t"
++                  # FragA.regstring # ",\n\t\t"
++                  # FragB.regstring # ",\n\t\t"
++                  # FragC.regstring # ";";
+ }
+ 
+-defm INT_WMMA_MMA_m32n8k16 : WMMA_MMA_G<"m32n8k16">;
+-defm INT_WMMA_MMA_m16n16k16 : WMMA_MMA_G<"m16n16k16">;
+-defm INT_WMMA_MMA_m8n32k16 : WMMA_MMA_G<"m8n32k16">;
++foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++  foreach layout_a = ["row", "col"] in {
++    foreach layout_b = ["row", "col"] in {
++      foreach frag_c = [WMMA_REGINFO<geom, "c", "f16">,
++                        WMMA_REGINFO<geom, "c", "f32">] in {
++        foreach frag_d = [WMMA_REGINFO<geom, "d", "f16">,
++                          WMMA_REGINFO<geom, "d", "f32">] in {
++          foreach satf = [0, 1] in {
++            def : WMMA_MMA<WMMA_REGINFO<geom, "a", "f16">,
++                           WMMA_REGINFO<geom, "b", "f16">,
++                           frag_c, frag_d, layout_a, layout_b, satf>;
++          } // satf
++        } // frag_d
++      } // frag_c
++    } // layout_b
++  } // layout_a
++} // geom
+-- 
+2.17.1
+

--- a/L/LLVM/v8/bundled/llvm_patches/0019-llvm-8.0-D59393-mma-ptx63-fix.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0019-llvm-8.0-D59393-mma-ptx63-fix.patch
@@ -1,0 +1,510 @@
+From be924be7f9e699775fe7690d4b421bebfed73aa9 Mon Sep 17 00:00:00 2001
+From: Artem Belevich <tra@google.com>
+Date: Thu, 25 Apr 2019 22:27:46 +0000
+Subject: [PATCH] [NVPTX] generate correct MMA instruction mnemonics with
+ PTX63+.
+
+PTX 6.3 requires using ".aligned" in the MMA instruction names.
+In order to generate correct name, now we pass current
+PTX version to each instruction as an extra constant operand
+and InstPrinter adjusts its output accordingly.
+
+Differential Revision: https://reviews.llvm.org/D59393
+
+llvm-svn: 359246
+---
+ .../NVPTX/InstPrinter/NVPTXInstPrinter.cpp    |  14 +
+ .../NVPTX/InstPrinter/NVPTXInstPrinter.h      |   2 +
+ lib/Target/NVPTX/NVPTXInstrInfo.td            |   4 +
+ lib/Target/NVPTX/NVPTXIntrinsics.td           | 279 ++++++++++--------
+ test/CodeGen/NVPTX/wmma.py                    |  17 +-
+ 5 files changed, 184 insertions(+), 132 deletions(-)
+
+diff --git a/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.cpp b/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.cpp
+index b774fe169d7..6fb577d5499 100644
+--- a/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.cpp
++++ b/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.cpp
+@@ -270,6 +270,20 @@ void NVPTXInstPrinter::printLdStCode(const MCInst *MI, int OpNum,
+     llvm_unreachable("Empty Modifier");
+ }
+ 
++void NVPTXInstPrinter::printMmaCode(const MCInst *MI, int OpNum, raw_ostream &O,
++                                    const char *Modifier) {
++  const MCOperand &MO = MI->getOperand(OpNum);
++  int Imm = (int)MO.getImm();
++  if (Modifier == nullptr || strcmp(Modifier, "version") == 0) {
++    O << Imm; // Just print out PTX version
++  } else if (strcmp(Modifier, "aligned") == 0) {
++    // PTX63 requires '.aligned' in the name of the instruction.
++    if (Imm >= 63)
++      O << ".aligned";
++  } else
++    llvm_unreachable("Unknown Modifier");
++}
++
+ void NVPTXInstPrinter::printMemOperand(const MCInst *MI, int OpNum,
+                                        raw_ostream &O, const char *Modifier) {
+   printOperand(MI, OpNum, O);
+diff --git a/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.h b/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.h
+index f0f223aa057..588439137f9 100644
+--- a/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.h
++++ b/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.h
+@@ -41,6 +41,8 @@ public:
+                     const char *Modifier = nullptr);
+   void printLdStCode(const MCInst *MI, int OpNum,
+                      raw_ostream &O, const char *Modifier = nullptr);
++  void printMmaCode(const MCInst *MI, int OpNum, raw_ostream &O,
++                    const char *Modifier = nullptr);
+   void printMemOperand(const MCInst *MI, int OpNum,
+                        raw_ostream &O, const char *Modifier = nullptr);
+   void printProtoIdent(const MCInst *MI, int OpNum,
+diff --git a/lib/Target/NVPTX/NVPTXInstrInfo.td b/lib/Target/NVPTX/NVPTXInstrInfo.td
+index 02a40b9f526..603d3212395 100644
+--- a/lib/Target/NVPTX/NVPTXInstrInfo.td
++++ b/lib/Target/NVPTX/NVPTXInstrInfo.td
+@@ -1549,6 +1549,10 @@ def LdStCode : Operand<i32> {
+   let PrintMethod = "printLdStCode";
+ }
+ 
++def MmaCode : Operand<i32> {
++  let PrintMethod = "printMmaCode";
++}
++
+ def SDTWrapper : SDTypeProfile<1, 1, [SDTCisSameAs<0, 1>, SDTCisPtrTy<0>]>;
+ def Wrapper    : SDNode<"NVPTXISD::Wrapper", SDTWrapper>;
+ 
+diff --git a/lib/Target/NVPTX/NVPTXIntrinsics.td b/lib/Target/NVPTX/NVPTXIntrinsics.td
+index b9a67ba5ed3..5cd534914f7 100644
+--- a/lib/Target/NVPTX/NVPTXIntrinsics.td
++++ b/lib/Target/NVPTX/NVPTXIntrinsics.td
+@@ -39,6 +39,24 @@ def AS_match {
+   }];
+ }
+ 
++// A node that will be replaced with the current PTX version.
++class PTX {
++  SDNodeXForm PTXVerXform = SDNodeXForm<imm, [{
++    return getI32Imm(Subtarget->getPTXVersion(), SDLoc(N));
++  }]>;
++  // (i32 0) will be XForm'ed to the currently used PTX version.
++  dag version = (PTXVerXform (i32 0));
++}
++def ptx : PTX;
++
++// Generates list of n sequential register names.
++// E.g. RegNames<3,"r">.ret -> ["r0", "r1", "r2" ]
++class RegSeq<int n, string prefix> {
++  list<string> ret = !if(n, !listconcat(RegSeq<!add(n,-1), prefix>.ret,
++                                        [prefix # !add(n, -1)]),
++                            []);
++}
++
+ //-----------------------------------
+ // Synchronization and shuffle functions
+ //-----------------------------------
+@@ -7385,14 +7403,6 @@ def INT_PTX_SREG_WARPSIZE :
+     NVPTXInst<(outs Int32Regs:$dst), (ins), "mov.u32 \t$dst, WARP_SZ;",
+               [(set Int32Regs:$dst, (int_nvvm_read_ptx_sreg_warpsize))]>;
+ 
+-class EmptyNVPTXInst : NVPTXInst<(outs), (ins), "?", []>;
+-// Generates list of n sequential register names.
+-class RegSeq<int n, string prefix> {
+-  list<string> ret = !if(n, !listconcat(RegSeq<!add(n,-1), prefix>.ret,
+-                                        [prefix # !add(n, -1)]),
+-                            []);
+-}
+-
+ // Helper class that represents a 'fragment' of an NVPTX *MMA instruction.
+ // In addition to target-independent fields provided by WMMA_REGS, it adds
+ // the fields commonly used to implement specific PTX instruction -- register
+@@ -7409,6 +7419,7 @@ class WMMA_REGINFO<string Geom, string Frag, string PtxEltType>
+ 
+   // List of register names for the fragment -- ["ra0", "ra1",...]
+   list<string> reg_names = RegSeq<!size(ptx_regs), "r"#frag>.ret;
++
+   // Generates "{{$r0, $r1,.... $rN-1}}" for use in asm string construction.
+   string regstring = "{{$" # !head(reg_names)
+                            # !foldl("", !tail(reg_names), a, b,
+@@ -7438,61 +7449,65 @@ class WMMA_REGINFO<string Geom, string Frag, string PtxEltType>
+   dag Ins = !dag(ins, ptx_regs, reg_names);
+ }
+ 
+-class BuildPattern<dag Outs, PatFrag IntrMatcher, dag Ins> {
++// Convert dag of arguments into a dag to match given intrinsic.
++class BuildPatternI<Intrinsic Intr, dag Ins> {
++  // Build a dag pattern that matches the intrinsic call.
++  dag ret = !foreach(tmp, Ins,
++                          !subst(imem, ADDRvar,
++                          !subst(MEMri64, ADDRri64,
++                          !subst(MEMri, ADDRri,
++                          !subst(ins, Intr, tmp)))));
++}
++
++// Same as above, but uses PatFrag instead of an Intrinsic.
++class BuildPatternPF<PatFrag Intr, dag Ins> {
+   // Build a dag pattern that matches the intrinsic call.
+-  // We want a dag that looks like this:
+-  // (set <output args>, (intrinsic <input arguments>)) where input and
+-  // output arguments are named patterns that would match corresponding
+-  // input/output arguments of the instruction.
+-  //
+-  // First we construct (set <output arguments>) from instruction's outs dag by
+-  // replacing dag operator 'outs' with 'set'.
+-  dag PatOuts = !foreach(tmp, Outs, !subst(outs, set, tmp));
+-  // Similarly, construct (intrinsic <input arguments>) sub-dag from
+-  // instruction's input arguments, only now we also need to replace operands
+-  // with patterns that would match them and the operator 'ins' with the
+-  // intrinsic.
+-  dag PatArgs = !foreach(tmp, Ins,
+-                              !subst(imem, ADDRvar,
+-                              !subst(MEMri64, ADDRri64,
+-                              !subst(MEMri, ADDRri,
+-                              !subst(ins, IntrMatcher, tmp)))));
+-  // Finally, consatenate both parts together. !con() requires both dags to have
+-  // the same operator, so we wrap PatArgs in a (set ...) dag.
+-  dag ret = !con(PatOuts, (set PatArgs));
++  dag ret = !foreach(tmp, Ins,
++                          !subst(imem, ADDRvar,
++                          !subst(MEMri64, ADDRri64,
++                          !subst(MEMri, ADDRri,
++                          !subst(ins, Intr, tmp)))));
++}
++
++// Common WMMA-related fields used for building patterns for all MMA instructions.
++class WMMA_INSTR<string _Intr, list<dag> _Args>
++  : NVPTXInst<(outs), (ins), "?", []> {
++  Intrinsic Intr = !cast<Intrinsic>(_Intr);
++  // Concatenate all arguments into a single dag.
++  dag Args = !foldl((ins), _Args, a, b, !con(a,b));
++  // Pre-build the pattern to match (intrinsic arg0, arg1, ...).
++  dag IntrinsicPattern = BuildPatternI<!cast<Intrinsic>(Intr), Args>.ret;
+ }
+ 
+ //
+ // wmma.load.[a|b|c].sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
+ //
+ 
+-class WMMA_LOAD_INTR_HELPER<WMMA_REGINFO Frag, string Layout, string Space,
+-                            bit WithStride>
+-                           : PatFrag <(ops),(ops)> {
+-  // Intrinsic that matches this instruction.
+-  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_LDST<"load", Frag, Layout,
+-                                                   WithStride>.record);
+-  let Operands = !if(WithStride, (ops node:$src, node:$ldm), (ops node:$src));
+-  let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
+-  let PredicateCode = !cond(!eq(Space, ".shared"): AS_match.shared,
+-                            !eq(Space, ".global"): AS_match.global,
+-                            1: AS_match.generic);
+-}
+-
+ class WMMA_LOAD<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
+                 DAGOperand SrcOp>
+-  : EmptyNVPTXInst,
++  : WMMA_INSTR<WMMA_NAME_LDST<"load", Frag, Layout, WithStride>.record,
++                              [!con((ins SrcOp:$src),
++                                    !if(WithStride, (ins Int32Regs:$ldm), (ins)))]>,
+     Requires<Frag.Predicates> {
+-  // Pattern that matches the intrinsic for this instruction variant.
+-  PatFrag IntrMatcher = WMMA_LOAD_INTR_HELPER<Frag, Layout, Space, WithStride>;
+-  dag Ins = !con((ins SrcOp:$src), !if(WithStride, (ins Int32Regs:$ldm), (ins)));
++  // Load/store intrinsics are overloaded on pointer's address space.
++  // To match the right intrinsic, we need to build AS-constrained PatFrag.
++  // Operands is a dag equivalent in shape to Args, but using (ops node:$name, .....).
++  dag PFOperands = !if(WithStride, (ops node:$src, node:$ldm), (ops node:$src));
++  // Build PatFrag that only matches particular address space.
++  PatFrag IntrFrag = PatFrag<PFOperands,
++                             !foreach(tmp, PFOperands, !subst(ops, Intr, tmp)),
++                             !cond(!eq(Space, ".shared"): AS_match.shared,
++                                   !eq(Space, ".global"): AS_match.global,
++                                   1: AS_match.generic)>;
++  // Build AS-constrained pattern.
++  let IntrinsicPattern = BuildPatternPF<IntrFrag, Args>.ret;
+ 
+-  let Pattern = [BuildPattern<Frag.Outs, IntrMatcher, Ins>.ret];
+   let OutOperandList = Frag.Outs;
+-  let InOperandList = Ins;
++  let InOperandList = !con(Args, (ins MmaCode:$ptx));
+   let AsmString = "wmma.load."
+                   # Frag.frag
+                   # ".sync"
++                  # "${ptx:aligned}"
+                   # "." # Layout
+                   # "." # Frag.geom
+                   # Space
+@@ -7506,87 +7521,79 @@ class WMMA_LOAD<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
+ //
+ // wmma.store.d.sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
+ //
+-class WMMA_STORE_INTR_HELPER<WMMA_REGINFO Frag, string Layout, string Space,
+-                             bit WithStride>
+-                            : PatFrag <(ops),(ops)> {
+-  // Intrinsic that matches this instruction.
+-  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_LDST<"store", Frag, Layout,
+-                                                   WithStride>.record);
+-  let Operands = !con((ops node:$dst),
+-                      !dag(ops, !foreach(tmp, Frag.regs, node), Frag.reg_names),
+-                      !if(WithStride, (ops node:$ldm), (ops)));
+-  let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
+-  let PredicateCode = !cond(!eq(Space, ".shared"): AS_match.shared,
+-                            !eq(Space, ".global"): AS_match.global,
+-                            1: AS_match.generic);
+-}
+-
+-class WMMA_STORE<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
+-                 DAGOperand DstOp>
+-  : EmptyNVPTXInst,
++class WMMA_STORE_D<WMMA_REGINFO Frag, string Layout, string Space,
++                   bit WithStride, DAGOperand DstOp>
++  : WMMA_INSTR<WMMA_NAME_LDST<"store", Frag, Layout, WithStride>.record,
++               [!con((ins DstOp:$dst),
++                     Frag.Ins,
++                     !if(WithStride, (ins Int32Regs:$ldm), (ins)))]>,
+     Requires<Frag.Predicates> {
+-  PatFrag IntrMatcher = WMMA_STORE_INTR_HELPER<Frag, Layout, Space, WithStride>;
+-  dag Ins = !con((ins DstOp:$src),
+-                 Frag.Ins,
+-                 !if(WithStride, (ins Int32Regs:$ldm), (ins)));
+-  let Pattern = [BuildPattern<(set), IntrMatcher, Ins>.ret];
++
++  // Load/store intrinsics are overloaded on pointer's address space.
++  // To match the right intrinsic, we need to build AS-constrained PatFrag.
++  // Operands is a dag equivalent in shape to Args, but using (ops node:$name, .....).
++  dag PFOperands = !con((ops node:$dst),
++                        !dag(ops, !foreach(tmp, Frag.regs, node), Frag.reg_names),
++                        !if(WithStride, (ops node:$ldm), (ops)));
++  // Build PatFrag that only matches particular address space.
++  PatFrag IntrFrag = PatFrag<PFOperands,
++                             !foreach(tmp, PFOperands, !subst(ops, Intr, tmp)),
++                             !cond(!eq(Space, ".shared"): AS_match.shared,
++                                   !eq(Space, ".global"): AS_match.global,
++                                   1: AS_match.generic)>;
++  // Build AS-constrained pattern.
++  let IntrinsicPattern = BuildPatternPF<IntrFrag, Args>.ret;
++
++  let InOperandList  = !con(Args, (ins MmaCode:$ptx));
+   let OutOperandList = (outs);
+-  let InOperandList = Ins;
+-  let AsmString = "wmma.store.d.sync."
+-                  # Layout
++  let AsmString = "wmma.store.d.sync"
++                  # "${ptx:aligned}"
++                  # "." # Layout
+                   # "." # Frag.geom
+                   # Space
+                   # "." # Frag.ptx_elt_type
+-                  # " \t[$src],"
++                  # " \t[$dst],"
+                   # Frag.regstring
+                   # !if(WithStride, ", $ldm", "")
+                   # ";";
+ }
+ 
+ // Create all load/store variants
+-foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
+-  foreach layout = ["row", "col"] in {
+-    foreach stride = [0, 1] in {
+-      foreach space = [".global", ".shared", ""] in {
+-        foreach addr = [imem, Int32Regs, Int64Regs, MEMri, MEMri64] in {
+-          foreach frag = [WMMA_REGINFO<geom, "a", "f16">,
+-                          WMMA_REGINFO<geom, "b", "f16">,
+-                          WMMA_REGINFO<geom, "c", "f16">,
+-                          WMMA_REGINFO<geom, "c", "f32">] in {
+-              def : WMMA_LOAD<frag, layout, space, stride, addr>;
+-          }
+-          foreach frag = [WMMA_REGINFO<geom, "d", "f16">,
+-                          WMMA_REGINFO<geom, "d", "f32">] in {
+-              def : WMMA_STORE<frag, layout, space, stride, addr>;
+-          }
+-        } // addr
+-      } // space
+-    } // stride
+-  } // layout
+-} // geom
++defset list<WMMA_INSTR> MMA_LDSTs  = {
++  foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++    foreach layout = ["row", "col"] in {
++      foreach stride = [0, 1] in {
++        foreach space = [".global", ".shared", ""] in {
++          foreach addr = [imem, Int32Regs, Int64Regs, MEMri, MEMri64] in {
++            foreach frag = [WMMA_REGINFO<geom, "a", "f16">,
++                            WMMA_REGINFO<geom, "b", "f16">,
++                            WMMA_REGINFO<geom, "c", "f16">,
++                            WMMA_REGINFO<geom, "c", "f32">] in {
++                def : WMMA_LOAD<frag, layout, space, stride, addr>;
++            }
++            foreach frag = [WMMA_REGINFO<geom, "d", "f16">,
++                            WMMA_REGINFO<geom, "d", "f32">] in {
++                def : WMMA_STORE_D<frag, layout, space, stride, addr>;
++            }
++          } // addr
++        } // space
++      } // stride
++    } // layout
++  } // geom
++} // defset
+ 
+ // WMMA.MMA
+ class WMMA_MMA<WMMA_REGINFO FragA, WMMA_REGINFO FragB,
+                WMMA_REGINFO FragC, WMMA_REGINFO FragD,
+                string ALayout, string BLayout, int Satfinite>
+-  : EmptyNVPTXInst,
++  : WMMA_INSTR<WMMA_NAME_MMA<ALayout, BLayout, FragC, FragD, Satfinite>.record,
++                             [FragA.Ins, FragB.Ins, FragC.Ins]>,
+     Requires<FragC.Predicates> {
+-  //Intrinsic Intr = int_nvvm_suld_1d_v4i32_zero;
+-  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_MMA<ALayout, BLayout, FragC, FragD, Satfinite>.record);
+-  dag Outs = FragD.Outs;
+-  dag Ins = !con(FragA.Ins,
+-                 FragB.Ins,
+-                 FragC.Ins);
+-
+-  // Construct the pattern to match corresponding intrinsic call.
+-  // mma does not load/store anything, so we don't need complex operand matching here.
+-  dag PatOuts = !foreach(tmp, Outs, !subst(outs, set, tmp));
+-  dag PatArgs = !foreach(tmp, Ins, !subst(ins, Intr, tmp));
+-  let Pattern = [!con(PatOuts, (set PatArgs))];
+-  let OutOperandList = Outs;
+-  let InOperandList  = Ins;
+-  let AsmString = "wmma.mma.sync."
+-                  # ALayout
++  let OutOperandList = FragD.Outs;
++  let InOperandList  = !con(Args, (ins MmaCode:$ptx));
++  let AsmString = "wmma.mma.sync"
++                  # "${ptx:aligned}"
++                  # "." # ALayout
+                   # "." # BLayout
+                   # "." # FragA.geom
+                   # "." # FragD.ptx_elt_type
+@@ -7598,20 +7605,34 @@ class WMMA_MMA<WMMA_REGINFO FragA, WMMA_REGINFO FragB,
+                   # FragC.regstring # ";";
+ }
+ 
+-foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
+-  foreach layout_a = ["row", "col"] in {
+-    foreach layout_b = ["row", "col"] in {
+-      foreach frag_c = [WMMA_REGINFO<geom, "c", "f16">,
+-                        WMMA_REGINFO<geom, "c", "f32">] in {
+-        foreach frag_d = [WMMA_REGINFO<geom, "d", "f16">,
+-                          WMMA_REGINFO<geom, "d", "f32">] in {
+-          foreach satf = [0, 1] in {
+-            def : WMMA_MMA<WMMA_REGINFO<geom, "a", "f16">,
+-                           WMMA_REGINFO<geom, "b", "f16">,
+-                           frag_c, frag_d, layout_a, layout_b, satf>;
+-          } // satf
+-        } // frag_d
+-      } // frag_c
+-    } // layout_b
+-  } // layout_a
+-} // geom
++defset list<WMMA_INSTR> MMAs  = {
++  foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++    foreach layout_a = ["row", "col"] in {
++      foreach layout_b = ["row", "col"] in {
++        foreach frag_c = [WMMA_REGINFO<geom, "c", "f16">,
++                          WMMA_REGINFO<geom, "c", "f32">] in {
++          foreach frag_d = [WMMA_REGINFO<geom, "d", "f16">,
++                            WMMA_REGINFO<geom, "d", "f32">] in {
++            foreach satf = [0, 1] in {
++              def : WMMA_MMA<WMMA_REGINFO<geom, "a", "f16">,
++                             WMMA_REGINFO<geom, "b", "f16">,
++                             frag_c, frag_d, layout_a, layout_b, satf>;
++            } // satf
++          } // frag_d
++        } // frag_c
++      } // layout_b
++    } // layout_a
++  } // geom
++} // defset
++
++// Constructing non-flat DAGs is still a pain. I can't !subst a dag node with a
++// dag, so the ptx.version must be appended *after* foreach replaces 'ins' with
++// the instruction record.
++class WMMA_PAT<WMMA_INSTR wi>
++      : Pat<wi.IntrinsicPattern,
++            !con(!foreach(tmp, wi.Args, !subst(ins, wi, tmp)),
++                 (wi ptx.version))>;
++
++// Build intrinsic->instruction patterns for all MMA instructions.
++foreach mma = !listconcat(MMAs, MMA_LDSTs) in
++  def : WMMA_PAT<mma>;
+diff --git a/test/CodeGen/NVPTX/wmma.py b/test/CodeGen/NVPTX/wmma.py
+index 14bbfd7df09..72d189ca050 100644
+--- a/test/CodeGen/NVPTX/wmma.py
++++ b/test/CodeGen/NVPTX/wmma.py
+@@ -3,9 +3,12 @@
+ 
+ # RUN: python %s > %t.ll
+ # RUN: llc < %t.ll -march=nvptx64 -mcpu=sm_70 -mattr=+ptx61 | FileCheck %t.ll
++# RUN: python %s --ptx=63 > %t-ptx63.ll
++# RUN: llc < %t-ptx63.ll -march=nvptx64 -mcpu=sm_70 -mattr=+ptx63 | FileCheck %t-ptx63.ll
+ 
+ from __future__ import print_function
+ 
++import argparse
+ from itertools import product
+ from string import Template
+ 
+@@ -64,7 +67,7 @@ define ${ret_ty} @test_${function}_o(i8 ${as}* %src ${extra_args}) {
+ }
+ """
+   intrinsic_template = "llvm.nvvm.wmma.${geom}.load.${abc}.${layout}${stride}.${itype}.${pspace}"
+-  instruction_template = "wmma.load.${abc}.sync.${layout}.${geom}${space}.${itype}"
++  instruction_template = "wmma.load.${abc}.sync${aligned}.${layout}.${geom}${space}.${itype}"
+ 
+   for geom, abc, layout, space, stride, itype in product(
+       known_geoms,
+@@ -76,6 +79,7 @@ define ${ret_ty} @test_${function}_o(i8 ${as}* %src ${extra_args}) {
+ 
+     params = {
+         "abc" : abc,
++        "aligned" : ".aligned" if ptx_version >= 63 else "",
+         "layout" : layout,
+         "space" : space,
+         "stride" : stride,
+@@ -135,7 +139,7 @@ define void @test_${function}_o(i8 ${as}* %src, ${args}${extra_args}) {
+ }
+ """
+   intrinsic_template = "llvm.nvvm.wmma.${geom}.store.${abc}.${layout}${stride}.${itype}.${pspace}"
+-  instruction_template = "wmma.store.${abc}.sync.${layout}.${geom}${space}.${itype}"
++  instruction_template = "wmma.store.${abc}.sync${aligned}.${layout}.${geom}${space}.${itype}"
+ 
+   for geom, abc, layout, space, stride, itype in product(
+       known_geoms,
+@@ -147,6 +151,7 @@ define void @test_${function}_o(i8 ${as}* %src, ${args}${extra_args}) {
+ 
+     params = {
+         "abc" : abc,
++        "aligned" : ".aligned" if ptx_version >= 63 else "",
+         "layout" : layout,
+         "space" : space,
+         "stride" : stride,
+@@ -191,7 +196,7 @@ define ${ret_ty} @test_${function}(
+ }
+ """
+   intrinsic_template = "llvm.nvvm.wmma.${geom}.mma.${alayout}.${blayout}.${dtype}.${ctype}${satf}"
+-  instruction_template = "wmma.mma.sync.${alayout}.${blayout}.${geom}.${dtype}.${ctype}${satf}"
++  instruction_template = "wmma.mma.sync${aligned}.${alayout}.${blayout}.${geom}.${dtype}.${ctype}${satf}"
+ 
+   for geom, alayout, blayout, ctype, dtype, satf in product(
+       known_geoms,
+@@ -202,6 +207,7 @@ define ${ret_ty} @test_${function}(
+       [".satfinite", ""]):
+ 
+     params = {
++        "aligned" : ".aligned" if ptx_version >= 63 else "",
+         "alayout" : alayout,
+         "blayout" : blayout,
+         "ctype" : ctype,
+@@ -230,4 +236,9 @@ def main():
+   gen_wmma_store_tests()
+   gen_wmma_mma_tests()
+ 
++parser = argparse.ArgumentParser()
++parser.add_argument('--ptx', type=int, default=60)
++args = parser.parse_args()
++ptx_version = args.ptx
++
+ main()
+-- 
+2.17.1
+

--- a/L/LLVM/v8/bundled/llvm_patches/0020-llvm8-WASM-addrspaces.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0020-llvm8-WASM-addrspaces.patch
@@ -1,0 +1,45 @@
+From 664994725a1783b526710584d8ad56a871cd53b9 Mon Sep 17 00:00:00 2001
+From: Julian P Samaroo <jpsamaroo@jpsamaroo.me>
+Date: Sun, 12 May 2019 00:00:00 -0500
+Subject: [PATCH] No-op addrspacecasts in WebAssembly target
+
+Patch authored by Tom Short (@tshort)
+---
+ lib/Target/WebAssembly/WebAssemblyISelLowering.cpp | 7 +++++++
+ lib/Target/WebAssembly/WebAssemblyISelLowering.h   | 2 ++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp b/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+index 003848e3422..4f67754793e 100644
+--- a/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
++++ b/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+@@ -1224,6 +1224,13 @@ SDValue WebAssemblyTargetLowering::LowerShift(SDValue Op,
+                      DAG.getConstant(Shift, DL, MVT::i32));
+ }
+ 
++bool WebAssemblyTargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
++                                                    unsigned DestAS) const {
++  assert(SrcAS != DestAS && "Expected different address spaces!");
++
++  return true;
++}
++
+ //===----------------------------------------------------------------------===//
+ //                          WebAssembly Optimization Hooks
+ //===----------------------------------------------------------------------===//
+diff --git a/lib/Target/WebAssembly/WebAssemblyISelLowering.h b/lib/Target/WebAssembly/WebAssemblyISelLowering.h
+index 59f4230ed88..d907e088ae5 100644
+--- a/lib/Target/WebAssembly/WebAssemblyISelLowering.h
++++ b/lib/Target/WebAssembly/WebAssemblyISelLowering.h
+@@ -103,6 +103,8 @@ private:
+   SDValue LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const;
+   SDValue LowerAccessVectorElement(SDValue Op, SelectionDAG &DAG) const;
+   SDValue LowerShift(SDValue Op, SelectionDAG &DAG) const;
++
++  bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override;
+ };
+ 
+ namespace WebAssembly {
+-- 
+2.18.1
+

--- a/L/LLVM/v8/bundled/llvm_patches/0021-llvm-8.0-D63688-wasm-isLocal.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0021-llvm-8.0-D63688-wasm-isLocal.patch
@@ -1,0 +1,39 @@
+From 83d5085a7fcbb4596d964dbe037c5ebf4de02b69 Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@alumni.harvard.edu>
+Date: Sun, 23 Jun 2019 00:29:59 +0000
+Subject: [PATCH] [Support] Fix build under Emscripten
+
+Summary:
+Emscripten's libc doesn't define MNT_LOCAL, thus causing a build
+failure in the fallback path. However, to the best of my knowledge,
+it also doesn't support remote file system mounts, so we may simply
+return `true` here (as we do for e.g. Fuchsia). With this fix, the
+core LLVM libraries build correctly under emscripten (though some
+of the tools and utils do not).
+
+Reviewers: kripken
+Differential Revision: https://reviews.llvm.org/D63688
+
+llvm-svn: 364143
+(cherry picked from commit 5f4ae7c45718618c4c571495e7d910d5722f70ad)
+---
+ llvm/lib/Support/Unix/Path.inc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/Support/Unix/Path.inc b/lib/Support/Unix/Path.inc
+index d7cc0d627d0..eb38a71fffb 100644
+--- a/lib/Support/Unix/Path.inc
++++ b/lib/Support/Unix/Path.inc
+@@ -398,6 +398,9 @@ static bool is_local_impl(struct STATVFS &Vfs) {
+ #elif defined(__Fuchsia__)
+   // Fuchsia doesn't yet support remote filesystem mounts.
+   return true;
++#elif defined(__EMSCRIPTEN__)
++  // Emscripten doesn't currently support remote filesystem mounts.
++  return true;
+ #elif defined(__HAIKU__)
+   // Haiku doesn't expose this information.
+   return false;
+-- 
+2.24.0
+

--- a/L/LLVM/v8/bundled/llvm_patches/0100-llvm-config-sysroot.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/0100-llvm-config-sysroot.patch
@@ -1,0 +1,15 @@
+diff --git a/tools/llvm-config/CMakeLists.txt b/tools/llvm-config/CMakeLists.txt
+index fc3dbaa9639..860fec06207 100644
+--- a/tools/llvm-config/CMakeLists.txt
++++ b/tools/llvm-config/CMakeLists.txt
+@@ -49,6 +49,10 @@ set(LLVM_HAS_RTTI ${LLVM_CONFIG_HAS_RTTI})
+ set(LLVM_DYLIB_VERSION "${LLVM_VERSION_MAJOR}${LLVM_VERSION_SUFFIX}")
+ set(LLVM_HAS_GLOBAL_ISEL "ON")
+ 
++# Do not embed --sysroot as it's non-portable
++string(REGEX REPLACE "--sysroot /[^ ]+" "" LLVM_CFLAGS ${LLVM_CFLAGS})
++string(REGEX REPLACE "--sysroot /[^ ]+" "" LLVM_CXXFLAGS ${LLVM_CXXFLAGS})
++
+ # Use the C++ link flags, since they should be a superset of C link flags.
+ set(LLVM_LDFLAGS "${CMAKE_CXX_LINK_FLAGS}")
+ set(LLVM_BUILDMODE ${CMAKE_BUILD_TYPE})

--- a/L/LLVM/v8/bundled/llvm_patches/9999-llvm-symver-jlprefix.patch
+++ b/L/LLVM/v8/bundled/llvm_patches/9999-llvm-symver-jlprefix.patch
@@ -1,0 +1,18 @@
+From f23277bb91a4925ba8763337137a3123a7600557 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Tue, 16 Jan 2018 17:29:05 -0500
+Subject: [PATCH] add JL prefix to all LLVM version suffixes
+
+---
+ tools/llvm-shlib/simple_version_script.map.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/llvm-shlib/simple_version_script.map.in b/tools/llvm-shlib/simple_version_script.map.in
+index e9515fe7862..af082581627 100644
+--- a/tools/llvm-shlib/simple_version_script.map.in
++++ b/tools/llvm-shlib/simple_version_script.map.in
+@@ -1 +1 @@
+-LLVM_@LLVM_VERSION_MAJOR@ { global: *; };
++JL_LLVM_@LLVM_VERSION_MAJOR@.@LLVM_VERSION_MINOR@ { global: *; };
+--
+2.15.1

--- a/L/LLVM/v9/build_tarballs.jl
+++ b/L/LLVM/v9/build_tarballs.jl
@@ -1,0 +1,9 @@
+version = v"9.0.1"
+
+include("../common.jl")
+
+platforms = expand_cxxstring_abis(supported_platforms())
+sources, script = configure(version, assert=false)
+build_tarballs(ARGS, "LLVM", version, sources, script,
+               platforms, products, dependencies,
+               preferred_gcc_version=v"7", preferred_llvm_version=v"8")

--- a/L/LLVM/v9/bundled/libcxx_patches/7005_libcxx_musl.patch
+++ b/L/LLVM/v9/bundled/libcxx_patches/7005_libcxx_musl.patch
@@ -1,0 +1,22 @@
+diff --git a/include/locale b/include/locale
+index 2043892fa2d..4af51464208 100644
+--- a/include/locale
++++ b/include/locale
+@@ -737,7 +737,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        long long __ll = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        long long __ll = strtoll(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;
+@@ -777,7 +777,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        unsigned long long __ll = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        unsigned long long __ll = strtoull(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;

--- a/L/LLVM/v9/bundled/llvm_patches/0001-llvm-D27629-AArch64-large_model_6.0.1.patch
+++ b/L/LLVM/v9/bundled/llvm_patches/0001-llvm-D27629-AArch64-large_model_6.0.1.patch
@@ -1,0 +1,53 @@
+From f76abe65e6d07fea5e838c4f8c9a9421c16debb0 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Thu, 5 Jul 2018 12:37:50 -0400
+Subject: [PATCH] Fix unwind info relocation with large code model on AArch64
+
+---
+ lib/MC/MCObjectFileInfo.cpp                   |  2 ++
+ .../AArch64/ELF_ARM64_large-relocations.s     | 20 +++++++++++++++++++
+ 2 files changed, 22 insertions(+)
+ create mode 100644 test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+
+diff --git a/lib/MC/MCObjectFileInfo.cpp b/lib/MC/MCObjectFileInfo.cpp
+index 328f000f37c..938b35f20d1 100644
+--- a/lib/MC/MCObjectFileInfo.cpp
++++ b/lib/MC/MCObjectFileInfo.cpp
+@@ -291,6 +291,8 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
+     break;
+   case Triple::ppc64:
+   case Triple::ppc64le:
++  case Triple::aarch64:
++  case Triple::aarch64_be:
+   case Triple::x86_64:
+     FDECFIEncoding = dwarf::DW_EH_PE_pcrel |
+                      (Large ? dwarf::DW_EH_PE_sdata8 : dwarf::DW_EH_PE_sdata4);
+diff --git a/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+new file mode 100644
+index 00000000000..66f28dabd79
+--- /dev/null
++++ b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
+@@ -0,0 +1,20 @@
++# RUN: llvm-mc -triple=arm64-none-linux-gnu -large-code-model -filetype=obj -o %T/large-reloc.o %s
++# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %T/large-reloc.o
++# RUN-BE: llvm-mc -triple=aarch64_be-none-linux-gnu -large-code-model -filetype=obj -o %T/be-large-reloc.o %s
++# RUN-BE: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -map-section be-large-reloc.o,.eh_frame=0x10000 -map-section be-large-reloc.o,.text=0xffff000000000000 -check=%s %T/be-large-reloc.o
++
++        .text
++        .globl  g
++        .p2align        2
++        .type   g,@function
++g:
++        .cfi_startproc
++        mov      x0, xzr
++        ret
++        .Lfunc_end0:
++        .size   g, .Lfunc_end0-g
++        .cfi_endproc
++
++# Skip the CIE and load the 8 bytes PC begin pointer.
++# Assuming the CIE and the FDE length are both 4 bytes.
++# rtdyld-check: *{8}(section_addr(large-reloc.o, .eh_frame) + (*{4}(section_addr(large-reloc.o, .eh_frame))) + 0xc) = g - (section_addr(large-reloc.o, .eh_frame) + (*{4}(section_addr(large-reloc.o, .eh_frame))) + 0xc)
+-- 
+2.18.0
+

--- a/L/LLVM/v9/bundled/llvm_patches/0002-llvm8-D34078-vectorize-fdiv.patch
+++ b/L/LLVM/v9/bundled/llvm_patches/0002-llvm8-D34078-vectorize-fdiv.patch
@@ -1,0 +1,42 @@
+diff --git a/lib/Analysis/IVDescriptors.cpp b/lib/Analysis/IVDescriptors.cpp
+index aaebc4a481e..91fe4c0003c 100644
+--- a/lib/Analysis/IVDescriptors.cpp
++++ b/lib/Analysis/IVDescriptors.cpp
+@@ -571,6 +571,7 @@ RecurrenceDescriptor::isRecurrenceInstr(Instruction *I, RecurrenceKind Kind,
+     return InstDesc(Kind == RK_IntegerOr, I);
+   case Instruction::Xor:
+     return InstDesc(Kind == RK_IntegerXor, I);
++  case Instruction::FDiv:
+   case Instruction::FMul:
+     return InstDesc(Kind == RK_FloatMult, I, UAI);
+   case Instruction::FSub:
+diff --git a/test/Transforms/LoopVectorize/float-reduction.ll b/test/Transforms/LoopVectorize/float-reduction.ll
+index f3b95d0ead7..669c54d55a2 100644
+--- a/test/Transforms/LoopVectorize/float-reduction.ll
++++ b/test/Transforms/LoopVectorize/float-reduction.ll
+@@ -44,3 +44,25 @@ for.body:                                         ; preds = %for.body, %entry
+ for.end:                                          ; preds = %for.body
+   ret float %sub
+ }
++
++;CHECK-LABEL: @foodiv(
++;CHECK: fdiv fast <4 x float>
++;CHECK: ret
++define float @foodiv(float* nocapture %A, i32* nocapture %n) nounwind uwtable readonly ssp {
++entry:
++  br label %for.body
++
++for.body:                                         ; preds = %for.body, %entry
++  %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
++  %sum.04 = phi float [ 1.000000e+00, %entry ], [ %sub, %for.body ]
++  %arrayidx = getelementptr inbounds float, float* %A, i64 %indvars.iv
++  %0 = load float, float* %arrayidx, align 4
++  %sub = fdiv fast float %sum.04, %0
++  %indvars.iv.next = add i64 %indvars.iv, 1
++  %lftr.wideiv = trunc i64 %indvars.iv.next to i32
++  %exitcond = icmp eq i32 %lftr.wideiv, 200
++  br i1 %exitcond, label %for.end, label %for.body
++
++for.end:                                          ; preds = %for.body
++  ret float %sub
++}

--- a/L/LLVM/v9/bundled/llvm_patches/0003-llvm-6.0-NVPTX-addrspaces.patch
+++ b/L/LLVM/v9/bundled/llvm_patches/0003-llvm-6.0-NVPTX-addrspaces.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/Target/NVPTX/NVPTXISelLowering.cpp b/lib/Target/NVPTX/NVPTXISelLowering.cpp
+index f1e4251a44b..73d49f5d7e4 100644
+--- a/lib/Target/NVPTX/NVPTXISelLowering.cpp
++++ b/lib/Target/NVPTX/NVPTXISelLowering.cpp
+@@ -1248,6 +1248,14 @@ SDValue NVPTXTargetLowering::getSqrtEstimate(SDValue Operand, SelectionDAG &DAG,
+   }
+ }
+ 
++bool NVPTXTargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
++                                               unsigned DestAS) const {
++  assert(SrcAS != DestAS && "Expected different address spaces!");
++
++  return (SrcAS  == ADDRESS_SPACE_GENERIC || SrcAS  > ADDRESS_SPACE_LOCAL) &&
++         (DestAS == ADDRESS_SPACE_GENERIC || DestAS > ADDRESS_SPACE_LOCAL);
++}
++
+ SDValue
+ NVPTXTargetLowering::LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const {
+   SDLoc dl(Op);
+diff --git a/lib/Target/NVPTX/NVPTXISelLowering.h b/lib/Target/NVPTX/NVPTXISelLowering.h
+index ef04a8573d4..68a9a7195c4 100644
+--- a/lib/Target/NVPTX/NVPTXISelLowering.h
++++ b/lib/Target/NVPTX/NVPTXISelLowering.h
+@@ -443,6 +443,8 @@ public:
+                                const NVPTXSubtarget &STI);
+   SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
+ 
++  bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override;
++
+   SDValue LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
+ 
+   const char *getTargetNodeName(unsigned Opcode) const override;

--- a/L/LLVM/v9/bundled/llvm_patches/0004-llvm-7.0-D44650.patch
+++ b/L/LLVM/v9/bundled/llvm_patches/0004-llvm-7.0-D44650.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/llvm-cfi-verify/CMakeLists.txt b/tools/llvm-cfi-verify/CMakeLists.txt
+index ae12bec5e80..9ffbe4e070d 100644
+--- a/tools/llvm-cfi-verify/CMakeLists.txt
++++ b/tools/llvm-cfi-verify/CMakeLists.txt
+@@ -11,7 +11,7 @@ set(LLVM_LINK_COMPONENTS
+   Symbolize
+   )
+ 
+-add_llvm_tool(llvm-cfi-verify
++add_llvm_tool(llvm-cfi-verify DISABLE_LLVM_LINK_LLVM_DYLIB
+   llvm-cfi-verify.cpp
+   )
+ 

--- a/L/LLVM/v9/bundled/llvm_patches/0005-llvm-6.0-DISABLE_ABI_CHECKS.patch
+++ b/L/LLVM/v9/bundled/llvm_patches/0005-llvm-6.0-DISABLE_ABI_CHECKS.patch
@@ -1,0 +1,39 @@
+From d793ba4bacae51ae25be19c1636fcf38707938fd Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 1 Jun 2018 17:43:55 -0400
+Subject: [PATCH] fix LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+
+---
+ cmake/modules/HandleLLVMOptions.cmake    | 2 +-
+ include/llvm/Config/abi-breaking.h.cmake | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/modules/HandleLLVMOptions.cmake b/cmake/modules/HandleLLVMOptions.cmake
+index 3d2dd48018c..b67ee6a896e 100644
+--- a/cmake/modules/HandleLLVMOptions.cmake
++++ b/cmake/modules/HandleLLVMOptions.cmake
+@@ -572,7 +572,7 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
+ 
+   if (LLVM_ENABLE_PEDANTIC AND LLVM_COMPILER_IS_GCC_COMPATIBLE)
+     append("-pedantic" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+-    append("-Wno-long-long" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
++    append("-Wno-long-long -Wundef" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+   endif()
+ 
+   add_flag_if_supported("-Wcovered-switch-default" COVERED_SWITCH_DEFAULT_FLAG)
+diff --git a/include/llvm/Config/abi-breaking.h.cmake b/include/llvm/Config/abi-breaking.h.cmake
+index 7ae401e5b8a..d52c4609101 100644
+--- a/include/llvm/Config/abi-breaking.h.cmake
++++ b/include/llvm/Config/abi-breaking.h.cmake
+@@ -20,7 +20,7 @@
+ 
+ /* Allow selectively disabling link-time mismatch checking so that header-only
+    ADT content from LLVM can be used without linking libSupport. */
+-#if !LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
++#ifndef LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+ 
+ // ABI_BREAKING_CHECKS protection: provides link-time failure when clients build
+ // mismatch with LLVM
+-- 
+2.17.0
+

--- a/L/LLVM/v9/bundled/llvm_patches/0010-llvm-exegesis-mingw.patch
+++ b/L/LLVM/v9/bundled/llvm_patches/0010-llvm-exegesis-mingw.patch
@@ -1,0 +1,24 @@
+From 9ba86352649a39b03adce98670714c4c8eb5341d Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Wed, 24 Jul 2019 21:19:20 -0400
+Subject: [PATCH] Fix build of llvm-exegis on mingw32
+
+---
+ llvm/tools/llvm-exegesis/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/llvm-exegesis/CMakeLists.txt b/tools/llvm-exegesis/CMakeLists.txt
+index a59e1b74024..7a30e0ea98f 100644
+--- a/tools/llvm-exegesis/CMakeLists.txt
++++ b/tools/llvm-exegesis/CMakeLists.txt
+@@ -4,7 +4,7 @@ set(LLVM_LINK_COMPONENTS
+   native
+   )
+ 
+-add_llvm_tool(llvm-exegesis
++add_llvm_tool(llvm-exegesis DISABLE_LLVM_LINK_LLVM_DYLIB
+   llvm-exegesis.cpp
+   )
+ 
+-- 
+2.22.0

--- a/L/LLVM/v9/bundled/llvm_patches/0011-llvm-test-plugin-mingw.patch
+++ b/L/LLVM/v9/bundled/llvm_patches/0011-llvm-test-plugin-mingw.patch
@@ -1,0 +1,24 @@
+From 9bd3774db73533c8df475639805ff1516aea274c Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Wed, 24 Jul 2019 21:45:33 -0400
+Subject: [PATCH] add missing components to TestPlugin
+
+---
+ llvm/unittests/Passes/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/unittests/Passes/CMakeLists.txt b/unittests/Passes/CMakeLists.txt
+index 3e83b527958..4b09f47c234 100644
+--- a/unittests/Passes/CMakeLists.txt
++++ b/unittests/Passes/CMakeLists.txt
+@@ -14,7 +14,7 @@ add_llvm_unittest(PluginsTests
+ export_executable_symbols(PluginsTests)
+ target_link_libraries(PluginsTests PRIVATE LLVMTestingSupport)
+ 
+-set(LLVM_LINK_COMPONENTS)
++set(LLVM_LINK_COMPONENTS Support Passes Core)
+ add_llvm_library(TestPlugin MODULE BUILDTREE_ONLY
+   TestPlugin.cpp
+   )
+-- 
+2.22.0

--- a/L/LLVM/v9/bundled/llvm_patches/0016-llvm7-revert-D44485.patch
+++ b/L/LLVM/v9/bundled/llvm_patches/0016-llvm7-revert-D44485.patch
@@ -1,0 +1,94 @@
+From 4370214628487ac8495f963ae05960b5ecc31103 Mon Sep 17 00:00:00 2001
+From: Jameson Nash <vtjnash@gmail.com>
+Date: Thu, 12 Sep 2019 11:45:07 -0400
+Subject: [PATCH] Revert "[MC] Always emit relocations for same-section
+ function references"
+
+This reverts commit 9232972575cafac29c3e4817c8714c9aca0e8585.
+---
+ lib/MC/WinCOFFObjectWriter.cpp | 12 +++++-------
+ test/MC/COFF/diff.s            | 25 ++++++++-----------------
+ 2 files changed, 13 insertions(+), 24 deletions(-)
+
+diff --git a/lib/MC/WinCOFFObjectWriter.cpp b/lib/MC/WinCOFFObjectWriter.cpp
+index 9ffecd99df6..0214161e03c 100644
+--- a/lib/MC/WinCOFFObjectWriter.cpp
++++ b/lib/MC/WinCOFFObjectWriter.cpp
+@@ -690,14 +690,12 @@ void WinCOFFObjectWriter::executePostLayoutBinding(MCAssembler &Asm,
+ bool WinCOFFObjectWriter::isSymbolRefDifferenceFullyResolvedImpl(
+     const MCAssembler &Asm, const MCSymbol &SymA, const MCFragment &FB,
+     bool InSet, bool IsPCRel) const {
+-  // Don't drop relocations between functions, even if they are in the same text
+-  // section. Multiple Visual C++ linker features depend on having the
+-  // relocations present. The /INCREMENTAL flag will cause these relocations to
+-  // point to thunks, and the /GUARD:CF flag assumes that it can use relocations
+-  // to approximate the set of all address taken functions. LLD's implementation
+-  // of /GUARD:CF also relies on the existance of these relocations.
++  // MS LINK expects to be able to replace all references to a function with a
++  // thunk to implement their /INCREMENTAL feature.  Make sure we don't optimize
++  // away any relocations to functions.
+   uint16_t Type = cast<MCSymbolCOFF>(SymA).getType();
+-  if ((Type >> COFF::SCT_COMPLEX_TYPE_SHIFT) == COFF::IMAGE_SYM_DTYPE_FUNCTION)
++  if (Asm.isIncrementalLinkerCompatible() &&
++      (Type >> COFF::SCT_COMPLEX_TYPE_SHIFT) == COFF::IMAGE_SYM_DTYPE_FUNCTION)
+     return false;
+   return MCObjectWriter::isSymbolRefDifferenceFullyResolvedImpl(Asm, SymA, FB,
+                                                                 InSet, IsPCRel);
+diff --git a/test/MC/COFF/diff.s b/test/MC/COFF/diff.s
+index f89e4ed8901..d68e628577b 100644
+--- a/test/MC/COFF/diff.s
++++ b/test/MC/COFF/diff.s
+@@ -1,14 +1,19 @@
+ // RUN: llvm-mc -filetype=obj -triple i686-pc-mingw32 %s | llvm-readobj -s -sr -sd | FileCheck %s
+ 
+-// COFF resolves differences between labels in the same section, unless that
+-// label is declared with function type.
+-
+ .section baz, "xr"
++	.def	X
++	.scl	2;
++	.type	32;
++	.endef
+ 	.globl	X
+ X:
+ 	mov	Y-X+42,	%eax
+ 	retl
+ 
++	.def	Y
++	.scl	2;
++	.type	32;
++	.endef
+ 	.globl	Y
+ Y:
+ 	retl
+@@ -25,11 +30,6 @@ _foobar:                                # @foobar
+ # %bb.0:
+ 	ret
+ 
+-	.globl	_baz
+-_baz:
+-	calll	_foobar
+-	retl
+-
+ 	.data
+ 	.globl	_rust_crate             # @rust_crate
+ 	.align	4
+@@ -39,15 +39,6 @@ _rust_crate:
+ 	.long	_foobar-_rust_crate
+ 	.long	_foobar-_rust_crate
+ 
+-// Even though _baz and _foobar are in the same .text section, we keep the
+-// relocation for compatibility with the VC linker's /guard:cf and /incremental
+-// flags, even on mingw.
+-
+-// CHECK:        Name: .text
+-// CHECK:        Relocations [
+-// CHECK-NEXT:     0x12 IMAGE_REL_I386_REL32 _foobar
+-// CHECK-NEXT:   ]
+-
+ // CHECK:        Name: .data
+ // CHECK:        Relocations [
+ // CHECK-NEXT:     0x4 IMAGE_REL_I386_DIR32 _foobar
+-- 
+2.17.1
+

--- a/L/LLVM/v9/bundled/llvm_patches/0020-llvm8-WASM-addrspaces.patch
+++ b/L/LLVM/v9/bundled/llvm_patches/0020-llvm8-WASM-addrspaces.patch
@@ -1,0 +1,45 @@
+From 664994725a1783b526710584d8ad56a871cd53b9 Mon Sep 17 00:00:00 2001
+From: Julian P Samaroo <jpsamaroo@jpsamaroo.me>
+Date: Sun, 12 May 2019 00:00:00 -0500
+Subject: [PATCH] No-op addrspacecasts in WebAssembly target
+
+Patch authored by Tom Short (@tshort)
+---
+ lib/Target/WebAssembly/WebAssemblyISelLowering.cpp | 7 +++++++
+ lib/Target/WebAssembly/WebAssemblyISelLowering.h   | 2 ++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp b/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+index 003848e3422..4f67754793e 100644
+--- a/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
++++ b/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+@@ -1224,6 +1224,13 @@ SDValue WebAssemblyTargetLowering::LowerShift(SDValue Op,
+                      DAG.getConstant(Shift, DL, MVT::i32));
+ }
+ 
++bool WebAssemblyTargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
++                                                    unsigned DestAS) const {
++  assert(SrcAS != DestAS && "Expected different address spaces!");
++
++  return true;
++}
++
+ //===----------------------------------------------------------------------===//
+ //                          WebAssembly Optimization Hooks
+ //===----------------------------------------------------------------------===//
+diff --git a/lib/Target/WebAssembly/WebAssemblyISelLowering.h b/lib/Target/WebAssembly/WebAssemblyISelLowering.h
+index 59f4230ed88..d907e088ae5 100644
+--- a/lib/Target/WebAssembly/WebAssemblyISelLowering.h
++++ b/lib/Target/WebAssembly/WebAssemblyISelLowering.h
+@@ -103,6 +103,8 @@ private:
+   SDValue LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const;
+   SDValue LowerAccessVectorElement(SDValue Op, SelectionDAG &DAG) const;
+   SDValue LowerShift(SDValue Op, SelectionDAG &DAG) const;
++
++  bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override;
+ };
+ 
+ namespace WebAssembly {
+-- 
+2.18.1
+

--- a/L/LLVM/v9/bundled/patches/0001-D72626-apple-codesign.patch
+++ b/L/LLVM/v9/bundled/patches/0001-D72626-apple-codesign.patch
@@ -1,0 +1,13 @@
+diff --git a/compiler-rt/cmake/Modules/AddCompilerRT.cmake b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -321,7 +321,7 @@
+         set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")
+         set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
+       endif()
+-      if(APPLE)
++      if(IOS)
+         # Ad-hoc sign the dylibs
+         add_custom_command(TARGET ${libname}
+           POST_BUILD  
+


### PR DESCRIPTION
Based on https://github.com/staticfloat/LLVMBuilder

Questions:

- [x] Do we want a recipe for LLVM6? It's part of LTS so maybe
- [x] This removes the assert build configuration