### PR TITLE
[CSDP] Revert use of `flagon`

### DIFF
--- a/C/Coin-OR/CSDP/build_tarballs.jl
+++ b/C/Coin-OR/CSDP/build_tarballs.jl
@@ -31,8 +31,16 @@ make CFLAGS="$CFLAGS" LIBS="$LIBS" CC="$CC"
 make install
 
 cd lib
+
+all_load="--whole-archive"
+noall_load="--no-whole-archive"
+if [[ "${target}" == *-apple-* ]]; then
+  all_load="-all_load"
+  noall_load="-noall_load"
+fi
+
 mkdir -p ${libdir}
-${CC} -fopenmp -fPIC -shared $(flagon --whole-archive) libsdp.a $(flagon --no-whole-archive) -o ${libdir}/libcsdp.${dlext} -lgomp -lopenblas -lm
+${CC} -fopenmp -fPIC -shared -Wl,${all_load} libsdp.a -Wl,${noall_load} -o ${libdir}/libcsdp.${dlext} -lgomp -lopenblas -lm
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Fix #1081.  @blegat could you please check when the tarballs are ready?  I think this was caused by my mistake in BB documentation (fixed by https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/800)