### PR TITLE
[libgeotiff] update build_tarballs to output shared libs

### DIFF
--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -32,6 +32,7 @@ fi
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
       -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
       ..
 
 make -j${nproc}
@@ -44,6 +45,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
+    LibraryProduct("libgeotiff", :libgeotiff),
     ExecutableProduct("makegeo", :makegeo),
     ExecutableProduct("geotifcp", :geotifcp),
     ExecutableProduct("listgeo", :listgeo),


### PR DESCRIPTION
I forgot to output the actual shared library in the first commit.

I tested it locally with `julia --color=yes build_tarballs.jl --verbose --debug` and no fatal errors?