### PR TITLE
JLL bump: libvorbis_jll

### DIFF
--- a/L/libvorbis/build_tarballs.jl
+++ b/L/libvorbis/build_tarballs.jl
@@ -47,4 +47,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of libvorbis_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
