### PR TITLE
Typo fix: _producs -> _products

### DIFF
--- a/generate_buildjl.jl
+++ b/generate_buildjl.jl
@@ -194,7 +194,7 @@ Core.eval(m, quote
 	# it just saves the inputs so that we can mess around with them:
 	_name = nothing
 	_version = nothing
-	_producs = nothing
+	_products = nothing
     function build_tarballs(A, name, version, sources, script, platforms, products, dependencies; kwargs...)
 		global _name = name
 		global _version = version


### PR DESCRIPTION
Before this PR:
```
$ julia --color=yes generate_buildjl.jl C/CompilerSupportLibraries/build_tarballs.jl JuliaBinaryWrappers/CompilerSupportLibraries_jll.jl CompilerSupportLibraries-v0.3.3+0
[ Info: Build tarballs script: C/CompilerSupportLibraries/build_tarballs.jl
[ Info: Repo name: JuliaBinaryWrappers/CompilerSupportLibraries_jll.jl
[ Info: Tag name: CompilerSupportLibraries-v0.3.3+0
[ Info: Building for 
ERROR: LoadError: UndefVarError: _products not defined
Stacktrace:
 [1] top-level scope at /home/blegat/git/Yggdrasil/generate_buildjl.jl:212
in expression starting at /home/blegat/git/Yggdrasil/generate_buildjl.jl:211
```
After this PR:
```
$ julia --color=yes generate_buildjl.jl C/CompilerSupportLibraries/build_tarballs.jl JuliaBinaryWrappers/CompilerSupportLibraries_jll.jl CompilerSupportLibraries-v0.3.3+0
[ Info: Build tarballs script: C/CompilerSupportLibraries/build_tarballs.jl
[ Info: Repo name: JuliaBinaryWrappers/CompilerSupportLibraries_jll.jl
[ Info: Tag name: CompilerSupportLibraries-v0.3.3+0
[ Info: Building for 
[ Info: Calculated 17132bd0c2f2c6d8426a601b57de2c4e670da64076ab7ab0f311dc3c39ed421c for CompilerSupportLibraries.v0.3.3.aarch64-linux-gnu-libgfortran3.tar.gz
...
[ Info: Writing out to /home/blegat/git/Yggdrasil/build/build_nothing.vnothing.jl
ERROR: LoadError: MethodError: no method matching print_buildjl(::IOStream, ::Nothing, ::Dict{Any,Any}, ::String)
Closest candidates are:
  print_buildjl(::IO, ::Array{T,1} where T, ::Dict, ::AbstractString) at /home/blegat/git/Yggdrasil/generate_buildjl.jl:86
Stacktrace:
 [1] (::var"#13#14")(::IOStream) at /home/blegat/git/Yggdrasil/generate_buildjl.jl:222
 [2] open(::var"#13#14", ::String, ::Vararg{String,N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./io.jl:298
 [3] open(::Function, ::String, ::String) at ./io.jl:296
 [4] top-level scope at /home/blegat/git/Yggdrasil/generate_buildjl.jl:221
 [5] include(::Module, ::String) at ./Base.jl:377
 [6] exec_options(::Base.JLOptions) at ./client.jl:288
 [7] _start() at ./client.jl:484
in expression starting at /home/blegat/git/Yggdrasil/generate_buildjl.jl:221
```