### PR TITLE
JLL bump: Wayland_protocols_jll

### DIFF
--- a/W/Wayland_protocols/build_tarballs.jl
+++ b/W/Wayland_protocols/build_tarballs.jl
@@ -34,4 +34,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Wayland_protocols_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
