### PR TITLE
[Chemfiles] Expand C++ string ABIs

### DIFF
--- a/C/Chemfiles/build_tarballs.jl
+++ b/C/Chemfiles/build_tarballs.jl
@@ -24,8 +24,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
<s>It has been reported in https://github.com/JuliaBinaryWrappers/Chemfiles_jll.jl/issues/1 that the 64-bit Windows library makes Julia crash upon `dlopen`ing it.  I did some tests in my fork of `Chemfiles_jll` (see for example the [AppVeyor jobs](https://ci.appveyor.com/project/giordano/chemfiles-jll-jl/history)) and I'm pretty convinced that we need to expand the C++ string ABI.</s> The [renewed audit pass](https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/616) about C++ string ABI confirms that this library needs to expand the ABIs.

CC: @Luthaf