### PR TITLE
[MicrosoftMPI] Install only one mpifptr.h header file

### DIFF
--- a/M/MicrosoftMPI/build_tarballs.jl
+++ b/M/MicrosoftMPI/build_tarballs.jl
@@ -34,6 +34,9 @@ mv *.exe *.dll bin
 mkdir -p lib
 mv *.lib lib
 mkdir -p include
+# Move to includedir only the mpifptr.h for current architecture
+mv "mpifptr${nbits}.h" "include/mpifptr.h"
+rm mpifptr*.h
 mv *.h *.man include
 mkdir -p src
 mv *.f90 src
@@ -48,7 +51,7 @@ products = [
     ExecutableProduct("mpiexec", :mpiexec),
 ]
 
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Build the tarballs.


### PR DESCRIPTION
In #845 I found that the header file `mpifptr.h` was expected, but currently we're installing `mpifptr32.h` and `mpifptr64.h`, which are actually identical.  With this PR I'm installing only one.  CC: @simonbyrne

BTW, I just noticed that msys2/MingW has a recipe to build MicrosoftMPI from source: https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-msmpi