### PR TITLE
[polymake] fix dependency-tree for stdlibs in nightly

### DIFF
--- a/P/polymake/bundled/patches/generate_deps_tree.jl
+++ b/P/polymake/bundled/patches/generate_deps_tree.jl
@@ -1,6 +1,26 @@
 using Pkg.Artifacts
 using polymake_jll
 
+# adapted from https://github.com/JuliaLang/julia/pull/38797
+function full_artifact_dir(m::Module)
+   artifacts_toml = joinpath(dirname(dirname(Base.pathof(m))), "StdlibArtifacts.toml")
+
+   # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
+   if isfile(artifacts_toml)
+       # we need to remove the _jll for the artifact name
+       meta = artifact_meta(string(m)[1:end-4], artifacts_toml)
+       hash = Base.SHA1(meta["git-tree-sha1"])
+       if !artifact_exists(hash)
+           dl_info = first(meta["download"])
+           download_artifact(hash, dl_info["url"], dl_info["sha256"])
+       end
+       return artifact_path(hash)
+   else
+      # Otherwise, we can just use the artifact directory given to us by the module
+      return m.artifact_dir
+   end
+end
+
 function prepare_deps_tree()
    mutable_artifacts_toml = joinpath(dirname(pathof(polymake_jll)), "..", "MutableArtifacts.toml")
    polymake_tree = "polymake_tree"
@@ -11,17 +31,18 @@ function prepare_deps_tree()
    # for compiling wrappers at run-time
    polymake_tree_hash = create_artifact() do art_dir
       mkpath(joinpath(art_dir,"deps"))
-      for dep in [polymake_jll.FLINT_jll,
-                  polymake_jll.GMP_jll,
-                  polymake_jll.MPFR_jll,
-                  polymake_jll.PPL_jll,
-                  polymake_jll.Perl_jll,
-                  polymake_jll.bliss_jll,
-                  polymake_jll.boost_jll,
-                  polymake_jll.cddlib_jll,
-                  polymake_jll.lrslib_jll,
-                  polymake_jll.normaliz_jll]
-         symlink(dep.artifact_dir, joinpath(art_dir,"deps","$dep"))
+      deps = [ polymake_jll.FLINT_jll,
+               polymake_jll.GMP_jll,
+               polymake_jll.MPFR_jll,
+               polymake_jll.PPL_jll,
+               polymake_jll.Perl_jll,
+               polymake_jll.bliss_jll,
+               polymake_jll.boost_jll,
+               polymake_jll.cddlib_jll,
+               polymake_jll.lrslib_jll,
+               polymake_jll.normaliz_jll ]
+      for dep in deps
+         symlink(full_artifact_dir(dep), joinpath(art_dir,"deps","$dep"))
       end
       for dir in readdir(polymake_jll.artifact_dir)
          symlink(joinpath(polymake_jll.artifact_dir,dir), joinpath(art_dir,dir))


### PR DESCRIPTION
Work around stdlibs in nightly that ship `GMP_jll` and `MPFR_jll` without headers by downloading the corresponding artifacts manually as suggested in https://github.com/JuliaLang/julia/pull/38797.

I tested the script with 1.3, 1.4, 1.5, and various nightly versions.