### PR TITLE
Switch GMP back to 6.1.2 to rebuild its JLL wrapper

### DIFF
--- a/G/GMP/build_tarballs.jl
+++ b/G/GMP/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder
 
 # Collection of sources required to build GMP
 name = "GMP"
-version = v"6.2.0"
+version = v"6.1.2"
 
 sources = [
     ArchiveSource("https://gmplib.org/download/gmp/gmp-$(version).tar.bz2",
-                  "f51c99cb114deb21a60075ffb494c1a210eb9d7cb729ed042ddb7de9534451ea"),
+                  "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2"),
     DirectorySource("./bundled"),
 ]
 
@@ -16,10 +16,15 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/gmp-*
 
+# Update config.status
+update_configure_scripts
+
+# Patch `configure` to include `$LDFLAGS` in its tests.  This is necessary on FreeBSD.
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/configure.patch
+
 # Include Julia-carried patches
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/gmp_alloc_overflow_func.patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/gmp-exception.patch
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/gmp-apple-arm64.patch
 
 flags=(--enable-cxx --enable-shared --disable-static)
 
@@ -28,8 +33,11 @@ if [[ ${proc_family} == intel ]]; then
     flags+=(--enable-fat)
 fi
 
-autoreconf
 ./configure --prefix=$prefix --build=${MACHTYPE} --host=${target} ${flags[@]}
+
+# Something is broken in the libtool that gets generated on macOS; I can't
+# figure out why, but `hardcode_action` is set to blank for CXX files.  /shrug
+sed -i -e 's&hardcode_action=$&hardcode_action=immediate&g' libtool
 
 make -j${nproc}
 make install
