### PR TITLE
JLL bump: GTK3_jll

### DIFF
--- a/G/GTK3/build_tarballs.jl
+++ b/G/GTK3/build_tarballs.jl
@@ -99,4 +99,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of GTK3_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
