### PR TITLE
[normaliz] rebuild to fix MPFR version, because FLINT needs MPFR

### DIFF
--- a/N/normaliz/build_tarballs.jl
+++ b/N/normaliz/build_tarballs.jl
@@ -37,6 +37,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GMP_jll", v"6.1.2"),
+    BuildDependency(PackageSpec(name="MPFR_jll", version=v"4.0.2")),
     Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82")),
     Dependency(PackageSpec(name="nauty_jll", uuid="55c6dc9b-343a-50ca-8ff2-b71adb3733d5")),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))


### PR DESCRIPTION
Since MPFR is only an indirect dependency the wrong version was pulled in during the latest rebuild.

So rebuild it to make those poor macos users happy again:
```
ERROR: LoadError: LoadError: InitError: could not load library /Users/runner/.julia/artifacts/34750e7597595ecce93a0a04cd79cbb7514e475f/lib/libnormaliz.3.dylib
dlopen(/Users/runner/.julia/artifacts/34750e7597595ecce93a0a04cd79cbb7514e475f/lib/libnormaliz.3.dylib, 1): Library not loaded: @rpath/libmpfr.6.dylib
  Referenced from: /Users/runner/.julia/artifacts/34750e7597595ecce93a0a04cd79cbb7514e475f/lib/libnormaliz.3.dylib
  Reason: Incompatible library version: libnormaliz.3.dylib requires version 8.0.0 or later, but libmpfr.dylib provides version 7.0.0
```