### PR TITLE
JLL bump: FriBidi_jll

### DIFF
--- a/F/FriBidi/build_tarballs.jl
+++ b/F/FriBidi/build_tarballs.jl
@@ -37,4 +37,3 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of FriBidi_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
