### PR TITLE
MPICH: enable Fortran support

### DIFF
--- a/M/MPICH/build_tarballs.jl
+++ b/M/MPICH/build_tarballs.jl
@@ -12,6 +12,10 @@ script = raw"""
 # Enter the funzone
 cd ${WORKSPACE}/srcdir/mpich-*
 
+# Remove wrong libtool files
+rm -f /opt/${target}/${target}/lib64/*.la
+rm -f /opt/${target}/${target}/lib/*.la
+
 atomic_patch -p1 ../patches/0001-romio-Use-tr-for-replacing-to-space-in-list-of-file-.patch
 pushd src/mpi/romio
 autoreconf -vi
@@ -32,8 +36,6 @@ fi
 
 # Build the library
 make -j${nproc}
-
-make check
 
 # Install the library
 make install

--- a/M/MPICH/build_tarballs.jl
+++ b/M/MPICH/build_tarballs.jl
@@ -27,6 +27,9 @@ if [[ "${target}" == i686-linux-musl ]]; then
     # thus we need to pass a cached value for this test
     EXTRA_FLAGS+=(ac_cv_sizeof_bool="1")
 fi
+if [[ "${target}" == *-apple* ]]; then
+    export CROSS_F77_SIZEOF_INTEGER=4
+fi
 ./configure --prefix=$prefix --host=$target \
     --enable-shared=yes \
     --enable-static=no \

--- a/M/MPICH/build_tarballs.jl
+++ b/M/MPICH/build_tarballs.jl
@@ -27,12 +27,13 @@ fi
     --enable-shared=yes \
     --enable-static=no \
     --disable-dependency-tracking \
-    --disable-fortran \
     --docdir=/tmp \
     "${EXTRA_FLAGS[@]}"
 
 # Build the library
 make -j${nproc}
+
+make check
 
 # Install the library
 make install


### PR DESCRIPTION
Attempt to enable the MPI Fortran compiler. 