### PR TITLE
[libpolymake_julia] make gmp and mpfr dependencies explicit to fix versions

### DIFF
--- a/L/libpolymake_julia/build_tarballs.jl
+++ b/L/libpolymake_julia/build_tarballs.jl
@@ -52,6 +52,8 @@ dependencies = [
     BuildDependency(PackageSpec(name="Julia_jll", version="v1.4.1")),
     Dependency("libcxxwrap_julia_jll"),
     Dependency(PackageSpec(name="polymake_jll", version=VersionSpec("4.2.0-4.2"))),
+    Dependency("GMP_jll", v"6.1.2"),
+    Dependency("MPFR_jll", v"4.0.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
they are already indirect dependencies from `polymake_jll` but that
doesn't restrict the versions at build-time, so we need them explicit to make it work with
julia < 1.6 on macos:

```
ERROR: LoadError: InitError: could not load library "/Users/runner/.julia/artifacts/953c9e0347aff95c09f1c94ce54315063283f315/lib/libpolymake_julia.dylib"
dlopen(/Users/runner/.julia/artifacts/953c9e0347aff95c09f1c94ce54315063283f315/lib/libpolymake_julia.dylib, 1): Library not loaded: @rpath/libmpfr.6.dylib
  Referenced from: /Users/runner/.julia/artifacts/953c9e0347aff95c09f1c94ce54315063283f315/lib/libpolymake_julia.dylib
  Reason: Incompatible library version: libpolymake_julia.dylib requires version 8.0.0 or later, but libmpfr.dylib provides version 7.0.0
```