### PR TITLE
JLL bump: Graphite2_jll

### DIFF
--- a/G/Graphite2/build_tarballs.jl
+++ b/G/Graphite2/build_tarballs.jl
@@ -39,4 +39,3 @@ dependencies = [
 # We require gcc 5+ so that mingw defines __MINGW_INTSAFE_WORKS, which allows `intsafe.h` to actually
 # have an effect.  Otherwise, we get a bevvy of errors around `SizeTMult` not being defined.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"5")
-


### PR DESCRIPTION
This pull request bumps the JLL version of Graphite2_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
