### PR TITLE
Add `alsa` as a dependency for `SDL2`

### DIFF
--- a/S/SDL2/build_tarballs.jl
+++ b/S/SDL2/build_tarballs.jl
@@ -50,6 +50,7 @@ dependencies = [
     Dependency("Xorg_libXrandr_jll"),
     Dependency("Xorg_libXScrnSaver_jll"),
     Dependency("Libglvnd_jll"),
+    Dependency("alsa_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
SDL2 needs to link against some kind of backing sound library to output on Linux; let's use `alsa` for that.

X-ref: https://github.com/JuliaPackaging/Yggdrasil/issues/1432