### PR TITLE
Update Singular, fix GMP dependency

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"4.1.3"  # this is actually 4.1.3p5 with some extra patches
 
 # Collection of sources required to build normaliz
 sources = [
-    GitSource("https://github.com/Singular/Sources.git", "eca06c1bccc0f72a9c3147f058fd8aad961ad7ee"),
+    GitSource("https://github.com/Singular/Sources.git", "17f0567a82824601e71ff151ecb63d656719b866"),
 ]
 
 # Bash recipe for building across all platforms
@@ -34,7 +34,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-platforms = filter!(p -> !(p isa Windows), platforms)
+platforms = filter!(p -> !Sys.iswindows(p), platforms)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
@@ -56,7 +56,7 @@ products = [
 dependencies = [
     Dependency("cddlib_jll"),
     Dependency("FLINT_jll"),
-    Dependency("GMP_jll"),
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency("MPFR_jll"),
 ]
 


### PR DESCRIPTION
Force GMP_jll to build with version 6.1.2, to ensure the resulting
binaries work in both Julia <= 1.5 and >= 1.6

CC @staticfloat @thofma 

If this works, we can next update PR #1695 similarly (CC @benlorenz).

Finally, I'd be tempted to apply this dependency patch to "all" JLLs using GMP_jll (with `[skip ci]`) just to make sure we don't run into this issue again by accident, down the line. Or is that a bad idea for some reason?