### PR TITLE
LibOSXUnwind: drop julia_compat

### DIFF
--- a/L/LibOSXUnwind/build_tarballs.jl
+++ b/L/LibOSXUnwind/build_tarballs.jl
@@ -47,4 +47,4 @@ dependencies = [
 ]
 
 # Build the tarballs
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.5.1")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
While only Julia >= 1.5.1 is built using LibOSXUnwind_jll 0.0.6,
the JLL is otherwise compatible with older Julia versions, too.

See [discuss here](https://github.com/JuliaPackaging/Yggdrasil/pull/2190#issuecomment-736309195).
Not sure if this should be merged or not; if it is, we need another update for the registry. I mostly
put it here to give all options as I see them to @staticfloat.

[skip build]