### PR TITLE
[boost] Build libraries missing on FreeBSD

### DIFF
--- a/B/boost/build_tarballs.jl
+++ b/B/boost/build_tarballs.jl
@@ -9,6 +9,7 @@ version = v"1.71.0"
 sources = [
     "https://dl.bintray.com/boostorg/release/$(version)/source/boost_$(version.major)_$(version.minor)_$(version.patch).tar.bz2" =>
     "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee",
+    "./bundled",
 ]
 
 # Bash recipe for building across all platforms
@@ -16,6 +17,11 @@ script = raw"""
 cd $WORKSPACE/srcdir/boost*/
 
 CXX=$CXX_FOR_BUILD ./bootstrap.sh --prefix=$prefix --without-libraries=python --with-toolset=gcc
+
+# Patch adapted from
+# https://svnweb.freebsd.org/ports/head/devel/boost-libs/files/patch-boost_math_tools_config.hpp?revision=439932&view=markup
+# to be able to build long double math libraries
+atomic_patch -p1 ../patches/boost_math_tools_config_hpp.patch
 
 rm project-config.jam
 toolset=gcc
@@ -39,49 +45,49 @@ elif [[ $target == *freebsd* ]]; then
     extraargs="address-model=64 link=shared"
     echo "using clang : 6.0 : $CXX : <linkflags>\\"$LDFLAGS\\" ;" > project-config.jam
 fi
-./b2 -j8 toolset=$toolset target-os=$targetos $extraargs variant=release --prefix=$prefix --without-python --layout=system install
+./b2 -j${nproc} toolset=$toolset target-os=$targetos $extraargs variant=release --prefix=$prefix --without-python --layout=system install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter(p -> !isa(p, FreeBSD), supported_platforms())
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libboost_math_tr1f", :libboost_math_tr1f),
-    LibraryProduct("libboost_thread", :libboost_thread),
-    LibraryProduct("libboost_unit_test_framework", :libboost_unit_test_framework),
-    LibraryProduct("libboost_type_erasure", :libboost_type_erasure),
+    LibraryProduct("libboost_atomic", :libboost_atomic),
     LibraryProduct("libboost_chrono", :libboost_chrono),
-    LibraryProduct("libboost_math_c99l", :libboost_math_c99l),
-    # boost_locale segfaults on windows, see #2
-    #LibraryProduct("libboost_locale", :libboost_locale),
-    LibraryProduct("libboost_program_options", :libboost_program_options),
+    LibraryProduct("libboost_container", :libboost_container),
+    LibraryProduct("libboost_context", :libboost_context),
+    LibraryProduct("libboost_contract", :libboost_contract),
+    LibraryProduct("libboost_coroutine", :libboost_coroutine),
     LibraryProduct("libboost_date_time", :libboost_date_time),
+    LibraryProduct("libboost_filesystem", :libboost_filesystem),
     LibraryProduct("libboost_graph", :libboost_graph),
     LibraryProduct("libboost_iostreams", :libboost_iostreams),
-    LibraryProduct("libboost_system", :libboost_system),
-    LibraryProduct("libboost_wave", :libboost_wave),
-    LibraryProduct("libboost_wserialization", :libboost_wserialization),
-    LibraryProduct("libboost_math_tr1l", :libboost_math_tr1l),
-    LibraryProduct("libboost_math_tr1", :libboost_math_tr1),
-    LibraryProduct("libboost_filesystem", :libboost_filesystem),
-    LibraryProduct("libboost_random", :libboost_random),
-    LibraryProduct("libboost_coroutine", :libboost_coroutine),
-    LibraryProduct("libboost_serialization", :libboost_serialization),
-    LibraryProduct("libboost_context", :libboost_context),
-    LibraryProduct("libboost_container", :libboost_container),
-    LibraryProduct("libboost_stacktrace_noop", :libboost_stacktrace_noop),
-    LibraryProduct("libboost_contract", :libboost_contract),
-    LibraryProduct("libboost_prg_exec_monitor", :libboost_prg_exec_monitor),
-    LibraryProduct("libboost_regex", :libboost_regex),
+    # boost_locale segfaults on windows, see https://github.com/benlorenz/boostBuilder/issues/2
+    #LibraryProduct("libboost_locale", :libboost_locale),
+    LibraryProduct("libboost_log", :libboost_log),
     LibraryProduct("libboost_log_setup", :libboost_log_setup),
     LibraryProduct("libboost_math_c99", :libboost_math_c99),
-    LibraryProduct("libboost_timer", :libboost_timer),
-    LibraryProduct("libboost_stacktrace_basic", :libboost_stacktrace_basic),
+    LibraryProduct("libboost_math_c99l", :libboost_math_c99l),
     LibraryProduct("libboost_math_c99f", :libboost_math_c99f),
-    LibraryProduct("libboost_log", :libboost_log),
-    LibraryProduct("libboost_atomic", :libboost_atomic)
+    LibraryProduct("libboost_math_tr1", :libboost_math_tr1),
+    LibraryProduct("libboost_math_tr1f", :libboost_math_tr1f),
+    LibraryProduct("libboost_math_tr1l", :libboost_math_tr1l),
+    LibraryProduct("libboost_prg_exec_monitor", :libboost_prg_exec_monitor),
+    LibraryProduct("libboost_program_options", :libboost_program_options),
+    LibraryProduct("libboost_random", :libboost_random),
+    LibraryProduct("libboost_regex", :libboost_regex),
+    LibraryProduct("libboost_serialization", :libboost_serialization),
+    LibraryProduct("libboost_stacktrace_basic", :libboost_stacktrace_basic),
+    LibraryProduct("libboost_stacktrace_noop", :libboost_stacktrace_noop),
+    LibraryProduct("libboost_system", :libboost_system),
+    LibraryProduct("libboost_thread", :libboost_thread),
+    LibraryProduct("libboost_timer", :libboost_timer),
+    LibraryProduct("libboost_type_erasure", :libboost_type_erasure),
+    LibraryProduct("libboost_unit_test_framework", :libboost_unit_test_framework),
+    LibraryProduct("libboost_wave", :libboost_wave),
+    LibraryProduct("libboost_wserialization", :libboost_wserialization),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/B/boost/bundled/patches/boost_math_tools_config_hpp.patch
+++ b/B/boost/bundled/patches/boost_math_tools_config_hpp.patch
@@ -1,0 +1,11 @@
+--- a/boost/math/tools/config.hpp
++++ b/boost/math/tools/config.hpp
+@@ -28,7 +28,7 @@
+ 
+ #include <boost/math/tools/user.hpp>
+ 
+-#if (defined(__CYGWIN__) || defined(__FreeBSD__) || defined(__NetBSD__) \
++#if (defined(__CYGWIN__) || defined(__NetBSD__) \
+    || (defined(__hppa) && !defined(__OpenBSD__)) || (defined(__NO_LONG_DOUBLE_MATH) && (DBL_MANT_DIG != LDBL_MANT_DIG))) \
+    && !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
+ #  define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS


### PR DESCRIPTION
This makes it possible to provide boost for FreeBSD: for some reasons not very clear from the log, `libboost_math_c99l` and `libboost_math_tr1l` are not built.  I also alphabetically sorted the products, to make it easier to go through them.