### PR TITLE
Add Birch Standard library

### DIFF
--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -1,0 +1,64 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Birch_Standard"
+version = v"1.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/lawmurray/Birch.git", "a533990b59b04ef4cd20f8d4fe91c4a220df1cfa"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+# add libraries for building birch on host
+apk add boost-dev yaml-dev
+
+# build and install driver on host system
+mkdir -p ${WORKSPACE}/srcdir/build_host
+autoreconf -vi
+bb_target=${MACHTYPE} CXX=${HOSTCXX} CPPFLAGS=-I/usr/include LDFLAGS=-L/usr/lib ./configure --prefix=${WORKSPACE}/srcdir/build_host --build=${MACHTYPE} --host=${MACHTYPE}
+make clean
+make -j${nproc}
+make install
+
+# build and install the standard library
+cd ${WORKSPACE}/srcdir/Birch/libraries/Standard/
+export BIRCH_PREFIX=${WORKSPACE}/srcdir/build_host
+export PATH=${WORKSPACE}/srcdir/build_host/bin:$PATH
+birch bootstrap
+CPPFLAGS="-I${prefix}/include" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-debug --enable-release
+make -j${nproc}
+make install
+
+# install license
+install_license LICENSE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# GLOB_NOMAGIC is not supported by musl
+filter!(p -> libc(p) != "musl", platforms)
+
+# Native support for Windows is not yet provided
+filter!(!Sys.iswindows, platforms)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libbirch-standard", :libbirch_standard),
+    LibraryProduct("libbirch-standard-debug", :libbirch_standard_debug),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("boost_jll"),
+    Dependency("Eigen_jll"),
+    Dependency("LibYAML_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies,
+               preferred_gcc_version=v"5")

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -55,7 +55,7 @@ dependencies = [
     Dependency("boost_jll"),
     Dependency("Eigen_jll"),
     Dependency("LibYAML_jll"),
-    Dependency("LibBirch_jll"),
+    Dependency(PackageSpec(name = "LibBirch_jll", version = version)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -55,7 +55,7 @@ dependencies = [
     Dependency("boost_jll"),
     Dependency("Eigen_jll"),
     Dependency("LibYAML_jll"),
-    BuildDependency("LibBirch_jll"),
+    Dependency("LibBirch_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -55,6 +55,7 @@ dependencies = [
     Dependency("boost_jll"),
     Dependency("Eigen_jll"),
     Dependency("LibYAML_jll"),
+    BuildDependency("LibBirch_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -16,6 +16,7 @@ script = raw"""
 apk add boost-dev yaml-dev
 
 # build and install driver on host system
+cd ${WORKSPACE}/srcdir/Birch/driver/
 mkdir -p ${WORKSPACE}/srcdir/build_host
 autoreconf -vi
 bb_target=${MACHTYPE} CXX=${HOSTCXX} CPPFLAGS=-I/usr/include LDFLAGS=-L/usr/lib ./configure --prefix=${WORKSPACE}/srcdir/build_host --build=${MACHTYPE} --host=${MACHTYPE}

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -31,7 +31,10 @@ make install
 cd ${WORKSPACE}/srcdir/Birch/libraries/Standard/
 export BIRCH_PREFIX=${WORKSPACE}/srcdir/build_host
 export PATH=${WORKSPACE}/srcdir/build_host/bin:$PATH
-atomic_patch -p3 ${WORKSPACE}/srcdir/stdio.patch
+# musl c library does not define stdin, stdout, and stderr macros as objects
+if [[ "${target}" == *-musl* ]]; then
+  atomic_patch -p3 ${WORKSPACE}/srcdir/stdio.patch
+fi
 birch bootstrap
 CPPFLAGS="-I${prefix}/include" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-debug --enable-release
 make -j${nproc}

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -55,9 +55,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("boost_jll"),
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency("Eigen_jll"),
-    Dependency("LibYAML_jll"),
     Dependency(PackageSpec(name = "LibBirch_jll", version = version)),
+    Dependency("LibYAML_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -3,7 +3,9 @@
 using BinaryBuilder, Pkg
 
 name = "Birch_Standard"
-version = v"1.0.0"
+# Birch's version is `(git describe --long || echo) | sed -E 's/v([0-9]+)-([0-9]+)-g[0-9a-f]+/\1.\2/'`
+# (see https://github.com/JuliaPackaging/Yggdrasil/pull/2156#discussion_r528224861)
+version = v"1.75"
 
 # Collection of sources required to complete build
 sources = [

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -22,7 +22,7 @@ apk add boost-dev yaml-dev
 cd ${WORKSPACE}/srcdir/Birch/driver/
 mkdir -p ${WORKSPACE}/srcdir/build_host
 autoreconf -vi
-bb_target=${MACHTYPE} CXX=${HOSTCXX} CPPFLAGS=-I/usr/include LDFLAGS=-L/usr/lib ./configure --prefix=${WORKSPACE}/srcdir/build_host --build=${MACHTYPE} --host=${MACHTYPE}
+CXX=${HOSTCXX} CPPFLAGS=-I/usr/include LDFLAGS=-L/usr/lib ./configure --prefix=${WORKSPACE}/srcdir/build_host --build=${MACHTYPE} --host=${MACHTYPE}
 make clean
 make -j${nproc}
 make install

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -40,9 +40,6 @@ install_license LICENSE
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
 
-# GLOB_NOMAGIC is not supported by musl
-filter!(p -> libc(p) != "musl", platforms)
-
 # Native support for Windows is not yet provided
 filter!(!Sys.iswindows, platforms)
 

--- a/B/Birch_Standard/build_tarballs.jl
+++ b/B/Birch_Standard/build_tarballs.jl
@@ -10,6 +10,7 @@ version = v"1.75"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/lawmurray/Birch.git", "a533990b59b04ef4cd20f8d4fe91c4a220df1cfa"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
@@ -30,6 +31,7 @@ make install
 cd ${WORKSPACE}/srcdir/Birch/libraries/Standard/
 export BIRCH_PREFIX=${WORKSPACE}/srcdir/build_host
 export PATH=${WORKSPACE}/srcdir/build_host/bin:$PATH
+atomic_patch -p3 ${WORKSPACE}/srcdir/stdio.patch
 birch bootstrap
 CPPFLAGS="-I${prefix}/include" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-debug --enable-release
 make -j${nproc}

--- a/B/Birch_Standard/bundled/stdio.patch
+++ b/B/Birch_Standard/bundled/stdio.patch
@@ -1,0 +1,13 @@
+diff -ruN Birch.orig/libraries/Standard/src/system/stdio.birch Birch/libraries/Standard/src/system/stdio.birch
+--- Birch.orig/libraries/Standard/src/system/stdio.birch	2020-11-24 01:37:30.887366775 +0100
++++ Birch/libraries/Standard/src/system/stdio.birch	2020-11-24 01:38:08.909768931 +0100
+@@ -1,3 +1,9 @@
++hpp{{
++  #undef stdin
++  #undef stdout
++  #undef stderr
++}}
++
+ /*
+  * Returns the file associated with stdin.
+  */


### PR DESCRIPTION
This PR adds the [Birch standard library](https://github.com/lawmurray/Birch/tree/master/libraries/Standard), hence I thought the name `Birch_Standard` would be appropriate. It was part of https://github.com/JuliaPackaging/Yggdrasil/pull/1924 but as mentioned in https://github.com/JuliaPackaging/Yggdrasil/pull/2155 I think I prefer a modular setup.

The patches for FreeBSD and musl included in https://github.com/JuliaPackaging/Yggdrasil/pull/1924 are not needed anymore, I moved them upstream.