### PR TITLE
JLL bump: Libcroco_jll

### DIFF
--- a/L/Libcroco/build_tarballs.jl
+++ b/L/Libcroco/build_tarballs.jl
@@ -45,3 +45,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Libcroco_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
