### PR TITLE
Fix libjulia_jll building regression

### DIFF
--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -18,8 +18,7 @@ function build_julia(version)
 
     # Bash recipe for building across all platforms
     script = raw"""
-    apk update
-    apk add coreutils libuv-dev utf8proc
+    apk add coreutils libuv-dev utf8proc samurai
 
     cd $WORKSPACE/srcdir/julia*
     version=$(cat VERSION)


### PR DESCRIPTION
Without this, we are now seeing the following:

     ---> apk add coreutils libuv-dev utf8proc
    ERROR: unsatisfiable constraints:
      ninja (virtual):
        provided by: samurai
        required by: world[ninja]
     ---> apk add coreutils libuv-dev utf8proc
    Previous command exited with 1
    Child Process exited, exit code 1