### PR TITLE
RootFS: Upgrade testsuite

### DIFF
--- a/0_RootFS/Rootfs/bundled/testsuite/Makefile
+++ b/0_RootFS/Rootfs/bundled/testsuite/Makefile
@@ -5,7 +5,7 @@ cleanall:
 install:
 
 LANGUAGES=c cxx fortran go rust
-PROJECTS=hello_world dyn_link
+PROJECTS=hello_world dyn_link openmp
 
 define unesc
 $(subst -,/,$(subst install-,,$(subst build-,,$(subst clean-,,$(subst run-,,$1)))))

--- a/0_RootFS/Rootfs/bundled/testsuite/c/openmp/Makefile
+++ b/0_RootFS/Rootfs/bundled/testsuite/c/openmp/Makefile
@@ -1,0 +1,8 @@
+PROJECT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+BINS = $(PROJECT_NAME)$(exeext)
+
+include ../../common.mk
+
+$(PROJECT_BUILD)/$(PROJECT_NAME)$(exeext): $(PROJECT_NAME).c
+	$(call color,$(CC),-o $@ $(CPPFLAGS) $(CFLAGS) -fopenmp $(LDFLAGS) $<)
+

--- a/0_RootFS/Rootfs/bundled/testsuite/c/openmp/openmp.c
+++ b/0_RootFS/Rootfs/bundled/testsuite/c/openmp/openmp.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main(void) {
+    #pragma omp parallel
+    {
+        printf("Hello, World... from thread = %d\n", omp_get_thread_num());
+    }
+    return 0;
+}

--- a/0_RootFS/Rootfs/bundled/testsuite/cxx/dyn_link/dyn_link.cc
+++ b/0_RootFS/Rootfs/bundled/testsuite/cxx/dyn_link/dyn_link.cc
@@ -2,6 +2,6 @@
 #include "librepeater.h"
 
 int main(void) {
-    std::cout << repeater(std::string("waka"), 16.0);
+    std::cout << repeater(std::string("waka"), 16.0) << std::endl;
     return 0;
 }

--- a/0_RootFS/Rootfs/bundled/testsuite/fortran/hello_world/Makefile
+++ b/0_RootFS/Rootfs/bundled/testsuite/fortran/hello_world/Makefile
@@ -12,4 +12,6 @@ endif
 $(PROJECT_BUILD)/$(PROJECT_NAME).o: $(PROJECT_NAME).f | $(PROJECT_BUILD)
 	$(call color,$(FC),-o $@ $(FFLAGS) -c $<)
 $(PROJECT_BUILD)/$(PROJECT_NAME)$(exeext): $(PROJECT_BUILD)/$(PROJECT_NAME).o
+	@# We want to compare linking with $(CC) as well as fully linking with $(FC)
 	$(call color,$(CC),-o $@ $(LDFLAGS) -lgfortran -lm $<)
+	$(call color,$(FC),-o $@ $(FFLAGS) $(LDFLAGS) -lgfortran -lm $(PROJECT_NAME).f)


### PR DESCRIPTION
This adds a few small improvements to our testsuite:

* It tests linking with both `$CC` and `$FC` when running the fortran test suite, to catch things like https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/630

* It adds an OpenMP test to the `c` test suites, so that I can try out linking against different versions of `libgomp`.

