### PR TITLE
[AZP] Allow skipping building of binaries with keyword in commit message

### DIFF
--- a/.ci/register_package.jl
+++ b/.ci/register_package.jl
@@ -27,11 +27,12 @@ dependencies = Dependency[dep for dep in merged["dependencies"] if !isa(dep, Bui
 lazy_artifacts = merged["lazy_artifacts"]
 build_version = BinaryBuilder.get_next_wrapper_version(name, version)
 repo = "JuliaBinaryWrappers/$(name)_jll.jl"
+code_dir = joinpath(Pkg.devdir(), "$(name)_jll")
 
 # Register JLL package using given metadata
 BinaryBuilder.init_jll_package(
     name,
-    joinpath(Pkg.devdir(), "$(name)_jll"),
+    code_dir,
     repo,
 )
 
@@ -48,26 +49,60 @@ function download_cached_binaries(download_dir, platforms)
     end
 end
 
+function download_binaries_from_release(download_dir, platforms)
+    probe_platform_engines!(;verbose=verbose)
+
+    # The version of the latest build is one build number less than the next one
+    # (pretty obvious, isn't it?).  Since we're supposed to be rebuilding the
+    # latest version, make sure the next build version is greater than 0
+    build_version.build[1] > 0 || error("The next version must have build number greater than 0")
+    latest_build_version = VersionNumber(build_version.major, build_version.minor, build_version.patch,
+                                         build_version.prerelease, build_version.build .- 1)
+    tag = "$(name)-v$(latest_build_version)"
+
+    for platform in platforms
+        filename = "$(name).v$(version).$(triplet(platform)).tar.gz"
+        url = "https://github.com/$(repo)/releases/download/$(tag)/$(filename)"
+        PlatformEngines.download(url, joinpath(download_dir, filename); verbose=verbose)
+    end
+end
+
 # Filter out build-time dependencies also here
 for json_obj in [merged, objs_unmerged...]
     json_obj["dependencies"] = Dependency[dep for dep in json_obj["dependencies"] if !isa(dep, BuildDependency)]
 end
+skip_build = get(ENV, "SKIP_BUILD", "false") == "true"
 mktempdir() do download_dir
     # Grab the binaries for our package
-    download_cached_binaries(download_dir, merged["platforms"])
+    if skip_build
+        # We only want to update the wrappers, so download the tarballs from the
+        # latest build.
+        download_binaries_from_release(download_dir, merged["platforms"])
+    else
+        # We are going to publish the new binaries we've just baked, take them
+        # out of the cache while they're hot.
+        download_cached_binaries(download_dir, merged["platforms"])
+    end
     
     # Push up the JLL package (pointing to as-of-yet missing tarballs)
     tag = "$(name)-v$(build_version)"
     upload_prefix = "https://github.com/$(repo)/releases/download/$(tag)"
 
+    # If we didn't rebuild the tarballs, save the original Artifacts.toml
+    artifacts_toml = skip_build ? read(joinpath(code_dir, "Artifacts.toml"), String) : ""
     # This loop over the unmerged objects necessary in the event that we have multiple packages being built by a single build_tarballs.jl
     for (i,json_obj) in enumerate(objs_unmerged)
         from_scratch = (i == 1)
         BinaryBuilder.rebuild_jll_package(json_obj; download_dir=download_dir, upload_prefix=upload_prefix, verbose=verbose, lazy_artifacts=json_obj["lazy_artifacts"], from_scratch=from_scratch)
     end
-    
-    # Upload them to GitHub releases
-    BinaryBuilder.upload_to_github_releases(repo, tag, download_dir; verbose=verbose)
+
+    if skip_build
+        # Restore Artifacts.toml
+        write(joinpath(code_dir, "Artifacts.toml"), artifacts_toml)
+    else
+        # Upload the tarballs to GitHub releases
+        BinaryBuilder.upload_to_github_releases(repo, tag, download_dir; verbose=verbose)
+    end
 end
 BinaryBuilder.push_jll_package(name, build_version)
 BinaryBuilder.register_jll(name, build_version, dependencies)

--- a/H/HelloWorldRust/build_tarballs.jl
+++ b/H/HelloWorldRust/build_tarballs.jl
@@ -35,5 +35,5 @@ products = [
 dependencies = [
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
+# Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers=[:c, :rust])

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,11 +24,23 @@ jobs:
 
       # Normally we look at the last pushed commit
       COMPARE_AGAINST="HEAD~1"
+      # Keyword to be used in the commit message to skip a rebuild
+      SKIP_BUILD_COOKIE="[skip build]"
+      # This variable will tell us whether we want to skip the build
+      SKIP_BUILD="false"
 
       # If we're on a PR though, we look at the entire branch at once
       if [[ $(Build.Reason) == "PullRequest" ]]; then
           TARGET_BRANCH="remotes/origin/$(System.PullRequest.TargetBranch)"
           COMPARE_AGAINST=$(git merge-base --fork-point ${TARGET_BRANCH} HEAD)
+          git fetch origin "refs/pull/$(System.PullRequest.PullRequestNumber)/head:refs/remotes/origin/pr/$(System.PullRequest.PullRequestNumber)"
+          if [[ "$(git show -s --format=%B origin/pr/$(System.PullRequest.PullRequestNumber))" == *"${SKIP_BUILD_COOKIE}"* ]]; then
+              SKIP_BUILD="true"
+          fi
+      else
+          if [[ "$(Build.SourceVersionMessage)" == *"${SKIP_BUILD_COOKIE}"* ]]; then
+              SKIP_BUILD="true"
+          fi
       fi
 
       $(JULIA) -e "using InteractiveUtils; versioninfo()"
@@ -135,7 +147,8 @@ jobs:
                                 'PROJECT':'${PROJECT}', \
                                 'PLATFORMS':'${PLATFORMS}', \
                                 'BB_HASH':'${BB_HASH}', \
-                                'PROJ_HASH':'${PROJ_HASH}'\
+                                'PROJ_HASH':'${PROJ_HASH}', \
+                                'SKIP_BUILD':'${SKIP_BUILD}' \
                             }, "
 
               # Some debugging info
@@ -143,6 +156,11 @@ jobs:
 
               # For $(PROJPLATFORMS)`, we need to know more...
               for PLATFORM in ${PLATFORMS}; do
+                  if [[ "${SKIP_BUILD}" == "true" ]]; then
+                      echo "The commit messages contains ${SKIP_BUILD_COOKIE}, skipping build"
+                      break
+                  fi
+
                   # Here, we hit the build cache to see if we can skip this particular combo
                   CACHE_URL="https://julia-bb-buildcache.s3.amazonaws.com/${BB_HASH}/${PROJ_HASH}/${PLATFORM}.tar.gz"
                   if curl --output /dev/null --silent --fail --HEAD "${CACHE_URL}"; then


### PR DESCRIPTION
The magic word is `[skip build]`, this tells to the pipeline to not build new
tarballs and reuse those from the latest build.  Fix #938.

Note: this is a proof-of-concept, not tested yet!