### PR TITLE
Remove almost all outdated platform specifications

### DIFF
--- a/0_RootFS/Go/build_tarballs.jl
+++ b/0_RootFS/Go/build_tarballs.jl
@@ -18,7 +18,7 @@ mv ${WORKSPACE}/srcdir/go ${prefix}/
 # We only build for Linux x86_64
 platforms = [
     # TODO: Switch to musl once https://github.com/rust-lang/rustup.rs/pull/1882 is released
-    Linux(:x86_64; libc=:musl),
+    Platform("x86_64", "linux"; libc="musl"),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/0_RootFS/Rust/build_tarballs.jl
+++ b/0_RootFS/Rust/build_tarballs.jl
@@ -50,7 +50,7 @@ ${CARGO_HOME}/bin/cargo install cargo-edit
 """
 
 # We assemble this giant tarball, then will split it up immediately after this:
-platforms = [Linux(:x86_64; libc=:glibc)]
+platforms = [Platform("x86_64", "linux"; libc="glibc")]
 products = [
     ExecutableProduct("cargo", :cargo),
 ]
@@ -65,7 +65,7 @@ rm(joinpath("products", first(values(build_info))[1]))
 
 # Take the hash of the unpacked MegaRust artifact, then split it into a bunch of smaller ones
 mega_rust_path = artifact_path(first(values(build_info))[3])
-rust_host = Linux(:x86_64; libc=:glibc)
+rust_host = Platform("x86_64", "linux"; libc="glibc")
 rust_host_triplet = BinaryBuilder.map_rust_target(rust_host)
 
 for target_platform in supported_platforms()

--- a/A/AccerionSensorAPI/build_tarballs.jl
+++ b/A/AccerionSensorAPI/build_tarballs.jl
@@ -24,15 +24,15 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl")
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/A/aiger/build_tarballs.jl
+++ b/A/aiger/build_tarballs.jl
@@ -27,16 +27,16 @@ PREFIX=$prefix make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "freebsd")
 ]
 
 

--- a/A/assimp/build_tarballs.jl
+++ b/A/assimp/build_tarballs.jl
@@ -27,8 +27,8 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [p for p in supported_platforms() if p != Linux(:i686, libc=:musl) &&
-                                                 p != Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+platforms = [p for p in supported_platforms() if p != Platform("i686", "linux"; libc="musl") &&
+                                                 p != Platform("armv7l", "linux"; libc="musl")
             ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -74,7 +74,7 @@ done
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [Linux(:x86_64)]
+platforms = [Platform("x86_64", "linux")]
 
 # The products that we will ensure are always built
 products = prefix -> [

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -78,13 +78,13 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:musl),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Windows(:x86_64),
-    MacOS(:x86_64),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    FreeBSD(:x86_64)
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("x86_64", "windows"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("x86_64", "freebsd")
 ]
 
 

--- a/B/bmon/build_tarballs.jl
+++ b/B/bmon/build_tarballs.jl
@@ -25,16 +25,16 @@ install_license LICENSE.*
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos")
 ]
 
 # The products that we will ensure are always built

--- a/C/CUDA/CUDA@10.0/build_tarballs.jl
+++ b/C/CUDA/CUDA@10.0/build_tarballs.jl
@@ -187,4 +187,4 @@ products = [
 ]
 
 build_tarballs(ARGS, name, version, [], script,
-               [Linux(:x86_64), MacOS(:x86_64), Windows(:x86_64)], products, dependencies)
+               [Platform("x86_64", "linux"), Platform("x86_64", "macos"), Platform("x86_64", "windows")], products, dependencies)

--- a/C/CUDA/CUDA@10.1/build_tarballs.jl
+++ b/C/CUDA/CUDA@10.1/build_tarballs.jl
@@ -198,4 +198,4 @@ products = [
 ]
 
 build_tarballs(ARGS, name, version, [], script,
-               [Linux(:x86_64), MacOS(:x86_64), Windows(:x86_64)], products, dependencies)
+               [Platform("x86_64", "linux"), Platform("x86_64", "macos"), Platform("x86_64", "windows")], products, dependencies)

--- a/C/CUDA/CUDA@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA@10.2/build_tarballs.jl
@@ -152,4 +152,4 @@ products = [
 ]
 
 build_tarballs(ARGS, name, version, [], script,
-               [Linux(:x86_64), Windows(:x86_64)], products, dependencies)
+               [Platform("x86_64", "linux"), Platform("x86_64", "windows")], products, dependencies)

--- a/C/CUDA/CUDA@11.0/build_tarballs.jl
+++ b/C/CUDA/CUDA@11.0/build_tarballs.jl
@@ -144,5 +144,5 @@ products = [
 ]
 
 build_tarballs(ARGS, name, version, [], script,
-               [Linux(:x86_64), Linux(:powerpc64le), Windows(:x86_64)],
+               [Platform("x86_64", "linux"), Platform("powerpc64le", "linux"), Platform("x86_64", "windows")],
                products, dependencies)

--- a/C/CUDA/CUDA@11.1/build_tarballs.jl
+++ b/C/CUDA/CUDA@11.1/build_tarballs.jl
@@ -144,5 +144,5 @@ products = [
 ]
 
 build_tarballs(ARGS, name, version, [], script,
-               [Linux(:x86_64), Linux(:powerpc64le), Windows(:x86_64)],
+               [Platform("x86_64", "linux"), Platform("powerpc64le", "linux"), Platform("x86_64", "windows")],
                products, dependencies)

--- a/C/CUDA/CUDA@9.0/build_tarballs.jl
+++ b/C/CUDA/CUDA@9.0/build_tarballs.jl
@@ -187,4 +187,4 @@ products = [
 ]
 
 build_tarballs(ARGS, name, version, [], script,
-               [Linux(:x86_64), MacOS(:x86_64), Windows(:x86_64)], products, dependencies)
+               [Platform("x86_64", "linux"), Platform("x86_64", "macos"), Platform("x86_64", "windows")], products, dependencies)

--- a/C/CUDA/CUDA@9.2/build_tarballs.jl
+++ b/C/CUDA/CUDA@9.2/build_tarballs.jl
@@ -187,4 +187,4 @@ products = [
 ]
 
 build_tarballs(ARGS, name, version, [], script,
-               [Linux(:x86_64), MacOS(:x86_64), Windows(:x86_64)], products, dependencies)
+               [Platform("x86_64", "linux"), Platform("x86_64", "macos"), Platform("x86_64", "windows")], products, dependencies)

--- a/C/CUDA/CUDA_full@10.0/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.0/build_tarballs.jl
@@ -96,18 +96,18 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 if should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux, script,
-                   [Linux(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-apple-darwin14")
     build_tarballs(non_reg_ARGS, name, version, sources_macos, script,
-                   [MacOS(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "macos")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_windows, script,
-                   [Windows(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "windows")], products, dependencies;
                    skip_audit=true)
 end

--- a/C/CUDA/CUDA_full@10.1/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.1/build_tarballs.jl
@@ -94,18 +94,18 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 if should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux, script,
-                   [Linux(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-apple-darwin14")
     build_tarballs(non_reg_ARGS, name, version, sources_macos, script,
-                   [MacOS(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "macos")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_windows, script,
-                   [Windows(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "windows")], products, dependencies;
                    skip_audit=true)
 end

--- a/C/CUDA/CUDA_full@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.2/build_tarballs.jl
@@ -94,18 +94,18 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 if should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux, script,
-                   [Linux(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-apple-darwin14")
     build_tarballs(non_reg_ARGS, name, version, sources_macos, script,
-                   [MacOS(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "macos")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_windows, script,
-                   [Windows(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "windows")], products, dependencies;
                    skip_audit=true)
 end

--- a/C/CUDA/CUDA_full@11.0/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@11.0/build_tarballs.jl
@@ -97,18 +97,18 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 if should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux, script,
-                   [Linux(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("powerpc64le-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_ppc64le, script,
-                   [Linux(:powerpc64le)], products, dependencies;
+                   [Platform("powerpc64le", "linux")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_win10, script,
-                   [Windows(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "windows")], products, dependencies;
                    skip_audit=true)
 end

--- a/C/CUDA/CUDA_full@11.1/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@11.1/build_tarballs.jl
@@ -100,18 +100,18 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 if should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux, script,
-                   [Linux(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("powerpc64le-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_ppc64le, script,
-                   [Linux(:powerpc64le)], products, dependencies;
+                   [Platform("powerpc64le", "linux")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_win10, script,
-                   [Windows(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "windows")], products, dependencies;
                    skip_audit=true)
 end

--- a/C/CUDA/CUDA_full@9.0/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@9.0/build_tarballs.jl
@@ -95,18 +95,18 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 if should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux, script,
-                   [Linux(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-apple-darwin14")
     build_tarballs(non_reg_ARGS, name, version, sources_macos, script,
-                   [MacOS(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "macos")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_windows, script,
-                   [Windows(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "windows")], products, dependencies;
                    skip_audit=true)
 end

--- a/C/CUDA/CUDA_full@9.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@9.2/build_tarballs.jl
@@ -96,18 +96,18 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 if should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux, script,
-                   [Linux(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-apple-darwin14")
     build_tarballs(non_reg_ARGS, name, version, sources_macos, script,
-                   [MacOS(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "macos")], products, dependencies;
                    skip_audit=true)
 end
 
 if should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_windows, script,
-                   [Windows(:x86_64)], products, dependencies;
+                   [Platform("x86_64", "windows")], products, dependencies;
                    skip_audit=true)
 end

--- a/C/CUDNN/common.jl
+++ b/C/CUDNN/common.jl
@@ -45,15 +45,15 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 if @isdefined(sources_linux_x64) && should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_x64, script,
-                   [Linux(:x86_64)], products, dependencies)
+                   [Platform("x86_64", "linux")], products, dependencies)
 end
 
 if @isdefined(sources_linux_ppc64le) && should_build_platform("powerpc64le-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_ppc64le, script,
-                   [Linux(:powerpc64le)], products, dependencies)
+                   [Platform("powerpc64le", "linux")], products, dependencies)
 end
 
 if @isdefined(sources_windows) && should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_windows, script,
-                   [Windows(:x86_64)], products, dependencies)
+                   [Platform("x86_64", "windows")], products, dependencies)
 end

--- a/C/CUTENSOR/common.jl
+++ b/C/CUTENSOR/common.jl
@@ -30,15 +30,15 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 if @isdefined(sources_linux_x64) && should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_x64, script,
-                   [Linux(:x86_64)], products, dependencies)
+                   [Platform("x86_64", "linux")], products, dependencies)
 end
 
 if @isdefined(sources_linux_ppc64le) && should_build_platform("powerpc64le-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_ppc64le, script,
-                   [Linux(:powerpc64le)], products, dependencies)
+                   [Platform("powerpc64le", "linux")], products, dependencies)
 end
 
 if @isdefined(sources_windows) && should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_windows, script,
-                   [Windows(:x86_64)], products, dependencies)
+                   [Platform("x86_64", "windows")], products, dependencies)
 end

--- a/C/ConnectFourSolver/build_tarballs.jl
+++ b/C/ConnectFourSolver/build_tarballs.jl
@@ -35,7 +35,7 @@ install_license ${WORKSPACE}/srcdir/connect4/LICENSE
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:glibc),
+    Platform("x86_64", "linux"; libc="glibc"),
 ]
 
 platforms = expand_cxxstring_abis(platforms)

--- a/C/CoolProp/build_tarballs.jl
+++ b/C/CoolProp/build_tarballs.jl
@@ -30,18 +30,18 @@ install_license $WORKSPACE/srcdir/CoolProp*/LICENSE
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64),
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd"),
+    Platform("i686", "windows"),
+    Platform("x86_64", "windows"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/C/coreutils/build_tarballs.jl
+++ b/C/coreutils/build_tarballs.jl
@@ -23,13 +23,13 @@ exit
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "freebsd")
 ]
 
 

--- a/D/Dex/build_tarballs.jl
+++ b/D/Dex/build_tarballs.jl
@@ -28,8 +28,8 @@ tar -czvf $prefix/share/webtemplates.tar.gz -C ./web static templates themes
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:musl),
-    Linux(:x86_64, libc=:glibc)
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="glibc")
 ]
 
 

--- a/D/difmap/build_tarballs.jl
+++ b/D/difmap/build_tarballs.jl
@@ -19,9 +19,9 @@ install_license ./README
 """
 
 platforms = [
-    Linux(:x86_64, libc=:musl),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:i686, libc=:glibc),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="glibc"),
 ]
 platforms = expand_gfortran_versions(platforms)
 

