### PR TITLE
Libglvnd: Disable initial-exec TLS model for musl

### DIFF
--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -15,7 +15,11 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/libglvnd-*/
 export CPPFLAGS="-I${prefix}/include"
+if [[ "${target}" == *musl* ]]; then
+./configure --prefix=${prefix} --host=${target} --disable-tls
+else
 ./configure --prefix=${prefix} --host=${target}
+fi
 make -j${nproc}
 make install
 # The license is embedded in the README file

--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libglvnd-*/
-export CPPFLAGS="-I${prefix}/include"
+export CPPFLAGS="-I${includedir}"
 FLAGS=()
 if [[ "${target}" == *musl* ]]; then
     FLAGS=(--disable-tls)
@@ -45,7 +45,7 @@ products = Product[
 dependencies = [
     Dependency("Xorg_libX11_jll"),
     Dependency("Xorg_libXext_jll"),
-    BuildDependency("Xorg_glproto_jll"),
+    BuildDependency("Xorg_xorgproto_jll"),
 ]
 
 # Build the tarballs.

--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -15,11 +15,11 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/libglvnd-*/
 export CPPFLAGS="-I${prefix}/include"
+FLAGS=()
 if [[ "${target}" == *musl* ]]; then
-./configure --prefix=${prefix} --host=${target} --disable-tls
-else
-./configure --prefix=${prefix} --host=${target}
+    FLAGS=(--disable-tls)
 fi
+./configure --prefix=${prefix} --host=${target} "${FLAGS[@]}"
 make -j${nproc}
 make install
 # The license is embedded in the README file
@@ -28,7 +28,7 @@ install_license README.md
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [p for p in supported_platforms() if p isa Union{Linux,FreeBSD}]
+platforms = filter!(p ->Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
 
 # The products that we will ensure are always built
 products = Product[
@@ -50,4 +50,3 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
Alpine's musl libc won't load `libGLdispatch.so` without this flag.