### PR TITLE
remove more docs from XML2

### DIFF
--- a/X/XML2/build_tarballs.jl
+++ b/X/XML2/build_tarballs.jl
@@ -23,7 +23,7 @@ make -j${nproc}
 make install
 
 # Remove heavy doc directories
-rm -rf ${prefix}/share/{doc/libxml2-*,gtk-doc/libxml2}
+rm -rf ${prefix}/share/{doc/libxml2-*,gtk-doc}
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Still quite a lot of docs here:

![image](https://user-images.githubusercontent.com/1282691/79248561-46f92900-7e7c-11ea-910d-3d559f212c5b.png)
