### PR TITLE
cimgui: Export `compile_commands.json`

### DIFF
--- a/C/CImGui/build_tarballs.jl
+++ b/C/CImGui/build_tarballs.jl
@@ -36,6 +36,7 @@ platforms = supported_platforms()
 products = [
     LibraryProduct("libcimgui", :libcimgui),
     LibraryProduct("libcimgui_helper", :libcimgui_helper),
+    FileProduct("share/compile_commands.json", :compile_commands)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/C/CImGui/bundled/wrapper/CMakeLists.txt
+++ b/C/CImGui/bundled/wrapper/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8.0)
 project(cimgui)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 add_library(cimgui SHARED)
 
 target_sources(cimgui PRIVATE cimgui.cpp)

--- a/C/CImGui/bundled/wrapper/CMakeLists.txt
+++ b/C/CImGui/bundled/wrapper/CMakeLists.txt
@@ -42,3 +42,5 @@ install(TARGETS cimgui_helper
         ARCHIVE DESTINATION lib/static
         INCLUDES DESTINATION include
         PUBLIC_HEADER DESTINATION include)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json DESTINATION lib)

--- a/C/CImGui/bundled/wrapper/CMakeLists.txt
+++ b/C/CImGui/bundled/wrapper/CMakeLists.txt
@@ -43,4 +43,4 @@ install(TARGETS cimgui_helper
         INCLUDES DESTINATION include
         PUBLIC_HEADER DESTINATION include)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json DESTINATION lib)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json DESTINATION share)


### PR DESCRIPTION
This file contains full compilation info and can be used in Clang.jl. 