### PR TITLE
[LLVM9] allow clang shlib on mingw

### DIFF
--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -199,11 +199,6 @@ if [[ "${target}" == *freebsd* ]]; then
     CMAKE_FLAGS+=(-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE)
 fi
 
-if [[ "${target}" == *mingw* ]]; then
-    # On LLVM9 clang dylib is only support on Unix
-    CMAKE_FLAGS+=(-DCLANG_LINK_CLANG_DYLIB=OFF)
-fi
-
 cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]} -DCMAKE_CXX_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS}" -DCMAKE_C_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS}"
 cmake -LA || true
 ninja -j${nproc} -vv

--- a/L/LLVM/v9/build_tarballs.jl
+++ b/L/LLVM/v9/build_tarballs.jl
@@ -2,7 +2,6 @@ version = v"9.0.1"
 
 include("../common.jl")
 
-
 platforms = expand_cxxstring_abis(supported_platforms())
 sources, script, products = configure(version, assert=false)
 build_tarballs(ARGS, "LLVM", version, sources, script,

--- a/L/LLVM/v9/bundled/patches/0700-clang-shlib-mingw.patch
+++ b/L/LLVM/v9/bundled/patches/0700-clang-shlib-mingw.patch
@@ -1,0 +1,44 @@
+From 8af61e19e2a40d5edecc78161deda415b0fa15f6 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Tue, 21 Jan 2020 21:45:39 -0500
+Subject: [PATCH] allow shlib on mingw
+
+---
+ clang/tools/CMakeLists.txt             | 4 +---
+ clang/tools/clang-shlib/CMakeLists.txt | 5 +++++
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/clang/tools/CMakeLists.txt b/clang/tools/CMakeLists.txt
+index e46c3669a2c..5608357fe58 100644
+--- a/clang/tools/CMakeLists.txt
++++ b/clang/tools/CMakeLists.txt
+@@ -15,9 +15,7 @@ add_clang_subdirectory(c-index-test)
+ 
+ add_clang_subdirectory(clang-rename)
+ add_clang_subdirectory(clang-refactor)
+-if(UNIX)
+-  add_clang_subdirectory(clang-shlib)
+-endif()
++add_clang_subdirectory(clang-shlib)
+ 
+ if(CLANG_ENABLE_ARCMT)
+   add_clang_subdirectory(arcmt-test)
+diff --git a/clang/tools/clang-shlib/CMakeLists.txt b/clang/tools/clang-shlib/CMakeLists.txt
+index a0fc8f6bfbd..63954c90fdf 100644
+--- a/clang/tools/clang-shlib/CMakeLists.txt
++++ b/clang/tools/clang-shlib/CMakeLists.txt
+@@ -3,6 +3,11 @@ if (NOT LLVM_ENABLE_PIC)
+   return()
+ endif()
+ 
++# Building libclang-cpp.so may not work on MSVC
++if (MSVC)
++  return()
++endif()
++
+ get_property(clang_libs GLOBAL PROPERTY CLANG_STATIC_LIBS)
+ 
+ foreach (lib ${clang_libs})
+-- 
+2.25.0
+


### PR DESCRIPTION
fix the cmake file for clang to build the shlib on mingw