### PR TITLE
Adds GIF and OpenJpeg support to the Leptonica library.

### DIFF
--- a/L/Leptonica/build_tarballs.jl
+++ b/L/Leptonica/build_tarballs.jl
@@ -48,6 +48,7 @@ dependencies = [
     Dependency(PackageSpec(name="Libtiff_jll", uuid="89763e89-9b03-5906-acba-b20f662cd828"))
     Dependency(PackageSpec(name="libwebp_jll", uuid="c5f90fcd-3b7e-5836-afba-fc50a0988cb2"))
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
+    Dependency(PackageSpec(name="OpenJpeg_jll", uuid="643b3616-a352-519d-856d-80112ee9badc"))
 ]
 
 # Build the tarballs.

--- a/L/Leptonica/build_tarballs.jl
+++ b/L/Leptonica/build_tarballs.jl
@@ -14,6 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/leptonica-*/
+export CPPFLAGS="-I$prefix/include"
 ./configure --prefix=$prefix --host=$target
 make -j${nproc}
 make install


### PR DESCRIPTION
Even though Giflib_jll was added as a dependency the configure script did not find gif_lib.h so GIF support was disabled.  You can see this in the Leptonica.log lines 325 to 327:
```
checking gif_lib.h usability... no
checking gif_lib.h presence... no
checking for gif_lib.h... no
```
Additionally you can test it with the julia code:
```
julia> using Leptonica_jll

julia> buffer = Vector{UInt8}()
0-element Array{UInt8,1}

julia> ccall((:pixReadMemGif, Leptonica_jll.liblept), Cvoid, (Ptr{UInt8}, Csize_t), buffer, 0)
Error in pixReadMemGif: function not present
```
Which is the stub that is compiled in when libgif wasn't linked.

This change defines CPPFLAGS to include the $prefix/include directory which allows `configure` to determine that gif_lib.h is available and thus GIF support is compiled into the library.