### PR TITLE
JLL bump: Xorg_libXcomposite_jll

### DIFF
--- a/X/Xorg_libXcomposite/build_tarballs.jl
+++ b/X/Xorg_libXcomposite/build_tarballs.jl
@@ -39,4 +39,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Xorg_libXcomposite_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
