### PR TITLE
Armadillo: use 64-bit integers for 64-bit OpenBLAS

### DIFF
--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -38,6 +38,12 @@ if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
     done
 
     export CXXFLAGS="${SYMB_DEFS[@]}"
+
+    # Force the configuration parameter ARMA_BLAS_LONG to be true, as in our
+    # setting 64-bit systems are going to need a 64-bit integer to be used for
+    # Armadillo's `blas_int` type.
+    sed -i 's|// #define ARMA_BLAS_LONG$|#define ARMA_BLAS_LONG|' ../include/armadillo_bits/config.hpp.cmake
+    cat ../include/armadillo_bits/config.hpp.cmake
 else
     # Force Armadillo's CMake configuration to accept OpenBLAS as a LAPACK
     # replacement.


### PR DESCRIPTION
After excitedly finally getting mlpack.jl merged into the Julia general registry, I opened up a Julia REPL in order to see the algorithms work nicely from Julia:

```
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.3.1 (2019-12-30)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> import mlpack

julia> x = rand(5, 5);

julia> mlpack.pca(x, verbose=true)
[INFO ] Performing PCA on dataset...
 ** On entry to DGESDDM parameter number 12 had an illegal value

signal (11): Segmentation fault
in expression starting at REPL[3]:1
_ZN6mlpack3pca3PCAINS0_14ExactSVDPolicyEE5ApplyERN4arma3MatIdEEm at /home/ryan/.julia/artifacts/b4f114f297d48107f4adc41bf1b195deb5baa2a1/lib/libmlpack_julia_pca.so (unknown line)
_Z6RunPCAIN6mlpack3pca14ExactSVDPolicyEEvRN4arma3MatIdEEmbd at /home/ryan/.julia/artifacts/b4f114f297d48107f4adc41bf1b195deb5baa2a1/lib/libmlpack_julia_pca.so (unknown line)
_ZL10mlpackMainv at /home/ryan/.julia/artifacts/b4f114f297d48107f4adc41bf1b195deb5baa2a1/lib/libmlpack_julia_pca.so (unknown line)
pca at /home/ryan/.julia/artifacts/b4f114f297d48107f4adc41bf1b195deb5baa2a1/lib/libmlpack_julia_pca.so (unknown line)
pca_mlpackMain at /home/ryan/.julia/packages/mlpack/4FGS7/src/pca.jl:10 [inlined]
#pca#32 at /home/ryan/.julia/packages/mlpack/4FGS7/src/pca.jl:111
#pca at ./none:0
unknown function (ip: 0x7facbc872635)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2141 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2305
jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1631 [inlined]
do_call at /buildworker/worker/package_linux64/build/src/interpreter.c:328
eval_value at /buildworker/worker/package_linux64/build/src/interpreter.c:417
eval_stmt_value at /buildworker/worker/package_linux64/build/src/interpreter.c:368 [inlined]
eval_body at /buildworker/worker/package_linux64/build/src/interpreter.c:778
jl_interpret_toplevel_thunk_callback at /buildworker/worker/package_linux64/build/src/interpreter.c:888
unknown function (ip: 0xfffffffffffffffe)
unknown function (ip: 0x7facd61fd58f)
unknown function (ip: 0x6)
jl_interpret_toplevel_thunk at /buildworker/worker/package_linux64/build/src/interpreter.c:897
jl_toplevel_eval_flex at /buildworker/worker/package_linux64/build/src/toplevel.c:814
jl_toplevel_eval_flex at /buildworker/worker/package_linux64/build/src/toplevel.c:764
jl_toplevel_eval_in at /buildworker/worker/package_linux64/build/src/toplevel.c:843
eval at ./boot.jl:330
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2135 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2305
eval_user_input at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.3/REPL/src/REPL.jl:86
macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.3/REPL/src/REPL.jl:118 [inlined]
#26 at ./task.jl:333
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2135 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2305
jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1631 [inlined]
start_task at /buildworker/worker/package_linux64/build/src/task.c:659
unknown function (ip: 0xffffffffffffffff)
Allocations: 1810578 (Pool: 1810075; Big: 503); GC: 2
Segmentation fault
```

This was not what I expected and I quickly proceeded through the five stages of grief.  Once reaching 'acceptance', I started debugging.

It turns out that the issue is in the interface between Armadillo and OpenBLAS.  I did not realize it, but OpenBLAS uses 64-bit `int`s for its interface.  Therefore, we have to enable `ARMA_BLAS_LONG`, otherwise it will try to call the functions with wrong-sized parameters, causing the aforementioned segfault. :)

There's no easy CMake configuration parameter for this one; the only way I see is to modify the include files.