### PR TITLE
JLL bump: Xorg_libX11_jll

### DIFF
--- a/X/Xorg_libX11/build_tarballs.jl
+++ b/X/Xorg_libX11/build_tarballs.jl
@@ -43,4 +43,3 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Xorg_libX11_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
