### PR TITLE
SCS_GPU: build libscsgpuindir against CUDA_full_jll

### DIFF
--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/scs*
 flags="DLONG=0 USE_OPENMP=0 BLAS64=1 BLASSUFFIX=_64_"
-blasldflags="-L${prefix}/lib -lopenblas64_"
+blasldflags="-L${libdir} -lopenblas64_"
 
 CUDA_PATH=$prefix/cuda make BLASLDFLAGS="${blasldflags}" ${flags} out/libscsgpuindir.${dlext}
 

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -2,11 +2,11 @@ using Pkg
 using BinaryBuilder
 
 name = "SCS_GPU"
-version = v"2.1.1"
+version = v"2.1.2"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "e6ab81db115bb37502de0a9917041a0bc2ded313")
+    GitSource("https://github.com/cvxgrp/scs.git", "4ed6c2abf28399c01a0417ff3456b2639560afa6")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -25,8 +25,6 @@ cp out/libscs*.${dlext} ${libdir}
 
 platforms = [
     Linux(:x86_64),
-    Windows(:x86_64),
-    MacOS(:x86_64),
 ]
 
 # The products that we will ensure are always built

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -1,6 +1,6 @@
 using BinaryBuilder
 
-name = "SCS"
+name = "SCS_GPU"
 version = v"2.1.1"
 
 # Collection of sources required to build SCSBuilder

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -1,3 +1,4 @@
+using Pkg
 using BinaryBuilder
 
 name = "SCS_GPU"
@@ -33,9 +34,12 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
+
+cuda_version = v"9.0.176"
+
 dependencies = [
     Dependency("OpenBLAS_jll"),
-    BuildDependency("CUDA_full_jll"),
+    BuildDependency(PackageSpec(name="CUDA_full_jll", version=cuda_version))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -1,0 +1,44 @@
+using BinaryBuilder
+
+name = "SCS"
+version = v"2.1.1"
+
+# Collection of sources required to build SCSBuilder
+sources = [
+    GitSource("https://github.com/cvxgrp/scs.git", "e6ab81db115bb37502de0a9917041a0bc2ded313")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/scs*
+flags="DLONG=0 USE_OPENMP=0 BLAS64=1 BLASSUFFIX=_64_"
+blasldflags="-L${prefix}/lib -lopenblas64_"
+
+CUDA_PATH=$prefix/cuda make BLASLDFLAGS="${blasldflags}" ${flags} out/libscsgpuindir.${dlext}
+
+mkdir -p ${libdir}
+cp out/libscs*.${dlext} ${libdir}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+
+platforms = [
+    Linux(:x86_64),
+    Windows(:x86_64),
+    MacOS(:x86_64),
+]
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libscsgpuindir", :libscsgpuindir, dont_dlopen=true)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("OpenBLAS_jll"),
+    BuildDependency("CUDA_full_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
Builds only `libscsgpuindir` against `CUDA_full_jll`;
this simplified the build script (only the GPU part is built) and I bit the bullet and tested the build locally ;)

this moves #1289 into a separate package following advice of @giordano;

I limited the platforms only to the supported by CUDA; here is the output of `ldd` on BB compiled library:
```
$ ldd ./products/lib/libscsgpuindir.so
        linux-vdso.so.1 (0x00007ffe2eeb9000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f985dc8f000)
        librt.so.1 => /usr/lib/librt.so.1 (0x00007f985dc84000)
        libopenblas64_.so => not found
        libcudart.so.11.0 => not found
        libcublas.so.11 => not found
        libcusparse.so.11 => not found
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f985dabb000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f985e03a000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f985da99000)
```

by comparison this is what I get compiling on an external machine:

```sh
$ ldd ./out/libscsgpuindir.so 
        linux-vdso.so.1 (0x00007ffd3377f000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f4f63b1b000)
        librt.so.1 => /usr/lib/librt.so.1 (0x00007f4f63b10000)
        libopenblas64_.so.0 => not found
        libcudart.so.10.2 => /opt/cuda/lib64/libcudart.so.10.2 (0x00007f4f63892000)
        libcublas.so.10 => /opt/cuda/lib64/libcublas.so.10 (0x00007f4f5f5dc000)
        libcusparse.so.10 => /opt/cuda/lib64/libcusparse.so.10 (0x00007f4f57976000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f4f577ad000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f4f63cbb000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f4f5778b000)
        libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f4f57785000)
        libcublasLt.so.10 => /opt/cuda/lib64/libcublasLt.so.10 (0x00007f4f558f2000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f4f55715000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f4f556fb000)
```

What I understand any CUDA > 9.0 (or maybe even earlier) would do;

@maleadt As I understand what you said in the other thread, witch such compiled SCS_GPU one can still `import SCS_GPU_jll` without `CUDA_jll` etc. What would be the optimal way for discovery CUDA at runtime?

At the moment we do the following: if SCS is compiled from source then possibly add `libscsgpuindir` (`libscsgpu` is the old name):
https://github.com/jump-dev/SCS.jl/blob/672b6711e924ca1af520b48db73da217bb00e6ba/deps/build.jl#L63

Then at _precompile_ time we add it to a `const available_solvers`:
https://github.com/jump-dev/SCS.jl/blob/672b6711e924ca1af520b48db73da217bb00e6ba/src/c_wrapper.jl#L90

Would it be feasible to check for CUDA at `__init__` and populate `available_solvers` there?