### PR TITLE
[normaliz] update to version 3.8.5

### DIFF
--- a/N/normaliz/build_tarballs.jl
+++ b/N/normaliz/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "normaliz"
-version = v"3.8.4"
+version = v"3.8.5"
 
 # Collection of sources required to build normaliz
 sources = [
     ArchiveSource("https://github.com/Normaliz/Normaliz/releases/download/v$version/normaliz-$version.tar.gz",
-                  "80d21ebaf1a2d472ccdc1e1b2e42b4d71f45f3b8df4d7195ff83edf38f8945c8")
+                  "cf4fdaaa6ffcd8d268b1f16dd4b64cf86f1eab55177e611f8ef672e7365435a0")
 ]
 
 # Bash recipe for building across all platforms
@@ -16,8 +16,6 @@ script = raw"""
 cd normaliz-*
 # avoid libtool problems
 rm "${prefix}/lib/libgmpxx.la"
-# workaround for #624: remove too old libstdc++ from CompilerSupportLibraries
-rm "${libdir}"/libstdc++*
 ./configure --prefix=$prefix --host=$target --build=${MACHTYPE} --with-gmp=$prefix CPPFLAGS=-I$prefix/include LDFLAGS=-L${libdir}
 make -j${nproc}
 make install

--- a/N/normaliz/build_tarballs.jl
+++ b/N/normaliz/build_tarballs.jl
@@ -16,7 +16,7 @@ script = raw"""
 cd normaliz-*
 # avoid libtool problems
 rm "${prefix}/lib/libgmpxx.la"
-./configure --prefix=$prefix --host=$target --build=${MACHTYPE} --with-gmp=$prefix CPPFLAGS=-I$prefix/include LDFLAGS=-L${libdir}
+./configure --prefix=$prefix --host=$target --build=${MACHTYPE} --with-flint=$prefix --with-nauty=$prefix --with-gmp=$prefix CPPFLAGS=-I$prefix/include LDFLAGS=-L${libdir}
 make -j${nproc}
 make install
 """
@@ -37,6 +37,8 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d")),
+    Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82")),
+    Dependency(PackageSpec(name="nauty_jll", uuid="55c6dc9b-343a-50ca-8ff2-b71adb3733d5")),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 


### PR DESCRIPTION
- remove workaround for #624 
- add `FLINT_jll` as dependency
- add `nauty_jll` as dependency