### PR TITLE
LibGit2: build for Julia v1.6 against MbedTLS_jll v2.24.0

### DIFF
--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -1,4 +1,4 @@
-using BinaryBuilder
+using BinaryBuilder, Pkg
 
 name = "LibGit2"
 version = v"1.2.1"

--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -58,7 +58,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(Pkg.Types.PackageSpec(name="MbedTLS_jll", version="2.24.0")),
+    Dependency(Pkg.Types.PackageSpec(name="MbedTLS_jll", version=v"2.24.0")),
     Dependency("LibSSH2_jll"),
 ]
 

--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "LibGit2"
-version = v"1.2.0"
+version = v"1.2.1"
 
 # Collection of sources required to build libgit2
 sources = [
@@ -58,7 +58,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("MbedTLS_jll"),
+    Dependency(Pkg.Types.PackageSpec(name="MbedTLS_jll", version="2.24.0")),
     Dependency("LibSSH2_jll"),
 ]
 


### PR DESCRIPTION
Julia v1.6 uses MbedTLS v2.24.0, so use that instead of the latest.

As a side note; this should not be necessary once we manage to get BBB working on julia v1.6+, since it should respect the julia compat better.