### PR TITLE
GMP 6.1.2: correct Julia compat

### DIFF
--- a/G/GMP@6.1.2/build_tarballs.jl
+++ b/G/GMP@6.1.2/build_tarballs.jl
@@ -58,5 +58,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6", julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6", julia_compat="~1.0, ~1.1, ~1.2, ~1.3, ~1.4, ~1.5")
 


### PR DESCRIPTION
[skip build]

This should deal with https://github.com/JuliaRegistries/General/pull/23421. The version specifier is not just "1.0-1.5" because I am trying to have this work in older Julia versions -- but perhaps that's misguided (I admit I don't fully understand how all the underlying tooling works), in that case it could of course be simplified 🤷 

Using "skip build" ought to be safe since the most recent GMP_jll is a 6.1.2 one, so the correct binaries will be reused.

