### PR TITLE
[Clang_jll]: ship internal headers

### DIFF
--- a/L/LLVM/Clang@9.0.1/build_tarballs.jl
+++ b/L/LLVM/Clang@9.0.1/build_tarballs.jl
@@ -2,5 +2,6 @@ name = "Clang"
 llvm_full_version = v"9.0.1+4"
 libllvm_version = v"9.0.1+5"
 
+# Include common LLVM stuff
 include("../common.jl")
 build_tarballs(ARGS, configure_extraction(ARGS, llvm_full_version, name, libllvm_version)...; skip_audit=true)

--- a/L/LLVM/LLVM@9.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM@9.0.1/build_tarballs.jl
@@ -2,6 +2,6 @@ name = "LLVM"
 llvm_full_version = v"9.0.1+4"
 libllvm_version = v"9.0.1+5"
 
-
+# Include common LLVM stuff
 include("../common.jl")
 build_tarballs(ARGS, configure_extraction(ARGS, llvm_full_version, name, libllvm_version)...; skip_audit=true)

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -274,6 +274,7 @@ mv -v ${LLVM_ARTIFACT_DIR}/include/clang* ${prefix}/include/
 mv -v ${LLVM_ARTIFACT_DIR}/tools/clang* ${prefix}/tools/
 mv -v ${LLVM_ARTIFACT_DIR}/$(basename ${libdir})/libclang*.${dlext}* ${libdir}/
 mv -v ${LLVM_ARTIFACT_DIR}/lib/libclang*.a ${prefix}/lib
+mv -v ${LLVM_ARTIFACT_DIR}/lib/clang ${prefix}/lib/clang
 install_license ${LLVM_ARTIFACT_DIR}/share/licenses/LLVM_full/*
 """
 
@@ -292,6 +293,7 @@ rm -vrf ${libdir}/libclang*.${dlext}*
 rm -vrf ${libdir}/*LLVM*.${dlext}*
 rm -vrf ${prefix}/lib/*LLVM*.a
 rm -vrf ${prefix}/lib/libclang*.a
+rm -vrf ${prefix}/lib/clang
 """
 
 function configure_build(ARGS, version)


### PR DESCRIPTION
We were missing these internal headers that get tucked away in `${prefix}/lib/clang/${version}`.