### PR TITLE
JLL bump: libpng_jll

### DIFF
--- a/L/libpng/build_tarballs.jl
+++ b/L/libpng/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"1.6.37"
 
 # Collection of sources required to build libpng
 sources = [
-    ArchiveSource("https://downloads.sourceforge.net/libpng/libpng-$(version).tar.gz",
+    ArchiveSource("https://sourceforge.net/projects/libpng/files/libpng16/$(version)/libpng-$(version).tar.gz",
                   "daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4"),
 ]
 


### PR DESCRIPTION
This pull request bumps the JLL version of libpng_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
