### PR TITLE
JLL bump: ICU_jll

### DIFF
--- a/I/ICU/build_tarballs.jl
+++ b/I/ICU/build_tarballs.jl
@@ -76,3 +76,4 @@ dependencies = Dependency[
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7")
+


### PR DESCRIPTION
This pull request bumps the JLL version of ICU_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
