### PR TITLE
[LLVM SPIRV translator] Add Julia 1.6 compat for LLVM 11.

### DIFF
--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@11/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@11/build_tarballs.jl
@@ -13,5 +13,4 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version=v"7")
-
+               preferred_gcc_version=v"7", julia_compat="1.6")


### PR DESCRIPTION
~Only merge when https://github.com/JuliaPackaging/Yggdrasil/commit/e85764c7f595eaf809269ff41b717131f98b7e2c#commitcomment-44214400 is resolved.~
Probably needs to wait on https://github.com/JuliaRegistries/General/pull/24728 too to avoid merge conflicts.