### PR TITLE
[libcgal_julia] Method sig fixes in v0.6.3

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -9,7 +9,7 @@ version = v"0.6.3"
 # Collection of sources required to build CGAL
 const sources = [
     GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "aac9f84518bcb34cb3554fddc31fa7a4929da5e9"),
+              "d66dd1616cfe2b35f4027f77e94dc7b04e109e18"),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder
 
 const name = "libcgal_julia"
 
-version = v"0.6.2"
+version = v"0.6.3"
 
 # Collection of sources required to build CGAL
 const sources = [
     GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "cd5cd8c3ff79afef72f2f282fe5ab6dc1b912fd1"),
+              "aac9f84518bcb34cb3554fddc31fa7a4929da5e9"),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
Since I'm using (and abusing) macros, I forget which implicitly create
lambdas with parameters that are either `const T&` or just plain `T`
(const ref vs. values).

Turns out it leads to issues when using mapped types in method
signatures, since it couldn't convert a plain julia type to a
corresponding C type when hitting `ccall`. Changing the parameter type
`T` to a `const T&` does the work. Don't think it had to be `const`,
just not a value-type.

In short: `Point23/Origin` interop (`==` testing, `Vector23` creation
from subtraction)