### PR TITLE
[ICU] Fix `libicudata` issues on armv7l

### DIFF
--- a/I/ICU/build_tarballs.jl
+++ b/I/ICU/build_tarballs.jl
@@ -16,6 +16,12 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/icu/
 
+# Apply patch to link `libicudata` against the default standard libraries
+# to avoid toolchain weirdness when you have a dynamic library that has
+# _no_ dependencies (not even `libc`).  See this bug report for more:
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=653457
+atomic_patch -p1 $WORKSPACE/srcdir/patches/yes_stdlibs.patch
+
 # Do the native build
 (
     cp -r source/ native_build/
@@ -62,7 +68,7 @@ platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["libicudata", "icudt$(version.major)"], :libicudata),
+    LibraryProduct(["libicudata", "icudt$(version.major)"], :libicudata; dont_dlopen=true),
     LibraryProduct(["libicui18n", "icuin$(version.major)"], :libicui18n),
     LibraryProduct(["libicuio", "icuio$(version.major)"], :libicuio),
     LibraryProduct(["libicutest", "icutest$(version.major)"], :libicutest),

--- a/I/ICU/bundled/patches/yes_stdlibs.patch
+++ b/I/ICU/bundled/patches/yes_stdlibs.patch
@@ -1,0 +1,9 @@
+--- a/source/config/mh-linux
++++ b/source/config/mh-linux
+@@ -21,7 +21,8 @@ LD_RPATH= -Wl,-zorigin,-rpath,'$$'ORIGIN
+ LD_RPATH_PRE = -Wl,-rpath,
+
+ ## These are the library specific LDFLAGS
+-LDFLAGSICUDT=-nodefaultlibs -nostdlib
++#LDFLAGSICUDT=-nodefaultlibs -nostdlib
++LDFLAGSICUDT=


### PR DESCRIPTION
armv7l has a slightly more persnickety linker than on other platforms,
and the weirdness that ICU does here, trying to create a "data-only"
shared library causes the linker to freak out.  It turns out most
distros patch away some of the weirdness, so we carry a patch as well.
Since it is highly unlikely any Julia package will ever want to load
this data directly, we'll also mark it as `dont_dlopen` for good
measure.