### PR TITLE
Bump rr

### DIFF
--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -7,8 +7,8 @@ version = v"5.3.1"
 
 # Collection of sources required to build rr
 sources = [
-    GitSource("https://github.com/mozilla/rr.git",
-              "c979313cf04ce78b09e5517b22f95ac068bb7c2d")
+    GitSource("https://github.com/Keno/rr.git",
+              "0362a9e4984e6b8fd5df617b504d2ddd3bef8b76")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This is rr master plus https://github.com/mozilla/rr/pull/2515 and one additional commit
I'm about to PR upstream. There's some question of whether the 2515 PR can be merged
in its current form, but for the moment it's required for us. We want to turn it on on CI, so
let's build a version that has it. We can revisit what to do once all the patch upstreaming is done.