### PR TITLE
libjulia 1.4.2: try again

### DIFF
--- a/L/libjulia/libjulia@1.4/build_tarballs.jl
+++ b/L/libjulia/libjulia@1.4/build_tarballs.jl
@@ -4,3 +4,4 @@ name, version, sources, script, platforms, products, dependencies = configure(v"
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7", lock_microarchitecture=false)
+


### PR DESCRIPTION
The previous two libjulia 1.4.2 PRs run into issues: the first got stuck because of a dependency problem, see https://github.com/JuliaRegistries/General/pull/23018. Then I made #1797 which should have fixed the issue, but Yggdrasil failed to push the changes to https://github.com/JuliaBinaryWrappers/libjulia_jll.jl. Perhaps third time is the charm...