### PR TITLE
[CUDA] Put the toolkit in a cuda subdirectory of the prefix.

### DIFF
--- a/C/CUDA/CUDA_full@10.0/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.0/build_tarballs.jl
@@ -27,6 +27,7 @@ mkdir ${temp}
 
 apk add p7zip
 
+mkdir ${prefix}/cuda
 if [[ ${target} == x86_64-linux-gnu ]]; then
     sh installer.run --tmpdir="${temp}" --extract="${temp}"
     cd ${temp}
@@ -37,10 +38,7 @@ if [[ ${target} == x86_64-linux-gnu ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins jre NsightCompute-1.0 doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-apple-darwin* ]]; then
     7z x installer.dmg 5.hfs -o${temp}
     cd ${temp}
@@ -52,19 +50,18 @@ elif [[ ${target} == x86_64-apple-darwin* ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins jre NsightCompute-1.0 doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     7z x installer.exe -o${temp}
     cd ${temp}
     find .
 
+    mv EULA.txt ${prefix}/cuda
+
     for project in cuobjdump memcheck nvcc cupti nvdisasm curand cusparse npp cufft \
                    cublas cudart cusolver nvrtc nvgraph nvprof nvprune; do
         [[ -d ${project} ]] || { echo "${project} does not exist!"; exit 1; }
-        cp -a ${project}/* ${prefix}
+        cp -a ${project}/* ${prefix}/cuda
     done
 
     # NVIDIA Tools Extension Library
@@ -73,19 +70,20 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     for file in nvtx_installer/*.*_*; do
         mv $file $(echo $file | sed 's/\.\(\w*\)_.*/.\1/')
     done
-    mv nvtx_installer/*.dll ${prefix}/bin
-    mv nvtx_installer/*64_*.lib ${prefix}/lib/x64
-    mv nvtx_installer/*32_*.lib ${prefix}/lib/Win32
-    mv nvtx_installer/*.h ${prefix}/include
-
-    install_license EULA.txt
+    mv nvtx_installer/*.dll ${prefix}/cuda/bin
+    mv nvtx_installer/*64_*.lib ${prefix}/cuda/lib/x64
+    mv nvtx_installer/*32_*.lib ${prefix}/cuda/lib/Win32
+    mv nvtx_installer/*.h ${prefix}/cuda/include
 
     # fixup
-    chmod +x ${prefix}/bin/*.exe
+    chmod +x ${prefix}/cuda/bin/*.exe
 
     # clean-up
-    rm ${prefix}/*.nvi
+    rm ${prefix}/cuda/*.nvi
 fi
+
+cd ${prefix}/cuda
+install_license EULA.txt
 """
 
 products = Product[

--- a/C/CUDA/CUDA_full@10.1/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.1/build_tarballs.jl
@@ -27,6 +27,7 @@ mkdir ${temp}
 
 apk add p7zip
 
+mkdir ${prefix}/cuda
 if [[ ${target} == x86_64-linux-gnu ]]; then
     sh installer.run --tmpdir="${temp}" --target "${temp}" --noexec
     cd ${temp}/builds/cuda-toolkit
@@ -35,10 +36,7 @@ if [[ ${target} == x86_64-linux-gnu ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins nsight-compute-2019.4.0 nsight-systems-2019.3.7.5 doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-apple-darwin* ]]; then
     7z x installer.dmg 5.hfs -o${temp}
     cd ${temp}
@@ -50,19 +48,18 @@ elif [[ ${target} == x86_64-apple-darwin* ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins nsight-compute-2019.4.0 NsightSystems-2019.3.7.5 doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     7z x installer.exe -o${temp}
     cd ${temp}
     find .
 
+    mv EULA.txt ${prefix}/cuda
+
     for project in cuobjdump memcheck nvcc cupti nvdisasm curand cusparse npp cufft \
                    cublas cudart cusolver nvrtc nvgraph nvprof nvprune; do
         [[ -d ${project} ]] || { echo "${project} does not exist!"; exit 1; }
-        cp -a ${project}/* ${prefix}
+        cp -a ${project}/* ${prefix}/cuda
     done
 
     # NVIDIA Tools Extension Library
@@ -71,19 +68,20 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     for file in nvtx_installer/*.*_*; do
         mv $file $(echo $file | sed 's/\.\(\w*\)_.*/.\1/')
     done
-    mv nvtx_installer/*.dll ${prefix}/bin
-    mv nvtx_installer/*64_*.lib ${prefix}/lib/x64
-    mv nvtx_installer/*32_*.lib ${prefix}/lib/Win32
-    mv nvtx_installer/*.h ${prefix}/include
-
-    install_license EULA.txt
+    mv nvtx_installer/*.dll ${prefix}/cuda/bin
+    mv nvtx_installer/*64_*.lib ${prefix}/cuda/lib/x64
+    mv nvtx_installer/*32_*.lib ${prefix}/cuda/lib/Win32
+    mv nvtx_installer/*.h ${prefix}/cuda/include
 
     # fixup
-    chmod +x ${prefix}/bin/*.exe
+    chmod +x ${prefix}/cuda/bin/*.exe
 
     # clean-up
-    rm ${prefix}/*.nvi
+    rm ${prefix}/cuda/*.nvi
 fi
+
+cd ${prefix}/cuda
+install_license EULA.txt
 """
 
 products = Product[

--- a/C/CUDA/CUDA_full@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.2/build_tarballs.jl
@@ -27,6 +27,7 @@ mkdir ${temp}
 
 apk add p7zip
 
+mkdir ${prefix}/cuda
 if [[ ${target} == x86_64-linux-gnu ]]; then
     sh installer.run --tmpdir="${temp}" --target "${temp}" --noexec
     cd ${temp}/builds/cuda-toolkit
@@ -35,10 +36,7 @@ if [[ ${target} == x86_64-linux-gnu ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins nsight-compute-2019.5.0 nsight-systems-2019.5.2 doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-apple-darwin* ]]; then
     7z x installer.dmg 5.hfs -o${temp}
     cd ${temp}
@@ -50,19 +48,18 @@ elif [[ ${target} == x86_64-apple-darwin* ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins nsight-compute-2019.5.0 NsightSystems-2019.5.2.16 doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     7z x installer.exe -o${temp}
     cd ${temp}
     find .
 
+    mv EULA.txt ${prefix}/cuda
+
     for project in cuobjdump memcheck nvcc cupti nvdisasm curand cusparse npp cufft \
                    cublas cudart cusolver nvrtc nvgraph nvprof nvprune; do
         [[ -d ${project} ]] || { echo "${project} does not exist!"; exit 1; }
-        cp -a ${project}/* ${prefix}
+        cp -a ${project}/* ${prefix}/cuda
     done
 
     # NVIDIA Tools Extension Library
@@ -71,19 +68,20 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     for file in nvtx_installer/*.*_*; do
         mv $file $(echo $file | sed 's/\.\(\w*\)_.*/.\1/')
     done
-    mv nvtx_installer/*.dll ${prefix}/bin
-    mv nvtx_installer/*64_*.lib ${prefix}/lib/x64
-    mv nvtx_installer/*32_*.lib ${prefix}/lib/Win32
-    mv nvtx_installer/*.h ${prefix}/include
-
-    install_license EULA.txt
+    mv nvtx_installer/*.dll ${prefix}/cuda/bin
+    mv nvtx_installer/*64_*.lib ${prefix}/cuda/lib/x64
+    mv nvtx_installer/*32_*.lib ${prefix}/cuda/lib/Win32
+    mv nvtx_installer/*.h ${prefix}/cuda/include
 
     # fixup
-    chmod +x ${prefix}/bin/*.exe
+    chmod +x ${prefix}/cuda/bin/*.exe
 
     # clean-up
-    rm ${prefix}/*.nvi
+    rm ${prefix}/cuda/*.nvi
 fi
+
+cd ${prefix}/cuda
+install_license EULA.txt
 """
 
 products = Product[

--- a/C/CUDA/CUDA_full@9.0/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@9.0/build_tarballs.jl
@@ -27,6 +27,7 @@ mkdir ${temp}
 
 apk add p7zip
 
+mkdir ${prefix}/cuda
 if [[ ${target} == x86_64-linux-gnu ]]; then
     sh installer.run --tmpdir="${temp}" --extract="${temp}"
     cd ${temp}
@@ -37,10 +38,7 @@ if [[ ${target} == x86_64-linux-gnu ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins jre doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-apple-darwin* ]]; then
     7z x installer.dmg -o${temp}
     cd ${temp}
@@ -51,19 +49,18 @@ elif [[ ${target} == x86_64-apple-darwin* ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins jre doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     7z x installer.exe -o${temp}
     cd ${temp}
     find .
 
+    mv EULA.txt ${prefix}/cuda
+
     for project in compiler curand cusparse npp cufft cublas cudart \
                    cusolver nvrtc nvgraph command_line_tools; do
         [[ -d ${project} ]] || { echo "${project} does not exist!"; exit 1; }
-        cp -a ${project}/* ${prefix}
+        cp -a ${project}/* ${prefix}/cuda
     done
 
     # NVIDIA Tools Extension Library
@@ -72,19 +69,20 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     for file in nvtx_installer/*.*_*; do
         mv $file $(echo $file | sed 's/\.\(\w*\)_.*/.\1/')
     done
-    mv nvtx_installer/*.dll ${prefix}/bin
-    mv nvtx_installer/*64_*.lib ${prefix}/lib/x64
-    mv nvtx_installer/*32_*.lib ${prefix}/lib/Win32
-    mv nvtx_installer/*.h ${prefix}/include
-
-    install_license EULA.txt
+    mv nvtx_installer/*.dll ${prefix}/cuda/bin
+    mv nvtx_installer/*64_*.lib ${prefix}/cuda/lib/x64
+    mv nvtx_installer/*32_*.lib ${prefix}/cuda/lib/Win32
+    mv nvtx_installer/*.h ${prefix}/cuda/include
 
     # fixup
-    chmod +x ${prefix}/bin/*.exe
+    chmod +x ${prefix}/cuda/bin/*.exe
 
     # clean-up
-    rm ${prefix}/*.nvi
+    rm ${prefix}/cuda/*.nvi
 fi
+
+cd ${prefix}/cuda
+install_license EULA.txt
 """
 
 products = Product[

--- a/C/CUDA/CUDA_full@9.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@9.2/build_tarballs.jl
@@ -27,6 +27,7 @@ mkdir ${temp}
 
 apk add p7zip
 
+mkdir ${prefix}/cuda
 if [[ ${target} == x86_64-linux-gnu ]]; then
     sh installer.run --tmpdir="${temp}" --extract="${temp}"
     cd ${temp}
@@ -37,10 +38,7 @@ if [[ ${target} == x86_64-linux-gnu ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins jre doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-apple-darwin* ]]; then
     7z x installer.dmg -o${temp}
     cd ${temp}
@@ -51,19 +49,18 @@ elif [[ ${target} == x86_64-apple-darwin* ]]; then
     # clean-up
     rm -r libnsight libnvvp nsightee_plugins jre doc
 
-    mv * ${prefix}
-    cd ${prefix}
-
-    install_license EULA.txt
+    mv * ${prefix}/cuda
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     7z x installer.exe -o${temp}
     cd ${temp}
     find .
 
+    mv EULA.txt ${prefix}/cuda
+
     for project in cuobjdump memcheck nvcc cupti nvdisasm curand cusparse npp cufft \
                    cublas cudart cusolver nvrtc nvgraph nvprof nvprune; do
         [[ -d ${project} ]] || { echo "${project} does not exist!"; exit 1; }
-        cp -a ${project}/* ${prefix}
+        cp -a ${project}/* ${prefix}/cuda
     done
 
     # NVIDIA Tools Extension Library
@@ -72,20 +69,21 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     for file in nvtx_installer/*.*_*; do
         mv $file $(echo $file | sed 's/\.\(\w*\)_.*/.\1/')
     done
-    mv nvtx_installer/*.dll ${prefix}/bin
-    mv nvtx_installer/*64_*.lib ${prefix}/lib/x64
-    mv nvtx_installer/*32_*.lib ${prefix}/lib/Win32
-    mv nvtx_installer/*.h ${prefix}/include
+    mv nvtx_installer/*.dll ${prefix}/cuda/bin
+    mv nvtx_installer/*64_*.lib ${prefix}/cuda/lib/x64
+    mv nvtx_installer/*32_*.lib ${prefix}/cuda/lib/Win32
+    mv nvtx_installer/*.h ${prefix}/cuda/include
     find .
 
-    install_license EULA.txt
-
     # fixup
-    chmod +x ${prefix}/bin/*.exe
+    chmod +x ${prefix}/cuda/bin/*.exe
 
     # clean-up
-    rm ${prefix}/*.nvi
+    rm ${prefix}/cuda/*.nvi
 fi
+
+cd ${prefix}/cuda
+install_license EULA.txt
 """
 
 products = Product[


### PR DESCRIPTION
Fixes https://github.com/JuliaPackaging/Yggdrasil/issues/844

I guess there isn't a mechanism for it right now (ship `${prefic}/etc/profile.d/cuda`?), but the package could set CUDA_HOME to `${prefix}/cuda` to help discoverability.