### PR TITLE
[PlatformSupport] Tell meson we need a wrapper for `i686-linux-musl`

### DIFF
--- a/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/build_toolchains.sh
+++ b/0_RootFS/PlatformSupport/bundled/buildsystem_toolchains/build_toolchains.sh
@@ -92,7 +92,8 @@ function meson_link_args()
 
 function meson_is_foreign()
 {
-    if [[ "$1" == x86_64-linux-* ]] || [[ "$1" == i686-linux-* ]]; then
+    # We can't run C++/Fortran executables for i686-linux-musl
+    if [[ "$1" == x86_64-linux-* ]] || [[ "$1" == i686-linux-gnu ]]; then
         echo "false"
     else
         echo "true"


### PR DESCRIPTION
We often need to manually tell meson to not try to run executables for this platform, and modifying the toolchain file is incredibly annoying.  We had to this for example in #961 and #91

@staticfloat I hope it isn't too late to get this into BB :grimacing: