### PR TITLE
Improve libjulia, rebuild libjulia 1.3.1 with the improvements

### DIFF
--- a/L/libjulia/libjulia@1.3/build_tarballs.jl
+++ b/L/libjulia/libjulia@1.3/build_tarballs.jl
@@ -1,6 +1,2 @@
 include("../common.jl")
-
-name, version, sources, script, platforms, products, dependencies = configure(v"1.3.1")
-
-# Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7", lock_microarchitecture=false)
+build_julia(v"1.3.1")


### PR DESCRIPTION
It is not clear to me right now why libjulia is not built for FreeBSD, so this PR is trying to figure it out, and then either solve it, or document it for future generations.