### PR TITLE
[HelloWorldGo] Update wrappers

### DIFF
--- a/.ci/register_package.jl
+++ b/.ci/register_package.jl
@@ -55,7 +55,10 @@ function download_binaries_from_release(download_dir, platforms)
     # The version of the latest build is one build number less than the next one
     # (pretty obvious, isn't it?).  Since we're supposed to be rebuilding the
     # latest version, make sure the next build version is greater than 0
-    build_version.build[1] > 0 || error("The next version must have build number greater than 0")
+    if build_version.build[1] > 0
+        error("The next version is $(build_version), but it must have build number greater than 0")
+    end
+    # Guess what's the latest released version.
     latest_build_version = VersionNumber(build_version.major, build_version.minor, build_version.patch,
                                          build_version.prerelease, build_version.build .- 1)
     tag = "$(name)-v$(latest_build_version)"

--- a/H/HelloWorldGo/build_tarballs.jl
+++ b/H/HelloWorldGo/build_tarballs.jl
@@ -23,7 +23,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
+dependencies = Dependency[
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers=[:c, :go])


### PR DESCRIPTION
In the previous commit I tried to test `[skip build]` with `HelloWorldRust_jll`,
but it failed because `HelloWorldRust_jll` had never been registered.  At least
we know that the check is working correctly :slightly_smiling_face: Trying again
with `HelloWorlGo_jll` which does have a registered version to update.