### PR TITLE
libcxxwrap 0.8.4 for Julia 1.4

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-julia_version = v"1.3.1"
+julia_version = v"1.4.2"
 
 name = "libcxxwrap_julia"
-version = v"0.8.3"
+version = v"0.8.4"
 
 const is_yggdrasil = haskey(ENV, "BUILD_BUILDNUMBER")
 git_repo = is_yggdrasil ? "https://github.com/JuliaInterop/libcxxwrap-julia.git" : joinpath(ENV["HOME"], "src/julia/libcxxwrap-julia/")


### PR DESCRIPTION
As discussed in PR #1948 this is the next update for libcxxwrap -- should only be merged after https://github.com/JuliaRegistries/General/pull/24616 (which needs manual intervention due to julia_compat).

Moreover, I strongly suggest we first test the 0.8.2 build with Julia 1.3, to make sure it really works there; if there is a systematic issue that needs to be fixed, then it'll be annoying to redo all Julia versions.

CC @barche @giordano