### PR TITLE
JLL bump: LibVPX_jll

### DIFF
--- a/L/LibVPX/build_tarballs.jl
+++ b/L/LibVPX/build_tarballs.jl
@@ -80,4 +80,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
-


### PR DESCRIPTION
This pull request bumps the JLL version of LibVPX_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
