### PR TITLE
MbedTLS 2.25 is incompatible with Julia 1.6

### DIFF
--- a/M/MbedTLS/build_tarballs.jl
+++ b/M/MbedTLS/build_tarballs.jl
@@ -58,4 +58,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.7")


### PR DESCRIPTION
libmbedcrypto changed its SOVERSION in 2.25, making this unlinkable on Julia v1.6.