### PR TITLE
libcxxwrap_julia for Julia 1.5: rebuild with GCC 8

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -59,4 +59,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    preferred_gcc_version = v"7", julia_compat = "^$(julia_version.major).$(julia_version.minor)")
+    preferred_gcc_version = v"8", julia_compat = "^$(julia_version.major).$(julia_version.minor)")


### PR DESCRIPTION
This may fix the crash reported here: <https://github.com/JuliaInterop/libcxxwrap-julia/issues/75>.

Once the binaries are built, I'll verify this locally with an artifact override.

CC @barche @benlorenz 