### PR TITLE
Add tree-sitter runtime lib.

### DIFF
--- a/T/tree_sitter/build_tarballs.jl
+++ b/T/tree_sitter/build_tarballs.jl
@@ -1,0 +1,46 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter"
+version = v"0.16.9"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter/archive/$(version).tar.gz",
+        "203747f99569120286809a74d30954a8538e8f54fab7bc09ee355f59d27ab972"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+install_license tree-sitter/LICENSE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter", :libtreesitter),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter/bundled/CMakeLists.txt
+++ b/T/tree_sitter/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/lib/include tree-sitter/lib/src)
+add_library(treesitter SHARED tree-sitter/lib/src/lib.c)
+
+install(TARGETS treesitter DESTINATION lib CONFIGURATIONS Release)


### PR DESCRIPTION
Closes #1302. This just builds the runtime library `libtreesitter`. Does not include individual language parsers, I'll add those in a separate PR once this one is done so that parsers can include this in their `dependencies`.