### PR TITLE
[libcgal-julia] Update to 0.7.0 + update build script

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -3,13 +3,19 @@
 using BinaryBuilder
 
 const name = "libcgal_julia"
-
-version = v"0.6.3"
+const version = v"0.7.0"
 
 # Collection of sources required to build CGAL
 const sources = [
     GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "d66dd1616cfe2b35f4027f77e94dc7b04e109e18"),
+              "da7c613b5462dc636675e331d634cd3104dfc775"),
+    # julia binaries
+    ArchiveSource("https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz",
+                  "faa707c8343780a6fe5eaf13490355e8190acf8e2c189b9e7ecbddb0fa2643ad"; unpack_target="julia-x86_64-linux-gnu"),
+    ArchiveSource("https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-apple-darwin14.tar.gz",
+                  "f2e5359f03314656c06e2a0a28a497f62e78f027dbe7f5155a5710b4914439b1"; unpack_target="julia-x86_64-apple-darwin14"),
+    ArchiveSource("https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-w64-mingw32.tar.gz",
+                  "c7b2db68156150d0e882e98e39269301d7bf56660f4fc2e38ed2734a7a8d1551"; unpack_target="julia-x86_64-w64-mingw32"),
 ]
 
 # Dependencies that must be installed before this package can be built
@@ -24,28 +30,30 @@ const script = raw"""
 # exit on error
 set -eu
 
-# HACK: download julia..
-curl -Lo julia.tar.gz https://github.com/JuliaPackaging/JuliaBuilder/releases/download/v1.0.0-2/julia-1.0.0-$target.tar.gz
-mkdir julia && tar xf julia.tar.gz -C julia
-Julia_PREFIX="$PWD/julia"
+## "find" julia
+case $target in
+  x86_64-linux-gnu)
+    Julia_PREFIX=${WORKSPACE}/srcdir/julia-$target/julia-1.3.1
+    ;;
+  x86_64-apple-darwin14|x86_64-w64-mingw32)
+    Julia_PREFIX=${WORKSPACE}/srcdir/julia-$target/juliabin
+    ;;
+esac
 
 ## configure build
-mkdir -p build && cd build
-
-cmake ../libcgal-julia*/ \
+cmake libcgal-julia*/ -B build \
   `# cmake specific` \
   -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TARGET_TOOLCHAIN" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_FLAGS="-march=x86-64" \
   -DCMAKE_FIND_ROOT_PATH="$prefix" \
   -DCMAKE_INSTALL_PREFIX="$prefix" \
   `# tell libcxxwrap-julia where julia is` \
   -DJulia_PREFIX="$Julia_PREFIX"
 
 ## and away we go..
-VERBOSE=ON cmake --build . --config Release --target install -- -j$nproc
+VERBOSE=ON cmake --build build --config Release --target install -- -j$nproc
 
-install_license ../libcgal-julia*/LICENSE
+install_license libcgal-julia*/LICENSE
 
 # HACK: Apparently, this isn't a simple build system anymore..
 case $target in
@@ -57,9 +65,8 @@ esac
 # platforms are passed in on the command line
 const platforms = [
     Linux(:x86_64, libc=:glibc),
-    Windows(:i686),
-    Windows(:x86_64),
     MacOS(:x86_64),
+    Windows(:x86_64),
 ] |> expand_cxxstring_abis
 
 # The products that we will ensure are always built
@@ -70,3 +77,4 @@ const products = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7")
+


### PR DESCRIPTION
In light of the most recent update to CxxWrap, a new version was issued alongside an update to the lib's buildscript, the latter being intensely inspired by `libcxxwrap_julia`'s recipe.

The buildscript update includes the addition of julia binaries as sources, much like `libcxxwrap_julia`.