--- a/E/ephemeralpg/build_tarballs.jl
+++ b/E/ephemeralpg/build_tarballs.jl
@@ -21,17 +21,17 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64),
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd"),
 ]
 
 

--- a/F/fakechroot/build_tarballs.jl
+++ b/F/fakechroot/build_tarballs.jl
@@ -22,11 +22,11 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc")
 ]
 
 

--- a/F/figtree/build_tarballs.jl
+++ b/F/figtree/build_tarballs.jl
@@ -24,17 +24,17 @@ mv "lib/libfigtree.${dlext}" "${libdir}/libfigtree.${dlext}"
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd")
 ]
 
 

--- a/G/GR/build_tarballs.jl
+++ b/G/GR/build_tarballs.jl
@@ -40,12 +40,12 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:x86_64, libc=:glibc),
-    Windows(:x86_64)
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "windows")
 ]
 platforms = expand_cxxstring_abis(platforms)
-push!(platforms, MacOS(:x86_64))
+push!(platforms, Platform("x86_64", "macos"))
 
 # The products that we will ensure are always built
 products = [

--- a/G/gperftools/build_tarballs.jl
+++ b/G/gperftools/build_tarballs.jl
@@ -39,13 +39,13 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd")
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -118,13 +118,13 @@ install_license ${WORKSPACE}/srcdir/hdf5-arm-linux-gnueabihf-*/share/COPYING
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64),
-    Linux(:i686),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:aarch64, libc=:glibc),
-    MacOS(),
-    Windows(:x86_64),
-    Windows(:i686),
+    Platform("x86_64", "linux"),
+    Platform("i686", "linux"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
+    Platform("i686", "windows"),
 ]
 
 # The products that we will ensure are always built

