### PR TITLE
JLL bump: Expat_jll

### DIFF
--- a/E/Expat/build_tarballs.jl
+++ b/E/Expat/build_tarballs.jl
@@ -37,3 +37,5 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
 
+
+# auto-bump


### PR DESCRIPTION
This pull request bumps the JLL version of Expat_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
