### PR TITLE
Bump rr

### DIFF
--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"5.4.1"
 # Collection of sources required to build rr
 sources = [
     GitSource("https://github.com/Keno/rr.git",
-              "816a528ad547d01b92f4183a1bad45227e5086b8")
+              "c941f45c3ef722b63a63eec1fdce7c8aa10101ca")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Tweaks when debug messages are printed to try to make them show up in failure cases like
https://build.julialang.org/#/builders/71/builds/666/steps/5/logs/stdio.