### PR TITLE
Convert HelFEM to use new libcxxwrap / libjulia

### DIFF
--- a/H/HelFEM/build_tarballs.jl
+++ b/H/HelFEM/build_tarballs.jl
@@ -1,7 +1,9 @@
 using BinaryBuilder, Pkg
 
+julia_version = v"1.5.3"
+
 name = "HelFEM"
-version = v"0.0.3"
+version = v"0.1.5"
 sources = [
     GitSource("https://github.com/mortenpi/HelFEM.git", "a4d3b2e6f16f7f7953afd5f69a44257a65c5b131")
 ]
@@ -20,20 +22,16 @@ else
     OPENBLAS="${libdir}/libopenblas.${dlext}"
 fi
 
-# On i686, it seems that we need to explicitly tell GCC that we want SSE2. Refs:
-#   https://github.com/JuliaLang/julia/blob/v1.4.1/src/atomics.h#L8-L10
-#   https://stackoverflow.com/questions/16410149/error-sse2-instruction-set-not-enabled-when-including-emmintrin-h
-if [[ "${target}" == i686* ]]; then
-    export CXXFLAGS="-msse -msse2"
-fi
-
 # Compile libhelfem as a static library
 cd ${WORKSPACE}/srcdir/HelFEM/
 cmake \
-    -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DHELFEM_BINARIES=OFF \
+    -DHELFEM_FIND_DEPS=ON \
     -DUSE_OPENMP=OFF \
-    -DHELFEM_BINARIES=OFF -DHELFEM_FIND_DEPS=ON \
     -B build/ -S .
 make -C build/ -j${nproc} helfem
 make -C build/ install
@@ -43,37 +41,35 @@ install_license LICENSE
 # Compile the CxxWrap wrapper as a shared library
 cd ${WORKSPACE}/srcdir/HelFEM/julia
 cmake \
-    -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release \
     -DBLAS_LIBRARIES=${OPENBLAS} \
-    -DJulia_PREFIX=$prefix -DCMAKE_FIND_ROOT_PATH=$prefix -DJlCxx_DIR=$prefix/lib/cmake/JlCxx \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_FIND_ROOT_PATH=${prefix} \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DJulia_PREFIX=${prefix} \
     -B build/ -S .
 make -C build/ -j${nproc}
 make -C build/ install
 """
 
 # These are the platforms the libcxxwrap_julia_jll is built on.
-platforms = [
-    Platform("x86_64", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
-    Platform("i686", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
-    Platform("armv7l", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
-    Platform("aarch64", "linux"; libc="glibc", cxxstring_abi = "cxx11"),
-    Platform("x86_64", "macos"),
-    Platform("x86_64", "windows"; cxxstring_abi = "cxx11"),
-    Platform("i686", "windows"; cxxstring_abi = "cxx11"),
-    Platform("x86_64", "freebsd"),
-]
+include("../../L/libjulia/common.jl")
+platforms = libjulia_platforms(julia_version)
+platforms = expand_cxxstring_abis(platforms)
 
 products = [
     LibraryProduct("libhelfem-cxxwrap", :libhelfem),
 ]
 
 dependencies = [
-    BuildDependency(PackageSpec(name = "Julia_jll", version = "1.4.1")),
-    Dependency(PackageSpec(name = "libcxxwrap_julia_jll", version = "0.8.0")),
+    BuildDependency(PackageSpec(name="libjulia_jll", version=julia_version)),
+    Dependency("libcxxwrap_julia_jll"),
     Dependency(PackageSpec(name = "armadillo_jll", version = "9.850.1")),
     Dependency(PackageSpec(name = "GSL_jll", version = "2.6.0")),
     Dependency(PackageSpec(name = "OpenBLAS_jll", version = "0.3.9")),
 ]
 
-# preferred_gcc_version = v"7" is a requirement from libcxxwrap_julia_jll
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7")
+# preferred_gcc_version = v"8" is a requirement from libcxxwrap_julia_jll
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    preferred_gcc_version=v"8",
+    julia_compat = "$(julia_version.major).$(julia_version.minor)")


### PR DESCRIPTION
Make some progress towards issue #2160 

Should not be merged before @mortenpi had a chance to review and comment. Also, there are some questions to discuss: 

1. Which version to use for this JLL? It really shouldn't be 0.0.3, as the list of dependencies changes, and that requires a new version.
2. Which Julia versions should this JLL be made compatible with? Right now, this is built for Julia 1.5.3 or later, and also only usable in Julia 1.5. But we could make versions supporting 1.4 or even 1.3 if that is desirable. But it's a bit extra work, so I first want to get this version working, and also hear from @mortenpi what his preferences are.
3. The two first points are actually somewhat related: in order to support multiple Julia versions, the trick we used in other JLLs is to use the patch level of the version string to indicate the Julia version; that would suggest to reversion this package to e.g. `0.3.X` where `X` is equal to the one in the Julia version 1.X. However, that would mean packages using HelFEM_jll may need to be updated. Then again, I found no such package in the general registry?