### PR TITLE
FFMPEG: Enable nvidia hardware acceleration 

### DIFF
--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -86,6 +86,7 @@ pkg-config --list-all
   --enable-libvpx      \
   --enable-encoders    \
   --enable-nvenc       \
+  --enable-cuda-llvm   \
   --enable-decoders    \
   --enable-muxers      \
   --enable-demuxers    \

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -47,6 +47,14 @@ else
     export ccARCH="x86_64"
 fi
 
+if [[ "${target}" == armv7-* ]]; then
+    export CUDA_ARGS=""
+elif [[ "${target}" == *-apple-* ]]; then
+    export CUDA_ARGS=""
+else
+    export CUDA_ARGS="--enable-nvenc --enable-cuda-llvm"
+fi
+
 pkg-config --list-all
 
 ./configure            \
@@ -85,8 +93,6 @@ pkg-config --list-all
   --enable-libx265     \
   --enable-libvpx      \
   --enable-encoders    \
-  --enable-nvenc       \
-  --enable-cuda-llvm   \
   --enable-decoders    \
   --enable-muxers      \
   --enable-demuxers    \
@@ -94,7 +100,7 @@ pkg-config --list-all
   --enable-openssl     \
   --disable-schannel   \
   --extra-cflags="-I${prefix}/include" \
-  --extra-ldflags="-L${libdir}"
+  --extra-ldflags="-L${libdir}" ${CUDA_ARGS}
 make -j${nproc}
 make install
 install_license LICENSE.md COPYING.*

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 # TODO: Theora once it's available
 script = raw"""
 cd $WORKSPACE/srcdir
-cd ffmpeg-4.1/
+cd ffmpeg-4.3/
 sed -i 's/-lflite"/-lflite -lasound"/' configure
 apk add coreutils yasm
 

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "FFMPEG"
-version = v"4.1.0"
+version = v"4.3.1"
 
 # Collection of sources required to build FFMPEG
 sources = [
     ArchiveSource("https://ffmpeg.org/releases/ffmpeg-$(version.major).$(version.minor).tar.bz2",
-                  "b684fb43244a5c4caae652af9022ed5d85ce15210835bce054a33fb26033a1a5"),
+                  "a7e87112fc49ad5b59e26726e3a7cae0ffae511cba5376c579ba3cb04483d6e2"),
 ]
 
 # Bash recipe for building across all platforms

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -47,9 +47,11 @@ else
     export ccARCH="x86_64"
 fi
 
-if [[ "${target}" == armv7-* ]]; then
+if [[ "${target}" == armv7l-* ]]; then
     export CUDA_ARGS=""
 elif [[ "${target}" == *-apple-* ]]; then
+    export CUDA_ARGS=""
+elif [[ "${target}" == *-unknown-freebsd* ]]; then
     export CUDA_ARGS=""
 else
     export CUDA_ARGS="--enable-nvenc --enable-cuda-llvm"

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -85,6 +85,7 @@ pkg-config --list-all
   --enable-libx265     \
   --enable-libvpx      \
   --enable-encoders    \
+  --enable-nvenc       \
   --enable-decoders    \
   --enable-muxers      \
   --enable-demuxers    \

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -122,7 +122,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 # TODO: Theora once it's available
 dependencies = [
-    Dependency("nv_codec_headers_jll"),
+    BuildDependency("nv_codec_headers_jll"),
     Dependency("libass_jll"),
     Dependency("libfdk_aac_jll"),
     Dependency("FriBidi_jll"),
@@ -141,4 +141,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
-

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -47,7 +47,7 @@ else
     export ccARCH="x86_64"
 fi
 
-if [[ "${target}" == armv7l-* ]]; then
+if [[ "${target}" == arm-* ]]; then
     export CUDA_ARGS=""
 elif [[ "${target}" == *-apple-* ]]; then
     export CUDA_ARGS=""

--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 # TODO: Theora once it's available
 script = raw"""
 cd $WORKSPACE/srcdir
-cd ffmpeg-4.3/
+cd ffmpeg-*/
 sed -i 's/-lflite"/-lflite -lasound"/' configure
 apk add coreutils yasm
 
@@ -122,6 +122,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 # TODO: Theora once it's available
 dependencies = [
+    Dependency("nv_codec_headers_jll"),
     Dependency("libass_jll"),
     Dependency("libfdk_aac_jll"),
     Dependency("FriBidi_jll"),

--- a/X/x264/build_tarballs.jl
+++ b/X/x264/build_tarballs.jl
@@ -3,13 +3,12 @@
 using BinaryBuilder
 
 name = "x264"
-version = v"2020.07.14"
+version = v"2019.05.25"
 
 # Collection of sources required to build x264
 sources = [
-    ArchiveSource("https://code.videolan.org/videolan/x264/-/archive/db0d417728460c647ed4a847222a535b00d3dbcb/x264-db0d417728460c647ed4a847222a535b00d3dbcb.tar.gz",
-                  "b79b7038ce083f152fdd35da2f0d770ac9189fa2319fd09012567bc3a33737af"),
-                  
+    ArchiveSource("https://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20190525-2245-stable.tar.bz2",
+                  "638581a18bff8e9375211955422eff145011c8ccfd0994d43bd194cd82984f7a"),
 ]
 
 # Bash recipe for building across all platforms

--- a/X/x264/build_tarballs.jl
+++ b/X/x264/build_tarballs.jl
@@ -3,12 +3,13 @@
 using BinaryBuilder
 
 name = "x264"
-version = v"2019.05.25"
+version = v"2020.07.14"
 
 # Collection of sources required to build x264
 sources = [
-    ArchiveSource("https://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20190525-2245-stable.tar.bz2",
-                  "638581a18bff8e9375211955422eff145011c8ccfd0994d43bd194cd82984f7a"),
+    ArchiveSource("https://code.videolan.org/videolan/x264/-/archive/db0d417728460c647ed4a847222a535b00d3dbcb/x264-db0d417728460c647ed4a847222a535b00d3dbcb.tar.gz",
+                  "b79b7038ce083f152fdd35da2f0d770ac9189fa2319fd09012567bc3a33737af"),
+                  
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Attempting to enable nvidia hardware acceleration optional functionality, as per https://trac.ffmpeg.org/wiki/HWAccelIntro

```
NVENC can be used for H.264 and HEVC encoding. FFmpeg supports NVENC through the h264_nvenc and hevc_nvenc encoders. In order to enable it in FFmpeg you need:

- A ​supported GPU
- Supported drivers for your operating system
​- The NVIDIA Codec SDK or compiling FFmpeg with --enable-cuda-llvm
- ffmpeg configured with --enable-nvenc (default if the drivers are detected while configuring)
Note: FFmpeg uses its own slightly modified runtime-loader for NVIDIA's CUDA/NVENC/NVDEC-related libraries. 
If you get an error from configure complaining about missing ffnvcodec, ​this project is what you need. It has a 
working Makefile with an install target: make install PREFIX=/usr. FFmpeg will look for its pkg-config file, called 
ffnvcodec.pc. Make sure it is in your PKG_CONFIG_PATH.

This means that running the following before compiling ffmpeg should suffice:

git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
cd nv-codec-headers
make
sudo make install

After compilation, you can use NVENC.

Usage example:

ffmpeg -i input -c:v h264_nvenc -profile high444p -pixel_format yuv444p -preset default output.mp4
You can see available presets, other options, and encoder info with ffmpeg -h encoder=h264_nvenc or ffmpeg -h encoder=hevc_nvenc.

Note: If you get the No NVENC capable devices found error make sure you're encoding to a supported pixel format. See encoder info as shown above.
```