### PR TITLE
[AZP] Update BinaryBuilderBase

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -36,7 +36,7 @@ version = "0.3.0"
 
 [[BinaryBuilderBase]]
 deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll"]
-git-tree-sha1 = "b89a4d163105a65e4e3ad0f211e4e68d7dead95f"
+git-tree-sha1 = "b0c6726e515f550c368d9c1d1f838d371a4e2241"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"


### PR DESCRIPTION
Get new fixed x86_64 shards for GCC 7 and 8, see
https://github.com/JuliaPackaging/Yggdrasil/pull/2415 and
https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/101.