### PR TITLE
MUMPS_seq: install headers in include/mumps_seq

### DIFF
--- a/M/MUMPS_seq/build_tarballs.jl
+++ b/M/MUMPS_seq/build_tarballs.jl
@@ -83,7 +83,9 @@ done
 cp *.${dlext} ${libdir}
 cd ..
 
-cp include/* ${prefix}/include
+mkdir -p ${prefix}/include/mumps_seq
+cp include/* ${prefix}/include/mumps_seq
+cp libseq/*.h ${prefix}/include/mumps_seq
 """
 
 platforms = expand_gfortran_versions(supported_platforms())


### PR DESCRIPTION
MUMPS_seq provides fake mpi.h and mpif.h that could conflict with
the actual header files from an MPI implementation.