### PR TITLE
analyse the rebuild tree for Yggdrasil

### DIFF
--- a/contrib/dependency_tree.jl
+++ b/contrib/dependency_tree.jl
@@ -1,0 +1,94 @@
+using BinaryBuilder
+
+const PATH = dirname(@__DIR__)
+build_recipes = readlines(`find $(PATH) -name build_tarballs.jl`)
+
+function process_meta(file)
+    # Read in input `.json` file
+    json = String(read(file))
+    buff = IOBuffer(strip(json))
+    objs = []
+    while !eof(buff)
+        push!(objs, BinaryBuilder.JSON.parse(buff))
+    end
+
+    # Merge the multiple outputs into one
+    merged = BinaryBuilder.merge_json_objects(objs)
+    BinaryBuilder.cleanup_merged_object!(merged)
+    merged
+end
+
+metadata = Any[]
+failed = String[]
+
+for recipe in build_recipes
+    @info "Processing recipe..." recipe
+    try 
+        run(`$(Base.julia_cmd()) $recipe --meta-json=tmp.json`)
+        meta = process_meta("tmp.json")
+        rm("tmp.json")
+        push!(metadata, meta)
+    catch err
+        bt = catch_backtrace()
+        push!(failed, recipe)
+        @error "Processing failed..." recipe _ex=(err, bt)
+    end
+end
+
+Base.nameof(d::BinaryBuilder.AbstractDependency) = d.pkg.name
+function stages(metadata)
+
+    seen = Set{String}()
+    stages = Any[]
+    current = Any[]
+    next = Any[]
+    worklist = metadata
+
+    while true
+        changed = false
+        for pkg in worklist
+            dependencies = pkg["dependencies"]
+            name = "$(pkg["name"])_jll"
+        
+            if all(d->in(nameof(d), seen), dependencies)
+                changed = true
+                push!(seen, name)
+                push!(current, pkg)
+            else
+                push!(next, pkg)
+            end
+        end
+        if !changed
+            if !isempty(next)
+                @error "Unsatisfiable dependencies or loop"
+            end
+            break
+        end
+        push!(stages, current)
+        worklist = next
+        current = Any[]
+        next = Any[]
+    end
+    return stages, next
+end
+
+function report(stages)
+    open("report.md", "w") do io
+        for (i, stage) in enumerate(stages)
+            println(io, "- Stage ", i, ":")
+            for pkg in stage
+                println(io, "  - `", pkg["name"], "`")
+            end
+        end
+    end
+end
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
For fun and so that I can test all packages on PowerPC I wrote this little script
that analyses the critical path length in the dependency tree:

