### PR TITLE
[0_RootFS] Fix interpreter of `flagon` utility

### DIFF
--- a/0_RootFS/Rootfs/bundled/utils/flagon
+++ b/0_RootFS/Rootfs/bundled/utils/flagon
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 #
 # Copyright (C) 2020 Mosè Giordano
 # License is MIT "Expat"


### PR DESCRIPTION
No idea why I used `/usr/bin/bash` instead of `/bin/bash`.  It goes without
saying that the former doesn't even exist in the build environment.