### PR TITLE
[Codespaces] Update to Julia v1.5, use stable BinaryBuilder

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-FROM julia:1.4
+FROM julia:1.5
 
 RUN apt-get update && apt-get install -y xz-utils bzip2 sudo git unzip
 
-RUN julia -e 'using Pkg; pkg"add BinaryBuilder#master"'
+RUN julia -e 'using Pkg; pkg"add BinaryBuilder"'
 RUN julia -e 'using Pkg; Pkg.API.precompile()'


### PR DESCRIPTION
`BinaryBuilder#master` isn't in a good shape at the moment and requires some random versions of Julia in the `release-1.6` branch.  I think that for the time being the best thing to do is to use last stable BinaryBuilder with Julia v1.5