### PR TITLE
JLL bump: FreeType2_jll

### DIFF
--- a/F/FreeType2/build_tarballs.jl
+++ b/F/FreeType2/build_tarballs.jl
@@ -36,3 +36,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of FreeType2_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
