### PR TITLE
Add flag to `auto_install_license` to check success

### DIFF
--- a/0_RootFS/Rootfs/bundled/conf/profile.d/license_utils.sh
+++ b/0_RootFS/Rootfs/bundled/conf/profile.d/license_utils.sh
@@ -37,5 +37,14 @@ auto_install_license () {
             fi
         fi
     fi
-}
 
+    if [[ "${@}" == "-c" ]]; then
+        if [[ -d "${prefix}/share/licenses/${SRC_NAME}" ]]; then
+            # If we pass the `-c` option, check if we installed anything,
+            # if not then return non-zero exit code.
+            return 0
+        else
+            return 1
+        fi
+    fi
+}


### PR DESCRIPTION
I want a way to check if `auto_install_license` installed anything, so that in the wizard we can warn the user if no license is found.