@@ -46,7 +54,7 @@ install_license COPYING*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis([supported_platforms(); MacOS(:aarch64)])
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/G/GMP/bundled/patches/configure.patch
+++ b/G/GMP/bundled/patches/configure.patch
@@ -1,0 +1,464 @@
+--- gmp-6.1.2/configure	2019-03-25 17:58:41.928471374 -0400
++++ gmp-6.1.2-LDFLAGS/configure	2019-03-26 13:08:07.756316866 -0400
+@@ -5880,7 +5880,7 @@ if test "$gmp_prog_cc_works" = yes; then
+ int main () { return 0; }
+ EOF
+   echo "Test compile: " >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -5934,7 +5934,7 @@ void *f() { return g(); }
+ int main () { return 0; }
+ EOF
+   echo "Test compile: function pointer return" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -5990,7 +5990,7 @@ int cmov () { return (n >= 0 ? n : 0); }
+ int main () { return 0; }
+ EOF
+   echo "Test compile: cmov instruction" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6047,7 +6047,7 @@ unsigned long gcc303 () { return (unsign
+ int main () { return 0; }
+ EOF
+   echo "Test compile: double -> ulong conversion" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6102,7 +6102,7 @@ unsigned long fneg () { return -fneg_dat
+ int main () { return 0; }
+ EOF
+   echo "Test compile: double negation" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6158,7 +6158,7 @@ float ftod () { return (float) ftod_data
+ int main () { return 0; }
+ EOF
+   echo "Test compile: double -> float conversion" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6243,7 +6243,7 @@ param_init ()
+ int main () { return 0; }
+ EOF
+   echo "Test compile: gnupro alpha ev6 char spilling" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6294,7 +6294,7 @@ if test "$gmp_prog_cc_works" = yes; then
+ int k; int foo () { __builtin_alloca (k); }
+ EOF
+   echo "Test compile: __builtin_alloca availability" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6340,7 +6340,7 @@ int foo ()
+ int main () { return 0; }
+ EOF
+   echo "Test compile: alloca array" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6418,7 +6418,7 @@ int f ()
+ int main () { return 0; }
+ EOF
+   echo "Test compile: abs int -> double conversion" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6483,7 +6483,7 @@ int dummy;
+ int main () { return 0; }
+ EOF
+   echo "Test compile: long long reliability test 1" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6544,7 +6544,7 @@ int dummy;
+ int main () { return 0; }
+ EOF
+   echo "Test compile: long long reliability test 2" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6605,7 +6605,7 @@ int dummy;
+ int main () { return 0; }
+ EOF
+   echo "Test compile: freebsd hacked gcc" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6704,7 +6704,7 @@ main ()
+ 
+ EOF
+   echo "Test compile: mpn_lshift_com optimization" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -6813,7 +6813,7 @@ main ()
+ 
+ EOF
+   echo "Test compile: mpn_lshift_com optimization 2" >&5
+-  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7325,7 +7325,7 @@ _main:
+ 	xorl	%eax, %eax
+ 	ret
+ EOF
+-  gmp_compile="$cc $cflags $cppflags conftest.s -o conftest >&5"
++  gmp_compile="$cc $cflags $cppflags $LDFLAGS conftest.s -o conftest >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7390,7 +7390,7 @@ $as_echo_n "checking compiler $cc $cflag
+   cat >conftest.c <<EOF
+ int main () { return 0; }
+ EOF
+-  gmp_compile="$cc $cflags -no-cpp-precomp conftest.c >conftest.out 2>&1"
++  gmp_compile="$cc $cflags $LDFLAGS -no-cpp-precomp conftest.c >conftest.out 2>&1"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7498,7 +7498,7 @@ if test "$gmp_prog_cc_works" = yes; then
+ int main () { return 0; }
+ EOF
+   echo "Test compile: " >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7552,7 +7552,7 @@ void *f() { return g(); }
+ int main () { return 0; }
+ EOF
+   echo "Test compile: function pointer return" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7608,7 +7608,7 @@ int cmov () { return (n >= 0 ? n : 0); }
+ int main () { return 0; }
+ EOF
+   echo "Test compile: cmov instruction" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7665,7 +7665,7 @@ unsigned long gcc303 () { return (unsign
+ int main () { return 0; }
+ EOF
+   echo "Test compile: double -> ulong conversion" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7720,7 +7720,7 @@ unsigned long fneg () { return -fneg_dat
+ int main () { return 0; }
+ EOF
+   echo "Test compile: double negation" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7776,7 +7776,7 @@ float ftod () { return (float) ftod_data
+ int main () { return 0; }
+ EOF
+   echo "Test compile: double -> float conversion" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7861,7 +7861,7 @@ param_init ()
+ int main () { return 0; }
+ EOF
+   echo "Test compile: gnupro alpha ev6 char spilling" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7912,7 +7912,7 @@ if test "$gmp_prog_cc_works" = yes; then
+ int k; int foo () { __builtin_alloca (k); }
+ EOF
+   echo "Test compile: __builtin_alloca availability" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -7958,7 +7958,7 @@ int foo ()
+ int main () { return 0; }
+ EOF
+   echo "Test compile: alloca array" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -8036,7 +8036,7 @@ int f ()
+ int main () { return 0; }
+ EOF
+   echo "Test compile: abs int -> double conversion" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -8101,7 +8101,7 @@ int dummy;
+ int main () { return 0; }
+ EOF
+   echo "Test compile: long long reliability test 1" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -8162,7 +8162,7 @@ int dummy;
+ int main () { return 0; }
+ EOF
+   echo "Test compile: long long reliability test 2" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -8223,7 +8223,7 @@ int dummy;
+ int main () { return 0; }
+ EOF
+   echo "Test compile: freebsd hacked gcc" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -8322,7 +8322,7 @@ main ()
+ 
+ EOF
+   echo "Test compile: mpn_lshift_com optimization" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -8431,7 +8431,7 @@ main ()
+ 
+ EOF
+   echo "Test compile: mpn_lshift_com optimization 2" >&5
+-  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  gmp_compile="$cc $cflags $cppflags $flag $LDFLAGS conftest.c >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -9987,7 +9987,7 @@ main ()
+   return 0;
+ }
+ EOF
+-gmp_compile="$CC_FOR_BUILD conftest.c"
++gmp_compile="$CC_FOR_BUILD $LDFLAGS conftest.c"
+ cc_for_build_works=no
+ if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+@@ -10019,7 +10019,7 @@ main ()
+   return 0;
+ }
+ EOF
+-gmp_compile="$HOST_CC conftest.c"
++gmp_compile="$HOST_CC $LDFLAGS conftest.c"
+ cc_for_build_works=no
+ if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+@@ -10052,7 +10052,7 @@ main ()
+   return 0;
+ }
+ EOF
+-gmp_compile="$i conftest.c"
++gmp_compile="$i $LDFLAGS conftest.c"
+ cc_for_build_works=no
+ if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+@@ -10132,7 +10132,7 @@ main ()
+ }
+ EOF
+ for i in .exe ,ff8 ""; do
+-  gmp_compile="$CC_FOR_BUILD conftest.c -o conftest$i"
++  gmp_compile="$CC_FOR_BUILD $LDFLAGS conftest.c -o conftest$i"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -10168,7 +10168,7 @@ main (int argc, char **argv)
+   return 0;
+ }
+ EOF
+-gmp_compile="$CC_FOR_BUILD conftest.c"
++gmp_compile="$CC_FOR_BUILD $LDFLAGS conftest.c"
+ if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -10210,7 +10210,7 @@ foo ()
+   return log (d);
+ }
+ EOF
+-gmp_compile="$CC_FOR_BUILD conftest.c -lm"
++gmp_compile="$CC_FOR_BUILD $LDFLAGS conftest.c -lm"
+ if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+@@ -10543,7 +10543,7 @@ if test "$gmp_prog_cxx_works" = yes; the
+ int main (void) { return 0; }
+ EOF
+   echo "Test compile: " >&5
+-  gmp_cxxcompile="$CXX $CPPFLAGS $CXXFLAGS conftest.cc >&5"
++  gmp_cxxcompile="$CXX $CPPFLAGS $CXXFLAGS $LDFLAGS conftest.cc >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_cxxcompile\""; } >&5
+   (eval $gmp_cxxcompile) 2>&5
+   ac_status=$?
+@@ -10583,7 +10583,7 @@ using namespace foo;
+ int main (void) { return 0; }
+ EOF
+   echo "Test compile: namespace" >&5
+-  gmp_cxxcompile="$CXX $CPPFLAGS $CXXFLAGS conftest.cc >&5"
++  gmp_cxxcompile="$CXX $CPPFLAGS $CXXFLAGS $LDFLAGS conftest.cc >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_cxxcompile\""; } >&5
+   (eval $gmp_cxxcompile) 2>&5
+   ac_status=$?
+@@ -10629,7 +10629,7 @@ void someoutput (void) { std::cout << 12
+ int main (void) { return 0; }
+ EOF
+   echo "Test compile: std iostream" >&5
+-  gmp_cxxcompile="$CXX $CPPFLAGS $CXXFLAGS conftest.cc >&5"
++  gmp_cxxcompile="$CXX $CPPFLAGS $CXXFLAGS $LDFLAGS conftest.cc >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_cxxcompile\""; } >&5
+   (eval $gmp_cxxcompile) 2>&5
+   ac_status=$?
+@@ -27095,7 +27095,7 @@ for tmp_underscore in "" "_"; do
+ ${tmp_gsym_prefix}main$gmp_cv_asm_label_suffix
+ 	addl	$ ${tmp_underscore}_GLOBAL_OFFSET_TABLE_, %ebx
+ EOF
+-  gmp_compile="$CCAS $CFLAGS $CPPFLAGS $lt_prog_compiler_pic conftest.s >&5 && $CC $CFLAGS $CPPFLAGS $lt_prog_compiler_pic conftest.$OBJEXT >&5"
++  gmp_compile="$CCAS $CFLAGS $CPPFLAGS $lt_prog_compiler_pic conftest.s >&5 && $CC $CFLAGS $CPPFLAGS $LDFLAGS $lt_prog_compiler_pic conftest.$OBJEXT >&5"
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
+   (eval $gmp_compile) 2>&5
+   ac_status=$?
+--- gmp-6.1.2/acinclude.m4	2016-12-16 10:45:27.000000000 -0500
++++ gmp-6.1.2-LDFLAGS/acinclude.m4	2019-03-26 13:08:01.328189815 -0400
+@@ -826,7 +826,7 @@ AC_DEFUN([GMP_PROG_CC_WORKS_PART_TEST],
+ [$3]
+ EOF
+   echo "Test compile: [$2]" >&AC_FD_CC
+-  gmp_compile="$1 conftest.c >&AC_FD_CC"
++  gmp_compile="$1 $LDFLAGS conftest.c >&AC_FD_CC"
+   if AC_TRY_EVAL(gmp_compile); then
+     cc_works_part=yes
+     if test "$cross_compiling" = no; then
+@@ -1147,7 +1147,7 @@ AC_DEFUN([GMP_GCC_NO_CPP_PRECOMP],
+   cat >conftest.c <<EOF
+ int main () { return 0; }
+ EOF
+-  gmp_compile="$2 $3 -no-cpp-precomp conftest.c >conftest.out 2>&1"
++  gmp_compile="$2 $3 $LDFLAGS -no-cpp-precomp conftest.c >conftest.out 2>&1"
+   if AC_TRY_EVAL(gmp_compile); then
+     if grep "unrecognized option.*-no-cpp-precomp" conftest.out >/dev/null; then : ;
+     else
+@@ -1328,7 +1328,7 @@ _main:
+ 	xorl	%eax, %eax
+ 	ret
+ EOF
+-  gmp_compile="$1 conftest.s -o conftest >&AC_FD_CC"
++  gmp_compile="$1 $LDFLAGS conftest.s -o conftest >&AC_FD_CC"
+   if AC_TRY_EVAL(gmp_compile); then
+     if AC_TRY_COMMAND([./a.out || ./b.out || ./a.exe || ./a_out.exe || ./conftest]); then
+       gmp_cv_os_x86_xmm=yes
+@@ -1495,7 +1495,7 @@ AC_DEFUN([GMP_PROG_CXX_WORKS_PART],
+ int main (void) { return 0; }
+ EOF
+   echo "Test compile: [$2]" >&AC_FD_CC
+-  gmp_cxxcompile="$1 conftest.cc >&AC_FD_CC"
++  gmp_cxxcompile="$1 $LDFLAGS conftest.cc >&AC_FD_CC"
+   if AC_TRY_EVAL(gmp_cxxcompile); then
+     if test "$cross_compiling" = no; then
+       if AC_TRY_COMMAND([./a.out || ./b.out || ./a.exe || ./a_out.exe || ./conftest]); then :;
+@@ -2382,7 +2382,7 @@ for tmp_underscore in "" "_"; do
+ ${tmp_gsym_prefix}main$gmp_cv_asm_label_suffix
+ 	addl	$ ${tmp_underscore}_GLOBAL_OFFSET_TABLE_, %ebx
+ EOF
+-  gmp_compile="$CCAS $CFLAGS $CPPFLAGS $lt_prog_compiler_pic conftest.s >&AC_FD_CC && $CC $CFLAGS $CPPFLAGS $lt_prog_compiler_pic conftest.$OBJEXT >&AC_FD_CC"
++  gmp_compile="$CCAS $CFLAGS $CPPFLAGS $lt_prog_compiler_pic conftest.s >&AC_FD_CC && $CC $CFLAGS $CPPFLAGS $LDFLAGS $lt_prog_compiler_pic conftest.$OBJEXT >&AC_FD_CC"
+   if AC_TRY_EVAL(gmp_compile); then
+     if test "$tmp_underscore" = "_"; then
+       gmp_cv_asm_x86_got_underscore=yes
+@@ -3856,7 +3856,7 @@ main ()
+   return 0;
+ }
+ EOF
+-gmp_compile="$1 conftest.c"
++gmp_compile="$1 $LDFLAGS conftest.c"
+ cc_for_build_works=no
+ if AC_TRY_EVAL(gmp_compile); then
+   if (./a.out || ./b.out || ./a.exe || ./a_out.exe || ./conftest) >&AC_FD_CC 2>&1; then
+@@ -3931,7 +3931,7 @@ main ()
+ }
+ EOF
+ for i in .exe ,ff8 ""; do
+-  gmp_compile="$CC_FOR_BUILD conftest.c -o conftest$i"
++  gmp_compile="$CC_FOR_BUILD $LDFLAGS conftest.c -o conftest$i"
+   if AC_TRY_EVAL(gmp_compile); then
+     if (./conftest) 2>&AC_FD_CC; then
+       gmp_cv_prog_exeext_for_build=$i
+@@ -3966,7 +3966,7 @@ main (int argc, char **argv)
+   return 0;
+ }
+ EOF
+-gmp_compile="$CC_FOR_BUILD conftest.c"
++gmp_compile="$CC_FOR_BUILD $LDFLAGS conftest.c"
+ if AC_TRY_EVAL(gmp_compile); then
+   gmp_cv_c_for_build_ansi=yes
+ else
+@@ -4007,7 +4007,7 @@ foo ()
+   return log (d);
+ }
+ EOF
+-gmp_compile="$CC_FOR_BUILD conftest.c -lm"
++gmp_compile="$CC_FOR_BUILD $LDFLAGS conftest.c -lm"
+ if AC_TRY_EVAL(gmp_compile); then
+   gmp_cv_check_libm_for_build=-lm
+ else
+

