### PR TITLE
update SCS to 2.1.2

### DIFF
--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -1,11 +1,11 @@
 using BinaryBuilder
 
 name = "SCS"
-version = v"2.1.1"
+version = v"2.1.2"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "d2c1ae92b8c5c6d45406afd007d1ddad74635cfd")
+    GitSource("https://github.com/cvxgrp/scs.git", "4ed6c2abf28399c01a0417ff3456b2639560afa6")
 ]
 
 # Bash recipe for building across all platforms
@@ -20,27 +20,6 @@ if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
 else
     blasldflags+=" -lopenblas"
 fi
-
-# Patch to reverse this WIN64 change: https://github.com/cvxgrp/scs/commit/9858d6b562f499de75493b85286276c19ad84c6f#diff-a9dbab3214616022c64ee2656440f544
-# Looks like it is known that this change causes trouble witn mingw32 (but not for mingw64?):
-# https://github.com/cvxgrp/scs/blob/e6ab81db115bb37502de0a9917041a0bc2ded313/.appveyor.yml#L13-L16
-cd include
-cp glbopts.h glbopts.h.orig
-cat > file.patch <<'END'
---- glbopts.h.orig
-+++ glbopts.h
-@@ -97,7 +97,7 @@
- #ifdef _WIN64
- /* #include <stdint.h> */
- /* typedef int64_t scs_int; */
--typedef long scs_int;
-+typedef __int64 scs_int;
- #else
- typedef long scs_int;
- #endif
-END
-patch -l glbopts.h.orig file.patch -o glbopts.h
-cd ..
 
 make BLASLDFLAGS="${blasldflags}" ${flags} out/libscsdir.${dlext}
 make BLASLDFLAGS="${blasldflags}" ${flags} out/libscsindir.${dlext}


### PR DESCRIPTION
the patch changing the definition of `scs_int` was dropped since it's already included in scs. It defines
```c
typedef int64_t scs_int;
```
instead of (old script):
```c
typedef __int64 scs_int;
```
but I don't know what is the difference; @ViralBShah @juan-pablo-vielma @migarstka