### PR TITLE
[AZP] Bump RegistryTools version

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -245,9 +245,9 @@ version = "1.1.0"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
-git-tree-sha1 = "14873d5a5c36b53897b47e64d123e363176f6cde"
+git-tree-sha1 = "94cf95fd962cc0594da4d676ed66b553f84ec246"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
-version = "1.3.3"
+version = "1.3.4"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"


### PR DESCRIPTION
New version of RegistryTools includes https://github.com/JuliaRegistries/RegistryTools.jl/pull/29, which should address https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/722