### PR TITLE
[OpenBLAS] OpenBLAS v0.3.10 should not include ILP64 aarch64

### DIFF
--- a/O/OpenBLAS/OpenBLAS@0.3.10/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS@0.3.10/build_tarballs.jl
@@ -15,4 +15,3 @@ dependencies = openblas_dependencies()
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"6", lock_microarchitecture=false, julia_compat="1.6")
-


### PR DESCRIPTION
We aren't ready to make this switch on `release-1.6`, this will be a `release-1.7` feature alongside libblastrampoline