### PR TITLE
JLL bump: Bzip2_jll

### DIFF
--- a/B/Bzip2/build_tarballs.jl
+++ b/B/Bzip2/build_tarballs.jl
@@ -6,8 +6,8 @@ version = v"1.0.6"
 
 # Collection of sources required to build bzip2
 sources = [
-    "https://github.com/enthought/bzip2-1.0.6.git" =>
-    "288acf97a15d558f96c24c89f578b724d6e06b0c"
+    GitSource("https://github.com/enthought/bzip2-1.0.6.git",
+              "288acf97a15d558f96c24c89f578b724d6e06b0c"),
 ]
 
 # Bash recipe for building across all platforms

--- a/B/Bzip2/build_tarballs.jl
+++ b/B/Bzip2/build_tarballs.jl
@@ -75,3 +75,4 @@ dependencies = [
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Bzip2_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
