### PR TITLE
JLL bump: at_spi2_atk_jll

### DIFF
--- a/A/at_spi2_atk/build_tarballs.jl
+++ b/A/at_spi2_atk/build_tarballs.jl
@@ -44,4 +44,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of at_spi2_atk_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
