### PR TITLE
JLL bump: LibSSH2_jll

### DIFF
--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -48,3 +48,5 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
 
+
+# auto-bump


### PR DESCRIPTION
This pull request bumps the JLL version of LibSSH2_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
