### PR TITLE
JLL bump: Cairo_jll

### DIFF
--- a/C/Cairo/build_tarballs.jl
+++ b/C/Cairo/build_tarballs.jl
@@ -67,4 +67,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
-


### PR DESCRIPTION
This pull request bumps the JLL version of Cairo_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
