### PR TITLE
Add hsamkt_roct (ROCT-Thunk-Interface)

### DIFF
--- a/H/hsakmt_roct/build_tarballs.jl
+++ b/H/hsakmt_roct/build_tarballs.jl
@@ -2,15 +2,13 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 
-name = "ROCT-Thunk-Interface"
+name = "hsakmt_roct"
 version = v"3.5.0"
 
 # Collection of sources required to build ROCT-Thunk-Interface
 sources = [
-    GitSource("https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface.git",
-              "d4b224fafc82decdf3210b68ae763a1f345bf3a1"),
-#    ArchiveSource("https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/archive/rocm-$(version).tar.gz",
-#                  "d9f458c16cb62c3c611328fd2f2ba3615da81e45f3b526e45ff43ab4a67ee4aa")
+    ArchiveSource("https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/archive/rocm-$(version).tar.gz",
+                  "d9f458c16cb62c3c611328fd2f2ba3615da81e45f3b526e45ff43ab4a67ee4aa")
 ]
 
 # Bash recipe for building across all platforms

--- a/H/hsakmt_roct/build_tarballs.jl
+++ b/H/hsakmt_roct/build_tarballs.jl
@@ -39,7 +39,6 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-# This is really a build dependency
 dependencies = [
     Dependency("NUMA_jll"),
 ]

--- a/R/ROCT-Thunk-Interface/build_tarballs.jl
+++ b/R/ROCT-Thunk-Interface/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "ROCT-Thunk-Interface"
+version = v"3.5.0"
+
+# Collection of sources required to build ROCT-Thunk-Interface
+sources = [
+    GitSource("https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface.git",
+              "d4b224fafc82decdf3210b68ae763a1f345bf3a1"),
+#    ArchiveSource("https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/archive/rocm-$(version).tar.gz",
+#                  "d9f458c16cb62c3c611328fd2f2ba3615da81e45f3b526e45ff43ab4a67ee4aa")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/ROCT-Thunk-Interface*/
+
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_C_FLAGS="-Dstatic_assert=_Static_assert" \
+      ..
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+# ROCT-Thunk-Interface only supports Linux
+platforms = [
+    Linux(:x86_64, libc=:glibc),
+]
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct(["libhsakmt"], :libhsakmt),
+]
+
+# Dependencies that must be installed before this package can be built
+# This is really a build dependency
+dependencies = [
+    Dependency("NUMA_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies,
+               preferred_gcc_version=v"8") 


### PR DESCRIPTION
Working on getting all the ROC* stuff for AMDGPU.

Questions remain
1. Should I pick GitSource or ArchiveSource?
2. What the heck to be call this library? I've seen it be referred to:
ROCT, ROCT-Thunk-Interface, hsakmt, rocm, roc, hsakmt-roc, hsakmt-rocm, hsakmt-roct, ROCT-Thunk-Interface-roc, ROCT-Thunk-Interface-rocm, HSARuntime 
