### PR TITLE
blosc rebuild after renamed libzstd dll

### DIFF
--- a/B/Blosc/build_tarballs.jl
+++ b/B/Blosc/build_tarballs.jl
@@ -48,7 +48,7 @@ dependencies = [
 	Dependency("Zlib_jll"),
 	Dependency("Zstd_jll"),
 	Dependency("Lz4_jll"),
-#	Dependency("Snappy_jll"),
+	# Dependency("Snappy_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Explanation at #970. I just tried

```
(Proj4) pkg> add Blosc_jll
  Resolving package versions...
  Installed Lz4_jll ─── v1.9.2+0
  Installed Blosc_jll ─ v1.14.3+0
   Updating `C:\Users\visser_mn\.julia\dev\Proj4\Project.toml`
  [0b7ba130] + Blosc_jll v1.14.3+0
   Updating `C:\Users\visser_mn\.julia\dev\Proj4\Manifest.toml`
  [0b7ba130] + Blosc_jll v1.14.3+0
  [5ced341a] + Lz4_jll v1.9.2+0

julia> using Blosc_jll
[ Info: Precompiling Blosc_jll [0b7ba130-8d10-5ba8-a3d6-c5182647fed9]
ERROR: InitError: could not load library "C:\Users\visser_mn\.julia\artifacts\579a09774380e99d70add2ba8682e426c8d2d76e\bin\libblosc.dll"
The specified module could not be found.
Stacktrace:
 [1] dlopen(::String, ::UInt32; throw_error::Bool) at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\Libdl\src\Libdl.jl:109
 [2] dlopen at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\Libdl\src\Libdl.jl:109 [inlined] (repeats 2 times)
 [3] __init__() at C:\Users\visser_mn\.julia\packages\Blosc_jll\O9WPW\src\wrappers\x86_64-w64-mingw32-cxx11.jl:45
 [4] _include_from_serialized(::String, ::Array{Any,1}) at .\loading.jl:697
 [5] _require_from_serialized(::String) at .\loading.jl:748
 [6] _require(::Base.PkgId) at .\loading.jl:1039
 [7] require(::Base.PkgId) at .\loading.jl:927
 [8] require(::Module, ::Symbol) at .\loading.jl:922
 [9] eval(::Module, ::Any) at .\boot.jl:331
 [10] eval_user_input(::Any, ::REPL.REPLBackend) at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\REPL\src\REPL.jl:86
 [11] run_backend(::REPL.REPLBackend) at C:\Users\visser_mn\.julia\packages\Revise\WkyNB\src\Revise.jl:1023
 [12] top-level scope at none:0
during initialization of module Blosc_jll
```