### PR TITLE
add ffplay

### DIFF
--- a/F/FFPLAY/build_tarballs.jl
+++ b/F/FFPLAY/build_tarballs.jl
@@ -1,0 +1,147 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+# TODO: replace *building* ffmpeg with a dependency on `FFMPEG_jll`
+
+name = "FFPLAY"
+version = v"4.1.0"
+
+# Collection of sources required to build FFPLAY
+sources = [
+    ArchiveSource("https://ffmpeg.org/releases/ffmpeg-$(version.major).$(version.minor).tar.bz2",
+                  "b684fb43244a5c4caae652af9022ed5d85ce15210835bce054a33fb26033a1a5"),
+]
+
+# Bash recipe for building across all platforms
+# TODO: Theora once it's available
+script = raw"""
+cd $WORKSPACE/srcdir
+cd ffmpeg-4.1/
+sed -i 's/-lflite"/-lflite -lasound"/' configure
+apk add coreutils yasm
+
+if [[ "${target}" == *-linux-* ]]; then
+    export ccOS="linux"
+elif [[ "${target}" == *-apple-* ]]; then
+    export ccOS="darwin"
+elif [[ "${target}" == *-w32-* ]]; then
+    export ccOS="mingw32"
+elif [[ "${target}" == *-w64-* ]]; then
+    export ccOS="mingw64"
+elif [[ "${target}" == *-unknown-freebsd* ]]; then
+    export ccOS="freebsd"
+else
+    export ccOS="linux"
+fi
+
+if [[ "${target}" == x86_64-* ]]; then
+    export ccARCH="x86_64"
+elif [[ "${target}" == i686-* ]]; then
+    export ccARCH="i686"
+elif [[ "${target}" == arm-* ]]; then
+    export ccARCH="arm"
+elif [[ "${target}" == aarch64-* ]]; then
+    export ccARCH="aarch64"
+elif [[ "${target}" == powerpc64le-* ]]; then
+    export ccARCH="powerpc64le"
+else
+    export ccARCH="x86_64"
+fi
+
+pkg-config --list-all
+
+./configure            \
+  --enable-cross-compile \
+  --cross-prefix=/opt/${target}/bin/${target}- \
+  --arch=${ccARCH}     \
+  --target-os=${ccOS}  \
+  --cc="${CC}"         \
+  --cxx="${CXX}"       \
+  --dep-cc="${CC}"     \
+  --ar=ar              \
+  --nm=nm              \
+  --objcc="${OBJC}"    \
+  --sysinclude=${prefix}/include \
+  --pkg-config=$(which pkg-config) \
+  --pkg-config-flags=--static \
+  --prefix=$prefix     \
+  --sysroot=/opt/${target}/${target}/sys-root \
+  --extra-libs=-lpthread \
+  --enable-gpl         \
+  --enable-version3    \
+  --enable-nonfree     \
+  --disable-static     \
+  --enable-shared      \
+  --enable-pic         \
+  --disable-debug      \
+  --disable-doc        \
+  --enable-avresample  \
+  --enable-libass      \
+  --enable-libfdk-aac  \
+  --enable-libfreetype \
+  --enable-libmp3lame  \
+  --enable-libopus     \
+  --enable-libvorbis   \
+  --enable-libx264     \
+  --enable-libx265     \
+  --enable-libvpx      \
+  --enable-encoders    \
+  --enable-decoders    \
+  --enable-muxers      \
+  --enable-demuxers    \
+  --enable-parsers     \
+  --enable-openssl     \
+  --disable-schannel   \
+  --extra-cflags="-I${prefix}/include" \
+  --extra-ldflags="-L${libdir}" \
+  --enable-ffplay
+make -j${nproc}
+make install
+install_license LICENSE.md COPYING.*
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("ffmpeg", :ffmpeg),
+    ExecutableProduct("ffprobe", :ffprobe),
+    ExecutableProduct("ffplay", :ffplay),
+    LibraryProduct(["libavcodec", "avcodec"], :libavcodec),
+    LibraryProduct(["libavdevice", "avdevice"], :libavdevice),
+    LibraryProduct(["libavfilter", "avfilter"], :libavfilter),
+    LibraryProduct(["libavformat", "avformat"], :libavformat),
+    LibraryProduct(["libavresample", "avresample"], :libavresample),
+    LibraryProduct(["libavutil", "avutil"], :libavutil),
+    LibraryProduct(["libpostproc", "postproc"], :libpostproc),
+    LibraryProduct(["libswresample", "swresample"], :libswresample),
+    LibraryProduct(["libswscale", "swscale"], :libswscale),
+]
+
+# Dependencies that must be installed before this package can be built
+# TODO: Theora once it's available
+dependencies = [
+    Dependency("libass_jll"),
+    Dependency("libfdk_aac_jll"),
+    Dependency("FriBidi_jll"),
+    Dependency("FreeType2_jll"),
+    Dependency("LAME_jll"),
+    Dependency("libvorbis_jll"),
+    Dependency("Ogg_jll"),
+    Dependency("LibVPX_jll"),
+    Dependency("x264_jll"),
+    Dependency("x265_jll"),
+    Dependency("Bzip2_jll"),
+    Dependency("Zlib_jll"),
+    Dependency("OpenSSL_jll"),
+    Dependency("Opus_jll"),
+    Dependency("SDL2_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+
+

--- a/F/FFPLAY/build_tarballs.jl
+++ b/F/FFPLAY/build_tarballs.jl
@@ -9,8 +9,7 @@ version = v"4.1.0"
 
 # Collection of sources required to build FFPLAY
 sources = [
-    ArchiveSource("https://ffmpeg.org/releases/ffmpeg-$(version.major).$(version.minor).tar.bz2",
-                  "b684fb43244a5c4caae652af9022ed5d85ce15210835bce054a33fb26033a1a5"),
+    ArchiveSource("https://github.com/yakir12/FFmpeg/archive/n$version.tar.gz", "b513e8646cd99d7982b6c23783b1948cfa5ef73f00c7ab5615dd8f70ca971b0c"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This is suboptimal since it rebuilds ffmpeg instead of relying on the existing FFMPEG_jll. But currently there is no way to build ffplay using an existing ffmpeg installation. This should be addressed (I added a TODO to the file and will add an issue as well).