### PR TITLE
Enable LAPACK in Armadillo

### DIFF
--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -34,6 +34,13 @@ if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
 fi
 
 cmake .. "${FLAGS[@]}"
+
+# Armadillo doesn't trust that OpenBLAS has LAPACK symbols in it (apparently
+# some distributions don't include them), so we have to manually enable
+# ARMA_USE_LAPACK in the configuration.
+sed -i 's/\/\* #undef ARMA_USE_LAPACK \*\//#define ARMA_USE_LAPACK/' \
+    tmp/include/armadillo_bits/config.hpp
+
 make -j${nproc}
 make install
 

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -6,8 +6,10 @@ using BinaryBuilder
 name = "armadillo"
 version = v"9.850.1"
 sources = [
-    (ArchiveSource("http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz",
-                   "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f"))]
+    ArchiveSource("http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz",
+                  "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f")
+]
+
 script = raw"""
 cd ${WORKSPACE}/srcdir/armadillo-*/
 mkdir build && cd build
@@ -27,7 +29,7 @@ if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
     for sym in sasum dasum snrm2 dnrm2 sdot ddot sgemv dgemv cgemv zgemv sgemm dgemm cgemm zgemm ssyrk dsyrk cherk zherk; do
         SYMB_DEFS+=("-D${sym}=${sym}_64")
     done
-    if [[ "${target}" == *-apple-* ]]; then
+    if [[ "${target}" == *-apple-* ]] || [[ "${target}" == *-mingw* ]]; then
         FLAGS+=(-DALLOW_OPENBLAS_MACOS=ON)
         for sym in cgbcon cgbsv cgbsvx cgbtrf cgbtrs cgecon cgees cgeev cgeevx cgehrd cgels cgelsd cgemm cgemv cgeqrf cgesdd cgesv cgesvd cgesvx cgetrf cgetri cgetrs cgges cggev cgtsv cgtsvx cheev cheevd cherk clangb clange clanhe clansy cpbtrf cpocon cposv cposvx cpotrf cpotri cpotrs ctrcon ctrsyl ctrtri ctrtrs cungqr dasum ddot dgbcon dgbsv dgbsvx dgbtrf dgbtrs dgecon dgees dgeev dgeevx dgehrd dgels dgelsd dgemm dgemv dgeqrf dgesdd dgesv dgesvd dgesvx dgetrf dgetri dgetrs dgges dggev dgtsv dgtsvx dlahqr dlangb dlange dlansy dlarnv dnrm2 dorgqr dpbtrf dpocon dposv dposvx dpotrf dpotri dpotrs dstedc dsyev dsyevd dsyrk dtrcon dtrevc dtrsyl dtrtri dtrtrs ilaenv sasum sdot sgbcon sgbsv sgbsvx sgbtrf sgbtrs sgecon sgees sgeev sgeevx sgehrd sgels sgelsd sgemm sgemv sgeqrf sgesdd sgesv sgesvd sgesvx sgetrf sgetri sgetrs sgges sggev sgtsv sgtsvx slahqr slangb slange slansy slarnv snrm2 sorgqr spbtrf spocon sposv sposvx spotrf spotri spotrs sstedc ssyev ssyevd ssyrk strcon strevc strsyl strtri strtrs zgbcon zgbsv zgbsvx zgbtrf zgbtrs zgecon zgees zgeev zgeevx zgehrd zgels zgelsd zgemm zgemv zgeqrf zgesdd zgesv zgesvd zgesvx zgetrf zgetri zgetrs zgges zggev zgtsv zgtsvx zheev zheevd zherk zlangb zlange zlanhe zlansy zpbtrf zpocon zposv zposvx zpotrf zpotri zpotrs ztrcon ztrsyl ztrtri ztrtrs zungqr; do
             SYMB_DEFS+=("-D${sym}=${sym}_64")
@@ -64,8 +66,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built.
 dependencies = [
-    "OpenBLAS_jll"
+    Dependency("OpenBLAS_jll")
 ]
 
-build_tarballs(ARGS, name, version, sources, script, platforms, products,
-        dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -19,6 +19,9 @@ FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
 
 if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
     FLAGS+=(-Dopenblas_LIBRARY="${libdir}/libopenblas64_.${dlext}")
+    # Force Armadillo's CMake configuration to accept OpenBLAS as a LAPACK
+    # replacement.
+    FLAGS+=(-DLAPACK_LIBRARY="${libdir}/libopenblas64_.${dlext}")
 
     SYMB_DEFS=()
     for sym in sasum dasum snrm2 dnrm2 sdot ddot sgemv dgemv cgemv zgemv sgemm dgemm cgemm zgemm ssyrk dsyrk cherk zherk; do
@@ -31,16 +34,13 @@ if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
         done
     fi
     export CXXFLAGS="${SYMB_DEFS[@]}"
+else
+    # Force Armadillo's CMake configuration to accept OpenBLAS as a LAPACK
+    # replacement.
+    FLAGS+=(-DLAPACK_LIBRARY="${libdir}/libopenblas.${dlext}")
 fi
 
 cmake .. "${FLAGS[@]}"
-
-# Armadillo doesn't trust that OpenBLAS has LAPACK symbols in it (apparently
-# some distributions don't include them), so we have to manually enable
-# ARMA_USE_LAPACK in the configuration.
-sed -i 's/\/\* #undef ARMA_USE_LAPACK \*\//#define ARMA_USE_LAPACK/' \
-    tmp/include/armadillo_bits/config.hpp
-
 make -j${nproc}
 make install
 

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -6,8 +6,8 @@ using BinaryBuilder
 name = "armadillo"
 version = v"9.850.1"
 sources = [
-    ("http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz" =>
-        "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f")]
+    (ArchiveSource("http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz",
+                   "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f"))]
 script = raw"""
 cd ${WORKSPACE}/srcdir/armadillo-*/
 mkdir build && cd build

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -4,10 +4,10 @@
 using BinaryBuilder
 
 name = "armadillo"
-version = v"9.800.3"
+version = v"9.850.1"
 sources = [
-    ("http://sourceforge.net/projects/arma/files/armadillo-9.800.3.tar.xz" =>
-        "a481e1dc880b7cb352f8a28b67fe005dc1117d4341277f12999a2355d40d7599")]
+    ("http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz" =>
+        "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f")]
 script = raw"""
 cd ${WORKSPACE}/srcdir/armadillo-*/
 mkdir build && cd build


### PR DESCRIPTION
I was very excited to finally use `armadillo_jll` and its dependency `mlpack_jll` to get the mlpack Julia bindings working.  But, when I tried to use them, I was presented with:

```
julia> mlpack.pca(x; verbose=true)
[INFO ] Performing PCA on dataset...

error: svd(): use of LAPACK must be enabled
terminate called after throwing an instance of 'std::logic_error'
  what():  svd(): use of LAPACK must be enabled

```

This meant that Armadillo had not been properly configured during the build to use the LAPACK functions that are available in OpenBLAS.  I dug into the CMake configuration of Armadillo, and the comments seem to indicate that there do exist some distributions of OpenBLAS that have the LAPACK symbols stripped out, so Armadillo disables LAPACK unless it's separately found.

This PR manually re-enables LAPACK during the Armadillo build process, so that the macro `ARMA_USE_LAPACK` is defined in the Armadillo headers that are produced as a part of `armadillo_jll`.

I also bumped the version of Armadillo because hey, why not? :)