--- a/H/Htop/build_tarballs.jl
+++ b/H/Htop/build_tarballs.jl
@@ -22,15 +22,15 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl")
 ]
 
 # The products that we will ensure are always built

--- a/H/hsa_rocr/build_tarballs.jl
+++ b/H/hsa_rocr/build_tarballs.jl
@@ -30,7 +30,7 @@ make install
 # platforms are passed in on the command line
 # Only supports Linux, seemingly only 64bit
 platforms = [
-    Linux(:x86_64, libc=:glibc),
+    Platform("x86_64", "linux"; libc="glibc"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/H/htslib/build_tarballs.jl
+++ b/H/htslib/build_tarballs.jl
@@ -35,7 +35,7 @@ fi
 # platforms are passed in on the command line
 # NOTE: Configuring i686-w64-mingw32 fails due to 'unable to find the recv()
 # function' error. So we skip it for now.
-platforms = [p for p in supported_platforms() if p != Windows(:i686)]
+platforms = [p for p in supported_platforms() if p != Platform("i686", "windows")]
 
 # The products that we will ensure are always built
 products = [

--- a/I/IntelOpenMP/build_tarballs.jl
+++ b/I/IntelOpenMP/build_tarballs.jl
@@ -54,17 +54,17 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 include("../../fancy_toys.jl")
 
 if should_build_platform("i686-w64-mingw32")
-    build_tarballs(non_reg_ARGS, name, version, sources_win32, script, [Windows(:i686)], products, [])
+    build_tarballs(non_reg_ARGS, name, version, sources_win32, script, [Platform("i686", "windows")], products, [])
 end
 if should_build_platform("x86_64-w64-mingw32")
-    build_tarballs(non_reg_ARGS, name, version, sources_win64, script, [Windows(:x86_64)], products, [])
+    build_tarballs(non_reg_ARGS, name, version, sources_win64, script, [Platform("x86_64", "windows")], products, [])
 end
 if should_build_platform("x86_64-apple-darwin14")
-    build_tarballs(non_reg_ARGS, name, version, sources_macos, script, [MacOS(:x86_64)], products, [])
+    build_tarballs(non_reg_ARGS, name, version, sources_macos, script, [Platform("x86_64", "macos")], products, [])
 end
 if should_build_platform("i686-linux-gnu")
-    build_tarballs(non_reg_ARGS, name, version, sources_linux32, script, [Linux(:i686)], products, [])
+    build_tarballs(non_reg_ARGS, name, version, sources_linux32, script, [Platform("i686", "linux")], products, [])
 end
 if should_build_platform("x86_64-linux-gnu")
-    build_tarballs(ARGS, name, version, sources_linux64, script, [Linux(:x86_64)], products, [])
+    build_tarballs(ARGS, name, version, sources_linux64, script, [Platform("x86_64", "linux")], products, [])
 end

--- a/I/IpoptMKL/build_tarballs.jl
+++ b/I/IpoptMKL/build_tarballs.jl
@@ -42,10 +42,10 @@ make install
 # disable Windows
 # https://stackoverflow.com/questions/16623407/build-error-bad-reloc-address
 platforms = [
-    Linux(:x86_64, libc=:glibc),
-    MacOS(:x86_64),
-    # Windows(:i686),
-    # Windows(:x86_64),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    # Platform("i686", "windows"),
+    # Platform("x86_64", "windows"),
 ]
 platforms = expand_gfortran_versions(expand_cxxstring_abis(platforms))
 

--- a/I/iODBC/build_tarballs.jl
+++ b/I/iODBC/build_tarballs.jl
@@ -22,17 +22,17 @@ make && make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd")
 ]
 
 

--- a/K/KaHyPar/build_tarballs.jl
+++ b/K/KaHyPar/build_tarballs.jl
@@ -25,13 +25,13 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64),
-    Windows(:i686),
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd"),
+    Platform("i686", "windows"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/L/LetsBeRational/build_tarballs.jl
+++ b/L/LetsBeRational/build_tarballs.jl
@@ -21,12 +21,12 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:glibc),
-    Linux(:x86_64, libc=:musl),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64)
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd"),
+    Platform("i686", "windows"),
+    Platform("x86_64", "windows")
 ]
 
 

