### PR TITLE
libcxxwrap 0.8.5 for Julia 1.5

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-julia_version = v"1.4.2"
+julia_version = v"1.5.3"
 
 name = "libcxxwrap_julia"
-version = v"0.8.4"
+version = v"0.8.5"
 
 const is_yggdrasil = haskey(ENV, "BUILD_BUILDNUMBER")
 git_repo = is_yggdrasil ? "https://github.com/JuliaInterop/libcxxwrap-julia.git" : joinpath(ENV["HOME"], "src/julia/libcxxwrap-julia/")
@@ -59,4 +59,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    preferred_gcc_version = v"7", julia_compat = "~$(julia_version.major).$(julia_version.minor)")
+    preferred_gcc_version = v"7", julia_compat = "^$(julia_version.major).$(julia_version.minor)")


### PR DESCRIPTION
This is marked as a draft, as it shouldn't be merged immediately; instead, first...
1. https://github.com/JuliaRegistries/General/pull/25105 should be merged...
2. ... and tested, i.e. libcxxwrap 0.8.4 for Julia 1.4 should be verified before we advance further
3. and I'd also like to test at least the macOS build artifact produced by this PR before merging.

CC @barche 