### PR TITLE
Bump `HELICS` version to `v2.4.1`

### DIFF
--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -15,11 +15,12 @@
 
 using BinaryBuilder
 
-HELICS_VERSION = v"2.4.0"
+HELICS_VERSION = v"2.4.1"
+HELICS_SHA = "ac077e9efe466881ea366721cb31fb37ea0e72a881a717323ba4f3cdda338be4"
 
 sources = [
     ArchiveSource("https://github.com/GMLC-TDC/HELICS/releases/download/v$HELICS_VERSION/Helics-v$HELICS_VERSION-source.tar.gz",
-                  "8de39728c7bb03be0bde0d506acc827bea732eddb7bb46892027b777b10dab27"),
+                  "$HELICS_SHA"),
 ]
 
 script = raw"""


### PR DESCRIPTION
Bumps the HELICS version to v2.4.1