### PR TITLE
[RootFS] Add more license file names for `auto_install_license`

### DIFF
--- a/0_RootFS/Rootfs/bundled/conf/profile.d/license_utils.sh
+++ b/0_RootFS/Rootfs/bundled/conf/profile.d/license_utils.sh
@@ -9,8 +9,8 @@ auto_install_license () {
         DIR="${WORKSPACE}/srcdir"
         # Build the list of known names for license files
         LICENSE_FILENAMES=()
-        for bname in COPYING COPYRIGHT LICENCE LICENSE ; do
-            for extension in "" .md .rtf .txt; do
+        for bname in COPYING COPYRIGHT LICENCE LICENSE NOTICE; do
+            for extension in "" .md .rtf .txt .MIT .BSD .GPL .GPLv2 .GPLv3; do
                 # These are actually going to be options for `find`
                 LICENSE_FILENAMES+=(-iname "${bname}${extension}" -o)
             done


### PR DESCRIPTION
Add some more common file names for the licenses.  `NOTICE` is often used for Apache licenses.

I've also seen sometimes files name like `LICENSE.MIT` that include the name of the license as extensions.  Not sure these extra extensions are a good idea, open to comments.