### PR TITLE
Use CMAKE_TARGET_TOOLCHAIN env var where possible

### DIFF
--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -18,7 +18,7 @@ cd cmake_build/
 if [[ "$target" == *-freebsd* || "$target" == *-apple-* ]]; then
   # Clang doesn't play nicely with OpenMP and
   # compilation fails with glog due to a c++11 error
-  CMAKE_FLAGS=(-DCMAKE_TOOLCHAIN_FILE=/opt/$target/${target}_gcc.cmake
+  CMAKE_FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_gcc.cmake
                -DMINIGLOG=ON)
 else
   CMAKE_FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -160,7 +160,7 @@ CMAKE_FLAGS+=(-DCLANG_TABLEGEN=${WORKSPACE}/bootstrap/bin/clang-tblgen)
 CMAKE_FLAGS+=(-DLLVM_CONFIG_PATH=${WORKSPACE}/bootstrap/bin/llvm-config)
 
 # Explicitly use our cmake toolchain file
-CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=/opt/${target}/${target}.cmake)
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
 
 # Manually set the host triplet, as otherwise on some platforms it tries to guess using
 # `ld -v`, which is hilariously wrong.

--- a/N/NNPACK/build_tarballs.jl
+++ b/N/NNPACK/build_tarballs.jl
@@ -46,9 +46,9 @@ if [[ "${target}" == *-linux-* ]]; then
 fi
 
 # On ARM/AArch64, use `clang` instead of `gcc`.
-TOOLCHAIN="/opt/${target}/${target}.cmake"
+TOOLCHAIN="${CMAKE_TARGET_TOOLCHAIN}"
 if [[ "${target}" == arm-* ]] || [[ "${target}" == aarch64-* ]]; then
-    TOOLCHAIN="/opt/${target}/${target}_clang.cmake"
+    TOOLCHAIN="${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake"
 fi
 
 # NNPACK wants "armv7l", not just "arm", so GIVE IT WHAT IT WANTS

--- a/S/Snowball/build_tarballs.jl
+++ b/S/Snowball/build_tarballs.jl
@@ -16,7 +16,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/libstemmer_c/
 cp ../CMakeLists.txt .
 rm Makefile
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.cmake
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
 make -j${nproc}
 make install
 install_license COPYING


### PR DESCRIPTION
[skip ci] [skip build]

This is part of an effort to reduce hardcoded uses of /opt