### PR TITLE
Update to ROCT 3.7.0 which fixes missing headers

### DIFF
--- a/H/hsakmt_roct/build_tarballs.jl
+++ b/H/hsakmt_roct/build_tarballs.jl
@@ -27,11 +27,10 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-# ROCT-Thunk-Interface only supports Linux
+# ROCT-Thunk-Interface only supports Linux, seemingly only 64bit
 platforms = [
     Linux(:x86_64, libc=:glibc),
 ]
-platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/H/hsakmt_roct/build_tarballs.jl
+++ b/H/hsakmt_roct/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "hsakmt_roct"
-version = v"3.5.0"
+version = v"3.7.0"
 
 # Collection of sources required to build ROCT-Thunk-Interface
 sources = [
     ArchiveSource("https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/archive/rocm-$(version).tar.gz",
-                  "d9f458c16cb62c3c611328fd2f2ba3615da81e45f3b526e45ff43ab4a67ee4aa")
+                  "b357fe7f425996c49f41748923ded1a140933de7564a70a828ed6ded6d896458")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Only when i tried to work on ROC runtime i realized that the headers were missing in the 3.5.0 build i submitted yesterday. 

Fortunately, the newest release (which also just arrived yesterday) just fixed their flawed cmake files, so, now everything is included as it should be.