### PR TITLE
JLL bump: Libglvnd_jll

### DIFF
--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -50,3 +50,4 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Libglvnd_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
