### PR TITLE
[OpenBLAS] Disable `TARGET=GENERIC` on OpenBLAS 0.3.12 and earlier

### DIFF
--- a/O/OpenBLAS/OpenBLAS@0.3.10/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS@0.3.10/build_tarballs.jl
@@ -15,3 +15,4 @@ dependencies = openblas_dependencies()
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"6", lock_microarchitecture=false, julia_compat="1.6")
+

--- a/O/OpenBLAS/common.jl
+++ b/O/OpenBLAS/common.jl
@@ -40,6 +40,7 @@ function openblas_script(;num_64bit_threads::Integer=32, openblas32::Bool=false,
     NUM_64BIT_THREADS=$(num_64bit_threads)
     OPENBLAS32=$(openblas32)
     AARCH64_ILP64=$(aarch64_ilp64)
+    version_patch=$(version.patch)
     """
     # Bash recipe for building across all platforms
     script *= raw"""
@@ -81,7 +82,14 @@ function openblas_script(;num_64bit_threads::Integer=32, openblas32::Bool=false,
     # On Intel and most aarch64 architectures, engage DYNAMIC_ARCH.
     # When using DYNAMIC_ARCH the TARGET specifies the minimum architecture requirement.
     if [[ ${proc_family} == intel ]]; then
-        flags+=(TARGET=GENERIC DYNAMIC_ARCH=1)
+        flags+=(DYNAMIC_ARCH=1)
+        # Before OpenBLAS 0.3.13, there appears to be a miscompilation bug with `clang` on setting `TARGET=GENERIC`
+        # As that is the case, we're just going to be safe and only use `TARGET=GENERIC` on 0.3.13+
+        if [ ${version_patch} -gt 12 ]; then
+            FLAGS+=(TARGET=GENERIC)
+        else
+            FLAGS+=(TARGET=)
+        fi
     elif [[ ${target} == aarch64-* ]] && [[ ${bb_full_target} != *-libgfortran3* ]]; then
         flags+=(TARGET=ARMV8 DYNAMIC_ARCH=1)
     # Otherwise, engage a specific target


### PR DESCRIPTION
Turns out that OpenBLAS 0.3.12 and earlier have some kind of
`clang`-related code generation bug when built like this.

The issue is that the call to `gotoblas->init()` here [0] does not
actually call `init` but instead calls `ztrsm_olnncopy`, presumably
because of some struct layout issue.  I briefly looked into it, but
since it only effects `clang` and doesn't effect `0.3.13`, I'm taking
the coward's way out and just not poking the compiler bear.

[0]
https://github.com/xianyi/OpenBLAS/blob/v0.3.10/driver/others/dynamic.c#L921

X-ref: https://github.com/JuliaLang/julia/pull/39719