### PR TITLE
JLL bump: nghttp2_jll

### DIFF
--- a/N/nghttp2/build_tarballs.jl
+++ b/N/nghttp2/build_tarballs.jl
@@ -34,3 +34,4 @@ dependencies = Dependency[]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of nghttp2_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
