### PR TITLE
[PROJ] build new major version 7

### DIFF
--- a/P/PROJ/build_tarballs.jl
+++ b/P/PROJ/build_tarballs.jl
@@ -20,9 +20,11 @@ apk add sqlite
 if [[ ${target} == *mingw* ]]; then
     SQLITE3_LIBRARY=${libdir}/libsqlite3-0.dll
     CURL_LIBRARY=${libdir}/libcurl-4.dll
+    TIFF_LIBRARY_RELEASE=${libdir}/libtiff-5.dll
 else
     SQLITE3_LIBRARY=${libdir}/libsqlite3.${dlext}
     CURL_LIBRARY=${libdir}/libcurl.${dlext}
+    TIFF_LIBRARY_RELEASE=${libdir}/libtiff.${dlext}
 fi
 
 mkdir build
@@ -34,9 +36,10 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DBUILD_TESTING=OFF \
       -DSQLITE3_INCLUDE_DIR=$prefix/include \
       -DSQLITE3_LIBRARY=$SQLITE3_LIBRARY \
-      -DCURL_LIBRARY=$CURL_LIBRARY \
       -DCURL_INCLUDE_DIR=$prefix/include \
+      -DCURL_LIBRARY=$CURL_LIBRARY \
       -DTIFF_INCLUDE_DIR=$prefix/include \
+      -DTIFF_LIBRARY_RELEASE=$TIFF_LIBRARY_RELEASE \
       ..
 make -j${nproc}
 make install

--- a/P/PROJ/build_tarballs.jl
+++ b/P/PROJ/build_tarballs.jl
@@ -17,6 +17,14 @@ cd $WORKSPACE/srcdir/proj-*/
 # cross-compiled one since it needs to be executed on the host
 apk add sqlite
 
+if [[ ${target} == *mingw* ]]; then
+    SQLITE3_LIBRARY=${libdir}/libsqlite3-0.dll
+    CURL_LIBRARY=${libdir}/libcurl-4.dll
+else
+    SQLITE3_LIBRARY=${libdir}/libsqlite3.${dlext}
+    CURL_LIBRARY=${libdir}/libcurl.${dlext}
+fi
+
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
@@ -24,6 +32,11 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_TESTING=OFF \
+      -DSQLITE3_INCLUDE_DIR=$prefix/include \
+      -DSQLITE3_LIBRARY=$SQLITE3_LIBRARY \
+      -DCURL_LIBRARY=$CURL_LIBRARY \
+      -DCURL_INCLUDE_DIR=$prefix/include \
+      -DTIFF_INCLUDE_DIR=$prefix/include \
       ..
 make -j${nproc}
 make install

--- a/P/PROJ/build_tarballs.jl
+++ b/P/PROJ/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder, Pkg
 
 name = "PROJ"
-version = v"6.3.2"
+version = v"7.0.1"
 
 # Collection of sources required to build PROJ
 sources = [
     ArchiveSource("https://download.osgeo.org/proj/proj-$version.tar.gz",
-        "cb776a70f40c35579ae4ba04fb4a388c1d1ce025a1df6171350dc19f25b80311"),
+        "a7026d39c9c80d51565cfc4b33d22631c11e491004e19020b3ff5a0791e1779f"),
 ]
 
 # Bash recipe for building across all platforms
@@ -17,26 +17,13 @@ cd $WORKSPACE/srcdir/proj-*/
 # cross-compiled one since it needs to be executed on the host
 apk add sqlite
 
-if [[ ${target} == *mingw* ]]; then
-    SQLITE3_LIBRARY=${libdir}/libsqlite3-0.dll
-else
-    SQLITE3_LIBRARY=${libdir}/libsqlite3.${dlext}
-fi
-
-if [[ "${target}" == powerpc64le-* ]]; then
-    # Need to remember to link against libdl
-    export LDFLAGS="-ldl"
-fi
-
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
       -DCMAKE_BUILD_TYPE=Release \
-      -DSQLITE3_INCLUDE_DIR=$prefix/include \
-      -DSQLITE3_LIBRARY=$SQLITE3_LIBRARY \
-      -DHAVE_PTHREAD_MUTEX_RECURSIVE_DEFN=1 \
-      -DBUILD_LIBPROJ_SHARED=ON \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=OFF \
       ..
 make -j${nproc}
 make install
@@ -55,6 +42,7 @@ products = [
     ExecutableProduct("gie", :gie),
     ExecutableProduct("proj", :proj),
     ExecutableProduct("projinfo", :projinfo),
+    ExecutableProduct("projsync", :projsync),
 
     # complete contents of share/proj, must be kept up to date
     FileProduct(joinpath("share", "proj", "CH"), :ch),
@@ -65,15 +53,17 @@ products = [
     FileProduct(joinpath("share", "proj", "nad.lst"), :nad_lst),
     FileProduct(joinpath("share", "proj", "nad27"), :nad27),
     FileProduct(joinpath("share", "proj", "nad83"), :nad83),
-    FileProduct(joinpath("share", "proj", "null"), :null),
     FileProduct(joinpath("share", "proj", "other.extra"), :other_extra),
     FileProduct(joinpath("share", "proj", "proj.db"), :proj_db),
+    FileProduct(joinpath("share", "proj", "proj.ini"), :proj_ini),
     FileProduct(joinpath("share", "proj", "world"), :world),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8")),
+    Dependency(PackageSpec(name="LibCURL_jll", uuid="deac9b47-8bc7-5906-a0fe-35ac56dc84c0")),
+    Dependency(PackageSpec(name="Libtiff_jll", uuid="89763e89-9b03-5906-acba-b20f662cd828")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
In #962 we just built the latest PROJ 6 release, but PROJ 7 is already out.

[Proj4.jl](https://github.com/JuliaGeo/Proj4.jl) was written for the PROJ 4 API, which is deprecated now. This is probably a good moment to both switch to the new API and rename (i.e. start a new) package named PROJ as well.