### PR TITLE
Add LibYAML

### DIFF
--- a/L/LibYAML/build_tarballs.jl
+++ b/L/LibYAML/build_tarballs.jl
@@ -1,0 +1,41 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "LibYAML"
+version = v"0.2.5"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("http://pyyaml.org/download/libyaml/yaml-$version.tar.gz", "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/yaml-*/
+
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+make -j${nproc}
+make install
+
+# Move library on Windows
+if [[ "${target}" == *-mingw* ]]; then
+    mv "${libdir}"/libyaml-*.${dlext} "${libdir}/libyaml.${dlext}"
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libyaml", :libyaml)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/L/LibYAML/build_tarballs.jl
+++ b/L/LibYAML/build_tarballs.jl
@@ -17,11 +17,6 @@ cd ${WORKSPACE}/srcdir/yaml-*/
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
-
-# Move library on Windows
-if [[ "${target}" == *-mingw* ]]; then
-    mv "${libdir}"/libyaml-*.${dlext} "${libdir}/libyaml.${dlext}"
-fi
 """
 
 # These are the platforms we will build for by default, unless further
@@ -30,7 +25,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libyaml", :libyaml)
+    LibraryProduct(["libyaml", "libyaml-0"], :libyaml)
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
This PR adds a build script for LibYAML. This is the first time I work with Yggdrasil and BinaryBuilder, so make sure to check it carefully :slightly_smiling_face: 

BTW actually I would like to build a library that requires LibYAML, and hence I tried to package LibYAML first. I managed to install the LibYAML_jll package locally, but I didn't know how to use this local JLL package in local builds of other packages - I always got a an error message since it couldn't be resolved (even though it is added to my global environment). Is it possible to use local JLL packages as dependencies in build_tarballs.jl files?