### PR TITLE
add build recipe for Enzyme

### DIFF
--- a/E/Enzyme/Enzyme@9/build_tarballs.jl
+++ b/E/Enzyme/Enzyme@9/build_tarballs.jl
@@ -1,0 +1,11 @@
+include("../common.jl")
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    BuildDependency(PackageSpec(name="LLVM_full_jll", version=v"9.0.1")),
+#    Dependency(PackageSpec(name="libLLVM_jll", version=v"9.0.1"))
+]
+
+# Build the tarballs.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"8", julia_compat="1.5")

--- a/E/Enzyme/common.jl
+++ b/E/Enzyme/common.jl
@@ -1,0 +1,47 @@
+using BinaryBuilder, Pkg
+
+name = "Enzyme"
+repo = "https://github.com/wsmoses/Enzyme.git"
+
+version = v"0.0.1"
+
+# Collection of sources required to build attr
+sources = [GitSource(repo, "307f98aa9619b697120e78e2a4255e36d7b64993")]
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd Enzyme
+# install_license LICENSE.TXT
+
+CMAKE_FLAGS=()
+
+# Release build for best performance
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+
+# Install things into $prefix
+CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+
+# Explicitly use our cmake toolchain file and tell CMake we're cross-compiling
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
+
+# Tell CMake where LLVM is
+CMAKE_FLAGS+=(-DLLVM_DIR="${prefix}/lib/cmake/llvm")
+
+# Force linking against shared lib
+CMAKE_FLAGS+=(-DLLVM_LINK_LLVM_DYLIB=ON)
+
+# Build the library
+CMAKE_FLAGS+=(-DBUILD_SHARED_LIBS=ON)
+cmake -B build -S enzyme -GNinja ${CMAKE_FLAGS[@]}
+ninja -C build -j ${nproc} install
+"""
+
+# The products that we will ensure are always built
+products = Product[
+    LibraryProduct(["LLVMEnzyme-9", "LLVMEnzyme"], :libEnzyme),
+]

--- a/E/Enzyme/common.jl
+++ b/E/Enzyme/common.jl
@@ -20,7 +20,7 @@ cd Enzyme
 CMAKE_FLAGS=()
 
 # Release build for best performance
-CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=RelWithDebInfo)
 
 # Install things into $prefix
 CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})


### PR DESCRIPTION
cc: @wsmoses

@giordano @staticfloat Enzyme is a compiler plugin for LLVM, so it has to be build against the right LLVM version, but it does support LLVM 7-9 (and higher). So the question is which version number to choose. Right now I used `0.0.1` instead of `9.0.1`, since we need Julia 1.4+ anyway for the project, but this yet again opens the question of how do I build something for LLVM 9 and LLVM 10 as variants :P 

