### PR TITLE
Configure libtiff with ZIP and JPEG.

### DIFF
--- a/L/Libtiff/build_tarballs.jl
+++ b/L/Libtiff/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/tiff-*/
-CPPFLAGS="-I${prefix}/include"
+export CPPFLAGS="-I${prefix}/include"
 
 ./configure --prefix=$prefix --host=$target
 make -j${nproc}

--- a/L/Libtiff/build_tarballs.jl
+++ b/L/Libtiff/build_tarballs.jl
@@ -7,8 +7,8 @@ version = v"4.0.10"
 
 # Collection of sources required to build Libtiff
 sources = [
-    "https://download.osgeo.org/libtiff/tiff-$(version).tar.gz" =>
-    "2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4"
+    ArchiveSource("https://download.osgeo.org/libtiff/tiff-$(version).tar.gz",
+                  "2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4")
 ]
 
 # Bash recipe for building across all platforms
@@ -32,9 +32,9 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "JpegTurbo_jll",
-    "Zlib_jll",
-    "Zstd_jll",
+    Dependency("JpegTurbo_jll"),
+    Dependency("Zlib_jll"),
+    Dependency("Zstd_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
It seems a bit sad to depend on Zlib and JPEG but not configure libtiff to enable them, so this PR does just that. Possibly some paths to those libraries will need to be configured as well, CI will tell.
