### PR TITLE
[skip build] [Libiconv] Add `libcharset` to products

### DIFF
--- a/L/Libiconv/build_tarballs.jl
+++ b/L/Libiconv/build_tarballs.jl
@@ -22,11 +22,12 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libiconv", :libiconv)
+    LibraryProduct("libcharset", :libcharset),
+    LibraryProduct("libiconv", :libiconv),
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Also, use download information in latest `Artifacts.toml` when only updating the
wrappers without rebuilding the package.