### PR TITLE
JLL bump: Xorg_libXrandr_jll

### DIFF
--- a/X/Xorg_libXrandr/build_tarballs.jl
+++ b/X/Xorg_libXrandr/build_tarballs.jl
@@ -40,4 +40,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Xorg_libXrandr_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
