### PR TITLE
[rr] Link libcapnproto statically

### DIFF
--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -40,7 +40,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 # This is really a build dependency
 dependencies = [
-    Dependency("capnproto_jll"),
+    BuildDependency("capnproto_jll"),
     Dependency("CompilerSupportLibraries_jll"),
 ]
 

--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -19,7 +19,7 @@ cd ${WORKSPACE}/srcdir/rr/
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-      -Ddisable32bit=ON -DBUILD_TESTS=OFF -DWILL_RUN_TESTS=OFF ..
+      -Ddisable32bit=ON -DBUILD_TESTS=OFF -DWILL_RUN_TESTS=OFF -Dstaticlibs=ON ..
 make -j${nproc}
 make install
 """


### PR DESCRIPTION
We ran into a Linux kernel bug on CI trying to get rr to properly find the .sos it depends on.
Rather than trying to make that whole dance work, just link rr statically, so we don't have
to worry about setting it up to be able to find the capnproto.so. Note that this isn't a true
static link since we're still linking the libc and CSL dynamically, but hopefully it's good enough
to avoid the errors we were seeing.