### PR TITLE
Enable `ALSA` backend for `libportaudio`

### DIFF
--- a/L/libportaudio/build_tarballs.jl
+++ b/L/libportaudio/build_tarballs.jl
@@ -71,6 +71,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    # Build against `ALSA` on Linux
+    "alsa_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This should make `libportaudio` actually useful on most Linux systems.