### PR TITLE
[oneAPI_Level_Zero] Rebuild to generate missing symlinks

### DIFF
--- a/O/oneAPI_Level_Zero/build_tarballs.jl
+++ b/O/oneAPI_Level_Zero/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"0.91.10"
 # Collection of sources required to build this package
 sources = [
     GitSource("https://github.com/oneapi-src/level-zero.git",
-              "ebb363e938a279cf866cb93d28e31aaf0791ea19")
+              "ebb363e938a279cf866cb93d28e31aaf0791ea19"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
I think the current tarballs are missing two symlinks, that are instead correctly generated by `symlink_soname_lib` when building a dependency, but not removed by `cleanup_dependencies` because they're missing in current `oneAPI_Level_Zero_jll` tarballs.

This is for example causing spurious warnings in https://github.com/JuliaPackaging/Yggdrasil/pull/901.

I'm triggering this build mostly to make sure that my understanding is correct.  I'm not sure why the two symlinks are missing from the current tarballs