### PR TITLE
[Qt] Build tools

### DIFF
--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -14,7 +14,6 @@ sources = [
 ]
 
 script = raw"""
-apk del ninja
 cd $WORKSPACE/srcdir
 
 BIN_DIR="/opt/bin/${bb_full_target}"
@@ -36,6 +35,7 @@ commonoptions=" \
 
 export OPENSSL_LIBS="-L${libdir} -lssl -lcrypto"
 
+rm `which llvm-config`
 apk add g++ linux-headers
 
 if [[ $target != x86_64-linux* ]]; then
@@ -282,10 +282,12 @@ dependencies = [
     Dependency("OpenSSL_jll"),
 ]
 
+dependencies_linux = [dependencies..., BuildDependency("Clang_jll")]
+
 include("../../fancy_toys.jl")
 
 if any(should_build_platform.(triplet.(platforms_linux)))
-    build_tarballs(ARGS, name, version, sources, script, platforms_linux, products, dependencies; preferred_gcc_version = v"7")
+    build_tarballs(ARGS, name, version, sources, script, platforms_linux, products, dependencies_linux; preferred_gcc_version = v"7")
 end
 if any(should_build_platform.(triplet.(platforms_win)))
     build_tarballs(ARGS, name, version, sources, script, platforms_win, products, dependencies; preferred_gcc_version = v"8")

--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -30,12 +30,11 @@ commonoptions=" \
 -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtconnectivity -skip qtdatavis3d -skip qtdoc -skip qtgamepad \
 -skip qtnetworkauth -skip qtpurchasing -skip qtremoteobjects -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus \
 -skip qtserialport -skip qtspeech -skip qtvirtualkeyboard -skip qtlocation -skip qtwayland -skip qtwebchannel -skip qtwebengine \
--skip qtwebglplugin -skip qtwebsockets -skip qtwebview -openssl-linked  -nomake examples -release \
+-skip qtwebglplugin -skip qtwebsockets -skip qtwebview  -skip qttools  -openssl-linked  -nomake examples -release \
 "
 
 export OPENSSL_LIBS="-L${libdir} -lssl -lcrypto"
 
-rm `which llvm-config`
 apk add g++ linux-headers
 
 if [[ $target != x86_64-linux* ]]; then
@@ -282,12 +281,10 @@ dependencies = [
     Dependency("OpenSSL_jll"),
 ]
 
-dependencies_linux = [dependencies..., BuildDependency("Clang_jll")]
-
 include("../../fancy_toys.jl")
 
 if any(should_build_platform.(triplet.(platforms_linux)))
-    build_tarballs(ARGS, name, version, sources, script, platforms_linux, products, dependencies_linux; preferred_gcc_version = v"7")
+    build_tarballs(ARGS, name, version, sources, script, platforms_linux, products, dependencies; preferred_gcc_version = v"7")
 end
 if any(should_build_platform.(triplet.(platforms_win)))
     build_tarballs(ARGS, name, version, sources, script, platforms_win, products, dependencies; preferred_gcc_version = v"8")

--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -31,7 +31,7 @@ commonoptions=" \
 -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtconnectivity -skip qtdatavis3d -skip qtdoc -skip qtgamepad \
 -skip qtnetworkauth -skip qtpurchasing -skip qtremoteobjects -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus \
 -skip qtserialport -skip qtspeech -skip qtvirtualkeyboard -skip qtlocation -skip qtwayland -skip qtwebchannel -skip qtwebengine \
--skip qtwebglplugin -skip qtwebsockets -skip qtwebview  -skip qttools  -openssl-linked  -nomake examples -release \
+-skip qtwebglplugin -skip qtwebsockets -skip qtwebview -openssl-linked  -nomake examples -release \
 "
 
 export OPENSSL_LIBS="-L${libdir} -lssl -lcrypto"

--- a/Q/QtTools/build_tarballs.jl
+++ b/Q/QtTools/build_tarballs.jl
@@ -1,0 +1,62 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "QtTools"
+version = v"5.15.2"
+
+# Collection of sources required to build qt5
+sources = [
+    ArchiveSource("https://download.qt.io/official_releases/qt/$(version.major).$(version.minor)/$version/submodules/qttools-everywhere-src-$version.tar.xz",
+                  "c189d0ce1ff7c739db9a3ace52ac3e24cb8fd6dbf234e49f075249b38f43c1cc"),
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir
+
+mkdir build
+cd build/
+
+qtsrcdir=`ls -d ../qttools-*`
+
+export PATH=$(echo "$PATH" | sed -e "s?${BIN_DIR}:??")
+ln -s /opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-g++ /usr/bin/g++
+
+qmake $qtsrcdir
+
+make -j${nproc}
+
+# It appends the root path here with the qmake dir, which is /workspace/artifacts/blah...
+make INSTALL_ROOT=$PWD/dummyroot install
+rsync -ua dummyroot/workspace/artifacts/*/* $prefix
+
+install_license $qtsrcdir/LICENSE.LGPL3_
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "freebsd"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("x86_64", "windows"),
+    Platform("i686", "windows"),
+    Platform("x86_64", "macos"),
+]
+
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("lrelease", :lrelease),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Qt_jll"),
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8")

--- a/Q/QtTools/build_tarballs.jl
+++ b/Q/QtTools/build_tarballs.jl
@@ -51,7 +51,7 @@ platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("lrelease", :lrelease),
+    FileProduct("bin/lrelease", :lrelease),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/Q/QtTools/build_tarballs.jl
+++ b/Q/QtTools/build_tarballs.jl
@@ -30,7 +30,7 @@ make -j${nproc}
 make INSTALL_ROOT=$PWD/dummyroot install
 rsync -ua dummyroot/workspace/artifacts/*/* $prefix
 
-install_license $qtsrcdir/LICENSE.LGPL3_
+install_license $qtsrcdir/LICENSE.LGPL3
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
As requested in PR #2340 and https://github.com/barche/QML.jl/issues/104 and a few other places ;)

I have verified that this builds a host lrelease, so it seems the build system makes an automatic distinction between build-time and runtime executables, e.g for macOS:

```
% file bin/lrelease
bin/lrelease: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, stripped
% file bin/qmlscene 
bin/qmlscene: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|BINDS_TO_WEAK|PIE>
```

