### PR TITLE
[Qhull] Add libqhull LibraryProduct

### DIFF
--- a/Q/Qhull/build_tarballs.jl
+++ b/Q/Qhull/build_tarballs.jl
@@ -55,6 +55,7 @@ products = [
     # Libraries
     # reentrant Qhull
     LibraryProduct(["libqhull_r", "qhull_r"], :libqhull_r),
+    LibraryProduct(["libqhull", "qhull"], :libqhull),
     
     # Files
     # Reentrant Qhull header files


### PR DESCRIPTION
This also adds the non-rentrant version of the library as a product, as needed by GR.

Edit: I don't know what loading both the reentrant and normal libs at the same time will do to the other clients of this JLL, so some caution is advised.