### PR TITLE
[libcgal-julia]: Minor update to v0.9.1

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 const name = "libcgal_julia"
-const version = v"0.9.0"
+const version = v"0.9.1"
 
 # Collection of sources required to build CGAL
 const sources = [
     GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "1bf5269e8fb0b11aa802b8e5872d5faa9367e977"),
+              "306c43938205c81d28cccf47eab5a24297dea5ba"),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
Instead of working about a method to map circulators/iterators directly
to julia (even though they're mostly pointers and dereferncing them
should be enough, the underlying types are unnecessarily complex), the
elements are collected in the C++-side into arrays.

As such, this patch includes a tiny change which involves copying the
beginning of the circulator instead of modifying it directly.

Sorry for the extra PR... I just feel this could have caused some
damage in the short term.