### PR TITLE
[libcgal_julia]: Update to v0.10.0, fix libcxxwrap_julia@v0.7.1

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder
 import Pkg: PackageSpec
 
 const name = "libcgal_julia"
-const version = v"0.10.0"
+const version = v"0.10.1"
 
 # Collection of sources required to build CGAL
 const sources = [
     GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "de78b38957e20103f85628374942944bfa19af2b"),
+              "631c98fcfb0305d1bb20e4c23bd539bbb85c4145"),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -14,7 +14,7 @@ const sources = [
 
 # Dependencies that must be installed before this package can be built
 const dependencies = [
-    BuildDependency("Julia_jll"),
+    BuildDependency(PackageSpec(name="Julia_jll", version="v1.4.1")),
 
     Dependency("CGAL_jll"),
     Dependency(PackageSpec(name="libcxxwrap_julia_jll", version=v"0.7.1")),

--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -1,14 +1,15 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
+import Pkg: PackageSpec
 
 const name = "libcgal_julia"
-const version = v"0.9.1"
+const version = v"0.10.0"
 
 # Collection of sources required to build CGAL
 const sources = [
     GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "306c43938205c81d28cccf47eab5a24297dea5ba"),
+              "de78b38957e20103f85628374942944bfa19af2b"),
 ]
 
 # Dependencies that must be installed before this package can be built
@@ -16,7 +17,7 @@ const dependencies = [
     BuildDependency("Julia_jll"),
 
     Dependency("CGAL_jll"),
-    Dependency("libcxxwrap_julia_jll"),
+    Dependency(PackageSpec(name="libcxxwrap_julia_jll", version=v"0.7.1")),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Fixing libcxxwrap_julia@v0.7.1 for now as I ran into a few issues with a newer
version of CxxWrap. For now, releasing a new version with new things, namely:

+ Most of the 2D Polygon package
+ 3/5 of the Principal Component Analysis package
* Few tweaks to a few methods, namely some return types in
  `triangulation_2` and `voronoi_delaunay`