### PR TITLE
[XZ] Fix generation of PIC code

### DIFF
--- a/X/XZ/build_tarballs.jl
+++ b/X/XZ/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/xz-*
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-fpic
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-pic
 make -j${nproc}
 make install
 """


### PR DESCRIPTION
The `configure` option was wrong, see #574 for reference.

Now I get
```
sandbox:${WORKSPACE}/destdir/lib # ar x liblzma.a 
sandbox:${WORKSPACE}/destdir/lib # readelf --relocs liblzma_la-index.o | grep lzma_free
000000000058  001800000009 R_X86_64_GOTPCREL 0000000000000000 lzma_free - 4
000000000547  001800000004 R_X86_64_PLT32    0000000000000000 lzma_free - 4
000000000c65  001800000004 R_X86_64_PLT32    0000000000000000 lzma_free - 4
000000000d18  001800000004 R_X86_64_PLT32    0000000000000000 lzma_free - 4
00000000006e  001800000004 R_X86_64_PLT32    0000000000000000 lzma_free - 4
000000000582  001800000004 R_X86_64_PLT32    0000000000000000 lzma_free - 4
```
As far as I understand, this means that the symbol has now position-independent code.