### PR TITLE
[Tar] Add builder

### DIFF
--- a/T/Tar/build_tarballs.jl
+++ b/T/Tar/build_tarballs.jl
@@ -1,0 +1,39 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "Tar"
+version = v"1.32"
+
+# Collection of sources required to build tar
+sources = [
+    "https://ftp.gnu.org/gnu/tar/tar-$(version.major).$(version.minor).tar.xz" =>
+    "d0d3ae07f103323be809bc3eac0dcc386d52c5262499fe05511ac4788af1fdd8",
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/tar-*/
+export FORCE_UNSAFE_CONFIGURE=1
+./configure --prefix=${prefix} --host=${target}
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line.  We are manually disabling
+# many platforms that do not seem to work.
+platforms = [p for p in supported_platforms() if !(p isa Windows)]
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("tar", :tar),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    "Attr_jll",
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
@StefanKarpinski I thought this could be useful for testing in `Tar.jl`, but it doesn't seem to be easy to build for Windows.  I could not find any patch in https://github.com/msys2/MINGW-packages/
```
MINGW-packages-master% find . -iname "*tar*" -type d
./mingw-w64-xmlstarlet-git
./mingw-w64-cantarell-fonts
```
I found http://gnuwin32.sourceforge.net/packages/gtar.htm but it's super-old.  It's also quite hard to google something like "build tar for windows"