### PR TITLE
JLL bump: Glib_jll

### DIFF
--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -69,4 +69,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Glib_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
