### PR TITLE
[NEO] Remove the circular dependency on oneAPI, and update deps.

### DIFF
--- a/N/NEO/build_tarballs.jl
+++ b/N/NEO/build_tarballs.jl
@@ -3,16 +3,23 @@
 using BinaryBuilder, Pkg
 
 name = "NEO"
-version = v"20.12.16259"
+version = v"20.15.16524"
 
 # Collection of sources required to build this package
 sources = [
     GitSource("https://github.com/intel/compute-runtime.git",
-              "43016c65591bd125a9590ea05ca83d094a628f79"),
+              "e0633548a9bd025c70bc7f3539eef094b1bc9ce1"),
+    # vendored dependencies
+    GitSource("https://github.com/oneapi-src/level-zero.git",
+              "ebb363e938a279cf866cb93d28e31aaf0791ea19"),  # v0.91.10
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
+# NEO builds against a very specific version of the oneL0 specification headers,
+# so we can't use regular (Build)Dependencies.
+mv level-zero level_zero
+
 cd compute-runtime
 install_license LICENSE
 
@@ -65,9 +72,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="gmmlib_jll", version=v"19.4.1")),
-    Dependency(PackageSpec(name="libigc_jll", version=v"1.0.3586")),
-    Dependency(PackageSpec(name="oneAPI_Level_Zero_jll", version=v"0.91.10")),
+    Dependency(PackageSpec(name="gmmlib_jll", version=v"20.1.1")),
+    Dependency(PackageSpec(name="libigc_jll", version=v"1.0.3771")),
+    # TODO: reverse compatibility bounds, where NEO (providing a oneL0 impl of, e.g., v0.91)
+    #       restricts oneAPI_Level_Zero_jll to be below that version too.
 ]
 
 # GCC 4 has constexpr incompatibilities


### PR DESCRIPTION
The circular dependency between oneAPI_Level_Zero and NEO turned out problematic, e.g., when upgrading NEO (which pulled in oneAPI_Level_Zero, depending on an older NEO, depending on conflicting deps):
```
ERROR: LoadError: Unsatisfiable requirements detected for package NEO_jll [700fe977]:
 NEO_jll [700fe977] log:
 ├─possible versions are: 20.12.16259 or uninstalled
 ├─restricted by compatibility requirements with libigc_jll [94295238] to versions: uninstalled
 │ └─libigc_jll [94295238] log:
 │   ├─possible versions are: [1.0.3586, 1.0.3771] or uninstalled
 │   └─restricted to versions 1.0.3771 by an explicit requirement, leaving only versions 1.0.3771
 └─restricted by compatibility requirements with oneAPI_Level_Zero_jll [0038a6a5] to versions: 20.12.16259 — no versions left
   └─oneAPI_Level_Zero_jll [0038a6a5] log:
     ├─possible versions are: 0.91.10 or uninstalled
     └─restricted to versions 0.91.10 by an explicit requirement, leaving only versions 0.91.10
```

Avoid this mess by not having NEO depend on oneAPI_Level_Zero, but vendoring the dependency instead. This is also more correct, since NEO implements oneAPI and thus should use the specific version it is compatible with (it only uses the oneAPI headers).

On the other hand, by removing this dependency it could be possible to install a too new oneAPI that's not implemented by NEO, so some reverse dependency bound would be useful. But BB doesn't support adding compat bounds to other packages from here.