### PR TITLE
[AZP] Update BinaryBuilderBase

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -36,7 +36,7 @@ version = "0.3.0"
 
 [[BinaryBuilderBase]]
 deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll"]
-git-tree-sha1 = "540c22a65ea6f34fe100c7db477cac25a4d6840b"
+git-tree-sha1 = "a4b358c4bafcf19a216946276a6ca1a4cd832a4d"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"


### PR DESCRIPTION
We had to revert https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/93
because it breaks registration of the LLVM package.