### PR TITLE
JLL bump: hicolor_icon_theme_jll

### DIFF
--- a/H/hicolor_icon_theme/build_tarballs.jl
+++ b/H/hicolor_icon_theme/build_tarballs.jl
@@ -34,3 +34,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of hicolor_icon_theme_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
