### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM julia:1.3
+
+RUN apt-get update && apt-get install -y xz-utils bzip2 sudo git unzip
+
+RUN julia -e 'using Pkg; Pkg.add("BinaryBuilder")'
+
+RUN julia -e 'using Pkg; Pkg.API.precompile()'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "extensions": [
+      "julialang.language-julia"
+    ],
+    "runArgs": ["--privileged"],
+    "dockerFile": "Dockerfile"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
With this, and if the VS Code `Remote - Container` extension is installed, VS Code will auto-provision an environment when this repo is opened in VS Code.