### PR TITLE
WIP: Validate `llvm-config` is functional

### DIFF
--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -249,6 +249,9 @@ if [[ "${target}" == *darwin* ]]; then
     ln -s libLLVM.dylib ${prefix}/lib/libLLVM-${LLVM_VER##*-}.dylib
 fi
 
+# Validate llvm-config works
+${prefix}/tools/llvm-config --version
+
 # Lit is a python dependency and there is no proper install target
 cp -r ${LLVM_SRCDIR}/utils/lit ${prefix}/tools/
 


### PR DESCRIPTION
On Apple Silicon the BB for LLVM has a `llvm-config` that is not functional:
```
$ ./usr/tools/llvm-config
[1]    53067 killed     ./usr/tools/llvm-config
```
This results in this line in "base/Makefile" storing an empty string
```
    @echo "const libllvm_version_string = \"$$($(LLVM_CONFIG_HOST) --version)\"" >> $@
```
which causes `version.jl` to fail during building Julia.

This PR attempts to ensure `llvm-config` is in a functional state but doesn't address the failure. Additionally, I've cannot locally validate this change as "PlatformSupport-aarch64-apple-darwin20.v2020.11.6.x86_64-linux-musl.unpacked"  has no download section.