### PR TITLE
[AZP] Fix detection of `[skip build]` and update wrappers for HWF

### DIFF
--- a/H/HelloWorldFortran/build_tarballs.jl
+++ b/H/HelloWorldFortran/build_tarballs.jl
@@ -27,5 +27,5 @@ products = [
 dependencies = [
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
+# Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
               SKIP_BUILD="true"
           fi
       else
-          if [[ "${BUILD_SOURCEVERSIONMESSAGE}" == *"${SKIP_BUILD_COOKIE}"* ]]; then
+          if [[ "$(git show -s --format=%B)" == *"${SKIP_BUILD_COOKIE}"* ]]; then
               SKIP_BUILD="true"
           fi
       fi


### PR DESCRIPTION
The undocumented environment variable `BUILD_SOURCEVERSIONMESSAGE` in Azure
Pipelines doesn't return anymore the full commit message but only the summary in
the first line.  Let's just stop hoping AZP will make things easier for us and
use git to get the full commit message.