### PR TITLE
Updated Tesseract to 4.1.1.

### DIFF
--- a/T/Tesseract/build_tarballs.jl
+++ b/T/Tesseract/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "Tesseract"
-version = v"4.1.0"
+version = v"4.1.1"
 
 # Collection of sources required to build Tesseract
 sources = [
     "https://github.com/tesseract-ocr/tesseract/archive/$(version).tar.gz" =>
-    "5c5ed5f1a76888dc57a83704f24ae02f8319849f5c4cf19d254296978a1a1961",
+    "2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb",
     "./bundled"
 ]
 
@@ -19,6 +19,7 @@ if [[ "${target}" == *-musl* ]] || [[ "${target}" == *-freebsd* ]]; then
     # Apply layman patch to make this work
     atomic_patch -p1 "$WORKSPACE/srcdir/patches/sys_time_musl_freebsd.patch"
 fi
+atomic_patch -p1 "$WORKSPACE/srcdir/patches/disable_fast_math.patch"
 ./autogen.sh
 ./configure --prefix=$prefix --host=$target
 make -j${nproc}

--- a/T/Tesseract/build_tarballs.jl
+++ b/T/Tesseract/build_tarballs.jl
@@ -7,9 +7,9 @@ version = v"4.1.1"
 
 # Collection of sources required to build Tesseract
 sources = [
-    "https://github.com/tesseract-ocr/tesseract/archive/$(version).tar.gz" =>
-    "2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb",
-    "./bundled"
+    ArchiveSource("https://github.com/tesseract-ocr/tesseract/archive/$(version).tar.gz",
+                  "2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
@@ -38,17 +38,17 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "Giflib_jll",
-    "JpegTurbo_jll",
-    "libpng_jll",
-    "Libtiff_jll",
-    "Zlib_jll",
-    "Leptonica_jll",
-    "CompilerSupportLibraries_jll",
+    Dependency("Giflib_jll"),
+    Dependency("JpegTurbo_jll"),
+    Dependency("libpng_jll"),
+    Dependency("Libtiff_jll"),
+    Dependency("Zlib_jll"),
+    Dependency("Leptonica_jll"),
+    Dependency("CompilerSupportLibraries_jll"),
     # Optional dependencies
-    # "ICU_jll",
-    "Cairo_jll",
-    "Pango_jll",
+    # Dependency("ICU_jll"),
+    Dependency("Cairo_jll"),
+    Dependency("Pango_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/T/Tesseract/bundled/patches/disable_fast_math.patch
+++ b/T/Tesseract/bundled/patches/disable_fast_math.patch
@@ -1,0 +1,11 @@
+--- a/src/arch/Makefile.am	2019-12-26 09:21:51.000000000 -0500
++++ b/src/arch/Makefile.am	2020-05-11 07:44:13.297714783 -0400
+@@ -46,7 +46,7 @@
+ libtesseract_sse_la_CXXFLAGS = -msse4.1
+ endif
+
+-libtesseract_native_la_CXXFLAGS = -O3 -ffast-math
++libtesseract_native_la_CXXFLAGS = -O3
+ if MARCH_NATIVE_OPT
+ libtesseract_native_la_CXXFLAGS += -march=native -mtune=native
+ endif


### PR DESCRIPTION
I disabled -ffast-math to conform with current requirements.  Unfortunately it doesn't appear you can disable it with a compile flag so I put together a patch to apply to the make file.