### PR TITLE
[hsa_rocr] Build for musl

### DIFF
--- a/H/hsa_rocr/build_tarballs.jl
+++ b/H/hsa_rocr/build_tarballs.jl
@@ -31,6 +31,7 @@ make install
 # Only supports Linux, seemingly only 64bit
 platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="musl"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 


### PR DESCRIPTION
ROCR doesn't need any special patches to run on musl, thankfully