### PR TITLE
JLL bump: Xorg_kbproto_jll

### DIFF
--- a/X/Xorg_kbproto/build_tarballs.jl
+++ b/X/Xorg_kbproto/build_tarballs.jl
@@ -35,3 +35,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Xorg_kbproto_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
