### PR TITLE
libunwind: Fix CFA-RSP patch for freebsd

### DIFF
--- a/L/LibUnwind/bundled/patches/libunwind-cfa-rsp.patch
+++ b/L/LibUnwind/bundled/patches/libunwind-cfa-rsp.patch
@@ -1,4 +1,4 @@
-commit e17f29435c902f80ed119ae33506fca1b57584f7
+commit 60f1b223e9979a24aaba2d3ec7ae44fdbe345114
 Author: Keno Fischer <keno@juliacomputing.com>
 Date:   Sat Feb 6 18:13:16 2021 -0500
 
@@ -45,178 +45,6 @@ index fab93c61..b845e2eb 100644
      unw_word_t ip;              /* instruction pointer */
      unw_word_t args_size;       /* size of arguments */
      unw_word_t eh_args[UNW_TDEP_NUM_EH_REGS];
-diff --git a/include/libunwind-aarch64.h b/include/libunwind-aarch64.h
-index 85812e15..e1f69a5c 100644
---- a/include/libunwind-aarch64.h
-+++ b/include/libunwind-aarch64.h
-@@ -146,12 +146,10 @@ typedef enum
-     UNW_AARCH64_FPSR,
-     UNW_AARCH64_FPCR,
- 
--    /* For AArch64, the CFA is the value of SP (x31) at the call site of the
--       previous frame.  */
--    UNW_AARCH64_CFA = UNW_AARCH64_SP,
--
-     UNW_TDEP_LAST_REG = UNW_AARCH64_FPCR,
- 
-+    UNW_AARCH64_CFA,
-+
-     UNW_TDEP_IP = UNW_AARCH64_X30,
-     UNW_TDEP_SP = UNW_AARCH64_SP,
-     UNW_TDEP_EH = UNW_AARCH64_X0,
-diff --git a/include/libunwind-arm.h b/include/libunwind-arm.h
-index 6709b7ab..58d93926 100644
---- a/include/libunwind-arm.h
-+++ b/include/libunwind-arm.h
-@@ -42,7 +42,7 @@ extern "C" {
-    require recompiling all users of this library.  Stack allocation is
-    relatively cheap and unwind-state copying is relatively rare, so we
-    want to err on making it rather too big than too small.  */
--   
-+
- /* FIXME for ARM. Too big?  What do other things use for similar tasks?  */
- #define UNW_TDEP_CURSOR_LEN     4096
- 
-@@ -69,7 +69,7 @@ typedef enum
-     UNW_ARM_R13,
-     UNW_ARM_R14,
-     UNW_ARM_R15,
--    
-+
-     /* VFPv2 s0-s31 (obsolescent numberings).  */
-     UNW_ARM_S0 = 64,
-     UNW_ARM_S1,
-@@ -103,7 +103,7 @@ typedef enum
-     UNW_ARM_S29,
-     UNW_ARM_S30,
-     UNW_ARM_S31,
--    
-+
-     /* FPA register numberings.  */
-     UNW_ARM_F0 = 96,
-     UNW_ARM_F1,
-@@ -113,7 +113,7 @@ typedef enum
-     UNW_ARM_F5,
-     UNW_ARM_F6,
-     UNW_ARM_F7,
--    
-+
-     /* iWMMXt GR register numberings.  */
-     UNW_ARM_wCGR0 = 104,
-     UNW_ARM_wCGR1,
-@@ -123,7 +123,7 @@ typedef enum
-     UNW_ARM_wCGR5,
-     UNW_ARM_wCGR6,
-     UNW_ARM_wCGR7,
--    
-+
-     /* iWMMXt register numberings.  */
-     UNW_ARM_wR0 = 112,
-     UNW_ARM_wR1,
-@@ -141,9 +141,9 @@ typedef enum
-     UNW_ARM_wR13,
-     UNW_ARM_wR14,
-     UNW_ARM_wR15,
--    
-+
-     /* Two-byte encodings from here on.  */
--    
-+
-     /* SPSR.  */
-     UNW_ARM_SPSR = 128,
-     UNW_ARM_SPSR_FIQ,
-@@ -151,7 +151,7 @@ typedef enum
-     UNW_ARM_SPSR_ABT,
-     UNW_ARM_SPSR_UND,
-     UNW_ARM_SPSR_SVC,
--    
-+
-     /* User mode registers.  */
-     UNW_ARM_R8_USR = 144,
-     UNW_ARM_R9_USR,
-@@ -160,7 +160,7 @@ typedef enum
-     UNW_ARM_R12_USR,
-     UNW_ARM_R13_USR,
-     UNW_ARM_R14_USR,
--    
-+
-     /* FIQ registers.  */
-     UNW_ARM_R8_FIQ = 151,
-     UNW_ARM_R9_FIQ,
-@@ -169,23 +169,23 @@ typedef enum
-     UNW_ARM_R12_FIQ,
-     UNW_ARM_R13_FIQ,
-     UNW_ARM_R14_FIQ,
--    
-+
-     /* IRQ registers.  */
-     UNW_ARM_R13_IRQ = 158,
-     UNW_ARM_R14_IRQ,
--    
-+
-     /* ABT registers.  */
-     UNW_ARM_R13_ABT = 160,
-     UNW_ARM_R14_ABT,
--    
-+
-     /* UND registers.  */
-     UNW_ARM_R13_UND = 162,
-     UNW_ARM_R14_UND,
--    
-+
-     /* SVC registers.  */
-     UNW_ARM_R13_SVC = 164,
-     UNW_ARM_R14_SVC,
--    
-+
-     /* iWMMXt control registers.  */
-     UNW_ARM_wC0 = 192,
-     UNW_ARM_wC1,
-diff --git a/src/aarch64/Gregs.c b/src/aarch64/Gregs.c
-index a8843734..4b8a684d 100644
---- a/src/aarch64/Gregs.c
-+++ b/src/aarch64/Gregs.c
-@@ -84,12 +84,13 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
-     case UNW_AARCH64_X27:
-     case UNW_AARCH64_X28:
-     case UNW_AARCH64_X29:
-+    case UNW_AARCH64_SP:
-     case UNW_AARCH64_PC:
-     case UNW_AARCH64_PSTATE:
-       loc = c->dwarf.loc[reg];
-       break;
- 
--    case UNW_AARCH64_SP:
-+    case UNW_AARCH64_CFA:
-       if (write)
-         return -UNW_EREADONLYREG;
-       *valp = c->dwarf.cfa;
-diff --git a/src/arm/Gregs.c b/src/arm/Gregs.c
-index 0d52f0b2..021a79ba 100644
---- a/src/arm/Gregs.c
-+++ b/src/arm/Gregs.c
-@@ -29,7 +29,7 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
-                  int write)
- {
-   dwarf_loc_t loc = DWARF_NULL_LOC;
--  
-+
-   switch (reg)
-     {
-     case UNW_ARM_R15:
-@@ -48,11 +48,11 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
-     case UNW_ARM_R10:
-     case UNW_ARM_R11:
-     case UNW_ARM_R12:
-+    case UNW_ARM_R13:
-     case UNW_ARM_R14:
-       loc = c->dwarf.loc[reg - UNW_ARM_R0];
-       break;
- 
--    case UNW_ARM_R13:
-     case UNW_ARM_CFA:
-       if (write)
-         return -UNW_EREADONLYREG;
 diff --git a/src/dwarf/Gparser.c b/src/dwarf/Gparser.c
 index 7d255aee..986c4a89 100644
 --- a/src/dwarf/Gparser.c
@@ -241,31 +69,6 @@ index 7d255aee..986c4a89 100644
          case DWARF_WHERE_CFAREL:
            new_loc[i] = DWARF_MEM_LOC (c, cfa + rs->reg.val[i]);
            break;
-diff --git a/src/hppa/Gregs.c b/src/hppa/Gregs.c
-index da0542c8..7b18968a 100644
---- a/src/hppa/Gregs.c
-+++ b/src/hppa/Gregs.c
-@@ -42,7 +42,6 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
-       break;
- 
-     case UNW_HPPA_CFA:
--    case UNW_HPPA_SP:
-       if (write)
-         return -UNW_EREADONLYREG;
-       *valp = c->dwarf.cfa;
-diff --git a/src/mips/Gregs.c b/src/mips/Gregs.c
-index 95194022..be581d31 100644
---- a/src/mips/Gregs.c
-+++ b/src/mips/Gregs.c
-@@ -31,7 +31,7 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
-                  int write)
- {
-   dwarf_loc_t loc = DWARF_NULL_LOC;
--  
-+
-   switch (reg)
-     {
-     case UNW_MIPS_R0:
 diff --git a/src/x86/Gregs.c b/src/x86/Gregs.c
 index 4a959261..9446d6c6 100644
 --- a/src/x86/Gregs.c
@@ -286,6 +89,35 @@ index 4a959261..9446d6c6 100644
      case UNW_X86_EBP: loc = c->dwarf.loc[EBP]; break;
      case UNW_X86_ESI: loc = c->dwarf.loc[ESI]; break;
      case UNW_X86_EDI: loc = c->dwarf.loc[EDI]; break;
+diff --git a/src/x86/Gstep.c b/src/x86/Gstep.c
+index 129b739a..e7722418 100644
+--- a/src/x86/Gstep.c
++++ b/src/x86/Gstep.c
+@@ -47,7 +47,7 @@ unw_step (unw_cursor_t *cursor)
+     {
+       /* DWARF failed, let's see if we can follow the frame-chain
+          or skip over the signal trampoline.  */
+-      struct dwarf_loc ebp_loc, eip_loc;
++      struct dwarf_loc ebp_loc, eip_loc, esp_loc;
+ 
+       /* We could get here because of missing/bad unwind information.
+          Validate all addresses before dereferencing. */
+@@ -77,6 +77,7 @@ unw_step (unw_cursor_t *cursor)
+                  c->dwarf.cfa);
+ 
+           ebp_loc = DWARF_LOC (c->dwarf.cfa, 0);
++          esp_loc = DWARF_VAL_LOC (c, c->dwarf.cfa);
+           eip_loc = DWARF_LOC (c->dwarf.cfa + 4, 0);
+           c->dwarf.cfa += 8;
+ 
+@@ -87,6 +88,7 @@ unw_step (unw_cursor_t *cursor)
+             c->dwarf.loc[i] = DWARF_NULL_LOC;
+ 
+           c->dwarf.loc[EBP] = ebp_loc;
++          c->dwarf.loc[ESP] = esp_loc;
+           c->dwarf.loc[EIP] = eip_loc;
+           c->dwarf.use_prev_instr = 1;
+         }
 diff --git a/src/x86_64/Gregs.c b/src/x86_64/Gregs.c
 index baf8a24f..dff5bcbe 100644
 --- a/src/x86_64/Gregs.c
@@ -306,3 +138,16 @@ index baf8a24f..dff5bcbe 100644
      case UNW_X86_64_RBP: loc = c->dwarf.loc[RBP]; break;
      case UNW_X86_64_RSI: loc = c->dwarf.loc[RSI]; break;
      case UNW_X86_64_RDI: loc = c->dwarf.loc[RDI]; break;
+diff --git a/src/x86_64/Gstep.c b/src/x86_64/Gstep.c
+index 10498170..963c60c2 100644
+--- a/src/x86_64/Gstep.c
++++ b/src/x86_64/Gstep.c
+@@ -160,7 +160,7 @@ unw_step (unw_cursor_t *cursor)
+             {
+               unw_word_t rbp1 = 0;
+               rbp_loc = DWARF_LOC(rbp, 0);
+-              rsp_loc = DWARF_NULL_LOC;
++              rsp_loc = DWARF_VAL_LOC(c, rbp);
+               rip_loc = DWARF_LOC (rbp + 8, 0);
+               ret = dwarf_get (&c->dwarf, rbp_loc, &rbp1);
+               Debug (1, "[RBP=0x%lx] = 0x%lx (cfa = 0x%lx) -> 0x%lx\n",


### PR DESCRIPTION
Also drop changes for other architectures (c.f. https://github.com/JuliaLang/julia/pull/39553).