### PR TITLE
MUMPS_seq: use OpenBLAS32

### DIFF
--- a/M/MUMPS_seq/build_tarballs.jl
+++ b/M/MUMPS_seq/build_tarballs.jl
@@ -25,7 +25,7 @@ make_args+=(OPTF=-O
             CC="$CC -fPIC ${CFLAGS[@]}"
             FC="gfortran -fPIC ${FFLAGS[@]}"
             FL="gfortran -fPIC"
-            LIBBLAS=-lopenblas)
+            LIBBLAS="-L${libdir} -lopenblas")
 
 if [[ "${target}" == *-apple* ]]; then
   make_args+=(RANLIB=echo)
@@ -49,7 +49,7 @@ gfortran -fPIC -shared -Wl,${all_load} libmpiseq.a ${libs[@]} -Wl,${noall_load} 
 cp libmpiseq.${dlext} ${libdir}
 
 cd ../lib
-libs=(-L${libdir} -lmetis ${OPENBLAS} -lmpiseq)
+libs=(-L${libdir} -lmetis -lopenblas -lmpiseq)
 gfortran -fPIC -shared -Wl,${all_load} libpord.a ${libs[@]} -Wl,${noall_load} ${extra[@]} -o libpord.${dlext}
 cp libpord.${dlext} ${libdir}
 

--- a/M/MUMPS_seq/build_tarballs.jl
+++ b/M/MUMPS_seq/build_tarballs.jl
@@ -82,6 +82,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
     Dependency("METIS_jll"),
     Dependency("OpenBLAS32_jll"),
 ]

--- a/M/MUMPS_seq/build_tarballs.jl
+++ b/M/MUMPS_seq/build_tarballs.jl
@@ -13,24 +13,6 @@ script = raw"""
 mkdir -p ${libdir}
 cd $WORKSPACE/srcdir/MUMPS_5.2.1
 
-OPENBLAS=(-lopenblas)
-FFLAGS=()
-CFLAGS=()
-if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
-  FFLAGS+=(-ffixed-line-length-none)  # replacing symbols below sometimes makes lines > 72 chars
-  OPENBLAS=(-lopenblas64_)
-  if [[ "${target}" == powerpc64le-linux-gnu ]]; then
-    OPENBLAS+=(-lgomp)
-  fi
-
-  syms=(DGEMM IDAMAX ISAMAX SNRM2 XERBLA ccopy cgemm cgemv cgeru cher clarfg cscal cswap ctrsm ctrsv cungqr cunmqr dcopy dgemm dgemv dger dlamch dlarfg dorgqr dormqr dnrm2 dscal dswap dtrsm dtrsv dznrm2 idamax isamax ilaenv scnrm2 scopy sgemm sgemv sger slamch slarfg sorgqr sormqr snrm2 sscal sswap strsm strsv xerbla zcopy zgemm zgemv zgeru zlarfg zscal zswap ztrsm ztrsv zungqr zunmqr)
-  for sym in ${syms[@]}
-  do
-    FFLAGS+=("-D${sym}=${sym}_64")
-    CFLAGS+=("-D${sym}=${sym}_64")
-  done
-fi
-
 makefile="Makefile.G95.SEQ"
 cp Make.inc/${makefile} Makefile.inc
 
@@ -43,7 +25,7 @@ make_args+=(OPTF=-O
             CC="$CC -fPIC ${CFLAGS[@]}"
             FC="gfortran -fPIC ${FFLAGS[@]}"
             FL="gfortran -fPIC"
-            LIBBLAS=${OPENBLAS})
+            LIBBLAS=-lopenblas)
 
 if [[ "${target}" == *-apple* ]]; then
   make_args+=(RANLIB=echo)
@@ -101,7 +83,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("METIS_jll"),
-    Dependency("OpenBLAS_jll"),
+    Dependency("OpenBLAS32_jll"),
 ]
 
 # Build the tarballs.

--- a/M/MUMPS_seq/build_tarballs.jl
+++ b/M/MUMPS_seq/build_tarballs.jl
@@ -16,7 +16,7 @@ cd $WORKSPACE/srcdir/MUMPS_5.2.1
 makefile="Makefile.G95.SEQ"
 cp Make.inc/${makefile} Makefile.inc
 
-make_args+=(OPTF=-O
+make_args+=(OPTF=-O3
             CDEFS=-DAdd_
             LMETISDIR=${libdir}
             IMETIS=-I${prefix}/include


### PR DESCRIPTION
This library is currently only used by Ipopt, which uses 32-bit Ints and segfaults if MUMPS_seq is linked against `libopenblas64_`.