### PR TITLE
Update recipe: tblis-v1.2.0 more Tier-1 platforms

### DIFF
--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -41,7 +41,12 @@ case ${target} in
         export BLI_CONFIG=amd
         export BLI_THREAD=openmp
         # Wrapper for posix_memalign calls.
-        sed -i "s/include <cstdlib>/include <cstdlib>\n inline int posix_memalign(void **memptr, size_t alignment, size_t size) { *memptr = 0; *memptr = _aligned_malloc(alignment, size); return (*memptr == 0 \&\& size != 0); }\n/" src/memory/aligned_allocator.hpp
+        echo \
+            'inline int posix_memalign(void **memptr, size_t alignment, size_t size)'\
+            '{ *memptr = 0; *memptr = _aligned_malloc(alignment, size); '\
+            '  return (*memptr == 0 && size != 0); }' |\
+            cat - src/memory/aligned_allocator.hpp >> aligned_allocator_new.hpp
+        mv aligned_allocator_new.hpp src/memory/aligned_allocator.hpp
         # Additional linking parameter needed for MinGW Autoconf.
         # Update Autoconf parameters and refresh.
         cd src/external/tci

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -14,17 +14,66 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd tblis/
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+
+for i in ./Makefile.* ./configure*; do
+
+    # Building in container forbids -march options
+    sed -i "s/-march[^ ]*//g" $i
+
+done
+
+case ${target} in
+    # Unlike stated in Wiki, 
+    # TBLIS automatically detects threading model.
+    *"x86_64"*"linux"*) 
+        export BLI_CONFIG=x86
+        export BLI_THREAD=openmp
+        ;;
+    *"x86_64"*"w64"*)
+        # Windows lacks support for some instructions.
+        # Building only for AMD processors.
+        export BLI_CONFIG=amd
+        export BLI_THREAD=openmp
+        ;;
+    *"x86_64"*"apple"*) 
+        export BLI_CONFIG=x86
+        export BLI_THREAD=openmp
+        export CC=gcc
+        export CXX=g++
+        ;;
+    *"x86_64"*"freebsd"*) 
+        export BLI_CONFIG=x86
+        export BLI_THREAD=openmp
+        export CC=gcc
+        export CXX=g++
+        ;;
+    *)
+        ;; 
+
+esac
+
+CFG_OPTION_POSIX="--prefix=${prefix} --build=${MACHTYPE} --host=${target}"
+# ./configure will warn about --enable-thread-model but it is actually effective.
+CFG_OPTION_TBLIS="--enable-config=${BLI_CONFIG} --enable-thread-model=${BLI_THREAD}"
+
+./configure ${CFG_OPTION_TBLIS} ${CFG_OPTION_POSIX}
 make -j${nproc}
-cp lib/.libs/libtblis.so.0.0.0 ${libdir}/libtblis.so.0
-cp src/external/tci/lib/.libs/libtci.so.0.0.0 ${libdir}/libtci.so.0
+make install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
     Linux(:x86_64, libc=:glibc),
-    Linux(:x86_64, libc=:musl)
+    # Some StdCpp headers missing for linux-musl toolchain.
+    # Linux(:x86_64, libc=:musl),
+    MacOS(:x86_64),
+    FreeBSD(:x86_64)
+    # Due to the following reasons, MinGW build is commented out:
+    # - Lack of support of some Intel XMM instructions;
+    # - Lack of posix_memalign (solvable as _aligned_malloc is available);
+    # - This build system fails to produce .dll on MinGW;
+    # Windows(:x86_64),
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -105,4 +105,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5")

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -8,6 +8,7 @@ version = v"1.2.0"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/devinamatthews/tblis.git", "3e4c4b82943726c443b6f408c9c9791dcad7a847")
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
@@ -41,8 +42,7 @@ case ${target} in
         export BLI_CONFIG=amd
         export BLI_THREAD=openmp
         # Wrapper for posix_memalign calls.
-        echo 'aW5saW5lIGludCBwb3NpeF9tZW1hbGlnbih2b2lkICoqbWVtcHRyLCBzaXplX3QgYWxpZ25tZW50LCBzaXplX3Qgc2l6ZSkKeyAqbWVtcHRyID0gMDsgKm1lbXB0ciA9IF9hbGlnbmVkX21hbGxvYyhhbGlnbm1lbnQsIHNpemUpOyAKICAgcmV0dXJuICgqbWVtcHRyID09IDAgJiYgc2l6ZSAhPSAwKTsgfQo=' | base64 -d | cat - src/memory/aligned_allocator.hpp >> aligned_allocator_new.hpp
-        mv aligned_allocator_new.hpp src/memory/aligned_allocator.hpp
+        patch src/memory/aligned_allocator.hpp < ${WORKSPACE}/srcdir/patches/aligned_allocator.hpp.mingw.patch
         # Additional linking parameter needed for MinGW Autoconf.
         # Update Autoconf parameters and refresh.
         cd src/external/tci
@@ -79,6 +79,9 @@ CFG_OPTION_TBLIS="--enable-config=${BLI_CONFIG} --enable-thread-model=${BLI_THRE
 make -j${nproc}
 make install
 
