### PR TITLE
JLL bump: Readline_jll

### DIFF
--- a/R/Readline/build_tarballs.jl
+++ b/R/Readline/build_tarballs.jl
@@ -58,3 +58,4 @@ dependencies = [
 
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of Readline_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
