### PR TITLE
JLL bump: gdk_pixbuf_jll

### DIFF
--- a/G/gdk_pixbuf/build_tarballs.jl
+++ b/G/gdk_pixbuf/build_tarballs.jl
@@ -62,3 +62,4 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of gdk_pixbuf_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
