### PR TITLE
libftd2xx disable windows x86

### DIFF
--- a/L/libftd2xx/build_tarballs.jl
+++ b/L/libftd2xx/build_tarballs.jl
@@ -81,7 +81,6 @@ platforms = [
     Linux(:aarch64, libc=:glibc),
     Linux(:i686, libc=:glibc),
     MacOS(:x86_64),
-    Windows(:i686),
     Windows(:x86_64),
 ]
 


### PR DESCRIPTION
NB: requires fix of https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/672 before usable on Linux