### PR TITLE
libcxxwrap_julia: switch to libjulia

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -2,8 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
+julia_version = v"1.3.1"
+
 name = "libcxxwrap_julia"
-version = v"0.8.0"
+version = v"0.8.2"
 
 const is_yggdrasil = haskey(ENV, "BUILD_BUILDNUMBER")
 git_repo = is_yggdrasil ? "https://github.com/JuliaInterop/libcxxwrap-julia.git" : joinpath(ENV["HOME"], "src/julia/libcxxwrap-julia/")
@@ -11,30 +13,38 @@ unpack_target = is_yggdrasil ? "" : "libcxxwrap-julia"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource(git_repo, "30997d732f6a317348a05b4ccb777dfbcc483525", unpack_target=unpack_target),
+    GitSource(git_repo, "2bba0c81ea00d58d3321540a0526098aa9eb3c8b", unpack_target=unpack_target),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 mkdir build
 cd build
-cmake -DJulia_PREFIX=$prefix -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../libcxxwrap-julia/
+
+cmake \
+    -DJulia_PREFIX=$prefix \
+    -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_FIND_ROOT_PATH=$prefix \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ../libcxxwrap-julia/
 VERBOSE=ON cmake --build . --config Release --target install -- -j${nproc}
 install_license $WORKSPACE/srcdir/libcxxwrap-julia*/LICENSE.md
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("x86_64", "freebsd"; cxxstring_abi = "cxx11"),
-    Platform("armv7l", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
-    Platform("aarch64", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
-    Platform("x86_64", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
-    Platform("i686", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
-    Platform("x86_64", "macos"; cxxstring_abi = "cxx11"),
-    Platform("x86_64", "windows"; cxxstring_abi = "cxx11"),
-    Platform("i686", "windows"; cxxstring_abi = "cxx11"),
-]
+platforms = supported_platforms()
+
+# skip i686 musl builds (not supported by libjulia_jll)
+filter!(p -> !(Sys.islinux(p) && libc(p) == "musl" && arch(p) == "i686"), platforms)
+
+# skip PowerPC builds in Julia 1.3 (not supported by libjulia_jll)
+if julia_version < v"1.4"
+    filter!(p -> !(Sys.islinux(p) && arch(p) == "powerpc64le"), platforms)
+end
+
+platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -44,8 +54,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(name="Julia_jll",version=v"1.4.1"))
+    BuildDependency(PackageSpec(name="libjulia_jll", version=julia_version))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7", julia_compat = "~$(julia_version.major).$(julia_version.minor)")


### PR DESCRIPTION
Also drop the restriction to the cxx11 ABI and add more platforms.

Motivation: while this is not the perfect next step for libcxxwrap_julia, I think it makes sense to do this now: switching to libjulia and adding more platforms will allow other packages using libcxxwrap_julia to do the same. Once (if?) we get "full" support for "julia_version" as part of the platform, adjusting `libcxxwrap_julia` and other JLLs depending on it to benefit from those shouldn't be hard; but it is unclear when this will be available; so why not implement those benefits we can already get now?

As a side effect, this will produce a fresh JLLWrapper based JLL :-)

However, this PR shouldn't be merged without @barche approving.

UPDATE: ... and of course it should pass the CI tests before all else ;-)

Close #1647 