### PR TITLE
LMDB 0.9.27

### DIFF
--- a/L/LMDB/build_tarballs.jl
+++ b/L/LMDB/build_tarballs.jl
@@ -1,17 +1,17 @@
 using BinaryBuilder
 
 name = "LMDB"
-version = v"0.9.25"
+version = v"0.9.27"
 
 # No sources, we're just building the testsuite
 sources = [
     ArchiveSource("https://git.openldap.org/openldap/openldap/-/archive/LMDB_$(version)/openldap-LMDB_$(version).tar.gz",
-                  "4f6eebe5ad98c10a75badd106f498ee2249d454352d048c78a49c99c940d4cae"),
+                  "752a3ebd4bbfa1830dff2ca4f5ff4c4be97da843810626d5dd9e2e4e5484a399"),
 ]
 
 # Bash recipe for building across all platforms
 # - CC: mdb_env_close0 segfaults on MacOS because CC is set to gcc in Makefile
-# - rm: remove man files (it does not name sense)
+# - rm: remove man files (it does not make sense)
 # - exeext: Makefile does not support extensions - need to rename execuables manually
 script = raw"""
 cd ${WORKSPACE}/srcdir/openldap-*/libraries/liblmdb


### PR DESCRIPTION
Skipping LMDB 0.9.26 as it [only impacts for FreeBSD](https://bugs.openldap.org/show_bug.cgi?id=9278).
Please let me know if you disagree and I'll do that PR first.