### PR TITLE
JLL bump: Pango_jll

### DIFF
--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -58,4 +58,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Pango_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
