### PR TITLE
[METIS@4 and MUMPS_seq@4] Build only static libraries

### DIFF
--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -25,8 +25,10 @@ cd Lib
 make -j${nproc} COPTIONS="${COPTIONS}"
 cd ..
 
-mkdir -p ${libdir}
-mv libmetis.a ${libdir}
+# We copy the .a files into ${prefix}/lib since the main purpose is to link them in other builds.
+# Specifically this is in a separate location than the typical location for libraries on Windows.
+mkdir -p ${prefix}/lib
+mv libmetis.a ${prefix}/lib
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -1,11 +1,11 @@
-using BinaryBuilder
+using BinaryBuilder, Pkg
 
 name = "METIS"
 version = v"4.0.3"
 
 # Collection of sources required to build METIS
 sources = [
-    ArchiveSource("http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD/metis-4.0.3.tar.gz",
+    ArchiveSource("http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD/metis-$(version).tar.gz",
                   "5efa35de80703c1b2c4d0de080fafbcf4e0d363a21149a1ad2f96e0144841a55"),
     DirectorySource("./bundled"),
 ]
@@ -17,7 +17,7 @@ if [[ "${target}" == *-mingw* ]]; then
 fi
 
 # build libmetis.a
-cd $WORKSPACE/srcdir/metis-4.0.3
+cd $WORKSPACE/srcdir/metis-*
 for f in ${WORKSPACE}/srcdir/patches/*.patch; do
   atomic_patch -p1 ${f}
 done
@@ -36,10 +36,13 @@ mv libmetis.a ${prefix}/lib
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
-products = Product[]
+products = Product[
+    Product("lib/libmetis.a", :libmetis_a)
+]
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[]
 
 # Build the tarballs
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"6")

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -12,13 +12,6 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-all_load="--whole-archive"
-noall_load="--no-whole-archive"
-COPTIONS="-fPIC"
-if [[ "${target}" == *-apple-* ]]; then
-  all_load="-all_load"
-  noall_load="-noall_load"
-fi
 if [[ "${target}" == *-mingw* ]]; then
   COPTIONS="${COPTIONS} -D__VC__"  # to resolve missing srand48/drand48 symbols
 fi
@@ -32,11 +25,8 @@ cd Lib
 make -j${nproc} COPTIONS="${COPTIONS}"
 cd ..
 
-# make a shared lib
-cc -fPIC -shared -Wl,${all_load} libmetis.a -Wl,${noall_load} -o libmetis.${dlext}
-
 mkdir -p ${libdir}
-mv libmetis.${dlext} ${libdir}
+cp libmetis.a ${libdir}
 """
 
 # These are the platforms we will build for by default, unless further
@@ -44,13 +34,10 @@ mv libmetis.${dlext} ${libdir}
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
-products = [
-    LibraryProduct("libmetis", :libmetis),
-]
+products = []
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
-]
+dependencies = Dependency[]
 
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -29,6 +29,8 @@ cd ..
 # Specifically this is in a separate location than the typical location for libraries on Windows.
 mkdir -p ${prefix}/lib
 mv libmetis.a ${prefix}/lib
+mkdir -p ${prefix}/include
+cp Lib/metis.h ${prefix}/include
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -36,7 +36,7 @@ mv libmetis.a ${prefix}/lib
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
-products = Product[
+products = [
     Product("lib/libmetis.a", :libmetis_a)
 ]
 

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -26,7 +26,7 @@ make -j${nproc} COPTIONS="${COPTIONS}"
 cd ..
 
 mkdir -p ${libdir}
-cp libmetis.a ${libdir}
+mv libmetis.a ${libdir}
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -37,7 +37,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    Product("lib/libmetis.a", :libmetis_a)
+    FileProduct("lib/libmetis.a", :libmetis_a)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -34,7 +34,7 @@ cp libmetis.a ${libdir}
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
-products = []
+products = Product[]
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[]

--- a/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
@@ -50,7 +50,7 @@ cp libseq/*.h ${prefix}/include/mumps_seq
 platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
-products = []
+products = Product[]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [

--- a/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
@@ -35,37 +35,13 @@ fi
 # NB: parallel build fails
 make alllib "${make_args[@]}"
 
-# build shared libs
-all_load="--whole-archive"
-noall_load="--no-whole-archive"
-extra=""
-if [[ "${target}" == *-apple-* ]]; then
-    all_load="-all_load"
-    noall_load="-noall_load"
-    extra="-Wl,-undefined -Wl,dynamic_lookup -headerpad_max_install_names"
-fi
-
 cd libseq
-gfortran -fPIC -shared -Wl,${all_load} libmpiseq.a ${libs[@]} -Wl,${noall_load} ${extra[@]} -o libmpiseq.${dlext}
-cp libmpiseq.${dlext} ${libdir}
+cp libmpiseq.a ${libdir}
 
 cd ../lib
-libs=(-L${libdir} -lmetis -lopenblas -lmpiseq)
-gfortran -fPIC -shared -Wl,${all_load} libpord.a ${libs[@]} -Wl,${noall_load} ${extra[@]} -o libpord.${dlext}
-cp libpord.${dlext} ${libdir}
+cp *.a ${libdir}
 
-libs+=(-lpord)
-gfortran -fPIC -shared -Wl,${all_load} libmumps_common.a ${libs[@]} -Wl,${noall_load} ${extra[@]} -o libmumps_common.${dlext}
-cp libmumps_common.${dlext} ${libdir}
-
-libs+=(-lmumps_common)
-for libname in cmumps dmumps smumps zmumps
-do
-  gfortran -fPIC -shared -Wl,${all_load} lib${libname}.a ${libs[@]} -Wl,${noall_load} ${extra[@]} -o lib${libname}.${dlext}
-done
-cp *.${dlext} ${libdir}
 cd ..
-
 mkdir -p ${prefix}/include/mumps_seq
 cp include/* ${prefix}/include/mumps_seq
 cp libseq/*.h ${prefix}/include/mumps_seq
@@ -74,12 +50,7 @@ cp libseq/*.h ${prefix}/include/mumps_seq
 platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
-products = [
-    LibraryProduct("libsmumps", :libsmumps),
-    LibraryProduct("libdmumps", :libdmumps),
-    LibraryProduct("libcmumps", :libcmumps),
-    LibraryProduct("libzmumps", :libzmumps),
-]
+products = []
 
 # Dependencies that must be installed before this package can be built
 dependencies = [

--- a/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
@@ -29,7 +29,7 @@ make_args+=(OPTF=-O3
             CC="$CC -fPIC ${CFLAGS[@]}"
             FC="gfortran -fPIC ${FFLAGS[@]}"
             FL="gfortran -fPIC"
-            LIBBLAS="-L${prefix}/lib -lopenblas")
+            LIBBLAS="-L${libdir} -lopenblas")
 
 if [[ "${target}" == *-apple* ]]; then
   make_args+=(RANLIB=echo)

--- a/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
@@ -55,7 +55,7 @@ cp libseq/*.h ${prefix}/include/mumps_seq
 platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
-products = Product[
+products = [
     FileProduct("lib/libsmumps.a", :libsmumps_a),
     FileProduct("lib/libdmumps.a", :libdmumps_a),
     FileProduct("lib/libcmumps.a", :libcmumps_a),

--- a/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
@@ -15,21 +15,21 @@ cd $WORKSPACE/srcdir/MUMPS_4.10.0
 
 # Patch from Coin-OR ThirdPartyMUMPS
 (cd src && atomic_patch -p2 $WORKSPACE/srcdir/patches/mumps.patch)
-# Patch from CoinMumpsBuilder
+# Patch from JuliaOpt CoinMumpsBuilder
 (cd src && atomic_patch -p3 $WORKSPACE/srcdir/patches/quiet.diff)
 
 cp Make.inc/Makefile.gfortran.SEQ Makefile.inc
 
 make_args+=(OPTF=-O3
             CDEFS=-DAdd_
-            LMETISDIR=${libdir}
+            LMETISDIR=${prefix}/lib
             IMETIS=-I${prefix}/include
             LMETIS='-L$(LMETISDIR) -lmetis'
             ORDERINGSF="-Dpord -Dmetis"
             CC="$CC -fPIC ${CFLAGS[@]}"
             FC="gfortran -fPIC ${FFLAGS[@]}"
             FL="gfortran -fPIC"
-            LIBBLAS="-L${libdir} -lopenblas")
+            LIBBLAS="-L${prefix}/lib -lopenblas")
 
 if [[ "${target}" == *-apple* ]]; then
   make_args+=(RANLIB=echo)
@@ -38,13 +38,13 @@ fi
 # NB: parallel build fails
 make alllib "${make_args[@]}"
 
-mkdir -p ${libdir}
+mkdir -p ${prefix}/lib
 
 cd libseq
-mv libmpiseq.a ${libdir}
+mv libmpiseq.a ${prefix}/lib
 
 cd ../lib
-mv *.a ${libdir}
+mv *.a ${prefix}/lib
 
 cd ..
 mkdir -p ${prefix}/include/mumps_seq

--- a/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@4/build_tarballs.jl
@@ -63,7 +63,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [.
+dependencies = [
     BuildDependency(PackageSpec(; name = "METIS_jll",
                                 uuid = "d00139f3-1899-568f-a2f0-47f597d42d70",
                                 version = v"4.0.3")),

--- a/M/MUMPS/MUMPS_seq@4/bundled/patches/quiet.diff
+++ b/M/MUMPS/MUMPS_seq@4/bundled/patches/quiet.diff
@@ -1,0 +1,20 @@
+index af0b62a..55e372e 100644
+--- a/MUMPS/src/dmumps_part1.F
++++ b/MUMPS/src/dmumps_part1.F
+@@ -104,16 +104,6 @@ C       matrix in assembled format (ICNTL(5)=0, and ICNTL(18) $\neq$ 3),
+         MPG     = id%ICNTL(3)
+         PROK    = ((MP.GT.0).AND.(id%ICNTL(4).GE.3))
+         PROKG   = ( MPG .GT. 0 .and. id%MYID .eq. MASTER )
+-        IF (PROKG) THEN
+-           IF (id%ICNTL(5) .NE. 1) THEN
+-              WRITE(MPG,'(A,I4,I12,I15)') 
+-     &             'Entering DMUMPS driver with JOB, N, NZ =', JOB,N,NZ
+-           ELSE
+-              WRITE(MPG,'(A,I4,I12,I15)') 
+-     &             'Entering DMUMPS driver with JOB, N, NELT =', JOB,N
+-     &             ,NELT
+-           ENDIF
+-        ENDIF
+       ELSE
+         MPG = 0
+         PROK = .FALSE.


### PR DESCRIPTION
[METIS@4] Build only static libraries to avoid conflict with METIS@5
[MUMPS_seq@4] Build only static libraries to avoid conflict with MUMPS_seq@5

@giordano If I am only building `.a` files, is there a build product I should specify?

cc @dpo We should update any packages that depend on METIS 4 to link against it statically. I think that is a safe way to do it to avoid conflict with METIS 5 being available as a shared library.