### PR TITLE
JLL bump: lrslib_jll

### DIFF
--- a/L/lrslib/build_tarballs.jl
+++ b/L/lrslib/build_tarballs.jl
@@ -61,3 +61,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of lrslib_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
