### PR TITLE
add FLANN

### DIFF
--- a/F/FLANN/build_tarballs.jl
+++ b/F/FLANN/build_tarballs.jl
@@ -1,0 +1,50 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "FLANN"
+version = v"1.9.1"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/mariusmuja/flann/archive/$version.tar.gz", "b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+
+cd $WORKSPACE/srcdir/flann-*
+
+#CMake doesn't work straight from clone, see https://github.com/mariusmuja/flann/issues/369 for source of workaround
+touch src/cpp/empty.cpp
+atomic_patch -p1 ../patches/cmake_empty_target.patch
+
+cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_TESTS=OFF \
+      -DBUILD_DOC=OFF \
+      -DBUILD_PYTHON_BINDINGS=OFF \
+      -DBUILD_MATLAB_BINDINGS=OFF
+
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libflann_cpp", :libflann_cpp),
+    LibraryProduct("libflann", :libflann)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/F/FLANN/build_tarballs.jl
+++ b/F/FLANN/build_tarballs.jl
@@ -18,7 +18,7 @@ cd $WORKSPACE/srcdir/flann-*
 
 #CMake doesn't work straight from clone, see https://github.com/mariusmuja/flann/issues/369 for source of workaround
 
-atomic_patch -p1 ../patches/cmake_empty_target.patch
+atomic_patch -p1 "$WORKSPACE/srcdir/patches/cmake_empty_target2.patch"
 
 touch src/cpp/empty.cpp
 
@@ -46,7 +46,9 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[]
+dependencies = Dependency[
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/F/FLANN/build_tarballs.jl
+++ b/F/FLANN/build_tarballs.jl
@@ -17,8 +17,10 @@ script = raw"""
 cd $WORKSPACE/srcdir/flann-*
 
 #CMake doesn't work straight from clone, see https://github.com/mariusmuja/flann/issues/369 for source of workaround
-touch src/cpp/empty.cpp
+
 atomic_patch -p1 ../patches/cmake_empty_target.patch
+
+touch src/cpp/empty.cpp
 
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/F/FLANN/build_tarballs.jl
+++ b/F/FLANN/build_tarballs.jl
@@ -18,7 +18,7 @@ cd $WORKSPACE/srcdir/flann-*
 
 #CMake doesn't work straight from clone, see https://github.com/mariusmuja/flann/issues/369 for source of workaround
 
-atomic_patch -p1 "$WORKSPACE/srcdir/patches/cmake_empty_target2.patch"
+atomic_patch -p1 "$WORKSPACE/srcdir/patches/cmake_empty_target.patch"
 
 touch src/cpp/empty.cpp
 

--- a/F/FLANN/bundled/patches/cmake_empty_target.patch
+++ b/F/FLANN/bundled/patches/cmake_empty_target.patch
@@ -1,7 +1,7 @@
-diff --git before/flann-1.9.1/src/cpp/CMakeLists.txt after/flann-1.9.1/src/cpp/CMakeLists.txt
+diff --git before/src/cpp/CMakeLists.txt after/src/cpp/CMakeLists.txt
 index 49c53f0..b453b27 100644
---- before/flann-1.9.1/src/cpp/CMakeLists.txt
-+++ after/flann-1.9.1/src/cpp/CMakeLists.txt
+--- before/src/cpp/CMakeLists.txt
++++ after/src/cpp/CMakeLists.txt
 @@ -29,7 +29,7 @@ if (BUILD_CUDA_LIB)
  endif()
  

--- a/F/FLANN/bundled/patches/cmake_empty_target.patch
+++ b/F/FLANN/bundled/patches/cmake_empty_target.patch
@@ -1,0 +1,22 @@
+diff --git before/flann-1.9.1/src/cpp/CMakeLists.txt after/flann-1.9.1/src/cpp/CMakeLists.txt
+index 49c53f0..b453b27 100644
+--- before/flann-1.9.1/src/cpp/CMakeLists.txt
++++ after/flann-1.9.1/src/cpp/CMakeLists.txt
+@@ -29,7 +29,7 @@ if (BUILD_CUDA_LIB)
+ endif()
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_COMPILER_IS_GNUCC)
+-    add_library(flann_cpp SHARED "")
++    add_library(flann_cpp SHARED "empty.cpp")
+     set_target_properties(flann_cpp PROPERTIES LINKER_LANGUAGE CXX)
+     target_link_libraries(flann_cpp -Wl,-whole-archive flann_cpp_s -Wl,-no-whole-archive)
+ 
+@@ -83,7 +83,7 @@ if (BUILD_C_BINDINGS)
+     set_property(TARGET flann_s PROPERTY COMPILE_DEFINITIONS FLANN_STATIC)
+ 
+     if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_COMPILER_IS_GNUCC)
+-        add_library(flann SHARED "")
++        add_library(flann SHARED "empty.cpp")
+         set_target_properties(flann PROPERTIES LINKER_LANGUAGE CXX)
+         target_link_libraries(flann -Wl,-whole-archive flann_s -Wl,-no-whole-archive)
+     else()


### PR DESCRIPTION
This PR adds a `build_tarballs` script to build the `Fast Library for Approximate Nearest Neighbors (FLANN)` .

There is a [well documented](https://github.com/mariusmuja/flann/search?q=no+sources&type=issues) issue with `CMake` not building as-is from a `git clone`, so I used a fix outlined in [this issue](https://github.com/mariusmuja/flann/issues/369) .

There was some warnings about use of `std::string` during the audit, so I am using `expand_cxxstring_abis(supported_platforms())`.