--- a/L/LibAMVW/build_tarballs.jl
+++ b/L/LibAMVW/build_tarballs.jl
@@ -63,12 +63,12 @@ $FC $FFLAGS \
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:glibc),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:x86_64, libc=:musl),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64),
-    Windows(:x86_64)
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd"),
+    Platform("x86_64", "windows")
 ]
 platforms = expand_gfortran_versions(platforms)
 

--- a/L/Libtask/build_tarballs.jl
+++ b/L/Libtask/build_tarballs.jl
@@ -24,14 +24,14 @@ script = read(script_file, String)
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:powerpc64le, libc=:glibc),
-    # Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:aarch64),
-    MacOS(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    # Platform("armv7l", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"),
+    Platform("x86_64", "macos"),
+    Platform("i686", "windows"),
+    Platform("x86_64", "windows")
 ]
 
 # The products that we will ensure are always built

--- a/L/Linux/build_tarballs.jl
+++ b/L/Linux/build_tarballs.jl
@@ -41,7 +41,7 @@ products = [
 ]
 
 platforms = [
-    Linux(:x86_64; libc=:glibc)
+    Platform("x86_64", "linux"; libc="glibc")
 ]
 
 dependencies = [

--- a/L/libasyncns/build_tarballs.jl
+++ b/L/libasyncns/build_tarballs.jl
@@ -24,14 +24,14 @@ exit
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl")
 ]
 
 

--- a/L/libcint/build_tarballs.jl
+++ b/L/libcint/build_tarballs.jl
@@ -28,8 +28,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64),
-    MacOS(:x86_64),
+    Platform("x86_64", "linux"),
+    Platform("x86_64", "macos"),
 ]
 
 # The products that we will ensure are always built

