### PR TITLE
Update glmnet to use latest source from R package

### DIFF
--- a/G/glmnet/build_tarballs.jl
+++ b/G/glmnet/build_tarballs.jl
@@ -31,7 +31,7 @@ if [[ ${target} != aarch64* ]] && [[ ${target} != arm* ]]; then
 fi
 mkdir -p ${libdir}
 ${FC} ${LDFLAGS} ${flags} glmnet5dpclean.f wls.f pb.f -o ${libdir}/libglmnet.${dlext}
-install_license DESCRIPTION
+install_license ../DESCRIPTION
 """
 
 # These are the platforms we will build for by default, unless further

--- a/G/glmnet/build_tarballs.jl
+++ b/G/glmnet/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/glmnet/src
 
-# Add stub for `setpb`, which normally comes from `pb.c` to connects the 
+# Add stub for `setpb`, which normally comes from `pb.c` to connect the 
 # progress meter to R, but we don't need that
 echo "
       subroutine setpb(val)
@@ -46,6 +46,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/glmnet/build_tarballs.jl
+++ b/G/glmnet/build_tarballs.jl
@@ -29,10 +29,9 @@ fi
 if [[ ${target} != aarch64* ]] && [[ ${target} != arm* ]]; then
     flags="${flags} -m${nbits}";
 fi
-${FC} ${LDFLAGS} ${flags} glmnet5dpclean.f wls.f pb.f -o libglmnet.${dlext}
-
-mkdir -p $libdir
-mv libglmnet.${dlext} $libdir/
+mkdir -p ${libdir}
+${FC} ${LDFLAGS} ${flags} glmnet5dpclean.f wls.f pb.f -o ${libdir}/libglmnet.${dlext}
+install_license DESCRIPTION
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Ref https://github.com/JuliaStats/GLMNet.jl/issues/46

The current glmnet build uses an [older version of glmnet](https://github.com/JuliaStats/GLMNet.jl/blob/8d8d22d573f7f608515fcf5f5192cf28cced8f1b/deps/glmnet5.f90) from 2014 that was copied into the GLMNet repo a long time ago, and this changes to build from the current [R package source](https://github.com/cran/glmnet) instead.

There are a couple of issues where I need some help:
- the original glmnet build was given version 5, because the file was named `glmnet5.f90` with no version info in the the file other than a datestamp. I figured it would make sense to sync the version to the tagged version of the R package, but the problem is that the most recent tag is currently v4.0.2, so there is the chance for a v5 conflict in future. I'd appreciate input on how to best solve this.
- there is a warning about no license file being present. The license is GPLv2, but many R packages only specify the choice of license in their [DESCRIPTION file](https://github.com/cran/glmnet/blob/b1a4b50de01e0cd24343959d7cf86452bac17b26/DESCRIPTION#L17) rather than including a separate and complete license file. What is the best way to resolve this?