### PR TITLE
JLL bump: Xorg_libXScrnSaver_jll

### DIFF
--- a/X/Xorg_libXScrnSaver/build_tarballs.jl
+++ b/X/Xorg_libXScrnSaver/build_tarballs.jl
@@ -39,3 +39,4 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Xorg_libXScrnSaver_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
