### PR TITLE
Fix MozillaCACerts version number

### DIFF
--- a/M/MozillaCACerts/build_tarballs.jl
+++ b/M/MozillaCACerts/build_tarballs.jl
@@ -5,7 +5,7 @@ using BinaryBuilder
 name = "MozillaCACerts"
 # Info and new versions here: https://curl.haxx.se/docs/caextract.html
 cacert_version = "2020-07-22"
-version = VersionNumber(replace(cacert_version, '_'=>'.'))
+version = VersionNumber(replace(cacert_version, '-'=>'.'))
 
 # Collection of sources required to build MozillaCACerts
 sources = [


### PR DESCRIPTION
Without this, the version number is an unholy union of versioning schemes, things like `2020.0.0-07-22+0`

@aviks can you verify that this fix is good?