### PR TITLE
JLL bump: Fontconfig_jll

### DIFF
--- a/F/Fontconfig/build_tarballs.jl
+++ b/F/Fontconfig/build_tarballs.jl
@@ -83,4 +83,3 @@ build_tarballs(ARGS, name, version, sources, script, platforms, products, depend
 ENV["FONTCONFIG_FILE"] = get(ENV, "FONTCONFIG_FILE", fonts_conf)
     ENV["FONTCONFIG_PATH"] = get(ENV, "FONTCONFIG_PATH", dirname(ENV["FONTCONFIG_FILE"]))
 """)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Fontconfig_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
