### PR TITLE
JLL bump: JpegTurbo_jll

### DIFF
--- a/J/JpegTurbo/build_tarballs.jl
+++ b/J/JpegTurbo/build_tarballs.jl
@@ -43,3 +43,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of JpegTurbo_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
