### PR TITLE
Go back to OpenBLAS 0.3.10

### DIFF
--- a/O/OpenBLAS/OpenBLAS32@0.3.10/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS32@0.3.10/build_tarballs.jl
@@ -1,0 +1,16 @@
+using BinaryBuilder
+
+include("../common.jl")
+
+# Collection of sources required to build OpenBLAS
+name = "OpenBLAS32"
+version = v"0.3.10"
+
+sources = openblas_sources(version)
+script = openblas_script(openblas32=true)
+platforms = openblas_platforms()
+products = openblas_products()
+dependencies = openblas_dependencies()
+
+# Build the tarballs
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6", lock_microarchitecture=false)

--- a/O/OpenBLAS/OpenBLAS32@0.3.10/bundled/patches/neoverse-generic-kernels.patch
+++ b/O/OpenBLAS/OpenBLAS32@0.3.10/bundled/patches/neoverse-generic-kernels.patch
@@ -1,0 +1,19 @@
+diff --git a/kernel/arm64/KERNEL.NEOVERSEN1 b/kernel/arm64/KERNEL.NEOVERSEN1
+index ea010db4..074d7215 100644
+--- a/kernel/arm64/KERNEL.NEOVERSEN1
++++ b/kernel/arm64/KERNEL.NEOVERSEN1
+@@ -91,10 +91,10 @@ IDAMAXKERNEL   = iamax_thunderx2t99.c
+ ICAMAXKERNEL   = izamax_thunderx2t99.c
+ IZAMAXKERNEL   = izamax_thunderx2t99.c
+ 
+-SNRM2KERNEL    = scnrm2_thunderx2t99.c
+-DNRM2KERNEL    = dznrm2_thunderx2t99.c
+-CNRM2KERNEL    = scnrm2_thunderx2t99.c
+-ZNRM2KERNEL    = dznrm2_thunderx2t99.c
++SNRM2KERNEL    = nrm2.S
++DNRM2KERNEL    = nrm2.S
++CNRM2KERNEL    = znrm2.S
++ZNRM2KERNEL    = znrm2.S
+ 
+ DDOTKERNEL     = dot_thunderx2t99.c
+ SDOTKERNEL     = dot_thunderx2t99.c

--- a/O/OpenBLAS/OpenBLAS32@0.3.10/bundled/patches/openblas-ofast-power.patch
+++ b/O/OpenBLAS/OpenBLAS32@0.3.10/bundled/patches/openblas-ofast-power.patch
@@ -1,0 +1,33 @@
+ Makefile.power | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile.power b/Makefile.power
+index 24d8aa8a..e53a243a 100644
+--- a/Makefile.power
++++ b/Makefile.power
+@@ -11,20 +11,20 @@ endif
+ 
+ ifeq ($(CORE), POWER9)
+ ifeq ($(USE_OPENMP), 1)
+-COMMON_OPT += -Ofast -mcpu=power9 -mtune=power9 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
++COMMON_OPT += -mcpu=power9 -mtune=power9 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power9 -mtune=power9 -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ else
+-COMMON_OPT += -Ofast -mcpu=power9 -mtune=power9 -mvsx -malign-power -fno-fast-math
++COMMON_OPT += -mcpu=power9 -mtune=power9 -mvsx -malign-power -fno-fast-math
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power9 -mtune=power9 -malign-power -fno-fast-math
+ endif
+ endif
+ 
+ ifeq ($(CORE), POWER8)
+ ifeq ($(USE_OPENMP), 1)
+-COMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
++COMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8 -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ else
+-COMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx -malign-power -fno-fast-math
++COMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx -malign-power -fno-fast-math
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8 -malign-power -fno-fast-math
+ endif
+ endif
+

