### PR TITLE
[0_RootFS] Remove libtool archives from GCCBoostrap tarballs

### DIFF
--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -653,6 +653,9 @@ function gcc_script(compiler_target::Platform)
     ## Build, build, build!
     make -j ${nproc}
     make install
+
+    # Remove misleading libtool archives
+    rm -f ${prefix}/${COMPILER_TARGET}/lib*/*.la
     """
 
     return script


### PR DESCRIPTION
When building a package, some of the libtool archives in
`/opt/${target}/${target}/lib*` contain wrong paths.  For example, for
`x86_64-linux-gnu`,
`/opt/x86_64-linux-gnu/x86_64-linux-gnu/lib64/libquadmath.la` has the following
`libdir`:

```sh
# Directory that this library needs to be installed in:
libdir='/workspace/destdir/x86_64-linux-gnu/lib/../lib64'
```

This happens because the file is generated and installed in `${prefix}` in
GCCBoostrap, but then in the RootFS this is placed in `/opt/${target}` instead
of `/workspace/destdir`.  Since these files often cause troubles during build
and aren't of any utility, we can just get rid of them.

I _think_ this is what we need for https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/689, but I didn't actually try if this does what I expect :grin: 