### PR TITLE
ImageMagick disable docs, disable static

### DIFF
--- a/I/ImageMagick/build_tarballs.jl
+++ b/I/ImageMagick/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/ImageMagick6*/
-./configure --prefix=$prefix --host=$target --without-x --disable-openmp --disable-installed --disable-dependency-tracking --without-frozenpaths --without-perl
+./configure --prefix=$prefix --host=$target --without-x --disable-openmp --disable-installed --disable-dependency-tracking --without-frozenpaths --without-perl --disable-docs --disable-static
 make -j${nproc}
 make install
 """


### PR DESCRIPTION
Output of `print_package_disk_usage()` says ImageMagick version = "6.9.10-12+0" takes 83.75 MiB on disk on Windows. Disabling docs and static libraries should bring this to about 42 MiB.

* `--disable-static` https://github.com/ImageMagick/ImageMagick/blob/7.0.10-3/Install-unix.txt#L204-L211
* `--disable-docs` https://github.com/ImageMagick/ImageMagick/blob/7.0.10-3/configure.ac#L3039-L3045
Note: the links are to ImageMagick v7 since I did not find v6.9 on github.