### PR TITLE
[GDAL] use external libtiff and libgeotiff libraries to build

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -47,6 +47,8 @@ rm -f ${prefix}/lib/*.la
 ./configure --prefix=$prefix --host=$target \
     --with-geos=${bindir}/geos-config \
     --with-proj=$prefix \
+    --with-tiff=$prefix \
+    --with-geotiff=$prefix \
     --with-libz=$prefix \
     --with-expat=$prefix \
     --with-zstd=$prefix \
@@ -106,6 +108,8 @@ dependencies = [
     Dependency("OpenJpeg_jll"),
     Dependency("Expat_jll"),
     Dependency("Zstd_jll"),
+    Dependency("Libtiff_jll"),
+    Dependency("libgeotiff_jll"),
     # The following libraries are dependencies of LibCURL_jll which is now a
     # stdlib, but the stdlib doesn't explicitly list its dependencies
     Dependency("LibSSH2_jll", v"1.9.0"),


### PR DESCRIPTION
This PR modifies the `GDAL` build script to add `Libtiff` and `libgeotiff` as dependencies and build using them as external versions rather than the internal versions shipped with the code. See discussion [here](https://github.com/JuliaGeo/GDAL.jl/issues/110) for background.

Tested locally on a small subset of OS/compiler combos with no issues.

cc @visr 