### PR TITLE
[LibCURL] Upgrade curl to 7.70.0 and add cacert

### DIFF
--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -4,13 +4,15 @@ using BinaryBuilder
 
 name = "LibCURL"
 version = v"7.70.0"
+cacert_version = "2020-01-01"
 
 # Collection of sources required to build LibCURL
 sources = [
     ArchiveSource("https://curl.haxx.se/download/curl-$(version).tar.gz", 
     "ca2feeb8ef13368ce5d5e5849a5fd5e2dd4755fecf7d8f0cc94000a4206fb8e7"), 
-    FileSource("https://curl.haxx.se/ca/cacert.pem", 
-    "adf770dfd574a0d6026bfaa270cb6879b063957177a991d453ff1d302c02081f")
+    FileSource("https://curl.haxx.se/ca/cacert-$cacert_version.pem", 
+    "adf770dfd574a0d6026bfaa270cb6879b063957177a991d453ff1d302c02081f",
+    filename="cacert.pem")
 ]
 
 # Bash recipe for building across all platforms
@@ -22,13 +24,14 @@ FLAGS=(
     # Disable....almost everything
     --without-ssl --without-gnutls --without-gssapi
     --without-libidn --without-libidn2 --without-libmetalink --without-librtmp
-    --without-nghttp2 --without-nss --without-polarssl
+    --without-nss --without-polarssl
     --without-spnego --without-libpsl --disable-ares --disable-manual
     --disable-ldap --disable-ldaps --without-zsh-functions-dir
     --disable-static
 
     # Two things we actually enable
     --with-libssh2=${prefix} --with-mbedtls=${prefix} --with-zlib=${prefix}
+    --with-nghttp2=${prefix}
 )
 
 # We need to tell it where to find libssh2 on windows
@@ -40,7 +43,7 @@ fi
 make -j${nproc}
 make install
 install_license COPYING
-cp ../cacert.pem $prefix/share/
+cp ../cacert.pem $prefix/share/cacert.pem
 """
 
 # These are the platforms we will build for by default, unless further
@@ -59,6 +62,7 @@ dependencies = [
     Dependency("LibSSH2_jll"),
     Dependency("MbedTLS_jll"),
     Dependency("Zlib_jll"),
+    Dependency("nghttp2_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -3,12 +3,14 @@
 using BinaryBuilder
 
 name = "LibCURL"
-version = v"7.68.0"
+version = v"7.70.0"
 
 # Collection of sources required to build LibCURL
 sources = [
-    "https://curl.haxx.se/download/curl-$(version).tar.bz2" =>
-    "207f54917dd6a2dc733065ccf18d61bb5bebeaceb5df49cd9445483e8623eeb9",
+    ArchiveSource("https://curl.haxx.se/download/curl-$(version).tar.gz", 
+    "ca2feeb8ef13368ce5d5e5849a5fd5e2dd4755fecf7d8f0cc94000a4206fb8e7"), 
+    FileSource("https://curl.haxx.se/ca/cacert.pem", 
+    "adf770dfd574a0d6026bfaa270cb6879b063957177a991d453ff1d302c02081f")
 ]
 
 # Bash recipe for building across all platforms
@@ -37,6 +39,8 @@ fi
 ./configure --prefix=$prefix --host=$target --build=${MACHTYPE} "${FLAGS[@]}"
 make -j${nproc}
 make install
+install_license COPYING
+cp ../cacert.pem $prefix/share/
 """
 
 # These are the platforms we will build for by default, unless further
@@ -47,13 +51,14 @@ platforms = supported_platforms()
 products = [
     LibraryProduct("libcurl", :libcurl),
     ExecutableProduct("curl", :curl),
+    FileProduct("share/cacert.pem", :cacert)
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "LibSSH2_jll",
-    "MbedTLS_jll",
-    "Zlib_jll",
+    Dependency("LibSSH2_jll"),
+    Dependency("MbedTLS_jll"),
+    Dependency("Zlib_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
The curl project extracts the mozilla CA certificate bundle, and and provides it for download in a format amenable to curl. We can use this to bypass the vagaries of the OS installed cert bundles.

Close #957.