### PR TITLE
FINUFFT: Fix GOMP linking

### DIFF
--- a/F/finufft/build_tarballs.jl
+++ b/F/finufft/build_tarballs.jl
@@ -15,7 +15,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/finufft*/
 # Overwrite LIBSFFT such that we do not require fftw3_threads or fftw3_omp for OMP support. Since the libraries in FFTW_jll already provide for threading, we do not loose anything.
 # Make use of the -DFFTW_PLAN_SAFE flag to allow for multiple threads using finufft at the same time.
-make lib CFLAGS="-fPIC -O3 -funroll-loops -fcx-limited-range -Iinclude" CXXFLAGS="-fPIC -O3 -funroll-loops -fcx-limited-range -Iinclude -std=c++14 -DFFTW_PLAN_SAFE" LIBSFFT="-lfftw3 -lfftw3f -lm"
+make lib CFLAGS="-fopenmp -fPIC -O3 -funroll-loops -fcx-limited-range -Iinclude" CXXFLAGS="-fopenmp -fPIC -O3 -funroll-loops -fcx-limited-range -Iinclude -std=c++14 -DFFTW_PLAN_SAFE" LIBSFFT="-lfftw3 -lfftw3f -lm"
 mv lib/libfinufft.so "${libdir}/libfinufft.${dlext}"
 """
 
@@ -36,4 +36,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"9")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8")

--- a/F/finufft/build_tarballs.jl
+++ b/F/finufft/build_tarballs.jl
@@ -36,4 +36,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"9")


### PR DESCRIPTION
~~GOMP linking does not work on GCC8 for whatever reason. Accordingly, FINUFFT is broken using multiple threads. However, it did work fine with the BinaryBuilder version 0.26 available on julia 1.5.2. GCCv9 should help with the performance anyway.~~

Please see my comment below.