### PR TITLE
Add local-regeneration to `recursively_regenerate_jlls.jl`

### DIFF
--- a/recursively_regenerate_jlls.jl
+++ b/recursively_regenerate_jlls.jl
@@ -130,7 +130,7 @@ function open_jll_bump_pr(dep_name::String)
     fork = BinaryBuilder.GitHub.create_fork("JuliaPackaging/Yggdrasil"; auth=gh_auth)
 
     mktempdir() do tmp
-        repo = LibGit2.clone(BinaryBuilder.get_yggdrasil(), tmp)
+        repo = LibGit2.clone(BinaryBuilder.Wizard.get_yggdrasil(), tmp)
         build_tarballs = build_tarballs_path(dep_name, tmp)
         if !isfile(build_tarballs)
             throw(ArgumentError("Invalid dep_name \"$(dep_name)\", no file $(build_tarballs)"))

--- a/recursively_regenerate_jlls.jl
+++ b/recursively_regenerate_jlls.jl
@@ -126,7 +126,7 @@ end
 # This borrows heavily from BinaryBuilder.yggdrasil_deploy()
 function open_jll_bump_pr(dep_name::String)
     @info("Opening JLL-bumping PR for $(dep_name)")
-    gh_auth = BinaryBuilder.github_auth(;allow_anonymous=false)
+    gh_auth = BinaryBuilder.Wizard.github_auth(;allow_anonymous=false)
     fork = BinaryBuilder.GitHub.create_fork("JuliaPackaging/Yggdrasil"; auth=gh_auth)
 
     mktempdir() do tmp


### PR DESCRIPTION
This allows us to easily generate a bunch of JLLs locally, to experiment
with alternate JLL generation techniques