### PR TITLE
Try fixing HelFEM_jll constraints

### DIFF
--- a/H/HelFEM/build_tarballs.jl
+++ b/H/HelFEM/build_tarballs.jl
@@ -51,19 +51,16 @@ make -C build/ -j${nproc}
 make -C build/ install
 """
 
-# These are the platforms libcxxwrap_julia_jll is built on.
-#
-# The libgfortran constraint is necessary because the default is libgfortran 3, but the
-# Julia_jll is only available for libgfortran 4.
+# These are the platforms the libcxxwrap_julia_jll is built on.
 platforms = [
-    Platform("x86_64", "linux"; libc="glibc", cxxstring_abi = "cxx11", libgfortran_version=v"4"),
-    Platform("i686", "linux"; libc="glibc", cxxstring_abi = "cxx11", libgfortran_version=v"4"),
-    Platform("armv7l", "linux"; libc="glibc", cxxstring_abi = "cxx11", libgfortran_version=v"4"),
-    Platform("aarch64", "linux"; libc="glibc", cxxstring_abi = "cxx11", libgfortran_version=v"4"),
-    Platform("x86_64", "macos", libgfortran_version=v"4"),
-    Platform("x86_64", "windows"; cxxstring_abi = "cxx11", libgfortran_version=v"4"),
-    Platform("i686", "windows"; cxxstring_abi = "cxx11", libgfortran_version=v"4"),
-    Platform("x86_64", "freebsd", libgfortran_version=v"4"),
+    Platform("x86_64", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
+    Platform("i686", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
+    Platform("armv7l", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
+    Platform("aarch64", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"; cxxstring_abi = "cxx11"),
+    Platform("i686", "windows"; cxxstring_abi = "cxx11"),
+    Platform("x86_64", "freebsd"),
 ]
 
 products = [
@@ -78,4 +75,5 @@ dependencies = [
     Dependency(PackageSpec(name = "OpenBLAS_jll", version = "0.3.9")),
 ]
 
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+# preferred_gcc_version = v"7" is a requirement from libcxxwrap_julia_jll
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7")


### PR DESCRIPTION
So, basically switch from `libgfortran_version=v"4"` to `preferred_gcc_version=v"7"`, to make sure all the dependencies are happy. First, let's see if it builds on all platforms.