### PR TITLE
Fix JLL with multiple build_tarballs

### DIFF
--- a/.ci/register_package.jl
+++ b/.ci/register_package.jl
@@ -10,9 +10,12 @@ while !eof(buff)
     push!(objs, BinaryBuilder.JSON.parse(buff))
 end
 
+objs_unmerged = deepcopy(objs) # Merging later on modifies the argument
+
 # Merge the multiple outputs into one
 merged = BinaryBuilder.merge_json_objects(objs)
 BinaryBuilder.cleanup_merged_object!(merged)
+BinaryBuilder.cleanup_merged_object!.(objs_unmerged)
 
 # Determine build version
 name = merged["name"]
@@ -44,7 +47,9 @@ function download_cached_binaries(download_dir, platforms)
 end
 
 # Filter out build-time dependencies also here
-merged["dependencies"] = Dependency[dep for dep in merged["dependencies"] if !isa(dep, BuildDependency)]
+for json_obj in [merged, objs_unmerged...]
+    json_obj["dependencies"] = Dependency[dep for dep in json_obj["dependencies"] if !isa(dep, BuildDependency)]
+end
 mktempdir() do download_dir
     # Grab the binaries for our package
     download_cached_binaries(download_dir, merged["platforms"])
@@ -53,7 +58,10 @@ mktempdir() do download_dir
     repo = "JuliaBinaryWrappers/$(name)_jll.jl"
     tag = "$(name)-v$(build_version)"
     upload_prefix = "https://github.com/$(repo)/releases/download/$(tag)"
-    BinaryBuilder.rebuild_jll_package(merged; download_dir=download_dir, upload_prefix=upload_prefix, verbose=verbose, lazy_artifacts=lazy_artifacts)
+    for (i,json_obj) in enumerate(objs_unmerged)
+        from_scratch = (i == 1)
+        BinaryBuilder.rebuild_jll_package(json_obj; download_dir=download_dir, upload_prefix=upload_prefix, verbose=verbose, lazy_artifacts=json_obj["lazy_artifacts"], from_scratch=from_scratch)
+    end
     
     # Upload them to GitHub releases
     BinaryBuilder.upload_to_github_releases(repo, tag, download_dir; verbose=verbose)


### PR DESCRIPTION
Fixes error with PR #586

This requires PR https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/754 to be merged and operational on Yggdrasil.

I generated a test-repo using these changes here: https://github.com/barche/Qt_jll.jl
This worked on both Mac and Linux (tested by calling qVersion in libqt5core). Note that the version is still 5.14.1 on my testrepo because I still had those binaries and didn't want to rebuild.

Disclaimer: I have no idea if this causes any side effects with other builds, or how to test this rigorously 🙃 