### PR TITLE
JLL bump: OpenSSL_jll

### DIFF
--- a/O/OpenSSL/build_tarballs.jl
+++ b/O/OpenSSL/build_tarballs.jl
@@ -69,4 +69,3 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of OpenSSL_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
