### PR TITLE
New Recipe: ecCodes v2.17.0

### DIFF
--- a/E/eccodes/build_tarballs.jl
+++ b/E/eccodes/build_tarballs.jl
@@ -13,12 +13,14 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-sed -e '91,93d' -e '88d' -e '60,86d' -e '55,57d' -e '51d' -e '23,49d' eccodes-2.17.0-Source/cmake/eccodes_test_endiness.cmake > new_endianess_test
+sed -e '21,93d' eccodes-2.17.0-Source/cmake/eccodes_test_endiness.cmake > new_endianess_test
+echo 'set( IEEE_BE ${ECCODES_BIG_ENDIAN} )' >> new_endianess_test
+echo 'set( IEEE_LE ${ECCODES_LITTLE_ENDIAN} )' >> new_endianess_test
 mv new_endianess_test eccodes-2.17.0-Source/cmake/eccodes_test_endiness.cmake
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DENABLE_NETCDF=OFF -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_FORTRAN=OFF -DIEEE=1 ../eccodes-2.17.0-Source/
-make
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DENABLE_NETCDF=OFF -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_FORTRAN=OFF ../eccodes-2.17.0-Source/
+make -j${nproc}
 make install
 install_license ../eccodes-2.17.0-Source/LICENSE
 """

--- a/E/eccodes/build_tarballs.jl
+++ b/E/eccodes/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "eccodes"
-version = v"1.0.0"
+version = v"2.17.0"
 
 # Collection of sources required to complete build
 sources = [

--- a/E/eccodes/build_tarballs.jl
+++ b/E/eccodes/build_tarballs.jl
@@ -17,6 +17,16 @@ sed -e '21,93d' eccodes-2.17.0-Source/cmake/eccodes_test_endiness.cmake > new_en
 echo 'set( IEEE_BE ${ECCODES_BIG_ENDIAN} )' >> new_endianess_test
 echo 'set( IEEE_LE ${ECCODES_LITTLE_ENDIAN} )' >> new_endianess_test
 mv new_endianess_test eccodes-2.17.0-Source/cmake/eccodes_test_endiness.cmake
+if [ ${target} = "x86_64-w64-mingw32" ] || [ ${target} = "i686-w64-mingw32"] ; then 
+    sed -e '318d' -e '320d' -e '322d' -e '358d' eccodes-2.17.0-Source/CMakeLists.txt -e '26 a add_compile_definitions(ECCODES_ON_WINDOWS)'> new_cmakelist
+    mv new_cmakelist eccodes-2.17.0-Source/CMakeLists.txt
+    sed -e '425d' eccodes-2.17.0-Source/src/grib_context.c > new_context
+    mv new_context eccodes-2.17.0-Source/src/grib_context.c
+    chmod +x eccodes-2.17.0-Source/cmake/ecbuild_windows_replace_symlinks.sh 
+else 
+    sed -e '318d' -e '320d' -e '322d' -e '358d' eccodes-2.17.0-Source/CMakeLists.txt > new_cmakelist
+    mv new_cmakelist eccodes-2.17.0-Source/CMakeLists.txt
+fi
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DENABLE_NETCDF=OFF -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_FORTRAN=OFF ../eccodes-2.17.0-Source/

--- a/E/eccodes/build_tarballs.jl
+++ b/E/eccodes/build_tarballs.jl
@@ -20,22 +20,12 @@ cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DENABLE_NETCDF=OFF -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_FORTRAN=OFF ../eccodes-2.17.0-Source/
 make
 make install
+cp ../eccodes-2.17.0-Source/LICENSE ${prefix}/share/licenses/eccodes
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
-]
-
+platforms = supported_platforms() 
 
 # The products that we will ensure are always built
 products = [

--- a/E/eccodes/build_tarballs.jl
+++ b/E/eccodes/build_tarballs.jl
@@ -1,0 +1,52 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "eccodes"
+version = v"1.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://confluence.ecmwf.int/download/attachments/45757960/eccodes-2.17.0-Source.tar.gz", "762d6b71993b54f65369d508f88e4c99e27d2c639c57a5978c284c49133cc335")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+sed -e '91,93d' -e '88d' -e '60,86d' -e '55,57d' -e '51d' -e '23,49d' eccodes-2.17.0-Source/cmake/eccodes_test_endiness.cmake > new_endianess_test
+mv new_endianess_test eccodes-2.17.0-Source/cmake/eccodes_test_endiness.cmake
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DENABLE_NETCDF=OFF -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_FORTRAN=OFF ../eccodes-2.17.0-Source/
+make
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Linux(:i686, libc=:glibc),
+    Linux(:x86_64, libc=:glibc),
+    Linux(:aarch64, libc=:glibc),
+    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
+    Linux(:powerpc64le, libc=:glibc),
+    Linux(:i686, libc=:musl),
+    Linux(:x86_64, libc=:musl),
+    Linux(:aarch64, libc=:musl),
+    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libeccodes", :eccodes)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f"))
+    Dependency(PackageSpec(name="OpenJpeg_jll", uuid="643b3616-a352-519d-856d-80112ee9badc"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/E/eccodes/build_tarballs.jl
+++ b/E/eccodes/build_tarballs.jl
@@ -17,10 +17,10 @@ sed -e '91,93d' -e '88d' -e '60,86d' -e '55,57d' -e '51d' -e '23,49d' eccodes-2.
 mv new_endianess_test eccodes-2.17.0-Source/cmake/eccodes_test_endiness.cmake
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DENABLE_NETCDF=OFF -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_FORTRAN=OFF ../eccodes-2.17.0-Source/
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DENABLE_NETCDF=OFF -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_FORTRAN=OFF -DIEEE=1 ../eccodes-2.17.0-Source/
 make
 make install
-cp ../eccodes-2.17.0-Source/LICENSE ${prefix}/share/licenses/eccodes
+install_license ../eccodes-2.17.0-Source/LICENSE
 """
 
 # These are the platforms we will build for by default, unless further

