### PR TITLE
Support windows for mdbtools

### DIFF
--- a/M/mdbtools/build_tarballs.jl
+++ b/M/mdbtools/build_tarballs.jl
@@ -15,11 +15,12 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd mdbtools/
-if [ $target = "x86_64-w64-mingw32" ] || [ $target = "i686-w64-mingw32" ]; then
+if [[ ${target} == *-mingw* ]]; then
     atomic_patch -p1 "${WORKSPACE}/srcdir/patches/locale_header.patch"
+    atomic_patch -p1 "${WORKSPACE}/srcdir/patches/build_shared_libraries_mingw.patch"
 fi
 autoreconf -if
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-man
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-man --enable-shared
 make -j${nproc}
 make install
 """
@@ -40,8 +41,8 @@ products = [
     ExecutableProduct("mdb-header", :mdb_header),
     ExecutableProduct("mdb-export", :mdb_export),
     ExecutableProduct("mdb-hexdump", :mdb_hexdump),
-    # LibraryProduct("libmdbsql", :libmdbsql),
-    # LibraryProduct("libmdb", :libmdb),
+    LibraryProduct("libmdbsql", :libmdbsql),
+    LibraryProduct("libmdb", :libmdb),
     ExecutableProduct("mdb-array", :mdb_array)
 ]
 

--- a/M/mdbtools/build_tarballs.jl
+++ b/M/mdbtools/build_tarballs.jl
@@ -7,13 +7,17 @@ version = v"0.8.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/cyberemissary/mdbtools.git", "b753ff36a0f1d88ae8a300ed6712f4aa2ddb7d08")
+    GitSource("https://github.com/cyberemissary/mdbtools.git", "b753ff36a0f1d88ae8a300ed6712f4aa2ddb7d08"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
 cd mdbtools/
+if [ $target = "x86_64-w64-mingw32" ] || [ $target = "i686-w64-mingw32" ]; then
+    atomic_patch -p1 "${WORKSPACE}/srcdir/patches/locale_header.patch"
+fi
 autoreconf -if
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-man
 make -j${nproc}
@@ -22,7 +26,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(exclude = [Windows(:i686), Windows(:x86_64)])
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
@@ -36,8 +40,8 @@ products = [
     ExecutableProduct("mdb-header", :mdb_header),
     ExecutableProduct("mdb-export", :mdb_export),
     ExecutableProduct("mdb-hexdump", :mdb_hexdump),
-    LibraryProduct("libmdbsql", :libmdbsql),
-    LibraryProduct("libmdb", :libmdb),
+    # LibraryProduct("libmdbsql", :libmdbsql),
+    # LibraryProduct("libmdb", :libmdb),
     ExecutableProduct("mdb-array", :mdb_array)
 ]
 

--- a/M/mdbtools/bundled/patches/build_shared_libraries_mingw.patch
+++ b/M/mdbtools/bundled/patches/build_shared_libraries_mingw.patch
@@ -1,0 +1,24 @@
+diff --git a/src/libmdb/Makefile.am b/src/libmdb/Makefile.am
+index aa823ba..bc2185b 100644
+--- a/src/libmdb/Makefile.am
++++ b/src/libmdb/Makefile.am
+@@ -1,5 +1,5 @@
+ lib_LTLIBRARIES	=	libmdb.la
+ libmdb_la_SOURCES=	catalog.c mem.c file.c table.c data.c dump.c backend.c money.c sargs.c index.c like.c write.c stats.c map.c props.c worktable.c options.c iconv.c
+-libmdb_la_LDFLAGS = -version-info 2:1:0 -export-symbols-regex '^(mdb_|_mdb_put_int16$$|_mdb_put_int32$$)'
++libmdb_la_LDFLAGS = -version-info 2:1:0 -export-symbols-regex '^(mdb_|_mdb_put_int16$$|_mdb_put_int32$$)' -no-undefined
+ AM_CFLAGS	=	-I$(top_srcdir)/include $(GLIB_CFLAGS)
+ LIBS = $(GLIB_LIBS) @LIBS@ @LIBICONV@
+diff --git a/src/sql/Makefile.am b/src/sql/Makefile.am
+index 94b0838..6a95a9a 100644
+--- a/src/sql/Makefile.am
++++ b/src/sql/Makefile.am
+@@ -2,7 +2,7 @@ BUILT_SOURCES = parser.h
+ AM_YFLAGS = -d
+ lib_LTLIBRARIES	=	libmdbsql.la
+ libmdbsql_la_SOURCES=	mdbsql.c parser.y lexer.l 
+-libmdbsql_la_LDFLAGS = -version-info 2:0:0 -export-symbols-regex '^mdb_sql_'
++libmdbsql_la_LDFLAGS = -version-info 2:0:0 -export-symbols-regex '^mdb_sql_' -no-undefined
+ CLEANFILES = parser.c parser.h lexer.c
+ AM_CFLAGS	=	-I$(top_srcdir)/include $(GLIB_CFLAGS)
+ LIBS	=	$(GLIB_LIBS)

--- a/M/mdbtools/bundled/patches/locale_header.patch
+++ b/M/mdbtools/bundled/patches/locale_header.patch
@@ -1,0 +1,15 @@
+diff --git a/src/sql/mdbsql.c b/src/sql/mdbsql.c
+index 6fb792d..da3de6a 100644
+--- a/src/sql/mdbsql.c
++++ b/src/sql/mdbsql.c
+@@ -32,8 +32,9 @@
+ #ifdef HAVE_STRPTIME
+ #include <time.h>
+ #include <stdio.h>
++#endif
++
+ #include <locale.h>
+-#endif
+ 
+ char *g_input_ptr;
+ 


### PR DESCRIPTION
- Add patch for Windows
- Remove LibraryProducts 
    - Windows only has static .a files
    - Most users are probably interested in the binaries

Reference: https://github.com/cyberemissary/mdbtools/issues/18