### PR TITLE
[FLINT] update to version 2.6.0

### DIFF
--- a/F/FLINT/build_tarballs.jl
+++ b/F/FLINT/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "FLINT"
-version = v"0.0.1"
+version = v"2.6.0"
 
 # Collection of sources required to build FLINT
 sources = [
-    GitSource("https://github.com/wbhart/flint2.git","dd1021a6cbaca75d94e6e066c26a3a5622884a7c")
+    GitSource("https://github.com/wbhart/flint2.git","1d0a2da90620cb8fa1adc79bc5e39e494381afc7")
 ]
 
 # Bash recipe for building across all platforms
@@ -18,11 +18,7 @@ cd flint2/
 if [[ ${target} == *musl* ]]; then
    # because of some ordering issue with pthread.h and sched.h includes
    export CFLAGS=-D_GNU_SOURCE=1
-   # and properly define _GNU_SOURCE here as well to avoid many warnings
-   sed -i -e 's/#define _GNU_SOURCE$/#define _GNU_SOURCE 1/' thread_pool.h configure
 elif [[ ${target} == *mingw* ]]; then
-   # fix arch detection:
-   sed -i -e 's/$(ARCH)/$ARCH/g' configure
    extraflags=--reentrant
 fi
 


### PR DESCRIPTION
Update to new release, remove some workarounds, switch to proper version number now that there is a proper release.