### PR TITLE
librsync build recipe

### DIFF
--- a/L/librsync/build_tarballs.jl
+++ b/L/librsync/build_tarballs.jl
@@ -1,0 +1,39 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "librsync"
+version = v"2.3.1"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/librsync/librsync.git", "028d9432d05ba4b75239e0ba35bcb36fbfc17e35")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd librsync/
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
+make -j${nproc}
+make install
+install_license COPYING
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("librsync", :librsync)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
+    Dependency(PackageSpec(name="Bzip2_jll", uuid="6e34b625-4abd-537c-b88f-471c36dfa7a0"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This adds a build recipe for `librsync`. 

The library has an optional command line binary called `rdiff` but that is not included since it depends on `libpopt` which we don't yet seem to have. So only the shared lib `librsync` is included for now. 

cc: @StefanKarpinski 