### PR TITLE
Fix GCC build on MacOS

### DIFF
--- a/0_RootFS/GCCBootstrap@4/bundled/patches/gcc485_texi.patch
+++ b/0_RootFS/GCCBootstrap@4/bundled/patches/gcc485_texi.patch
@@ -1,0 +1,28 @@
+--- ./gcc/doc/gcc.texi.orig	2017-03-01 16:56:48.000000000 -0800
++++ ./gcc/doc/gcc.texi	2017-03-01 17:03:38.000000000 -0800
+@@ -86,9 +86,15 @@
+ @item GNU Press
+ @tab Website: www.gnupress.org
+ @item a division of the
+-@tab General: @tex press@@gnu.org @end tex
++@tab General: 
++@tex 
++press@@gnu.org 
++@end tex
+ @item Free Software Foundation
+-@tab Orders:  @tex sales@@gnu.org @end tex
++@tab Orders:  
++@tex 
++sales@@gnu.org 
++@end tex
+ @item 51 Franklin Street, Fifth Floor
+ @tab Tel 617-542-5942
+ @item Boston, MA 02110-1301 USA
+@@ -108,6 +114,7 @@
+ @sp 1
+ @insertcopying
+ @end titlepage
++
+ @summarycontents
+ @contents
+ @page

--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -345,12 +345,7 @@ function gcc_script(compiler_target::Platform)
         export NM_FOR_TARGET=${prefix}/bin/llvm-nm
         export RANLIB_FOR_TARGET=${prefix}/bin/llvm-ranlib
 
-        # GCC build doesn't pay attention to DSYMUTIL or DSYMUTIL_FOR_TARGET, tsk tsk
-        mkdir -p ${prefix}/bin
-        ln -s llvm-dsymutil ${prefix}/bin/dsymutil
-        ln -s llvm-${prefix}/bin/${COMPILER_TARGET}-as
-
-        # GCC build needs a little exdtra help finding our binutils
+        # GCC build needs a little extra help finding our binutils
         GCC_CONF_ARGS="${GCC_CONF_ARGS} --with-ld=${prefix}/bin/${COMPILER_TARGET}-ld"
         GCC_CONF_ARGS="${GCC_CONF_ARGS} --with-as=${prefix}/bin/${COMPILER_TARGET}-as"
 


### PR DESCRIPTION
Our libtapi build is naming `dsymutil` differently, so fix that.  Also,
fix a GCC docs issue that we weren't hitting before