### PR TITLE
[libcgal-julia] Update libcgal_julia for Julia 1.5

### DIFF
--- a/L/libcgal_julia/libcgal_julia@1.5/build_tarballs.jl
+++ b/L/libcgal_julia/libcgal_julia@1.5/build_tarballs.jl
@@ -1,0 +1,2 @@
+julia_version = v"1.5.3"
+include("../common.jl")


### PR DESCRIPTION
Apologies if I'm submitting this too fast after the 1.4 update, but I'd assume concurrent updates aren't necessarily an issue since they're effectively different versions.  Unless registering "future" versions (if it ends up happening) is an issue, here's another PR.

**EDIT**: Maybe next time I'll just wait for previous versions to hit the registry, avoid complications ^^ For quick reference, here's the previous version's Registry PR: JuliaRegistries/General#27271