### PR TITLE
[LibGit2] Add patch to fix zlib stream handling

### DIFF
--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder, Pkg
 
 name = "LibGit2"
-version = v"1.2.2"
+version = v"1.2.3"
 
 # Collection of sources required to build libgit2
 sources = [
@@ -16,6 +16,7 @@ cd $WORKSPACE/srcdir/libgit2*/
 
 atomic_patch -p1 $WORKSPACE/srcdir/patches/libgit2-agent-nonfatal.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/libgit2-hostkey.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/libgit2-continue-zlib.patch
 
 BUILD_FLAGS=(
     -DCMAKE_BUILD_TYPE=Release

--- a/L/LibGit2/bundled/patches/libgit2-continue-zlib.patch
+++ b/L/LibGit2/bundled/patches/libgit2-continue-zlib.patch
@@ -1,0 +1,43 @@
+commit 99ddda527b0e1964898c2bc9fbc23ea7afe96ae5
+Author: Edward Thomson <ethomson@edwardthomson.com>
+Date:   Tue Dec 15 23:03:03 2020 +0000
+
+    pack: continue zlib while we can make progress
+    
+    Continue the zlib stream as long as we can make progress; stop when we
+    stop getting output _or_ when zlib stops taking input from us.
+    
+    (cherry picked from commit 93f61c5a9f638e76189cef2dbde7839a9af5ff54)
+
+diff --git a/src/pack.c b/src/pack.c
+index 1b5cf670f..1a208a051 100644
+--- a/src/pack.c
++++ b/src/pack.c
+@@ -841,7 +841,7 @@ static int packfile_unpack_compressed(
+ 
+ 	do {
+ 		size_t bytes = buffer_len - total;
+-		unsigned int window_len;
++		unsigned int window_len, consumed;
+ 		unsigned char *in;
+ 
+ 		if ((in = pack_window_open(p, mwindow, *position, &window_len)) == NULL) {
+@@ -857,10 +857,15 @@ static int packfile_unpack_compressed(
+ 
+ 		git_mwindow_close(mwindow);
+ 
+-		if (!bytes)
+-			break;
++		consumed = window_len - (unsigned int)zstream.in_len;
++
++		if (!bytes && !consumed) {
++			git_error_set(GIT_ERROR_ZLIB, "error inflating zlib stream");
++			error = -1;
++			goto out;
++		}
+ 
+-		*position += window_len - zstream.in_len;
++		*position += consumed;
+ 		total += bytes;
+ 	} while (!git_zstream_eos(&zstream));
+ 


### PR DESCRIPTION
libgit2 v1.1.0 has a bug with zlib stream handling, causing clone error on 32-bit systems.
This backports the patch to fix the bug. (xref: https://github.com/libgit2/libgit2/pull/5740)