--- a/L/libconfuse/build_tarballs.jl
+++ b/L/libconfuse/build_tarballs.jl
@@ -24,19 +24,19 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd"),
+    Platform("i686", "windows"),
+    Platform("x86_64", "windows")
 ]
 
 # The products that we will ensure are always built

--- a/L/libevent/build_tarballs.jl
+++ b/L/libevent/build_tarballs.jl
@@ -22,17 +22,17 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd")
 ]
 
 # The products that we will ensure are always built

--- a/L/libftd2xx/build_tarballs.jl
+++ b/L/libftd2xx/build_tarballs.jl
@@ -75,12 +75,12 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:i686, libc=:glibc),
-    MacOS(:x86_64),
-    Windows(:x86_64),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
 ]
 
 

--- a/L/libinchi/build_tarballs.jl
+++ b/L/libinchi/build_tarballs.jl
@@ -26,9 +26,9 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Windows(:x86_64),
-    MacOS(:x86_64),
-    Linux(:x86_64, libc=:glibc)
+    Platform("x86_64", "windows"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "linux"; libc="glibc")
 ]
 
 

--- a/L/libnl/build_tarballs.jl
+++ b/L/libnl/build_tarballs.jl
@@ -22,15 +22,15 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl")
 ]
 
 # The products that we will ensure are always built

--- a/M/MAGMA/build_tarballs.jl
+++ b/M/MAGMA/build_tarballs.jl
@@ -35,9 +35,9 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64),
-    Windows(:x86_64),
-    MacOS(:x86_64),
+    Platform("x86_64", "linux"),
+    Platform("x86_64", "windows"),
+    Platform("x86_64", "macos"),
 ]
 platforms = expand_gcc_versions(platforms)
 

--- a/M/MKL/build_tarballs.jl
+++ b/M/MKL/build_tarballs.jl
@@ -27,10 +27,10 @@ fi
 """
 
 platforms = [
-    Linux(:x86_64, libc=:glibc),
-    MacOS(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    Platform("i686", "windows"),
+    Platform("x86_64", "windows"),
 ]
 
 # The products that we will ensure are always built
@@ -46,8 +46,8 @@ dependencies = [
 
 non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 include("../../fancy_toys.jl")
-no_autofix_platforms = [Windows(:i686), Windows(:x86_64), MacOS(:x86_64)]
-autofix_platforms = [Linux(:x86_64)]
+no_autofix_platforms = [Platform("i686", "windows"), Platform("x86_64", "windows"), Platform("x86_64", "macos")]
+autofix_platforms = [Platform("x86_64", "linux")]
 if any(should_build_platform.(triplet.(no_autofix_platforms)))
     # Need to disable autofix: updating linkage of libmkl_intel_thread.dylib on
     # macOS causes runtime issues:

--- a/M/MariaDB_Connector_C/build_tarballs.jl
+++ b/M/MariaDB_Connector_C/build_tarballs.jl
@@ -62,8 +62,8 @@ install_license ../COPYING.LIB
 
 # MariaDB doesn't support non *86 platforms with Musl, see
 # https://gitlab.alpinelinux.org/alpine/aports/commit/ad7c54bd9b6d8e60e88a313a92c83d083f196db8
-platforms = supported_platforms(; exclude = [Linux(:aarch64, libc=:musl),
-                                             Linux(:armv7l, libc=:musl, call_abi=:eabihf)])
+platforms = supported_platforms(; exclude = [Platform("aarch64", "linux"; libc="musl"),
+                                             Platform("armv7l", "linux"; libc="musl")])
 
 # The products that we will ensure are always built
 products = [

--- a/M/MariaDB_Connector_ODBC/build_tarballs.jl
+++ b/M/MariaDB_Connector_ODBC/build_tarballs.jl
@@ -70,19 +70,19 @@ make install
 """
 
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    # Linux(:aarch64, libc=:glibc),
-    # Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    # Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    # Linux(:aarch64, libc=:musl),
-    # Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    # FreeBSD(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64),
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    # Platform("aarch64", "linux"; libc="glibc"),
+    # Platform("armv7l", "linux"; libc="glibc"),
+    # Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    # Platform("aarch64", "linux"; libc="musl"),
+    # Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    # Platform("x86_64", "freebsd"),
+    Platform("i686", "windows"),
+    Platform("x86_64", "windows"),
 ]
 
 # The products that we will ensure are always built

--- a/M/Mesa/build_tarballs.jl
+++ b/M/Mesa/build_tarballs.jl
@@ -25,8 +25,8 @@ install_license ../mesa*/docs/license.html
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Windows(:x86_64),
-    Windows(:i686)
+    Platform("x86_64", "windows"),
+    Platform("i686", "windows")
 ]
 
 # The products that we will ensure are always built

--- a/M/Mingw/build_tarballs.jl
+++ b/M/Mingw/build_tarballs.jl
@@ -62,8 +62,8 @@ make install DESTDIR=${sysroot}
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Windows(:i686),
-    Windows(:x86_64),
+    Platform("i686", "windows"),
+    Platform("x86_64", "windows"),
 ]
 
 # The products that we will ensure are always built

--- a/N/NUMA/build_tarballs.jl
+++ b/N/NUMA/build_tarballs.jl
@@ -24,15 +24,15 @@ install_license LICENSE.*
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl")
 ]
 
 

