### PR TITLE
[MPFR] Rebuild for Julia 1.6+ as v4.1.1, requiring GMP 6.2.0+

### DIFF
--- a/M/MPFR/build_tarballs.jl
+++ b/M/MPFR/build_tarballs.jl
@@ -1,6 +1,6 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder
+using BinaryBuilder, Pkg
 
 name = "MPFR"
 version = v"4.1.0"
@@ -34,8 +34,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # We explicitly ask for GMP v6.1.2 so that it is compatible with both GMP v6.1.2 and v6.2.0+
-    Dependency("GMP_jll", v"6.1.2"),
+    Dependency(PackageSpec(name="GMP_jll", version=v"6.2.0")),
 ]
 
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"5")
+# Note: we explicitly lie about this because we don't have the new
+# versioning APIs worked out in BB yet.
+version = v"4.1.1"
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"5", julia_compat="1.6")


### PR DESCRIPTION
This is actually MPFR v4.1.0, but we're calling it v4.1.1 so that we
cans add compat entries on Julia and GMP that weren't there for v4.1.0