--- a/O/OpenBLAS/OpenBLAS32@0.3.10/bundled/patches/openblas-winexit.patch
+++ b/O/OpenBLAS/OpenBLAS32@0.3.10/bundled/patches/openblas-winexit.patch
@@ -1,0 +1,177 @@
+From f919c3301fabbaa5d965dcc7b1c3d6892a8c730a Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliacomputing.com>
+Date: Sat, 14 Mar 2020 12:05:19 +0100
+
+---
+ driver/others/memory.c | 131 +----------------------------------------
+ 1 file changed, 2 insertions(+), 129 deletions(-)
+
+diff --git a/driver/others/memory.c b/driver/others/memory.c
+index 62a5a021..23f8fe65 100644
+--- a/driver/others/memory.c
++++ b/driver/others/memory.c
+@@ -1510,7 +1510,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -1547,74 +1547,12 @@ void DESTRUCTOR gotoblas_quit(void) {
+ #endif
+ }
+ 
+-#if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-#if defined(SMP)
+-      blas_thread_memory_cleanup();
+-#endif
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-	gotoblas_quit();
+-	return 0;
+-}
+ #ifdef _WIN64
+ #pragma comment(linker, "/INCLUDE:_tls_used")
+ #else
+ #pragma comment(linker, "/INCLUDE:__tls_used")
+ #endif
+ 
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-static int(*p_process_term)(void) = on_process_term;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-#endif
+-
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ /* Don't call me; this is just work around for PGI / Sun bug */
+ void gotoblas_dummy_for_PGI(void) {
+@@ -3104,7 +3042,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -3133,71 +3071,6 @@ void DESTRUCTOR gotoblas_quit(void) {
+ #endif
+ }
+ 
+-#if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-	gotoblas_quit();
+-	return 0;
+-}
+-#ifdef _WIN64
+-#pragma comment(linker, "/INCLUDE:_tls_used")
+-#else
+-#pragma comment(linker, "/INCLUDE:__tls_used")
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-static int(*p_process_term)(void) = on_process_term;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-#endif
+-
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ /* Don't call me; this is just work around for PGI / Sun bug */
+ void gotoblas_dummy_for_PGI(void) {

--- a/O/OpenBLAS/OpenBLAS@0.3.10/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS@0.3.10/build_tarballs.jl
@@ -1,0 +1,17 @@
+using BinaryBuilder
+
+include("../common.jl")
+
+# Collection of sources required to build OpenBLAS
+name = "OpenBLAS"
+version = v"0.3.10"
+
+sources = openblas_sources(version)
+script = openblas_script()
+platforms = openblas_platforms(;experimental=true)
+products = openblas_products()
+dependencies = openblas_dependencies()
+
+# Build the tarballs
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"6", lock_microarchitecture=false, julia_compat="1.6")

--- a/O/OpenBLAS/OpenBLAS@0.3.10/bundled/patches/neoverse-generic-kernels.patch
+++ b/O/OpenBLAS/OpenBLAS@0.3.10/bundled/patches/neoverse-generic-kernels.patch
@@ -1,0 +1,19 @@
+diff --git a/kernel/arm64/KERNEL.NEOVERSEN1 b/kernel/arm64/KERNEL.NEOVERSEN1
+index ea010db4..074d7215 100644
+--- a/kernel/arm64/KERNEL.NEOVERSEN1
++++ b/kernel/arm64/KERNEL.NEOVERSEN1
+@@ -91,10 +91,10 @@ IDAMAXKERNEL   = iamax_thunderx2t99.c
+ ICAMAXKERNEL   = izamax_thunderx2t99.c
+ IZAMAXKERNEL   = izamax_thunderx2t99.c
+ 
+-SNRM2KERNEL    = scnrm2_thunderx2t99.c
+-DNRM2KERNEL    = dznrm2_thunderx2t99.c
+-CNRM2KERNEL    = scnrm2_thunderx2t99.c
+-ZNRM2KERNEL    = dznrm2_thunderx2t99.c
++SNRM2KERNEL    = nrm2.S
++DNRM2KERNEL    = nrm2.S
++CNRM2KERNEL    = znrm2.S
++ZNRM2KERNEL    = znrm2.S
+ 
+ DDOTKERNEL     = dot_thunderx2t99.c
+ SDOTKERNEL     = dot_thunderx2t99.c

--- a/O/OpenBLAS/OpenBLAS@0.3.10/bundled/patches/openblas-ofast-power.patch
+++ b/O/OpenBLAS/OpenBLAS@0.3.10/bundled/patches/openblas-ofast-power.patch
@@ -1,0 +1,33 @@
+ Makefile.power | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile.power b/Makefile.power
+index 24d8aa8a..e53a243a 100644
+--- a/Makefile.power
++++ b/Makefile.power
+@@ -11,20 +11,20 @@ endif
+ 
+ ifeq ($(CORE), POWER9)
+ ifeq ($(USE_OPENMP), 1)
+-COMMON_OPT += -Ofast -mcpu=power9 -mtune=power9 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
++COMMON_OPT += -mcpu=power9 -mtune=power9 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power9 -mtune=power9 -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ else
+-COMMON_OPT += -Ofast -mcpu=power9 -mtune=power9 -mvsx -malign-power -fno-fast-math
++COMMON_OPT += -mcpu=power9 -mtune=power9 -mvsx -malign-power -fno-fast-math
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power9 -mtune=power9 -malign-power -fno-fast-math
+ endif
+ endif
+ 
+ ifeq ($(CORE), POWER8)
+ ifeq ($(USE_OPENMP), 1)
+-COMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
++COMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8 -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ else
+-COMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx -malign-power -fno-fast-math
++COMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx -malign-power -fno-fast-math
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8 -malign-power -fno-fast-math
+ endif
+ endif
+

