### PR TITLE
JLL bump: LZO_jll

### DIFF
--- a/L/LZO/build_tarballs.jl
+++ b/L/LZO/build_tarballs.jl
@@ -34,4 +34,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of LZO_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
