### PR TITLE
Fix libjulia 1.4.2 dependency issue on Julia 1.6

### DIFF
--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -217,24 +217,20 @@ function configure(version)
         Dependency("LibCURL_jll"),
         Dependency("Zlib_jll"),
         Dependency("p7zip_jll"),
+        Dependency("MPFR_jll"),
+        Dependency("GMP_jll"),
     ]
     if version.major == 1 && version.minor == 4
         push!(dependencies, Dependency(PackageSpec(name="OpenBLAS_jll", version=v"0.3.5")))
         push!(dependencies, Dependency(PackageSpec(name="libLLVM_jll", version=v"8.0.1")))
-        push!(dependencies, Dependency(PackageSpec(name="MPFR_jll", version=v"4.0.2")))
-        push!(dependencies, Dependency(PackageSpec(name="GMP_jll", version=v"6.1.2")))
         push!(dependencies, Dependency(PackageSpec(name="LibGit2_jll", version=v"0.28.2")))
     elseif version.major == 1 && version.minor == 5
         push!(dependencies, Dependency(PackageSpec(name="OpenBLAS_jll", version=v"0.3.9")))
         push!(dependencies, Dependency(PackageSpec(name="libLLVM_jll", version=v"9.0.1")))
-        push!(dependencies, Dependency(PackageSpec(name="MPFR_jll", version=v"4.1.0")))
-        push!(dependencies, Dependency(PackageSpec(name="GMP_jll", version=v"6.1.2")))
         push!(dependencies, Dependency(PackageSpec(name="LibGit2_jll", version=v"0.28.2")))
     elseif version.major == 1 && version.minor == 6
         push!(dependencies, Dependency(PackageSpec(name="OpenBLAS_jll", version=v"0.3.10")))
         push!(dependencies, Dependency(PackageSpec(name="libLLVM_jll", version=v"9.0.1")))
-        push!(dependencies, Dependency(PackageSpec(name="MPFR_jll", version=v"4.1.0")))
-        push!(dependencies, Dependency(PackageSpec(name="GMP_jll", version=v"6.2.0")))
         push!(dependencies, Dependency(PackageSpec(name="LibGit2_jll", version=v"1.0.1")))
     end
 

--- a/L/libjulia/libjulia@1.4/build_tarballs.jl
+++ b/L/libjulia/libjulia@1.4/build_tarballs.jl
@@ -4,4 +4,3 @@ name, version, sources, script, platforms, products, dependencies = configure(v"
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7", lock_microarchitecture=false)
-


### PR DESCRIPTION
This fix is required so that libjulia_jll 1.4.2 can be added in Julia 1.6.
See <https://github.com/JuliaRegistries/General/pull/23018>.

It relies on that fact that we set `julia_version` for all platforms, which
should ensure that GMP_jll and MPFR_jll are resolved to the correct versions.
