### PR TITLE
JLL bump: normaliz_jll

### DIFF
--- a/N/normaliz/build_tarballs.jl
+++ b/N/normaliz/build_tarballs.jl
@@ -44,3 +44,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6")
+


### PR DESCRIPTION
This pull request bumps the JLL version of normaliz_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
