### PR TITLE
[ImageMagick] rename `convert` to not conflict with Base

### DIFF
--- a/I/ImageMagick/build_tarballs.jl
+++ b/I/ImageMagick/build_tarballs.jl
@@ -25,7 +25,7 @@ platforms = expand_cxxstring_abis(supported_platforms())
 # The products that we will ensure are always built
 products = [
     LibraryProduct(["libMagickWand", "libMagickWand-6.Q16"], :libwand),
-    ExecutableProduct("convert", :convert),
+    ExecutableProduct("convert", :imagemagick_convert),
     ExecutableProduct("identify", :identify),
 ]
 


### PR DESCRIPTION
Companion PR to https://github.com/JuliaBinaryWrappers/ImageMagick_jll.jl/pull/1 so the changes there don't get overwritten if the `build_tarballs` gets updated.

Another, just in case:
[ci skip]
[skip ci]