### PR TITLE
[libcgal-julia] Update to v0.13

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder
 import Pkg: PackageSpec
 
 const name = "libcgal_julia"
-const version = v"0.12"
+const version = v"0.13"
 
 # Collection of sources required to build CGAL
 const sources = [
     GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "d887f187eb44f6b4030710ebc776c79cd1b3e117"),
+              "2dba797281fad91fa2cd30512dab111ef4ef0fb6"),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
Bit more significant of an update:

* Revise the way kernels are defined, experiment with conversions to
  have different functionality from different kernels to "work
  together".  It's a shoddy approach, but this allows the usage of other
  types and functionality outside the linear kernel.
+ Consequently, add `Circular_arc_2` and `Circular_arc_3` from the
  circular and spherical kernels respectively.
+ Add circular and spherical intersection functions.
* Break global functions sources in terms of the kernel they're from.
* Revise function to collect iterators/circulators into arrays by
  obtaining the respective input's `value_type`.
* Rename and hide a few functions based on chosen constructions type.