### PR TITLE
New Recipe: lib4ti2 1.6.9

### DIFF
--- a/L/lib4ti2/build_tarballs.jl
+++ b/L/lib4ti2/build_tarballs.jl
@@ -1,0 +1,111 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+# Julia does not allow identifiers starting with a digit, so we can't
+# call this just "4ti2"
+name = "lib4ti2"
+version = v"1.6.9"
+
+# Collection of sources required to build 4ti2
+sources = [
+    ArchiveSource("https://github.com/4ti2/4ti2/releases/download/Release_$(version.major)_$(version.minor)_$(version.patch)/4ti2-$(version).tar.gz",
+                  "3053e7467b5585ad852f6a56e78e28352653943e7249ad5e5174d4744d174966"),
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/4ti2-*
+
+# Remove misleading libtool files 
+rm -f ${prefix}/lib/*.la
+rm -f /opt/${target}/${target}/lib*/*.la
+rm -f /opt/${MACHTYPE}/${MACHTYPE}/lib*/*.la
+
+# Patch #1 for fixing cross-compilation: The correctness of the patch
+# relies on us using clang or GCC (in a new enough version) as compiler;
+# otherwise we ought to turn off ftrapv support to be on the safe side.
+atomic_patch -p1 ../patches/ftrapv.patch
+
+# Patch #2 for fixing cross-compilation: The code detecting presence and
+# usability of GMP is broken for cross compilation; fix that
+atomic_patch -p1 ../patches/gmp.patch
+
+# Patch to fix compilation on mingw32: add missing #include <time.h>
+atomic_patch -p1 ../patches/time.patch
+
+
+./configure \
+    --prefix=$prefix \
+    --build=${MACHTYPE} \
+    --host=$target \
+    --with-gcc-arch=pentium4 \
+    --with-gmp=${prefix} \
+    --with-glpk=${prefix} \
+    --enable-shared \
+    --disable-static
+make -j${nproc}
+make install
+
+rm -rf ${WORKSPACE}/destdir/${target}
+
+# On Windows, make sure non-versioned filename exists...
+if [[ ${target} == *mingw* ]]; then
+    cp -v ${prefix}/bin/lib4ti2common-*.dll ${prefix}/bin/lib4ti2common.dll
+    cp -v ${prefix}/bin/lib4ti2gmp-*.dll ${prefix}/bin/lib4ti2gmp.dll
+    cp -v ${prefix}/bin/lib4ti2int32-*.dll ${prefix}/bin/lib4ti2int32.dll
+    cp -v ${prefix}/bin/lib4ti2int64-*.dll ${prefix}/bin/lib4ti2int64.dll
+    cp -v ${prefix}/bin/lib4ti2util-*.dll ${prefix}/bin/lib4ti2util.dll
+    cp -v ${prefix}/bin/libzsolve-*.dll ${prefix}/bin/libzsolve.dll
+fi
+"""
+
+# Build for all platforms
+platforms = supported_platforms()
+
+# 4ti2 contains std::string values; to avoid incompatibilities across
+# the GCC 4/5 version boundary, we need the following:
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+   LibraryProduct("lib4ti2gmp", :lib4ti2),
+   LibraryProduct("lib4ti2int32", :lib4ti2int32),
+   LibraryProduct("lib4ti2int64", :lib4ti2int64),
+   LibraryProduct("libzsolve", :libzsolve),
+
+   # The commented out executables below are shell scripts, and are not
+   # handled on Windows currently, which is why they are commented out
+   # for now.
+   # Also, Julia identifiers can't start with a digit, so we have to add
+   # a prefix to the symbol used to refer to some of the executables.
+   ExecutableProduct("4ti2gmp", :exe4ti2gmp),
+   ExecutableProduct("4ti2int32", :exe4ti2int32),
+   ExecutableProduct("4ti2int64", :exe4ti2int64),
+   #ExecutableProduct("circuits", :circuits),
+   ExecutableProduct("genmodel", :genmodel),
+   ExecutableProduct("gensymm", :gensymm),
+   #ExecutableProduct("graver", :graver),
+   #ExecutableProduct("groebner", :groebner),
+   #ExecutableProduct("hilbert", :hilbert),
+   #ExecutableProduct("markov", :markov),
+   #ExecutableProduct("minimize", :minimize),
+   #ExecutableProduct("normalform", :normalform),
+   ExecutableProduct("output", :output),
+   ExecutableProduct("ppi", :ppi),
+   #ExecutableProduct("qsolve", :qsolve),
+   #ExecutableProduct("rays", :rays),
+   #ExecutableProduct("walk", :walk),
+   #ExecutableProduct("zbasis", :zbasis),
+   ExecutableProduct("zsolve", :zsolve),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("GMP_jll"),
+    Dependency("GLPK_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/L/lib4ti2/bundled/patches/ftrapv.patch
+++ b/L/lib4ti2/bundled/patches/ftrapv.patch
@@ -1,0 +1,40 @@
+From 4fc8909e7099a37125bec79b51184ea082140f8f Mon Sep 17 00:00:00 2001
+From: Max Horn <max@quendi.de>
+Date: Thu, 30 Apr 2020 16:30:44 +0200
+Subject: [PATCH] configure: patch -ftrapv support detection
+
+---
+ configure | 10 ++--------
+ 1 file changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/configure b/configure
+index 4aa8e51..3e42e5d 100755
+--- a/configure
++++ b/configure
+@@ -9208,10 +9208,7 @@ CXXFLAGS="${CXXFLAGS} ${TRAPV_FLAG}"
+ $as_echo_n "checking whether -ftrapv actually seems to work for int... " >&6; }
+ trapv_int=no
+ if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
++  trapv_int=no
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+@@ -9247,10 +9244,7 @@ $as_echo "$trapv_int" >&6; }
+ $as_echo_n "checking whether -ftrapv actually seems to work for long long... " >&6; }
+ trapv_long_long=no
+ if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
++  trapv_long_long=no
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-- 
+2.26.1.107.gefe3874640
+

--- a/L/lib4ti2/bundled/patches/gmp.patch
+++ b/L/lib4ti2/bundled/patches/gmp.patch
@@ -1,0 +1,14 @@
+diff --git a/configure b/configure
+index 3e42e5d..a7fb9b6 100755
+--- a/configure
++++ b/configure
+@@ -23235,6 +23235,9 @@ if ac_fn_cxx_try_link "$LINENO"; then :
+ $as_echo "unknown" >&6; }
+ 				echo "WARNING: You appear to be cross compiling, so there is no way to determine"
+ 				echo "whether your GMP version is new enough. I am assuming it is."
++				gmp_found="yes"
++				GMP_HAVE_CXX=yes
++				GMP_LIBS="$GMP_LIBS -lgmpxx -lgmp"
+ 
+ 
+ 

--- a/L/lib4ti2/bundled/patches/time.patch
+++ b/L/lib4ti2/bundled/patches/time.patch
@@ -1,0 +1,12 @@
+diff --git a/src/zsolve/Heuristics.hpp b/src/zsolve/Heuristics.hpp
+index eb09e8a..c7111a7 100644
+--- a/src/zsolve/Heuristics.hpp
++++ b/src/zsolve/Heuristics.hpp
+@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ #include <fstream>
+ #include <map>
+ #include <cstdlib>
++#include <time.h>
+ 
+ #include "zsolve/BitSet.h"
+ #include "zsolve/LinearSystem.hpp"


### PR DESCRIPTION
This contains some nasty workarounds for issues with `libstdc++.la` -- I wonder if these hint at an issue with the build environment? Or perhaps I am doing something stupid?  (perhaps @benlorenz has an idea -- but don't feel compelled to look, or waste time on this).

There are a few issues building everything for all platforms, so I may have to disable some. But I thought I should submit this now, even though it is not 100% ready, in the hopes that somebody has feedback on the `libstdc++.la` problems, and also so that I can show this more easily to people who might be interested in using this (e.g. @mohamed-barakat). And finally perhaps there are other things I should be doing differently here, then it'd be good to hear about it sooner rather than later :-).