### PR TITLE
Bump MbedTLS to v2.16.6

### DIFF
--- a/M/MbedTLS/build_tarballs.jl
+++ b/M/MbedTLS/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder
 
 name = "MbedTLS"
-version = v"2.16.0"
+version = v"2.16.6"
 
 # Collection of sources required to build MbedTLS
 sources = [
-    "https://github.com/ARMmbed/mbedtls.git" =>
-    "fb1972db23da39bd11d4f9c9ea6266eee665605b",
+    GitSource("https://github.com/ARMmbed/mbedtls.git",
+              "2a1d9332d55d1270084232e42df08fdb08129f1b"),
 ]
 
 # Bash recipe for building across all platforms
@@ -14,9 +14,10 @@ script = raw"""
 cd $WORKSPACE/srcdir/mbedtls
 mkdir -p $prefix/lib
 
-# llvm-ranlib gets confused, use binutils
+# llvm-ranlib gets confused, use the binutils one
 if [[ "${target}" == *apple* ]]; then
     ln -sf /opt/${target}/bin/${target}-ranlib /opt/bin/ranlib
+    ln -sf /opt/${target}/bin/${target}-ranlib /opt/bin/${target}-ranlib
 fi
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" -DUSE_SHARED_MBEDTLS_LIBRARY=On
 make -j${nproc} && make install


### PR DESCRIPTION
We needed to change the `ranlib` symlink to include `${target}-ranlib` as well, since we now set the `RANLIB` environment variable to point to that filename.