### PR TITLE
JLL bump: Gnome_themes_extra

### DIFF
--- a/G/Gnome_themes_extra/build_tarballs.jl
+++ b/G/Gnome_themes_extra/build_tarballs.jl
@@ -56,3 +56,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Gnome_themes_extra.
It was generated via the `recursively_regenerate_jlls.jl` script.
