### PR TITLE
Bump tectonic to 0.3.3

### DIFF
--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -16,6 +16,9 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/tectonic-*/
+# This should help when building with Musl as host with Rust v1.43:
+# https://github.com/rust-lang/rust/issues/59302
+export RUSTFLAGS="-C target-feature=-crt-static"
 cargo build --release -j${nproc}
 cp target/${rust_target}/release/tectonic${exeext} ${bindir}/
 """

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -52,7 +52,7 @@ dependencies = [
     Dependency("FreeType2_jll"),
     Dependency("Graphite2_jll"),
     Dependency("HarfBuzz_jll"),
-    Dependency(PackageSpec(; name="ICU_jll", version=v"67.1.0")),
+    Dependency("ICU_jll", v"67.1.0", compat="67.1.0"),
     Dependency("OpenSSL_jll"),
     Dependency("Zlib_jll"),
     Dependency("libpng_jll"),

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -3,13 +3,13 @@
 using BinaryBuilder, Pkg
 
 name = "tectonic"
-version = v"0.1.15"
+version = v"0.3.3"
 
 # Collection of sources required to build tar
 sources = [
     ArchiveSource(
         "https://github.com/tectonic-typesetting/tectonic/archive/tectonic@$(version).tar.gz",
-        "0e55188eafc1b58f3660a303fcdd6adc071051b9eb728119837fbeed2309914f"
+        "c0aa60186f2e7f37af67dafbdccfc7a99ca5ce084651d8fcabe7561b941dcb97"
     )
 ]
 


### PR DESCRIPTION
From what I can see locally, the `rust` version the BB provides is now too old to build this. What's needed to update that?