### PR TITLE
[SDL2_ttf] Do not build with X, add missing runtime dependencies

### DIFF
--- a/S/SDL2_ttf/build_tarballs.jl
+++ b/S/SDL2_ttf/build_tarballs.jl
@@ -7,19 +7,14 @@ version = v"2.0.15"
 
 # Collection of sources required to build SDL2_ttf
 sources = [
-    "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$(version).tar.gz" =>
-    "a9eceb1ad88c1f1545cd7bd28e7cbc0b2c14191d40238f531a15b01b1b22cd33",
-    "./bundled",
+    ArchiveSource("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$(version).tar.gz",
+                  "a9eceb1ad88c1f1545cd7bd28e7cbc0b2c14191d40238f531a15b01b1b22cd33"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/SDL2_ttf-*/
-
-FLAGS=()
-if [[ "${target}" == *-linux-* ]] || [[ "${target}" == *-freebsd* ]]; then
-    FLAGS+=(--with-x)
-fi
 
 atomic_patch -p1 ../patches/configure_in-v2.0.15.patch
 atomic_patch -p1 ../patches/Makefile_in_dont_build_programs.patch
@@ -56,8 +51,15 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "SDL2_jll",
-    "FreeType2_jll",
+    Dependency("SDL2_jll"),
+    Dependency("FreeType2_jll"),
+    # The following libraries aren't needed for the build, but libSDL2_ttf is
+    # dynamically linked to them regardless.
+    Dependency("libpng_jll"),
+    Dependency("HarfBuzz_jll"),
+    Dependency("Graphite2_jll"),
+    Dependency("Glib_jll"),
+    Dependency("PCRE_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This library is apparently dinamically linked to a bunch of libraries even if
they aren't present during the build:
```
% ldd libSDL2_ttf.so
        linux-vdso.so.1 (0x00007fff724ee000)
        libfreetype.so.6 => /usr/lib/libfreetype.so.6 (0x00007f7d7f567000)
        libz.so.1 => /usr/lib/libz.so.1 (0x00007f7d7f54d000)
        libbz2.so.1.0 => /usr/lib/libbz2.so.1.0 (0x00007f7d7f53a000)
        libSDL2-2.0.so.0 => /usr/lib/libSDL2-2.0.so.0 (0x00007f7d7f3be000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f7d7f279000)
        libiconv.so.2 => /usr/lib/libiconv.so.2 (0x00007f7d7f193000)
        libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f7d7f18b000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f7d7f169000)
        librt.so.1 => /usr/lib/librt.so.1 (0x00007f7d7f15e000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f7d7ef97000)
        libpng16.so.16 => /usr/lib/libpng16.so.16 (0x00007f7d7ef60000)
        libharfbuzz.so.0 => /usr/lib/libharfbuzz.so.0 (0x00007f7d7ee91000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f7d7f88f000)
        libgraphite2.so.3 => /usr/lib/libgraphite2.so.3 (0x00007f7d7ee6a000)
        libglib-2.0.so.0 => /usr/lib/libglib-2.0.so.0 (0x00007f7d7ed41000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f7d7ed27000)
        libpcre.so.1 => /usr/lib/libpcre.so.1 (0x00007f7d7ecb5000)
```
Let's add them as dependencies to make sure they're found at runtime.
Additionally, both Archlinux and Debian don't link to X libraries, I guess we
should trust they made a good decision.