### PR TITLE
Add libmlpack_julia_kde LibraryProduct.

### DIFF
--- a/M/mlpack/build_tarballs.jl
+++ b/M/mlpack/build_tarballs.jl
@@ -134,6 +134,7 @@ products = [
         :libmlpack_julia_hoeffding_tree),
     LibraryProduct("libmlpack_julia_image_converter",
         :libmlpack_julia_image_converter),
+    LibraryProduct("libmlpack_julia_kde", :libmlpack_julia_kde),
     LibraryProduct("libmlpack_julia_kernel_pca", :libmlpack_julia_kernel_pca),
     LibraryProduct("libmlpack_julia_kfn", :libmlpack_julia_kfn),
     LibraryProduct("libmlpack_julia_kmeans", :libmlpack_julia_kmeans),


### PR DESCRIPTION
It's the rules: it can never go right the first time. I was tricked by #1649's first-time green build into believing I had everything right, but this is clearly too good to be true. Upon trying to update the mlpack.jl package that depends on mlpack_jll, I discovered the gotcha, which is just that I forgot a LibraryProduct. Oops... :)

(round two: rebase on master, not the #1649 branch)