### PR TITLE
Fix typo in GAP_jll init_block

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -104,6 +104,7 @@ dependencies = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"7",
                init_block = """
+
     sym = dlsym(libgap_handle, :GAP_InitJuliaMemoryInterface)
-    ccall(sym, Nothing, (Any, Ptr{Nothing}), @__MODULE__), C_NULL)
+    ccall(sym, Nothing, (Any, Ptr{Nothing}), @__MODULE__, C_NULL)
 """)


### PR DESCRIPTION
Tested it locally, too