### PR TITLE
JLL bump: XML2_jll

### DIFF
--- a/X/XML2/build_tarballs.jl
+++ b/X/XML2/build_tarballs.jl
@@ -46,3 +46,5 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
 
+
+# auto-bump


### PR DESCRIPTION
This pull request bumps the JLL version of XML2_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
