### PR TITLE
Add Poppler

### DIFF
--- a/P/Poppler/build_tarballs.jl
+++ b/P/Poppler/build_tarballs.jl
@@ -36,6 +36,7 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    BuildDependency("Xorg_xorgproto_jll"),
     Dependency("JpegTurbo_jll"),
     Dependency("Cairo_jll"),
     #Dependency("gdk_pixbuf_jll"),

--- a/P/Poppler/build_tarballs.jl
+++ b/P/Poppler/build_tarballs.jl
@@ -8,30 +8,52 @@ version = v"0.87.0"
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://poppler.freedesktop.org/poppler-0.87.0.tar.xz", "6f602b9c24c2d05780be93e7306201012e41459f289b8279a27a79431ad4150e")
-    ArchiveSource("https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz", "1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/poppler-0.87.0/
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-    -DCMAKE_BUILD_TYPE=Release -DBUILD_GTK_TESTS=OFF -DENABLE_CMS=lcms2 \
-    -DENABLE_GLIB=OFF -DENABLE_QT5=OFF -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
-    -DWITH_GObjectIntrospection=OFF
+cd $WORKSPACE/srcdir/poppler-*/
+
+# Create link ${bindir} before starting.  `OpenJPEGTargets.cmake` will try to
+# look for some executables in `sys-root/usr/local/bin`
+ln -s ${bindir} /opt/${target}/${target}/sys-root/usr/local/bin
+export CXXFLAGS="-I${prefix}/include/openjpeg-2.3"
+
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_GTK_TESTS=OFF \
+    -DENABLE_CMS=lcms2 \
+    -DENABLE_GLIB=OFF \
+    -DENABLE_QT5=OFF \
+    -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
+    -DWITH_GObjectIntrospection=OFF \
+    ..
 make -j${nproc}
 make install
-
-cd $WORKSPACE/srcdir/poppler-data-0.4.9/
-make prefix=$prefix install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
-products = Product[
+products = [
+    LibraryProduct("libpoppler-cpp", :libpoppler_cpp),
+    LibraryProduct("libpoppler", :libpoppler),
+    ExecutableProduct("pdfattach", :pdfattach),
+    ExecutableProduct("pdfdetach", :pdfdetach),
+    ExecutableProduct("pdffonts", :pdffonts),
+    ExecutableProduct("pdfimages", :pdfimages),
+    ExecutableProduct("pdfinfo", :pdfinfo),
+    ExecutableProduct("pdfseparate", :pdfseparate),
+    ExecutableProduct("pdftocairo", :pdftocairo),
+    ExecutableProduct("pdftohtml", :pdftohtml),
+    ExecutableProduct("pdftoppm", :pdftoppm),
+    ExecutableProduct("pdftops", :pdftops),
+    ExecutableProduct("pdftotext", :pdftotext),
+    ExecutableProduct("pdfunite", :pdfunite),
 ]
 
 # Dependencies that must be installed before this package can be built
@@ -48,4 +70,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5")

--- a/P/Poppler/build_tarballs.jl
+++ b/P/Poppler/build_tarballs.jl
@@ -19,6 +19,11 @@ cd $WORKSPACE/srcdir/poppler-*/
 ln -s ${bindir} /opt/${target}/${target}/sys-root/usr/local/bin
 export CXXFLAGS="-I${prefix}/include/openjpeg-2.3"
 
+if [[ "${target}" == "${MACHTYPE}" ]]; then
+    # When building for the host platform, the system libexpat is picked up
+    rm /usr/lib/libexpat.so*
+fi
+
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/P/Poppler/build_tarballs.jl
+++ b/P/Poppler/build_tarballs.jl
@@ -1,0 +1,50 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Poppler"
+version = v"0.87.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://poppler.freedesktop.org/poppler-0.87.0.tar.xz", "6f602b9c24c2d05780be93e7306201012e41459f289b8279a27a79431ad4150e")
+    ArchiveSource("https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz", "1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/poppler-0.87.0/
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release -DBUILD_GTK_TESTS=OFF -DENABLE_CMS=lcms2 \
+    -DENABLE_GLIB=OFF -DENABLE_QT5=OFF -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
+    -DWITH_GObjectIntrospection=OFF
+make -j${nproc}
+make install
+
+cd $WORKSPACE/srcdir/poppler-data-0.4.9/
+make prefix=$prefix install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+
+# The products that we will ensure are always built
+products = Product[
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("JpegTurbo_jll"),
+    Dependency("Cairo_jll"),
+    #Dependency("gdk_pixbuf_jll"),
+    #Dependency("GTK3_jll"),
+    Dependency("Libtiff_jll"),
+    Dependency("libpng_jll"),
+    Dependency("OpenJpeg_jll"),
+    Dependency("Fontconfig_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This doesn't work yet, giving the following error:

```julia

CMake Error at /opt/i686-linux-gnu/i686-linux-gnu/sys-root/usr/local/lib/openjpeg-2.3/OpenJPEGTargets.cmake:78 (message):
  The imported target "opj_decompress" references the file

     "/opt/i686-linux-gnu/i686-linux-gnu/sys-root/usr/local/bin/opj_decompress"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/opt/i686-linux-gnu/i686-linux-gnu/sys-root/usr/local/lib/openjpeg-2.3/OpenJPEGTargets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /opt/i686-linux-gnu/i686-linux-gnu/sys-root/usr/local/lib/openjpeg-2.3/OpenJPEGConfig.cmake:28 (include)
  CMakeLists.txt:205 (find_package)


-- Configuring incomplete, errors occurred!
See also "/workspace/srcdir/poppler-0.87.0/CMakeFiles/CMakeOutput.log".
See also "/workspace/srcdir/poppler-0.87.0/CMakeFiles/CMakeError.log".
Previous command exited with 1
ERROR: LoadError: Build for Poppler on i686-linux-gnu did not complete successfully
```

but I'm putting it up in hopes of getting some help figuring out what's wrong.

I've commented out `GTK3` and `gdk_pixbuf` since I've set `DENABLE_GLIB=OFF` to start easy, but we might want that at some point.