### PR TITLE
[LASzip] add ExecutableProduct

### DIFF
--- a/L/LASzip/build_tarballs.jl
+++ b/L/LASzip/build_tarballs.jl
@@ -32,7 +32,8 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["liblaszip", "liblaszip3"], :liblaszip)
+    LibraryProduct(["liblaszip", "liblaszip3"], :liblaszip),
+    ExecutableProduct("laszip", :laszip_path),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
Which is used to pipe Laz files in LasIO.jl, and is needed for https://github.com/visr/LasIO.jl/pull/37