### PR TITLE
[libcgal-julia] Modularize + target more platforms

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -3,17 +3,22 @@
 using BinaryBuilder
 import Pkg: PackageSpec
 
-const name = "libcgal_julia"
-const version = v"0.14"
+name = "libcgal_julia"
+version = v"0.14"
+
+isyggdrasil = get(ENV, "YGGDRASIL", "") == "true"
+rname = "libcgal-julia"
 
 # Collection of sources required to build CGAL
-const sources = [
-    GitSource("https://github.com/rgcv/libcgal-julia.git",
-              "5a880a6ee33c3e4ecf200bcc4b56ca5d7307db9e"),
+sources = [
+    isyggdrasil ?
+        GitSource("https://github.com/rgcv/$rname.git",
+                  "2e4dbb3fbf94e82960764ce6cbea490fcb46a9cd") :
+        DirectorySource(joinpath(ENV["HOME"], "src/github/rgcv/$rname"))
 ]
 
 # Dependencies that must be installed before this package can be built
-const dependencies = [
+dependencies = [
     BuildDependency(PackageSpec(name="Julia_jll", version="v1.4.1")),
 
     Dependency("CGAL_jll"),
@@ -21,43 +26,55 @@ const dependencies = [
 ]
 
 # Bash recipe for building across all platforms
-const script = raw"""
+jlcgaldir = ifelse(isyggdrasil, rname, ".")
+script = raw"""
 ## pre-build setup
 # exit on error
 set -eu
 
+macosflags=
+case $target in
+  *apple-darwin*)
+    macosflags="-DCMAKE_CXX_COMPILER_ID=AppleClang"
+    macosflags="$macosflags -DCMAKE_CXX_COMPILER_VERSION=10.0.0"
+    macosflags="$macosflags -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT=11"
+    ;;
+esac
+""" * """
 ## configure build
-cmake libcgal-julia*/ -B build \
+cmake $jlcgaldir -B /tmp/build """ * raw"""\
   `# cmake specific` \
-  -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TARGET_TOOLCHAIN" \
+  -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TARGET_TOOLCHAIN \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_FIND_ROOT_PATH="$prefix" \
-  -DCMAKE_INSTALL_PREFIX="$prefix" \
+  -DCMAKE_FIND_ROOT_PATH=$prefix \
+  -DCMAKE_INSTALL_PREFIX=$prefix \
+  $macosflags \
   `# tell jlcxx where julia is` \
-  -DJulia_PREFIX="$prefix"
+  -DJulia_PREFIX=$prefix
 
 ## and away we go..
-VERBOSE=ON cmake --build build --config Release --target install -- -j$nproc
-
-install_license libcgal-julia*/LICENSE
-
-# HACK: Apparently, this isn't a simple build system anymore..
-case $target in
-  *mingw32*) mv "$prefix/lib/"*.dll "$prefix/bin" ;;
-esac
+VERBOSE=ON cmake --build /tmp/build --config Release --target install -- -j$nproc
+""" * """
+install_license $jlcgaldir/LICENSE
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-const platforms = [
-    Linux(:x86_64, libc=:glibc),
-    MacOS(:x86_64),
-    Windows(:x86_64),
-] |> expand_cxxstring_abis
-filter!(p->cxxstring_abi(p) === :cxx11, platforms)
+platforms = [
+    FreeBSD(:x86_64; compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+    Linux(:aarch64; libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+    # generates plentiful warnings about parameter passing ABI changes, better
+    # safe than sorry
+    # Linux(:armv7l; libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+    Linux(:i686; libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+    Linux(:x86_64; libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+    MacOS(:x86_64; compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+    Windows(:i686; compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+    Windows(:x86_64; compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+]
 
 # The products that we will ensure are always built
-const products = [
+products = [
     LibraryProduct("libcgal_julia_exact", :libcgal_julia_exact),
     LibraryProduct("libcgal_julia_inexact", :libcgal_julia_inexact),
 ]


### PR DESCRIPTION
As is, the script can be used locally as well (given the sources are in
the path specified within the script).  armv7l is not being targetted
due to a series of warnings regarding changes in parameter passing ABI
in GCC 7.1.  I'm guessing a dependency is at fault here. Sadly, it isn't
CGAL since I just updated it.  I suspect it's boost, but it's no big
deal.  Better target one less platform than reduce compatibility scope,
I suppose.

I'm not terribly adept when it comes to these lower level c++ compiler
nuances.  I've seen `-Wno-psabi` silences said messages, and if
silencing them is enough, I could go further and add back armv7l.  But
it seems unwise to do so.  Better safe than sorry.