### PR TITLE
JLL bump: Libuuid_jll

### DIFF
--- a/L/Libuuid/build_tarballs.jl
+++ b/L/Libuuid/build_tarballs.jl
@@ -35,4 +35,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Libuuid_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
