### PR TITLE
[CGAL]: Bump to 5.0.1

### DIFF
--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -6,16 +6,16 @@ const name, version = "CGAL", v"5.0.1"
 
 # Collection of sources required to build CGAL
 const sources = [
-    "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-$version/CGAL-$version.tar.xz" =>
-        "66021111fe536268d044e5e01bd26e691d7b493c217a1ca4d9427284dd4b2a02",
+    FileSource("https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-$version/CGAL-$version.tar.xz",
+               "66021111fe536268d044e5e01bd26e691d7b493c217a1ca4d9427284dd4b2a02"),
 ]
 
 # Dependencies that must be installed before this package can be built
 const dependencies = [
-    "boost_jll",
-    "GMP_jll",
-    "MPFR_jll",
-    "Zlib_jll",
+    Dependency("boost_jll"),
+    Dependency("GMP_jll"),
+    Dependency("MPFR_jll"),
+    Dependency("Zlib_jll"),
 ]
 
 # Bash recipe for building across all platforms

--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -2,13 +2,12 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 
-const name, version = "CGAL", v"5"
-const sversion = "$(version.major).$(version.minor)"
+const name, version = "CGAL", v"5.0.1"
 
 # Collection of sources required to build CGAL
 const sources = [
-    "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-$sversion/CGAL-$sversion.tar.xz" =>
-        "e1e7e932988c5d149aa471c1afd69915b7603b5b31b9b317a0debb20ecd42dcc",
+    "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-$version/CGAL-$version.tar.xz" =>
+        "66021111fe536268d044e5e01bd26e691d7b493c217a1ca4d9427284dd4b2a02",
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
Small patch, see [release notes](https://github.com/CGAL/cgal/releases/tag/releases%2FCGAL-5.0.1)