- Stage 1:
  - `Xorg_dri3proto`
  - `Xorg_kbproto`
  - `Xorg_xcb_proto`
  - `Xorg_damageproto`
  - `Xorg_randrproto`
  - `XPA`
  - `xxHash`
  - `Xorg_util_macros`
  - `Xorg_glproto`
  - `Xorg_compositeproto`
  - `x264`
  - `Xorg_xtrans`
  - `Xorg_inputproto`
  - `Xorg_renderproto`
  - `Xorg_xproto`
  - `Xorg_libXau`
  - `Xorg_scrnsaverproto`
  - `Xorg_fixesproto`
  - `Xorg_dri2proto`
  - `Xorg_xineramaproto`
  - `Xorg_xf86vidmodeproto`
  - `Xorg_libpciaccess`
  - `Xorg_libxshmfence`
  - `Xorg_recordproto`
  - `XZ`
  - `Xorg_libpthread_stubs`
  - `Xorg_xorgproto`
  - `x265`
  - `Xorg_xextproto`
  - `SQLite`
  - `sais`
  - `s3gof3r`
  - `spglib`
  - `sdsl_lite`
  - `SuiteSparseGraphBLAS`
  - `SoftPosit`
  - `Snowball`
  - `Glibc`
  - `Musl`
  - `OpenLibm`
  - `OptimPack`
  - `Opus`
  - `OATHToolkit`
  - `Ogg`
  - `OpenBLASHighCoreCount`
  - `OpenBLAS`
  - `OpenBLAS`
  - `OpenBLAS`
  - `OpenBLASHighCoreCount`
  - `OpenBLAS32`
  - `OpenSSL`
  - `OpenMPI`
  - `zrl`
  - `Zstd`
  - `z3`
  - `ZeroMQ`
  - `Zlib`
  - `MbedTLS`
  - `METIS`
  - `mpg123`
  - `Mineos`
  - `METIS`
  - `Minuit2`
  - `CompilerSupportLibraries`
  - `coordgenlibs`
  - `CoinUtils`
  - `CALCEPH`
  - `CImGui`
  - `CSPICE`
  - `CUTEst`
  - `Chemfiles`
  - `libcxxwrap_julia`
  - `COINBLAS`
  - `capnproto`
  - `Cuba`
  - `CUDA`
  - `libnl`
  - `Libcap_Ng`
  - `libusb`
  - `LAME`
  - `libdivsufsort`
  - `libsharp2`
  - `libexif`
  - `librealsense`
  - `libsodium`
  - `libmodplug`
  - `LZO`
  - `libserialport`
  - `Linux`
  - `libconfuse`
  - `libpng`
  - `libportaudio_ringbuffer`
  - `Libxc`
  - `libvorbis`
  - `LCIO`
  - `Libiconv`
  - `LibVPX`
  - `L_BFGS_B`
  - `Libffi`
  - `liblsl`
  - `Libmount`
  - `libxls`
  - `lm_Sensors`
  - `LibUnwind`
  - `Lz4`
  - `LibOSXUnwind`
  - `LibUV`
  - `libftd2xx`
  - `Libgpg_error`
  - `libfdk_aac`
  - `libevent`
  - `LibSSH2`
  - `Libuuid`
  - `libcap`
  - `LLVM_full`
  - `libLLVM`
  - `libLLVM`
  - `LLVM_full`
  - `LLVM_full`
  - `LLVM_full`
  - `Libtask`
  - `rr`
  - `Rmath`
  - `ReadStat`
  - `JpegTurbo`
  - `PCRE`
  - `Pixman`
  - `PYTHIA`
  - `PROJ`
  - `pprof`
  - `PATHlib`
  - `P4est`
  - `Patchelf`
  - `PCRE2`
  - `PROPACK`
  - `peco`
  - `p7zip`
  - `utf8proc`
  - `Darknet`
  - `DecFP`
  - `dSFMT`
  - `EarCut`
  - `ECOS`
  - `Edlib`
  - `ERFA`
  - `EDFlib`
  - `Expat`
  - `QuantReg`
  - `QD`
  - `Qhull`
  - `KaHyPar`
  - `KAShim`
  - `KCP`
  - `Keyutils`
  - `IntelOpenMP`
  - `ICU`
  - `iso_codes`
  - `iperf`
  - `breakpad`
  - `Bison`
  - `Bzip2`
  - `boost`
  - `Ninja`
  - `NOMAD`
  - `NNPACK`
  - `NUMA`
  - `GSL`
  - `Gumbo`
  - `GMP`
  - `git_crypt`
  - `ghr`
  - `Giflib`
  - `glmnet`
  - `GEOS`
  - `Geant4`
  - `Graphite2`
  - `GibbsSeaWater`
  - `GSL`
  - `HelloWorldC`
  - `HDF5`
  - `HelloWorldFortran`
  - `HelloWorldCxx`
  - `HelloWorldRust`
  - `HELICS`
  - `hub`
  - `hicolor_icon_theme`
  - `HelloWorldGo`
  - `hidapi`
  - `VerizonEctoken`
  - `vmtouch`
  - `Arpack`
  - `armadillo`
  - `ASL`
  - `Attr`
  - `adwaita_icon_theme`
  - `aiger`
  - `alsa`
  - `TerminalImageViewer`
  - `Tar`
  - `Tcl`
  - `tree_sitter_c`
  - `Triangle`
  - `WCS`
  - `FriBidi`
  - `FFTW`
  - `FreeType2`
  - `Fontconfig`
  - `FastJet`
  - `FLAC`
