### PR TITLE
Fix artifact uploading

### DIFF
--- a/H/HelloWorldGo/build_tarballs.jl
+++ b/H/HelloWorldGo/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "HelloWorldGo"
-version = v"1.0.3"
+version = v"1.0.4"
 
 # No sources, we're just building the testsuite
 sources = [

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,17 +211,22 @@ jobs:
       CONTENT_TYPE="application/x-gtar"
       BUCKET="julia-bb-buildcache"
       BUCKET_PATH="${BB_HASH}/${PROJ_HASH}/${PLATFORM}.tar.gz"
-      S3SIGNATURE=$(echo -en "PUT\n\n${CONTENT_TYPE}\n$(date -R)\n${ACL}\n/${BUCKET}/${BUCKET_PATH}" | openssl sha1 -hmac "${S3SECRET}" -binary | base64)
+      DATE="$(date -R)"
+      S3SIGNATURE=$(echo -en "PUT\n\n${CONTENT_TYPE}\n${DATE}\n${ACL}\n/${BUCKET}/${BUCKET_PATH}" | openssl sha1 -hmac "${S3SECRET}" -binary | base64)
       HOST="${BUCKET}.s3.amazonaws.com"
       echo "Uploading artifact to https://${HOST}/${BUCKET_PATH}"
       curl -X PUT -T "${TARBALLS[0]}" \
           -H "Host: ${HOST}" \
-          -H "Date: $(date -R)" \
+          -H "Date: ${DATE}" \
           -H "Content-Type: ${CONTENT_TYPE}" \
           -H "${ACL}" \
           -H "Authorization: AWS ${S3KEY}:${S3SIGNATURE}" \
           "https://${HOST}/${BUCKET_PATH}"
 
+      if [[ "$?" != 0 ]]; then
+          echo "Failed to upload artifact!" >&2
+          exit 1
+      fi
     env:
       GITHUB_TOKEN: $(GITHUB_TOKEN)
       S3KEY: $(S3KEY)


### PR DESCRIPTION
We were signing metadata which included a timestamp; cache that timestamp so that there's no chance that it can change between us signing it, then transmitting it.  Also, explicitly check that the upload succeeded, so that we don't try to register something that doesn't exist.