### PR TITLE
[LLVMBootstrap] Use GCC 7 for LLVM 11

### DIFF
--- a/0_RootFS/LLVMBootstrap@11/build_tarballs.jl
+++ b/0_RootFS/LLVMBootstrap@11/build_tarballs.jl
@@ -7,8 +7,10 @@ name = "LLVMBootstrap"
 version = v"11.0.1"
 sources, script, products, dependencies = llvm_build_args(;version=version)
 ndARGS, deploy_target = find_deploy_arg(ARGS)
+# Earlier versions of GCC can cause Clang to fail with `error: unknown target CPU 'x86-64'`
+# https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/112#issuecomment-776940748
 build_info = build_tarballs(ndARGS, name, version, sources, script, [host_platform], products, dependencies;
-                            skip_audit=true, preferred_gcc_version=v"5.1")
+                            skip_audit=true, preferred_gcc_version=v"7.1")
 if deploy_target !== nothing
     upload_and_insert_shards(deploy_target, name, version, build_info)
 end


### PR DESCRIPTION
Addresses the `error: unknown target CPU 'x86-64'` problem noted in: https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/112#issuecomment-772088375. Follow up to: https://github.com/JuliaPackaging/Yggdrasil/pull/2473