### PR TITLE
[CGAL] Update to v5.0.3

### DIFF
--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -3,13 +3,12 @@
 using BinaryBuilder
 
 name    = "CGAL"
-version = v"5.0.2"
-
+version = v"5.0.3"
 
 # Collection of sources required to build CGAL
 sources = [
     ArchiveSource("https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-$version/CGAL-$version.tar.xz",
-                  "bb3594ba390735404f0972ece301f369b1ff12646ad25e48056b4d49c976e1fa"),
+                  "e5a3672e35e5e92e3c1b4452cd3c1d554f3177dc512bd98b29edf21866a4288c"),
 ]
 
 # Dependencies that must be installed before this package can be built
@@ -26,33 +25,33 @@ script = raw"""
 # exit on error
 set -eu
 
-## configure build
-cmake CGAL*/ -B build \
+cmake -B build \
   `# cmake specific` \
-  -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TARGET_TOOLCHAIN"\
+  -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TARGET_TOOLCHAIN \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX="$prefix" \
-  -DCMAKE_FIND_ROOT_PATH="$prefix" \
+  -DCMAKE_INSTALL_PREFIX=$prefix \
+  -DCMAKE_FIND_ROOT_PATH=$prefix \
   `# cgal specific` \
   -DCGAL_HEADER_ONLY=OFF \
   -DWITH_CGAL_Core=ON \
   -DWITH_CGAL_ImageIO=ON \
-  -DWITH_CGAL_Qt5=OFF
+  -DWITH_CGAL_Qt5=OFF \
+  CGAL-*/
 
 ## and away we go..
 cmake --build build --config Release --target install -- -j$nproc
-install_license CGAL*/LICENSE*
+install_license CGAL-*/LICENSE*
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-const platforms = expand_cxxstring_abis(supported_platforms())
+platforms = expand_cxxstring_abis(supported_platforms())
 # The products that we will ensure are always built
-const products = [
+products = [
     LibraryProduct("libCGAL", :libCGAL),
     LibraryProduct("libCGAL_Core", :libCGAL_Core),
     LibraryProduct("libCGAL_ImageIO", :libCGAL_ImageIO),
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7")


### PR DESCRIPTION
[Bug fix release](https://github.com/CGAL/cgal/releases/tag/releases%2FCGAL-5.0.3)

Preferred minimal GCC version ~~is now~~ already was 7. Misread
a diff. Figures, I should be sleeping.

Includes some touches to the buildscript itself, but very minimal.