### PR TITLE
JLL bump: Xorg_libXext_jll

### DIFF
--- a/X/Xorg_libXext/build_tarballs.jl
+++ b/X/Xorg_libXext/build_tarballs.jl
@@ -39,4 +39,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Xorg_libXext_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
