### PR TITLE
OpenBLAS32: An LP64 openblas with 32-bit BlasInt on 64-bit platforms

### DIFF
--- a/O/OpenBLAS/OpenBLAS32@0.3.9/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS32@0.3.9/build_tarballs.jl
@@ -8,9 +8,13 @@ name = "OpenBLAS32"
 version = v"0.3.9"
 
 sources = openblas_sources(version)
-script = openblas_script(openblas32=1)
+script = openblas_script(openblas32=true)
 platforms = openblas_platforms()
-products = openblas_products()
+
+products = [
+    LibraryProduct("libopenblas", :libopenblas)
+]
+
 dependencies = Dependency[]
 
 # Build the tarballs

--- a/O/OpenBLAS/OpenBLAS32@0.3.9/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS32@0.3.9/build_tarballs.jl
@@ -1,0 +1,17 @@
+using BinaryBuilder
+
+include("../common.jl")
+
+
+# Collection of sources required to build OpenBLAS
+name = "OpenBLAS32"
+version = v"0.3.9"
+
+sources = openblas_sources(version)
+script = openblas_script(openblas32=1)
+platforms = openblas_platforms()
+products = openblas_products()
+dependencies = Dependency[]
+
+# Build the tarballs
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6")

--- a/O/OpenBLAS/OpenBLAS32@0.3.9/bundled/patches/openblas-ofast-power.patch
+++ b/O/OpenBLAS/OpenBLAS32@0.3.9/bundled/patches/openblas-ofast-power.patch
@@ -1,0 +1,33 @@
+ Makefile.power | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile.power b/Makefile.power
+index 24d8aa8a..e53a243a 100644
+--- a/Makefile.power
++++ b/Makefile.power
+@@ -11,20 +11,20 @@ endif
+ 
+ ifeq ($(CORE), POWER9)
+ ifeq ($(USE_OPENMP), 1)
+-COMMON_OPT += -Ofast -mcpu=power9 -mtune=power9 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
++COMMON_OPT += -mcpu=power9 -mtune=power9 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power9 -mtune=power9 -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ else
+-COMMON_OPT += -Ofast -mcpu=power9 -mtune=power9 -mvsx -malign-power -fno-fast-math
++COMMON_OPT += -mcpu=power9 -mtune=power9 -mvsx -malign-power -fno-fast-math
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power9 -mtune=power9 -malign-power -fno-fast-math
+ endif
+ endif
+ 
+ ifeq ($(CORE), POWER8)
+ ifeq ($(USE_OPENMP), 1)
+-COMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
++COMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8 -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ else
+-COMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx -malign-power -fno-fast-math
++COMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx -malign-power -fno-fast-math
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8 -malign-power -fno-fast-math
+ endif
+ endif
+

--- a/O/OpenBLAS/OpenBLAS32@0.3.9/bundled/patches/openblas-winexit.patch
+++ b/O/OpenBLAS/OpenBLAS32@0.3.9/bundled/patches/openblas-winexit.patch
@@ -1,0 +1,177 @@
+From f919c3301fabbaa5d965dcc7b1c3d6892a8c730a Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliacomputing.com>
+Date: Sat, 14 Mar 2020 12:05:19 +0100
+
+---
+ driver/others/memory.c | 131 +----------------------------------------
+ 1 file changed, 2 insertions(+), 129 deletions(-)
+
+diff --git a/driver/others/memory.c b/driver/others/memory.c
+index 62a5a021..23f8fe65 100644
+--- a/driver/others/memory.c
++++ b/driver/others/memory.c
+@@ -1510,7 +1510,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -1547,74 +1547,12 @@ void DESTRUCTOR gotoblas_quit(void) {
+ #endif
+ }
+ 
+-#if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-#if defined(SMP)
+-      blas_thread_memory_cleanup();
+-#endif
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-	gotoblas_quit();
+-	return 0;
+-}
+ #ifdef _WIN64
+ #pragma comment(linker, "/INCLUDE:_tls_used")
+ #else
+ #pragma comment(linker, "/INCLUDE:__tls_used")
+ #endif
+ 
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-static int(*p_process_term)(void) = on_process_term;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-#endif
+-
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ /* Don't call me; this is just work around for PGI / Sun bug */
+ void gotoblas_dummy_for_PGI(void) {
+@@ -3104,7 +3042,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -3133,71 +3071,6 @@ void DESTRUCTOR gotoblas_quit(void) {
+ #endif
+ }
+ 
+-#if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-	gotoblas_quit();
+-	return 0;
+-}
+-#ifdef _WIN64
+-#pragma comment(linker, "/INCLUDE:_tls_used")
+-#else
+-#pragma comment(linker, "/INCLUDE:__tls_used")
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-static int(*p_process_term)(void) = on_process_term;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-#endif
+-
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ /* Don't call me; this is just work around for PGI / Sun bug */
+ void gotoblas_dummy_for_PGI(void) {

--- a/O/OpenBLAS/common.jl
+++ b/O/OpenBLAS/common.jl
@@ -43,7 +43,7 @@ function openblas_script(;num_64bit_threads=32, openblas32=0, kwargs...)
     flags+=(NO_STATIC=1)
 
     if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
-        if [[ ${openblas32} == 1 ]]; then
+        if [[ ${OPENBLAS32} == 1 ]]; then
             # We're building an LP64 BLAS with 32-bit BlasInt on a 64-bit platform
             LIBPREFIX=libopenblas
         else

--- a/O/OpenBLAS/common.jl
+++ b/O/OpenBLAS/common.jl
@@ -22,7 +22,7 @@ function openblas_sources(version::VersionNumber; kwargs...)
     ]
 end
 
