### PR TITLE
JLL bump: libass_jll

### DIFF
--- a/L/libass/build_tarballs.jl
+++ b/L/libass/build_tarballs.jl
@@ -38,4 +38,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of libass_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
