### PR TITLE
Stop removing /opt/${target}/${target}/lib*/*.la

### DIFF
--- a/C/Coin-OR/Cbc/build_tarballs.jl
+++ b/C/Coin-OR/Cbc/build_tarballs.jl
@@ -16,7 +16,6 @@ cd $WORKSPACE/srcdir/Cbc*
 
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
 update_configure_scripts
 
 # old and custom autoconf

--- a/C/Coin-OR/Cgl/build_tarballs.jl
+++ b/C/Coin-OR/Cgl/build_tarballs.jl
@@ -15,7 +15,6 @@ cd $WORKSPACE/srcdir/Cgl*
 
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
 update_configure_scripts
 
 # old and custom autoconf

--- a/C/Coin-OR/Clp/build_tarballs.jl
+++ b/C/Coin-OR/Clp/build_tarballs.jl
@@ -15,7 +15,6 @@ cd $WORKSPACE/srcdir/Clp*
 
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
 update_configure_scripts
 
 # old and custom autoconf

--- a/C/Coin-OR/CoinUtils/build_tarballs.jl
+++ b/C/Coin-OR/CoinUtils/build_tarballs.jl
@@ -15,7 +15,6 @@ cd $WORKSPACE/srcdir/CoinUtils*
 
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
 update_configure_scripts
 
 # Without fixing this configure reports that we can't build shared

--- a/C/Coin-OR/Osi/build_tarballs.jl
+++ b/C/Coin-OR/Osi/build_tarballs.jl
@@ -14,7 +14,6 @@ cd $WORKSPACE/srcdir/Osi*
 
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
 update_configure_scripts
 
 # old and custom autoconf

--- a/G/gperftools/build_tarballs.jl
+++ b/G/gperftools/build_tarballs.jl
@@ -16,8 +16,6 @@ cd $WORKSPACE/srcdir/gperftools*/
 
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
-rm -f /opt/${MACHTYPE}/${MACHTYPE}/lib*/*.la
 
 if [[ "${target}" == *-linux-* ]]; then
     # https://github.com/gperftools/gperftools/blob/e5f77d6485bd2f6ce43862e3e57118b1bb97d30a/README

--- a/I/Ipopt/build_tarballs.jl
+++ b/I/Ipopt/build_tarballs.jl
@@ -15,7 +15,6 @@ cd Ipopt-releases-*
 
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
 
 LIBASL=(-L${libdir} -lasl)
 if [[ "${target}" == *-linux-* ]]; then

--- a/I/IpoptMKL/build_tarballs.jl
+++ b/I/IpoptMKL/build_tarballs.jl
@@ -15,7 +15,6 @@ cd Ipopt-releases-*
 
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
 
 LIBASL=(-L${libdir} -lasl)
 if [[ "${target}" == *-linux-* ]]; then

--- a/L/lib4ti2/build_tarballs.jl
+++ b/L/lib4ti2/build_tarballs.jl
@@ -20,8 +20,6 @@ cd ${WORKSPACE}/srcdir/4ti2-*
 
 # Remove misleading libtool files 
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
-rm -f /opt/${MACHTYPE}/${MACHTYPE}/lib*/*.la
 
 # Patch #1 for fixing cross-compilation: The correctness of the patch
 # relies on us using clang or GCC (in a new enough version) as compiler;

--- a/M/MPICH/build_tarballs.jl
+++ b/M/MPICH/build_tarballs.jl
@@ -13,10 +13,6 @@ script = raw"""
 # Enter the funzone
 cd ${WORKSPACE}/srcdir/mpich-*
 
-# Remove wrong libtool files
-rm -f /opt/${target}/${target}/lib64/*.la
-rm -f /opt/${target}/${target}/lib/*.la
-
 if [[ "${target}" == powerpc64le-* ]]; then
     # I don't understand why, but the extra link flags we append in the gfortran
     # wrapper confuse the build system: the rule to build libmpifort has an

--- a/N/nauty/build_tarballs.jl
+++ b/N/nauty/build_tarballs.jl
@@ -18,8 +18,6 @@ cd ${WORKSPACE}/srcdir/nauty*
 
 # Remove misleading libtool files 
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
-rm -f /opt/${MACHTYPE}/${MACHTYPE}/lib*/*.la
 
 # Patch based on one from Debian: add autotools build system which creates a
 # shared library; compared to the Debian version, a bunch of things we don't

--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -26,7 +26,6 @@ cd $WORKSPACE/srcdir/sdpa-*
 
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
-rm -f /opt/${target}/${target}/lib*/*.la
 update_configure_scripts
 
 # Apply patches


### PR DESCRIPTION
[skip ci]

In theory, those files should be gone. In practice... well, let's see how much this PR breaks (or doesn't) :-)