### PR TITLE
Bump rr

### DIFF
--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"5.4.1"
 # Collection of sources required to build rr
 sources = [
     GitSource("https://github.com/Keno/rr.git",
-              "96f70613699b2b2215be22605c5387fa706fd1d5")
+              "dc50efb04f29e21890c92534781ce11b5c91372a")
 ]
 
 # Bash recipe for building across all platforms

--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"5.4.1"
 # Collection of sources required to build rr
 sources = [
     GitSource("https://github.com/Keno/rr.git",
-              "f17f62ab0f68394073d8a04f47ccec38afbd515a")
+              "96f70613699b2b2215be22605c5387fa706fd1d5")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Updates https://github.com/rr-debugger/rr/pull/2772 to the latest version of the PR.
Carries https://github.com/rr-debugger/rr/pull/2785 and https://github.com/rr-debugger/rr/pull/2787, which should help https://github.com/JuliaLang/julia/issues/39068.