### PR TITLE
JLL bump: FreeType2_jll

### DIFF
--- a/F/FreeType2/build_tarballs.jl
+++ b/F/FreeType2/build_tarballs.jl
@@ -36,3 +36,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+

--- a/F/FreeType2/build_tarballs.jl
+++ b/F/FreeType2/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"2.10.1"
 # Collection of sources required to build FreeType2
 sources = [
     ArchiveSource("https://download.savannah.gnu.org/releases/freetype/freetype-$(version).tar.gz",
-               "3a60d391fd579440561bf0e7f31af2222bc610ad6ce4d9d7bd2165bca8669110")
+                  "3a60d391fd579440561bf0e7f31af2222bc610ad6ce4d9d7bd2165bca8669110")
 ]
 
 # Bash recipe for building across all platforms
@@ -30,8 +30,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "Bzip2_jll",
-    "Zlib_jll",
+    Dependency("Bzip2_jll"),
+    Dependency("Zlib_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This pull request bumps the JLL version of FreeType2_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
