### PR TITLE
Rebuild many Julia deps for v1.6+

### DIFF
--- a/O/OpenBLAS/OpenBLAS@0.3.10/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS@0.3.10/build_tarballs.jl
@@ -13,4 +13,5 @@ products = openblas_products()
 dependencies = openblas_dependencies()
 
 # Build the tarballs
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6", lock_microarchitecture=false)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"6", lock_microarchitecture=false, julia_compat="1.6")

--- a/O/OpenLibm/build_tarballs.jl
+++ b/O/OpenLibm/build_tarballs.jl
@@ -45,4 +45,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; lock_microarchitecture=false)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; lock_microarchitecture=false, julia_compat="1.6")

--- a/P/p7zip/build_tarballs.jl
+++ b/P/p7zip/build_tarballs.jl
@@ -79,5 +79,7 @@ products = [
 dependencies = [
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+# Note: we explicitly lie about this because we don't have the new
+# versioning APIs worked out in BB yet.
+version = v"16.02.1"
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
This PR contains a bundle (hopefully not too large) of dependencies that need to be rebuilt/restricted to v1.6+ so that we can expand into experimental platforms.