### PR TITLE
JLL bump: Wayland_jll

### DIFF
--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -47,4 +47,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
-


### PR DESCRIPTION
This pull request bumps the JLL version of Wayland_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
