### PR TITLE
[Readline] update to 8.0.4

### DIFF
--- a/R/Readline/build_tarballs.jl
+++ b/R/Readline/build_tarballs.jl
@@ -3,17 +3,30 @@
 using BinaryBuilder
 
 name = "Readline"
-version = v"8.0"
+version = v"8.0.4"
 
 # Collection of sources required to build Readline
 sources = [
-    "https://ftp.gnu.org/gnu/readline/readline-$(version.major).$(version.minor).tar.gz" =>
-    "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461",
+    ArchiveSource("https://ftp.gnu.org/gnu/readline/readline-$(version.major).$(version.minor).tar.gz",
+                  "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461"),
+    FileSource("https://ftp.gnu.org/gnu/readline/readline-$(version.major).$(version.minor)-patches/readline80-001",
+               "d8e5e98933cf5756f862243c0601cb69d3667bb33f2c7b751fe4e40b2c3fd069"),
+    FileSource("https://ftp.gnu.org/gnu/readline/readline-$(version.major).$(version.minor)-patches/readline80-002",
+               "36b0febff1e560091ae7476026921f31b6d1dd4c918dcb7b741aa2dad1aec8f7"),
+    FileSource("https://ftp.gnu.org/gnu/readline/readline-$(version.major).$(version.minor)-patches/readline80-003",
+               "94ddb2210b71eb5389c7756865d60e343666dfb722c85892f8226b26bb3eeaef"),
+    FileSource("https://ftp.gnu.org/gnu/readline/readline-$(version.major).$(version.minor)-patches/readline80-004",
+               "b1aa3d2a40eee2dea9708229740742e649c32bb8db13535ea78f8ac15377394c"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/readline-*/
+
+atomic_patch -p0 ${WORKSPACE}/srcdir/readline80-001
+atomic_patch -p0 ${WORKSPACE}/srcdir/readline80-002
+atomic_patch -p0 ${WORKSPACE}/srcdir/readline80-003
+atomic_patch -p0 ${WORKSPACE}/srcdir/readline80-004
 
 export CPPFLAGS="-I${prefix}/include"
 if [[ "${target}" == *-mingw* ]]; then

--- a/R/Readline/build_tarballs.jl
+++ b/R/Readline/build_tarballs.jl
@@ -38,6 +38,7 @@ fi
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-curses
 make -j${nproc} SHLIB_LIBS="-lncurses${NCURSES_ABI_VER}"
 make install
+install_license COPYING
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Actually my main motivation to make this was that the Readline_jll repository is 5 months old and the generated code there is outdated; e.g. Readline_jll is lacking the `artifact_dir` variable. But I figured it doesn't hurt to also get some fixes in there ;-).