### PR TITLE
[utf8proc] Manually build the shared library for Windows

### DIFF
--- a/U/utf8proc/build_tarballs.jl
+++ b/U/utf8proc/build_tarballs.jl
@@ -12,11 +12,17 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/utf8proc-*
-make -j${nproc} libutf8proc.a
 
-mkdir -p ${prefix}/lib ${prefix}/include
-cp libutf8proc.a ${prefix}/lib/
-cp utf8proc.h ${prefix}/include/
+if [[ "${target}" == *-mingw* ]]; then
+    make -j${nproc} libutf8proc.a
+    mkdir -p ${libdir} ${prefix}/include
+    cp utf8proc.h ${prefix}/include/
+    ar x libutf8proc.a
+    cc -shared -o "${libdir}/libutf8proc.${dlext}" *.o
+else
+    make -j${nproc}
+    make install prefix=${prefix} libdir=${libdir}
+fi
 """
 
 # These are the platforms we will build for by default, unless further
@@ -25,7 +31,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    FileProduct("lib/libutf8proc.a", :libutf8proc),
+    LibraryProduct("libutf8proc", :libutf8proc),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
The `Makefile` doesn't have a rule for the Windows shared library, thus we have
to build it manually.