### PR TITLE
JLL bump: x265_jll

### DIFF
--- a/X/x265/build_tarballs.jl
+++ b/X/x265/build_tarballs.jl
@@ -42,4 +42,3 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of x265_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
