### PR TITLE
[libigc] Disable cross compilation.

### DIFF
--- a/L/libigc/bundled/patches/gcc-constexpr_assert_bug.patch
+++ b/L/libigc/bundled/patches/gcc-constexpr_assert_bug.patch
@@ -1,0 +1,13 @@
+diff --git a/IGC/Compiler/CISACodeGen/CISABuilder.cpp b/IGC/Compiler/CISACodeGen/CISABuilder.cpp
+index 2496ad87..f4b89939 100644
+--- a/IGC/Compiler/CISACodeGen/CISABuilder.cpp
++++ b/IGC/Compiler/CISACodeGen/CISABuilder.cpp
+@@ -199,7 +199,7 @@ namespace IGC
+         case EXEC_SIZE_8:  lanes = 8; break;
+         case EXEC_SIZE_16: lanes = 16; break;
+         case EXEC_SIZE_32: lanes = 32; break;
+-        default: assert(false);
++        default: break;
+         }
+         return lanes;
+     }


### PR DESCRIPTION
Listening to @giordano's stream taught me that we don't actually need to cross-compile when targeting 32/64-bit glibc, so let's not do that! :smile:  Now, I know that wasn't the point he was trying to get across, but libigc is a pain to cross-compile. In fact, I think it even causes my binaries to segfault when used by another package (https://github.com/intel/intel-graphics-compiler/issues/128), so let's disable cross-compilation for now. The compiler is only supported on Intel anyhow, and I'm happy to revisit once upstream has dealt with some of the issues.