### PR TITLE
[SPIRV] Add recipe for SPIRV Tools.

### DIFF
--- a/S/SPIRV_Tools/build_tarballs.jl
+++ b/S/SPIRV_Tools/build_tarballs.jl
@@ -1,0 +1,69 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "SPIRV_Tools"
+version = v"2020.2"
+
+# Collection of sources required to build IGC
+sources = [
+    GitSource("https://github.com/KhronosGroup/SPIRV-Tools.git", "fd8e130510a6b002b28eee5885a9505040a9bdc9"),
+    # vendored dependencies
+    # TODO: put SPIRV-Headers in a separate package and use -DSPIRV-Headers_SOURCE_DIR
+    GitSource("https://github.com/KhronosGroup/SPIRV-Headers.git", "2ad0492fb00919d99500f1da74abf5ad3c870e4e"), # master
+    GitSource("https://github.com/google/effcee.git", "6fa2a03cebb4fb18fbad086d53d1054928bef54e"), # 2019.0
+    GitSource("https://github.com/google/re2.git", "209eda1b607909cf3c9ad084264039546155aeaa"), # 2020-04-01
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+# put vendored dependencies in places they will be picked up by the build system
+mv SPIRV-Headers SPIRV-Tools/external/spirv-headers
+mv effcee SPIRV-Tools/external/effcee
+mv re2 SPIRV-Tools/external/re2
+
+cd SPIRV-Tools
+install_license LICENSE
+
+CMAKE_FLAGS=()
+
+# Release build for best performance
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+
+# Install things into $prefix
+CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+
+# Explicitly use our cmake toolchain file
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+
+# Skip tests
+CMAKE_FLAGS+=(-DSPIRV_SKIP_TESTS=ON)
+
+# Don't use -Werror
+CMAKE_FLAGS+=(-DSPIRV_WERROR=OFF)
+
+cmake -B build -S . -GNinja ${CMAKE_FLAGS[@]}
+ninja -C build -j ${nproc} install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("spirv-as", :spirv_as),
+    ExecutableProduct("spirv-cfg", :spirv_cfg),
+    ExecutableProduct("spirv-dis", :spirv_dis),
+    ExecutableProduct("spirv-link", :spirv_link),
+    ExecutableProduct("spirv-opt", :spirv_opt),
+    ExecutableProduct("spirv-reduce", :spirv_reduce),
+    ExecutableProduct("spirv-val", :spirv_val),
+    LibraryProduct("libSPIRV-Tools-shared", :libSPIRV_Tools),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
Recipe has some vendored deps, of which at least SPIRV-Headers could be moved out. But lacking an Any platform, and with no other packages using the SPIRV Headers, I left it in for now.