--- a/E/eccodes/bundled/patches/unix.patch
+++ b/E/eccodes/bundled/patches/unix.patch
@@ -1,0 +1,83 @@
+diff --git a/cmake/eccodes_test_endiness.cmake b/cmake/eccodes_test_endiness.cmake
+index 0f1870d..182ffe7 100644
+--- a/cmake/eccodes_test_endiness.cmake
++++ b/cmake/eccodes_test_endiness.cmake
+@@ -18,76 +18,5 @@ endif()
+ 
+ set( ECCODES_BIG_ENDIAN    ${ECCODES_BIG_ENDIAN}    )
+ set( ECCODES_LITTLE_ENDIAN ${ECCODES_LITTLE_ENDIAN} )
+-
+-if( NOT DEFINED IEEE_BE )
+-    check_c_source_runs(
+-       "int compare(unsigned char* a,unsigned char* b) {
+-         while(*a != 0) if (*(b++)!=*(a++)) return 1;
+-         return 0;
+-       }
+-       int main(int argc,char** argv) {
+-         unsigned char dc[]={0x30,0x61,0xDE,0x80,0x93,0x67,0xCC,0xD9,0};
+-         double da=1.23456789e-75;
+-         unsigned char* ca;
+-
+-         unsigned char fc[]={0x05,0x83,0x48,0x22,0};
+-         float fa=1.23456789e-35;
+-
+-         if (sizeof(double)!=8) return 1;
+-
+-         ca=(unsigned char*)&da;
+-         if (compare(dc,ca)) return 1;
+-
+-         if (sizeof(float)!=4) return 1;
+-
+-         ca=(unsigned char*)&fa;
+-         if (compare(fc,ca)) return 1;
+-
+-         return 0;
+-       }" IEEE_BE )
+-
+-    if( "${IEEE_BE}" STREQUAL "" )
+-      set( IEEE_BE 0 CACHE INTERNAL "Test IEEE_BE")
+-    endif()
+-
+-endif()
+-
+-if( ECCODES_BIG_ENDIAN AND NOT IEEE_BE )
+-    ecbuild_critical("Failed to sanity check on endiness: OS should be Big-Endian but compiled code runs differently -- to ignore this pass -DIEEE_BE=1 to CMake/ecBuild")
+-endif()
+-
+-if( NOT DEFINED IEEE_LE )
+-    check_c_source_runs(
+-       "int compare(unsigned char* a,unsigned char* b) {
+-         while(*a != 0) if (*(b++)!=*(a++)) return 1;
+-         return 0;
+-       }
+-       int main(int argc,char** argv) {
+-         unsigned char dc[]={0xD9,0xCC,0x67,0x93,0x80,0xDE,0x61,0x30,0};
+-         double da=1.23456789e-75;
+-         unsigned char* ca;
+-
+-         unsigned char fc[]={0x22,0x48,0x83,0x05,0};
+-         float fa=1.23456789e-35;
+-
+-         if (sizeof(double)!=8) return 1;
+-
+-         ca=(unsigned char*)&da;
+-         if (compare(dc,ca)) return 1;
+-
+-         if (sizeof(float)!=4) return 1;
+-
+-         ca=(unsigned char*)&fa;
+-         if (compare(fc,ca)) return 1;
+-
+-         return 0;
+-       }" IEEE_LE )
+-
+-    if( "${IEEE_LE}" STREQUAL "" )
+-      set( IEEE_LE 0 CACHE INTERNAL "Test IEEE_LE")
+-    endif()
+-endif()
+-
+-if( ECCODES_LITTLE_ENDIAN AND NOT IEEE_LE )
+-    ecbuild_critical("Failed to sanity check on endiness: OS should be Little-Endian but compiled code runs differently -- to ignore this pass -DIEEE_LE=1 to CMake/ecBuild")
+-endif()
++set( IEEE_BE ${ECCODES_BIG_ENDIAN} )
++set( IEEE_LE ${ECCODES_LITTLE_ENDIAN} )

