### PR TITLE
add other build tools to cmake toolchains

### DIFF
--- a/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_macos_clang.j2
+++ b/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_macos_clang.j2
@@ -17,8 +17,15 @@ set(CMAKE_SYSTEM_FRAMEWORK_PATH
 )
 set(CMAKE_INSTALL_PREFIX $ENV{prefix})
 
-set(CMAKE_C_COMPILER /opt/bin/clang)
+set(CMAKE_C_COMPILER   /opt/bin/clang)
 set(CMAKE_CXX_COMPILER /opt/bin/clang++)
+
+set(CMAKE_LINKER  /opt/bin/{{TARGET}}-ld)
+set(CMAKE_OBJCOPY /opt/bin/{{TARGET}}-objcopy)
+
+set(CMAKE_AR     /opt/bin/{{TARGET}}-ar)
+set(CMAKE_NM     /opt/bin/{{TARGET}}-nm)
+set(CMAKE_RANLIB /opt/bin/{{TARGET}}-ranlib)
 
 if( $ENV{CC} MATCHES ccache )
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)

--- a/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_macos_gcc.j2
+++ b/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_macos_gcc.j2
@@ -17,7 +17,7 @@ set(CMAKE_SYSTEM_FRAMEWORK_PATH
 )
 set(CMAKE_INSTALL_PREFIX $ENV{prefix})
 
-set(CMAKE_C_COMPILER /opt/bin/{{TARGET}-gcc)
+set(CMAKE_C_COMPILER /opt/bin/{{TARGET}}-gcc)
 set(CMAKE_CXX_COMPILER /opt/bin/{{TARGET}}-g++)
 
 if( $ENV{CC} MATCHES ccache )

--- a/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_macos_gcc.j2
+++ b/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_macos_gcc.j2
@@ -17,8 +17,15 @@ set(CMAKE_SYSTEM_FRAMEWORK_PATH
 )
 set(CMAKE_INSTALL_PREFIX $ENV{prefix})
 
-set(CMAKE_C_COMPILER /opt/bin/{{TARGET}}-gcc)
+set(CMAKE_C_COMPILER   /opt/bin/{{TARGET}}-gcc)
 set(CMAKE_CXX_COMPILER /opt/bin/{{TARGET}}-g++)
+
+set(CMAKE_LINKER  /opt/bin/{{TARGET}}-ld)
+set(CMAKE_OBJCOPY /opt/bin/{{TARGET}}-objcopy)
+
+set(CMAKE_AR     /opt/{{TARGET}}/bin/{{TARGET}}-gcc-ar)
+set(CMAKE_NM     /opt/{{TARGET}}/bin/{{TARGET}}-gcc-nm)
+set(CMAKE_RANLIB /opt/{{TARGET}}/bin/{{TARGET}}-gcc-ranlib)
 
 if( $ENV{CC} MATCHES ccache )
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)

--- a/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_simple_clang.j2
+++ b/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_simple_clang.j2
@@ -5,8 +5,16 @@ set(CMAKE_SYSTEM_PROCESSOR {{ARCH}})
 set(CMAKE_SYSROOT /opt/{{TARGET}}/{{TARGET}}/sys-root/)
 set(CMAKE_INSTALL_PREFIX $ENV{prefix})
 
-set(CMAKE_C_COMPILER /opt/bin/clang)
+set(CMAKE_C_COMPILER   /opt/bin/clang)
 set(CMAKE_CXX_COMPILER /opt/bin/clang++)
+
+set(CMAKE_LINKER  /opt/bin/{{TARGET}}-ld)
+set(CMAKE_OBJCOPY /opt/bin/{{TARGET}}-objcopy)
+
+set(CMAKE_AR     /opt/bin/{{TARGET}}-ar)
+set(CMAKE_NM     /opt/bin/{{TARGET}}-nm)
+set(CMAKE_RANLIB /opt/bin/{{TARGET}}-ranlib)
+
 
 if( $ENV{CC} MATCHES ccache )
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)

--- a/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_simple_gcc.j2
+++ b/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_simple_gcc.j2
@@ -7,6 +7,11 @@ set(CMAKE_INSTALL_PREFIX $ENV{prefix})
 
 set(CMAKE_C_COMPILER /opt/bin/{{TARGET}}-gcc)
 set(CMAKE_CXX_COMPILER /opt/bin/{{TARGET}}-g++)
+set(CMAKE_AR /opt/bin/{{TARGET}}-ar)
+set(CMAKE_LINKER /opt/bin/{{TARGET}}-ld)
+set(CMAKE_NM /opt/bin/{{TARGET}}-nm)
+set(CMAKE_RANLIB /opt/bin/{{TARGET}}-ranlib)
+set(CMAKE_OBJCOPY /opt/bin/{{TARGET}}-objcopy)
 
 if( $ENV{CC} MATCHES ccache )
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)

--- a/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_simple_gcc.j2
+++ b/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/cmake_simple_gcc.j2
@@ -5,13 +5,15 @@ set(CMAKE_SYSTEM_PROCESSOR {{ARCH}})
 set(CMAKE_SYSROOT /opt/{{TARGET}}/{{TARGET}}/sys-root/)
 set(CMAKE_INSTALL_PREFIX $ENV{prefix})
 
-set(CMAKE_C_COMPILER /opt/bin/{{TARGET}}-gcc)
+set(CMAKE_C_COMPILER   /opt/bin/{{TARGET}}-gcc)
 set(CMAKE_CXX_COMPILER /opt/bin/{{TARGET}}-g++)
-set(CMAKE_AR /opt/bin/{{TARGET}}-ar)
-set(CMAKE_LINKER /opt/bin/{{TARGET}}-ld)
-set(CMAKE_NM /opt/bin/{{TARGET}}-nm)
-set(CMAKE_RANLIB /opt/bin/{{TARGET}}-ranlib)
+
+set(CMAKE_LINKER  /opt/bin/{{TARGET}}-ld)
 set(CMAKE_OBJCOPY /opt/bin/{{TARGET}}-objcopy)
+
+set(CMAKE_AR     /opt/{{TARGET}}/bin/{{TARGET}}-gcc-ar)
+set(CMAKE_NM     /opt/{{TARGET}}/bin/{{TARGET}}-gcc-nm)
+set(CMAKE_RANLIB /opt/{{TARGET}}/bin/{{TARGET}}-gcc-ranlib)
 
 if( $ENV{CC} MATCHES ccache )
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)


### PR DESCRIPTION
In order to  bootstrap LLVM properly I need to provide my own toolchain file currently
since the one we use doesn't note which `nm` etc to use

https://github.com/JuliaPackaging/Yggdrasil/pull/296/files#diff-08724ed72679c754126058e3bfd19c92R76

@staticfloat please review and merge