### PR TITLE
tree-sitter parsers

### DIFF
--- a/T/tree_sitter_bash/build_tarballs.jl
+++ b/T/tree_sitter_bash/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_bash"
+version = v"0.16.1"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-bash/archive/v$(version).tar.gz",
+        "5359c81aa6d63057ecd9eea485d1951bb68aae75c1b486c05ec29997259f5161"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_bash", :libtreesitter_bash),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_bash/bundled/CMakeLists.txt
+++ b/T/tree_sitter_bash/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_bash)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_bash SHARED tree-sitter/src/parser.c tree-sitter/src/scanner.cc)
+
+install(TARGETS treesitter_bash DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_c/build_tarballs.jl
+++ b/T/tree_sitter_c/build_tarballs.jl
@@ -3,40 +3,35 @@
 using BinaryBuilder, Pkg
 
 name = "tree_sitter_c"
-version = v"0.16.0"
-
+version = v"0.16.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/tree-sitter/tree-sitter.git", "d8c3f472d23ad79f519651d5cf715b56467d35d0")
-    GitSource("https://github.com/tree-sitter/tree-sitter-c.git", "6002fcd5e86bb1e8670157bb008b97dbaf656d95")
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-c/archive/$(version).tar.gz",
+        "7aa44dd4c3ea1dd24739dec86a95c88f66654c1e52bc8a033925b1f60f4de054"
+    ),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-echo 'cmake_minimum_required(VERSION 3.13)
-project(treesitter)
-set(CMAKE_C_STANDARD 99)
-
-include_directories(tree-sitter/lib/include tree-sitter/lib/src)
-
-add_library(treesitter SHARED tree-sitter/lib/src/lib.c)
-
-include_directories(tree-sitter-c/src)
-add_library(treesitter_c SHARED tree-sitter-c/src/parser.c)
-
-install(TARGETS treesitter_c DESTINATION lib CONFIGURATIONS Release)
-install(TARGETS treesitter DESTINATION lib CONFIGURATIONS Release)' > CMakeLists.txt
+mv tree-sitter-* tree-sitter
 
 BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
 mkdir build && cd build
 cmake .. "${BUILD_FLAGS[@]}"
 make -j${nproc}
 make install
