### PR TITLE
[AZP] Search in parent directories for `build_tarballs.jl` files

### DIFF
--- a/H/HelloWorldC/bundled/CMakeLists.txt
+++ b/H/HelloWorldC/bundled/CMakeLists.txt
@@ -1,3 +1,4 @@
 cmake_minimum_required(VERSION 2.8.9)
 project(hello_world)
 add_executable(hello_world /usr/share/testsuite/c/hello_world/hello_world.c)
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,8 +46,12 @@ jobs:
           NAME=$(basename "${PROJECT}")
           echo "Considering ${PROJECT}"
           # Only accept things that contain a `build_tarballs.jl`
-          if [[ ! -f "${PROJECT}/build_tarballs.jl" ]]; then
-              echo " --> Skipping as it does not have a build_tarballs.jl"
+          while [[ ! -f "${PROJECT}/build_tarballs.jl" ]] && [[ "${PROJECT}" == */* ]]; do
+              echo " --> ${PROJECT} does not contain a build_tarballs.jl, moving up a directory"
+              PROJECT="$(dirname "${PROJECT}")"
+          done
+          if [[ "${PROJECT}" != */* ]]; then
+              echo " --> Skipping as we could not find a build_tarballs.jl"
               continue
           fi
 


### PR DESCRIPTION
As shown in https://dev.azure.com/JuliaPackaging/Yggdrasil/_build/results?buildId=1866&view=logs&j=96c13d9d-dfd2-51e5-2f76-4a0b3ce09abc&t=09532434-8b0a-5f0e-118d-a3181cde5ec8, there are cases where we edit only patches or similar, and these commits get dropped from CI because we don't find the `build_tarballs.jl` file sitting in a parent directory.