### PR TITLE
[LLVM]: ship static libraries in `libLLVM` and `Clang`

### DIFF
--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -251,10 +251,11 @@ LLVM_ARTIFACT_DIR=$(dirname $(dirname $(realpath ${prefix}/tools/opt${exeext})))
 rm -rf ${prefix}
 
 # Copy over `llvm-config`, `libLLVM` and `include`, specifically.
-mkdir -p ${prefix}/include ${prefix}/tools ${libdir}
+mkdir -p ${prefix}/include ${prefix}/tools ${libdir} ${prefix}/lib
 mv -v ${LLVM_ARTIFACT_DIR}/include/llvm* ${prefix}/include/
 mv -v ${LLVM_ARTIFACT_DIR}/tools/llvm-config* ${prefix}/tools/
 mv -v ${LLVM_ARTIFACT_DIR}/$(basename ${libdir})/*LLVM*.${dlext}* ${libdir}/
+mv -v ${LLVM_ARTIFACT_DIR}/lib/*LLVM*.a ${prefix}/lib
 install_license ${LLVM_ARTIFACT_DIR}/share/licenses/LLVM_full/*
 """
 
@@ -266,10 +267,11 @@ LLVM_ARTIFACT_DIR=$(dirname $(dirname $(realpath ${prefix}/tools/opt${exeext})))
 rm -rf ${prefix}
 
 # Copy over `clang`, `libclang` and `include`, specifically.
-mkdir -p ${prefix}/include ${prefix}/tools ${libdir}
+mkdir -p ${prefix}/include ${prefix}/tools ${libdir} ${prefix}/lib
 mv -v ${LLVM_ARTIFACT_DIR}/include/clang* ${prefix}/include/
 mv -v ${LLVM_ARTIFACT_DIR}/tools/clang* ${prefix}/tools/
 mv -v ${LLVM_ARTIFACT_DIR}/$(basename ${libdir})/libclang*.${dlext}* ${libdir}/
+mv -v ${LLVM_ARTIFACT_DIR}/lib/libclang*.a ${prefix}/lib
 install_license ${LLVM_ARTIFACT_DIR}/share/licenses/LLVM_full/*
 """
 
@@ -286,6 +288,8 @@ rm -vrf ${prefix}/include/{clang*,llvm*}
 rm -vrf ${prefix}/tools/{clang*,llvm-config}
 rm -vrf ${libdir}/libclang*.${dlext}*
 rm -vrf ${libdir}/*LLVM*.${dlext}*
+rm -vrf ${prefix}/lib/*LLVM*.a
+rm -vrf ${prefix}/lib/libclang*.a
 """
 
 function configure_build(ARGS, version)

--- a/L/LLVM/libLLVM@9.0.1/build_tarballs.jl
+++ b/L/LLVM/libLLVM@9.0.1/build_tarballs.jl
@@ -1,5 +1,6 @@
 name = "libLLVM"
 version = v"9.0.1"
 
+# Include common tools
 include("../common.jl")
 build_tarballs(ARGS, configure_extraction(ARGS, version, name)...; skip_audit=true)


### PR DESCRIPTION
`llvm-config` spits out lots of warnings if the static libraries aren't available, so just ship 'em.