### PR TITLE
MbedTLS: enable MD4

### DIFF
--- a/M/MbedTLS/build_tarballs.jl
+++ b/M/MbedTLS/build_tarballs.jl
@@ -18,6 +18,10 @@ mkdir -p $prefix/lib
 if [[ "${target}" == *apple* ]]; then
     ln -sf /opt/${target}/bin/${target}-ranlib /opt/bin/ranlib
 fi
+
+# enable MD4
+sed "s|//#define MBEDTLS_MD4_C|#define MBEDTLS_MD4_C|" -i include/mbedtls/config.h 
+
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" -DUSE_SHARED_MBEDTLS_LIBRARY=On
 make -j${nproc} && make install
 """


### PR DESCRIPTION
It is needed for NTLM support in LibGit2.