- Stage 2:
  - `Xorg_libXdmcp`
  - `XML2`
  - `XGBoost`
  - `Xorg_libICE`
  - `SCS`
  - `SuiteSparse`
  - `Sundials`
  - `opusfile`
  - `OpenSpiel`
  - `Osi`
  - `OpenSpecFun`
  - `MPICH`
  - `mlpack`
  - `MPFR`
  - `MKL`
  - `cddlib`
  - `CGAL`
  - `LCIO_Julia_Wrapper`
  - `libportaudio`
  - `Luna`
  - `lrslib`
  - `Libgcrypt`
  - `libsndfile`
  - `LibCURL`
  - `libass`
  - `LibGit2`
  - `libcgal_julia`
  - `Libtiff`
  - `PPL`
  - `Python`
  - `PARMETIS`
  - `Dbus`
  - `Elfutils`
  - `ImageMagick`
  - `bliss`
  - `bsdiff_endsley`
  - `bsdiff_classic`
  - `normaliz`
  - `Nettle`
  - `GLPK`
  - `GDAL`
  - `Gettext`
  - `htslib`
  - `Wayland`
  - `FastJet_Julia_Wrapper`
  - `FLINT`
  - `FastTransforms`
  - `FFMPEG`
- Stage 3:
  - `Xorg_libSM`
  - `XSLT`
  - `Sundials`
  - `SCALAPACK`
  - `MPC`
  - `MariaDB_Connector_C`
  - `MUMPS`
  - `CFITSIO`
  - `Ncurses`
  - `Glib`
  - `Gnuastro`
  - `Git`
  - `Graphene`
  - `Htop`
  - `ATK`
  - `tmux`
  - `Wayland_protocols`
- Stage 4:
  - `Xorg_libxcb`
  - `SymEngine`
  - `SharedMimeInfo`
  - `Libcroco`
  - `Readline`
  - `Qemu`
  - `bmon`
- Stage 5:
  - `Xorg_xcb_util`
  - `Xorg_libX11`
  - `Lua`
  - `gdk_pixbuf`
- Stage 6:
  - `Xorg_libXt`
  - `Xorg_xcb_util_renderutil`
  - `Xorg_libXfixes`
  - `Xorg_xcb_util_image`
  - `Xorg_libxkbfile`
  - `Xorg_libXrender`
  - `Xorg_libXcomposite`
  - `Xorg_xcb_util_wm`
  - `Xorg_libXext`
  - `Xorg_libXpm`
  - `Xorg_libXxf86vm`
  - `Xorg_xcb_util_keysyms`
  - `Xorg_libXi`
  - `Xorg_libXft`
  - `Xorg_libXcursor`
  - `Xorg_libXdamage`
  - `Cairo`
  - `Libglvnd`
  - `Libepoxy`
  - `libwebp`
  - `Leptonica`
  - `GLEW`
  - `HarfBuzz`
  - `Tk`
- Stage 7:
  - `Xorg_libXinerama`
  - `Xorg_xkbcomp`
  - `Xorg_libXScrnSaver`
  - `Xorg_libXmu`
  - `Xorg_libXtst`
  - `Xorg_libXrandr`
  - `Xorg_xkeyboard_config`
  - `SDL2`
  - `SDL2_image`
  - `SDL2_ttf`
  - `SDL2_gfx`
  - `Pango`
  - `GLFW`
  - `at_spi2_core`
  - `at_spi2_atk`
  - `Tesseract`
- Stage 8:
  - `xkbcommon`
  - `SDL2_mixer`
  - `Librsvg`
  - `GTK3`
  - `GtkSourceView`
- Stage 9:
  - `Gnome_themes_extra`