### PR TITLE
[Clp] Add -DNDEBUG

### DIFF
--- a/C/Coin-OR/Clp/build_tarballs.jl
+++ b/C/Coin-OR/Clp/build_tarballs.jl
@@ -21,7 +21,7 @@ update_configure_scripts
 mkdir build
 cd build/
 
-export CPPFLAGS="${CPPFLAGS} -I${prefix}/include -I$prefix/include/coin"
+export CPPFLAGS="${CPPFLAGS} -DNDEBUG -I${prefix}/include -I$prefix/include/coin"
 export CXXFLAGS="${CXXFLAGS} -std=c++11"
 if [[ ${target} == *mingw* ]]; then
     export LDFLAGS="-L$prefix/bin"


### PR DESCRIPTION
Use `-DNDEBUG` to try to be on par with the performance of the original builders: https://github.com/JuliaOpt/Clp.jl/pull/77#issuecomment-615006008