### PR TITLE
[SuiteSparse] Update to 5.8.1 and link to LBT

### DIFF
--- a/S/SuiteSparse/SuiteSparse/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse/build_tarballs.jl
@@ -1,15 +1,4 @@
-using BinaryBuilder, Pkg
-
-name = "SuiteSparse"
-version = v"5.4.0"
-
-# Collection of sources required to build SuiteSparse
-sources = [
-    ArchiveSource("https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v$(version).tar.gz",
-                  "d9d62d539410d66550d0b795503a556830831f50087723cb191a030525eda770"),
-    DirectorySource("./bundled"),
-]
-
+include("../common.jl")
 
 # Bash recipe for building across all platforms
 script = raw"""
@@ -29,11 +18,9 @@ else
     FLAGS+=(LDFLAGS="${LDFLAGS} -L${libdir}")
 fi
 
-if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
+BLAS_NAME=blastrampoline
+if [[ ${nbits} == 64 ]]; then
     SUN="-DSUN64 -DLONGBLAS='long long'"
-    BLAS_NAME=openblas64_
-else
-    BLAS_NAME=openblas
 fi
 
 FLAGS+=(BLAS="-l${BLAS_NAME}" LAPACK="-l${BLAS_NAME}")
@@ -49,19 +36,19 @@ for proj in SuiteSparse_config AMD BTF CAMD CCOLAMD COLAMD CHOLMOD LDL KLU UMFPA
     make -j${nproc} -C $proj "${FLAGS[@]}" install CFOPENMP="$CFOPENMP"
 done
 
-# For now, we'll have to adjust the name of the OpenBLAS library on macOS and FreeBSD.
+# For now, we'll have to adjust the name of the Lbt library on macOS and FreeBSD.
 # Eventually, this should be fixed upstream
 if [[ ${target} == *-apple-* ]] || [[ ${target} == *freebsd* ]]; then
-    echo "-- Modifying library name for OpenBLAS"
+    echo "-- Modifying library name for Lbt"
 
     for nm in libcholmod libspqr libumfpack; do
         # Figure out what version it probably latched on to:
         if [[ ${target} == *-apple-* ]]; then
-            OPENBLAS_LINK=$(otool -L ${libdir}/${nm}.dylib | grep lib${BLAS_NAME} | awk '{ print $1 }')
-            install_name_tool -change ${OPENBLAS_LINK} @rpath/lib${BLAS_NAME}.dylib ${libdir}/${nm}.dylib
+            LBT_LINK=$(otool -L ${libdir}/${nm}.dylib | grep lib${BLAS_NAME} | awk '{ print $1 }')
+            install_name_tool -change ${LBT_LINK} @rpath/lib${BLAS_NAME}.dylib ${libdir}/${nm}.dylib
         elif [[ ${target} == *freebsd* ]]; then
-            OPENBLAS_LINK=$(readelf -d ${libdir}/${nm}.so | grep lib${BLAS_NAME} | sed -e 's/.*\[\(.*\)\].*/\1/')
-            patchelf --replace-needed ${OPENBLAS_LINK} lib${BLAS_NAME}.so ${libdir}/${nm}.so
+            LBT_LINK=$(readelf -d ${libdir}/${nm}.so | grep lib${BLAS_NAME} | sed -e 's/.*\[\(.*\)\].*/\1/')
+            patchelf --replace-needed ${LBT_LINK} lib${BLAS_NAME}.so ${libdir}/${nm}.so
         fi
     done
 fi
@@ -101,12 +88,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenBLAS_jll", version=v"0.3.10")),
+    Dependency("libblastrampoline_jll"),
 #    Dependency("METIS_jll"),
 ]
 
 # Note: we explicitly lie about this because we don't have the new
 # versioning APIs worked out in BB yet.
-version = v"5.4.1"
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
-
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.7")

--- a/S/SuiteSparse/SuiteSparse/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse/build_tarballs.jl
@@ -2,7 +2,7 @@ include("../common.jl")
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/SuiteSparse-*
+cd $WORKSPACE/srcdir/SuiteSparse*
 
 # Apply Jameson's shlib patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/SuiteSparse-shlib.patch
@@ -66,32 +66,8 @@ cd $WORKSPACE/srcdir/SuiteSparse_wrapper
 "${CC}" -O2 -shared -fPIC -I${prefix}/include SuiteSparse_wrapper.c -o ${libdir}/libsuitesparse_wrapper.${dlext} -L${libdir} -lcholmod
 """
 
