### PR TITLE
[AZP] Temporarily revert changes to `.ci/register_package.jl`

### DIFF
--- a/.ci/register_package.jl
+++ b/.ci/register_package.jl
@@ -10,13 +10,9 @@ while !eof(buff)
     push!(objs, BinaryBuilder.JSON.parse(buff))
 end
 
-# Merging modifies `obj`, so let's keep an unmerged version around
-objs_unmerged = deepcopy(objs)
-
 # Merge the multiple outputs into one
 merged = BinaryBuilder.merge_json_objects(objs)
 BinaryBuilder.cleanup_merged_object!(merged)
-BinaryBuilder.cleanup_merged_object!.(objs_unmerged)
 
 # Determine build version
 name = merged["name"]
@@ -48,9 +44,7 @@ function download_cached_binaries(download_dir, platforms)
 end
 
 # Filter out build-time dependencies also here
-for json_obj in [merged, objs_unmerged...]
-    json_obj["dependencies"] = Dependency[dep for dep in json_obj["dependencies"] if !isa(dep, BuildDependency)]
-end
+merged["dependencies"] = Dependency[dep for dep in merged["dependencies"] if !isa(dep, BuildDependency)]
 mktempdir() do download_dir
     # Grab the binaries for our package
     download_cached_binaries(download_dir, merged["platforms"])
@@ -59,12 +53,7 @@ mktempdir() do download_dir
     repo = "JuliaBinaryWrappers/$(name)_jll.jl"
     tag = "$(name)-v$(build_version)"
     upload_prefix = "https://github.com/$(repo)/releases/download/$(tag)"
-
-    # This loop over the unmerged objects necessary in the event that we have multiple packages being built by a single build_tarballs.jl
-    for (i,json_obj) in enumerate(objs_unmerged)
-        from_scratch = (i == 1)
-        BinaryBuilder.rebuild_jll_package(json_obj; download_dir=download_dir, upload_prefix=upload_prefix, verbose=verbose, lazy_artifacts=json_obj["lazy_artifacts"], from_scratch=from_scratch)
-    end
+    BinaryBuilder.rebuild_jll_package(merged; download_dir=download_dir, upload_prefix=upload_prefix, verbose=verbose, lazy_artifacts=lazy_artifacts)
     
     # Upload them to GitHub releases
     BinaryBuilder.upload_to_github_releases(repo, tag, download_dir; verbose=verbose)


### PR DESCRIPTION
This reverts changes in #894.

This is to be reverted once we upgrade BinaryBuilder here, hopefully in the next few days!