--- a/E/eccodes/bundled/patches/windows.patch
+++ b/E/eccodes/bundled/patches/windows.patch
@@ -1,0 +1,127 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1f49e55..e1bbcde 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,6 +24,7 @@ set( CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH}
+ 
+ include( ecbuild_system NO_POLICY_SCOPE )
+ 
++add_compile_definitions(ECCODES_ON_WINDOWS)
+ ecbuild_requires_macro_version( 2.7.2 )
+ 
+ ###############################################################################
+@@ -315,11 +316,8 @@ if( EC_OS_NAME MATCHES "windows" )
+     # Suppress compliler warnings - see ECC-850
+     # Suppress warnings about using 'insecure' functions. Fixing this would require changes all over
+     # the codebase which would damage portability.
+-    ecbuild_add_c_flags("/D_CRT_SECURE_NO_WARNINGS")
+     # Suppress warnings about using well-known C functions.
+-    ecbuild_add_c_flags("/D_CRT_NONSTDC_NO_DEPRECATE")
+     # Suppress C4267: warns about possible loss of data when converting 'size_t' to 'int'.
+-    ecbuild_add_c_flags("/wd4267")
+ endif()
+ 
+ ###############################################################################
+@@ -355,7 +353,6 @@ configure_file( eccodes_config.h.in eccodes_config.h )
+ add_definitions( -DHAVE_ECCODES_CONFIG_H )
+ 
+ if( CMAKE_COMPILER_IS_GNUCC )
+-    ecbuild_add_c_flags("-pedantic")
+ endif()
+ 
+ ###############################################################################
+diff --git a/cmake/eccodes_test_endiness.cmake b/cmake/eccodes_test_endiness.cmake
+index 0f1870d..182ffe7 100644
+--- a/cmake/eccodes_test_endiness.cmake
++++ b/cmake/eccodes_test_endiness.cmake
+@@ -18,76 +18,5 @@ endif()
+ 
+ set( ECCODES_BIG_ENDIAN    ${ECCODES_BIG_ENDIAN}    )
+ set( ECCODES_LITTLE_ENDIAN ${ECCODES_LITTLE_ENDIAN} )
+-
+-if( NOT DEFINED IEEE_BE )
+-    check_c_source_runs(
+-       "int compare(unsigned char* a,unsigned char* b) {
+-         while(*a != 0) if (*(b++)!=*(a++)) return 1;
+-         return 0;
+-       }
+-       int main(int argc,char** argv) {
+-         unsigned char dc[]={0x30,0x61,0xDE,0x80,0x93,0x67,0xCC,0xD9,0};
+-         double da=1.23456789e-75;
+-         unsigned char* ca;
+-
+-         unsigned char fc[]={0x05,0x83,0x48,0x22,0};
+-         float fa=1.23456789e-35;
+-
+-         if (sizeof(double)!=8) return 1;
+-
+-         ca=(unsigned char*)&da;
+-         if (compare(dc,ca)) return 1;
+-
+-         if (sizeof(float)!=4) return 1;
+-
+-         ca=(unsigned char*)&fa;
+-         if (compare(fc,ca)) return 1;
+-
+-         return 0;
+-       }" IEEE_BE )
+-
+-    if( "${IEEE_BE}" STREQUAL "" )
+-      set( IEEE_BE 0 CACHE INTERNAL "Test IEEE_BE")
+-    endif()
+-
+-endif()
+-
+-if( ECCODES_BIG_ENDIAN AND NOT IEEE_BE )
+-    ecbuild_critical("Failed to sanity check on endiness: OS should be Big-Endian but compiled code runs differently -- to ignore this pass -DIEEE_BE=1 to CMake/ecBuild")
+-endif()
+-
+-if( NOT DEFINED IEEE_LE )
+-    check_c_source_runs(
+-       "int compare(unsigned char* a,unsigned char* b) {
+-         while(*a != 0) if (*(b++)!=*(a++)) return 1;
+-         return 0;
+-       }
+-       int main(int argc,char** argv) {
+-         unsigned char dc[]={0xD9,0xCC,0x67,0x93,0x80,0xDE,0x61,0x30,0};
+-         double da=1.23456789e-75;
+-         unsigned char* ca;
+-
+-         unsigned char fc[]={0x22,0x48,0x83,0x05,0};
+-         float fa=1.23456789e-35;
+-
+-         if (sizeof(double)!=8) return 1;
+-
+-         ca=(unsigned char*)&da;
+-         if (compare(dc,ca)) return 1;
+-
+-         if (sizeof(float)!=4) return 1;
+-
+-         ca=(unsigned char*)&fa;
+-         if (compare(fc,ca)) return 1;
+-
+-         return 0;
+-       }" IEEE_LE )
+-
+-    if( "${IEEE_LE}" STREQUAL "" )
+-      set( IEEE_LE 0 CACHE INTERNAL "Test IEEE_LE")
+-    endif()
+-endif()
+-
+-if( ECCODES_LITTLE_ENDIAN AND NOT IEEE_LE )
+-    ecbuild_critical("Failed to sanity check on endiness: OS should be Little-Endian but compiled code runs differently -- to ignore this pass -DIEEE_LE=1 to CMake/ecBuild")
+-endif()
++set( IEEE_BE ${ECCODES_BIG_ENDIAN} )
++set( IEEE_LE ${ECCODES_LITTLE_ENDIAN} )
+diff --git a/src/grib_context.c b/src/grib_context.c
+index 415f9e9..ccc187b 100644
+--- a/src/grib_context.c
++++ b/src/grib_context.c
+@@ -422,7 +422,6 @@ grib_context* grib_context_get_default()
+          * But on Windows a file can be opened in binary or text mode. In binary mode the system behaves exactly as in UNIX.
+          */
+ #ifdef ECCODES_ON_WINDOWS
+-        _set_fmode(_O_BINARY);
+ #endif
+ 
+         default_grib_context.inited                = 1;


### PR DESCRIPTION
I think this works? I had to go in and change the version to 2.17 because I didn't understand that entry in the wizard. It should build on MacOS since conda-forge supports it, but I don't have an Apple computer so the wizard didn't generate that. The sed patch in the script is to knock out where cmake was calling try_run because the ECMWF developers didn't trust the `test_big_endian` function.