### PR TITLE
Add _64 to OpenBLAS symbols on Linuxes and FreeBSD also for Armadillo.

### DIFF
--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -32,7 +32,7 @@ if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
     if [[ "${target}" == *-apple-* ]] || [[ "${target}" == *-mingw* ]]; then
         FLAGS+=(-DALLOW_OPENBLAS_MACOS=ON)
     fi
-    if [[ "${target}" == *-linux-* || "${target} == *-freebsd* || "${target}" == *-apple-* ]]; then
+    if [[ "${target}" == *-linux-* || "${target}" == *-freebsd* || "${target}" == *-apple-* ]]; then
         for sym in cgbcon cgbsv cgbsvx cgbtrf cgbtrs cgecon cgees cgeev cgeevx cgehrd cgels cgelsd cgemm cgemv cgeqrf cgesdd cgesv cgesvd cgesvx cgetrf cgetri cgetrs cgges cggev cgtsv cgtsvx cheev cheevd cherk clangb clange clanhe clansy cpbtrf cpocon cposv cposvx cpotrf cpotri cpotrs ctrcon ctrsyl ctrtri ctrtrs cungqr dasum ddot dgbcon dgbsv dgbsvx dgbtrf dgbtrs dgecon dgees dgeev dgeevx dgehrd dgels dgelsd dgemm dgemv dgeqrf dgesdd dgesv dgesvd dgesvx dgetrf dgetri dgetrs dgges dggev dgtsv dgtsvx dlahqr dlangb dlange dlansy dlarnv dnrm2 dorgqr dpbtrf dpocon dposv dposvx dpotrf dpotri dpotrs dstedc dsyev dsyevd dsyrk dtrcon dtrevc dtrsyl dtrtri dtrtrs ilaenv sasum sdot sgbcon sgbsv sgbsvx sgbtrf sgbtrs sgecon sgees sgeev sgeevx sgehrd sgels sgelsd sgemm sgemv sgeqrf sgesdd sgesv sgesvd sgesvx sgetrf sgetri sgetrs sgges sggev sgtsv sgtsvx slahqr slangb slange slansy slarnv snrm2 sorgqr spbtrf spocon sposv sposvx spotrf spotri spotrs sstedc ssyev ssyevd ssyrk strcon strevc strsyl strtri strtrs zgbcon zgbsv zgbsvx zgbtrf zgbtrs zgecon zgees zgeev zgeevx zgehrd zgels zgelsd zgemm zgemv zgeqrf zgesdd zgesv zgesvd zgesvx zgetrf zgetri zgetrs zgges zggev zgtsv zgtsvx zheev zheevd zherk zlangb zlange zlanhe zlansy zpbtrf zpocon zposv zposvx zpotrf zpotri zpotrs ztrcon ztrsyl ztrtri ztrtrs zungqr; do
             SYMB_DEFS+=("-D${sym}=${sym}_64")
         done

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -31,10 +31,12 @@ if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
     done
     if [[ "${target}" == *-apple-* ]] || [[ "${target}" == *-mingw* ]]; then
         FLAGS+=(-DALLOW_OPENBLAS_MACOS=ON)
+    fi
+    if [[ "${target}" == *-linux-* || "${target} == *-freebsd* || "${target}" == *-apple-* ]]; then
         for sym in cgbcon cgbsv cgbsvx cgbtrf cgbtrs cgecon cgees cgeev cgeevx cgehrd cgels cgelsd cgemm cgemv cgeqrf cgesdd cgesv cgesvd cgesvx cgetrf cgetri cgetrs cgges cggev cgtsv cgtsvx cheev cheevd cherk clangb clange clanhe clansy cpbtrf cpocon cposv cposvx cpotrf cpotri cpotrs ctrcon ctrsyl ctrtri ctrtrs cungqr dasum ddot dgbcon dgbsv dgbsvx dgbtrf dgbtrs dgecon dgees dgeev dgeevx dgehrd dgels dgelsd dgemm dgemv dgeqrf dgesdd dgesv dgesvd dgesvx dgetrf dgetri dgetrs dgges dggev dgtsv dgtsvx dlahqr dlangb dlange dlansy dlarnv dnrm2 dorgqr dpbtrf dpocon dposv dposvx dpotrf dpotri dpotrs dstedc dsyev dsyevd dsyrk dtrcon dtrevc dtrsyl dtrtri dtrtrs ilaenv sasum sdot sgbcon sgbsv sgbsvx sgbtrf sgbtrs sgecon sgees sgeev sgeevx sgehrd sgels sgelsd sgemm sgemv sgeqrf sgesdd sgesv sgesvd sgesvx sgetrf sgetri sgetrs sgges sggev sgtsv sgtsvx slahqr slangb slange slansy slarnv snrm2 sorgqr spbtrf spocon sposv sposvx spotrf spotri spotrs sstedc ssyev ssyevd ssyrk strcon strevc strsyl strtri strtrs zgbcon zgbsv zgbsvx zgbtrf zgbtrs zgecon zgees zgeev zgeevx zgehrd zgels zgelsd zgemm zgemv zgeqrf zgesdd zgesv zgesvd zgesvx zgetrf zgetri zgetrs zgges zggev zgtsv zgtsvx zheev zheevd zherk zlangb zlange zlanhe zlansy zpbtrf zpocon zposv zposvx zpotrf zpotri zpotrs ztrcon ztrsyl ztrtri ztrtrs zungqr; do
             SYMB_DEFS+=("-D${sym}=${sym}_64")
         done
-    fi
+    
     export CXXFLAGS="${SYMB_DEFS[@]}"
 else
     # Force Armadillo's CMake configuration to accept OpenBLAS as a LAPACK

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -32,7 +32,8 @@ if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
     if [[ "${target}" == *-apple-* ]] || [[ "${target}" == *-mingw* ]]; then
         FLAGS+=(-DALLOW_OPENBLAS_MACOS=ON)
     fi
-    if [[ "${target}" == *-linux-* || "${target}" == *-freebsd* || "${target}" == *-apple-* ]]; then
+    if [[ "${target}" == *-linux-* || "${target}" == *-freebsd* ||
+          "${target}" == *-apple-* || "${target}" == *-mingw* ]]; then
         for sym in cgbcon cgbsv cgbsvx cgbtrf cgbtrs cgecon cgees cgeev cgeevx cgehrd cgels cgelsd cgemm cgemv cgeqrf cgesdd cgesv cgesvd cgesvx cgetrf cgetri cgetrs cgges cggev cgtsv cgtsvx cheev cheevd cherk clangb clange clanhe clansy cpbtrf cpocon cposv cposvx cpotrf cpotri cpotrs ctrcon ctrsyl ctrtri ctrtrs cungqr dasum ddot dgbcon dgbsv dgbsvx dgbtrf dgbtrs dgecon dgees dgeev dgeevx dgehrd dgels dgelsd dgemm dgemv dgeqrf dgesdd dgesv dgesvd dgesvx dgetrf dgetri dgetrs dgges dggev dgtsv dgtsvx dlahqr dlangb dlange dlansy dlarnv dnrm2 dorgqr dpbtrf dpocon dposv dposvx dpotrf dpotri dpotrs dstedc dsyev dsyevd dsyrk dtrcon dtrevc dtrsyl dtrtri dtrtrs ilaenv sasum sdot sgbcon sgbsv sgbsvx sgbtrf sgbtrs sgecon sgees sgeev sgeevx sgehrd sgels sgelsd sgemm sgemv sgeqrf sgesdd sgesv sgesvd sgesvx sgetrf sgetri sgetrs sgges sggev sgtsv sgtsvx slahqr slangb slange slansy slarnv snrm2 sorgqr spbtrf spocon sposv sposvx spotrf spotri spotrs sstedc ssyev ssyevd ssyrk strcon strevc strsyl strtri strtrs zgbcon zgbsv zgbsvx zgbtrf zgbtrs zgecon zgees zgeev zgeevx zgehrd zgels zgelsd zgemm zgemv zgeqrf zgesdd zgesv zgesvd zgesvx zgetrf zgetri zgetrs zgges zggev zgtsv zgtsvx zheev zheevd zherk zlangb zlange zlanhe zlansy zpbtrf zpocon zposv zposvx zpotrf zpotri zpotrs ztrcon ztrsyl ztrtri ztrtrs zungqr; do
             SYMB_DEFS+=("-D${sym}=${sym}_64")
         done

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -36,7 +36,8 @@ if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
         for sym in cgbcon cgbsv cgbsvx cgbtrf cgbtrs cgecon cgees cgeev cgeevx cgehrd cgels cgelsd cgemm cgemv cgeqrf cgesdd cgesv cgesvd cgesvx cgetrf cgetri cgetrs cgges cggev cgtsv cgtsvx cheev cheevd cherk clangb clange clanhe clansy cpbtrf cpocon cposv cposvx cpotrf cpotri cpotrs ctrcon ctrsyl ctrtri ctrtrs cungqr dasum ddot dgbcon dgbsv dgbsvx dgbtrf dgbtrs dgecon dgees dgeev dgeevx dgehrd dgels dgelsd dgemm dgemv dgeqrf dgesdd dgesv dgesvd dgesvx dgetrf dgetri dgetrs dgges dggev dgtsv dgtsvx dlahqr dlangb dlange dlansy dlarnv dnrm2 dorgqr dpbtrf dpocon dposv dposvx dpotrf dpotri dpotrs dstedc dsyev dsyevd dsyrk dtrcon dtrevc dtrsyl dtrtri dtrtrs ilaenv sasum sdot sgbcon sgbsv sgbsvx sgbtrf sgbtrs sgecon sgees sgeev sgeevx sgehrd sgels sgelsd sgemm sgemv sgeqrf sgesdd sgesv sgesvd sgesvx sgetrf sgetri sgetrs sgges sggev sgtsv sgtsvx slahqr slangb slange slansy slarnv snrm2 sorgqr spbtrf spocon sposv sposvx spotrf spotri spotrs sstedc ssyev ssyevd ssyrk strcon strevc strsyl strtri strtrs zgbcon zgbsv zgbsvx zgbtrf zgbtrs zgecon zgees zgeev zgeevx zgehrd zgels zgelsd zgemm zgemv zgeqrf zgesdd zgesv zgesvd zgesvx zgetrf zgetri zgetrs zgges zggev zgtsv zgtsvx zheev zheevd zherk zlangb zlange zlanhe zlansy zpbtrf zpocon zposv zposvx zpotrf zpotri zpotrs ztrcon ztrsyl ztrtri ztrtrs zungqr; do
             SYMB_DEFS+=("-D${sym}=${sym}_64")
         done
-    
+    fi
+
     export CXXFLAGS="${SYMB_DEFS[@]}"
 else
     # Force Armadillo's CMake configuration to accept OpenBLAS as a LAPACK

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -6,8 +6,8 @@ using BinaryBuilder
 name = "armadillo"
 version = v"9.850.1"
 sources = [
-    "http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz" =>
-                  "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f"
+    ArchiveSource("http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz",
+                  "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f")
 ]
 
 script = raw"""
@@ -60,7 +60,6 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.
 platforms = supported_platforms()
-platforms = [Linux(:x86_64)]
 
 # The products that we will ensure are always built.
 products = [

--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -6,8 +6,8 @@ using BinaryBuilder
 name = "armadillo"
 version = v"9.850.1"
 sources = [
-    ArchiveSource("http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz",
-                  "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f")
+    "http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz" =>
+                  "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f"
 ]
 
 script = raw"""
@@ -32,12 +32,10 @@ if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
     if [[ "${target}" == *-apple-* ]] || [[ "${target}" == *-mingw* ]]; then
         FLAGS+=(-DALLOW_OPENBLAS_MACOS=ON)
     fi
-    if [[ "${target}" == *-linux-* || "${target}" == *-freebsd* ||
-          "${target}" == *-apple-* || "${target}" == *-mingw* ]]; then
-        for sym in cgbcon cgbsv cgbsvx cgbtrf cgbtrs cgecon cgees cgeev cgeevx cgehrd cgels cgelsd cgemm cgemv cgeqrf cgesdd cgesv cgesvd cgesvx cgetrf cgetri cgetrs cgges cggev cgtsv cgtsvx cheev cheevd cherk clangb clange clanhe clansy cpbtrf cpocon cposv cposvx cpotrf cpotri cpotrs ctrcon ctrsyl ctrtri ctrtrs cungqr dasum ddot dgbcon dgbsv dgbsvx dgbtrf dgbtrs dgecon dgees dgeev dgeevx dgehrd dgels dgelsd dgemm dgemv dgeqrf dgesdd dgesv dgesvd dgesvx dgetrf dgetri dgetrs dgges dggev dgtsv dgtsvx dlahqr dlangb dlange dlansy dlarnv dnrm2 dorgqr dpbtrf dpocon dposv dposvx dpotrf dpotri dpotrs dstedc dsyev dsyevd dsyrk dtrcon dtrevc dtrsyl dtrtri dtrtrs ilaenv sasum sdot sgbcon sgbsv sgbsvx sgbtrf sgbtrs sgecon sgees sgeev sgeevx sgehrd sgels sgelsd sgemm sgemv sgeqrf sgesdd sgesv sgesvd sgesvx sgetrf sgetri sgetrs sgges sggev sgtsv sgtsvx slahqr slangb slange slansy slarnv snrm2 sorgqr spbtrf spocon sposv sposvx spotrf spotri spotrs sstedc ssyev ssyevd ssyrk strcon strevc strsyl strtri strtrs zgbcon zgbsv zgbsvx zgbtrf zgbtrs zgecon zgees zgeev zgeevx zgehrd zgels zgelsd zgemm zgemv zgeqrf zgesdd zgesv zgesvd zgesvx zgetrf zgetri zgetrs zgges zggev zgtsv zgtsvx zheev zheevd zherk zlangb zlange zlanhe zlansy zpbtrf zpocon zposv zposvx zpotrf zpotri zpotrs ztrcon ztrsyl ztrtri ztrtrs zungqr; do
-            SYMB_DEFS+=("-D${sym}=${sym}_64")
-        done
-    fi
+
+    for sym in cgbcon cgbsv cgbsvx cgbtrf cgbtrs cgecon cgees cgeev cgeevx cgehrd cgels cgelsd cgemm cgemv cgeqrf cgesdd cgesv cgesvd cgesvx cgetrf cgetri cgetrs cgges cggev cgtsv cgtsvx cheev cheevd cherk clangb clange clanhe clansy cpbtrf cpocon cposv cposvx cpotrf cpotri cpotrs ctrcon ctrsyl ctrtri ctrtrs cungqr dasum ddot dgbcon dgbsv dgbsvx dgbtrf dgbtrs dgecon dgees dgeev dgeevx dgehrd dgels dgelsd dgemm dgemv dgeqrf dgesdd dgesv dgesvd dgesvx dgetrf dgetri dgetrs dgges dggev dgtsv dgtsvx dlahqr dlangb dlange dlansy dlarnv dnrm2 dorgqr dpbtrf dpocon dposv dposvx dpotrf dpotri dpotrs dstedc dsyev dsyevd dsyrk dtrcon dtrevc dtrsyl dtrtri dtrtrs ilaenv sasum sdot sgbcon sgbsv sgbsvx sgbtrf sgbtrs sgecon sgees sgeev sgeevx sgehrd sgels sgelsd sgemm sgemv sgeqrf sgesdd sgesv sgesvd sgesvx sgetrf sgetri sgetrs sgges sggev sgtsv sgtsvx slahqr slangb slange slansy slarnv snrm2 sorgqr spbtrf spocon sposv sposvx spotrf spotri spotrs sstedc ssyev ssyevd ssyrk strcon strevc strsyl strtri strtrs zgbcon zgbsv zgbsvx zgbtrf zgbtrs zgecon zgees zgeev zgeevx zgehrd zgels zgelsd zgemm zgemv zgeqrf zgesdd zgesv zgesvd zgesvx zgetrf zgetri zgetrs zgges zggev zgtsv zgtsvx zheev zheevd zherk zlangb zlange zlanhe zlansy zpbtrf zpocon zposv zposvx zpotrf zpotri zpotrs ztrcon ztrsyl ztrtri ztrtrs zungqr; do
+        SYMB_DEFS+=("-D${sym}=${sym}_64")
+    done
 
     export CXXFLAGS="${SYMB_DEFS[@]}"
 else
@@ -62,6 +60,7 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.
 platforms = supported_platforms()
+platforms = [Linux(:x86_64)]
 
 # The products that we will ensure are always built.
 products = [


### PR DESCRIPTION
This is part of an attempt to debug #539, which is failing due to linking errors of the following form:

```
[23:36:31] /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/local/lib/libarmadillo.so: undefined reference to `spocon_'
[23:36:31] /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/local/lib/libarmadillo.so: undefined reference to `dgbsvx_'
[23:36:31] /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/local/lib/libarmadillo.so: undefined reference to `zgesvd_'
[23:36:31] /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/local/lib/libarmadillo.so: undefined reference to `dgesdd_'
[23:36:31] /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/local/lib/libarmadillo.so: undefined reference to `spotrs_'
[23:36:31] /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/local/lib/libarmadillo.so: undefined reference to `zlangb_'
[23:36:31] /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/local/lib/libarmadillo.so: undefined reference to `spbtrf_'
[23:36:31] /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/local/lib/libarmadillo.so: undefined reference to `strcon_'
[23:36:31] /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root/usr/local/lib/libarmadillo.so: undefined reference to `zgtsv_'
[23:36:31] ../../../../lib/libmlpack.so.3.2: undefined reference to `wrapper2_dgesvd_64_'
```

See https://dev.azure.com/JuliaPackaging/Yggdrasil/_build/results?buildId=1774&view=logs&jobId=18f3b4d5-8303-59d0-bd61-78346cf22e3f&j=18f3b4d5-8303-59d0-bd61-78346cf22e3f&t=01a1ca50-4afb-526e-b091-a410e7fd3e21 for an example.

I noticed that the builds were failing specifically for those 64-bit non-Windows and non-aarch64 architectures where not *all* OpenBLAS symbols had `_64` appended.  I suppose that this means that on Linux and FreeBSD, the OpenBLAS .so has symbols like `sasum_64_` and not just `sasum_`, and when I build locally this seems to be the case.

So, this PR perhaps will fix #539, in that the symbols will be named correctly in `libarmadillo.so`.

@giordano let me know what you think. :+1: