### PR TITLE
Update FLINT_jll

### DIFF
--- a/F/FLINT/build_tarballs.jl
+++ b/F/FLINT/build_tarballs.jl
@@ -3,12 +3,13 @@
 using BinaryBuilder, Pkg
 
 name = "FLINT"
-version = v"2.6.3"
+version = v"2.6.999"
 
 # Collection of sources required to build FLINT
 sources = [
-    ArchiveSource("http://www.flintlib.org/flint-$(version).tar.gz",
-                  "ce1a750a01fa53715cad934856d4b2ed76f1d1520bac0527ace7d5b53e342ee3")
+    GitSource("https://github.com/wbhart/flint2.git", "60401a410e335f3c243ec069f5c72a2d8365a626"),
+#    ArchiveSource("http://www.flintlib.org/flint-$(version).tar.gz",
+#                  "ce1a750a01fa53715cad934856d4b2ed76f1d1520bac0527ace7d5b53e342ee3")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
... to a pre-release snapshot of 2.7. Since we can't use semver prerelease versions for Julia packages / JLLs in the registry, instead use 2.6.999

CC @tthsqe12 @fieker @hannes14 @wbhart