### PR TITLE
[LibCURL] Explicitly request macOS 10.11+

### DIFF
--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -39,6 +39,9 @@ if [[ ${target} == *mingw* ]]; then
 elif [[ ${target} == *darwin* ]]; then
     # On Darwin, we need to use SecureTransport (native TLS library)
     FLAGS+=(--with-secure-transport)
+
+    # We need to explicitly request a higher `-mmacosx-version-min` here, so that it doesn't 
+    export CFLAGS=-mmacosx-version-min=10.11
 else
     # On all other systems, we use MbedTLS
     FLAGS+=(--with-mbedtls=${prefix})


### PR DESCRIPTION
This fixes a `___isOSVersionAtLeast` symbol reference error.