--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -47,7 +47,7 @@ elif [[ "${target}" == *-apple-* ]]; then
    ./configure --prefix=$prefix --build=${MACHTYPE} --host=${target}  --disable-utilities --enable-shared --disable-static
    make -j${nproc}
 else
-    # do not exist on Linux(:x86_64)
+    # do not exist on Platform("x86_64", "linux")
     if [ ! -f ${libdir}/libhdf5.so ]; then
         ln -s ${libdir}/libhdf5.so.* ${libdir}/libhdf5.so
     fi
@@ -68,16 +68,16 @@ nc-config --all
 # platforms are passed in on the command line
 # Set equal to the supported platforms in HDF5
 platforms = [
-    Linux(:x86_64),
-    Linux(:i686),
+    Platform("x86_64", "linux"),
+    Platform("i686", "linux"),
     # HDF5_jll on armv7l should use the same glibc as the root filesystem
     # before it can be used
     # https://github.com/JuliaPackaging/Yggdrasil/pull/1090#discussion_r432683488
-    # Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:aarch64, libc=:glibc),
-    MacOS(),
-    Windows(:x86_64),
-    Windows(:i686),
+    # Platform("armv7l", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
+    Platform("i686", "windows"),
 ]
 
 # The products that we will ensure are always built

--- a/N/ntl/build_tarballs.jl
+++ b/N/ntl/build_tarballs.jl
@@ -21,9 +21,9 @@ install_license ../doc/copying.txt
 
 # Bootstrapping problem; only do natively-runnable platforms
 platforms = [
-    Linux(:x86_64),
-    Linux(:i686),
-    Linux(:x86_64; libc=:musl),
+    Platform("x86_64", "linux"),
+    Platform("i686", "linux"),
+    Platform("x86_64", "linux"; libc="musl"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/O/OATHToolkit/build_tarballs.jl
+++ b/O/OATHToolkit/build_tarballs.jl
@@ -22,17 +22,17 @@ install_license COPYING
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd")
 ]
 
 

--- a/O/OCaml/build_tarballs.jl
+++ b/O/OCaml/build_tarballs.jl
@@ -27,10 +27,10 @@ done
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl")
 ]
 
 

--- a/O/Openresty/build_tarballs.jl
+++ b/O/Openresty/build_tarballs.jl
@@ -29,10 +29,10 @@ install_license $prefix/COPYRIGHT
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl")
 ]
 
 

--- a/O/oneAPI_Level_Zero/oneAPI_Level_Zero_Loader/build_tarballs.jl
+++ b/O/oneAPI_Level_Zero/oneAPI_Level_Zero_Loader/build_tarballs.jl
@@ -21,8 +21,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc")
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/P/PATHlib/build_tarballs.jl
+++ b/P/PATHlib/build_tarballs.jl
@@ -70,11 +70,11 @@ install_license pathlib-*/LICENSE
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64; libc=:glibc),
-    Linux(:i686; libc=:glibc),
-    MacOS(),
-    Windows(:x86_64),
-    Windows(:i686),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
+    Platform("i686", "windows"),
 ]
 platforms = expand_gfortran_versions(platforms)
 

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -73,7 +73,7 @@ fi
 """
 
 # We attempt to build for all defined platforms
-platforms = expand_gfortran_versions(supported_platforms(exclude=[Windows(:i686)]))
+platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686", "windows")]))
 
 products = [
     LibraryProduct("libpetsc", :libpetsc),

--- a/P/PGPLOT/build_tarballs.jl
+++ b/P/PGPLOT/build_tarballs.jl
@@ -19,9 +19,9 @@ install_license ../pgplot/copyright.notice
 """
 
 platforms = [
-    Linux(:x86_64, libc=:musl),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:i686, libc=:glibc),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="glibc"),
 ]
 platforms = expand_gfortran_versions(platforms)
 

--- a/P/PYTHIA/v8/build_tarballs.jl
+++ b/P/PYTHIA/v8/build_tarballs.jl
@@ -23,9 +23,9 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:glibc),
-    Linux(:powerpc64le, libc=:glibc),
-    MacOS(:x86_64)
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("x86_64", "macos")
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/P/Patchelf/build_tarballs.jl
+++ b/P/Patchelf/build_tarballs.jl
@@ -23,7 +23,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64; libc=:glibc),
+    Platform("x86_64", "linux"; libc="glibc"),
 ]
 
 # The products that we will ensure are always built

--- a/P/Perl/build_tarballs.jl
+++ b/P/Perl/build_tarballs.jl
@@ -96,11 +96,11 @@ sed -i -e "s#--sysroot[ =]\S\+##g" \
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    MacOS(:x86_64)
-    Linux(:x86_64, libc=:glibc)
-    Linux(:i686, libc=:glibc)
-    Linux(:x86_64, libc=:musl)
-    Linux(:i686, libc=:musl)
+    Platform("x86_64", "macos")
+    Platform("x86_64", "linux"; libc="glibc")
+    Platform("i686", "linux"; libc="glibc")
+    Platform("x86_64", "linux"; libc="musl")
+    Platform("i686", "linux"; libc="musl")
 ]
 
 

