### PR TITLE
[polymake] bump to 4.2 and add patch for sigint

### DIFF
--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -94,9 +94,10 @@ install_license COPYING
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
- MacOS(:x86_64),
- Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
 ]
+platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -94,7 +94,7 @@ install_license COPYING
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
- MacOS(:x86_64, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
+ MacOS(:x86_64),
  Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
 ]
 

--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -109,17 +109,17 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("CompilerSupportLibraries_jll")
-    Dependency("FLINT_jll")
+    Dependency("CompilerSupportLibraries_jll"),
+    Dependency("FLINT_jll"),
     Dependency("GMP_jll", v"6.1.2"),
     Dependency("MPFR_jll", v"4.0.2"),
-    Dependency("PPL_jll")
-    Dependency(PackageSpec(name="Perl_jll", uuid="83958c19-0796-5285-893e-a1267f8ec499", version=v"5.30.3"))
-    Dependency("bliss_jll")
-    Dependency("boost_jll")
-    Dependency("cddlib_jll")
-    Dependency("lrslib_jll")
-    Dependency("normaliz_jll")
+    Dependency("PPL_jll"),
+    Dependency(PackageSpec(name="Perl_jll", uuid="83958c19-0796-5285-893e-a1267f8ec499", version=v"5.30.3")),
+    Dependency("bliss_jll"),
+    Dependency("boost_jll"),
+    Dependency("cddlib_jll"),
+    Dependency("lrslib_jll"),
+    Dependency("normaliz_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/P/polymake/bundled/config/config-x86_64-apple-darwin14.ninja
+++ b/P/polymake/bundled/config/config-x86_64-apple-darwin14.ninja
@@ -2,7 +2,7 @@
 configure.command=/workspace/srcdir/polymake/configure CXX=clang++ --with-libcxx --with-lrs-include=/workspace/destdir/include/lrslib
 root=/workspace/srcdir/polymake
 core.includes=-I${root}/include/core-wrappers -I${root}/include/core
-app.includes=-I${root}/include/app-wrappers -I${root}/include/apps -I${root}/include/external/permlib -I${root}/include/external/TOSimplex
+app.includes=-I${root}/include/app-wrappers -I${root}/include/apps -I${root}/include/external/permlib -I${root}/include/external/TOSimplex -I${root}/include/external/Miniball
 
 CC = clang -target x86_64-apple-darwin14 --sysroot /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root
 CXX = clang++ -target x86_64-apple-darwin14 --sysroot /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root
@@ -23,7 +23,7 @@ LDsharedFLAGS = -mmacosx-version-min=10.8 -L/workspace/destdir/lib -Wl,-rpath,/w
 LDcallableFLAGS = -mmacosx-version-min=10.8  -L/workspace/destdir/lib -Wl,-rpath,/workspace/destdir/lib -dynamiclib -undefined dynamic_lookup -fstack-protector-strong  -mmacosx-version-min=10.8 -fstack-protector-strong
 LDsonameFLAGS = -install_name /workspace/destdir/lib/
 LIBS =  -lc++ -lflint -lmpfr -lgmp -lpthread
-ExternalHeaders =  permlib TOSimplex
+ExternalHeaders =  permlib TOSimplex Miniball
 Arch = darwin.x86_64
 BundledExts = cdd atint bliss flint libnormaliz lrs ppl sympol
 BuildModes = Opt Debug

--- a/P/polymake/bundled/patches/sigint.patch
+++ b/P/polymake/bundled/patches/sigint.patch
@@ -1,0 +1,13 @@
+diff --git a/perllib/Polymake/Main.pm b/perllib/Polymake/Main.pm
+index ce048584af..7a9a723dac 100644
+--- a/perllib/Polymake/Main.pm
++++ b/perllib/Polymake/Main.pm
+@@ -23,7 +23,7 @@ sub import {
+    (undef, my ($user_opts, $must_reset_SIGCHLD)) = @_;
+ 
+    # this guarantees initialization of internal structures for signal handling
+-   local $SIG{INT} = 'IGNORE';
++   local $SIG{USR1} = 'IGNORE';
+ 
+    # these redefinitions must happen before the whole slew of polymake perl code is loaded!
+    if ($must_reset_SIGCHLD) {


### PR DESCRIPTION
The sigint patch make sure that the Ctrl+C handler of julia is kept, otherwise julia will terminate immediately when ctrl+c is pressed after polymake_jll was loaded (and initialized).
Switched to archive source.