### PR TITLE
[libcgal-julia] Update to v0.9.0 + purge julia dependency hack

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -3,23 +3,18 @@
 using BinaryBuilder
 
 const name = "libcgal_julia"
-const version = v"0.8.0"
+const version = v"0.9.0"
 
 # Collection of sources required to build CGAL
 const sources = [
     GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "ce3b4312d8ba161d85ff6bd2c4aed788f5523613"),
-    # julia binaries
-    ArchiveSource("https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz",
-                  "faa707c8343780a6fe5eaf13490355e8190acf8e2c189b9e7ecbddb0fa2643ad"; unpack_target="julia-x86_64-linux-gnu"),
-    ArchiveSource("https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-apple-darwin14.tar.gz",
-                  "f2e5359f03314656c06e2a0a28a497f62e78f027dbe7f5155a5710b4914439b1"; unpack_target="julia-x86_64-apple-darwin14"),
-    ArchiveSource("https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-w64-mingw32.tar.gz",
-                  "c7b2db68156150d0e882e98e39269301d7bf56660f4fc2e38ed2734a7a8d1551"; unpack_target="julia-x86_64-w64-mingw32"),
+              "1bf5269e8fb0b11aa802b8e5872d5faa9367e977"),
 ]
 
 # Dependencies that must be installed before this package can be built
 const dependencies = [
+    BuildDependency("Julia_jll"),
+
     Dependency("CGAL_jll"),
     Dependency("libcxxwrap_julia_jll"),
 ]
@@ -30,16 +25,6 @@ const script = raw"""
 # exit on error
 set -eu
 
-## "find" julia
-case $target in
-  x86_64-linux-gnu)
-    Julia_PREFIX=${WORKSPACE}/srcdir/julia-$target/julia-1.3.1
-    ;;
-  x86_64-apple-darwin14|x86_64-w64-mingw32)
-    Julia_PREFIX=${WORKSPACE}/srcdir/julia-$target/juliabin
-    ;;
-esac
-
 ## configure build
 cmake libcgal-julia*/ -B build \
   `# cmake specific` \
@@ -47,8 +32,8 @@ cmake libcgal-julia*/ -B build \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_FIND_ROOT_PATH="$prefix" \
   -DCMAKE_INSTALL_PREFIX="$prefix" \
-  `# tell libcxxwrap-julia where julia is` \
-  -DJulia_PREFIX="$Julia_PREFIX"
+  `# tell jlcxx where julia is` \
+  -DJulia_PREFIX="$prefix"
 
 ## and away we go..
 VERBOSE=ON cmake --build build --config Release --target install -- -j$nproc
@@ -68,6 +53,7 @@ const platforms = [
     MacOS(:x86_64),
     Windows(:x86_64),
 ] |> expand_cxxstring_abis
+filter!(p->cxxstring_abi(p) === :cxx11, platforms)
 
 # The products that we will ensure are always built
 const products = [


### PR DESCRIPTION
The library exposes a few more 2D Triangulation types and methods, as
well as some missing 2D Voronoi Diagram methods.

Furthermore, the buildscript itself has been updated to use `Julia_jll`
as a build dependency instead of unpacking platform specific tarballs,
hacked within the buildscript.