### PR TITLE
[AlgRemez] Build against GMP v6.1.2

### DIFF
--- a/A/AlgRemez/build_tarballs.jl
+++ b/A/AlgRemez/build_tarballs.jl
@@ -29,7 +29,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency("GMP_jll", v"6.1.2"),
     Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
 ]
 


### PR DESCRIPTION
Version info of GMP_jll is added.

Fix #2027