### PR TITLE
Add the SPIRV to LLVM translator.

### DIFF
--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@10/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@10/build_tarballs.jl
@@ -1,0 +1,16 @@
+include("../common.jl")
+
+version = v"10.0"
+
+# Collection of sources required to build attr
+sources = [GitSource(repo, "7743482f2053582be990e93ca46d15239c509c9d")]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    BuildDependency(PackageSpec(name="LLVM_full_jll", version=v"10.0.0")),
+    #Dependency(PackageSpec(name="libLLVM_jll", version=v"10.0.0"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"7")

--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@8/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@8/build_tarballs.jl
@@ -1,0 +1,19 @@
+include("../common.jl")
+
+version = v"8.0"
+
+# Collection of sources required to build attr
+sources = [GitSource(repo, "20240c9e4284a839337a04fb6001d8bf6b26fb62")]
+
+# LLVM 8's add_llvm_library does not work on Windows
+platforms = filter(p -> !(p isa Windows), platforms)
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    BuildDependency(PackageSpec(name="LLVM_full_jll", version=v"8.0.1")),
+    #Dependency(PackageSpec(name="libLLVM_jll", version=v"8.0.1"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"7")

--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@9/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@9/build_tarballs.jl
@@ -1,0 +1,16 @@
+include("../common.jl")
+
+version = v"9.0"
+
+# Collection of sources required to build attr
+sources = [GitSource(repo, "17b72562e002a4653e31829e89cf14ce35892896")]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    BuildDependency(PackageSpec(name="LLVM_full_jll", version=v"9.0.1")),
+    #Dependency(PackageSpec(name="libLLVM_jll", version=v"9.0.1"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"7")

--- a/S/SPIRV_LLVM_Translator/common.jl
+++ b/S/SPIRV_LLVM_Translator/common.jl
@@ -1,0 +1,42 @@
+using BinaryBuilder, Pkg
+
+name = "SPIRV_LLVM_Translator"
+repo = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git"
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd SPIRV-LLVM-Translator
+install_license LICENSE.TXT
+
+CMAKE_FLAGS=()
+
+# Release build for best performance
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+
+# Install things into $prefix
+CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+
+# Explicitly use our cmake toolchain file and tell CMake we're cross-compiling
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
+
+# Tell CMake where LLVM is
+CMAKE_FLAGS+=(-DLLVM_DIR="${prefix}/lib/cmake/llvm")
+
+# Build the library
+CMAKE_FLAGS+=(-DBUILD_SHARED_LIBS=ON)
+
+cmake -B build -S . -GNinja ${CMAKE_FLAGS[@]}
+ninja -C build llvm-spirv install
+install -Dm755 build/tools/llvm-spirv/llvm-spirv${exeext} -t ${bindir}
+"""
+
+# The products that we will ensure are always built
+products = Product[
+    LibraryProduct(["libLLVMSPIRVLib", "LLVMSPIRVLib"], :libLLVMSPIRV),
+    ExecutableProduct("llvm-spirv", :llvm_spirv),
+]


### PR DESCRIPTION
This tool uses LLVM, so I guess this will be a bit tricky :-) Some thoughts:

- `get_addable_spec` errored, so constructing the PackageSpec manually here
- I need LLVM_full for building (for the CMake files), and Julia's libLLVM at run time; depending on both seems to result in ugly warnings during artifact set-up (symlink already exists)
- This currently only works with 1.5/LLVM9, https://github.com/JuliaRegistries/General/blob/3c3a2496d5a6f62ea0e08542b37d9558fdd28a40/L/libLLVM_jll/Compat.toml, but I assume we will have a version of libLLVM_jll compatible with other Julia versions?