### PR TITLE
HiGHS: expanding platforms with patch

### DIFF
--- a/H/HiGHS/build_tarballs.jl
+++ b/H/HiGHS/build_tarballs.jl
@@ -8,6 +8,7 @@ version = v"0.1.3"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/ERGO-Code/HiGHS.git", "0dc437abd75ba9a56d24e4f4f5a60bd89a2839a5"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms

--- a/H/HiGHS/bundled/patches/mm_malloc.patch
+++ b/H/HiGHS/bundled/patches/mm_malloc.patch
@@ -1,0 +1,11 @@
+--- mm_malloc.h
++++ mm_malloc.h
+@@ -31,7 +31,7 @@
+ #ifndef __cplusplus
+ extern int posix_memalign (void **, size_t, size_t);
+ #else
+-extern "C" int posix_memalign (void **, size_t, size_t) throw ();
++extern "C" int posix_memalign (void **, size_t, size_t);
+ #endif
+
+ static __inline void *


### PR DESCRIPTION
Following the fix in https://github.com/JuliaPackaging/Yggdrasil/blob/48ac662cd53e02aff0189c81008874a04f7172c7/Z/ZeroMQ/build_tarballs.jl#L24
we can expand the platorms HiGHS is currently building on (I hope)