### PR TITLE
Remove man pages from GCCBootstrap sysroot

### DIFF
--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -744,6 +744,9 @@ function gcc_script(compiler_target::Platform)
 
     # Remove misleading libtool archives
     rm -f ${prefix}/${COMPILER_TARGET}/lib*/*.la
+
+    # Remove heavy doc directories
+    rm -rf ${sysroot}/usr/share/man
     """
 
     return script


### PR DESCRIPTION
Reduces the GCCBootstrap shard size by removing unneeded man pages.
```
281M	./aarch64-apple-darwin20/sys-root/usr/share/man
```