### PR TITLE
[GDAL] fix versions of libcurl and dependencies

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -99,14 +99,14 @@ dependencies = [
     Dependency(PackageSpec(name="PROJ_jll", version="7.2")),
     Dependency("Zlib_jll"),
     Dependency("SQLite_jll"),
-    Dependency("LibCURL_jll"),
+    Dependency("LibCURL_jll", v"7.71.1"),
     Dependency("OpenJpeg_jll"),
     Dependency("Expat_jll"),
     Dependency("Zstd_jll"),
     # The following libraries are dependencies of LibCURL_jll which is now a
     # stdlib, but the stdlib doesn't explicitly list its dependencies
-    Dependency("LibSSH2_jll"),
-    Dependency("MbedTLS_jll"),
+    Dependency("LibSSH2_jll", v"1.9.0"),
+    Dependency("MbedTLS_jll", v"2.16.8"),
     Dependency("nghttp2_jll", v"1.40.0"),
 ]
 


### PR DESCRIPTION
Just like done in https://github.com/visr/Yggdrasil/blob/8f23bd062f9efd77cc87e2aa5e664006b72d32d1/N/NetCDF/build_tarballs.jl#L72-L74
Will hopefully further fix #2140.