### PR TITLE
Add Amazon root certificate to AmazonCACerts

### DIFF
--- a/A/AmazonCACerts/build_tarballs.jl
+++ b/A/AmazonCACerts/build_tarballs.jl
@@ -1,28 +1,40 @@
 # This script downloads and bundles CA certificates from Amazon Web Services (AWS).
-# Right now only the RDS root certificate is included, but more could be added in the future.
+# Currently this makes the following three .pem files available:
+# - Amazon root certificate: to use SSL/TLS with various AWS services, including serverless RDS
+# - RDS root certificate: to use SSL/TLS with non-serverless RDS (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)
+# - A combined .pem file of the two certificates above, to make it easier to use SSL/TLS with either serverless or non-serverless RDS
 
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 
 name = "AmazonCACerts"
-# Info here: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
-certificate_version = "2019"
-certificate_filename = "rds-ca-$certificate_version-root.pem"
-tarball_version = VersionNumber(certificate_version)
+
+amazon_root_certificate_filename = "AmazonRootCA1.pem"
+rds_root_certificate_version = "2019"
+rds_root_certificate_filename = "rds-ca-$rds_root_certificate_version-root.pem"
+combined_root_certificates_filename = "combined-amazon-root-ca.pem"
+
+tarball_version = VersionNumber("$rds_root_certificate_version.1")
 
 # Collection of sources required to build AmazonCACerts
 sources = [
-    FileSource("https://s3.amazonaws.com/rds-downloads/$certificate_filename",
+    FileSource("https://www.amazontrust.com/repository/$amazon_root_certificate_filename",
+    "2c43952ee9e000ff2acc4e2ed0897c0a72ad5fa72c3d934e81741cbd54f05bd1",
+    filename="$amazon_root_certificate_filename"),
+
+    FileSource("https://s3.amazonaws.com/rds-downloads/$rds_root_certificate_filename",
     "d464378fbb8b981d2b28a1deafffd0113554e6adfb34535134f411bf3c689e73",
-    filename="$certificate_filename")
+    filename="$rds_root_certificate_filename")
 ]
 
 # Bash recipe for building across all platforms
 script = """
 cd \$WORKSPACE/srcdir/
 mkdir -p \$prefix/share
-cp $certificate_filename \$prefix/share/$certificate_filename
+cp $amazon_root_certificate_filename \$prefix/share/$amazon_root_certificate_filename
+cp $rds_root_certificate_filename \$prefix/share/$rds_root_certificate_filename
+cat $rds_root_certificate_filename $amazon_root_certificate_filename > \$prefix/share/$combined_root_certificates_filename
 """
 
 # These are the platforms we will build for by default, unless further
@@ -31,7 +43,9 @@ platforms = [AnyPlatform()]
 
 # The products that we will ensure are always built
 products = [
-    FileProduct("share/$certificate_filename", :rds_ca_root_certificate)
+    FileProduct("share/$amazon_root_certificate_filename", :amazon_ca_root_certificate),
+    FileProduct("share/$rds_root_certificate_filename", :rds_ca_root_certificate),
+    FileProduct("share/$combined_root_certificates_filename", :combined_ca_root_certificates),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
Adding the AmazonRootCA1.pem root certificate (taken from https://www.amazontrust.com/repository/), which can be used e.g. to connect to a serverless RDS database.

Also combining this certificate with the RDS root certificate that was already there, so as to make it easier to use SSL/TLS with either serverless or non-serverless RDS.