### PR TITLE
Experiment: Add more platforms to LCIO

### DIFF
--- a/L/LCIO/build_tarballs.jl
+++ b/L/LCIO/build_tarballs.jl
@@ -23,11 +23,12 @@ cmake --build . --target install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(cxxstring_abi=:cxx11)),
-    MacOS(:x86_64, compiler_abi=CompilerABI(cxxstring_abi=:cxx11))
-]
+platforms = supported_platforms()
+filter!(!Sys.isfreebsd, platforms)
+filter!(!Sys.iswindows, platforms)
+filter!(p -> arch(p) != "armv7l", platforms)
 platforms = expand_cxxstring_abis(platforms)
+
 # The products that we will ensure are always built
 products = [
     LibraryProduct("liblcio", :liblcio),


### PR DESCRIPTION
This is an experiment to see which platforms really pass/fail right now and how, and whether it really is necessary to only build with the C++11 string ABI (which is independent of whether or not the C++ code uses C++03 or something newer).

CC @jstrube whose JLL this really is (I don't mean to intrude but this came up while working on PR #1921)