### PR TITLE
GLPK_jll: Add exact dependency for GMP_jll

### DIFF
--- a/G/GLPK/build_tarballs.jl
+++ b/G/GLPK/build_tarballs.jl
@@ -31,9 +31,13 @@ products = [
     LibraryProduct("libglpk", :libglpk)
 ]
 
+GMP_packagespec = PackageSpec(; name = "GMP_jll",
+                              uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d",
+                              version = v"6.1.2")
+
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("GMP_jll")
+    Dependency(GMP_packagespec)
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
A recent tag of GMP_jll broke GLPK: https://github.com/JuliaOpt/GLPK.jl/issues/140

We should probably endeavor to make sure that _all_ jll dependencies have explicit versions.