### PR TITLE
JLL bump: nauty_jll

### DIFF
--- a/N/nauty/build_tarballs.jl
+++ b/N/nauty/build_tarballs.jl
@@ -113,3 +113,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+


### PR DESCRIPTION
This pull request bumps the JLL version of nauty_jll.
It was generated via the `recursively_regenerate_jlls.jl` script.
