### PR TITLE
[Rootfs] Pass `--no-chown` only to `apk add`

### DIFF
--- a/0_RootFS/Rootfs/bundled/utils/apk_wrapper.sh
+++ b/0_RootFS/Rootfs/bundled/utils/apk_wrapper.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-# We run in a single-user environment, we can't afford running `chown` when
-# installing packages.
-/sbin/apk --no-chown "$@"
+if [[ "${1}" == "add" ]]; then
+    # We run in a single-user environment, we can't afford running `chown` when
+    # installing packages.
+    /sbin/apk --no-chown "$@"
+else
+    /sbin/apk "$@"
+fi


### PR DESCRIPTION
As far as I can see, only `apk add` accepts this option.  In particular, forcing
`--no-chown` everywhere breaks `apk del`.

Ref: https://github.com/JuliaPackaging/Yggdrasil/pull/2468#issuecomment-770438499.