### PR TITLE
Add libjulia_platforms() helper

### DIFF
--- a/F/FastJet_Julia_Wrapper/build_tarballs.jl
+++ b/F/FastJet_Julia_Wrapper/build_tarballs.jl
@@ -25,9 +25,9 @@ install_license $WORKSPACE/srcdir/FastJet_Julia_Wrapper/LICENSE.md
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms())
-# skip i686 musl builds (not supported by libjulia_jll)
-filter!(p -> !(Sys.islinux(p) && libc(p) == "musl" && arch(p) == "i686"), platforms)
+include("../../L/libjulia/common.jl")
+platforms = expand_cxxstring_abis(libjulia_platforms(julia_version))
+
 # the plugins aren't found on win. Disable for now, but this is not a fundamental limitation.
 filter!(!Sys.iswindows, platforms)
 

--- a/L/LCIO_Julia_Wrapper/build_tarballs.jl
+++ b/L/LCIO_Julia_Wrapper/build_tarballs.jl
@@ -24,12 +24,11 @@ install_license $WORKSPACE/srcdir/LCIO_Julia_Wrapper/LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+include("../../L/libjulia/common.jl")
+platforms = libjulia_platforms(julia_version)
 filter!(!Sys.isfreebsd, platforms)
 filter!(!Sys.iswindows, platforms)
 filter!(p -> arch(p) != "armv7l", platforms)
-# skip i686 musl builds (not supported by libjulia_jll)
-filter!(p -> !(Sys.islinux(p) && libc(p) == "musl" && arch(p) == "i686"), platforms)
 
 platforms = expand_cxxstring_abis(platforms)
 

--- a/L/Libtask/build_tarballs.jl
+++ b/L/Libtask/build_tarballs.jl
@@ -43,15 +43,8 @@ install_license LICENSE.md
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-
-# skip i686 musl builds (not supported by libjulia_jll)
-filter!(p -> !(Sys.islinux(p) && libc(p) == "musl" && arch(p) == "i686"), platforms)
-
-# skip PowerPC builds in Julia 1.3 (not supported by libjulia_jll)
-if julia_version < v"1.4"
-    filter!(p -> !(Sys.islinux(p) && arch(p) == "powerpc64le"), platforms)
-end
+include("../../L/libjulia/common.jl")
+platforms = libjulia_platforms(julia_version)
 
 # The products that we will ensure are always built
 products = [

--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -34,16 +34,8 @@ install_license $WORKSPACE/srcdir/libcxxwrap-julia*/LICENSE.md
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-
-# skip i686 musl builds (not supported by libjulia_jll)
-filter!(p -> !(Sys.islinux(p) && libc(p) == "musl" && arch(p) == "i686"), platforms)
-
-# skip PowerPC builds in Julia 1.3 (not supported by libjulia_jll)
-if julia_version < v"1.4"
-    filter!(p -> !(Sys.islinux(p) && arch(p) == "powerpc64le"), platforms)
-end
-
+include("../../L/libjulia/common.jl")
+platforms = libjulia_platforms(julia_version)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/L/libsingular_julia/common.jl
+++ b/L/libsingular_julia/common.jl
@@ -31,16 +31,8 @@ install_license LICENSE.md
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-
-# skip i686 musl builds (not supported by libjulia_jll)
-filter!(p -> !(Sys.islinux(p) && libc(p) == "musl" && arch(p) == "i686"), platforms)
-
-# skip PowerPC builds in Julia 1.3 (not supported by libjulia_jll)
-if julia_version < v"1.4"
-    filter!(p -> !(Sys.islinux(p) && arch(p) == "powerpc64le"), platforms)
-end
-
+include("../../L/libjulia/common.jl")
+platforms = libjulia_platforms(julia_version)
 platforms = filter!(!Sys.iswindows, platforms) # Singular does not support Windows
 platforms = expand_cxxstring_abis(platforms)
 


### PR DESCRIPTION
... so that packages using libjulia_jll have an easier time to select
the right base set of platforms. Now they can just start with the result
of `libjulia_platforms()` instead of `supported_platforms()` and then
selectively remove those which are not supported.

Also adapt a few JLL recipes to use the new helper.

This PR should ultimately be marked as "skip ci, skip build", I think, but first I'd like to make sure everything still builds.