### PR TITLE
Singular_jll v400.101.390

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -1,13 +1,39 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
+import Pkg.Types: VersionSpec
 
+# Singular_jll versions are decoupled from the upstream versions. Whenever we
+# package a new official Singular release, we initially map its version
+# X.Y.ZpN to X0Y.Z00.N00. So for example version 4.1.3p5 becomes 401.300.500.
+#
+# This reflects the fact that 4.2.0 will only be made if there is a change to
+# Singular language itself, i.e., this is a pretty major change. The third digit
+# is changed for regular interim releases, and corresponds roughly to a semver
+# minor release; and the `p5` truly is a patch level.
+#
+# Moreover, all our packages using Singular_jll use `~` in their compat
+# ranges. Together, this allows us to increment the patch level of the JLL for
+# minor tweaks. If a rebuild of the JLL is needed which keeps the upstream
+# version identical but breaks ABI compatibility for any reason, we can
+# increment the minor version e.g. go from 401.300.500 to 401.301.500.
+#
+# To package prerelease versions, we can also adjust the minor version; e.g. we may
+# map a prerelease of 4.1.4 to 401.390.000.
+#
+# There is currently no plan to change the major version, except when Singular itself
+# changes its major version. It simply seemed sensible to apply the same transformation
+# to all components.
+#
+# WARNING WARNING WARNING: any change to the the version of this JLL should be carefully
+# coordinated with corresponding changes to FLINT_jll.jl, LoadFlint.jl, Nemo.jl,
+# libsingular_julia_jll, Singular.jl, and possibly other packages.
 name = "Singular"
-version = v"4.1.4"  # this is actually a snapshot made after 4.1.3p5
+version = v"401.390.000"  # a snapshot of 4.1.4-DEV
 
 # Collection of sources required to build normaliz
 sources = [
-    GitSource("https://github.com/Singular/Singular.git", "acbd65cb88b23a4271a7494672f740318bcc2bc6"),
+    GitSource("https://github.com/Singular/Singular.git", "eaa7752eb5d84ef7620492a274dcf88b30f152de"),
 ]
 
 # Bash recipe for building across all platforms
@@ -34,7 +60,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-platforms = filter!(p -> !Sys.iswindows(p), platforms)
+filter!(!Sys.iswindows, platforms)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
@@ -55,7 +81,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("cddlib_jll"),
-    Dependency("FLINT_jll"),
+    Dependency(PackageSpec(name="FLINT_jll", version=VersionSpec("200.690"))), # snapshot of 2.7.0-DEV
     Dependency("GMP_jll", v"6.1.2"),
     Dependency("MPFR_jll", v"4.0.2"),
 ]


### PR DESCRIPTION
CC @thofma @benlorenz one more step towards https://github.com/oscar-system/Oscar.jl/issues/193

Note that for Singular, versioning is a bit awkward; we have versions like 4.1.3p5 -- so there are two patch levels (!?!); the 4 is basically constant, and even the 1 changes rarely. And in the past, I think there were ABI breaks even in patch level releases... Anyway, I am going to ask Hans tomorrow to please call the next release 4.2 ;-).
