### PR TITLE
[GDAL] Add expat support

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -43,6 +43,7 @@ rm -f ${prefix}/lib/*.la
     --with-geos=${bindir}/geos-config \
     --with-proj=$prefix \
     --with-libz=$prefix \
+    --with-expat=$prefix \
     --with-sqlite3=$prefix \
     --with-curl=${bindir}/curl-config \
     --with-openjpeg \
@@ -92,6 +93,7 @@ dependencies = [
     Dependency("SQLite_jll"),
     Dependency("LibCURL_jll"),
     Dependency("OpenJpeg_jll"),
+    Dependency("Expat_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -94,6 +94,11 @@ dependencies = [
     Dependency("LibCURL_jll"),
     Dependency("OpenJpeg_jll"),
     Dependency("Expat_jll"),
+    # The following libraries are dependencies of LibCURL_jll which is now a
+    # stdlib, but the stdlib doesn't explicitly list its dependencies
+    Dependency("LibSSH2_jll"),
+    Dependency("MbedTLS_jll"),
+    Dependency("nghttp2_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Works on Linux, let's see what all other platforms do.

Should support many webbased xml formats in GDAL. See also https://github.com/JuliaGeo/GDAL.jl/issues/65 and ping @visr.