### PR TITLE
[libpolymake_julia] adjust Julia_jll dependency to fix registration issue in #1786

### DIFF
--- a/L/libpolymake_julia/build_tarballs.jl
+++ b/L/libpolymake_julia/build_tarballs.jl
@@ -52,8 +52,8 @@ dependencies = [
     BuildDependency(PackageSpec(name="Julia_jll", version=v"1.4.1")),
     Dependency("libcxxwrap_julia_jll"),
     Dependency(PackageSpec(name="polymake_jll", version=VersionSpec("4.2.0-4.2"))),
-    BuildDependency("GMP_jll", v"6.1.2"),
-    BuildDependency("MPFR_jll", v"4.0.2"),
+    BuildDependency(PackageSpec(name="GMP_jll", version=v"6.1.2")),
+    BuildDependency(PackageSpec(name="MPFR_jll", version=v"4.0.2")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libpolymake_julia/build_tarballs.jl
+++ b/L/libpolymake_julia/build_tarballs.jl
@@ -49,11 +49,11 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
-    BuildDependency(PackageSpec(name="Julia_jll", version="v1.4.1")),
+    BuildDependency(PackageSpec(name="Julia_jll", version=v"1.4.1")),
     Dependency("libcxxwrap_julia_jll"),
     Dependency(PackageSpec(name="polymake_jll", version=VersionSpec("4.2.0-4.2"))),
-    Dependency("GMP_jll", v"6.1.2"),
-    Dependency("MPFR_jll", v"4.0.2"),
+    BuildDependency("GMP_jll", v"6.1.2"),
+    BuildDependency("MPFR_jll", v"4.0.2"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
@giordano The registration issue seems to come from some change in Pkg.jl that was in included in the latest nightly.
From two days ago:
```
$ /tmp/julia/julia-1e7fb1d844/bin/julia -e 'using InteractiveUtils; versioninfo(); using Pkg; @show PackageSpec(name="Julia_jll", version="v1.4.1");'
Julia Version 1.6.0-DEV.1186
Commit 1e7fb1d844 (2020-10-12 07:50 UTC)
...
PackageSpec(name = "Julia_jll", version = "v1.4.1") = PackageSpec(
  name = Julia_jll
  version = VersionSpec("1.4.1")
)
```

Fresh download:
```
$ /tmp/julia/julia-a1da84c3b0/bin/julia -e 'using InteractiveUtils; versioninfo(); using Pkg; @show PackageSpec(name="Julia_jll", version="v1.4.1");'
Julia Version 1.6.0-DEV.1210
Commit a1da84c3b0 (2020-10-13 13:46 UTC)
...
ERROR: ArgumentError: invalid base 10 digit 'v' in "v1"
Stacktrace:
 [1] tryparse_internal(#unused#::Type{Int64}, s::SubString{String}, startpos::Int64, endpos::Int64, base_::Int64, raise::Bool)
   @ Base ./parse.jl:137
 [2] parse(::Type{Int64}, s::SubString{String}; base::Nothing)
   @ Base ./parse.jl:241
 [3] parse
   @ ./parse.jl:241 [inlined]
 [4] Pkg.Types.VersionBound(s::SubString{String})
   @ Pkg.Types /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Pkg/src/versions.jl:97
 [5] Pkg.Types.VersionRange(s::String)
   @ Pkg.Types /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Pkg/src/versions.jl:143
 [6] VersionSpec
   @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Pkg/src/versions.jl:225 [inlined]
 [7] #Package#246
   @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Pkg/src/API.jl:1413 [inlined]
 [8] top-level scope
   @ show.jl:895
```
I will try to look into the recent Pkg.jl changes what may have caused this.

Also make gmp and mpfr BuildDependency only, I remember vaguely that changing the dependencies in a rebuild may also cause registration issues?