### PR TITLE
[AZP] Try to load the package before registration

### DIFF
--- a/.ci/register_package.jl
+++ b/.ci/register_package.jl
@@ -108,4 +108,10 @@ mktempdir() do download_dir
     end
 end
 BinaryBuilder.push_jll_package(name, build_version)
+mktempdir() do dir
+    Pkg.activate(dir)
+    Pkg.dev(code_dir)
+    module_name = Symbol(name * "_jll")
+    @eval using $(module_name)
+end
 BinaryBuilder.register_jll(name, build_version, dependencies)


### PR DESCRIPTION
Fix #594.  However we probably want to have a way to skip this step when we know that this is going to fail, like some LLVM versions