### PR TITLE
[ASL] add `n_cc` and `cvar`

### DIFF
--- a/A/ASL/bundled/asl-extra/aslinterface.cc
+++ b/A/ASL/bundled/asl-extra/aslinterface.cc
@@ -116,6 +116,10 @@ int asl_nlnc(ASL *asl) {
   return asl->i.nlnc_;
 }
 
+int asl_n_cc(ASL *asl) {
+  return asl->i.n_cc_;
+}
+
 int asl_nnzj(ASL *asl) {
   return asl->i.nzc_;
 }
@@ -150,6 +154,10 @@ double *asl_lcon(ASL *asl) {
 
 double *asl_ucon(ASL *asl) {
   return asl->i.Urhsx_;
+}
+
+int *asl_cvar(ASL *asl) {
+  return asl->i.cvar_;
 }
 
 // Objective.

--- a/A/ASL/bundled/asl-extra/aslinterface.h
+++ b/A/ASL/bundled/asl-extra/aslinterface.h
@@ -45,6 +45,7 @@ int asl_nlnc(   ASL *asl);
 int asl_nnzj(   ASL *asl);
 int asl_nnzh(   ASL *asl);
 int asl_islp(   ASL *asl);
+int asl_n_cc(   ASL *asl);
 
 double *asl_x0(  ASL *asl);
 double *asl_y0(  ASL *asl);
@@ -52,6 +53,7 @@ double *asl_lvar(ASL *asl);
 double *asl_uvar(ASL *asl);
 double *asl_lcon(ASL *asl);
 double *asl_ucon(ASL *asl);
+int    *asl_cvar(ASL *asl);
 
 void asl_varscale(ASL *asl, double *s, int *err);
 void asl_lagscale(ASL *asl, double  s, int *err);


### PR DESCRIPTION
Recover _n_cc_ (integer) and _cvar_ (array of integer) from ASL to handle complementarity constraints.