### PR TITLE
[GDAL] compat to PROJ_jll =7.2.1 instead of =7.2.0

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -101,7 +101,7 @@ dependencies = [
     # fix to minor PROJ version; also update PROJ_LIBS above
     # needed for Windows because of https://github.com/OSGeo/PROJ/blob/949171a6e/cmake/ProjVersion.cmake#L40-L46
     # to avoid this problem https://github.com/JuliaGeo/GDAL.jl/pull/102
-    Dependency(PackageSpec(name="PROJ_jll", version="7.2")),
+    Dependency(PackageSpec(name="PROJ_jll", version="7.2.1")),
     Dependency("Zlib_jll"),
     Dependency("SQLite_jll"),
     Dependency("LibCURL_jll", v"7.71.1"),


### PR DESCRIPTION
We only need to limit the compat to the minor version, but that is currently not working, see https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/89.
So this at least allows using the latest patch release of PROJ, because right now GDAL_jll will require exactly 7.2.0:
https://github.com/JuliaBinaryWrappers/GDAL_jll.jl/blob/48a43ba63eaab4f34e125b51c9f8338942f44ef6/Project.toml#L27