### PR TITLE
GMP: add back exception patch

### DIFF
--- a/G/GMP/build_tarballs.jl
+++ b/G/GMP/build_tarballs.jl
@@ -18,6 +18,7 @@ cd $WORKSPACE/srcdir/gmp-*
 
 # Include Julia-carried patches
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/gmp_alloc_overflow_func.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/gmp-exception.patch
 
 flags=(--enable-cxx --enable-shared --disable-static)
 

--- a/G/GMP/bundled/patches/gmp-exception.patch
+++ b/G/GMP/bundled/patches/gmp-exception.patch
@@ -1,0 +1,14 @@
+diff --git a/errno.c b/errno.c
+index b4be555..3f772a5 100644
+--- a/errno.c
++++ b/errno.c
+@@ -68,5 +68,8 @@ __gmp_sqrt_of_negative (void)
+ void
+ __gmp_divide_by_zero (void)
+ {
++  /* try to force a division by zero system exception */
++  __gmp_junk = 10 / __gmp_0;
++
+   __gmp_exception (GMP_ERROR_DIVISION_BY_ZERO);
+ }
+


### PR DESCRIPTION
This PR adds back a new version of the GMP exception patch, in order to match https://github.com/JuliaLang/julia/pull/36343.

Before this PR here is merged, we should make sure that the compat requirement of GMP_jll 6.2, namely `julia >= 1.6`, is preserved; I think if we just merge this, the fix in https://github.com/JuliaRegistries/General/pull/16517 is effectively reverted.

I see two options:
- this PR is merged and then once the JLL is in the registry, immediately a PR similar to https://github.com/JuliaRegistries/General/pull/16517 is merged there
- better of course would be to add a feature to BinaryBuilder that allows specifying a Julia version range / minimal version (see also discussion in https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/511)
