### PR TITLE
Add Armadillo build script

### DIFF
--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -14,16 +14,36 @@ mkdir build && cd build
 
 FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
        -DCMAKE_INSTALL_PREFIX=${prefix}
+       -DCMAKE_BUILD_TYPE=Release
        -DBUILD_SHARED_LIBS=ON)
 
-# Slightly different handling is needed on x64 Windows.
-if [[ "$target" == "x86_64*mingw*" ]]; then
+if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
     FLAGS+=(-Dopenblas_LIBRARY="${libdir}/libopenblas64_.${dlext}")
+
+    SYMB_DEFS=()
+    for sym in sasum dasum snrm2 dnrm2 sdot ddot sgemv dgemv cgemv zgemv sgemm dgemm cgemm zgemm ssyrk dsyrk cherk zherk; do
+        SYMB_DEFS+=("-D${sym}=${sym}_64")
+    done
+    if [[ "${target}" == *-apple-* ]]; then
+        FLAGS+=(-DALLOW_OPENBLAS_MACOS=ON)
+        for sym in cgbcon cgbsv cgbsvx cgbtrf cgbtrs cgecon cgees cgeev cgeevx cgehrd cgels cgelsd cgemm cgemv cgeqrf cgesdd cgesv cgesvd cgesvx cgetrf cgetri cgetrs cgges cggev cgtsv cgtsvx cheev cheevd cherk clangb clange clanhe clansy cpbtrf cpocon cposv cposvx cpotrf cpotri cpotrs ctrcon ctrsyl ctrtri ctrtrs cungqr dasum ddot dgbcon dgbsv dgbsvx dgbtrf dgbtrs dgecon dgees dgeev dgeevx dgehrd dgels dgelsd dgemm dgemv dgeqrf dgesdd dgesv dgesvd dgesvx dgetrf dgetri dgetrs dgges dggev dgtsv dgtsvx dlahqr dlangb dlange dlansy dlarnv dnrm2 dorgqr dpbtrf dpocon dposv dposvx dpotrf dpotri dpotrs dstedc dsyev dsyevd dsyrk dtrcon dtrevc dtrsyl dtrtri dtrtrs ilaenv sasum sdot sgbcon sgbsv sgbsvx sgbtrf sgbtrs sgecon sgees sgeev sgeevx sgehrd sgels sgelsd sgemm sgemv sgeqrf sgesdd sgesv sgesvd sgesvx sgetrf sgetri sgetrs sgges sggev sgtsv sgtsvx slahqr slangb slange slansy slarnv snrm2 sorgqr spbtrf spocon sposv sposvx spotrf spotri spotrs sstedc ssyev ssyevd ssyrk strcon strevc strsyl strtri strtrs zgbcon zgbsv zgbsvx zgbtrf zgbtrs zgecon zgees zgeev zgeevx zgehrd zgels zgelsd zgemm zgemv zgeqrf zgesdd zgesv zgesvd zgesvx zgetrf zgetri zgetrs zgges zggev zgtsv zgtsvx zheev zheevd zherk zlangb zlange zlanhe zlansy zpbtrf zpocon zposv zposvx zpotrf zpotri zpotrs ztrcon ztrsyl ztrtri ztrtrs zungqr; do
+            SYMB_DEFS+=("-D${sym}=${sym}_64")
+        done
+    fi
+    export CXXFLAGS="${SYMB_DEFS[@]}"
 fi
 
 cmake .. "${FLAGS[@]}"
 make -j${nproc}
 make install
+
+# Armadillo links against a _very_ specific version of OpenBLAS on macOS by
+# default:
+if [[ ${target} == *apple* ]]; then
+    # Figure out what version it probably latched on to:
+    OPENBLAS_LINK=$(otool -L ${libdir}/libarmadillo.dylib | grep libopenblas64_ | awk '{ print $1 }')
+    install_name_tool -change ${OPENBLAS_LINK} @rpath/libopenblas64_.dylib ${libdir}/libarmadillo.dylib
+fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -16,8 +16,8 @@ FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
        -DCMAKE_INSTALL_PREFIX=${prefix}
        -DBUILD_SHARED_LIBS=ON)
 
