### PR TITLE
Use BinaryBuilderBase archive_artifact

### DIFF
--- a/0_RootFS/common.jl
+++ b/0_RootFS/common.jl
@@ -1,5 +1,6 @@
 using SHA, BinaryBuilder, Pkg, Pkg.Artifacts, Base.BinaryPlatforms
 using BinaryBuilder: CompilerShard, BinaryBuilderBase
+using BinaryBuilderBase: archive_artifact
 
 host_platform = Platform("x86_64", "linux"; libc="musl")
 


### PR DESCRIPTION
Uses `pigz` for compressiong the "unpacked" artifact. Uses the changes from: https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/113