### PR TITLE
new version of AzStorage

### DIFF
--- a/A/AzStorage/build_tarballs.jl
+++ b/A/AzStorage/build_tarballs.jl
@@ -3,13 +3,13 @@
 using BinaryBuilder
 
 name = "AzStorage"
-version = v"0.1.0"
+version = v"0.2.0"
 
 # Collection of sources required to build AzStorage
 sources = [
     GitSource(
         "https://github.com/ChevronETC/AzStorage.jl.git",
-        "c043e64b8a453f9a580c973c4f5cf0a84b142e6c"
+        "a03de2683bff7fde4f660590998714ce922d6274"
     )
 ]
 

--- a/A/AzStorage/build_tarballs.jl
+++ b/A/AzStorage/build_tarballs.jl
@@ -40,7 +40,15 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("LibCURL_jll")
+    # libcurl changed compatibility version for macOS from v7.71 to v7.73 (v11
+    # to v12)
+    Dependency("LibCURL_jll", v"7.71.1"),
+    # The following libraries are dependencies of LibCURL_jll which is now a
+    # stdlib, but the stdlib doesn't explicitly list its dependencies
+    Dependency("LibSSH2_jll"),
+    Dependency("MbedTLS_jll"),
+    Dependency("nghttp2_jll"),
+    Dependency("Zlib_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
The new version of AzStorage removes the list of retryable error codes to the Julia package.  This means that we can now update these error codes as needed without requiring any changes to the jll.