### PR TITLE
Add CUDNN v7.6.5.

### DIFF
--- a/C/CUDNN/CUDNN_CUDA10.0/build_tarballs.jl
+++ b/C/CUDNN/CUDNN_CUDA10.0/build_tarballs.jl
@@ -1,0 +1,18 @@
+using BinaryBuilder
+
+cuda_version = v"10.0.130"  # NOTE: could be less specific
+
+sources_linux = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/10.0_20191031/cudnn-10.0-linux-x64-v7.6.5.32.tgz",
+                   "28355e395f0b2b93ac2c83b61360b35ba6cd0377e44e78be197b6b61b4b492ba")
+]
+sources_macos = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/10.0_20191031/cudnn-10.0-osx-x64-v7.6.5.32.tgz",
+                  "6fa0b819374da49102e285ecf7fcb8879df4d0b3cc430cc8b781cdeb41009b47")
+]
+sources_windows = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/10.0_20191031/cudnn-10.0-windows10-x64-v7.6.5.32.zip",
+                  "2767db23ae2cd869ac008235e2adab81430f951a92a62160884c80ab5902b9e8")
+]
+
+include("../common.jl")

--- a/C/CUDNN/CUDNN_CUDA10.1/build_tarballs.jl
+++ b/C/CUDNN/CUDNN_CUDA10.1/build_tarballs.jl
@@ -1,0 +1,18 @@
+using BinaryBuilder
+
+cuda_version = v"10.1.243"  # NOTE: could be less specific
+
+sources_linux = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/10.1_20191031/cudnn-10.1-linux-x64-v7.6.5.32.tgz",
+                  "7eaec8039a2c30ab0bc758d303588767693def6bf49b22485a2c00bf2e136cb3")
+]
+sources_macos = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/10.1_20191031/cudnn-10.1-osx-x64-v7.6.5.32.tgz",
+                  "8ecce28a5ed388a2b9b2d239e08d7c550f53b79288e6d9e5eb4c152bfc711aff")
+]
+sources_windows = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/10.1_20191031/cudnn-10.1-windows10-x64-v7.6.5.32.zip",
+                  "5e4275d738cc3a105cf6558b70b8a2ff514989ca1cd17bc8515086e20561a652")
+]
+
+include("../common.jl")

--- a/C/CUDNN/CUDNN_CUDA10.2/build_tarballs.jl
+++ b/C/CUDNN/CUDNN_CUDA10.2/build_tarballs.jl
@@ -1,0 +1,14 @@
+using BinaryBuilder
+
+cuda_version = v"10.2.89"   # NOTE: could be less specific
+
+sources_linux = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/10.2_20191118/cudnn-10.2-linux-x64-v7.6.5.32.tgz",
+                  "600267f2caaed2fd58eb214ba669d8ea35f396a7d19b94822e6b36f9f7088c20")
+]
+sources_windows = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/10.2_20191118/cudnn-10.2-windows10-x64-v7.6.5.32.zip",
+                  "fba812f60c61bc33b81db06cd55e8d769774d036186571d724295c71c9936064")
+]
+
+include("../common.jl")

--- a/C/CUDNN/CUDNN_CUDA9.0/build_tarballs.jl
+++ b/C/CUDNN/CUDNN_CUDA9.0/build_tarballs.jl
@@ -1,0 +1,14 @@
+using BinaryBuilder
+
+cuda_version = v"9.0.176"   # NOTE: could be less specific
+
+sources_linux = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/9.0_20191031/cudnn-9.0-linux-x64-v7.6.5.32.tgz",
+                  "bd0a4c0090d5b02feec3f195738968690cc2470b9bc6026e6fe8ff245cd261c8")
+]
+sources_windows = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/9.0_20191031/cudnn-9.0-windows10-x64-v7.6.5.32.zip",
+                  "c7401514a6d7d24e8541f88c12e4328f165b5c5afd010ee462d356cac2158268")
+]
+
+include("../common.jl")

--- a/C/CUDNN/CUDNN_CUDA9.2/build_tarballs.jl
+++ b/C/CUDNN/CUDNN_CUDA9.2/build_tarballs.jl
@@ -1,0 +1,14 @@
+using BinaryBuilder
+
+cuda_version = v"9.2.148"   # NOTE: could be less specific
+
+sources_linux = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/9.2_20191031/cudnn-9.2-linux-x64-v7.6.5.32.tgz",
+                  "a2a2c7a8ba7b16d323b651766ee37dcfdbc2b50d920f73f8fde85005424960e4")
+]
+sources_windows = [
+    ArchiveSource("https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/9.2_20191031/cudnn-9.2-windows10-x64-v7.6.5.32.zip",
+                  "ffa553df2e9af1703bb7786a784356989dac5c415bf5bca73e52b1789ddd4984")
+]
+
+include("../common.jl")

--- a/C/CUDNN/common.jl
+++ b/C/CUDNN/common.jl
@@ -1,0 +1,57 @@
+include("../../fancy_toys.jl")
+
+version = v"7.6.5"
+
+name = "CUDNN_CUDA$(cuda_version.major).$(cuda_version.minor)"
+
+script = raw"""
+cd ${WORKSPACE}/srcdir
+if [[ ${target} == x86_64-linux-gnu ]]; then
+    cd cuda
+    find .
+
+    install_license NVIDIA_SLA_cuDNN_Support.txt
+
+    mv lib64/libcudnn.so* ${libdir}
+    mv include/* ${prefix}/include
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    cd cuda
+    find .
+
+    install_license NVIDIA_SLA_cuDNN_Support.txt
+
+    mv bin/cudnn64_*.dll ${libdir}
+    mv include/* ${prefix}/include
+elif [[ ${target} == x86_64-apple-darwin* ]]; then
+    cd cuda
+    find .
+
+    install_license NVIDIA_SLA_cuDNN_Support.txt
+
+    mv lib/libcudnn.*dylib ${libdir}
+    mv include/* ${prefix}/include
+fi
+"""
+
+products = [
+    LibraryProduct(["libcudnn", "cudnn64_$(version.major)"], :libcudnn),
+]
+
+dependencies = [Dependency(PackageSpec(name="CUDA_jll", version=cuda_version))]
+
+non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
+
+if @isdefined(sources_linux) && should_build_platform("x86_64-linux-gnu")
+    build_tarballs(non_reg_ARGS, name, version, sources_linux, script,
+                   [Linux(:x86_64)], products, dependencies)
+end
+
+if @isdefined(sources_windows) && should_build_platform("x86_64-w64-mingw32")
+    build_tarballs(ARGS, name, version, sources_windows, script,
+                   [Windows(:x86_64)], products, dependencies)
+end
+
+if @isdefined(sources_macos) && should_build_platform("x86_64-apple-darwin14")
+    build_tarballs(ARGS, name, version, sources_macos, script,
+                   [MacOS(:x86_64)], products, dependencies)
+end


### PR DESCRIPTION
Couple of comments/questions:
- since we can't download the CUDNN tarballs without authenticating, I downloaded and hashed the manually and `scp`d them to @staticfloat's home folder on `arctic3` :trollface:
- lacking a proper mechanism, I created several packages for each combination of CUDA/CUDNN
- the PackageSpec linking CUDNN to CUDA is too strict, e.g. it would suffice to depend on e.g. CUDA v10.1 instead of v10.1.243, but I don't think we have a way of expressing that?