### PR TITLE
JLL bump: Xorg_libXau_jll

### DIFF
--- a/X/Xorg_libXau/build_tarballs.jl
+++ b/X/Xorg_libXau/build_tarballs.jl
@@ -38,4 +38,3 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Xorg_libXau_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
