### PR TITLE
[HDF5] add symlinks on more platforms

### DIFF
--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -66,18 +66,14 @@ fi
 
 # We need to be able to access `libhdf5` and `libhdf5_hl` directly, so symlink it from the hashed filename from manylinux pypi
 if [[ ! ${target} == *-mingw* ]]; then
-    if [[ ! -f ${libdir}/libhdf5${ext} ]]; then
+    if [[ ! -f ${libdir}/libhdf5${dlext} ]]; then
         libhdf5name=$(basename ${libdir}/libhdf5-*.${dlext}*)
-        base="${libhdf5name%%.*}"
-        ext="${libhdf5name#$base}"
-        ln -s ${libhdf5name} ${libdir}/libhdf5${ext}
+        ln -s ${libhdf5name} ${libdir}/libhdf5${dlext}
     fi
 
-    if [[ ! -f ${libdir}/libhdf5_hl${ext} ]]; then
+    if [[ ! -f ${libdir}/libhdf5_hl${dlext} ]]; then
         libhdf5_hlname=$(basename ${libdir}/libhdf5_hl-*.${dlext}*)
-        base="${libhdf5_hlname%%.*}"
-        ext="${libhdf5_hlname#$base}"
-        ln -s ${libhdf5_hlname} ${libdir}/libhdf5_hl${ext}
+        ln -s ${libhdf5_hlname} ${libdir}/libhdf5_hl${dlext}
     fi
 fi
 

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -64,28 +64,28 @@ else
     install_license aarch64-*/info/licenses/COPYING
 fi
 
-# We need to be able to access `libhdf5` and `libhdf5_hl` directly, so symlink it from the hashed filename from manylinux pypi
-if [[ ${target} == *86*linux* ]]; then
-    libhdf5name=$(basename ${libdir}/libhdf5-*.${dlext}*)
-    base="${libhdf5name%%.*}"
-    ext="${libhdf5name#$base}"
-    ln -s ${libhdf5name} ${libdir}/libhdf5${ext}
-    libhdf5_hlname=$(basename ${libdir}/libhdf5_hl-*.${dlext}*)
-    base="${libhdf5_hlname%%.*}"
-    ext="${libhdf5_hlname#$base}"
-    ln -s ${libhdf5_hlname} ${libdir}/libhdf5_hl${ext}
-fi
-
+# We want to have the files with the simple name lib.extension, without
+# soversion, to make linking to these libraries easier
 if [[ ! ${target} == *-mingw* ]]; then
-    if [[ ! -f ${libdir}/libhdf5${dlext} ]]; then
-        ln -s ${libdir}/libhdf5.*${dlext} ${libdir}/libhdf5${dlext}
-    fi
+    for lib in libhdf5 libhdf5_hl; do
+        # We also need to be able to access `libhdf5` and `libhdf5_hl` directly,
+        # so symlink it from the hashed filename from manylinux pypi
+        if [[ ${target} == *86*linux* ]]; then
+            name=$(basename ${libdir}/${lib}-*.${dlext}*)
+            base="${name%%.*}"
+            ext="${name#$base}"
+            ln -s "${name}" "${libdir}/${lib}${ext}"
+        fi
 
-    if [[ ! -f ${libdir}/libhdf5_hl${dlext} ]]; then
-        ln -s ${libdir}/libhdf5_hl.*${dlext} ${libdir}/libhdf5_hl${dlext}
-    fi
+        dest="${libdir}/${lib}.${dlext}"
+        if [[ ! -f "${dest}" ]]; then
+            link_target=$(find ${libdir} -name "${lib}.*.${dlext}" -or -name "${lib}.${dlext}.*")
+            ln -s $(basename "${link_target}") "${dest}"
+        fi
+        # Double check that the file links to an existing file
+        [ -f $(realpath "${dest}") ]
+    done
 fi
-
 """
 
 # These are the platforms we will build for by default, unless further

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -65,15 +65,24 @@ else
 fi
 
 # We need to be able to access `libhdf5` and `libhdf5_hl` directly, so symlink it from the hashed filename from manylinux pypi
+if [[ ${target} == *86*linux* ]]; then
+    libhdf5name=$(basename ${libdir}/libhdf5-*.${dlext}*)
+    base="${libhdf5name%%.*}"
+    ext="${libhdf5name#$base}"
+    ln -s ${libhdf5name} ${libdir}/libhdf5${ext}
+    libhdf5_hlname=$(basename ${libdir}/libhdf5_hl-*.${dlext}*)
+    base="${libhdf5_hlname%%.*}"
+    ext="${libhdf5_hlname#$base}"
+    ln -s ${libhdf5_hlname} ${libdir}/libhdf5_hl${ext}
+fi
+
 if [[ ! ${target} == *-mingw* ]]; then
     if [[ ! -f ${libdir}/libhdf5${dlext} ]]; then
-        libhdf5name=$(basename ${libdir}/libhdf5-*.${dlext}*)
-        ln -s ${libhdf5name} ${libdir}/libhdf5${dlext}
+        ln -s ${libdir}/libhdf5.*${dlext} ${libdir}/libhdf5${dlext}
     fi
 
     if [[ ! -f ${libdir}/libhdf5_hl${dlext} ]]; then
-        libhdf5_hlname=$(basename ${libdir}/libhdf5_hl-*.${dlext}*)
-        ln -s ${libhdf5_hlname} ${libdir}/libhdf5_hl${dlext}
+        ln -s ${libdir}/libhdf5_hl.*${dlext} ${libdir}/libhdf5_hl${dlext}
     fi
 fi
 

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -65,18 +65,21 @@ else
 fi
 
 # We need to be able to access `libhdf5` and `libhdf5_hl` directly, so symlink it from the hashed filename from manylinux pypi
-if [[ ${target} == *86*linux* ]]; then
-    libhdf5name=$(basename ${libdir}/libhdf5-*.${dlext}*)
-    base="${libhdf5name%%.*}"
-    ext="${libhdf5name#$base}"
-    ln -s ${libhdf5name} ${libdir}/libhdf5${ext}
+if [[ ! ${target} == *-mingw* ]]; then
+    if [[ ! -f ${libdir}/libhdf5${ext} ]]; then
+        libhdf5name=$(basename ${libdir}/libhdf5-*.${dlext}*)
+        base="${libhdf5name%%.*}"
+        ext="${libhdf5name#$base}"
+        ln -s ${libhdf5name} ${libdir}/libhdf5${ext}
+    fi
 
-    libhdf5_hlname=$(basename ${libdir}/libhdf5_hl-*.${dlext}*)
-    base="${libhdf5_hlname%%.*}"
-    ext="${libhdf5_hlname#$base}"
-    ln -s ${libhdf5_hlname} ${libdir}/libhdf5_hl${ext}
+    if [[ ! -f ${libdir}/libhdf5_hl${ext} ]]; then
+        libhdf5_hlname=$(basename ${libdir}/libhdf5_hl-*.${dlext}*)
+        base="${libhdf5_hlname%%.*}"
+        ext="${libhdf5_hlname#$base}"
+        ln -s ${libhdf5_hlname} ${libdir}/libhdf5_hl${ext}
+    fi
 fi
-
 
 """
 


### PR DESCRIPTION
This will hopefully help #2133. On `x86_64-apple-darwin` and `x86_64-linux-gnu` it failed to find the HDF5 library.

cc @musm @giordano 