-function openblas_script(;num_64bit_threads=32, openblas32=0, kwargs...)
+function openblas_script(;num_64bit_threads::Integer=32, openblas32::Bool=false, kwargs...)
     # Allow some basic configuration
     script = """
     NUM_64BIT_THREADS=$(num_64bit_threads)
@@ -47,7 +47,7 @@ function openblas_script(;num_64bit_threads=32, openblas32=0, kwargs...)
             # We're building an LP64 BLAS with 32-bit BlasInt on a 64-bit platform
             LIBPREFIX=libopenblas
         else
-            # If we're building for a 64-bit platform (that is not aarch64), engage ILP64
+            # We're building an ILP64 BLAS with 64-bit BlasInt
             LIBPREFIX=libopenblas64_
             flags+=(INTERFACE64=1 SYMBOLSUFFIX=64_)
         fi

--- a/O/OpenBLAS/common.jl
+++ b/O/OpenBLAS/common.jl
@@ -43,7 +43,7 @@ function openblas_script(;num_64bit_threads::Integer=32, openblas32::Bool=false,
     flags+=(NO_STATIC=1)
 
     if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
-        if [[ ${OPENBLAS32} == 1 ]]; then
+        if [[ "${OPENBLAS32}" == "true" ]]; then
             # We're building an LP64 BLAS with 32-bit BlasInt on a 64-bit platform
             LIBPREFIX=libopenblas
         else

--- a/O/OpenBLAS/common.jl
+++ b/O/OpenBLAS/common.jl
@@ -22,10 +22,11 @@ function openblas_sources(version::VersionNumber; kwargs...)
     ]
 end
 
-function openblas_script(;num_64bit_threads=32, kwargs...)
+function openblas_script(;num_64bit_threads=32, openblas32=0, kwargs...)
     # Allow some basic configuration
     script = """
     NUM_64BIT_THREADS=$(num_64bit_threads)
+    OPENBLAS32=$(openblas32)
     """
     # Bash recipe for building across all platforms
     script *= raw"""
@@ -42,9 +43,14 @@ function openblas_script(;num_64bit_threads=32, kwargs...)
     flags+=(NO_STATIC=1)
 
     if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
-        # If we're building for a 64-bit platform (that is not aarch64), engage ILP64
-        LIBPREFIX=libopenblas64_
-        flags+=(INTERFACE64=1 SYMBOLSUFFIX=64_)
+        if [[ ${openblas32} == 1 ]]; then
+            # We're building an LP64 BLAS with 32-bit BlasInt on a 64-bit platform
+            LIBPREFIX=libopenblas
+        else
+            # If we're building for a 64-bit platform (that is not aarch64), engage ILP64
+            LIBPREFIX=libopenblas64_
+            flags+=(INTERFACE64=1 SYMBOLSUFFIX=64_)
+        fi
     else
         LIBPREFIX=libopenblas
     fi


### PR DESCRIPTION
@staticfloat @giordano 

Many libraries hardcode the assumption of a 32-bit BLAS even on 64-bit platforms. @staticfloat suggested two options - OpenBLAS32_jll for such packages which provides a 32-bit BLAS on all platforms (includeing 64-bit) which would be nice for interoperability, or building 32-bit stubs that dispatch to 64-bit. I like OpenBLAS32_jll since I don’t have to write new code, and packages that need this can simply just pull it in.

I am not sure if this is the best way to build the 32-bit variant of OpenBLAS on 64-bit platforms. Requesting a review on how best to organize this.