### PR TITLE
Singular: backport upstream fix

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -27,7 +27,7 @@ import Pkg.Types: VersionSpec
 # to all components.
 #
 name = "Singular"
-version = v"402.000.000"
+version = v"402.000.001"
 upstream_version = v"4.2.0"
 
 # Collection of sources required to build normaliz
@@ -35,11 +35,17 @@ sources = [
     #GitSource("https://github.com/Singular/Singular.git", "8cf4d31bb708e264c0e6082a13985538a2acd84f"),
     ArchiveSource("https://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/$(upstream_version.major)-$(upstream_version.minor)-$(upstream_version.patch)/singular-$(upstream_version).tar.gz",
                   "5b0f6c036b4a6f58bf620204b004ec6ca3a5007acc8352fec55eade2fc9d63f6"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd [Ss]ingular*
+
+for f in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 ${f}
+done
+
 #./autogen.sh
 export CPPFLAGS="-I${prefix}/include"
 ./configure --prefix=$prefix --host=$target --build=${MACHTYPE} \

--- a/S/Singular/bundled/patches/0001-fix-add-n_InitMPZ-and-n_MPZ-for-Zn.patch
+++ b/S/Singular/bundled/patches/0001-fix-add-n_InitMPZ-and-n_MPZ-for-Zn.patch
@@ -1,0 +1,45 @@
+From 7234fd1a537971f2cbb4cd784dd3021e3d533776 Mon Sep 17 00:00:00 2001
+From: Hans Schoenemann <hannes@mathematik.uni-kl.de>
+Date: Fri, 8 Jan 2021 17:10:03 +0100
+Subject: [PATCH] fix: add n_InitMPZ and n_MPZ for Zn
+
+---
+ libpolys/coeffs/rmodulon.cc | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/libpolys/coeffs/rmodulon.cc b/libpolys/coeffs/rmodulon.cc
+index 72ba1ae01..b67f44786 100644
+--- a/libpolys/coeffs/rmodulon.cc
++++ b/libpolys/coeffs/rmodulon.cc
+@@ -862,6 +862,19 @@ nMapFunc nrnSetMap(const coeffs src, const coeffs dst)
+   return NULL;      // default
+ }
+ 
++static number nrnInitMPZ(mpz_t m, const coeffs r)
++{
++  mpz_ptr erg = (mpz_ptr)omAllocBin(gmp_nrz_bin);
++  mpz_init_set(erg,m);
++  mpz_mod(erg, erg, r->modNumber);
++  return (number) erg;
++}
++
++static void nrnMPZ(mpz_t m, number &n, const coeffs)
++{
++  mpz_init_set(m, (mpz_ptr)n);
++}
++
+ /*
+  * set the exponent (allocate and init tables) (TODO)
+  */
+@@ -1021,6 +1034,8 @@ BOOLEAN nrnInitChar (coeffs r, void* p)
+   r->nCoeffIsEqual = nrnCoeffIsEqual;
+   r->cfKillChar    = nrnKillChar;
+   r->cfQuot1       = nrnQuot1;
++  r->cfInitMPZ     = nrnInitMPZ;
++  r->cfMPZ         = nrnMPZ;
+ #if SI_INTEGER_VARIANT==2
+   r->cfWriteFd     = nrzWriteFd;
+   r->cfReadFd      = nrzReadFd;
+-- 
+2.28.0
+


### PR DESCRIPTION
Ideally this would be built with https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/93 in effect (e.g. via https://github.com/JuliaPackaging/Yggdrasil/pull/2369). Then we could see if the VersionSpec change works as intended.