--- a/O/OpenBLAS/OpenBLAS@0.3.10/bundled/patches/openblas-winexit.patch
+++ b/O/OpenBLAS/OpenBLAS@0.3.10/bundled/patches/openblas-winexit.patch
@@ -1,0 +1,177 @@
+From f919c3301fabbaa5d965dcc7b1c3d6892a8c730a Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliacomputing.com>
+Date: Sat, 14 Mar 2020 12:05:19 +0100
+
+---
+ driver/others/memory.c | 131 +----------------------------------------
+ 1 file changed, 2 insertions(+), 129 deletions(-)
+
+diff --git a/driver/others/memory.c b/driver/others/memory.c
+index 62a5a021..23f8fe65 100644
+--- a/driver/others/memory.c
++++ b/driver/others/memory.c
+@@ -1510,7 +1510,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -1547,74 +1547,12 @@ void DESTRUCTOR gotoblas_quit(void) {
+ #endif
+ }
+ 
+-#if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-#if defined(SMP)
+-      blas_thread_memory_cleanup();
+-#endif
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-	gotoblas_quit();
+-	return 0;
+-}
+ #ifdef _WIN64
+ #pragma comment(linker, "/INCLUDE:_tls_used")
+ #else
+ #pragma comment(linker, "/INCLUDE:__tls_used")
+ #endif
+ 
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-static int(*p_process_term)(void) = on_process_term;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-#endif
+-
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ /* Don't call me; this is just work around for PGI / Sun bug */
+ void gotoblas_dummy_for_PGI(void) {
+@@ -3104,7 +3042,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -3133,71 +3071,6 @@ void DESTRUCTOR gotoblas_quit(void) {
+ #endif
+ }
+ 
+-#if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-	gotoblas_quit();
+-	return 0;
+-}
+-#ifdef _WIN64
+-#pragma comment(linker, "/INCLUDE:_tls_used")
+-#else
+-#pragma comment(linker, "/INCLUDE:__tls_used")
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-static int(*p_process_term)(void) = on_process_term;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-#endif
+-
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ /* Don't call me; this is just work around for PGI / Sun bug */
+ void gotoblas_dummy_for_PGI(void) {

--- a/O/OpenBLAS/OpenBLASHighCoreCount@0.3.10/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASHighCoreCount@0.3.10/build_tarballs.jl
@@ -1,0 +1,16 @@
+using BinaryBuilder
+
+include("../common.jl")
+
+# Collection of sources required to build OpenBLAS
+name = "OpenBLASHighCoreCount"
+version = v"0.3.10"
+
+sources = openblas_sources(version)
+script = openblas_script(num_64bit_threads=128)
+platforms = openblas_platforms()
+products = openblas_products()
+dependencies = openblas_dependencies()
+
+# Build the tarballs
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6", lock_microarchitecture=false)

--- a/O/OpenBLAS/OpenBLASHighCoreCount@0.3.10/bundled/patches/neoverse-generic-kernels.patch
+++ b/O/OpenBLAS/OpenBLASHighCoreCount@0.3.10/bundled/patches/neoverse-generic-kernels.patch
@@ -1,0 +1,19 @@
+diff --git a/kernel/arm64/KERNEL.NEOVERSEN1 b/kernel/arm64/KERNEL.NEOVERSEN1
+index ea010db4..074d7215 100644
+--- a/kernel/arm64/KERNEL.NEOVERSEN1
++++ b/kernel/arm64/KERNEL.NEOVERSEN1
+@@ -91,10 +91,10 @@ IDAMAXKERNEL   = iamax_thunderx2t99.c
+ ICAMAXKERNEL   = izamax_thunderx2t99.c
+ IZAMAXKERNEL   = izamax_thunderx2t99.c
+ 
+-SNRM2KERNEL    = scnrm2_thunderx2t99.c
+-DNRM2KERNEL    = dznrm2_thunderx2t99.c
+-CNRM2KERNEL    = scnrm2_thunderx2t99.c
+-ZNRM2KERNEL    = dznrm2_thunderx2t99.c
++SNRM2KERNEL    = nrm2.S
++DNRM2KERNEL    = nrm2.S
++CNRM2KERNEL    = znrm2.S
++ZNRM2KERNEL    = znrm2.S
+ 
+ DDOTKERNEL     = dot_thunderx2t99.c
+ SDOTKERNEL     = dot_thunderx2t99.c

--- a/O/OpenBLAS/OpenBLASHighCoreCount@0.3.10/bundled/patches/openblas-ofast-power.patch
+++ b/O/OpenBLAS/OpenBLASHighCoreCount@0.3.10/bundled/patches/openblas-ofast-power.patch
@@ -1,0 +1,33 @@
+ Makefile.power | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile.power b/Makefile.power
+index 24d8aa8a..e53a243a 100644
+--- a/Makefile.power
++++ b/Makefile.power
+@@ -11,20 +11,20 @@ endif
+ 
+ ifeq ($(CORE), POWER9)
+ ifeq ($(USE_OPENMP), 1)
+-COMMON_OPT += -Ofast -mcpu=power9 -mtune=power9 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
++COMMON_OPT += -mcpu=power9 -mtune=power9 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power9 -mtune=power9 -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ else
+-COMMON_OPT += -Ofast -mcpu=power9 -mtune=power9 -mvsx -malign-power -fno-fast-math
++COMMON_OPT += -mcpu=power9 -mtune=power9 -mvsx -malign-power -fno-fast-math
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power9 -mtune=power9 -malign-power -fno-fast-math
+ endif
+ endif
+ 
+ ifeq ($(CORE), POWER8)
+ ifeq ($(USE_OPENMP), 1)
+-COMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
++COMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8 -malign-power -DUSE_OPENMP -fno-fast-math -fopenmp
+ else
+-COMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx -malign-power -fno-fast-math
++COMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx -malign-power -fno-fast-math
+ FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8 -malign-power -fno-fast-math
+ endif
+ endif
+

--- a/O/OpenBLAS/OpenBLASHighCoreCount@0.3.10/bundled/patches/openblas-winexit.patch
+++ b/O/OpenBLAS/OpenBLASHighCoreCount@0.3.10/bundled/patches/openblas-winexit.patch
@@ -1,0 +1,177 @@
+From f919c3301fabbaa5d965dcc7b1c3d6892a8c730a Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliacomputing.com>
+Date: Sat, 14 Mar 2020 12:05:19 +0100
+
+---
+ driver/others/memory.c | 131 +----------------------------------------
+ 1 file changed, 2 insertions(+), 129 deletions(-)
+
+diff --git a/driver/others/memory.c b/driver/others/memory.c
+index 62a5a021..23f8fe65 100644
+--- a/driver/others/memory.c
++++ b/driver/others/memory.c
+@@ -1510,7 +1510,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -1547,74 +1547,12 @@ void DESTRUCTOR gotoblas_quit(void) {
+ #endif
+ }
+ 
+-#if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-#if defined(SMP)
+-      blas_thread_memory_cleanup();
+-#endif
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-	gotoblas_quit();
+-	return 0;
+-}
+ #ifdef _WIN64
+ #pragma comment(linker, "/INCLUDE:_tls_used")
+ #else
+ #pragma comment(linker, "/INCLUDE:__tls_used")
+ #endif
+ 
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-static int(*p_process_term)(void) = on_process_term;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-#endif
+-
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ /* Don't call me; this is just work around for PGI / Sun bug */
+ void gotoblas_dummy_for_PGI(void) {
+@@ -3104,7 +3042,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -3133,71 +3071,6 @@ void DESTRUCTOR gotoblas_quit(void) {
+ #endif
+ }
+ 
+-#if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-	gotoblas_quit();
+-	return 0;
+-}
+-#ifdef _WIN64
+-#pragma comment(linker, "/INCLUDE:_tls_used")
+-#else
+-#pragma comment(linker, "/INCLUDE:__tls_used")
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-static int(*p_process_term)(void) = on_process_term;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-#endif
+-
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ /* Don't call me; this is just work around for PGI / Sun bug */
+ void gotoblas_dummy_for_PGI(void) {


### PR DESCRIPTION
OpenBLAS 0.3.12 was causing a suspicious number of CI timeouts. Since we're using 0.3.10 successfully so far, go back to it, but add the Neoverse patch, which should hopefully be stable for the 1.6 release. We can try again afterwards.