### PR TITLE
[MbedTLS]: Fix lack of `+x` permissions on DLLs

### DIFF
--- a/M/MbedTLS/build_tarballs.jl
+++ b/M/MbedTLS/build_tarballs.jl
@@ -32,6 +32,12 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DUSE_SHARED_MBEDTLS_LIBRARY=On \
     ..
 make -j${nproc} && make install
+
+if [[ "${target}" == *mingw* ]]; then
+    # For some reason, the build system doesn't set the `.dll` files as
+    # executable, which prevents them from being loaded.
+    chmod +x ${bindir}/*.dll
+fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/MbedTLS/build_tarballs.jl
+++ b/M/MbedTLS/build_tarballs.jl
@@ -35,8 +35,10 @@ make -j${nproc} && make install
 
 if [[ "${target}" == *mingw* ]]; then
     # For some reason, the build system doesn't set the `.dll` files as
-    # executable, which prevents them from being loaded.
-    chmod +x ${libdir}/*.dll
+    # executable, which prevents them from being loaded.  Also, we need
+    # to explicitly use `${prefix}/lib` here because the build system
+    # is a simple one, and blindly uses `/lib`, even on Windows.
+    chmod +x ${prefix}/lib/*.dll
 fi
 """
 

--- a/M/MbedTLS/build_tarballs.jl
+++ b/M/MbedTLS/build_tarballs.jl
@@ -36,7 +36,7 @@ make -j${nproc} && make install
 if [[ "${target}" == *mingw* ]]; then
     # For some reason, the build system doesn't set the `.dll` files as
     # executable, which prevents them from being loaded.
-    chmod +x ${bindir}/*.dll
+    chmod +x ${libdir}/*.dll
 fi
 """
 


### PR DESCRIPTION
I don't know why, but the MbedTLS build system seems to be lacking the executable permission on its installed DLLs.