### PR TITLE
[Libglvnd] Retrigger build to fix dependencies of JLL package

### DIFF
--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -43,5 +43,5 @@ dependencies = [
     "Xorg_glproto_jll",
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
+# Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
For some mysterious reasons, `Libglvnd_jll.jl` [depends](https://github.com/JuliaRegistries/General/blob/ca3fd0f77200a9cd4823170dd90a007d84e56e16/L/Libglvnd_jll/Deps.toml) on both `X11_jll` and `Xorg_libX11_jll`.  This doesn't make any sense, in [this commit](https://github.com/JuliaPackaging/Yggdrasil/commit/45c59bc13354f1301850f1ed85414a78e5798bd1#diff-b1b205d69c72c8422f64d9eb38d15640) `X11_jll` was removed from the dependencies, and `Xorg_libX11_jll` was added, they've never been together in the list of dependencies :confused: