### PR TITLE
build libscsindirgpu.so against CUDA_full_jll

### DIFF
--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -43,7 +43,7 @@ platforms = supported_platforms()
 products = [
     LibraryProduct("libscsindir", :libscsindir),
     LibraryProduct("libscsdir", :libscsdir),
-    LibraryProduct("libscsgpuindir", :libscsgpuindir)
+    LibraryProduct("libscsgpuindir", :libscsgpuindir, dont_dlopen=true)
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
the GitSource commit is bumped for easier handling of `CUDA_PATH` and it already includes the fix mentioned in the build script