### PR TITLE
JLL bump: libfdk_aac_jll

### DIFF
--- a/L/libfdk_aac/build_tarballs.jl
+++ b/L/libfdk_aac/build_tarballs.jl
@@ -35,3 +35,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of libfdk_aac_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
