### PR TITLE
JLL bump: LAME_jll

### DIFF
--- a/L/LAME/build_tarballs.jl
+++ b/L/LAME/build_tarballs.jl
@@ -40,3 +40,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of LAME_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
