### PR TITLE
JLL bump: FFMPEG

### DIFF
--- a/F/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/build_tarballs.jl
@@ -138,4 +138,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
-


### PR DESCRIPTION
This pull request bumps the JLL version of FFMPEG.
It was generated via the `recursively_regenerate_jlls.jl` script.
