### PR TITLE
add libgeotiff

### DIFF
--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -1,0 +1,46 @@
+using BinaryBuilder, Pkg
+
+name = "libgeotiff"
+version = v"1.6.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/OSGeo/libgeotiff/releases/download/$version/libgeotiff-$version.tar.gz", "9311017e5284cffb86f2c7b7a9df1fb5ebcdc61c30468fb2e6bca36e4272ebca")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+
+cd $WORKSPACE/srcdir/libgeotiff-*/
+
+#point linker to correct libstdc++, otherwise will fail on linking executables
+export LDFLAGS="$LDFLAGS -lstdc++"
+
+cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_BUILD_TYPE=Release
+
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("makegeo", :makegeo),
+    ExecutableProduct("geotifcp", :geotifcp),
+    ExecutableProduct("listgeo", :listgeo),
+    ExecutableProduct("applygeo", :applygeo)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="PROJ_jll", uuid="58948b4f-47e0-5654-a9ad-f609743f8632"))
+    Dependency(PackageSpec(name="Libtiff_jll", uuid="89763e89-9b03-5906-acba-b20f662cd828"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -5,7 +5,8 @@ version = v"1.6.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/OSGeo/libgeotiff/releases/download/$version/libgeotiff-$version.tar.gz", "9311017e5284cffb86f2c7b7a9df1fb5ebcdc61c30468fb2e6bca36e4272ebca")
+    ArchiveSource("https://github.com/OSGeo/libgeotiff/releases/download/$version/libgeotiff-$version.tar.gz", "9311017e5284cffb86f2c7b7a9df1fb5ebcdc61c30468fb2e6bca36e4272ebca"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
@@ -13,12 +14,25 @@ script = raw"""
 
 cd $WORKSPACE/srcdir/libgeotiff-*/
 
-#point linker to correct libstdc++, otherwise will fail on linking executables
-export LDFLAGS="$LDFLAGS -lstdc++"
+# Who knows why they want to install Windows binaries not build with MSVC to
+# ${prefix} instead of ${prefix}/bin
+atomic_patch -p1 ../patches/more-reasonable-default-bin-subdir.patch
+
+mkdir build && cd build
+
+# Hint to find libstc++, required to link against C++ libs when using C compiler
+if [[ "${target}" == *-linux-* ]]; then
+    if [[ "${nbits}" == 32 ]]; then
+        export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib"
+    else
+        export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib64"
+    fi
+fi
 
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_BUILD_TYPE=Release \
+      ..
 
 make -j${nproc}
 make install
@@ -33,13 +47,13 @@ products = [
     ExecutableProduct("makegeo", :makegeo),
     ExecutableProduct("geotifcp", :geotifcp),
     ExecutableProduct("listgeo", :listgeo),
-    ExecutableProduct("applygeo", :applygeo)
+    ExecutableProduct("applygeo", :applygeo),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="PROJ_jll", uuid="58948b4f-47e0-5654-a9ad-f609743f8632"))
-    Dependency(PackageSpec(name="Libtiff_jll", uuid="89763e89-9b03-5906-acba-b20f662cd828"))
+    Dependency(PackageSpec(name="PROJ_jll", uuid="58948b4f-47e0-5654-a9ad-f609743f8632")),
+    Dependency(PackageSpec(name="Libtiff_jll", uuid="89763e89-9b03-5906-acba-b20f662cd828")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libgeotiff/bundled/patches/more-reasonable-default-bin-subdir.patch
+++ b/L/libgeotiff/bundled/patches/more-reasonable-default-bin-subdir.patch
@@ -1,0 +1,29 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -246,22 +246,14 @@
+ 
+ #    ${PROJECT_BINARY_DIR}/geotiff_version.h
+ 
++SET(DEFAULT_BIN_SUBDIR bin)
++SET(DEFAULT_DATA_SUBDIR share)
++SET(DEFAULT_INCLUDE_SUBDIR include)
+ IF(WIN32)
+-    SET(DEFAULT_LIB_SUBDIR lib)
+-    SET(DEFAULT_DATA_SUBDIR .)
+-    SET(DEFAULT_INCLUDE_SUBDIR include)
+-
+-    IF(MSVC)
+-        SET(DEFAULT_BIN_SUBDIR bin)
+-    ELSE()
+-        SET(DEFAULT_BIN_SUBDIR .)
+-    ENDIF()
++    SET(DEFAULT_LIB_SUBDIR bin)
+ ELSE()
+     # Common locatoins for Unix and Mac OS X
+-    SET(DEFAULT_BIN_SUBDIR bin)
+     SET(DEFAULT_LIB_SUBDIR lib)
+-    SET(DEFAULT_DATA_SUBDIR share)
+-    SET(DEFAULT_INCLUDE_SUBDIR include)
+ ENDIF()
+ 
+ # Locations are changeable by user to customize layout of GeoTIFF installation


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` script to build [libgeotiff](https://github.com/OSGeo/libgeotiff).

I created the file using `BinaryBuilder.run_wizard()`. The only modification I had to make outside of the repo notes is the addition of a `export LDFLAGS="$LDFLAGS -lstdc++"` step. Otherwise I kept running into linking issue with the wrong libstdc++ being used in the sandbox

```
[ 92%] Linking C executable makegeo
cd /workspace/srcdir/libgeotiff-1.6.0/bin && /usr/bin/cmake -E cmake_link_script CMakeFiles/makegeo.dir/link.txt --verbose=false
/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/7.1.0/../../../../x86_64-linux-gnu/bin/ld: warning: libstdc++.so.6, needed by /opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/local/lib/libproj.so.21.0.2, not found (try using -rpath or -rpath-link)
```