### PR TITLE
Tweak a bunch of packages to build against GMP 6.1.2 resp. MPFR 4.0.2

### DIFF
--- a/A/Antic/build_tarballs.jl
+++ b/A/Antic/build_tarballs.jl
@@ -38,7 +38,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82"))
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
 ]
 

--- a/A/Antic/build_tarballs.jl
+++ b/A/Antic/build_tarballs.jl
@@ -39,7 +39,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82"))
     Dependency("GMP_jll", v"6.1.2"),
-    Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
+    Dependency("MPFR_jll", v"4.0.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/Arb/build_tarballs.jl
+++ b/A/Arb/build_tarballs.jl
@@ -45,7 +45,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82", version=v"2.6.2"))
     Dependency("GMP_jll", v"6.1.2"),
-    Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
+    Dependency("MPFR_jll", v"4.0.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/Arb/build_tarballs.jl
+++ b/A/Arb/build_tarballs.jl
@@ -44,7 +44,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82", version=v"2.6.2"))
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
 ]
 

--- a/B/bliss/build_tarballs.jl
+++ b/B/bliss/build_tarballs.jl
@@ -42,7 +42,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 dependencies = [
     Dependency("boost_jll"),
     Dependency("GMP_jll", v"6.1.2"),
-    Dependency("MPFR_jll"),
+    Dependency("MPFR_jll", v"4.0.2"),
     Dependency("Zlib_jll"),
 ]
 

--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("boost_jll"),
-    Dependency("GMP_jll"),
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency("MPFR_jll"),
     Dependency("Zlib_jll"),
 ]

--- a/C/cddlib/build_tarballs.jl
+++ b/C/cddlib/build_tarballs.jl
@@ -34,7 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FLINT/build_tarballs.jl
+++ b/F/FLINT/build_tarballs.jl
@@ -37,7 +37,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GMP_jll", v"6.1.2"),
-    Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
+    Dependency("MPFR_jll", v"4.0.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FLINT/build_tarballs.jl
+++ b/F/FLINT/build_tarballs.jl
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
 ]
 

--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -55,7 +55,7 @@ products = [
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
     Dependency("FFTW_jll"),
-    Dependency("MPFR_jll"),
+    Dependency("MPFR_jll", v"4.0.2"),
     Dependency("OpenBLAS_jll"),
 ]
 

--- a/G/GLPK/build_tarballs.jl
+++ b/G/GLPK/build_tarballs.jl
@@ -33,7 +33,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("GMP_jll")
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -45,7 +45,7 @@ products = Product[
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Zlib_jll"),
-    Dependency("GMP_jll"),
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency("Nettle_jll"),
 ]
 

--- a/I/ISL/build_tarballs.jl
+++ b/I/ISL/build_tarballs.jl
@@ -34,7 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/LEAN_Community/build_tarballs.jl
+++ b/L/LEAN_Community/build_tarballs.jl
@@ -41,7 +41,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/lib4ti2/build_tarballs.jl
+++ b/L/lib4ti2/build_tarballs.jl
@@ -105,7 +105,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("GMP_jll"),
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency("GLPK_jll"),
 ]
 

--- a/L/lrslib/build_tarballs.jl
+++ b/L/lrslib/build_tarballs.jl
@@ -56,7 +56,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/MPC/build_tarballs.jl
+++ b/M/MPC/build_tarballs.jl
@@ -36,7 +36,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GMP_jll", v"6.1.2"),
-    "MPFR_jll",
+    Dependency("MPFR_jll", v"4.0.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/MPC/build_tarballs.jl
+++ b/M/MPC/build_tarballs.jl
@@ -35,7 +35,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "GMP_jll",
+    Dependency("GMP_jll", v"6.1.2"),
     "MPFR_jll",
 ]
 

--- a/M/MPFI/build_tarballs.jl
+++ b/M/MPFI/build_tarballs.jl
@@ -37,7 +37,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll",  uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
 ]
 

--- a/M/MPFI/build_tarballs.jl
+++ b/M/MPFI/build_tarballs.jl
@@ -38,7 +38,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GMP_jll", v"6.1.2"),
-    Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
+    Dependency("MPFR_jll", v"4.0.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/MPFR/build_tarballs.jl
+++ b/M/MPFR/build_tarballs.jl
@@ -35,7 +35,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "GMP_jll",
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/N/Nettle/build_tarballs.jl
+++ b/N/Nettle/build_tarballs.jl
@@ -37,7 +37,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "GMP_jll",
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/N/nauty/build_tarballs.jl
+++ b/N/nauty/build_tarballs.jl
@@ -108,7 +108,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("GMP_jll"), # for sumlines
+    Dependency("GMP_jll", v"6.1.2"), # for sumlines
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/N/normaliz/build_tarballs.jl
+++ b/N/normaliz/build_tarballs.jl
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d")),
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82")),
     Dependency(PackageSpec(name="nauty_jll", uuid="55c6dc9b-343a-50ca-8ff2-b71adb3733d5")),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))

--- a/N/ntl/build_tarballs.jl
+++ b/N/ntl/build_tarballs.jl
@@ -34,7 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("GMP_jll"),
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/P/PPL/build_tarballs.jl
+++ b/P/PPL/build_tarballs.jl
@@ -38,7 +38,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -103,7 +103,7 @@ dependencies = [
     Dependency("CompilerSupportLibraries_jll")
     Dependency("FLINT_jll")
     Dependency("GMP_jll", v"6.1.2"),
-    Dependency("MPFR_jll")
+    Dependency("MPFR_jll", v"4.0.2"),
     Dependency("PPL_jll")
     Dependency(PackageSpec(name="Perl_jll", uuid="83958c19-0796-5285-893e-a1267f8ec499", version=v"5.30.3"))
     Dependency("bliss_jll")

--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -102,7 +102,7 @@ products = [
 dependencies = [
     Dependency("CompilerSupportLibraries_jll")
     Dependency("FLINT_jll")
-    Dependency("GMP_jll")
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency("MPFR_jll")
     Dependency("PPL_jll")
     Dependency(PackageSpec(name="Perl_jll", uuid="83958c19-0796-5285-893e-a1267f8ec499", version=v"5.30.3"))

--- a/S/SymEngine/build_tarballs.jl
+++ b/S/SymEngine/build_tarballs.jl
@@ -37,7 +37,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "GMP_jll",
+    Dependency("GMP_jll", v"6.1.2"),
     "MPFR_jll",
     "MPC_jll",
 ]

--- a/S/SymEngine/build_tarballs.jl
+++ b/S/SymEngine/build_tarballs.jl
@@ -38,7 +38,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GMP_jll", v"6.1.2"),
-    "MPFR_jll",
+    Dependency("MPFR_jll", v"4.0.2"),
     "MPC_jll",
 ]
 


### PR DESCRIPTION
... to ensure that future updates for these will keep working with Julia <= 1.5.

[skip ci]

It seems best to do this now in one batch, instead of having updates which forget to changes this trickle in over time. 