### PR TITLE
[GMP] Add GMP 6.2.1

### DIFF
--- a/G/GMP/GMP@6.1.2/build_tarballs.jl
+++ b/G/GMP/GMP@6.1.2/build_tarballs.jl
@@ -1,62 +1,8 @@
-# Note that this script can accept some limited command-line arguments, run
-# `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder
-
-# Collection of sources required to build GMP
-name = "GMP"
 version = v"6.1.2"
 
-sources = [
-    ArchiveSource("https://gmplib.org/download/gmp/gmp-$(version).tar.bz2",
-                  "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2"),
-    DirectorySource("./bundled"),
-]
+include("../common.jl")
 
-# Bash recipe for building across all platforms
-script = raw"""
-cd $WORKSPACE/srcdir/gmp-*
-
-# Include Julia-carried patches
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/gmp_alloc_overflow_func.patch
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/gmp-exception.patch
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/gmp-apple-arm64.patch
-
-flags=(--enable-cxx --enable-shared --disable-static)
-
-# On x86_64 architectures, build fat binary
-if [[ ${proc_family} == intel ]]; then
-    flags+=(--enable-fat)
-fi
-
-autoreconf
-./configure --prefix=$prefix --build=${MACHTYPE} --host=${target} ${flags[@]}
-
-make -j${nproc}
-make install
-
-# On Windows, we need to make sure that the non-versioned dll names exist too
-if [[ ${target} == *mingw* ]]; then
-    cp -v ${libdir}/libgmp-*.dll "${libdir}/libgmp.dll"
-    cp -v ${libdir}/libgmpxx-*.dll "${libdir}/libgmpxx.dll"
-fi
-
-# GMP is dual-licensed, install all license files
-install_license COPYING*
-"""
-
-# We enable experimental platforms as this is a core Julia dependency
-platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
-
-# The products that we will ensure are always built
-products = [
-    LibraryProduct("libgmp", :libgmp),
-    LibraryProduct("libgmpxx", :libgmpxx),
-]
-
-# Dependencies that must be installed before this package can be built
-dependencies = [
-]
-
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6", julia_compat="~1.0, ~1.1, ~1.2, ~1.3, ~1.4, ~1.5")
+# Build the tarballs
+build_tarballs(ARGS, configure(version)...;
+               preferred_gcc_version=v"6", julia_compat="~1.0, ~1.1, ~1.2, ~1.3, ~1.4, ~1.5")
 

--- a/G/GMP/GMP@6.2.1/build_tarballs.jl
+++ b/G/GMP/GMP@6.2.1/build_tarballs.jl
@@ -1,8 +1,8 @@
-version = v"6.2.0"
+version = v"6.2.1"
 
 include("../common.jl")
 
 # Build the tarballs
 build_tarballs(ARGS, configure(version)...;
-               preferred_gcc_version=v"6", julia_compat="1.6")
+               preferred_gcc_version=v"6", julia_compat="1.7")
 

--- a/G/GMP/GMP@6.2.1/bundled/patches/gmp-exception.patch
+++ b/G/GMP/GMP@6.2.1/bundled/patches/gmp-exception.patch
@@ -1,0 +1,1 @@
+../../../GMP@6.2.0/bundled/patches/gmp-exception.patch

--- a/G/GMP/GMP@6.2.1/bundled/patches/gmp_alloc_overflow_func.patch
+++ b/G/GMP/GMP@6.2.1/bundled/patches/gmp_alloc_overflow_func.patch
@@ -1,0 +1,1 @@
+../../../GMP@6.2.0/bundled/patches/gmp_alloc_overflow_func.patch

--- a/G/GMP/common.jl
+++ b/G/GMP/common.jl
@@ -1,0 +1,68 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+function configure(version)
+    name = "GMP"
+
+    hash = Dict(
+        v"6.1.2" => "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2",
+        v"6.2.0" => "f51c99cb114deb21a60075ffb494c1a210eb9d7cb729ed042ddb7de9534451ea",
+        v"6.2.1" => "eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c",
+    )
+
+    # Collection of sources required to complete build
+    sources = [
+        ArchiveSource("https://gmplib.org/download/gmp/gmp-$(version).tar.bz2", hash[version]),
+        DirectorySource("./bundled"; follow_symlinks=true),
+    ]
+
+    # Bash recipe for building across all platforms
+    script = raw"""
+cd $WORKSPACE/srcdir/gmp-*
+
+# Include Julia-carried patches
+for f in $WORKSPACE/srcdir/patches/*.patch; do
+    echo "Applying patch ${f}"
+    atomic_patch -p1 ${f}
+done
+
+flags=(--enable-cxx --enable-shared --disable-static)
+
+# On x86_64 architectures, build fat binary
+if [[ ${proc_family} == intel ]]; then
+    flags+=(--enable-fat)
+fi
+
+autoreconf
+./configure --prefix=$prefix --build=${MACHTYPE} --host=${target} ${flags[@]}
+
+make -j${nproc}
+make install
+
+# On Windows, we need to make sure that the non-versioned dll names exist too
+if [[ ${target} == *mingw* ]]; then
+    cp -v ${libdir}/libgmp-*.dll "${libdir}/libgmp.dll"
+    cp -v ${libdir}/libgmpxx-*.dll "${libdir}/libgmpxx.dll"
+fi
+
+# GMP is dual-licensed, install all license files
+install_license COPYING*
+"""
+
+    # We enable experimental platforms as this is a core Julia dependency
+    platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+
+    # The products that we will ensure are always built
+    products = [
+        LibraryProduct("libgmp", :libgmp),
+        LibraryProduct("libgmpxx", :libgmpxx),
+    ]
+
+    # Dependencies that must be installed before this package can be built
+    dependencies = Dependency[
+    ]
+
+    return name, version, sources, script, platforms, products, dependencies
+end
+


### PR DESCRIPTION
GMP release notes for 6.2.1 (https://gmplib.org/gmp6.2)

> Initial support for Darwin on arm64, and improved portability.  
