### PR TITLE
add build recipe for CvxCompress

### DIFF
--- a/C/CvxCompress/build_tarballs.jl
+++ b/C/CvxCompress/build_tarballs.jl
@@ -16,7 +16,8 @@ sources = [
 # Bash recipe for building across platforms
 script = raw"""
 cd ${WORKSPACE}/srcdir/CvxCompress
-make
+make -j${nproc}
+mkdir -p ${libdir}
 cp libcvxcompress.so ${libdir}/libcvxcompress.${dlext}
 """
 

--- a/C/CvxCompress/build_tarballs.jl
+++ b/C/CvxCompress/build_tarballs.jl
@@ -10,13 +10,21 @@ sources = [
     GitSource(
         "https://github.com/ChevronETC/CvxCompress.git",
         "55e072862196e917e3ecece81f014e93d60cdf81"
-    )
+    ),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across platforms
 script = raw"""
 cd ${WORKSPACE}/srcdir/CvxCompress
-make -j${nproc}
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/cross-compile-cvxcompress-gencode.patch
+${CXX_FOR_BUILD} -O2 -o CvxCompress_GenCode Wavelet_Transform_Slow.cpp CvxCompress_GenCode.cpp
+./CvxCompress_GenCode
+FLAGS=()
+if [[ "${target}" == *-apple-* ]]; then
+    FLAGS=(LDFLAGS="-fopenmp -lm")
+fi
+make -j${nproc} "${FLAGS[@]}"
 mkdir -p ${libdir}
 cp libcvxcompress.so ${libdir}/libcvxcompress.${dlext}
 """
@@ -24,10 +32,7 @@ cp libcvxcompress.so ${libdir}/libcvxcompress.${dlext}
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 # TODO update make to adjust the intrinsic code generation to support more platforms
-platforms = [
-  Linux(:x86_64, libc=:glibc),
-  Linux(:x86_64, libc=:musl)
-]
+platforms = [p for p in supported_platforms() if arch(p) === :x86_64 && !Sys.iswindows(p)]
 
 # The products that we will ensure are always built
 products = [

--- a/C/CvxCompress/build_tarballs.jl
+++ b/C/CvxCompress/build_tarballs.jl
@@ -1,6 +1,6 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder
+using BinaryBuilder, Pkg
 
 name = "CvxCompress"
 version = v"1.0.0"

--- a/C/CvxCompress/build_tarballs.jl
+++ b/C/CvxCompress/build_tarballs.jl
@@ -23,9 +23,7 @@ cp libcvxcompress.so ${libdir}/libcvxcompress.${dlext}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-  Linux(:x86_64, libc=:glibc)
-]
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
@@ -33,7 +31,9 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = []
+dependencies = [
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
+]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/C/CvxCompress/build_tarballs.jl
+++ b/C/CvxCompress/build_tarballs.jl
@@ -9,7 +9,7 @@ version = v"1.0.0"
 sources = [
     GitSource(
         "https://github.com/ChevronETC/CvxCompress.git",
-        "89928d6639661a246d0a36ccbbc3469bd6de1a8d"
+        "55e072862196e917e3ecece81f014e93d60cdf81"
     )
 ]
 

--- a/C/CvxCompress/build_tarballs.jl
+++ b/C/CvxCompress/build_tarballs.jl
@@ -1,0 +1,36 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "CvxCompress"
+version = v"1.0.0"
+
+# Collection of sources required to build AzStorage
+sources = [
+    GitSource(
+        "https://github.com/ChevronETC/CvxCompress.git",
+        "89928d6639661a246d0a36ccbbc3469bd6de1a8d"
+    )
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+make
+cp libcvxcompress.so ${libdir}/libcvxcompress.${dlext}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+# TODO - add libgomp dependency
+products = [
+    LibraryProduct("libcvxcompress", :libcvxcompress)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = []
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/C/CvxCompress/build_tarballs.jl
+++ b/C/CvxCompress/build_tarballs.jl
@@ -5,7 +5,7 @@ using BinaryBuilder
 name = "CvxCompress"
 version = v"1.0.0"
 
-# Collection of sources required to build AzStorage
+# Collection of sources required to build CvxCompress
 sources = [
     GitSource(
         "https://github.com/ChevronETC/CvxCompress.git",
@@ -13,18 +13,20 @@ sources = [
     )
 ]
 
-# Bash recipe for building across all platforms
+# Bash recipe for building across platforms
 script = raw"""
+cd ${WORKSPACE}/srcdir/CvxCompress
 make
 cp libcvxcompress.so ${libdir}/libcvxcompress.${dlext}
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = [
+  Linux(:x86_64, libc=:glibc)
+]
 
 # The products that we will ensure are always built
-# TODO - add libgomp dependency
 products = [
     LibraryProduct("libcvxcompress", :libcvxcompress)
 ]

--- a/C/CvxCompress/build_tarballs.jl
+++ b/C/CvxCompress/build_tarballs.jl
@@ -23,7 +23,11 @@ cp libcvxcompress.so ${libdir}/libcvxcompress.${dlext}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+# TODO update make to adjust the intrinsic code generation to support more platforms
+platforms = [
+  Linux(:x86_64, libc=:glibc),
+  Linux(:x86_64, libc=:musl)
+]
 
 # The products that we will ensure are always built
 products = [

--- a/C/CvxCompress/bundled/patches/cross-compile-cvxcompress-gencode.patch
+++ b/C/CvxCompress/bundled/patches/cross-compile-cvxcompress-gencode.patch
@@ -1,0 +1,22 @@
+diff --git a/makefile b/makefile
+index 620d241..a7f08a9 100644
+--- a/makefile
++++ b/makefile
+@@ -1,5 +1,6 @@
+ CC = gcc
+ CXX = g++
++CXX_BUILD = $(CXX)
+ CFLAGS=-fopenmp -O3 -fPIC -mavx -g
+ LDFLAGS=-fopenmp -lm -lrt
+ 
+@@ -19,8 +20,8 @@ CvxCompress_Test: CvxCompress_Test.o $(OBJECTS)
+ CvxCompress_Test_Dyn: CvxCompress_Test.o libcvxcompress.so
+ 	$(CXX) $(LDFLAGS) CvxCompress_Test.o  -L. -lcvxcompress -o $@
+ 
+-CvxCompress_GenCode: CvxCompress_GenCode.o CvxCompress.hxx Wavelet_Transform_Slow.o
+-	$(CXX) -O2 Wavelet_Transform_Slow.o  CvxCompress_GenCode.o -o CvxCompress_GenCode
++CvxCompress_GenCode: CvxCompress_GenCode.cpp CvxCompress.hxx Wavelet_Transform_Slow.cpp
++	$(CXX_BUILD) -O2 Wavelet_Transform_Slow.cpp CvxCompress_GenCode.cpp -o $@
+ 
+ Test_Compression: Test_Compression.o $(OBJECTS)
+ 	$(CXX) $(LDFLAGS) $(OBJECTS)  Test_Compression.o -o Test_Compression


### PR DESCRIPTION
Hello,

This is in support of the CxvCompress.jl package (https://github.com/ChevronETC/CvxCompress.jl). CxvCompress.jl uses C code for an efficient compression algorithm used in seismic analysis.

Thanks!