### PR TITLE
JLL bump: Librsvg_jll

### DIFF
--- a/L/Librsvg/build_tarballs.jl
+++ b/L/Librsvg/build_tarballs.jl
@@ -96,3 +96,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers=[:c, :rust])
+


### PR DESCRIPTION
This pull request bumps the JLL version of Librsvg_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
