### PR TITLE
[openblas]: Set SONAME to unversioned filename

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,5 @@ FROM julia:1.3
 
 RUN apt-get update && apt-get install -y xz-utils bzip2 sudo git unzip
 
-RUN julia -e 'using Pkg; Pkg.add("BinaryBuilder")'
-
+RUN julia -e 'using Pkg; pkg"add BinaryBuilder#master"'
 RUN julia -e 'using Pkg; Pkg.API.precompile()'

--- a/O/OpenBLAS/OpenBLAS@0.3.5/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS@0.3.5/build_tarballs.jl
@@ -2,7 +2,6 @@ using BinaryBuilder
 
 include("../common.jl")
 
-# Collection of sources required to build OpenBLAS
 name = "OpenBLAS"
 version = v"0.3.5"
 

--- a/O/OpenBLAS/OpenBLAS@0.3.7/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS@0.3.7/build_tarballs.jl
@@ -2,8 +2,6 @@ using BinaryBuilder
 
 include("../common.jl")
 
-
-# Collection of sources required to build OpenBLAS
 name = "OpenBLAS"
 version = v"0.3.7"
 

--- a/O/OpenBLAS/common.jl
+++ b/O/OpenBLAS/common.jl
@@ -110,7 +110,7 @@ function openblas_script(;kwargs...)
                 ln -vsf ${name} ${l}
             fi
         done
-    end
+    done
 
     # Next, we set the SONAME of the library to a non-versioned name,
     # so that other projects (such as SuiteSparse) can link against us


### PR DESCRIPTION
We need to set the SONAME of `libopenblas` to be `libopenblas.so`, not
`libopenblas.so.0.3.7`, in order for our builds of SuiteSparse to work
across versions.  We actually were trying to do this, but the logic
seems to have bitrotten somewhere.