### PR TITLE
JLL bump: PCRE2_jll

### DIFF
--- a/P/PCRE2/build_tarballs.jl
+++ b/P/PCRE2/build_tarballs.jl
@@ -55,4 +55,3 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of PCRE2_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
