### PR TITLE
BinaryBuilder jlls for unicorn emulator library

### DIFF
--- a/L/libunicorn/build_tarballs.jl
+++ b/L/libunicorn/build_tarballs.jl
@@ -1,0 +1,46 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libunicorn"
+version = v"1.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/oblivia-simplex/unicorn.git", "cb2c6c18e713806aeedbc4a71e18f541b77cd903")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd unicorn/
+export PREFIX=$prefix
+make && make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Linux(:i686, libc=:glibc),
+    Linux(:x86_64, libc=:glibc),
+    Linux(:aarch64, libc=:glibc),
+    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
+    Linux(:powerpc64le, libc=:glibc),
+    Linux(:i686, libc=:musl),
+    Linux(:x86_64, libc=:musl),
+    Linux(:aarch64, libc=:musl),
+    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libunicorn", :libunicorn)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/U/Unicorn/build_tarballs.jl
+++ b/U/Unicorn/build_tarballs.jl
@@ -21,19 +21,7 @@ install_license COPYING*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64)
-]
+platforms = filter(!Sys.iswindows, supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/U/Unicorn/build_tarballs.jl
+++ b/U/Unicorn/build_tarballs.jl
@@ -2,20 +2,21 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-name = "libunicorn"
-version = v"1.1.0"
+name = "Unicorn"
+version = v"1.0.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/oblivia-simplex/unicorn.git", "cb2c6c18e713806aeedbc4a71e18f541b77cd903")
+    GitSource("https://github.com/oblivia-simplex/unicorn.git", "cda971566980d3a051a730f63019e74eeeb44703")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd unicorn/
-export PREFIX=$prefix
-make && make install
+ln -s /usr/bin/make /usr/bin/gmake
+cd ${WORKSPACE}/srcdir/unicorn
+make -j $(nproc)
+make PREFIX=${prefix} install
+install_license COPYING*
 """
 
 # These are the platforms we will build for by default, unless further
@@ -29,7 +30,9 @@ platforms = [
     Linux(:i686, libc=:musl),
     Linux(:x86_64, libc=:musl),
     Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf)
+    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
+    MacOS(:x86_64),
+    FreeBSD(:x86_64)
 ]
 
 


### PR DESCRIPTION
I've been having some trouble with the BinaryBuilder wizard, which keeps failing with a 404 error when it tries to communicate with the github API, so I wrote the build_tarballs.jl script to a local file, and put together this PR manually. 

This is a wrapper for the Unicorn emulation library. 