### PR TITLE
[GDAL] specify patch version of proj_jll_version

### DIFF
--- a/G/GDAL/GDAL@julia-1.3/build_tarballs.jl
+++ b/G/GDAL/GDAL@julia-1.3/build_tarballs.jl
@@ -11,7 +11,7 @@ min_julia_version = v"1.3"
 # Note that this currently fixes it to the exact JLL version that is used,
 # this is issue https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/89.
 # Ideally we could by default allow any version X??.Y?? here, i.e. the PROJ minor version.
-proj_jll_version = "700.201"
+proj_jll_version = "700.201.100"
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, configure(version_offset, min_julia_version, proj_jll_version)...;


### PR DESCRIPTION
See https://github.com/JuliaRegistries/General/pull/30206#issuecomment-780412386.

Since the previous build has not been used anywhere yet, I guess it is fine to leave the version_offset as is? Or should I bump the patch version offset?