### PR TITLE
[AZP] Fix registration doing extra work

### DIFF
--- a/.ci/register_package.jl
+++ b/.ci/register_package.jl
@@ -45,6 +45,7 @@ end
 
 # Filter out build-time dependencies also here
 merged["dependencies"] = Dependency[dep for dep in merged["dependencies"] if !isa(dep, BuildDependency)]
+BinaryBuilder.push_jll_package(name, build_version)
 mktempdir() do download_dir
     # Grab the binaries for our package
     download_cached_binaries(download_dir, merged["platforms"])
@@ -58,5 +59,4 @@ mktempdir() do download_dir
     # Upload them to GitHub releases
     BinaryBuilder.upload_to_github_releases(repo, tag, download_dir; verbose=verbose)
 end
-BinaryBuilder.push_jll_package(name, build_version)
 BinaryBuilder.register_jll(name, build_version, dependencies)


### PR DESCRIPTION
For some reason, I was iterating over the `objs` object instead of the nice merged object?  I don't know why.  @giordano do you have any idea why I would have been doing that?  This is definitely a case of me looking at this and thinking to myself "now why on earth would I have ever done that?"