### PR TITLE
[libcxxwrap-julia] Binaries for Julia 1.3

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -3,22 +3,32 @@
 using BinaryBuilder, Pkg
 
 name = "libcxxwrap_julia"
-version = v"0.8.0"
-
-const is_yggdrasil = haskey(ENV, "BUILD_BUILDNUMBER")
-git_repo = is_yggdrasil ? "https://github.com/JuliaInterop/libcxxwrap-julia.git" : joinpath(ENV["HOME"], "src/julia/libcxxwrap-julia/")
-unpack_target = is_yggdrasil ? "" : "libcxxwrap-julia"
+version = v"0.8.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource(git_repo, "30997d732f6a317348a05b4ccb777dfbcc483525", unpack_target=unpack_target),
+    GitSource("https://github.com/JuliaInterop/libcxxwrap-julia.git", "1fe29d1c71622d8cfbfcbc1653933009a65bf753"),
+    ArchiveSource("https://julialang-s3.julialang.org/bin/linux/armv7l/1.3/julia-1.3.1-linux-armv7l.tar.gz", "965c8fab2214f8ce1b3d449d088561a6de61be42543b48c3bbadaed5b02bf824"; unpack_target="julia-arm-linux-gnueabihf"),
+    ArchiveSource("https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz", "faa707c8343780a6fe5eaf13490355e8190acf8e2c189b9e7ecbddb0fa2643ad"; unpack_target="julia-x86_64-linux-gnu"),
+    ArchiveSource("https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-apple-darwin14.tar.gz", "f2e5359f03314656c06e2a0a28a497f62e78f027dbe7f5155a5710b4914439b1"; unpack_target="julia-x86_64-apple-darwin14"),
+    ArchiveSource("https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-w64-mingw32.tar.gz", "c7b2db68156150d0e882e98e39269301d7bf56660f4fc2e38ed2734a7a8d1551"; unpack_target="julia-x86_64-w64-mingw32"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
+
+case "$target" in
+	arm-linux-gnueabihf|x86_64-linux-gnu)
+        Julia_PREFIX=${WORKSPACE}/srcdir/julia-$target/julia-1.3.1
+        ;;
+    x86_64-apple-darwin14|x86_64-w64-mingw32)
+        Julia_PREFIX=${WORKSPACE}/srcdir/julia-$target/juliabin
+        ;;
+esac
+
 mkdir build
 cd build
-cmake -DJulia_PREFIX=$prefix -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../libcxxwrap-julia/
+cmake -DJulia_PREFIX=$Julia_PREFIX -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../libcxxwrap-julia/
 VERBOSE=ON cmake --build . --config Release --target install -- -j${nproc}
 install_license $WORKSPACE/srcdir/libcxxwrap-julia*/LICENSE.md
 """
@@ -26,14 +36,10 @@ install_license $WORKSPACE/srcdir/libcxxwrap-julia*/LICENSE.md
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    FreeBSD(:x86_64; compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
     Linux(:armv7l; libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
-    Linux(:aarch64; libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
     Linux(:x86_64; libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
-    Linux(:i686; libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
     MacOS(:x86_64; compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
     Windows(:x86_64; compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
-    Windows(:i686; compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
 ]
 
 # The products that we will ensure are always built
@@ -44,8 +50,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(name="Julia_jll",version=v"1.4.1"))
+    #BuildDependency(PackageSpec(name="Julia_jll",version=v"1.4.1"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7", julia_compat="~1.3")


### PR DESCRIPTION
This builds version 0.8.1 of `libcxxwrap-0.8.1` against Julia 1.3 and with a compat entry of `julia_compat="~1.3"`. The plan is to have a version 0.8.2 with compat 1.4 (since 1.4 and 1.5 appear to be binary compatible).

If I understand correctly, this means 0.8.1 will get loaded on Julia 1.3 and 0.8.2 will get loaded on julia 1.4 and later, with a libcxxwrap-julia compat entry of "0.8" in CxxWrap.

CC @fingolfin 