### PR TITLE
[Codespaces] Update to Julia v1.6 and BinaryBuilder#master

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-FROM julia:1.5
+FROM julia:1.6
 
 RUN apt-get update && apt-get install -y xz-utils bzip2 sudo git unzip
 
-RUN julia -e 'using Pkg; pkg"add BinaryBuilder"'
+RUN julia -e 'using Pkg; pkg"add BinaryBuilderBase#master BinaryBuilder#master"'
 RUN julia -e 'using Pkg; Pkg.API.precompile()'


### PR DESCRIPTION
Note: RC1 is not yet available in Docker Hub, we'll probably need to wait a few
days more before merging this.