### PR TITLE
Fix some version literals and BuildDependency versions

### DIFF
--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -10,7 +10,7 @@ llvm_tags = Dict(
     v"9.0.1" => "c1a0a213378a458fbea1a5c77b315c7dce08fd05",
 )
 
-function llvm_sources(;version = "v8.0.1", kwargs...)
+function llvm_sources(;version = v"8.0.1", kwargs...)
     return [
         "https://github.com/llvm/llvm-project.git" =>
         llvm_tags[version],

--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -19,7 +19,7 @@ sources = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(name="Julia_jll", version="v1.4.1")),
+    BuildDependency(PackageSpec(name="Julia_jll", version=v"1.4.1")),
 
     Dependency("CGAL_jll"),
     Dependency("libcxxwrap_julia_jll"),

--- a/L/libsingular_julia/build_tarballs.jl
+++ b/L/libsingular_julia/build_tarballs.jl
@@ -53,9 +53,11 @@ const products = [
 # Dependencies that must be installed before this package can be built
 const dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
-    BuildDependency(PackageSpec(name="Julia_jll", version="v1.4.1")),
+    BuildDependency(PackageSpec(name="Julia_jll", version=v"1.4.1")),
     Dependency("libcxxwrap_julia_jll"),
     Dependency("Singular_jll"),
+    BuildDependency(PackageSpec(name="GMP_jll", version=v"6.1.2")),
+    BuildDependency(PackageSpec(name="MPFR_jll", version=v"4.0.2")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -113,7 +113,7 @@ dependencies = [
     Dependency("libcxxwrap_julia_jll"),
     Dependency("OpenBLAS32_jll"),
     Dependency("CompilerSupportLibraries_jll"),
-    BuildDependency(PackageSpec(name="Julia_jll", version="v1.4.1")),
+    BuildDependency(PackageSpec(name="Julia_jll", version=v"1.4.1")),
     BuildDependency(MUMPS_seq_packagespec),
     BuildDependency(METIS_packagespec),
 ]


### PR DESCRIPTION
- replace `"vX.Y"` by `v"X.Y"`
- make build dependency of libsingular_julia on GMP_jll and MPFR_jll explicit and add missing version restrictions to ensure future binaries will have maximal compatibility (this mirrors a corresponding change in libpolymake_julia, see PR #1790 by @benlorenz who pointed out to me that this will be needed here, too)

[skip ci]