### PR TITLE
Bump rr

### DIFF
--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"5.4.1"
 # Collection of sources required to build rr
 sources = [
     GitSource("https://github.com/Keno/rr.git",
-              "82910b8f189b79529cf678ec30a7f2f087d08072")
+              "03ffb97f74dc9cc7b5bed1102cbf83d25f5e5644")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Carries https://github.com/rr-debugger/rr/pull/2800 to reduce verbosity of CI test failures (while keeping error logs if rr itself crashes).

cc @vtjnash @KristofferC 