### PR TITLE
[Gettext] Add XML2 to the dependencies

### DIFF
--- a/G/Gettext/build_tarballs.jl
+++ b/G/Gettext/build_tarballs.jl
@@ -23,7 +23,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libgettext", :libgettext)
+    LibraryProduct(["libgettextlib", "libgettextlib-0-20"], :libgettext)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/G/Gettext/build_tarballs.jl
+++ b/G/Gettext/build_tarballs.jl
@@ -11,8 +11,8 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/gettext-*/
-
-./configure --prefix=$prefix --host=$target CFLAGS="-O2"
+export CFLAGS="-O2"
+./configure --prefix=$prefix --host=$target
 make -j${nproc}
 make install
 """
@@ -29,6 +29,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     "Libiconv_jll",
+    "XML2_jll",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This is to make sure that the libraries are linked against our own libxml2 on macOS:
```
sandbox:${WORKSPACE}/srcdir/gettext-0.20.1 # otool -L ${libdir}/libgettextlib.dylib 
/workspace/destdir/lib/libgettextlib.dylib:
        /workspace/destdir/lib/libgettextlib-0.20.1.dylib (compatibility version 0.0.0, current version 0.0.0)
        /workspace/destdir/lib/libintl.8.dylib (compatibility version 10.0.0, current version 10.6.0)
        @rpath/libxml2.2.dylib (compatibility version 12.0.0, current version 12.9.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
        @rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
        @rpath/libiconv.2.dylib (compatibility version 9.0.0, current version 9.1.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1153.18.0)
```

However I'm wondering whether we should stop providing libxml2 on macOS, since there `/usr/lib/libxm2.2.dylib` that is required anyway by other system libraries.  See https://github.com/JuliaGtk/GtkSourceWidget.jl/pull/9 for more context, and [this Travis job](https://travis-ci.com/giordano/GtkSourceWidget.jl/jobs/271165510) for the output of `otool -L` on many shared libraries used by Julia.