### PR TITLE
[libcgal_julia]: Update to version v0.5.1

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder
 
 const name = "libcgal_julia"
 
-version = v"0.4.0"
+version = v"0.5.0"
 
 # Collection of sources required to build CGAL
 const sources = [
     "https://github.com/rgcv/libcgal-julia.git" =>
-        "8d97853ac3baf5fee431d005b23a45e0390a9f81"
+        "d5e3d823dd6b0f210736ef93e7bc62c7e1d5b414"
 ]
 
 # Dependencies that must be installed before this package can be built
@@ -64,7 +64,8 @@ const platforms = [
 
 # The products that we will ensure are always built
 const products = [
-    LibraryProduct("libcgal_julia", :libcgal_julia),
+    LibraryProduct("libcgal_julia_exact", :libcgal_julia_exact),
+    LibraryProduct("libcgal_julia_inexact", :libcgal_julia_inexact),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -4,11 +4,12 @@ using BinaryBuilder
 
 const name = "libcgal_julia"
 
-version = v"0.5.0"
+version = v"0.5.1"
 
 # Collection of sources required to build CGAL
 const sources = [
-    GitSource("https://github.com/rgcv/libcgal-julia.git", "d5e3d823dd6b0f210736ef93e7bc62c7e1d5b414"),
+    GitSource("https://github.com/rgcv/libcgal-julia.git",
+              "370a0af377082ed73c57e7392a74645500ba2a0a"),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -8,14 +8,13 @@ version = v"0.5.0"
 
 # Collection of sources required to build CGAL
 const sources = [
-    "https://github.com/rgcv/libcgal-julia.git" =>
-        "d5e3d823dd6b0f210736ef93e7bc62c7e1d5b414"
+    GitSource("https://github.com/rgcv/libcgal-julia.git", "d5e3d823dd6b0f210736ef93e7bc62c7e1d5b414"),
 ]
 
 # Dependencies that must be installed before this package can be built
 const dependencies = [
-    "CGAL_jll",
-    "libcxxwrap_julia_jll",
+    Dependency("CGAL_jll"),
+    Dependency("libcxxwrap_julia_jll"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Includes a few new things:

+ WIP crude mapping of 2D Voronoi Diagram and Delaunay Triangulation
+ Another Circular kernel intersection (includes CK -> LK construct
  conversion to avoid exposing CK types)
+ Deliver two separate artifacts: one compiled with an inexact
constructions (i.e. doubles), and another with exact constructions (i.e.
  CORE bignums). This is a breaking change since artifact names change!!