### PR TITLE
Add `unpaper`

### DIFF
--- a/U/unpaper/build_tarballs.jl
+++ b/U/unpaper/build_tarballs.jl
@@ -1,0 +1,38 @@
+using BinaryBuilder
+
+name = "unpaper"
+version = v"6.1"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://www.flameeyes.com/files/unpaper-6.1.tar.xz",
+                  "237c84f5da544b3f7709827f9f12c37c346cdf029b1128fb4633f9bafa5cb930"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/unpaper-6.1/
+apk add libxslt
+update_configure_scripts
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("unpaper", :unpaper),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+    Dependency("FFMPEG_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+# FFMPEG uses `preferred_gcc_version=v"8"`.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")

--- a/U/unpaper/build_tarballs.jl
+++ b/U/unpaper/build_tarballs.jl
@@ -15,6 +15,12 @@ cd $WORKSPACE/srcdir/unpaper-6.1/
 apk add libxslt
 if [[ "${target}" == *-linux-* ]]; then
     export LDFLAGS="-lstdc++"
+elif [[ "${target}" == *-mingw* ]]; then
+    # FFMPEG_jll installs the pkgconfig files in the wrong directory for Windows
+    export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${libdir}/pkgconfig"
+    # Give some hints to the linker
+    export LDFLAGS="-L${libdir}"
+    export LIBAV_LIBS="-lavformat -lavutil -lavcodec"
 fi
 update_configure_scripts
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}

--- a/U/unpaper/build_tarballs.jl
+++ b/U/unpaper/build_tarballs.jl
@@ -13,6 +13,9 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/unpaper-6.1/
 apk add libxslt
+if [[ "${target}" == *-linux-* ]]; then
+    export LDFLAGS="-lstdc++"
+fi
 update_configure_scripts
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}


### PR DESCRIPTION
This errors out with:
```
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: warning: libstdc++.so.6, needed by /workspace/destdir/lib/libx265.so.169, not found (try using -rpath or -rpath-link)
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `__cxa_guard_acquire@CXXABI_1.3'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `operator delete(void*)@GLIBCXX_3.4'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `vtable for __cxxabiv1::__si_class_type_info@CXXABI_1.3'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `operator delete[](void*)@GLIBCXX_3.4'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `operator new(unsigned int)@GLIBCXX_3.4'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `vtable for __cxxabiv1::__vmi_class_type_info@CXXABI_1.3'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `__cxa_pure_virtual@CXXABI_1.3'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `__dynamic_cast@CXXABI_1.3'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `vtable for __cxxabiv1::__class_type_info@CXXABI_1.3'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `__cxa_guard_release@CXXABI_1.3'
/opt/i686-linux-gnu/bin/../lib/gcc/i686-linux-gnu/8.1.0/../../../../i686-linux-gnu/bin/ld: /workspace/destdir/lib/libx265.so.169: undefined reference to `operator new[](unsigned int)@GLIBCXX_3.4'
collect2: error: ld returned 1 exit status
make: *** [Makefile:624: unpaper] Error 1
Previous command exited with 2
```

Some googling suggests I need to link against `libstdc++`, which I think means to call `export LDFLAGS = something` before `configure` but I'm not sure what to put there. Alternatively, if I set `CC=g++` then I get different errors e.g.
```
file.c:199:33: error: invalid conversion from ‘int’ to ‘AVPixelFormat’ [-fpermissive]
     codec_ctx->pix_fmt = image->format;
                          ~~~~~~~^~~~~~
```
My searching suggests that calling `g++` avoids the linking problem but is stricter in some ways, hence the new errors.

I'm also not sure if `preferred_gcc_version=v"8"` is helping here; the [build tricks](https://github.com/JuliaPackaging/Yggdrasil/wiki/Build-Tricks#building-with-an-old-gcc-version-a-library-that-has-dependencies-built-with-newer-gcc-versions) led me to think it might be important.

Lastly, I'm not sure if the products are right; I never got far enough to see exactly what they are. I think I just need the command line executable though.

I'd appreciate any help :).