### PR TITLE
[GMP] add libgmpxx to products

### DIFF
--- a/G/GMP/build_tarballs.jl
+++ b/G/GMP/build_tarballs.jl
@@ -45,6 +45,7 @@ make install
 # On Windows, we need to make sure that the non-versioned dll names exist too
 if [[ ${target} == *mingw* ]]; then
     cp -v ${prefix}/bin/libgmp-*.dll ${prefix}/bin/libgmp.dll
+    cp -v ${prefix}/bin/libgmpxx-*.dll ${prefix}/bin/libgmpxx.dll
 fi
 
 # GMP is dual-licensed, install all license files
@@ -58,6 +59,7 @@ platforms = supported_platforms()
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libgmp", :libgmp),
+    LibraryProduct("libgmpxx", :libgmpxx),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/G/GMP/build_tarballs.jl
+++ b/G/GMP/build_tarballs.jl
@@ -7,9 +7,9 @@ name = "GMP"
 version = v"6.1.2"
 
 sources = [
-    "https://gmplib.org/download/gmp/gmp-$(version).tar.bz2" =>
-    "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2",
-    "./bundled",
+    ArchiveSource("https://gmplib.org/download/gmp/gmp-$(version).tar.bz2",
+                  "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
@@ -44,8 +44,8 @@ make install
 
 # On Windows, we need to make sure that the non-versioned dll names exist too
 if [[ ${target} == *mingw* ]]; then
-    cp -v ${prefix}/bin/libgmp-*.dll ${prefix}/bin/libgmp.dll
-    cp -v ${prefix}/bin/libgmpxx-*.dll ${prefix}/bin/libgmpxx.dll
+    cp -v ${libdir}/libgmp-*.dll "${libdir}/libgmp.dll"
+    cp -v ${libdir}/libgmpxx-*.dll "${libdir}/libgmpxx.dll"
 fi
 
 # GMP is dual-licensed, install all license files
@@ -54,7 +54,7 @@ install_license COPYING*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
Without the product declaration it is not dlopened automatically and then not found by other libraries that depend on it, see: https://github.com/JuliaBinaryWrappers/normaliz_jll.jl/issues/1

I also added libgmpxx.dll for windows, similar to libgmp.dll.

The same happens on linux when there is no system-libgmpxx.so available:
```
julia> using normaliz_jll
ERROR: InitError: could not load library "~/.julia/artifacts/3673e354da051c278f4d8a839105527345ec219a/lib/libnormaliz.so"
libgmpxx.so.4: cannot open shared object file: No such file or directory
Stacktrace:
 [1] dlopen at /var/tmp/portage/dev-lang/julia-1.4.0_rc2/work/julia-1.4.0-rc2/usr/share/julia/stdlib/v1.4/Libdl/src/Libdl.jl:109 [inlined] (repeats 2 times)
 [2] __init__() at ~/.julia/dev/normaliz_jll/src/wrappers/x86_64-linux-gnu-cxx11.jl:74
during initialization of module normaliz_jll
```