### PR TITLE
[polymake] builder for x86_64 linux and mac os

### DIFF
--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -100,7 +100,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("CompilerSupportLibraries_jll")
-    Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82",version=v"2.6.0"))
+    Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82",version=v"2.6.2"))
     Dependency("GMP_jll")
     Dependency("MPFR_jll")
     Dependency("PPL_jll")

--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -1,0 +1,143 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "polymake"
+version = v"4.1.0"
+
+# Collection of sources required to build polymake
+sources = [
+    GitSource("https://github.com/polymake/polymake.git", "8704ebbba9f8cc2b07f824a283ffed49a8c036be")
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/polymake
+
+perl_version=5.30.3
+
+# to be able to generate a similiar dependency tree at runtime
+# we prepare a symlink tree for all dependencies
+mkdir -p ${prefix}/deps
+for dir in FLINT GMP MPFR PPL Perl bliss boost cddlib lrslib normaliz; do
+   ln -s .. ${prefix}/deps/${dir}_jll
+done
+
+atomic_patch -p1 ../patches/relocatable.patch
+if [[ $target == *darwin* ]]; then
+  # we cannot run configure and instead provide config files
+  mkdir -p build/Opt
+  mkdir -p build/perlx/$perl_version/apple-darwin14
+  cp ../config/config-$target.ninja build/config.ninja
+  cp ../config/build-Opt-$target.ninja build/Opt/build.ninja
+  cp ../config/targets.ninja build/targets.ninja
+  ln -s ../config.ninja build/Opt/config.ninja
+  cp ../config/perlx-config-$target.ninja build/perlx/$perl_version/apple-darwin14/config.ninja
+  # for a modified pure perl JSON module and to make miniperl find the correct modules
+  export PERL5LIB=$prefix/lib/perl5/$perl_version:$prefix/lib/perl5/$perl_version/darwin-2level:$WORKSPACE/srcdir/patches
+  atomic_patch -p1 ../patches/polymake-cross.patch
+  atomic_patch -p1 ../patches/polymake-cross-build.patch
+else
+  ./configure CFLAGS="-Wno-error" CC="$CC" CXX="$CXX" \
+              PERL=${prefix}/deps/Perl_jll/bin/perl LDFLAGS="$LDFLAGS" \
+              --prefix=${prefix} \
+              --with-flint=${prefix}/deps/FLINT_jll \
+              --with-gmp=${prefix}/deps/GMP_jll \
+              --with-mpfr=${prefix}/deps/MPFR_jll \
+              --with-ppl=${prefix}/deps/PPL_jll \
+              --with-bliss=${prefix}/deps/bliss_jll \
+              --with-boost=${prefix}/deps/boost_jll \
+              --with-cdd=${prefix}/deps/cddlib_jll \
+              --with-lrs=${prefix}/deps/lrslib_jll \
+              --with-libnormaliz=${prefix}/deps/normaliz_jll \
+              --without-singular \
+              --without-native
+fi
+
+ninja -v -C build/Opt -j${nproc}
+
+ninja -v -C build/Opt install
+
+# undo patch needed for building
+if [[ $target == *darwin* ]]; then
+  atomic_patch -R -p1 ../patches/polymake-cross-build.patch
+fi
+install -m 444 -D support/*.pl $prefix/share/polymake/support/
+
+# replace miniperl
+sed -i -e "s/miniperl-for-build/perl/" ${libdir}/polymake/config.ninja ${bindir}/polymake*
+# replace binary path with env
+sed -i -e "s#$bindir/perl#/usr/bin/env perl#g" ${libdir}/polymake/config.ninja ${bindir}/polymake*
+# remove target and sysroot
+sed -i -e "s#--sysroot[ =]\S\+##g" ${libdir}/polymake/config.ninja
+sed -i -e "s#-target[ =]\S\+##g" ${libdir}/polymake/config.ninja
+
+# copy of build config that has prefix as a variable
+sed -e "s#${prefix}#\${prefix}#g" ${libdir}/polymake/config.ninja > ${libdir}/polymake/config-reloc.ninja
+
+# cleanup symlink tree
+rm -rf ${prefix}/deps
+
+install_license COPYING
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+ MacOS(:x86_64, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+ Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+]
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libpolymake", :libpolymake; dont_dlopen=true)
+    LibraryProduct("libpolymake-apps-rt", :libpolymake_apps_rt; dont_dlopen=true)
+    ExecutableProduct("polymake", :polymake)
+    ExecutableProduct("polymake-config", Symbol("polymake_config"))
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll")
+    Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82",version=v"2.6.0"))
+    Dependency("GMP_jll")
+    Dependency("MPFR_jll")
+    Dependency("PPL_jll")
+    Dependency(PackageSpec(name="Perl_jll", uuid="83958c19-0796-5285-893e-a1267f8ec499", version=v"5.30.3"))
+    Dependency("bliss_jll")
+    Dependency("boost_jll")
+    Dependency("cddlib_jll")
+    Dependency("lrslib_jll")
+    Dependency("normaliz_jll")
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7", init_block="""
+
+   mutable_artifacts_toml = joinpath(dirname(@__DIR__), "MutableArtifacts.toml")
+   polymake_tree = "polymake_tree"
+   polymake_tree_hash = artifact_hash(polymake_tree, mutable_artifacts_toml)
+
+   # create a directory tree for polymake with links to dependencies
+   # looking similiar to the tree in the build environment
+   # for compiling wrappers at run-time
+   polymake_tree_hash = create_artifact() do art_dir
+      mkpath(joinpath(art_dir,"deps"))
+      for dep in [FLINT_jll, GMP_jll, MPFR_jll, PPL_jll, Perl_jll, bliss_jll, boost_jll, cddlib_jll, lrslib_jll, normaliz_jll]
+         symlink(dep.artifact_dir, joinpath(art_dir,"deps","\$dep"))
+      end
+      for dir in readdir(polymake_jll.artifact_dir)
+         symlink(joinpath(polymake_jll.artifact_dir,dir), joinpath(art_dir,dir))
+      end
+   end
+   bind_artifact!(mutable_artifacts_toml,
+      polymake_tree,
+      polymake_tree_hash;
+      force=true
+   )
+
+   # Point polymake to our custom tree
+   ENV["POLYMAKE_DEPS_TREE"] = artifact_path(polymake_tree_hash)
+""")
+

--- a/P/polymake/bundled/config/build-Opt-x86_64-apple-darwin14.ninja
+++ b/P/polymake/bundled/config/build-Opt-x86_64-apple-darwin14.ninja
@@ -1,0 +1,18 @@
+builddir=/workspace/srcdir/polymake/build
+buildmode=Opt
+buildtop=${builddir}/${buildmode}
+config.file=${builddir}/config.ninja
+include ${config.file}
+perlxpath=perlx/5.30.3/apple-darwin14
+include ${builddir}/${perlxpath}/config.ninja
+include ${root}/support/rules.ninja
+CmodeFLAGS=${COptFLAGS}
+CexternModeFLAGS=${CexternOptFLAGS}
+CmodeCACHE=${COptCACHE}
+LDmodeFLAGS=${LDOptFLAGS}
+
+include ${builddir}/targets.ninja
+
+# should rerun the target generation if any of the included files changes
+build build.ninja: phony | ${config.file} ${builddir}/targets.ninja
+

--- a/P/polymake/bundled/config/config-x86_64-apple-darwin14.ninja
+++ b/P/polymake/bundled/config/config-x86_64-apple-darwin14.ninja
@@ -1,0 +1,66 @@
+# last configured with:
+configure.command=/workspace/srcdir/polymake/configure CXX=clang++ --with-libcxx --with-lrs-include=/workspace/destdir/include/lrslib
+root=/workspace/srcdir/polymake
+core.includes=-I${root}/include/core-wrappers -I${root}/include/core
+app.includes=-I${root}/include/app-wrappers -I${root}/include/apps -I${root}/include/external/permlib -I${root}/include/external/TOSimplex
+
+CC = clang -target x86_64-apple-darwin14 --sysroot /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root
+CXX = clang++ -target x86_64-apple-darwin14 --sysroot /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root
+CFLAGS = -mmacosx-version-min=10.8 -I/workspace/destdir/deps/GMP_jll/include -I/workspace/destdir/deps/MPFR_jll/include
+CXXFLAGS = -stdlib=libc++ -std=c++14 -mmacosx-version-min=10.8 -I/workspace/destdir/deps/GMP_jll/include -I/workspace/destdir/deps/MPFR_jll/include -I/workspace/destdir/deps/boost_jll/include -I/workspace/destdir/deps/FLINT_jll/include -DPOLYMAKE_WITH_FLINT
+ARCHFLAGS = 
+CsharedFLAGS = -fPIC -pipe
+CXXOPT = -O3
+CXXDEBUG = -g
+CXXCOV = --coverage -O1
+CXXSANITIZE = -fno-omit-frame-pointer -O1 -g
+CflagsSuppressWarnings = 
+CLANGversion = 4.0
+CPPStd = 201402
+XcodeVersion = 9.1.0
+LDFLAGS = -mmacosx-version-min=10.8 -L/workspace/destdir/deps/GMP_jll/lib -Wl,-rpath,/workspace/destdir/deps/GMP_jll/lib -L/workspace/destdir/deps/MPFR_jll/lib -Wl,-rpath,/workspace/destdir/deps/MPFR_jll/lib -L/workspace/destdir/deps/FLINT_jll/lib -Wl,-rpath,/workspace/destdir/deps/FLINT_jll/lib -stdlib=libc++
+LDsharedFLAGS = -mmacosx-version-min=10.8 -L/workspace/destdir/lib -Wl,-rpath,/workspace/destdir/lib -dynamiclib -undefined dynamic_lookup -fstack-protector-strong
+LDcallableFLAGS = -mmacosx-version-min=10.8  -L/workspace/destdir/lib -Wl,-rpath,/workspace/destdir/lib -dynamiclib -undefined dynamic_lookup -fstack-protector-strong  -mmacosx-version-min=10.8 -fstack-protector-strong
+LDsonameFLAGS = -install_name /workspace/destdir/lib/
+LIBS =  -lc++ -lflint -lmpfr -lgmp -lpthread
+ExternalHeaders =  permlib TOSimplex
+Arch = darwin.x86_64
+BundledExts = cdd atint bliss flint libnormaliz lrs ppl sympol
+BuildModes = Opt Debug
+InstallTop = /workspace/destdir/share/polymake
+InstallArch = /workspace/destdir/lib/polymake
+InstallBin = /workspace/destdir/bin
+InstallInc = /workspace/destdir/include
+InstallLib = /workspace/destdir/lib
+InstallDoc = /workspace/destdir/share/polymake/doc
+AR = ar
+GMP.version = 6.1.2
+MPFR.version = 4.0.2
+bundled.atint.RequireExtensions=cdd
+bundled.bliss.CXXFLAGS = -I/workspace/destdir/deps/bliss_jll/include
+bundled.bliss.LDFLAGS = -L/workspace/destdir/deps/bliss_jll/lib -Wl,-rpath,/workspace/destdir/deps/bliss_jll/lib
+bundled.bliss.LIBS = -lbliss
+bundled.bliss.RequireExtensions=
+bundled.cdd.UseBundled = 0
+bundled.cdd.CFLAGS = -I/workspace/destdir/deps/cddlib_jll/include/cddlib
+bundled.cdd.LDFLAGS = -L/workspace/destdir/deps/cddlib_jll/lib -Wl,-rpath,/workspace/destdir/deps/cddlib_jll/lib
+bundled.cdd.LIBS = -lcddgmp
+bundled.cdd.RequireExtensions=
+bundled.flint.RequireExtensions=
+bundled.libnormaliz.UseBundled = 0
+bundled.libnormaliz.CXXFLAGS = -I/workspace/destdir/deps/normaliz_jll/include
+bundled.libnormaliz.LDFLAGS = -L/workspace/destdir/deps/normaliz_jll/lib -Wl,-rpath,/workspace/destdir/deps/normaliz_jll/lib
+bundled.libnormaliz.LIBS = -lnormaliz  -lflint -lgmpxx
+bundled.libnormaliz.RequireExtensions=
+bundled.lrs.UseBundled = 0
+bundled.lrs.CFLAGS =  -DHAVE_LRSDRIVER -I/workspace/destdir/deps/lrslib_jll/include/lrslib
+bundled.lrs.LDFLAGS = -L/workspace/destdir/deps/lrslib_jll/lib -Wl,-rpath,/workspace/destdir/deps/lrslib_jll/lib
+bundled.lrs.LIBS = -llrs
+bundled.lrs.RequireExtensions=
+bundled.ppl.CXXFLAGS = -I/workspace/destdir/deps/PPL_jll/include -Wno-class-memaccess
+bundled.ppl.LDFLAGS = -L/workspace/destdir/deps/PPL_jll/lib -Wl,-rpath,/workspace/destdir/deps/PPL_jll/lib
+bundled.ppl.LIBS = -lppl
+bundled.ppl.RequireExtensions=
+bundled.sympol.UseBundled = 1
+bundled.sympol.CXXFLAGS = -I${root}/bundled/sympol/external/sympol -DPOLYMAKE_WITH_PPL
+bundled.sympol.RequireExtensions=lrs cdd ppl

--- a/P/polymake/bundled/config/perlx-config-x86_64-apple-darwin14.ninja
+++ b/P/polymake/bundled/config/perlx-config-x86_64-apple-darwin14.ninja
@@ -1,0 +1,5 @@
+PERL=/workspace/destdir/deps/Perl_jll/bin/miniperl-for-build
+CXXglueFLAGS=-I/workspace/destdir/deps/Perl_jll/lib/perl5/5.30.3/darwin-2level/CORE -fno-common -DPERL_DARWIN -mmacosx-version-min=10.8 -fno-strict-aliasing -pipe -fstack-protector-strong -DPERL_USE_SAFE_PUTENV -I/workspace/destdir/deps/Perl_jll/include -DPerlVersion=5303 -Wno-nonnull
+LIBperlFLAGS=-L/workspace/destdir/deps/Perl_jll/lib/perl5/5.30.3/darwin-2level/CORE -lperl
+ExtUtils_xsubpp=/workspace/destdir/deps/Perl_jll/lib/perl5/5.30.3/ExtUtils/xsubpp
+ExtUtils_typemap=/workspace/destdir/deps/Perl_jll/lib/perl5/5.30.3/ExtUtils/typemap

--- a/P/polymake/bundled/config/targets.ninja
+++ b/P/polymake/bundled/config/targets.ninja
@@ -1,0 +1,2 @@
+build all: phony
+build install: phony

--- a/P/polymake/bundled/patches/JSON/Tiny.pm
+++ b/P/polymake/bundled/patches/JSON/Tiny.pm
@@ -1,0 +1,299 @@
+package JSON::Tiny;
+
+# Minimalistic JSON. Adapted from Mojo::JSON. (c)2012-2015 David Oswald
+# License: Artistic 2.0 license.
+# http://www.perlfoundation.org/artistic_license_2_0
+
+use strict;
+use warnings;
+use Carp 'croak';
+use Exporter 'import';
+#use Scalar::Util 'blessed';
+#use Encode ();
+#use B;
+
+our $VERSION = '0.58';
+our @EXPORT_OK = qw(decode_json encode_json false from_json j to_json true);
+
+# Literal names
+# Users may override Booleans with literal 0 or 1 if desired.
+our($FALSE, $TRUE) = map { bless \(my $dummy = $_), 'JSON::Tiny::_Bool' } 0, 1;
+
+# Escaped special character map with u2028 and u2029
+my %ESCAPE = (
+  '"'     => '"',
+  '\\'    => '\\',
+  '/'     => '/',
+  'b'     => "\x08",
+  'f'     => "\x0c",
+  'n'     => "\x0a",
+  'r'     => "\x0d",
+  't'     => "\x09",
+  'u2028' => "\x{2028}",
+  'u2029' => "\x{2029}"
+);
+my %REVERSE = map { $ESCAPE{$_} => "\\$_" } keys %ESCAPE;
+
+for(0x00 .. 0x1f) {
+  my $packed = pack 'C', $_;
+  $REVERSE{$packed} = sprintf '\u%.4X', $_ unless defined $REVERSE{$packed};
+}
+
+sub decode_json {
+  my $err = _decode(\my $value, shift);
+  return defined $err ? croak $err : $value;
+}
+
+#sub encode_json { Encode::encode 'UTF-8', _encode_value(shift) }
+
+sub false () {$FALSE}  ## no critic (prototypes)
+
+sub from_json {
+  my $err = _decode(\my $value, shift, 1);
+  return defined $err ? croak $err : $value;
+}
+
+sub j {
+  return encode_json $_[0] if ref $_[0] eq 'ARRAY' || ref $_[0] eq 'HASH';
+  return decode_json $_[0];
+}
+
+sub to_json { _encode_value(shift) }
+
+sub true () {$TRUE} ## no critic (prototypes)
+
+sub _decode {
+  my $valueref = shift;
+
+  eval {
+
+    # Missing input
+    die "Missing or empty input\n" unless length( local $_ = shift );
+
+    # UTF-8
+    $_ = eval { Encode::decode('UTF-8', $_, 1) } unless shift;
+    die "Input is not UTF-8 encoded\n" unless defined $_;
+
+    # Value
+    $$valueref = _decode_value();
+
+    # Leftover data
+    return m/\G[\x20\x09\x0a\x0d]*\z/gc || _throw('Unexpected data');
+  } ? return undef : chomp $@;
+
+  return $@;
+}
+
+sub _decode_array {
+  my @array;
+  until (m/\G[\x20\x09\x0a\x0d]*\]/gc) {
+
+    # Value
+    push @array, _decode_value();
+
+    # Separator
+    redo if m/\G[\x20\x09\x0a\x0d]*,/gc;
+
+    # End
+    last if m/\G[\x20\x09\x0a\x0d]*\]/gc;
+
+    # Invalid character
+    _throw('Expected comma or right square bracket while parsing array');
+  }
+
+  return \@array;
+}
+
+sub _decode_object {
+  my %hash;
+  until (m/\G[\x20\x09\x0a\x0d]*\}/gc) {
+
+    # Quote
+    m/\G[\x20\x09\x0a\x0d]*"/gc
+      or _throw('Expected string while parsing object');
+
+    # Key
+    my $key = _decode_string();
+
+    # Colon
+    m/\G[\x20\x09\x0a\x0d]*:/gc
+      or _throw('Expected colon while parsing object');
+
+    # Value
+    $hash{$key} = _decode_value();
+
+    # Separator
+    redo if m/\G[\x20\x09\x0a\x0d]*,/gc;
+
+    # End
+    last if m/\G[\x20\x09\x0a\x0d]*\}/gc;
+
+    # Invalid character
+    _throw('Expected comma or right curly bracket while parsing object');
+  }
+
+  return \%hash;
+}
+
+sub _decode_string {
+  my $pos = pos;
+  
+  # Extract string with escaped characters
+  m!\G((?:(?:[^\x00-\x1f\\"]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4})){0,32766})*)!gc; # segfault on 5.8.x in t/20-mojo-json.t
+  my $str = $1;
+
+  # Invalid character
+  unless (m/\G"/gc) {
+    _throw('Unexpected character or invalid escape while parsing string')
+      if m/\G[\x00-\x1f\\]/;
+    _throw('Unterminated string');
+  }
+
+  # Unescape popular characters
+  if (index($str, '\\u') < 0) {
+    $str =~ s!\\(["\\/bfnrt])!$ESCAPE{$1}!gs;
+    return $str;
+  }
+
+  # Unescape everything else
+  my $buffer = '';
+  while ($str =~ m/\G([^\\]*)\\(?:([^u])|u(.{4}))/gc) {
+    $buffer .= $1;
+
+    # Popular character
+    if ($2) { $buffer .= $ESCAPE{$2} }
+
+    # Escaped
+    else {
+      my $ord = hex $3;
+
+      # Surrogate pair
+      if (($ord & 0xf800) == 0xd800) {
+
+        # High surrogate
+        ($ord & 0xfc00) == 0xd800
+          or pos($_) = $pos + pos($str), _throw('Missing high-surrogate');
+
+        # Low surrogate
+        $str =~ m/\G\\u([Dd][C-Fc-f]..)/gc
+          or pos($_) = $pos + pos($str), _throw('Missing low-surrogate');
+
+        $ord = 0x10000 + ($ord - 0xd800) * 0x400 + (hex($1) - 0xdc00);
+      }
+
+      # Character
+      $buffer .= pack 'U', $ord;
+    }
+  }
+
+  # The rest
+  return $buffer . substr $str, pos $str, length $str;
+}
+
+sub _decode_value {
+
+  # Leading whitespace
+  m/\G[\x20\x09\x0a\x0d]*/gc;
+
+  # String
+  return _decode_string() if m/\G"/gc;
+
+  # Object
+  return _decode_object() if m/\G\{/gc;
+
+  # Array
+  return _decode_array() if m/\G\[/gc;
+
+  # Number
+  my ($i) = /\G([-]?(?:0|[1-9][0-9]*)(?:\.[0-9]*)?(?:[eE][+-]?[0-9]+)?)/gc;
+  return 0 + $i if defined $i;
+
+  # True
+  return $TRUE if m/\Gtrue/gc;
+
+  # False
+  return $FALSE if m/\Gfalse/gc;
+
+  # Null
+  return undef if m/\Gnull/gc;  ## no critic (return)
+
+  # Invalid character
+  _throw('Expected string, array, object, number, boolean or null');
+}
+
+sub _encode_array {
+  '[' . join(',', map { _encode_value($_) } @{$_[0]}) . ']';
+}
+
+sub _encode_object {
+  my $object = shift;
+  my @pairs = map { _encode_string($_) . ':' . _encode_value($object->{$_}) }
+    sort keys %$object;
+  return '{' . join(',', @pairs) . '}';
+}
+
+sub _encode_string {
+  my $str = shift;
+  $str =~ s!([\x00-\x1f\x{2028}\x{2029}\\"/])!$REVERSE{$1}!gs;
+  return "\"$str\"";
+}
+
+sub _encode_value {
+  my $value = shift;
+
+  # Reference
+  if (my $ref = ref $value) {
+
+    # Object
+    return _encode_object($value) if $ref eq 'HASH';
+
+    # Array
+    return _encode_array($value) if $ref eq 'ARRAY';
+
+    # True or false
+    return $$value ? 'true' : 'false' if $ref eq 'SCALAR';
+    return $value  ? 'true' : 'false' if $ref eq 'JSON::Tiny::_Bool';
+
+    # Blessed reference with TO_JSON method
+    if (blessed $value && (my $sub = $value->can('TO_JSON'))) {
+      return _encode_value($value->$sub);
+    }
+  }
+
+  # Null
+  return 'null' unless defined $value;
+
+
+  # Number (bitwise operators change behavior based on the internal value type)
+
+  #  return $value
+  #    if B::svref_2object(\$value)->FLAGS & (B::SVp_IOK | B::SVp_NOK)
+  #    # filter out "upgraded" strings whose numeric form doesn't strictly match
+  #    && 0 + $value eq $value
+  #    # filter out inf and nan
+  #    && $value * 0 == 0;
+
+  # String
+  return _encode_string($value);
+}
+
+sub _throw {
+
+  # Leading whitespace
+  m/\G[\x20\x09\x0a\x0d]*/gc;
+
+  # Context
+  my $context = 'Malformed JSON: ' . shift;
+  if (m/\G\z/gc) { $context .= ' before end of data' }
+  else {
+    my @lines = split "\n", substr($_, 0, pos);
+    $context .= ' at line ' . @lines . ', offset ' . length(pop @lines || '');
+  }
+
+  die "$context\n";
+}
+
+# Emulate boolean type
+package JSON::Tiny::_Bool;
+use overload '""' => sub { ${$_[0]} }, fallback => 1;
+1;

--- a/P/polymake/bundled/patches/polymake-cross-build.patch
+++ b/P/polymake/bundled/patches/polymake-cross-build.patch
@@ -1,0 +1,217 @@
+diff --git a/support/generate_cpperl_modules.pl b/support/generate_cpperl_modules.pl
+index dda9bf7d3c..daf723ecc3 100644
+--- a/support/generate_cpperl_modules.pl
++++ b/support/generate_cpperl_modules.pl
+@@ -20,8 +20,8 @@
+ package Polymake::GenerateCppPerl;
+ 
+ use strict;
+-use JSON;
+-use Fcntl ':flock';
++use JSON::Tiny 'from_json';
++#use Fcntl ':flock';
+ 
+ my $default_chunk_size = 40;
+ my ($temp_module, $ext_config, $allow_report_config_file_dependency);
+@@ -48,8 +48,6 @@ if (@ARGV >= 2) {
+    if (@update) {
+       open my $R, ">>", $gen_rules
+         or die "can't append to $gen_rules: $!\n";
+-      flock $R, LOCK_EX
+-        or die "can't lock $gen_rules: $!\n";
+       print $R "#\@update @update\n";
+    }
+ } else {
+@@ -180,7 +178,8 @@ sub read_def_file {
+    local $/;
+    open my $in, "<:utf8", $def_file
+      or die "can't read definition file $def_file: $!\n";
+-   JSON->new->relaxed->utf8->decode(<$in>);
++   #JSON->new->relaxed->utf8->decode(<$in>);
++   from_json(<$in>);
+ }
+ 
+ sub distinct {
+diff --git a/support/generate_ninja_targets.pl b/support/generate_ninja_targets.pl
+index f084af2a08..24bab37d0f 100644
+--- a/support/generate_ninja_targets.pl
++++ b/support/generate_ninja_targets.pl
+@@ -128,7 +128,7 @@ sub process_app_sources {
+ 
+       my $ignore_sources = delete $custom_flags{IGNORE};
+ 
+-      foreach my $src_file (glob "$app/src/*.{cc,cpp,C}") {
++      foreach my $src_file (glob "$app/src/*.cc") {
+          my ($src_name, $obj_name)=basename($src_file, "(?:cc|cpp|C)");
+          push @all_source_files, $src_file;
+          next if $ignore_sources->{$src_name};
+@@ -161,7 +161,7 @@ build $obj_file : cxxcompile $src_file_in_rules$pre_gen
+          }
+       }
+ 
+-      foreach my $src_file (glob "$cpperl_gen_dir/*.{cc,cpp,C}") {
++      foreach my $src_file (glob "$cpperl_gen_dir/*.cc") {
+          my $src_file_in_rules= $src_file =~ s/^\Q$srcroot\E/$srcrootname/r;
+          if (defined (my $def_file=$cpperl_mods{$src_file_in_rules})) {
+             # cpperl definition exists - check the main C++ module
+@@ -370,7 +370,7 @@ sub generate_targets {
+         or die "can't write to $bundled_flags: $!\n";
+       foreach my $bundled (@bundled_rev) {
+          my @look_in = ($bundled, $ConfigFlags{"bundled.$bundled.RequireExtensions"} =~ /(\S+)/g);
+-         my @includes = glob("$root/bundled/{".join(",", @look_in)."}/include/app*");
++         my @includes= grep { -d $_ } map {glob("$root/bundled/$_/include/app*")} @look_in;
+          s/^\Q$root\E/$srcrootname/ for @includes;
+          print $B "bundled.$bundled.includes=", (map { " -I$_" } @includes), "\n\n";
+       }
+@@ -500,7 +500,7 @@ build install : install_core || all $install_deps
+       my @bundled_config_scripts = map { s/^\Q$root\E/$srcrootname/r } grep { -f }
+                                    map { "$root/bundled/$_/support/configure.pl" } @bundled;
+       print <<"---";
+-build \${config.file}: reconfigure | \${root}/support/configure.pl @bundled_config_scripts
++# build \${config.file}: reconfigure | \${root}/support/configure.pl @bundled_config_scripts
+ ---
+    } else {
+       if (-f "$srcroot/support/rules.ninja") {
+diff --git a/support/install.pl b/support/install.pl
+index 010ea05066..6cd94a0204 100644
+--- a/support/install.pl
++++ b/support/install.pl
+@@ -18,7 +18,7 @@ use strict;
+ use feature 'state';
+ use vars qw( $dirmode $group $permmask $root $ext_root $builddir $config_file %ConfigFlags $buildmode
+              $xsmod @callable @fakelibs );
+-use POSIX qw ( :fcntl_h read write lseek );
++#use POSIX qw ( :fcntl_h read write lseek );
+ use File::Path;
+ use Config;
+ 
+@@ -136,7 +136,7 @@ sub install_core {
+       }
+    }
+ 
+-   foreach my $dir (glob_all_apps("{perllib,rules,scripts}")) {
++   foreach my $dir (map {glob_all_apps($_)} qw(perllib rules scripts)) {
+       copy_dir($dir, $InstallTop.substr($dir, length($root)), clean_dir => 1);
+    }
+ 
+@@ -189,7 +189,7 @@ sub install_core {
+       if (-l $lib_file) {
+          copy_link($lib_file, $to);
+       } else {
+-         copy_file($lib_file, $to, mode => 0555, $^O eq "darwin" ? (lib_id => $to) : ());
++         copy_file($lib_file, $to, mode => 0555, $Config::Config{osname} eq "darwin" ? (lib_id => $to) : ());
+       }
+    }
+    make_dir("$InstallArch/lib", clean_dir => 1);
+@@ -201,7 +201,7 @@ sub install_core {
+    # These symlinks are used by the callable library bootstrap module.
+    # Any change in naming scheme must be reflected in Main.cc as well.
+    rel_symlink($InstallTop, "$InstallArch/shared");
+-   if ($^O eq "darwin" && $ConfigFlags{FinkBase}) {
++   if ($Config::Config{osname} eq "darwin" && $ConfigFlags{FinkBase}) {
+       rel_symlink($ConfigFlags{FinkBase}, "$InstallArch/fink-base");
+    }
+ 
+@@ -215,7 +215,7 @@ sub install_core {
+             copy_link($lib_file, "$InstallLib/$basename");
+          } else {
+             $stub_lib_name //= $to;
+-            copy_file($lib_file, $to, mode => 0555, $^O eq "darwin" ? (lib_id => $stub_lib_name) : ());
++            copy_file($lib_file, $to, mode => 0555, $Config::Config{osname} eq "darwin" ? (lib_id => $stub_lib_name) : ());
+             # This symlink is also used by the callable library bootstrap module.
+             rel_symlink($to, "$InstallLib/$basename");
+          }
+@@ -373,35 +373,37 @@ sub copy {
+    my ($fmode, $mtime) = (stat $from)[2, 9];
+    if (defined $mode) {
+       # verbatim copy: assuming binary file
+-      my $in = POSIX::open $from, O_RDONLY;
+-      defined($in)
+-         or die "$0: can't read $from: $!\n";
+-      my $dummy = O_WRONLY + O_CREAT + O_TRUNC;  # bug in AutoLoader!
+-      my $out;
+-      if ($concat) {
+-         open $out, ">>$to";
+-      } else {
+-         $out = creat $to, 0600;
+-      }
+-      defined($out)
+-         or die "$0: can't create $to: $!\n";
+-
+-      my $trailing_zeroes;
+-      while ((my $size = read $in, $_, 1024) > 0) {
+-         if ($_ eq ($size == 1024 ? $z1024 : pack("x$size"))) {
+-            lseek $out, $size, SEEK_CUR;
+-            $trailing_zeroes = 1;
+-         } else {
+-            write $out, $_, $size;
+-            $trailing_zeroes = 0;
+-         }
+-      }
+-      if ($trailing_zeroes) {
+-         lseek $out, -1, SEEK_CUR;
+-         write $out, "\0", 1;
+-      }
+-      POSIX::close $in;
+-      POSIX::close $out;
++      #my $in = POSIX::open $from, O_RDONLY;
++      #defined($in)
++      #   or die "$0: can't read $from: $!\n";
++      #my $dummy = O_WRONLY + O_CREAT + O_TRUNC;  # bug in AutoLoader!
++      #my $out;
++      #if ($concat) {
++      #   open $out, ">>$to";
++      #} else {
++      #   $out = creat $to, 0600;
++      #}
++      #defined($out)
++      #   or die "$0: can't create $to: $!\n";
++
++      #my $trailing_zeroes;
++      #while ((my $size = read $in, $_, 1024) > 0) {
++      #   if ($_ eq ($size == 1024 ? $z1024 : pack("x$size"))) {
++      #      lseek $out, $size, SEEK_CUR;
++      #      $trailing_zeroes = 1;
++      #   } else {
++      #      write $out, $_, $size;
++      #      $trailing_zeroes = 0;
++      #   }
++      #}
++      #if ($trailing_zeroes) {
++      #   lseek $out, -1, SEEK_CUR;
++      #   write $out, "\0", 1;
++      #}
++      #POSIX::close $in;
++      #POSIX::close $out;
++
++      system("install -m 0600 $from $to");
+ 
+       if (my $lib_id = $options{lib_id}) {
+          substr($lib_id, 0, length($destdir)) = "";
+@@ -545,7 +547,7 @@ sub install_bin_scripts {
+    $_ = <S>;
+    close S;
+ 
+-   if ($^O eq "darwin" && $ConfigFlags{ARCHFLAGS} =~ /-arch /) {
++   if ($Config::Config{osname} eq "darwin" && $ConfigFlags{ARCHFLAGS} =~ /-arch /) {
+       s{^\#!/usr/bin/env perl}{#!/usr/bin/arch $ConfigFlags{ARCHFLAGS} $^X}s;
+    } else {
+       s{^\#!/usr/bin/env perl}{#!$Config::Config{perlpath}}s;
+@@ -557,7 +559,7 @@ sub install_bin_scripts {
+    \$Arch="$ConfigFlags{Arch}";
+    \@BundledExts=qw(@BundledExts);
+ ---
+-   if ($^O eq "darwin" && $ConfigFlags{FinkBase}) {
++   if ($Config::Config{osname} eq "darwin" && $ConfigFlags{FinkBase}) {
+       $init_block.="   \@addlibs=qw($ConfigFlags{FinkBase}/lib/perl5);\n";
+    }
+    s/(^BEGIN\s*\{\s*\n)(?s:.*?)(^\}\n)/$1$init_block$2/m;
+@@ -583,7 +585,7 @@ sub install_bin_scripts {
+    $_ = <S>;
+    close S;
+ 
+-   if ($^O eq "darwin" && $ConfigFlags{ARCHFLAGS} =~ /-arch /) {
++   if ($Config::Config{osname} eq "darwin" && $ConfigFlags{ARCHFLAGS} =~ /-arch /) {
+       s{^\#!\S+}{#!/usr/bin/arch $ConfigFlags{ARCHFLAGS} $^X}s;
+    } else {
+       s{^\#!\S+}{#!$Config::Config{perlpath}}s;

--- a/P/polymake/bundled/patches/polymake-cross.patch
+++ b/P/polymake/bundled/patches/polymake-cross.patch
@@ -1,0 +1,61 @@
+diff --git a/perl/polymake-config b/perl/polymake-config
+index 8990e897d9..23a55ff67a 100644
+--- a/perl/polymake-config
++++ b/perl/polymake-config
+@@ -90,7 +90,7 @@ while (defined ($_=shift)) {
+       my ($major, $minor)=split /\./, $Version;
+       my $version_for_c=sprintf("%d%02d", $major, $minor);
+       $_="-DPOLYMAKE_VERSION=$version_for_c $ConfigFlags{CsharedFLAGS} $ConfigFlags{CXXFLAGS}";
+-      if ($^O eq "darwin") {
++      if ($ConfigFlags{Arch} =~ /^darwin/) {
+          s/\$\{ARCHFLAGS\}/$ConfigFlags{ARCHFLAGS}/;
+       }
+ 
+@@ -160,7 +160,7 @@ while (defined ($_=shift)) {
+          }
+       }
+       close CC;
+-      if ($^O eq "darwin") {
++      if ($ConfigFlags{Arch} =~ /^darwin/) {
+          $ldflags = "$ConfigFlags{ARCHFLAGS} $ldflags -flat_namespace";
+       } else {
+          $ldflags .= " -Wl,-E";
+diff --git a/support/generate_applib_fake.pl b/support/generate_applib_fake.pl
+index 3b6762df05..a671fd1c6b 100644
+--- a/support/generate_applib_fake.pl
++++ b/support/generate_applib_fake.pl
+@@ -21,7 +21,7 @@ use strict;
+ use Config;
+ 
+ my @out;
+-my $nmopts= $^O eq "darwin" ? "-Ugp" : "--defined-only --extern-only -p";
++my $nmopts= $Config::Config{osname} eq "darwin" ? "-Ugp" : "--defined-only --extern-only -p";
+ 
+ for my $shlib (@ARGV) {
+    -r $shlib or die "shared module $shlib does not exist or unreadable\n";
+@@ -36,7 +36,7 @@ for my $shlib (@ARGV) {
+ 
+    while (<SYMS>) {
+       if (/ [TW] ([_ZNK]+$prefix\w+)$/) {
+-	  if ( $^O eq "darwin" ) {    # aliases don't seem to work on MacOS, so we actually define the functions with empty body
++	  if ( $Config::Config{osname} eq "darwin" ) {    # aliases don't seem to work on MacOS, so we actually define the functions with empty body
+ 	      my $functionname = $1;
+ 	      $functionname =~ s/^__/_/;
+ 	      push @out, "void $functionname() {};\n";
+@@ -49,14 +49,14 @@ for my $shlib (@ARGV) {
+ }
+ 
+ if (@out) {
+-   if ($^O eq "darwin") {
++   if ($Config::Config{osname} eq "darwin") {
+       print "#ifndef POLYMAKE_FAKE_FUNCTIONS\n";
+    }
+    print <<'.';
+ void __dummy() __attribute__((visibility ("hidden")));
+ void __dummy() { }
+ .
+-   if ($^O eq "darwin") {
++   if ($Config::Config{osname} eq "darwin") {
+       print "#endif\n";
+    }
+    print "#ifdef POLYMAKE_FAKE_FUNCTIONS\n", @out, "#endif\n";

--- a/P/polymake/bundled/patches/relocatable.patch
+++ b/P/polymake/bundled/patches/relocatable.patch
@@ -1,0 +1,217 @@
+diff --git a/support/configure.pl b/support/configure.pl
+index 616b11224d..e0cfed17cd 100644
+--- a/support/configure.pl
++++ b/support/configure.pl
+@@ -33,6 +33,7 @@ you can specify its location on the command line:
+ use Config;
+ use Cwd;
+ use File::Path;
++use File::Basename qw( dirname );
+ 
+ use strict 'vars', 'subs';
+ use lib "perllib";
+@@ -1710,8 +1711,9 @@ sub write_perl_specific_configuration_file {
+    my $includePerlCore = defined($XcodeVersion) && v_cmp($XcodeVersion, "10.0") >= 0 && $Config::Config{perlpath} eq "/usr/bin/perl" ? "-iwithsysroot " : "-I";
+ 
+    # fedora has ExtUtils::ParseXS in vendorlib
+-   my ($xsubpp) = grep { -e $_ } map { "$Config::Config{$_}/ExtUtils/xsubpp" } qw(privlib vendorlib);
+-   my ($typemap) = grep { -e $_ } map { "$Config::Config{$_}/ExtUtils/typemap" } qw(privlib vendorlib);
++   my $perldir = File::Basename::dirname($^X);
++   my ($xsubpp) = grep { -e $_ } map { s/\.\.\./$perldir/r } map { "$Config::Config{$_}/ExtUtils/xsubpp" } qw(privlib vendorlib);
++   my ($typemap) = grep { -e $_ } map { s/\.\.\./$perldir/r } map { "$Config::Config{$_}/ExtUtils/typemap" } qw(privlib vendorlib);
+ 
+    print $conf <<"---";
+ PERL=$Config::Config{perlpath}
+diff --git a/support/install_utils.pl b/support/install_utils.pl
+index e2950c7062..f5a1b80348 100644
+--- a/support/install_utils.pl
++++ b/support/install_utils.pl
+@@ -44,8 +44,14 @@ sub load_config_file {
+      }
+   }
+   close $cf;
+-  $root eq $values{root}
+-     or die "configuration file $config_file does not match the top directory $root\n";
++  unless ($root eq $values{root}) {
++     (my $newprefix = $root) =~ s#/share/polymake$##;
++     (my $oldprefix = $values{root}) =~ s#/share/polymake$##;
++     warn "configuration file $config_file does not match the top directory $root - adjusting\n";
++     foreach (keys(%values)) {
++        $values{$_} =~ s/$oldprefix/$newprefix/g;
++     }
++  }
+   %values;
+ }
+ 
+diff --git a/support/install.pl b/support/install.pl
+index 010ea05066..7b03cafc14 100644
+--- a/support/install.pl
++++ b/support/install.pl
+@@ -552,8 +552,10 @@ sub install_bin_scripts {
+    }
+ 
+    my $init_block = <<"---";
+-   \$InstallTop='$ConfigFlags{InstallTop}';
+-   \$InstallArch='$ConfigFlags{InstallArch}';
++   use Cwd qw( abs_path );
++   use File::Basename qw( dirname );
++   \$InstallTop=abs_path(dirname(\$0)."/../share/polymake");
++   \$InstallArch=abs_path(dirname(\$0)."/../lib/polymake");
+    \$Arch="$ConfigFlags{Arch}";
+    \@BundledExts=qw(@BundledExts);
+ ---
+@@ -589,9 +591,10 @@ sub install_bin_scripts {
+       s{^\#!\S+}{#!$Config::Config{perlpath}}s;
+    }
+ 
++   s{use strict;}{use strict;\nuse Cwd qw( abs_path );\nuse File::Basename qw( dirname );};
+    s{=Version(?=;)}{=$Version};
+-   s{=InstallTop(?=;)}{='$ConfigFlags{InstallTop}'};
+-   s{=InstallArch(?=;)}{='$ConfigFlags{InstallArch}'};
++   s{=InstallTop(?=;)}{=abs_path(dirname(\$0)."/../share/polymake")};
++   s{=InstallArch(?=;)}{=abs_path(dirname(\$0)."/../lib/polymake")};
+ 
+    if (-e "$InstallBin/polymake-config") {
+       unlink "$InstallBin/polymake-config"
+@@ -641,6 +644,9 @@ sub transform_core_config_file {
+ 
+    s{[ =] -Wl,-z, \K now}{lazy}x;
+ 
++   s{[ =] -target [ =] \S+}{}x;
++   s{[ =] --sysroot [ =] \S+}{}x;
++
+    if ($buildmode eq "San") {
+       s{^\s* PERL \s*= .*\n \K}{PERLSANITIZE = $ConfigFlags{PERLSANITIZE}\n}xm;
+    }
+diff --git a/lib/callable/src/perl/Main.cc b/lib/callable/src/perl/Main.cc
+index 4a11f833bb..c27e284774 100644
+--- a/lib/callable/src/perl/Main.cc
++++ b/lib/callable/src/perl/Main.cc
+@@ -84,6 +84,7 @@ std::string read_rel_link(std::string link, bool mandatory=true)
+       return {};
+    }
+ 
++   do {
+    std::string result(link_stat.st_size+1, '\0');
+    if (readlink(link.c_str(), const_cast<char*>(result.c_str()), link_stat.st_size+1) != link_stat.st_size)
+       throw std::runtime_error("polymake::Main - readlink(" + link + ") failed");
+@@ -101,8 +102,27 @@ std::string read_rel_link(std::string link, bool mandatory=true)
+          throw std::runtime_error("polymake::Main - path " + link + " does not contain enough folder levels");
+       link.erase(slash+1);
+    }
++   link = link+result;
++   } while (lstat(link.c_str(), &link_stat) == 0 && S_ISLNK(link_stat.st_mode));
+ 
+-   return link+result;
++   return link;
++}
++
++std::string find_perl(std::string libperl) {
++   struct stat link_stat;
++   while (lstat(libperl.c_str(), &link_stat) == 0 && S_ISLNK(link_stat.st_mode)) {
++      libperl = read_rel_link(libperl);
++   }
++   auto slash=libperl.rfind('/');
++   libperl.erase(slash+1);
++   // lib is in lib/perl5/<version>/<arch>/CORE:
++   libperl += "../../../../../bin/perl";
++   char perlpath[PATH_MAX];
++   char *res = realpath(libperl.c_str(), perlpath);
++   if (res)
++       return std::string(perlpath);
++   else
++      throw std::runtime_error("polymake::Main - unable to find real path of perl - guessed: " + libperl);
+ }
+ 
+ // Follow symbolic links created by the installation script
+@@ -190,6 +210,8 @@ Main::Main(const std::string& user_opts, std::string install_top, std::string in
+    if (install_top.empty())
+       deduce_install_dirs(dli_polymake.dli_fname, install_top, install_arch);
+ 
++   std::string perl = find_perl(std::string(dli_perl.dli_fname));
++
+    std::string script_arg(scr0);
+    script_arg += install_top;
+    script_arg += scr8InstallTop;
+@@ -206,7 +228,7 @@ Main::Main(const std::string& user_opts, std::string install_top, std::string in
+    script_arg += must_reset_SIGCHLD();
+    script_arg += scr8reset_SIGCHLD;
+ 
+-   const char* perl_start_args[] = { "perl", "-e", script_arg.c_str(), 0 };
++   const char* perl_start_args[] = { perl.c_str(), "-e", script_arg.c_str(), 0 };
+    int argc = sizeof(perl_start_args) / sizeof(perl_start_args[0])-1;
+    const char** argv = perl_start_args;
+    char *** const env = PmGetEnvironPtr;
+diff --git a/perllib/Polymake/Configure.pm b/perllib/Polymake/Configure.pm
+index 4e872f553e..4fb83ad279 100644
+--- a/perllib/Polymake/Configure.pm
++++ b/perllib/Polymake/Configure.pm
+@@ -149,6 +149,8 @@ sub enter_program {
+ sub load_config_vars {
+    return if defined $Arch;
+    return unless -f (my $conf_file="$Polymake::InstallArch/config.ninja");
++   $conf_file = "$Polymake::InstallArch/config-reloc.ninja"
++      if -f "$Polymake::InstallArch/config-reloc.ninja";
+    open my $CF, $conf_file
+      or die "can't read $conf_file: $!\n";
+    local $_;
+@@ -198,7 +200,9 @@ sub create_extension_build_trees {
+    my ($ext, $ext_build_root)=@_;
+    local $BuildModes="$BuildModes $ENV{POLYMAKE_BUILD_MODE}" if index($BuildModes, $ENV{POLYMAKE_BUILD_MODE}) < 0;
+    create_build_trees($Polymake::InstallArch, $ext_build_root,
+-                      include => [ "$Polymake::InstallArch/config.ninja",
++                      include => [ -f "$Polymake::InstallArch/config-reloc.ninja" ?
++                                   "$Polymake::InstallArch/config-reloc.ninja" :
++                                   "$Polymake::InstallArch/config.ninja",
+                                    map { $_->is_bundled ? () : $_->build_dir."/config.ninja" } @{$ext->requires} ],
+                       $Polymake::InstallArch =~ m{/build(\.[^/]+)?/\w+$}
+                       ? (addvars => "PERL=$Config::Config{perlpath}\n") : ());
+diff --git a/perllib/Polymake/Core/CPlusPlusGenerator.pm b/perllib/Polymake/Core/CPlusPlusGenerator.pm
+index 8ba9419499..e9f92f171b 100644
+--- a/perllib/Polymake/Core/CPlusPlusGenerator.pm
++++ b/perllib/Polymake/Core/CPlusPlusGenerator.pm
+@@ -931,12 +931,16 @@ Set the variable $Polymake::User::Verbose::cpp to a positive value and repeat fo
+ ##############################################################################################
+ sub write_temp_build_ninja_file {
+    my ($file, $app, $extension, $src_name, $def_src_dir, $stem, $so_name) = @_;
++
+    open my $conf, ">", $file
+      or die "can't create $file: $!\n";
++   my $configpath = exists $ENV{POLYMAKE_DEPS_TREE} && -f "$InstallArch/config-reloc.ninja" ?
++      "$InstallArch/config-reloc.ninja\nprefix=$ENV{POLYMAKE_DEPS_TREE}" :
++      "$InstallArch/config.ninja";
+    print $conf <<"---";
+-config.file=$InstallArch/config.ninja
++config.file=$configpath
+ include \${config.file}
+-PERL=$Config::Config{perlpath}
++PERL=$^X
+ ---
+    my $cxxflags = "-DPOLYMAKE_APPNAME=".$app->name;
+    my $cxxincludes = '${app.includes} ${core.includes}';
+diff --git a/perllib/Polymake/Core/Extension.pm b/perllib/Polymake/Core/Extension.pm
+index 97c5f662da..174b7becd9 100644
+--- a/perllib/Polymake/Core/Extension.pm
++++ b/perllib/Polymake/Core/Extension.pm
+@@ -474,7 +474,7 @@ For the meanwhile, the extension will stay disabled for architecture $Arch.
+                while (<$bf>) {
+                   # the core system configuration file is included first:
+                   # does it match the current system?
+-                  if (m{^\s*include\s+(\S+)/config.ninja\s*$}) {
++                  if (m{^\s*include\s+(\S+)/config(?:-reloc)?.ninja\s*$}) {
+                      return 1 if $1 eq $InstallArch;
+                      last;
+                   }
+diff --git a/perllib/Polymake/ConfigureStandalone.pm b/perllib/Polymake/ConfigureStandalone.pm
+index 9cf0b7b0a8..1a13040bd6 100644
+--- a/perllib/Polymake/ConfigureStandalone.pm
++++ b/perllib/Polymake/ConfigureStandalone.pm
+@@ -399,6 +399,8 @@ config.file=\${builddir}/config.ninja
+       print $conf <<"---";
+ root.config.file=${$include_list}[0]
+ ---
++      print $conf "prefix=$ENV{POLYMAKE_DEPS_TREE}\n"
++         if length($ENV{POLYMAKE_DEPS_TREE});
+       foreach my $included (@$include_list) {
+          print $conf "include $included\n";
+       }


### PR DESCRIPTION
This is rather involved build recipe for polymake (https://polymake.org) which is needed for Polymake.jl.

The main obstacles are:
  - polymake doesn't really support cross-compilation (it needs to run the correct perl during configuration and build)
  - polymake needs headers and libraries of all dependencies at _runtime_ to compile C++ snippets for template-instantiations for the perl-C++ interface.

Changes for cross compilation:
  - prepared config files for MacOS
  - patches (some are needed only during build)
  - custom JSON module
  - use miniperl during build

Changes for relocatability:
  - extra build configuration file `config-reloc.ninja`
    using prefix as ninja variable (supplied via environment variable variable)
  - remove target + sysroot flags from configuration
  - need directory tree similiar to prefix at run-time to compile C++ wrappers:
    - during build: symlink all dependencies (target `..`) in directory `${prefix}/deps` and use these paths for configuration
    - at runtime: init block creates artifact with a similiar tree with symlinks to artifact locations for all dependencies (e.g. `ln -s $(GMP_jll.artifact_dir) $(artifact_dir)/deps/GMP_jll`)

Platforms:
  - Windows not supported by polymake
  - restricted by `Perl_jll` and we don't have pre-generated config files for other platforms (yet)
  - only MacOS and `x86_64` Linux important for now

This will probably take quite a while to compile.