+# Copy license file
+mkdir -p ${prefix}/share/licenses/tblis
+cp LICENSE ${prefix}/share/licenses/tblis
 """
 
 # These are the platforms we will build for by default, unless further

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -79,11 +79,6 @@ CFG_OPTION_TBLIS="--enable-config=${BLI_CONFIG} --enable-thread-model=${BLI_THRE
 make -j${nproc}
 make install
 
-if [[ ${target} == *"x86_64"*"w64"* ]]; then
-    # Rename binary files for MinGW
-    mv ${prefix}/bin/libtci-0.dll ${prefix}/bin/libtci.dll 
-    mv ${prefix}/bin/libtblis-0.dll ${prefix}/bin/libtblis.dll 
-fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -41,11 +41,7 @@ case ${target} in
         export BLI_CONFIG=amd
         export BLI_THREAD=openmp
         # Wrapper for posix_memalign calls.
-        echo \
-            'inline int posix_memalign(void **memptr, size_t alignment, size_t size)'\
-            '{ *memptr = 0; *memptr = _aligned_malloc(alignment, size); '\
-            '  return (*memptr == 0 && size != 0); }' |\
-            cat - src/memory/aligned_allocator.hpp >> aligned_allocator_new.hpp
+        echo 'aW5saW5lIGludCBwb3NpeF9tZW1hbGlnbih2b2lkICoqbWVtcHRyLCBzaXplX3QgYWxpZ25tZW50LCBzaXplX3Qgc2l6ZSkKeyAqbWVtcHRyID0gMDsgKm1lbXB0ciA9IF9hbGlnbmVkX21hbGxvYyhhbGlnbm1lbnQsIHNpemUpOyAKICAgcmV0dXJuICgqbWVtcHRyID09IDAgJiYgc2l6ZSAhPSAwKTsgfQo=' | base64 -d | cat - src/memory/aligned_allocator.hpp >> aligned_allocator_new.hpp
         mv aligned_allocator_new.hpp src/memory/aligned_allocator.hpp
         # Additional linking parameter needed for MinGW Autoconf.
         # Update Autoconf parameters and refresh.

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -25,15 +25,9 @@ done
 case ${target} in
     # Unlike stated in Wiki, 
     # TBLIS automatically detects threading model.
-    *"x86_64"*"linux"*"gnu"*) 
+    *"x86_64"*"linux"*) 
         export BLI_CONFIG=x86
         export BLI_THREAD=openmp
-        ;;
-    *"x86_64"*"linux"*"musl"*)
-        export BLI_CONFIG=x86
-        export BLI_THREAD=openmp
-        export CXXBASEPATH=$(dirname $(qfind /opt/ -name iostream | tail -n 1))
-        export CPATH=$CXXBASEPATH:$CXXBASEPATH/${target}
         ;;
     *"x86_64"*"w64"*)
         # Windows lacks support for some instructions.
@@ -111,4 +105,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7.1.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -80,8 +80,7 @@ make -j${nproc}
 make install
 
 # Copy license file
-mkdir -p ${prefix}/share/licenses/tblis
-cp LICENSE ${prefix}/share/licenses/tblis
+install_license LICENSE
 """
 
 # These are the platforms we will build for by default, unless further

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -92,8 +92,8 @@ platforms = [
     Linux(:x86_64, libc=:glibc),
     Linux(:x86_64, libc=:musl),
     MacOS(:x86_64),
-    FreeBSD(:x86_64)
-    Windows(:x86_64),
+    FreeBSD(:x86_64),
+    Windows(:x86_64)
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -25,9 +25,15 @@ done
 case ${target} in
     # Unlike stated in Wiki, 
     # TBLIS automatically detects threading model.
-    *"x86_64"*"linux"*) 
+    *"x86_64"*"linux"*"gnu"*) 
         export BLI_CONFIG=x86
         export BLI_THREAD=openmp
+        ;;
+    *"x86_64"*"linux"*"musl"*)
+        export BLI_CONFIG=x86
+        export BLI_THREAD=pthreads
+        export CC=clang
+        export CXX=clang++
         ;;
     *"x86_64"*"w64"*)
         # Windows lacks support for some instructions.
@@ -84,7 +90,7 @@ fi
 # platforms are passed in on the command line
 platforms = [
     Linux(:x86_64, libc=:glibc),
-    Linux(:x86_64, libc=:musl),
+    Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
     MacOS(:x86_64),
     FreeBSD(:x86_64),
     Windows(:x86_64)
@@ -105,4 +111,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7.1.0")

--- a/T/tblis/bundled/patches/aligned_allocator.hpp.mingw.patch
+++ b/T/tblis/bundled/patches/aligned_allocator.hpp.mingw.patch
@@ -1,0 +1,13 @@
+--- aligned_allocator.hpp	2020-09-24 16:33:17.771220891 +0900
++++ aligned_allocator.hpp	2020-09-24 16:35:19.754294209 +0900
+@@ -2,6 +2,10 @@
+ #define _TBLIS_ALIGNED_ALLOCATOR_HPP_
+ 
+ #include <cstdlib>
++inline int posix_memalign(void **memptr, size_t alignment, size_t size)
++{ *memptr = 0; *memptr = _aligned_malloc(alignment, size); 
++   return (*memptr == 0 && size != 0); }
++
+ #include <new>
+ 
+ #if TBLIS_HAVE_HBWMALLOC_H


### PR DESCRIPTION
Previous script seems not compiling on containers provided by current master.
Container build does not allow specifying -march options.

This update:
- Patches scripts before compiling to remove incompatible options;
- Adds support for macOS and FreeBSD;

Limitations:
- [x] MUSL Linux is dropping C++03 ABI to prefer Clang++ due to seemingly misconfigured G++ include path;
- [x] Current autotool's not giving dynamic libraries under MinGW - Resolved with editing.