### PR TITLE
CImGui: Split imgui and cimgui libs

### DIFF
--- a/C/CImGui/build_tarballs.jl
+++ b/C/CImGui/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "CImGui"
-version = v"1.75.0+2"
+version = v"1.75.0"
 
 # Collection of sources required to build CImGui
 sources = [

--- a/C/CImGui/build_tarballs.jl
+++ b/C/CImGui/build_tarballs.jl
@@ -3,15 +3,15 @@
 using BinaryBuilder
 
 name = "CImGui"
-version = v"1.76.0"
+version = v"1.75.0+2"
 
 # Collection of sources required to build CImGui
 sources = [
     GitSource("https://github.com/ocornut/imgui.git",
-              "5503c0a12e0c929e84b3f61b2cb4bb9177ea3da1"),
+              "58b3e02b95b4c7c5bb9128a28c6d55546501bf93"),
 
     GitSource("https://github.com/cimgui/cimgui.git",
-              "be187bcdc43b124250f7c0f6b4c216a4094053b1"),
+              "c5eea0b2dbfb2fc763292c410aba69a72eccfc4f"),
 
     DirectorySource("./bundled"),
 ]
@@ -34,6 +34,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
+    LibraryProduct("libimgui-cpp", :libimgui),
     LibraryProduct("libcimgui", :libcimgui),
     LibraryProduct("libcimgui_helper", :libcimgui_helper),
     FileProduct("share/compile_commands.json", :compile_commands)

--- a/C/CImGui/bundled/wrapper/CMakeLists.txt
+++ b/C/CImGui/bundled/wrapper/CMakeLists.txt
@@ -3,15 +3,16 @@ project(cimgui)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-add_library(cimgui SHARED)
+add_library(imgui-cpp SHARED)
 
-target_sources(cimgui PRIVATE cimgui.cpp)
-target_sources(cimgui PRIVATE ./imgui/imgui.cpp)
-target_sources(cimgui PRIVATE ./imgui/imgui_draw.cpp)
-target_sources(cimgui PRIVATE ./imgui/imgui_demo.cpp)
-target_sources(cimgui PRIVATE ./imgui/imgui_widgets.cpp)
+target_sources(imgui-cpp PRIVATE ./imgui/imgui.cpp)
+target_sources(imgui-cpp PRIVATE ./imgui/imgui_draw.cpp)
+target_sources(imgui-cpp PRIVATE ./imgui/imgui_demo.cpp)
+target_sources(imgui-cpp PRIVATE ./imgui/imgui_widgets.cpp)
 
-target_include_directories(cimgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/imgui)
+target_include_directories(imgui-cpp PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/imgui>
+        $<INSTALL_INTERFACE:include>)
 
 add_definitions("-DIMGUI_DISABLE_OBSOLETE_FUNCTIONS=1")
 
@@ -21,7 +22,30 @@ else(WIN32)
     add_definitions("-DIMGUI_IMPL_API=extern \"C\" ")
 endif(WIN32)
 
+set_property(TARGET imgui-cpp APPEND PROPERTY
+    PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/imgui/imgui.h
+                  ${CMAKE_CURRENT_SOURCE_DIR}/imgui/imgui_internal.h
+                  ${CMAKE_CURRENT_SOURCE_DIR}/imgui/imconfig.h
+                  ${CMAKE_CURRENT_SOURCE_DIR}/imgui/imstb_rectpack.h
+                  ${CMAKE_CURRENT_SOURCE_DIR}/imgui/imstb_textedit.h
+                  ${CMAKE_CURRENT_SOURCE_DIR}/imgui/imstb_truetype.h
+                  )
+
+install(TARGETS imgui-cpp
+        EXPORT imgui-cpp-targets
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include)
+
+install(EXPORT imgui-cpp-targets
+        FILE imgui-cpp-config.cmake
+        DESTINATION lib/cmake/imgui-cpp)
+
+add_library(cimgui SHARED cimgui.cpp)
+target_include_directories(cimgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(cimgui PROPERTIES PUBLIC_HEADER cimgui.h)
+target_link_libraries(cimgui imgui-cpp)
 
 install(TARGETS cimgui
         EXPORT cimgui-targets


### PR DESCRIPTION
With this PR, CImGui_jll ships a stand-alone libimgui-cpp.so that can be reused in cimplot. 