### PR TITLE
[libcgal_julia] Fix method ambiguity with v0.6.2 bump

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder
 
 const name = "libcgal_julia"
 
-version = v"0.6.1"
+version = v"0.6.2"
 
 # Collection of sources required to build CGAL
 const sources = [
     GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "019daea1373e91fb8c2e95b29db26751a4917df8"),
+              "cd5cd8c3ff79afef72f2f282fe5ab6dc1b912fd1"),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
`abs` and `sqrt` were being defined for `Union{Float64,Ref{Float64}}`
using the inexact constructions kernel variant library, causing method
ambiguity issues regarding the aforementioned methods. New version fixes
said issue.