### PR TITLE
Update HelFEM to 0.0.3

### DIFF
--- a/H/HelFEM/build_tarballs.jl
+++ b/H/HelFEM/build_tarballs.jl
@@ -1,9 +1,9 @@
 using BinaryBuilder, Pkg
 
 name = "HelFEM"
-version = v"0.0.2"
+version = v"0.0.3"
 sources = [
-    GitSource("https://github.com/mortenpi/HelFEM.git", "f2a1dcd456ab1c6c530ff9ae3b916bde2ebf9ae6")
+    GitSource("https://github.com/mortenpi/HelFEM.git", "a4d3b2e6f16f7f7953afd5f69a44257a65c5b131")
 ]
 
 script = raw"""


### PR DESCRIPTION
Wraps `lobatto` (https://github.com/mortenpi/HelFEM/compare/HelFEM_jll/v0.0.2...mortenpi:HelFEM_jll/v0.0.3).