### PR TITLE
FLINT 2.7.1

### DIFF
--- a/F/FLINT/build_tarballs.jl
+++ b/F/FLINT/build_tarballs.jl
@@ -25,14 +25,14 @@ using BinaryBuilder, Pkg
 # coordinated with corresponding changes to Singular_jll.jl, LoadFlint.jl, Nemo.jl,
 # and possibly other packages.
 name = "FLINT"
-version = v"200.700.000"  # WARNING: don't change this
-upstream_version = v"2.7.0"
+version = v"200.700.100"  # WARNING: don't change this
+upstream_version = v"2.7.1"
 
 # Collection of sources required to build FLINT
 sources = [
 #    GitSource("https://github.com/wbhart/flint2.git", "12c069ea98cd8d2c1b556bbd85568c4891f126fa"),
-    ArchiveSource("https://github.com/wbhart/flint2/archive/v$(upstream_version).tar.gz",
-                  "c1885e64faf0eccc0d48e0a4346ae7c862e858dcb6809890232cbba0b917d2e3")
+    ArchiveSource("https://www.flintlib.org/flint-$(upstream_version).tar.gz",
+                  "186e2fd9ab67df8a05b122fb018269b382e4babcdb17353c4be1fe364dca481e")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
CC @thofma @benlorenz (since we are now using tight versioning, there should be no need to worry about this right now -- once all JLLs depending on this are updated, we can look into adjusting LoadFlint, Nemo, etc.)