--- a/P/pandoc/build_tarballs.jl
+++ b/P/pandoc/build_tarballs.jl
@@ -31,10 +31,10 @@ install_license COPYING.md
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64),
-    MacOS(),
-    Windows(:x86_64),
-    Windows(:i686),
+    Platform("x86_64", "linux"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
+    Platform("i686", "windows"),
 ]
 
 # The products that we will ensure are always built

--- a/Q/Qemu/build_tarballs.jl
+++ b/Q/Qemu/build_tarballs.jl
@@ -37,8 +37,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64; libc=:glibc),
-    MacOS(),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
 ]
 
 # The products that we will ensure are always built

--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -110,12 +110,12 @@ install_license $WORKSPACE/srcdir/qt-everywhere-src-*/LICENSE.LGPLv3
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms_linux = [
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:x86_64, libc=:glibc),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
 ]
 platforms_linux = expand_cxxstring_abis(platforms_linux)
-platforms_win = expand_cxxstring_abis([Windows(:x86_64)])
-platforms_macos = [ MacOS(:x86_64) ]
+platforms_win = expand_cxxstring_abis([Platform("x86_64", "windows")])
+platforms_macos = [ Platform("x86_64", "macos") ]
 
 # The products that we will ensure are always built
 products = [

--- a/R/ruby/build_tarballs.jl
+++ b/R/ruby/build_tarballs.jl
@@ -42,7 +42,7 @@ done
 # so this might be a problem when trying to get those to work.
 platforms = filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
 # TODO: fix armv7l musl. Probably an upstream issue though
-filter!(!=(Linux(:armv7l, libc=:musl, call_abi=:eabihf)), platforms)
+filter!(!=(Platform("armv7l", "linux"; libc="musl")), platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/RootFS.md
+++ b/RootFS.md
@@ -97,5 +97,5 @@ The [`BinaryBuilder.jl`](https://github.com/JuliaPackaging/BinaryBuilder.jl) Jul
 ```julia
 Pkg.add("BinaryBuilder")
 using BinaryBuilder
-BinaryBuilder.runshell(Linux(:x86_64))
+BinaryBuilder.runshell(Platform("x86_64", "linux"))
 ```

--- a/S/SBC/build_tarballs.jl
+++ b/S/SBC/build_tarballs.jl
@@ -23,15 +23,15 @@ exit
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl")
 ]
 
 

--- a/S/SCIP/build_tarballs.jl
+++ b/S/SCIP/build_tarballs.jl
@@ -24,19 +24,19 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64),
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd"),
+    Platform("i686", "windows"),
+    Platform("x86_64", "windows"),
 ]
 
 platforms = expand_cxxstring_abis(platforms)

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -25,7 +25,7 @@ cp out/libscs*.${dlext} ${libdir}
 # platforms are passed in on the command line
 
 platforms = [
-    Linux(:x86_64),
+    Platform("x86_64", "linux"),
 ]
 
 # The products that we will ensure are always built

--- a/S/SEAL/build_tarballs.jl
+++ b/S/SEAL/build_tarballs.jl
@@ -55,13 +55,13 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:musl),
-    MacOS(:x86_64),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    FreeBSD(:x86_64),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:aarch64, libc=:musl)
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("x86_64", "freebsd"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="musl")
 ]
 
 # Fix incompatibilities across the GCC 4/5 version boundary due to std::string,

--- a/T/TVM/build_tarballs.jl
+++ b/T/TVM/build_tarballs.jl
@@ -40,14 +40,14 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64; libc=:glibc),
+    Platform("x86_64", "linux"; libc="glibc"),
 
     # Fails with can't find `execinfo.h`
-    #Linux(:x86_64; libc=:musl),
-    MacOS(:x86_64),
+    #Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
 
     # dll import woes
-    #Windows(:x86_64),
+    #Platform("x86_64", "windows"),
 ]
 
 # The products that we will ensure are always built

--- a/T/TerminalImageViewer/build_tarballs.jl
+++ b/T/TerminalImageViewer/build_tarballs.jl
@@ -22,17 +22,17 @@ make prefix=${prefix} install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd")
 ]
 
 platforms = expand_cxxstring_abis(platforms)

--- a/T/TurboPFor/build_tarballs.jl
+++ b/T/TurboPFor/build_tarballs.jl
@@ -27,15 +27,15 @@ install_license ${WORKSPACE}/srcdir/license.txt
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-# platforms = [Linux(:x86_64)]
+# platforms = [Platform("x86_64", "linux")]
 platforms = [
-     Linux(:x86_64, libc=:glibc),
-     Linux(:aarch64, libc=:glibc),
-     Linux(:x86_64, libc=:musl),
-     Linux(:aarch64, libc=:musl),
-     MacOS(:x86_64),
-     # FreeBSD(:x86_64),
-     Windows(:x86_64),
+     Platform("x86_64", "linux"; libc="glibc"),
+     Platform("aarch64", "linux"; libc="glibc"),
+     Platform("x86_64", "linux"; libc="musl"),
+     Platform("aarch64", "linux"; libc="musl"),
+     Platform("x86_64", "macos"),
+     # Platform("x86_64", "freebsd"),
+     Platform("x86_64", "windows"),
 ]
 
 # The products that we will ensure are always built

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -86,11 +86,11 @@ install_license LICENSE
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:glibc),
+    Platform("x86_64", "linux"; libc="glibc"),
     Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64),
