### PR TITLE
Better `curl` invocation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,14 +167,15 @@ jobs:
 
                   # Here, we hit the build cache to see if we can skip this particular combo
                   CACHE_URL="https://julia-bb-buildcache.s3.amazonaws.com/${BB_HASH}/${PROJ_HASH}/${PLATFORM}.tar.gz"
-                  if curl --output /tmp/curl_${PROJ_HASH}_${PLATFORM}.log --silent --fail --HEAD "${CACHE_URL}"; then
+                  CURL_HTTP_CODE=$(curl --output /tmp/curl_${PROJ_HASH}_${PLATFORM}.log --silent --include --fail --HEAD "${CACHE_URL}" --write-output '%{http_code}')
+                  if [[ "${CURL_HTTP_CODE}" == "200" ]]; then
                       echo "    ${PLATFORM}: skipping, existant"
                       continue;
                   fi
                   echo "    ${PLATFORM}: building"
 
                   # Debugging: let's see why `curl` failed:
-                  tail -n 30 /tmp/curl_${PROJ_HASH}_${PLATFORM}.log || true
+                  cat /tmp/curl_${PROJ_HASH}_${PLATFORM}.log || true
 
                   # Otherwise, emit the build
                   VAR_PROJPLATFORMS="${VAR_PROJPLATFORMS} '${NAME}-${PLATFORM}':{ \


### PR DESCRIPTION
This allows us to get both the HTTP status code (which we want to be
`200`) and write out the full set of HEAD request/repsonse values