### PR TITLE
JLL bump: Zlib_jll

### DIFF
--- a/Z/Zlib/build_tarballs.jl
+++ b/Z/Zlib/build_tarballs.jl
@@ -40,4 +40,3 @@ dependencies = Dependency[
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Zlib_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
