### PR TITLE
glibc minimum 2.17

### DIFF
--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -194,17 +194,12 @@ function gcc_sources(gcc_version::VersionNumber, compiler_target::Platform; kwar
 
     if Sys.islinux(compiler_target) && libc(compiler_target) == "glibc"
         # Depending on our architecture, we choose different versions of glibc
-        if arch(compiler_target) in ["x86_64", "i686"]
-            libc_sources = [
-                ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.12.2.tar.xz",
-                              "0eb4fdf7301a59d3822194f20a2782858955291dd93be264b8b8d4d56f87203f"),
-            ]
-        elseif arch(compiler_target) in ["armv7l", "aarch64"]
+        if arch(compiler_target) in ["armv7l", "aarch64"]
             libc_sources = [
                 ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.19.tar.xz",
                               "2d3997f588401ea095a0b27227b1d50cdfdd416236f6567b564549d3b46ea2a2"),
             ]
-        elseif arch(compiler_target) in ["powerpc64le"]
+        elseif arch(compiler_target) in ["powerpc64le", "x86_64", "i686"]
             libc_sources = [
                 ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.17.tar.xz",
                               "6914e337401e0e0ade23694e1b2c52a5f09e4eda3270c67e7c3ba93a89b5b23e"),


### PR DESCRIPTION
Ok, so, I have absolutely no idea if I updated all the places that needed updating. glibc 2.17 seems to have been released around 25-Dec-2012 (9 years ago). I've checked the other sources of libc in this file, and none of them seem older than that date. I've been having difficulties building I think pretty basic building blocks on BinaryBuilder I think partly due to the the old glibc version. This includes:

- TCP wrappers
- systemd: the systemd documentation lists glibc 2.16 as the minimum supported version
- jack2

The reason I'm concerned about these packages in particular is because PortAudio.jl, the Julia package for playing sounds, is unpublished, I think due to the lack of PulseAudio and jack2 support, and systemd in particular seems to be a critical part of PulseAudio. Maybe @ssfrr might have more to say about this.

I've yet to successfully update header files to link to the linux headers. It seems to open a rabbit hole: every time you update one header, then you need to update a whole bunch of others. So I think this is really the only option. However, I am admitted not very knowledgeable about this kind of thing.


