### PR TITLE
JLL bump: LibVPX_jll

### DIFF
--- a/L/LibVPX/build_tarballs.jl
+++ b/L/LibVPX/build_tarballs.jl
@@ -80,3 +80,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+

--- a/L/LibVPX/build_tarballs.jl
+++ b/L/LibVPX/build_tarballs.jl
@@ -7,8 +7,8 @@ version = v"1.8.1"
 
 # Collection of sources required to build LibVPX
 sources = [
-    "https://github.com/webmproject/libvpx/archive/v$(version).tar.gz" =>
-    "df19b8f24758e90640e1ab228ab4a4676ec3df19d23e4593375e6f3847dee03e",
+    ArchiveSource("https://github.com/webmproject/libvpx/archive/v$(version).tar.gz",
+                  "df19b8f24758e90640e1ab228ab4a4676ec3df19d23e4593375e6f3847dee03e"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This pull request bumps the JLL version of LibVPX_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
