### PR TITLE
JLL bump: Libepoxy_jll

### DIFF
--- a/L/Libepoxy/build_tarballs.jl
+++ b/L/Libepoxy/build_tarballs.jl
@@ -42,3 +42,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Libepoxy_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
