### PR TITLE
[Eigen] Switch to download Gitlab archive instead of deprecated Bitbucket archive

### DIFF
--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -4,8 +4,8 @@ name = "Eigen"
 version = v"3.3.7"
 
 sources = [
-    ArchiveSource("https://bitbucket.org/eigen/eigen/get/$(version).tar.bz2",
-                  "9f13cf90dedbe3e52a19f43000d71fdf72e986beb9a5436dddcd61ff9d77a3ce")
+    ArchiveSource("https://gitlab.com/libeigen/eigen/-/archive/$(version)/eigen-$(version).tar.bz2",
+                  "685adf14bd8e9c015b78097c1dc22f2f01343756f196acdc76a678e1ae352e11")
 ]
 
 # Bash recipe for building across all platforms

--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -10,7 +10,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/eigen-eigen-*
+cd $WORKSPACE/srcdir/eigen-*
 
 mkdir build
 cd build/


### PR DESCRIPTION
The Bitbucket repository of Eigen has been deprecated some time ago  (see https://bitbucket.org/eigen/eigen/src/default/README.md ), so it  probably make more sense to use the Gitlab archives, that are the one  linked in the official  Eigen website as well: http://eigen.tuxfamily.org/index.php?title=Main_Page .

Note that the hash is different probably due to the differences between Bitbucket and GitLab automatically generated archives.