### PR TITLE
[XML2] Make sure libxml2 is linked to our own libiconv on macOS

### DIFF
--- a/X/XML2/build_tarballs.jl
+++ b/X/XML2/build_tarballs.jl
@@ -14,8 +14,10 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd ${WORKSPACE}/srcdir/libxml2-*
-./autogen.sh
-./configure --prefix=${prefix} --host=${target} --without-python --with-zlib=${prefix}
+./autogen.sh --prefix=${prefix} --host=${target} \
+    --without-python \
+    --with-zlib=${prefix} \
+    --with-iconv=${prefix}
 make -j${nproc} install
 """
 
@@ -25,12 +27,15 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libxml2", :libxml2)
+    LibraryProduct("libxml2", :libxml2),
+    ExecutableProduct("xmlcatalog", :xmlcatalog),
+    ExecutableProduct("xmllint", :xmllint),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "Zlib_jll"
+    "Zlib_jll",
+    "Libiconv_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
With this, on macOS I get:
```
sandbox:${WORKSPACE}/srcdir/libxml2-2.9.9 # otool -L ${libdir}/libxml2.2.dylib 
/workspace/destdir/lib/libxml2.2.dylib:
        /workspace/destdir/lib/libxml2.2.dylib (compatibility version 12.0.0, current version 12.9.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
        @rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
        @rpath/libiconv.2.dylib (compatibility version 9.0.0, current version 9.1.0)
```

See https://github.com/JuliaGtk/GtkSourceWidget.jl/pull/9 for reference