### PR TITLE
JLL bump: Opus_jll

### DIFF
--- a/O/Opus/build_tarballs.jl
+++ b/O/Opus/build_tarballs.jl
@@ -43,4 +43,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
-


### PR DESCRIPTION
This pull request bumps the JLL version of Opus_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
