### PR TITLE
JLL bump: SDL2

### DIFF
--- a/S/SDL2/build_tarballs.jl
+++ b/S/SDL2/build_tarballs.jl
@@ -55,3 +55,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of SDL2.
It was generated via the `recursively_regenerate_jlls.jl` script.
