### PR TITLE
[AZP] Fix check on the environment variable with the commit message

### DIFF
--- a/H/HelloWorldRust/build_tarballs.jl
+++ b/H/HelloWorldRust/build_tarballs.jl
@@ -35,5 +35,5 @@ products = [
 dependencies = [
 ]
 
-# Build the tarballs.
+# Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers=[:c, :rust])

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,8 @@ jobs:
       # This variable will tell us whether we want to skip the build
       SKIP_BUILD="false"
 
-      # If we're on a PR though, we look at the entire branch at once
       if [[ $(Build.Reason) == "PullRequest" ]]; then
+          # If we're on a PR though, we look at the entire branch at once
           TARGET_BRANCH="remotes/origin/$(System.PullRequest.TargetBranch)"
           COMPARE_AGAINST=$(git merge-base --fork-point ${TARGET_BRANCH} HEAD)
           git fetch origin "refs/pull/$(System.PullRequest.PullRequestNumber)/head:refs/remotes/origin/pr/$(System.PullRequest.PullRequestNumber)"
@@ -38,7 +38,7 @@ jobs:
               SKIP_BUILD="true"
           fi
       else
-          if [[ "$(Build.SourceVersionMessage)" == *"${SKIP_BUILD_COOKIE}"* ]]; then
+          if [[ '$(Build.SourceVersionMessage)' == *"${SKIP_BUILD_COOKIE}"* ]]; then
               SKIP_BUILD="true"
           fi
       fi


### PR DESCRIPTION
Even though the macro syntax for environment variables in Azure Pipelines _looks
like_ command substitution, that is processed before runtime, see
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#macro-syntax-variables.
Thus we have to protect `$(Build.SourceVersionMessage)` with single quotes to
avoid evaluating its value.

This makes it possible to safely type `[skip build]` in the commit message.