### PR TITLE
Singular: build against MPFR 4.0.2

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -57,7 +57,7 @@ dependencies = [
     Dependency("cddlib_jll"),
     Dependency("FLINT_jll"),
     Dependency("GMP_jll", v"6.1.2"),
-    Dependency("MPFR_jll"),
+    Dependency("MPFR_jll", v"4.0.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Similar to the issues with GMP_jll (see PR #1718), this prevents issues on macOS when trying to load Singular_jll in Julia <= 1.4 which ships with MPFR 4.0.2, and binaries linked against MPFR 4.1.0 won't load there on macOS.

This will likely be affected by the same bug https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/45 but I hope that won't matter?

This is also something that should be applied to other patches, similar to PR #1739.