### PR TITLE
JLL bump: HarfBuzz_jll

### DIFF
--- a/H/HarfBuzz/build_tarballs.jl
+++ b/H/HarfBuzz/build_tarballs.jl
@@ -55,3 +55,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"5")
+


### PR DESCRIPTION
This pull request bumps the JLL version of HarfBuzz_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
