### PR TITLE
update MPFR and make build options explicit

### DIFF
--- a/M/MPFR/build_tarballs.jl
+++ b/M/MPFR/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"4.1.0"
 # Collection of sources required to build MPFR
 sources = [
     "https://www.mpfr.org/mpfr-current/mpfr-$(version).tar.xz" =>
-    "1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a",
+    "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f",
 ]
 
 # Bash recipe for building across all platforms

--- a/M/MPFR/build_tarballs.jl
+++ b/M/MPFR/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "MPFR"
-version = v"4.0.2"
+version = v"4.1.0"
 
 # Collection of sources required to build MPFR
 sources = [
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/mpfr-*
-./configure --prefix=$prefix --host=$target --enable-shared --disable-static --with-gmp=${prefix}
+./configure --prefix=$prefix --host=$target --enable-shared --disable-static --with-gmp=${prefix} --enable-thread-safe --enable-shared-cache --disable-float128 --disable-decimal-float
 make -j${nproc}
 make install
 


### PR DESCRIPTION
These are usually auto-detected, but we want to make them explicit to ensure the builds are consistent.

I'm expecting this may fail on some platforms, as we've noticed regressions in this area (https://github.com/JuliaLang/julia/issues/35796) currently.