### PR TITLE
[PlatformSupport] Link `${sysroot}/usr/local` to entire `${prefix}`

### DIFF
--- a/0_RootFS/PlatformSupport/build_tarballs.jl
+++ b/0_RootFS/PlatformSupport/build_tarballs.jl
@@ -126,12 +126,10 @@ cd ${WORKSPACE}/srcdir/buildsystem_toolchains
 ./build_toolchains.sh ${COMPILER_TARGET}
 mv ${COMPILER_TARGET}/* ${prefix}
 
-# We create a link from ${COMPILER_TARGET}/sys-root/usr/local/lib to /workspace/destdir/lib
+# We create a link from ${COMPILER_TARGET}/sys-root/usr/local to ${prefix}.
 # This is the most reliable way for our sysroot'ed compilers to find destination
 # libraries so far, hopefully this changes in the future.
-mkdir -p ${sysroot}/usr/local
-ln -sf /workspace/destdir/lib ${sysroot}/usr/local/lib
-ln -sf /workspace/destdir/lib64 ${sysroot}/usr/local/lib64
+ln -s "${prefix}" "${sysroot}/usr/local"
 """
 
 # Build the artifacts


### PR DESCRIPTION
We're currently linking only `lib/` and `lib64/` to the prefix, however CMake
find modules often find libraries in `${sysroot}/usr/local/lib` and then use
relative paths to executables or header files, that therefore can't be found.
With this change we link `${sysroot}/usr/local` to the entire prefix, which
should alleviate these issues, until the time we don't need to add this link at
all.