--- a/G/GMP/bundled/patches/gmp-exception.patch
+++ b/G/GMP/bundled/patches/gmp-exception.patch
@@ -1,14 +1,35 @@
-diff --git a/errno.c b/errno.c
-index b4be555..3f772a5 100644
---- a/errno.c
-+++ b/errno.c
-@@ -68,5 +68,8 @@ __gmp_sqrt_of_negative (void)
- void
- __gmp_divide_by_zero (void)
- {
-+  /* try to force a division by zero system exception */
-+  __gmp_junk = 10 / __gmp_0;
+diff -r 842c2ba359bf errno.c
+--- a/errno.c	Sun Jan 24 22:06:51 2016 +0100
++++ b/errno.c	Thu Jan 28 13:37:54 2016 -0500
+@@ -33,24 +33,24 @@
+ see https://www.gnu.org/licenses/.  */
+ 
+ #include <stdlib.h>
 +
-   __gmp_exception (GMP_ERROR_DIVISION_BY_ZERO);
++#include <signal.h>
++
+ #include "gmp.h"
+ #include "gmp-impl.h"
+ 
+ int gmp_errno = 0;
+ 
+ 
+-/* The deliberate divide by zero triggers an exception on most systems.  On
+-   those where it doesn't, for example power and powerpc, use abort instead.
+-
+-   Enhancement: Perhaps raise(SIGFPE) (or the same with kill()) would be
+-   better than abort.  Perhaps it'd be possible to get the BSD style
+-   FPE_INTDIV_TRAP parameter in there too.  */
+-
++/* Use SIGFPE on systems which have it. Otherwise, deliberate divide
++   by zero, which triggers an exception on most systems. On those
++   where it doesn't, for example power and powerpc, use abort instead. */
+ void
+ __gmp_exception (int error_bit)
+ {
+   gmp_errno |= error_bit;
+   __gmp_junk = 10 / __gmp_0;
++  raise (SIGFPE);
+   abort ();
  }
-
+ 


### PR DESCRIPTION
This is temporary and shall be reverted once the update is complete.

Uses expand_cxxstring_abis so a full rebuild is needed.