### PR TITLE
Add prefix first argument to LibraryProduct

### DIFF
--- a/generate_buildjl.jl
+++ b/generate_buildjl.jl
@@ -81,6 +81,15 @@ function product_hashes_from_github_release(repo_name::AbstractString, tag_name:
     return product_hashes
 end
 
+# `repr` calls `BinaryBuilder.repr` which does not print the `prefix, `
+# first argument that is needed by `BinaryProvider`.
+# TODO: determine whether this first argument also need to be added for
+#       `ExecutableProduct` and `FileProduct`.
+_repr(p) = repr(p)
+function _repr(p::LibraryProduct)
+    return replace(repr(p), "(" => "(prefix, ")
+end
+
 function print_buildjl(io::IO, products::Vector, product_hashes::Dict,
                        bin_path::AbstractString)
     print(io, """
@@ -94,7 +103,7 @@ function print_buildjl(io::IO, products::Vector, product_hashes::Dict,
     # Print out products
     print(io, "products = [\n")
     for prod in products
-        print(io, "    $(repr(prod)),\n")
+        print(io, "    $(_repr(prod)),\n")
     end
     print(io, "]\n\n")
 

--- a/generate_buildjl.jl
+++ b/generate_buildjl.jl
@@ -83,10 +83,7 @@ end
 
 # `repr` calls `BinaryBuilder.repr` which does not print the `prefix, `
 # first argument that is needed by `BinaryProvider`.
-# TODO: determine whether this first argument also need to be added for
-#       `ExecutableProduct` and `FileProduct`.
-_repr(p) = repr(p)
-function _repr(p::LibraryProduct)
+function _repr(p::Product)
     return replace(repr(p), "(" => "(prefix, ")
 end
 


### PR DESCRIPTION
Without this, the generated `build.jl` throws a `MethodError` when trying to create the `LibraryProduct` object.