### PR TITLE
LibOSXUnwind: rebuild 0.0.6

### DIFF
--- a/L/LibOSXUnwind/build_tarballs.jl
+++ b/L/LibOSXUnwind/build_tarballs.jl
@@ -35,7 +35,7 @@ cp -aR include ${prefix}/
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter(Sys.isapple, supported_platforms(;experimental=true))
+platforms = filter(Sys.isapple, supported_platforms())
 
 # The products that we will ensure are always built
 products = [
@@ -47,4 +47,4 @@ dependencies = [
 ]
 
 # Build the tarballs
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.5.1")


### PR DESCRIPTION
... without experimental platforms and with correct julia_compat bound

See https://github.com/JuliaPackaging/Yggdrasil/pull/2190#issuecomment-735318854
and also https://github.com/JuliaRegistries/General/pull/25468

Ping @giordano @staticfloat

A follow up PR could re-enable the experimental platforms, as long as it increases the version to at least 0.0.7