### PR TITLE
[oneL0] Depened on an implementation of the API, for now.

### DIFF
--- a/O/oneAPI_Level_Zero/build_tarballs.jl
+++ b/O/oneAPI_Level_Zero/build_tarballs.jl
@@ -41,6 +41,11 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     BuildDependency("OpenCL_Headers_jll"),
+    Dependency("NEO_jll"), # FIXME: OptionalDependency
+    # oneL0 doesn't depend on NEO, it just needs _a_ implementation to be available.
+    # it does so by looking for (dlopening) known drivers at module load time,
+    # so this package's JLL should put any implementation on the library search path
+    # without actually depending on it. For now, use a regular dependency.
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;


### PR DESCRIPTION
```julia
    Dependency("NEO_jll"), # FIXME: OptionalDependency
    # oneL0 doesn't depend on NEO, it just needs _a_ implementation to be available.
    # it does so by looking for (dlopening) known drivers at module load time,
    # so this package's JLL should put any implementation on the library search path
    # without actually depending on it. For now, use a regular dependency.
```

We could create an `OptionalDependency`, which the JLL code could look for (`isdefined(Main, :OptDep_jll)`) and put on the search path. Thoughts? Or is there a mechanism already to do so?