-# Slightly different handling is needed on different platforms.
-if [[ "${nbits}" == 64 ]]; then
+# Slightly different handling is needed on x64 Windows.
+if [[ "$target" == "x86_64*mingw*" ]]; then
     FLAGS+=(-Dopenblas_LIBRARY="${libdir}/libopenblas64_.${dlext}")
 fi
 

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -15,14 +15,12 @@ script = raw"""
     if [[ $target == i686*mingw* ]]
     then
         cmake \
-            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/destdir/ \
             .
     elif [[ $target == x86_64*mingw* ]]
     then
         cmake \
-            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
             -Dopenblas_LIBRARY=$prefix/lib/libopenblas64_.a \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/destdir/ \

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -9,30 +9,21 @@ sources = [
     ("http://sourceforge.net/projects/arma/files/armadillo-9.800.3.tar.xz" =>
         "a481e1dc880b7cb352f8a28b67fe005dc1117d4341277f12999a2355d40d7599")]
 script = raw"""
-    cd ${WORKSPACE}/srcdir/armadillo-*/
+cd ${WORKSPACE}/srcdir/armadillo-*/
+mkdir build && cd build
 
-    # Slightly different handling is needed on different platforms.
-    if [[ $target == i686*mingw* ]]
-    then
-        cmake \
-            -DBUILD_SHARED_LIBS=ON \
-            -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/destdir/ \
-            .
-    elif [[ $target == x86_64*mingw* ]]
-    then
-        cmake \
-            -Dopenblas_LIBRARY=$prefix/lib/libopenblas64_.a \
-            -DBUILD_SHARED_LIBS=ON \
-            -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/destdir/ \
-            .
-    else
-        cmake \
-            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-            -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/destdir/ \
-            .
-    fi
+FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
+       -DCMAKE_INSTALL_PREFIX=${prefix}
+       -DBUILD_SHARED_LIBS=ON)
 
-    make install
+# Slightly different handling is needed on different platforms.
+if [[ "${nbits}" == 64 ]]; then
+    FLAGS+=(-Dopenblas_LIBRARY="${libdir}/libopenblas64_.${dlext}")
+fi
+
+cmake .. "${FLAGS[@]}"
+make -j${nproc}
+make install
 """
 
 # These are the platforms we will build for by default, unless further

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -1,0 +1,55 @@
+# Build script for Armadillo: C++ library for linear algebra.  It contains a
+# library libarmadillo.so that is a wrapper for OpenBLAS, and header files.
+
+using BinaryBuilder
+
+name = "armadillo"
+version = v"9.800.3"
+sources = [
+    ("http://sourceforge.net/projects/arma/files/armadillo-9.800.3.tar.xz" =>
+        "a481e1dc880b7cb352f8a28b67fe005dc1117d4341277f12999a2355d40d7599")]
+script = raw"""
+    cd ${WORKSPACE}/srcdir/armadillo-*/
+
+    # Slightly different handling is needed on different platforms.
+    if [[ $target == i686*mingw* ]]
+    then
+        cmake \
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/destdir/ \
+            .
+    elif [[ $target == x86_64*mingw* ]]
+    then
+        cmake \
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+            -Dopenblas_LIBRARY=$prefix/lib/libopenblas64_.a \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/destdir/ \
+            .
+    else
+        cmake \
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+            -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/destdir/ \
+            .
+    fi
+
+    make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line.
+platforms = supported_platforms()
+
+# The products that we will ensure are always built.
+products = [
+    LibraryProduct("libarmadillo", :libarmadillo)
+]
+
+# Dependencies that must be installed before this package can be built.
+dependencies = [
+    "OpenBLAS_jll"
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products,
+        dependencies)


### PR DESCRIPTION
This is a dependency of mlpack (#368).  @giordano suggested that I pull it out as a separate package.  I decided to package `libarmadillo.so`, but it's still possible to use Armadillo as a header-only library.  `libarmadillo.so` is basically just a wrapper around OpenBLAS.

Armadillo's quite easy to package, so I think that this should be good to go.  For downstream packages that link against Armadillo, there may be problems until https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/604 is fixed (I think that caused issues with mlpack, which depends on Armadillo).  In any case, this appeared to build fine locally for me.