### PR TITLE
[AZP] Bump BinaryBuilder to latest version on master

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -16,7 +16,7 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilder]]
 deps = ["Base64", "Dates", "GitHub", "HTTP", "InteractiveUtils", "JLD2", "JSON", "LibGit2", "Libdl", "MbedTLS", "ObjectFile", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Sockets", "UUIDs", "ghr_jll"]
-git-tree-sha1 = "50f3c78ff741e7718025385195b29e11b5390350"
+git-tree-sha1 = "9293d485f0c4dfe1f8f97c5d18dee4127c7d81f2"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"


### PR DESCRIPTION
This fixes an issue with generation of JLL wrappers for armv7l