### PR TITLE
[Arb] update build_tarballs.jl

### DIFF
--- a/A/Arb/build_tarballs.jl
+++ b/A/Arb/build_tarballs.jl
@@ -43,7 +43,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82", version=v"2.6.2"))
+    Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82"))
     Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
     Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
 ]


### PR DESCRIPTION
This removes an explicit version for one of the dependencies. It was not needed and is doing more harm than good (sorry!).

If we merge this, will the `Arb_jll` julia package have the corrected compat entry? Or do I need to adjust the Registry manually?