### PR TITLE
[AZP] Update to latest BinaryBuilder

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -28,7 +28,7 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilder]]
 deps = ["ArgParse", "BinaryBuilderBase", "Dates", "Downloads", "GitHub", "HTTP", "JLD2", "JSON", "LibGit2", "Libdl", "Logging", "LoggingExtras", "ObjectFile", "OutputCollectors", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Sockets", "UUIDs", "ghr_jll"]
-git-tree-sha1 = "ef0c656c6aee5a00ed906e142fc454210970d5f4"
+git-tree-sha1 = "0e6a460dbe39bd50f342a8a4bba53f6431e14117"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"

--- a/.ci/register_package.jl
+++ b/.ci/register_package.jl
@@ -116,4 +116,4 @@ mktempdir() do download_dir
 end
 
 # Sub off to Registrator to create a PR to General
-BinaryBuilder.register_jll(name, build_version, dependencies, julia_compat)
+BinaryBuilder.register_jll(name, build_version, dependencies, julia_compat; lazy_artifacts=json_obj["lazy_artifacts"])


### PR DESCRIPTION
This includes https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/986.
Also, correctly register JLLs with lazy artifacts.