### PR TITLE
[LibCURL] Bump to `v7.73.0`, use native TLS libraries on MacOS and Windows

### DIFF
--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -71,4 +71,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat = "1.6")

--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -34,10 +34,10 @@ if [[ ${target} == *mingw* ]]; then
     # We need to tell it where to find libssh2 on windows
     FLAGS+=(LDFLAGS="${LDFLAGS} -L${prefix}/bin")
 
-    # We also need to tell it to link against schannel (buildin TLS library)
+    # We also need to tell it to link against schannel (native TLS library)
     FLAGS+=(--with-schannel)
 elif [[ ${target} == *darwin* ]]; then
-    # On Darwin, we need to use SecureTransport
+    # On Darwin, we need to use SecureTransport (native TLS library)
     FLAGS+=(--with-secure-transport)
 else
     # On all other systems, we use MbedTLS


### PR DESCRIPTION
We have had struggles in integration with special certificates for restrictive installs; let's move towards using the native TLS libraries on Mac and Windows, but still using MbedTLS on Linux where we don't want to depend on OpenSSL for licensing reasons.