### PR TITLE
[Cbc] Expand libgfortran version

### DIFF
--- a/C/Coin-OR/Cbc/build_tarballs.jl
+++ b/C/Coin-OR/Cbc/build_tarballs.jl
@@ -65,5 +65,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+build_tarballs(ARGS, name, version, sources, script, expand_gfortran_versions(platforms), products, dependencies;
                preferred_gcc_version=gcc_version)

--- a/C/Coin-OR/Cbc/build_tarballs.jl
+++ b/C/Coin-OR/Cbc/build_tarballs.jl
@@ -25,7 +25,7 @@ update_configure_scripts
 mkdir build
 cd build/
 
-export CPPFLAGS="${CPPFLAGS} -I${prefix}/include -I$prefix/include/coin"
+export CPPFLAGS="${CPPFLAGS} -DNDEBUG -I${prefix}/include -I$prefix/include/coin"
 export CXXFLAGS="${CXXFLAGS} -std=c++11"
 if [[ ${target} == *mingw* ]]; then
     export LDFLAGS="-L$prefix/bin"


### PR DESCRIPTION
To be honest, I'm not entirely sure why, but it does look like we need to expand the libgfortran version also in Cbc, as suggested by @ViralBShah at https://github.com/JuliaPackaging/Yggdrasil/pull/869#issuecomment-614993593.  I've built it locally for `x86_64-linux-gnu-libgfortran4-cxx11` and now the library `libCbc.so` correctly looks for the symbol
```
% nm libCbcSolver.so|grep _ZTv0_n720_NK21OsiClpSolverInterface10getRowNameB5cxx11Eij|c++filt 
                 U virtual thunk to OsiClpSolverInterface::getRowName[abi:cxx11](int, unsigned int) const
```