### PR TITLE
 New Recipe: Arb v2.18.0

### DIFF
--- a/A/Arb/build_tarballs.jl
+++ b/A/Arb/build_tarballs.jl
@@ -27,15 +27,18 @@ make install LIBDIR=$(basename ${libdir})
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
-]
+
+platforms = supported_platforms()
+
+#platforms = [
+#    Linux(:i686, libc=:glibc),
+#    Linux(:x86_64, libc=:glibc),
+#    Linux(:aarch64, libc=:glibc),
+#    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
+#    Linux(:powerpc64le, libc=:glibc),
+#    MacOS(:x86_64),
+#    FreeBSD(:x86_64)
+#]
 
 
 # The products that we will ensure are always built

--- a/A/Arb/build_tarballs.jl
+++ b/A/Arb/build_tarballs.jl
@@ -17,7 +17,6 @@ cd arb/
 
 if [[ ${target} == *musl* ]]; then
    export CFLAGS=-D_GNU_SOURCE=1
-   sed -i -e 's/#define _GNU_SOURCE$/#define _GNU_SOURCE 1/' thread_pool.h configure;
 fi
 
 ./configure --prefix=$prefix --disable-static --enable-shared --with-gmp=$prefix --with-mpfr=$prefix --with-flint=$prefix ${extraflags}

--- a/A/Arb/build_tarballs.jl
+++ b/A/Arb/build_tarballs.jl
@@ -1,0 +1,54 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Arb"
+version = v"2.18.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/fredrik-johansson/arb.git", "137f3b5e13e31163634e91f8547aaae7c1ad8c32")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd arb/
+
+if [[ ${target} == *musl* ]]; then
+   export CFLAGS=-D_GNU_SOURCE=1
+   sed -i -e 's/#define _GNU_SOURCE$/#define _GNU_SOURCE 1/' thread_pool.h configure;
+fi
+
+./configure --prefix=$prefix --disable-static --enable-shared --with-gmp=$prefix --with-mpfr=$prefix --with-flint=$prefix ${extraflags}
+make -j${nproc}
+make install LIBDIR=$(basename ${libdir})
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Linux(:i686, libc=:glibc),
+    Linux(:x86_64, libc=:glibc),
+    Linux(:aarch64, libc=:glibc),
+    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
+    Linux(:powerpc64le, libc=:glibc),
+    MacOS(:x86_64),
+    FreeBSD(:x86_64)
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libarb", :libarb)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82"))
+    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/A/Arb/build_tarballs.jl
+++ b/A/Arb/build_tarballs.jl
@@ -34,17 +34,6 @@ make install LIBDIR=$(basename ${libdir})
 
 platforms = supported_platforms()
 
-#platforms = [
-#    Linux(:i686, libc=:glibc),
-#    Linux(:x86_64, libc=:glibc),
-#    Linux(:aarch64, libc=:glibc),
-#    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-#    Linux(:powerpc64le, libc=:glibc),
-#    MacOS(:x86_64),
-#    FreeBSD(:x86_64)
-#]
-
-
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libarb", :libarb)

--- a/A/Arb/build_tarballs.jl
+++ b/A/Arb/build_tarballs.jl
@@ -17,6 +17,11 @@ cd arb/
 
 if [[ ${target} == *musl* ]]; then
    export CFLAGS=-D_GNU_SOURCE=1
+elif [[ ${target} == *mingw* ]]; then
+   # /lib is hardcoded in many places
+   sed -i -e "s#/lib\>#/$(basename ${libdir})#g" configure
+   # MSYS_NT-6.3 is not detected as MINGW
+   extraflags=--build=MINGW${nbits}
 fi
 
 ./configure --prefix=$prefix --disable-static --enable-shared --with-gmp=$prefix --with-mpfr=$prefix --with-flint=$prefix ${extraflags}


### PR DESCRIPTION
This will be failing for a few platforms (I have included the list of platforms for which it worked).

I don't care too much about musl (nor do I know what this is :)). But I do care about Windows!

I think there are two problems for Windows. When linking, he is trying to find libflint.dll in `$prefix/lib/` instead of `$prefix/bin/`. Secondly, it produces `libarb.so` instead of `libarb.dll`.

In my old builder repository, I worked around this "succesfully", see https://github.com/thofma/ArbBuilder/blob/master/build_tarballs.jl

But there is surely a better way. Any hint appreciated @benlorenz 