### PR TITLE
JLL bump: Pixman_jll

### DIFF
--- a/P/Pixman/build_tarballs.jl
+++ b/P/Pixman/build_tarballs.jl
@@ -32,4 +32,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6")
-


### PR DESCRIPTION
This pull request bumps the JLL version of Pixman_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
