### PR TITLE
[Mesa] Add builder for Mesa

### DIFF
--- a/M/Mesa/build_tarballs.jl
+++ b/M/Mesa/build_tarballs.jl
@@ -1,0 +1,43 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Mesa"
+version = v"20.1.5"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("ftp://ftp.freedesktop.org/pub/mesa/mesa-$version.tar.xz", "fac1861e6e0bf1aec893f8d86dbfb9d8a0f426ff06b05256df10e3ad7e02c69b"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+mkdir build
+cd build
+apk add py3-mako
+meson -D b_ndebug=true -D buildtype=release -D strip=true -D llvm=false ../mesa* --cross-file="${MESON_TARGET_TOOLCHAIN}"
+ninja -j${nproc}
+ninja install
+mv $prefix/bin/opengl32.dll $prefix/bin/opengl32sw.dll
+install_license ../mesa*/docs/license.html
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Windows(:x86_64),
+    Windows(:i686)
+]
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("opengl32sw", :opengl32sw; dont_dlopen=true)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+  Dependency("Zlib_jll")
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This builds opengl32sw.dll as required by #1330. Note that it can't be a `LibraryProduct` since the loading of the DLL is determined by Qt's internal OpenGL version checking. We need the path in the `FileProduct` so it can be added to the `PATH` before launching a Qt OpenGL application, which will then dlopen `opengl32sw.dll` if no compatible OpenGL driver is installed (requires Qt built with `-opengl dynamic`). Unfortunately the relative path `"opengl32sw.dll"` is hard-coded into the Qt source code, so there is no way to supply this path to Qt other than updating `PATH`.

This build takes the easy route, omitting the faster LLVM driver, which I couldn't get to build. This is a minor issue, since even though the LLVM variant is a lot faster than the standard software driver, it is still a poor substitute for proper hardware OpenGL.