### PR TITLE
JLL bump: LibCURL_jll

### DIFF
--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -67,4 +67,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of LibCURL_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
