### PR TITLE
JLL bump: Libgcrypt_jll

### DIFF
--- a/L/Libgcrypt/build_tarballs.jl
+++ b/L/Libgcrypt/build_tarballs.jl
@@ -38,4 +38,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Libgcrypt_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
