### PR TITLE
Bundle `ldid` into the rootfs

### DIFF
--- a/0_RootFS/Rootfs/build_tarballs.jl
+++ b/0_RootFS/Rootfs/build_tarballs.jl
@@ -102,8 +102,8 @@ sources = [
                   "d60f75f0dedcc4fd249dbc7519d6f3ce6df490033d276ef1cf27453ef4938d32"),
     # We're going to bundle a version of `ldid` into the rootfs for now.  When we split this up,
     # we'll do this in a nicer way by using JLLs directly, but until then, this is what we've got.
-    ArchiveSource("https://github.com/JuliaBinaryWrappers/ldid_jll.jl/releases/download/ldid-v2.1.2%2B0/ldid.v2.1.2.i686-linux-musl-cxx11.tar.gz",
-                  "367e7d47bb07d8188b51a9d651f8845dd7da2daba66c46a4774a068c9fa5fd36",
+    ArchiveSource("https://github.com/JuliaBinaryWrappers/ldid_jll.jl/releases/download/ldid-v2.1.2%2B0/ldid.v2.1.2.x86_64-linux-musl-cxx11.tar.gz",
+                  "960ebcd32842f81d140293157d90e4e829fd16241bf5b0a23929e4938256a572",
                   unpack_target="ldid"),
     ArchiveSource("https://github.com/JuliaBinaryWrappers/libplist_jll.jl/releases/download/libplist-v2.2.0%2B0/libplist.v2.2.0.x86_64-linux-musl.tar.gz",
                   "1b02d6fd8b77b71eaf672f15fecd8b38ef1e167baf469399b7d52435c11d414b",

--- a/0_RootFS/Rootfs/build_tarballs.jl
+++ b/0_RootFS/Rootfs/build_tarballs.jl
@@ -100,6 +100,14 @@ sources = [
     # We need a very recent version of meson to build gtk stuffs, so let's just grab the latest
     ArchiveSource("https://github.com/mesonbuild/meson/releases/download/0.52.0/meson-0.52.0.tar.gz",
                   "d60f75f0dedcc4fd249dbc7519d6f3ce6df490033d276ef1cf27453ef4938d32"),
+    # We're going to bundle a version of `ldid` into the rootfs for now.  When we split this up,
+    # we'll do this in a nicer way by using JLLs directly, but until then, this is what we've got.
+    ArchiveSource("https://github.com/JuliaBinaryWrappers/ldid_jll.jl/releases/download/ldid-v2.1.2%2B0/ldid.v2.1.2.i686-linux-musl-cxx11.tar.gz",
+                  "367e7d47bb07d8188b51a9d651f8845dd7da2daba66c46a4774a068c9fa5fd36",
+                  unpack_target="ldid"),
+    ArchiveSource("https://github.com/JuliaBinaryWrappers/libplist_jll.jl/releases/download/libplist-v2.2.0%2B0/libplist.v2.2.0.x86_64-linux-musl.tar.gz",
+                  "1b02d6fd8b77b71eaf672f15fecd8b38ef1e167baf469399b7d52435c11d414b",
+                  unpack_target="ldid"),
     # And also our own local patches, utilities, etc...
     DirectorySource("./bundled"),
 ]
@@ -171,6 +179,8 @@ cp -vd ${WORKSPACE}/srcdir/utils/atomic_patch.sh ./usr/local/bin/atomic_patch
 cp -vd ${WORKSPACE}/srcdir/utils/install_license.sh ./usr/local/bin/install_license
 cp -vd ${WORKSPACE}/srcdir/utils/replace_includes.sh ./usr/local/bin/replace_includes
 cp -vd ${WORKSPACE}/srcdir/utils/config.* ./usr/local/share/configure_scripts/
+cp -vd ${WORKSPACE}/srcdir/ldid/bin/* ./usr/local/bin/
+cp -vdr ${WORKSPACE}/srcdir/ldid/lib/* ./usr/local/lib/
 chmod +x ./usr/local/bin/*
 
 # Deploy configuration


### PR DESCRIPTION
This gives us the ability to easily ad-hoc sign mach-o
libraries/executables, which is important for Big Sur, especially M1
machines.