### PR TITLE
Disable non-POSIX TLS usage in libgomp

### DIFF
--- a/0_RootFS/GCCBootstrap@4/bundled/patches/musl_disable_tls.patch
+++ b/0_RootFS/GCCBootstrap@4/bundled/patches/musl_disable_tls.patch
@@ -1,0 +1,19 @@
+--- a/gcc/libgomp/configure.tgt	2020-09-30 20:53:48.451232161 -0500
++++ b/gcc/libgomp/configure.tgt	2020-09-30 20:54:49.194468515 -0500
+@@ -10,16 +10,6 @@
+ #  XCFLAGS		Add extra compile flags to use.
+ #  XLDFLAGS		Add extra link flags to use.
+ 
+-# Optimize TLS usage by avoiding the overhead of dynamic allocation.
+-if test $gcc_cv_have_tls = yes ; then
+-  case "${target}" in
+-
+-    *-*-linux*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=initial-exec"
+-	;;
+-  esac
+-fi
+-
+ # Since we require POSIX threads, assume a POSIX system by default.
+ config_path="posix"
+ 

--- a/0_RootFS/GCCBootstrap@5/bundled/patches/musl_disable_tls.patch
+++ b/0_RootFS/GCCBootstrap@5/bundled/patches/musl_disable_tls.patch
@@ -1,0 +1,26 @@
+--- a/gcc/libgomp/configure.tgt	2020-09-30 21:05:24.538481160 -0500
++++ b/gcc/libgomp/configure.tgt	2020-09-30 21:05:34.669353797 -0500
+@@ -10,23 +10,6 @@
+ #  XCFLAGS		Add extra compile flags to use.
+ #  XLDFLAGS		Add extra link flags to use.
+ 
+-# Optimize TLS usage by avoiding the overhead of dynamic allocation.
+-if test $gcc_cv_have_tls = yes ; then
+-  case "${target}" in
+-
+-    *-*-k*bsd*-gnu*)
+-	;;
+-
+-    *-*-linux* | *-*-gnu*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=initial-exec"
+-	;;
+-
+-    *-*-rtems*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=local-exec"
+-	;;
+-  esac
+-fi
+-
+ # Since we require POSIX threads, assume a POSIX system by default.
+ config_path="posix"
+ 

--- a/0_RootFS/GCCBootstrap@6/bundled/patches/musl_disable_tls.patch
+++ b/0_RootFS/GCCBootstrap@6/bundled/patches/musl_disable_tls.patch
@@ -1,0 +1,26 @@
+--- a/gcc/libgomp/configure.tgt	2020-09-30 21:02:37.562580331 -0500
++++ b/gcc/libgomp/configure.tgt	2020-09-30 21:02:51.535404669 -0500
+@@ -10,23 +10,6 @@
+ #  XCFLAGS		Add extra compile flags to use.
+ #  XLDFLAGS		Add extra link flags to use.
+ 
+-# Optimize TLS usage by avoiding the overhead of dynamic allocation.
+-if test $gcc_cv_have_tls = yes ; then
+-  case "${target}" in
+-
+-    *-*-k*bsd*-gnu*)
+-	;;
+-
+-    *-*-linux* | *-*-gnu*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=initial-exec"
+-	;;
+-
+-    *-*-rtems*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=local-exec"
+-	;;
+-  esac
+-fi
+-
+ # Since we require POSIX threads, assume a POSIX system by default.
+ config_path="posix"
+ 

--- a/0_RootFS/GCCBootstrap@7/bundled/patches/musl_disable_tls.patch
+++ b/0_RootFS/GCCBootstrap@7/bundled/patches/musl_disable_tls.patch
@@ -1,0 +1,26 @@
+--- a/gcc/libgomp/configure.tgt	2020-09-30 21:03:36.980833342 -0500
++++ b/gcc/libgomp/configure.tgt	2020-09-30 21:03:50.471663740 -0500
+@@ -10,23 +10,6 @@
+ #  XCFLAGS		Add extra compile flags to use.
+ #  XLDFLAGS		Add extra link flags to use.
+ 
+-# Optimize TLS usage by avoiding the overhead of dynamic allocation.
+-if test $gcc_cv_have_tls = yes ; then
+-  case "${target}" in
+-
+-    *-*-k*bsd*-gnu*)
+-	;;
+-
+-    *-*-linux* | *-*-gnu*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=initial-exec"
+-	;;
+-
+-    *-*-rtems*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=local-exec"
+-	;;
+-  esac
+-fi
+-
+ # Since we require POSIX threads, assume a POSIX system by default.
+ config_path="posix"
+ 