-    Windows(:x86_64)
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd"),
+    Platform("x86_64", "windows")
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -22,19 +22,19 @@ cp target/${rust_target}/release/tectonic${exeext} ${bindir}/
 
 # Some platforms disabled for now due issues with rust and musl cross compilation. See #1673.
 platforms = [
-    FreeBSD(:x86_64),
-    Linux(:aarch64, libc=:glibc),
-    # Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    # Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    Linux(:i686, libc=:glibc),
-    # Linux(:i686, libc=:musl),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    # Linux(:x86_64, libc=:musl),
-    MacOS(:x86_64),
-    # Windows(:i686),
-    Windows(:x86_64),
+    Platform("x86_64", "freebsd"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    # Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    # Platform("armv7l", "linux"; libc="musl"),
+    Platform("i686", "linux"; libc="glibc"),
+    # Platform("i686", "linux"; libc="musl"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    # Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    # Platform("i686", "windows"),
+    Platform("x86_64", "windows"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/T/tmux/build_tarballs.jl
+++ b/T/tmux/build_tarballs.jl
@@ -24,17 +24,17 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd")
 ]
 
 # The products that we will ensure are always built

--- a/U/UCX/build_tarballs.jl
+++ b/U/UCX/build_tarballs.jl
@@ -31,8 +31,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:glibc),
-    Linux(:powerpc64le, libc=:glibc),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
 ]
 
 

--- a/V/VerizonEctoken/build_tarballs.jl
+++ b/V/VerizonEctoken/build_tarballs.jl
@@ -27,7 +27,7 @@ exit
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:glibc)
+    Platform("x86_64", "linux"; libc="glibc")
 ]
 
 # The products that we will ensure are always built

--- a/V/vmtouch/build_tarballs.jl
+++ b/V/vmtouch/build_tarballs.jl
@@ -22,17 +22,17 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "freebsd")
 ]
 
 # The products that we will ensure are always built

--- a/W/Wine/build_tarballs.jl
+++ b/W/Wine/build_tarballs.jl
@@ -28,8 +28,8 @@ dependencies = [
     "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GnuTLS-v3.6.5-0/build_GnuTLS.v3.6.5.jl",
 ]
 
-platform32 = Linux(:i686; libc=:musl)
-platform64 = Linux(:x86_64; libc=:musl)
+platform32 = Platform("i686", "linux"; libc="musl")
+platform64 = Platform("x86_64", "linux"; libc="musl")
 
 wine64_build_script = raw"""
 # First, build wine64, making the actual build directory itself the thing we will install.

--- a/W/wget/build_tarballs.jl
+++ b/W/wget/build_tarballs.jl
@@ -21,16 +21,16 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64)
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "macos")
 ]
 
 

--- a/X/XRTServer/build_tarballs.jl
+++ b/X/XRTServer/build_tarballs.jl
@@ -111,7 +111,7 @@ done
 """
 
 # We attempt to build for only x86_64-linux-gnu
-platforms = [Linux(:x86_64)]
+platforms = [Platform("x86_64", "linux")]
 
 products(prefix) = [
     ExecutableProduct(prefix, "xrt_server", :xrt_server),

--- a/X/XRTServer_lite/build_tarballs.jl
+++ b/X/XRTServer_lite/build_tarballs.jl
@@ -62,7 +62,7 @@ done
 """
 
 # We attempt to build for only x86_64-linux-gnu
-platforms = [Linux(:x86_64)]
+platforms = [Platform("x86_64", "linux")]
 
 products(prefix) = [
     ExecutableProduct(prefix, "xrt_server", :xrt_server),

--- a/Z/z3/build_tarballs.jl
+++ b/Z/z3/build_tarballs.jl
@@ -44,10 +44,10 @@ install_license ${WORKSPACE}/srcdir/z3/LICENSE.txt
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms_libcxxwrap = [
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:x86_64, libc=:glibc),
-    MacOS(:x86_64),
-    Windows(:x86_64)
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows")
 ]
 
 platforms = filter(x->!(x in platforms_libcxxwrap), supported_platforms())


### PR DESCRIPTION
The only exception is for package using a custom compiler_abi, which in turn
is mostly (only?) JLLs which use libcxxwrap-julia and copy its restrictions.
But hopefully libcxxwrap-julia can soon use libjulia and support far more
platforms, including all C++ ABI variants.

[skip ci]

Motivation: I hope that this will take away some pain from other JLL authors/maintainers in that they don't each have to relearn from scratch about this change when they next want to update "their" JLLs. (I mean, they do need to learn about the change in some way, but I think that having "correct" code in there as a basis for modification makes it a lot simpler).

BTW, I dropped the `call_abi=:eabihf` in `Linux(:armv7l, libc=:glibc, call_abi=:eabihf)` as I saw in the documentation (and verified in code) that `eabihf` is the default anyway.
