### PR TITLE
New recipe: GAP

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -1,0 +1,79 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, BinaryBuilderBase, Pkg
+
+name = "GAP"
+version = v"4.11.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/gap-system/gap.git", "a20c8f40883c8656a240317d732229dbe7c3b5ab"),
+#    ArchiveSource("https://github.com/gap-system/gap/releases/download/v$(version)/gap-$(version)-core.tar.bz2",
+#                  "6637f66409bc91af21eaa38368153270b71b13b55b75cc1550ed867c629901d1"),
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/gap*
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/configure.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/Makefile.patch
+
+# run autogen.sh if compiling from it source and/or if configure was patched
+./autogen.sh
+
+# compile GAP
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
+    --with-gmp=${prefix} \
+    --with-readline=${prefix} \
+    --with-zlib=${prefix} \
+    --with-gc=julia \
+    --with-julia
+make -j${nproc}
+
+# install GAP binaries
+make install-bin install-headers install-libgap
+
+# get rid of the wrapper shell script, which is useless for us
+mv ${WORKSPACE}/destdir/bin/gap.real ${WORKSPACE}/destdir/bin/gap
+
+# install sysinfo.gap but patch out
+mkdir -p ${WORKSPACE}/destdir/share/gap/
+sed -e 's;$PWD;@GAPROOT@;g' sysinfo.gap > ${WORKSPACE}/destdir/share/gap/sysinfo.gap
+
+# We deliberately do NOT install the GAP library, documentation, etc. because
+# they are identical across all platforms; instead, we use another platform
+# independent artifact to ship them to the user.
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# we only care about 64bit builds
+filter!(p -> nbits(p) == 64, platforms)
+
+# Windows is not supported
+filter!(!Sys.iswindows, platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("gap", :gap),
+    LibraryProduct("libgap", :libgap),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("GMP_jll", v"6.1.2"),
+    Dependency("Readline_jll"),
+    Dependency("Zlib_jll"),
+
+    # GAP tries hard to produce a binary that works in all Julia versions,
+    # regardless of which version of Julia it was compiled again; so the
+    # version restriction below could be dropped or changed if necessary
+    BuildDependency(PackageSpec(name="libjulia_jll", version=v"1.4.2")),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7")

--- a/G/GAP/bundled/patches/Makefile.patch
+++ b/G/GAP/bundled/patches/Makefile.patch
@@ -1,0 +1,40 @@
+diff --git a/Makefile.rules b/Makefile.rules
+index 43bce8df9..110172810 100644
+--- a/Makefile.rules
++++ b/Makefile.rules
+@@ -570,7 +570,7 @@ EXTERN_FILES += $(GMP_FILES)
+ gmp: $(GMP_FILES)
+ $(GMP_FILES):
+ 	touch "$(abs_srcdir)/extern/gmp/doc/gmp.info"
+-	MAKE=$(MAKE) $(srcdir)/cnf/build-extern.sh gmp "$(abs_srcdir)/extern/gmp" ABI=$(ABI) --disable-static --enable-shared
++	MAKE=$(MAKE) $(srcdir)/cnf/build-extern.sh gmp "$(abs_srcdir)/extern/gmp" CC=$(CC) CXX=$(CXX) --build=$(build) --host=$(host) ABI=$(ABI) --disable-static --enable-shared
+ 
+ .PHONY: gmp
+ 
+@@ -607,7 +607,7 @@ $(ZLIB_FILES):
+ else
+ 
+ $(ZLIB_FILES):
+-	MAKE=$(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" $(srcdir)/cnf/build-extern.sh zlib "$(abs_srcdir)/extern/zlib"
++	MAKE=$(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" $(srcdir)/cnf/build-extern.sh zlib "$(abs_srcdir)/extern/zlib" CC=$(CC) CXX=$(CXX) --build=$(build) --host=$(host)
+ 
+ endif # SYS_IS_CYGWIN32
+ 
+@@ -640,7 +640,7 @@ EXTERN_FILES += $(LIBATOMIC_OPS_FILES)
+ libatomic_ops: $(LIBATOMIC_OPS_FILES)
+ $(LIBATOMIC_OPS_FILES):
+ 	MAKE=$(MAKE) CC="$(CC)"  \
+-	$(srcdir)/cnf/build-extern.sh libatomic_ops "$(abs_srcdir)/hpcgap/extern/libatomic_ops" --disable-static --enable-shared
++	$(srcdir)/cnf/build-extern.sh libatomic_ops "$(abs_srcdir)/hpcgap/extern/libatomic_ops" CC=$(CC) CXX=$(CXX) --build=$(build) --host=$(host) --disable-static --enable-shared
+ 
+ # TODO: MAKEFLAGS=-j1
+ 
+@@ -681,7 +681,7 @@ $(BOEHM_GC_FILES):
+ 	CC="$(CC)" \
+ 	ATOMIC_OPS_CFLAGS=$(LIBATOMIC_OPS_CPPFLAGS) \
+ 	ATOMIC_OPS_LIBS=$(LIBATOMIC_OPS_LDFLAGS) \
+-	$(srcdir)/cnf/build-extern.sh gc "$(abs_srcdir)/hpcgap/extern/gc" --disable-static --enable-shared --enable-large-config
++	$(srcdir)/cnf/build-extern.sh gc "$(abs_srcdir)/hpcgap/extern/gc" CC=$(CC) CXX=$(CXX) --build=$(build) --host=$(host) --disable-static --enable-shared --enable-large-config
+ 
+ ifeq ($(BUILD_LIBATOMIC_OPS),yes)
+ $(BOEHM_GC_FILES): $(LIBATOMIC_OPS_FILES)

--- a/G/GAP/bundled/patches/configure.patch
+++ b/G/GAP/bundled/patches/configure.patch
@@ -1,0 +1,45 @@
+diff --git a/configure.ac b/configure.ac
+index 0b89a87f9..fd21b1800 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -701,35 +701,20 @@ AS_IF([test "x$with_julia" != xno ],[
+         [ AC_MSG_ERROR([invalid argument to --with-julia]) ] )
+       JULIA_PATH="${PATH}"
+     ])
+-    AC_PATH_PROG([JULIA], [julia], [], [$JULIA_PATH])
++    dnl AC_PATH_PROG([JULIA], [julia], [], [$JULIA_PATH])
+   ])
+-  AS_IF([test "x$JULIA" = x],[ AC_MSG_ERROR([no julia executable found]) ])
+-
+-  JL_SHARE=$($JULIA --startup-file=no -e 'print(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia"))')
+-  AS_IF([test -f "${JL_SHARE}/julia-config.jl"], [], [AC_MSG_ERROR([no julia-config.jl found])])
++  dnl AS_IF([test "x$JULIA" = x],[ AC_MSG_ERROR([no julia executable found]) ])
+ 
+   AC_MSG_CHECKING([for JULIA_CPPFLAGS])
+-  JULIA_CPPFLAGS=$(${JULIA} --startup-file=no ${JL_SHARE}/julia-config.jl --cflags 2>/dev/null)
+-  AS_IF([ test $? != 0 ], [AC_MSG_ERROR([failed to obtain JULIA_CPPFLAGS from julia-config.jl])])
+-  JULIA_CPPFLAGS=${JULIA_CPPFLAGS/-std=gnu99/}  # need to remove -std=gnu99 for our C++ code
+-  # remove apostrophes, they mess up quoting when used in shell code(although
+-  # they are fine inside of Makefiles); this could cause problems if any
+-  # paths involve spaces, but then we likely will haves problem in other
+-  # places; in any case, if anybody ever cares about this, we can work on
+-  # finding a better solution.
+-  JULIA_CPPFLAGS=${JULIA_CPPFLAGS//\'/}
++  JULIA_CPPFLAGS="-I/workspace/destdir/include/julia -fPIC"
+   AC_MSG_RESULT([${JULIA_CPPFLAGS}])
+ 
+   AC_MSG_CHECKING([for JULIA_LDFLAGS])
+-  JULIA_LDFLAGS=$(${JULIA} --startup-file=no ${JL_SHARE}/julia-config.jl --ldflags)
+-  AS_IF([ test $? != 0 ], [AC_MSG_ERROR([failed to obtain JULIA_LDFLAGS from julia-config.jl])])
+-  JULIA_LDFLAGS=${JULIA_LDFLAGS//\'/}
++  JULIA_LDFLAGS="-L/workspace/destdir/lib -L/workspace/destdir/lib/julia"
+   AC_MSG_RESULT([${JULIA_LDFLAGS}])
+ 
+   AC_MSG_CHECKING([for JULIA_LIBS])
+-  JULIA_LIBS=$(${JULIA} --startup-file=no ${JL_SHARE}/julia-config.jl --ldlibs)
+-  AS_IF([ test $? != 0 ], [AC_MSG_ERROR([failed to obtain JULIA_LIBS from julia-config.jl])])
+-  JULIA_LIBS=${JULIA_LIBS//\'/}
++  JULIA_LIBS="-Wl,-rpath,/workspace/destdir/lib -Wl,-rpath,/workspace/destdir/lib/julia -ljulia"
+   AC_MSG_RESULT([${JULIA_LIBS}])
+ ],
+ [


### PR DESCRIPTION
TODO:
- [x] <s>need to make separate versions for Julia 1.3; for 1.4+1.5; and for Julia >= 1.6 (once https://github.com/JuliaLang/julia/pull/36064 is merged)</s> Patch GAP's Julia interface to work around differences in the Julia API/ABI
- [x] add in core GAP packages (GAPDoc, primgrp, ...)
- [x] test the whole thing works as desired
- [x] figure out what (if anything) can or needs to be done about the main GAP executable
- [x] work on adjusting GAP so the patches in here won't be necessary anymore

UPDATE: this is now ready for merging