--- a/0_RootFS/GCCBootstrap@8/bundled/patches/musl_disable_tls.patch
+++ b/0_RootFS/GCCBootstrap@8/bundled/patches/musl_disable_tls.patch
@@ -1,0 +1,26 @@
+--- a/gcc/libgomp/configure.tgt	2020-09-30 21:06:46.507450670 -0500
++++ b/gcc/libgomp/configure.tgt	2020-09-30 21:06:56.086330247 -0500
+@@ -10,23 +10,6 @@
+ #  XCFLAGS		Add extra compile flags to use.
+ #  XLDFLAGS		Add extra link flags to use.
+ 
+-# Optimize TLS usage by avoiding the overhead of dynamic allocation.
+-if test $gcc_cv_have_tls = yes ; then
+-  case "${target}" in
+-
+-    *-*-k*bsd*-gnu*)
+-	;;
+-
+-    *-*-linux* | *-*-gnu*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=initial-exec"
+-	;;
+-
+-    *-*-rtems*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=local-exec"
+-	;;
+-  esac
+-fi
+-
+ # Since we require POSIX threads, assume a POSIX system by default.
+ config_path="posix"
+ 

--- a/0_RootFS/GCCBootstrap@9/bundled/patches/musl_disable_tls.patch
+++ b/0_RootFS/GCCBootstrap@9/bundled/patches/musl_disable_tls.patch
@@ -1,0 +1,26 @@
+--- a/gcc/libgomp/configure.tgt	2020-09-30 21:07:34.427848229 -0500
++++ b/gcc/libgomp/configure.tgt	2020-09-30 21:07:49.426659669 -0500
+@@ -10,23 +10,6 @@
+ #  XCFLAGS		Add extra compile flags to use.
+ #  XLDFLAGS		Add extra link flags to use.
+ 
+-# Optimize TLS usage by avoiding the overhead of dynamic allocation.
+-if test $gcc_cv_have_tls = yes ; then
+-  case "${target}" in
+-
+-    *-*-k*bsd*-gnu*)
+-	;;
+-
+-    *-*-linux* | *-*-gnu*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=initial-exec -DUSING_INITIAL_EXEC_TLS"
+-	;;
+-
+-    *-*-rtems*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=local-exec"
+-	;;
+-  esac
+-fi
+-
+ # Since we require POSIX threads, assume a POSIX system by default.
+ config_path="posix"
+ 

--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -330,6 +330,11 @@ function gcc_script(compiler_target::Platform)
         atomic_patch -p1 "${p}" || true
     done
 
+    # Disable any non-POSIX usage of TLS for musl
+    if [[ "${COMPILER_TARGET}" == *musl* ]]; then
+        patch -p1 $WORKSPACE/srcdir/gcc-*/libgomp/configure.tgt $WORKSPACE/srcdir/patches/musl_disable_tls.patch
+    fi
+
 
     # If we're on MacOS, we need to install cctools first, separately.
     if [[ ${COMPILER_TARGET} == *-darwin* ]]; then
@@ -649,7 +654,7 @@ function gcc_script(compiler_target::Platform)
 
     elif [[ "${COMPILER_TARGET}" == *freebsd* ]]; then
         GCC_CONF_ARGS="${GCC_CONF_ARGS} --enable-languages=c,c++,fortran"
-       
+
     # On mingw32 override native system header directories
     elif [[ "${COMPILER_TARGET}" == *mingw* ]]; then
         GCC_CONF_ARGS="${GCC_CONF_ARGS} --enable-languages=c,c++,fortran"


### PR DESCRIPTION
Similar idea to #1716. Should allow `libgomp.so` to load on musl without any errors.