### PR TITLE
JLL bump: Gettext_jll

### DIFF
--- a/G/Gettext/build_tarballs.jl
+++ b/G/Gettext/build_tarballs.jl
@@ -34,3 +34,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Gettext_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
