### PR TITLE
[EDFlib] Add required build options

### DIFF
--- a/E/EDFlib/build_tarballs.jl
+++ b/E/EDFlib/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/edflib
 mkdir ${libdir}
-${CC} edflib.c -shared -fPIC -o ${libdir}/libedflib.${dlext}
+${CC} edflib.c -shared -fPIC -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -o ${libdir}/libedflib.${dlext}
 # No separate license file, it just lives in the README and in the source files
 install_license README.md
 """


### PR DESCRIPTION
A comment in edflib.h says that the library needs to be compiled with `-D_LARGEFILE64_SOURCE` and `-D_LARGEFILE_SOURCE`. I missed that when initially adding the builder. 🙄 