### PR TITLE
[SDL2_image] [SDL2_mixer] Trigger build

### DIFF
--- a/S/SDL2_image/build_tarballs.jl
+++ b/S/SDL2_image/build_tarballs.jl
@@ -45,5 +45,5 @@ dependencies = [
     PackageSpec(name="Libtiff_jll", uuid="89763e89-9b03-5906-acba-b20f662cd828")
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
+# Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/S/SDL2_mixer/build_tarballs.jl
+++ b/S/SDL2_mixer/build_tarballs.jl
@@ -44,5 +44,5 @@ dependencies = [
     PackageSpec(name="mpg123_jll", uuid="3205ef68-7822-558b-ad0d-1b4740f12437")
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
+# Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This should magically remove the dependency on libiconv for the macOS library.