### PR TITLE
[librsync] build rdiff executable

### DIFF
--- a/L/librsync/build_tarballs.jl
+++ b/L/librsync/build_tarballs.jl
@@ -27,12 +27,14 @@ platforms = supported_platforms()
 # The products that we will ensure are always built
 products = [
     LibraryProduct("librsync", :librsync)
+    ExecutableProduct("rdiff", :rdiff)
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
     Dependency(PackageSpec(name="Bzip2_jll", uuid="6e34b625-4abd-537c-b88f-471c36dfa7a0"))
+    Dependency(PackageSpec(name="Popt_jll", uuid="e80236cf-ab1d-5f5d-8534-1d1285fe49e8"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
We now build the `rdiff` executable in addition to the shared lib. 

cc: @StefanKarpinski 