### PR TITLE
Update z3 to 4.8.9, switch to new libcxxwrap

### DIFF
--- a/Z/z3/build_tarballs.jl
+++ b/Z/z3/build_tarballs.jl
@@ -2,84 +2,54 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 
+julia_version = v"1.5.3"
 name = "z3"
-version = v"4.8.8"
+version = v"4.8.9"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/Z3Prover/z3.git", "ad55a1f1c617a7f0c3dd735c0780fc758424c7f1"),
-    ArchiveSource("https://julialang-s3.julialang.org/bin/linux/armv7l/1.3/julia-1.3.1-linux-armv7l.tar.gz", "965c8fab2214f8ce1b3d449d088561a6de61be42543b48c3bbadaed5b02bf824"; unpack_target="julia-arm-linux-gnueabihf"),
-    ArchiveSource("https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz", "faa707c8343780a6fe5eaf13490355e8190acf8e2c189b9e7ecbddb0fa2643ad"; unpack_target="julia-x86_64-linux-gnu"),
-    ArchiveSource("https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-apple-darwin14.tar.gz", "f2e5359f03314656c06e2a0a28a497f62e78f027dbe7f5155a5710b4914439b1"; unpack_target="julia-x86_64-apple-darwin14"),
-    ArchiveSource("https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-w64-mingw32.tar.gz", "c7b2db68156150d0e882e98e39269301d7bf56660f4fc2e38ed2734a7a8d1551"; unpack_target="julia-x86_64-w64-mingw32"),
+    ArchiveSource("https://github.com/Z3Prover/z3/archive/z3-$(version).tar.gz",
+        "c9fd04b9b33be74fffaac3ec2bc2c320d1a4cc32e395203c55126b12a14ff3f4"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-case $target in
-  arm-linux-gnueabihf|x86_64-linux-gnu)
-    Julia_PREFIX=${WORKSPACE}/srcdir/julia-$target/julia-1.3.1
-    Julia_ARGS="-DZ3_BUILD_JULIA_BINDINGS=True -DJulia_PREFIX=${Julia_PREFIX}"
-    ;;
-  x86_64-apple-darwin14|x86_64-w64-mingw32)
-    Julia_PREFIX=${WORKSPACE}/srcdir/julia-$target/juliabin
-    Julia_ARGS="-DZ3_BUILD_JULIA_BINDINGS=True -DJulia_PREFIX=${Julia_PREFIX}"
-    ;;
-esac
-
-cd $WORKSPACE/srcdir/z3/
+cd z3*
 
 mkdir z3-build && cd z3-build
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
-    -DCMAKE_FIND_ROOT_PATH="${prefix}" \
+cmake \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_FIND_ROOT_PATH="${prefix}" \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-    ${Julia_ARGS} \
+    -DJulia_PREFIX="$prefix" \
+    -DZ3_BUILD_JULIA_BINDINGS=True \
     ..
 make -j${nproc}
 make install
-install_license ${WORKSPACE}/srcdir/z3/LICENSE.txt
+install_license ../LICENSE.txt
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms_libcxxwrap = [
-    Platform("armv7l", "linux"; libc="glibc"),
-    Platform("x86_64", "linux"; libc="glibc"),
-    Platform("x86_64", "macos"),
-    Platform("x86_64", "windows")
-]
-
-platforms = filter(x->!(x in platforms_libcxxwrap), supported_platforms())
-
-platforms_libcxxwrap = expand_cxxstring_abis(platforms_libcxxwrap)
+include("../../L/libjulia/common.jl")
+platforms = libjulia_platforms(julia_version)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
-products_libcxxwrap = [
+products = [
     LibraryProduct("libz3", :libz3),
     LibraryProduct("libz3jl", :libz3jl),
     ExecutableProduct("z3", :z3)
 ]
 
-products = [
-    LibraryProduct("libz3", :libz3),
-    ExecutableProduct("z3", :z3)
-]
-
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
-    Dependency("libcxxwrap_julia_jll")
+dependencies = [
+    BuildDependency(PackageSpec(name="libjulia_jll", version=julia_version)),
+    Dependency("libcxxwrap_julia_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
-
-include("../../fancy_toys.jl")
-
-if any(should_build_platform.(triplet.(platforms_libcxxwrap)))
-    build_tarballs(non_reg_ARGS, name, version, sources, script, platforms_libcxxwrap, products_libcxxwrap, dependencies; preferred_gcc_version=v"8")
-end
-if any(should_build_platform.(triplet.(platforms)))
-    build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
-end
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    preferred_gcc_version=v"8",
+    julia_compat = "$(julia_version.major).$(julia_version.minor)")


### PR DESCRIPTION
Makes some progress towards issue #2160, and simplifies the build recipe considerably at the same time (possible since the platforms supported of libjulia are a superset of those platforms for which Julia even builds).

Should not be merged before @ahumenberger had a chance to review and comment. Also, there are some questions to discuss: 

1. Which Julia versions should this JLL be made compatible with? Right now, this is built for Julia 1.5.3 or later, and also only usable in Julia 1.5. But we could make versions supporting 1.4 or even 1.3 if that is desirable. But it's a bit extra work, so I first want to get this version working, and also hear from @ahumenberger what his preferences are.
2. In order to support multiple Julia versions (so only if this is resired), the trick we used in other JLLs is to use the patch level of the version string to indicate the Julia version; but that means we couldn't use the raw upstream version as version for the JLL. But it is already known that JLLs will stop have to try and use upstream versions as their own version anyway, as doing so has all kinds of problems (e.g. upstream not following semver; or the need, as here, to make update that require a new version of the JLL, despite the upstream version not having changed). There are various ways to do this. One is to map z3 4.8.9 to something like JLL version 400.800.900 and then use 400.800.903, 400.800.904, 400.800.905 for the versions for Julia 1.3/1.4/1.5 respectively (then Z3.jl could use a compat bound of `400.800.900 - 400.800.999` or so);  another would be to use versions 400.809.3, 400.809.4, 400.809.5 support Julia 1.4/1.5/1.5; then the compat bound could be `~400.809`. Of course many variations of this pattern are possible.