### PR TITLE
JLL bump: XSLT_jll

### DIFF
--- a/X/XSLT/build_tarballs.jl
+++ b/X/XSLT/build_tarballs.jl
@@ -39,3 +39,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of XSLT_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
