### PR TITLE
JLL bump: Perl_jll

### DIFF
--- a/P/Perl/build_tarballs.jl
+++ b/P/Perl/build_tarballs.jl
@@ -117,4 +117,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
This pull request bumps the JLL version of Perl_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
