### PR TITLE
JLL bump: Git_jll

### DIFF
--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -72,4 +72,3 @@ dependencies = [
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Git_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
