### PR TITLE
[Clp] Avoid setting CXXFLAGS

### DIFF
--- a/C/Coin-OR/Clp/build_tarballs.jl
+++ b/C/Coin-OR/Clp/build_tarballs.jl
@@ -22,7 +22,6 @@ mkdir build
 cd build/
 
 export CPPFLAGS="${CPPFLAGS} -DNDEBUG -I${prefix}/include -I$prefix/include/coin"
-export CXXFLAGS="${CXXFLAGS} -std=c++11"
 if [[ ${target} == *mingw* ]]; then
     export LDFLAGS="-L$prefix/bin"
 elif [[ ${target} == *linux* ]]; then


### PR DESCRIPTION
This ensures that `-O3` etc. get passed to the compiler.