### PR TITLE
Don't use abort in _check

### DIFF
--- a/0_RootFS/Rootfs/bundled/utils/sandbox.c
+++ b/0_RootFS/Rootfs/bundled/utils/sandbox.c
@@ -144,7 +144,9 @@ static const char * get_plan9_opts() {
 static void _check(int ok, int line) {
   if (!ok) {
     fprintf(stderr, "At line %d, ABORTED (%d: %s)!\n", line, errno, strerror(errno));
-    abort();
+    fflush(stdout);
+    fflush(stderr);
+    _exit(1);
   }
 }
 #define check(ok) _check(ok, __LINE__)


### PR DESCRIPTION
Abort tries to send SIGABRT to the current process, but init can't receive signals.
Use _exit instead.

Incidentally, this also causes attached debugging tools to go crazy, which I belive
is a kernel bug (https://lkml.org/lkml/2020/4/11/38).