### PR TITLE
JLL bump: PCRE_jll

### DIFF
--- a/P/PCRE/build_tarballs.jl
+++ b/P/PCRE/build_tarballs.jl
@@ -32,4 +32,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of PCRE_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
