### PR TITLE
libsingular_julia for Julia 1.4

### DIFF
--- a/L/libsingular_julia/libsingular_julia@1.4/build_tarballs.jl
+++ b/L/libsingular_julia/libsingular_julia@1.4/build_tarballs.jl
@@ -1,0 +1,2 @@
+const julia_version = v"1.4.2"
+include("../common.jl")


### PR DESCRIPTION
This is a draft for now: On the one hand, I am waiting for https://github.com/Nemocas/Nemo.jl/pull/919 to be merged and a new release of Nemo.jl, so that I can then in turn update https://github.com/oscar-system/Singular.jl/ to use libsingular_julia_jll 0.3 and the new Nemo.jl.

On the other hand, there is this bug in https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/89 which affects this JLL, too (although we are not immediately affected, as it just our "second layer of defense", so we can ultimately proceed even if that bug is not yet fixed in BBB)