### PR TITLE
[pandoc] Do not use JLL dependencies

### DIFF
--- a/P/pandoc/build_tarballs.jl
+++ b/P/pandoc/build_tarballs.jl
@@ -44,9 +44,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
-	Dependency("Zlib_jll"),
-	Dependency("Libiconv_jll")
+dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Since we are not building the binaries from source, it is better not to use our
own Zlib and Libiconv libraries and just trust that the system ones will work.

Fixes https://github.com/JuliaBinaryWrappers/pandoc_jll.jl/issues/1