### PR TITLE
JLL bump: Bzip2_jll

### DIFF
--- a/B/Bzip2/build_tarballs.jl
+++ b/B/Bzip2/build_tarballs.jl
@@ -75,3 +75,4 @@ dependencies = [
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Bzip2_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
