### PR TITLE
Wizard recipe: peco-v0.5.7

### DIFF
--- a/P/peco/build_tarballs.jl
+++ b/P/peco/build_tarballs.jl
@@ -7,17 +7,14 @@ version = v"0.5.7"
 
 # Collection of sources required to complete build
 sources = [
-    "https://github.com/peco/peco/archive/v0.5.7.tar.gz" =>
+    "https://github.com/peco/peco/archive/v$(version).tar.gz" =>
     "9bf4f10b3587270834380e1ea939625bd47eaa166bfabd050e66fad3ffd8f9b0",
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/peco-*/
-make build
-go build cmd/peco/peco.go 
-mkdir -p ${bindir}
-cp peco ${bindir}
+go build -o ${bindir}/peco${exeext} cmd/peco/peco.go
 """
 
 # These are the platforms we will build for by default, unless further
@@ -31,7 +28,6 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/P/peco/build_tarballs.jl
+++ b/P/peco/build_tarballs.jl
@@ -1,0 +1,38 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "peco"
+version = v"0.5.7"
+
+# Collection of sources required to complete build
+sources = [
+    "https://github.com/peco/peco/archive/v0.5.7.tar.gz" =>
+    "9bf4f10b3587270834380e1ea939625bd47eaa166bfabd050e66fad3ffd8f9b0",
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/peco-*/
+make build
+go build cmd/peco/peco.go 
+mkdir -p ${bindir}
+cp peco ${bindir}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("peco", :peco)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers = [:go,:c])


### PR DESCRIPTION
This pull request contains a new build recipe I built using the BinaryBuilder.jl wizard:

* Package name: peco
* Version: v0.5.7

@staticfloat please review and merge.

Created with https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/553.  Fix #374.  CC: @rapus95