### PR TITLE
Update libsingular to 0.6 for Julia 1.5

### DIFF
--- a/L/libsingular_julia/libsingular_julia@1.5/build_tarballs.jl
+++ b/L/libsingular_julia/libsingular_julia@1.5/build_tarballs.jl
@@ -1,3 +1,2 @@
 julia_version = v"1.5.3"
 include("../common.jl")
-


### PR DESCRIPTION
CC @thofma 

I would suggest to wait with merging this PR until #2391 is merged and the result got accepted in the general registry, to avoid trouble -- but perhaps I am overly careful here and the infrastructure can handle it? What I am concerned about is this: what if the registry ends up getting PRs for 0.6.4 and 0.6.5 very close to each other, will it really automerge both and in the right order?