-mkdir ${prefix}/include
-cp ../tree-sitter/lib/include/tree_sitter/api.h ${prefix}/include/
-install_license ../tree-sitter/LICENSE
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
 """
 
 # These are the platforms we will build for by default, unless further
@@ -46,7 +41,6 @@ platforms = supported_platforms()
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libtreesitter_c", :libtreesitter_c),
-    LibraryProduct("libtreesitter", :libtreesitter)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/T/tree_sitter_c/bundled/CMakeLists.txt
+++ b/T/tree_sitter_c/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_c)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_c SHARED tree-sitter/src/parser.c)
+
+install(TARGETS treesitter_c DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_cpp/build_tarballs.jl
+++ b/T/tree_sitter_cpp/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_cpp"
+version = v"0.16.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-cpp/archive/v$(version).tar.gz",
+        "1a744ee94e9c3bcfa9c639d49ab1d4b60ebea9474d88aafa5955cbab0afe4ca6"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_cpp", :libtreesitter_cpp),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_cpp/bundled/CMakeLists.txt
+++ b/T/tree_sitter_cpp/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_cpp)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_cpp SHARED tree-sitter/src/parser.c tree-sitter/src/scanner.cc)
+
+install(TARGETS treesitter_cpp DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_go/build_tarballs.jl
+++ b/T/tree_sitter_go/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_go"
+version = v"0.16.1"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-go/archive/v$(version).tar.gz",
+        "7278f1fd4dc4de8a13b0f60407425d38c5cb3973e1938d3031a68e1e69bd0b75"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+    cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_go", :libtreesitter_go),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_go/bundled/CMakeLists.txt
+++ b/T/tree_sitter_go/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_go)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_go SHARED tree-sitter/src/parser.c)
+
+install(TARGETS treesitter_go DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_html/build_tarballs.jl
+++ b/T/tree_sitter_html/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_html"
+version = v"0.16.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-html/archive/v$(version).tar.gz",
+        "2ddef4999fd1213746d0b16ac4bf54f56983332e0288a795129fd9bb2a4012b4"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_html", :libtreesitter_html),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_html/bundled/CMakeLists.txt
+++ b/T/tree_sitter_html/bundled/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_html)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_html SHARED tree-sitter/src/parser.c tree-sitter/src/scanner.cc)
+add_compile_definitions(UINT8_MAX=0xFF)
+add_compile_definitions(UINT16_MAX=0xFFFF)
+
+install(TARGETS treesitter_html DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_java/build_tarballs.jl
+++ b/T/tree_sitter_java/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_java"
+version = v"0.16.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-java/archive/v$(version).tar.gz",
+        "41af0051be7f9cfb2b85aece37979d1097fddf538b8984fb7726bf1edea4a7ce"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_java", :libtreesitter_java),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_java/bundled/CMakeLists.txt
+++ b/T/tree_sitter_java/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_java)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_java SHARED tree-sitter/src/parser.c)
+
+install(TARGETS treesitter_java DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_javascript/build_tarballs.jl
+++ b/T/tree_sitter_javascript/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_javascript"
+version = v"0.16.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-javascript/archive/v$(version).tar.gz",
+        "6790f58e491f723454d7e508f9fde27f61a5e05cda57b4f75e9f4887c996a534"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+    cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_javascript", :libtreesitter_javascript),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_javascript/bundled/CMakeLists.txt
+++ b/T/tree_sitter_javascript/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_javascript)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_javascript SHARED tree-sitter/src/parser.c tree-sitter/src/scanner.c)
+
+install(TARGETS treesitter_javascript DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_json/build_tarballs.jl
+++ b/T/tree_sitter_json/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_json"
+version = v"0.16.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-json/archive/v$(version).tar.gz",
+        "cbf0fefd2825a2db1770013111f49ec609c4fe090a8909e9780458629c22d1f4"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_json", :libtreesitter_json),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_json/bundled/CMakeLists.txt
+++ b/T/tree_sitter_json/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_json)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_json SHARED tree-sitter/src/parser.c)
+
+install(TARGETS treesitter_json DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_julia/build_tarballs.jl
+++ b/T/tree_sitter_julia/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_julia"
+version = v"0.0.4"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-julia/archive/v$(version).tar.gz",
+        "58e6413cbad3e945f884aa3628305c8258e08807537263911afa6ffca31f03fc"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+    cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_julia", :libtreesitter_julia),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_julia/bundled/CMakeLists.txt
+++ b/T/tree_sitter_julia/bundled/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_julia)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+file(GLOB SOURCE_JULIA tree-sitter/src/*.c)
+add_library(treesitter_julia SHARED ${SOURCE_JULIA})
+
+install(TARGETS treesitter_julia DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_php/build_tarballs.jl
+++ b/T/tree_sitter_php/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_php"
+version = v"0.16.2"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-php/archive/v$(version).tar.gz",
+        "0cb8882348528ae4b86e6673f00fa6725439bb08d8c6d7896dd6a888a58d1c03"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_php", :libtreesitter_php),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_php/bundled/CMakeLists.txt
+++ b/T/tree_sitter_php/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_php)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_php SHARED tree-sitter/src/parser.c tree-sitter/src/scanner.cc)
+
+install(TARGETS treesitter_php DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_python/build_tarballs.jl
+++ b/T/tree_sitter_python/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_python"
+version = v"0.16.1"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-python/archive/v$(version).tar.gz",
+        "b1ccedf10f930042ec2c46335394424634d797c3039e61478612934e81fa943c"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+    cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_python", :libtreesitter_python),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_python/bundled/CMakeLists.txt
+++ b/T/tree_sitter_python/bundled/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_python)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_python SHARED tree-sitter/src/parser.c tree-sitter/src/scanner.cc)
+add_compile_definitions(UINT8_MAX=255)
+
+install(TARGETS treesitter_python DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_ruby/build_tarballs.jl
+++ b/T/tree_sitter_ruby/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_ruby"
+version = v"0.16.2"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-ruby/archive/v$(version).tar.gz",
+        "1a63b43f82837a1194cab997475a22f82bfd820dd32999aa1444cfeae70f7596"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_ruby", :libtreesitter_ruby),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_ruby/bundled/CMakeLists.txt
+++ b/T/tree_sitter_ruby/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_ruby)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_ruby SHARED tree-sitter/src/parser.c tree-sitter/src/scanner.cc)
+
+install(TARGETS treesitter_ruby DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_rust/build_tarballs.jl
+++ b/T/tree_sitter_rust/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_rust"
+version = v"0.16.1"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-rust/archive/v$(version).tar.gz",
+        "8c34f19a9270ee60367ee235226ff1108341f944e0bd245cb47e1c2721f0c39b"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_rust", :libtreesitter_rust),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_rust/bundled/CMakeLists.txt
+++ b/T/tree_sitter_rust/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_rust)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+add_library(treesitter_rust SHARED tree-sitter/src/parser.c tree-sitter/src/scanner.c)
+
+install(TARGETS treesitter_rust DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_typescript/build_tarballs.jl
+++ b/T/tree_sitter_typescript/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_typescript"
+version = v"0.16.2"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/tree-sitter/tree-sitter-typescript/archive/v$(version).tar.gz",
+        "3e1fc16daab965f21dc56a919b32a730e889ea2ba1330af5edc5950f4e6b18b6"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+   cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_typescript", :libtreesitter_typescript),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tree_sitter_typescript/bundled/CMakeLists.txt
+++ b/T/tree_sitter_typescript/bundled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_typescript)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/typescript/src)
+add_library(treesitter_typescript SHARED tree-sitter/typescript/src/parser.c tree-sitter/typescript/src/scanner.c)
+
+install(TARGETS treesitter_typescript DESTINATION lib CONFIGURATIONS Release)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
       EXCLUDED_NAMES=" "
 
       # This is the dynamic mapping we're going to build up, if it's empty we don't do anything
-      PROJECTS_ACCEPTED=""
+      PROJECTS_ACCEPTED=()
       for PROJECT in ${PROJECTS}; do
           NAME=$(basename "${PROJECT}")
           echo "Considering ${PROJECT}"
@@ -83,11 +83,15 @@ jobs:
           fi
 
           # Otherwise, emit a build with `PROJECT` set to `${PROJECT}`
-          echo " --> Accepted!"
-          PROJECTS_ACCEPTED="${PROJECTS_ACCEPTED} ${PROJECT}"
+          if [[ " ${PROJECTS_ACCEPTED[@]} " =~ " ${PROJECT} " ]]; then
+              echo " --> Already in accepted projects, skipping"
+          else
+              echo " --> Accepted!"
+              PROJECTS_ACCEPTED+=("${PROJECT}")
+          fi
       done
-      if [[ -n "${PROJECTS_ACCEPTED}" ]]; then
-          if [[ $(echo "${PROJECTS_ACCEPTED}" | awk '{print NF}') -gt 20 ]]; then
+      if [[ -n "${PROJECTS_ACCEPTED[@]}" ]]; then
+          if [[ ${#PROJECTS_ACCEPTED[@]} -gt 20 ]]; then
               echo "Too many projects requested"
               exit 1
           fi
@@ -100,7 +104,7 @@ jobs:
 
           # Next, for each project, download its sources. We do this by generating meta.json
           # files, then parsing them with `download_sources.jl`
-          for PROJECT in ${PROJECTS_ACCEPTED}; do
+          for PROJECT in "${PROJECTS_ACCEPTED[@]}"; do
               NAME=$(basename ${PROJECT})
 
               # We always invoke a `build_tarballs.jl` file from its own directory
@@ -116,7 +120,7 @@ jobs:
           done
 
           # Emit project variable declarations
-          for PROJECT in ${PROJECTS_ACCEPTED}; do
+          for PROJECT in "${PROJECTS_ACCEPTED[@]}"; do
               NAME=$(basename ${PROJECT})
           done
 
@@ -124,7 +128,7 @@ jobs:
           VAR_PROJECTS="##vso[task.setVariable variable=projects;isOutput=true]{"
           VAR_PROJPLATFORMS="##vso[task.setVariable variable=projplatforms;isOutput=true]{"
           echo "Determining builds to queue..."
-          for PROJECT in ${PROJECTS_ACCEPTED}; do
+          for PROJECT in "${PROJECTS_ACCEPTED[@]}"; do
               NAME=$(basename ${PROJECT})
 
               # "project source hash" is a combination of meta.json (to absorb


### PR DESCRIPTION
Builds the following parsers:

- bash
- c (modifies the current build script, only builds the parser, not the runtime since that's provided by `tree_sitter_jll` now)
- cpp
- go
- html
- java
- javascript
- json
- julia ~~(takes quite a while to build, hopefully this won't time out. If it does then will probably need fixes to the underlying `grammar.js` that generates the c code)~~
- php
- python
- ruby
- rust
- typescript