### PR TITLE
[Eigen] Do not install FindEigen3.cmake file

### DIFF
--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -22,7 +22,6 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
 make -j${nproc}
 make install
 cd ..
-cp cmake/FindEigen3.cmake ${prefix}/share/eigen3/cmake/
 install_license COPYING.*
 """
 


### PR DESCRIPTION
Eigen already installs a Eigen3Config.cmake file in share/eigen3/cmake, 
so there is no need to additionally install the FindEigen3.cmake file.

Furthermore, ${prefix}/share/eigen3/cmake is not on the CMAKE_MODULE_PATH, 
so in any case the FindEigen3.cmake file installed there would be ignored by CMake.

@dpo @giordano 