### PR TITLE
JLL bump: Ncurses_jll

### DIFF
--- a/N/Ncurses/build_tarballs.jl
+++ b/N/Ncurses/build_tarballs.jl
@@ -92,3 +92,4 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Ncurses_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
