### PR TITLE
[SuiteSparseGraphBLAS] Add SuiteSparseGraphBLAS

### DIFF
--- a/S/SuiteSparseGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparseGraphBLAS/build_tarballs.jl
@@ -13,8 +13,14 @@ sources = [
 script = raw"""
 # Compile GraphBLAS
 cd $WORKSPACE/srcdir/SuiteSparse-*/GraphBLAS/build
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_SHARED_LIBS=ON ..
-make install -j${nproc}
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} ..
+make -j${nproc} install
+if [[ ! -f "${libdir}/libgraphblas.${dlext}" ]]; then
+    # For mysterious reasons, the shared library is not installed
+    # when building for Windows
+    mkdir -p "${libdir}"
+    cp "libgraphblas.${dlext}" "${libdir}"
+fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/S/SuiteSparseGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparseGraphBLAS/build_tarballs.jl
@@ -1,0 +1,34 @@
+using BinaryBuilder
+
+name = "SuiteSparseGraphBLAS"
+version = v"5.6.0"
+
+# Collection of sources required to build SuiteSparse
+sources = [
+    "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v$(version).tar.gz" =>
+    "76d34d9f6dafc592b69af14f58c1dc59e24853dcd7c2e8f4c98ffa223f6a1adb"
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+# Compile GraphBLAS
+cd $WORKSPACE/srcdir/SuiteSparse-*/GraphBLAS/build
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} ..
+make install -j${nproc}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libgraphblas", :libgraphblas),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/S/SuiteSparseGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparseGraphBLAS/build_tarballs.jl
@@ -38,4 +38,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"5")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6")

--- a/S/SuiteSparseGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparseGraphBLAS/build_tarballs.jl
@@ -31,4 +31,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"5")

--- a/S/SuiteSparseGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparseGraphBLAS/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 script = raw"""
 # Compile GraphBLAS
 cd $WORKSPACE/srcdir/SuiteSparse-*/GraphBLAS/build
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} ..
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_SHARED_LIBS=ON ..
 make install -j${nproc}
 """
 

--- a/S/SuiteSparseGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparseGraphBLAS/build_tarballs.jl
@@ -5,8 +5,8 @@ version = v"5.6.0"
 
 # Collection of sources required to build SuiteSparse
 sources = [
-    "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v$(version).tar.gz" =>
-    "76d34d9f6dafc592b69af14f58c1dc59e24853dcd7c2e8f4c98ffa223f6a1adb"
+    FileSource("https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v$(version).tar.gz",
+               "76d34d9f6dafc592b69af14f58c1dc59e24853dcd7c2e8f4c98ffa223f6a1adb")
 ]
 
 # Bash recipe for building across all platforms
@@ -34,7 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "CompilerSupportLibraries_jll",
+    Dependency("CompilerSupportLibraries_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/SuiteSparseGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparseGraphBLAS/build_tarballs.jl
@@ -34,6 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    "CompilerSupportLibraries_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/SuiteSparseGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparseGraphBLAS/build_tarballs.jl
@@ -5,15 +5,16 @@ version = v"5.6.0"
 
 # Collection of sources required to build SuiteSparse
 sources = [
-    FileSource("https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v$(version).tar.gz",
-               "76d34d9f6dafc592b69af14f58c1dc59e24853dcd7c2e8f4c98ffa223f6a1adb")
+    ArchiveSource("https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v$(version).tar.gz",
+                  "76d34d9f6dafc592b69af14f58c1dc59e24853dcd7c2e8f4c98ffa223f6a1adb")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 # Compile GraphBLAS
 cd $WORKSPACE/srcdir/SuiteSparse-*/GraphBLAS/build
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} ..
+cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DUSER_NONE=1
 make -j${nproc} install
 if [[ ! -f "${libdir}/libgraphblas.${dlext}" ]]; then
     # For mysterious reasons, the shared library is not installed
@@ -33,8 +34,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
-    Dependency("CompilerSupportLibraries_jll"),
+dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
We are bumping SuiteSparse to 5.6 here for GraphBLAS so that we get GraphBLAS 3, and can skip older versions. The libgraphblas is completely independent from anything else in SuiteSparse and thus this should be ok.