### PR TITLE
[polymake] minor improvements for relocatability

### DIFF
--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -40,7 +40,8 @@ if [[ $target == *darwin* ]]; then
   atomic_patch -p1 ../patches/polymake-cross-build.patch
 else
   ./configure CFLAGS="-Wno-error" CC="$CC" CXX="$CXX" \
-              PERL=${prefix}/deps/Perl_jll/bin/perl LDFLAGS="$LDFLAGS" \
+              PERL=${prefix}/deps/Perl_jll/bin/perl \
+              LDFLAGS="$LDFLAGS -L${prefix}/deps/Perl_jll/lib -Wl,-rpath,${prefix}/deps/Perl_jll/lib" \
               --prefix=${prefix} \
               --with-flint=${prefix}/deps/FLINT_jll \
               --with-gmp=${prefix}/deps/GMP_jll \

--- a/P/polymake/bundled/patches/relocatable.patch
+++ b/P/polymake/bundled/patches/relocatable.patch
@@ -68,8 +68,8 @@ index 010ea05066..7b03cafc14 100644
     s{=Version(?=;)}{=$Version};
 -   s{=InstallTop(?=;)}{='$ConfigFlags{InstallTop}'};
 -   s{=InstallArch(?=;)}{='$ConfigFlags{InstallArch}'};
-+   s{=InstallTop(?=;)}{=abs_path(dirname(\$0)."/../share/polymake")};
-+   s{=InstallArch(?=;)}{=abs_path(dirname(\$0)."/../lib/polymake")};
++   s{=InstallTop(?=;)}{=dirname(\$0)."/../share/polymake"};
++   s{=InstallArch(?=;)}{=dirname(\$0)."/../lib/polymake"};
  
     if (-e "$InstallBin/polymake-config") {
        unlink "$InstallBin/polymake-config"


### PR DESCRIPTION
These changes are only needed when building `libpolymake_julia` outside of BinaryBuilder using `polymake_jll` as an artifact, e.g. for our development workflow and tests.