### PR TITLE
[QT] enable OpenSSL support

### DIFF
--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -34,6 +34,8 @@ commonoptions=" \
 -skip qtwebglplugin -skip qtwebsockets -skip qtwebview  -skip qttools  -openssl-linked  -nomake examples -release \
 "
 
+export OPENSSL_LIBS="-L${libdir} -lssl -lcrypto"
+
 apk add g++ linux-headers
 
 if [[ $target != x86_64-linux* ]]; then
@@ -272,7 +274,7 @@ dependencies = [
     Dependency("Xorg_xcb_util_keysyms_jll"),
     Dependency("Xorg_xcb_util_renderutil_jll"),
     Dependency("xkbcommon_jll"),
-    BuildDependency("Libglvnd_jll"),
+    Dependency("Libglvnd_jll"),
     Dependency("Fontconfig_jll"),
     Dependency("Glib_jll"),
     Dependency("Zlib_jll"),

--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -279,7 +279,7 @@ dependencies = [
     Dependency("Glib_jll"),
     Dependency("Zlib_jll"),
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("OpenSSL_jll")
+    Dependency("OpenSSL_jll"),
 ]
 
 include("../../fancy_toys.jl")

--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -30,7 +30,7 @@ commonoptions=" \
 -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtconnectivity -skip qtdatavis3d -skip qtdoc -skip qtgamepad \
 -skip qtnetworkauth -skip qtpurchasing -skip qtremoteobjects -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus \
 -skip qtserialport -skip qtspeech -skip qtvirtualkeyboard -skip qtlocation -skip qtwayland -skip qtwebchannel -skip qtwebengine \
--skip qtwebglplugin -skip qtwebsockets -skip qtwebview  -skip qttools -nomake examples -release \
+-skip qtwebglplugin -skip qtwebsockets -skip qtwebview  -skip qttools  -openssl-linked  -nomake examples -release \
 "
 
 apk add g++ linux-headers
@@ -276,6 +276,7 @@ dependencies = [
     Dependency("Glib_jll"),
     Dependency("Zlib_jll"),
     Dependency("CompilerSupportLibraries_jll"),
+    Dependency("OpenSSL_jll")
 ]
 
 include("../../fancy_toys.jl")

--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -14,6 +14,7 @@ sources = [
 ]
 
 script = raw"""
+apk del ninja
 cd $WORKSPACE/srcdir
 
 BIN_DIR="/opt/bin/${bb_full_target}"


### PR DESCRIPTION
OpenSSL support for QT.  Looks like it was disabled by default, at least for Linux x64.