### PR TITLE
Update pprof to latest revision

### DIFF
--- a/P/pprof/build_tarballs.jl
+++ b/P/pprof/build_tarballs.jl
@@ -2,12 +2,11 @@ using BinaryBuilder
 
 name = "pprof"
 
-# PProf doesn't have proper versions yet
-# so we use Go's pseudo version
-# `TZ=UTC git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd" $hash`
+# Note that google/pprof doesn't have proper release versions. We are
+# identifying a version by a specific commit hash, off of `pprof`'s
+# main branch.
 
 hash = "20978b51388db0648809a2c5cc88b494c7945ec1"
-timestamp = "20201109224723"
 version = v"0.1.0"
 
 # Collection of sources required to build pprof

--- a/P/pprof/build_tarballs.jl
+++ b/P/pprof/build_tarballs.jl
@@ -11,8 +11,8 @@ version = v"0.1.0"
 
 # Collection of sources required to build pprof
 sources = [
-    "https://github.com/google/pprof.git" =>
-    hash,
+    GitSource("https://github.com/google/pprof.git",
+              hash),
 ]
 
 # Bash recipe for building across all platforms

--- a/P/pprof/build_tarballs.jl
+++ b/P/pprof/build_tarballs.jl
@@ -6,8 +6,8 @@ name = "pprof"
 # so we use Go's pseudo version
 # `TZ=UTC git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd" $hash`
 
-hash = "f9b734f9ee64d0f5b63636a45cc77ed2744997ab"
-timestamp = "20191205061153"
+hash = "20978b51388db0648809a2c5cc88b494c7945ec1"
+timestamp = "20201109224723"
 version = Base.VersionNumber("0.0.0-$timestamp")
 
 # Collection of sources required to build pprof

--- a/P/pprof/build_tarballs.jl
+++ b/P/pprof/build_tarballs.jl
@@ -8,7 +8,7 @@ name = "pprof"
 
 hash = "20978b51388db0648809a2c5cc88b494c7945ec1"
 timestamp = "20201109224723"
-version = Base.VersionNumber("0.0.0-$timestamp")
+version = v"0.1.0"
 
 # Collection of sources required to build pprof
 sources = [


### PR DESCRIPTION
Bump from 20191205061153 => 20201109224723

My personal interest is to pull in https://github.com/google/pprof/pull/564, which adds support for displaying names with `"` in them, which julia functions sometimes have (e.g. `var"#foo#23"`)

Includes:
- https://github.com/google/pprof/pull/564
- https://github.com/google/pprof/pull/575
- https://github.com/google/pprof/pull/574
- https://github.com/google/pprof/pull/571
- https://github.com/google/pprof/pull/572
- https://github.com/google/pprof/pull/570
- https://github.com/google/pprof/pull/562
- https://github.com/google/pprof/pull/561
- https://github.com/google/pprof/pull/565
- https://github.com/google/pprof/pull/560
- https://github.com/google/pprof/pull/563
- https://github.com/google/pprof/pull/557
- https://github.com/google/pprof/pull/554
- https://github.com/google/pprof/pull/552
- https://github.com/google/pprof/pull/545
- https://github.com/google/pprof/pull/549
- https://github.com/google/pprof/pull/547
- https://github.com/google/pprof/pull/541
- https://github.com/google/pprof/pull/534
- https://github.com/google/pprof/pull/542
- https://github.com/google/pprof/pull/535
- https://github.com/google/pprof/pull/531
- https://github.com/google/pprof/pull/530
- https://github.com/google/pprof/pull/528
- https://github.com/google/pprof/pull/522
- https://github.com/google/pprof/pull/525
- https://github.com/google/pprof/pull/527
- https://github.com/google/pprof/pull/519
- https://github.com/google/pprof/pull/520
- https://github.com/google/pprof/pull/517
- https://github.com/google/pprof/pull/518
- https://github.com/google/pprof/pull/514
- https://github.com/google/pprof/pull/513
- https://github.com/google/pprof/pull/510
- https://github.com/google/pprof/pull/508
- https://github.com/google/pprof/pull/506
- https://github.com/google/pprof/pull/509
- https://github.com/google/pprof/pull/504