### PR TITLE
JLL bump: adwaita_icon_theme_jll

### DIFF
--- a/A/adwaita_icon_theme/build_tarballs.jl
+++ b/A/adwaita_icon_theme/build_tarballs.jl
@@ -39,4 +39,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of adwaita_icon_theme_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