-# We enable experimental platforms as this is a core Julia dependency
-platforms = supported_platforms(;experimental=true)
-
-# The products that we will ensure are always built
-products = [
-    LibraryProduct("libsuitesparseconfig",   :libsuitesparseconfig),
-    LibraryProduct("libamd",                 :libamd),
-    LibraryProduct("libbtf",                 :libbtf),
-    LibraryProduct("libcamd",                :libcamd),
-    LibraryProduct("libccolamd",             :libccolamd),
-    LibraryProduct("libcolamd",              :libcolamd),
-    LibraryProduct("libcholmod",             :libcholmod),
-    LibraryProduct("libldl",                 :libldl),
-    LibraryProduct("libklu",                 :libklu),
-    LibraryProduct("libumfpack",             :libumfpack),
-    LibraryProduct("librbio",                :librbio),
-    LibraryProduct("libspqr",                :libspqr),
-    LibraryProduct("libsuitesparse_wrapper", :libsuitesparse_wrapper),
-]
-
-# Dependencies that must be installed before this package can be built
-dependencies = [
-    Dependency("libblastrampoline_jll"),
-#    Dependency("METIS_jll"),
-]
 
 # Note: we explicitly lie about this because we don't have the new
 # versioning APIs worked out in BB yet.
+#version = 5.4.1
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.7")

--- a/S/SuiteSparse/SuiteSparse/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse/build_tarballs.jl
@@ -2,7 +2,7 @@ include("../common.jl")
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/SuiteSparse*
+cd $WORKSPACE/srcdir/SuiteSparse
 
 # Apply Jameson's shlib patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/SuiteSparse-shlib.patch

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -1,0 +1,11 @@
+using BinaryBuilder, Pkg
+
+name = "SuiteSparse"
+version = v"5.8.1"
+
+# Collection of sources required to build SuiteSparse
+sources = [
+    GitSource("https://github.com/DrTimothyAldenDavis/SuiteSparse.git",
+              "1869379f464f0f8dac471edb4e6d010b2b0e639d"),
+    DirectorySource("./bundled"),
+]

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -9,3 +9,29 @@ sources = [
               "1869379f464f0f8dac471edb4e6d010b2b0e639d"),
     DirectorySource("./bundled"),
 ]
+
+# We enable experimental platforms as this is a core Julia dependency
+platforms = supported_platforms(;experimental=true)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libsuitesparseconfig",   :libsuitesparseconfig),
+    LibraryProduct("libamd",                 :libamd),
+    LibraryProduct("libbtf",                 :libbtf),
+    LibraryProduct("libcamd",                :libcamd),
+    LibraryProduct("libccolamd",             :libccolamd),
+    LibraryProduct("libcolamd",              :libcolamd),
+    LibraryProduct("libcholmod",             :libcholmod),
+    LibraryProduct("libldl",                 :libldl),
+    LibraryProduct("libklu",                 :libklu),
+    LibraryProduct("libumfpack",             :libumfpack),
+    LibraryProduct("librbio",                :librbio),
+    LibraryProduct("libspqr",                :libspqr),
+    LibraryProduct("libsuitesparse_wrapper", :libsuitesparse_wrapper),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("libblastrampoline_jll"),
+#    Dependency("METIS_jll"),
+]


### PR DESCRIPTION
Link to LBT (instead of OpenBLAS). Also uses ilp64 BLAS on aarch64 by default.