### PR TITLE
[GStreamer] Add builder

### DIFF
--- a/G/GStreamer/build_tarballs.jl
+++ b/G/GStreamer/build_tarballs.jl
@@ -30,15 +30,15 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libgstcheck-1.0", :libgstcheck),
+    LibraryProduct(["libgstcheck-1.0", "libgstcheck-1"], :libgstcheck),
     ExecutableProduct("gst-tester-1.0", :gst_tester),
-    LibraryProduct("libgstnet-1.0", :libgstnet),
-    LibraryProduct("libgstreamer-1.0", :libgstreamer),
+    LibraryProduct(["libgstnet-1.0", "libgstnet-1"], :libgstnet),
+    LibraryProduct(["libgstreamer-1.0", "libgstreamer-1"], :libgstreamer),
     ExecutableProduct("gst-launch-1.0", :gst_launch),
     ExecutableProduct("gst-stats-1.0", :gst_stats),
     ExecutableProduct("gst-typefind-1.0", :gst_typefind),
-    LibraryProduct("libgstcontroller-1.0", :libgstcontroller),
-    LibraryProduct("libgstbase-1.0", :libgstbase),
+    LibraryProduct(["libgstcontroller-1.0", "libgstcontroller-1"], :libgstcontroller),
+    LibraryProduct(["libgstbase-1.0", "libgstbase-1"], :libgstbase),
     ExecutableProduct("gst-inspect-1.0", :gst_inspect)
 ]
 

--- a/G/GStreamer/build_tarballs.jl
+++ b/G/GStreamer/build_tarballs.jl
@@ -46,7 +46,7 @@ dependencies = [
     Dependency(PackageSpec(name="Glib_jll", uuid="7746bdde-850d-59dc-9ae8-88ece973131d"))
     Dependency(PackageSpec(name="LibUnwind_jll", uuid="745a5e78-f969-53e9-954f-d19f2f74f4e3"))
     Dependency(PackageSpec(name="Elfutils_jll", uuid="ab5a07f8-06af-567f-a878-e8bb879eba5a"))
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"), v"6.1.2")
     Dependency(PackageSpec(name="GSL_jll", uuid="1b77fbbe-d8ee-58f0-85f9-836ddc23a7a4"))
     Dependency(PackageSpec(name="libcap_jll", uuid="eef66a8b-8d7a-5724-a8d2-7c31ae1e29ed"))
 ]

--- a/G/GStreamer/build_tarballs.jl
+++ b/G/GStreamer/build_tarballs.jl
@@ -30,15 +30,15 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libgstcheck", :libgstcheck),
+    LibraryProduct("libgstcheck-1.0", :libgstcheck),
     ExecutableProduct("gst-tester-1.0", :gst_tester),
-    LibraryProduct("libgstnet", :libgstnet),
-    LibraryProduct("libgstreamer", :libgstreamer),
+    LibraryProduct("libgstnet-1.0", :libgstnet),
+    LibraryProduct("libgstreamer-1.0", :libgstreamer),
     ExecutableProduct("gst-launch-1.0", :gst_launch),
     ExecutableProduct("gst-stats-1.0", :gst_stats),
     ExecutableProduct("gst-typefind-1.0", :gst_typefind),
-    LibraryProduct("libgstcontroller", :libgstcontroller),
-    LibraryProduct("libgstbase", :libgstbase),
+    LibraryProduct("libgstcontroller-1.0", :libgstcontroller),
+    LibraryProduct("libgstbase-1.0", :libgstbase),
     ExecutableProduct("gst-inspect-1.0", :gst_inspect)
 ]
 

--- a/G/GStreamer/build_tarballs.jl
+++ b/G/GStreamer/build_tarballs.jl
@@ -25,7 +25,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(exclude=[Platform("i686", "linux", libc = "musl"), Platform("powerpc64le", "linux")])
 
 # The products that we will ensure are always built
 products = [

--- a/G/GStreamer/build_tarballs.jl
+++ b/G/GStreamer/build_tarballs.jl
@@ -26,20 +26,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    MacOS(:x86_64),
-    FreeBSD(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64)
-]
-
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/GStreamer/build_tarballs.jl
+++ b/G/GStreamer/build_tarballs.jl
@@ -20,7 +20,7 @@ cd gstreamer-*
 mkdir build
 cd build
 meson .. --cross-file=${MESON_TARGET_TOOLCHAIN}
-ninja
+ninja -j${nproc}
 ninja install
 """
 

--- a/G/GStreamer/build_tarballs.jl
+++ b/G/GStreamer/build_tarballs.jl
@@ -13,8 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-apk add bash-completion
-apk add libcap gettext
+apk add bash-completion libcap gettext
 cd gstreamer-*
 mkdir build
 cd build
@@ -29,16 +28,16 @@ platforms = supported_platforms(exclude=[Platform("i686", "linux", libc = "musl"
 
 # The products that we will ensure are always built
 products = [
+    LibraryProduct(["libgstbase-1.0", "libgstbase-1"], :libgstbase),
     LibraryProduct(["libgstcheck-1.0", "libgstcheck-1"], :libgstcheck),
-    ExecutableProduct("gst-tester-1.0", :gst_tester),
+    LibraryProduct(["libgstcontroller-1.0", "libgstcontroller-1"], :libgstcontroller),
     LibraryProduct(["libgstnet-1.0", "libgstnet-1"], :libgstnet),
     LibraryProduct(["libgstreamer-1.0", "libgstreamer-1"], :libgstreamer),
+    ExecutableProduct("gst-inspect-1.0", :gst_inspect),
     ExecutableProduct("gst-launch-1.0", :gst_launch),
     ExecutableProduct("gst-stats-1.0", :gst_stats),
+    ExecutableProduct("gst-tester-1.0", :gst_tester),
     ExecutableProduct("gst-typefind-1.0", :gst_typefind),
-    LibraryProduct(["libgstcontroller-1.0", "libgstcontroller-1"], :libgstcontroller),
-    LibraryProduct(["libgstbase-1.0", "libgstbase-1"], :libgstbase),
-    ExecutableProduct("gst-inspect-1.0", :gst_inspect)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/G/GStreamer/build_tarballs.jl
+++ b/G/GStreamer/build_tarballs.jl
@@ -14,8 +14,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 apk add bash-completion
-apk add libcap
-apk add gettext
+apk add libcap gettext
 cd gstreamer-*
 mkdir build
 cd build

--- a/G/GStreamer/build_tarballs.jl
+++ b/G/GStreamer/build_tarballs.jl
@@ -1,0 +1,69 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "GStreamer"
+version = v"1.18.3"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-$(version).tar.xz", "0c2e09e18f2df69a99b5cb3bd53c597b3cc2e35cf6c98043bb86a66f3d312100")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+apk add bash-completion
+apk add libcap
+apk add gettext
+cd gstreamer-*
+mkdir build
+cd build
+meson .. --cross-file=${MESON_TARGET_TOOLCHAIN}
+ninja
+ninja install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Linux(:i686, libc=:glibc),
+    Linux(:x86_64, libc=:glibc),
+    Linux(:aarch64, libc=:glibc),
+    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
+    Linux(:x86_64, libc=:musl),
+    Linux(:aarch64, libc=:musl),
+    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
+    MacOS(:x86_64),
+    FreeBSD(:x86_64),
+    Windows(:i686),
+    Windows(:x86_64)
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libgstcheck", :libgstcheck),
+    ExecutableProduct("gst-tester-1.0", :gst_tester),
+    LibraryProduct("libgstnet", :libgstnet),
+    LibraryProduct("libgstreamer", :libgstreamer),
+    ExecutableProduct("gst-launch-1.0", :gst_launch),
+    ExecutableProduct("gst-stats-1.0", :gst_stats),
+    ExecutableProduct("gst-typefind-1.0", :gst_typefind),
+    LibraryProduct("libgstcontroller", :libgstcontroller),
+    LibraryProduct("libgstbase", :libgstbase),
+    ExecutableProduct("gst-inspect-1.0", :gst_inspect)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="Glib_jll", uuid="7746bdde-850d-59dc-9ae8-88ece973131d"))
+    Dependency(PackageSpec(name="LibUnwind_jll", uuid="745a5e78-f969-53e9-954f-d19f2f74f4e3"))
+    Dependency(PackageSpec(name="Elfutils_jll", uuid="ab5a07f8-06af-567f-a878-e8bb879eba5a"))
+    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+    Dependency(PackageSpec(name="GSL_jll", uuid="1b77fbbe-d8ee-58f0-85f9-836ddc23a7a4"))
+    Dependency(PackageSpec(name="libcap_jll", uuid="eef66a8b-8d7a-5724-a8d2-7c31ae1e29ed"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
I'm not sure what's going on 32 bit musl and powerpc. The errors I'm getting are, respectively,

```
ninja: job failed: /opt/bin/i686-linux-musl-cc  -o tests/examples/streams/stream-status 'tests/examples/streams/45a1c43@@stream-status@exe/stream-status.c.o' -Wl,--as-needed -Wl,--no-undefined -Wl,-Bsymbolic-functions -Wl,--start-group gst/libgstreamer-1.0.so.0.1803.0 /workspace/destdir/lib/libglib-2.0.so /workspace/destdir/lib/libgobject-2.0.so -Wl,--export-dynamic /workspace/destdir/lib/libgmodule-2.0.so -pthread -lm -Wl,--end-group '-Wl,-rpath,$ORIGIN/../../../gst:/workspace/destdir/lib' -Wl,-rpath-link,/workspace/srcdir/gstreamer-1.18.3/build/gst -Wl,-rpath-link,/workspace/destdir/lib
/workspace/destdir/lib/libunwind.so.8: undefined reference to `setcontext'
collect2: error: ld returned 1 exit status
```

```
ninja: job failed: /opt/bin/powerpc64le-linux-gnu-cc  -o libs/gst/helpers/gst-ptp-helper 'libs/gst/helpers/3fa1036@@gst-ptp-helper@exe/gst-ptp-helper.c.o' -Wl,--as-needed -Wl,--no-undefined -Wl,-Bsymbolic-functions -Wl,-rpath-link,/workspace/destdir/lib64 -Wl,--start-group gst/libgstreamer-1.0.so.0.1803.0 -Wl,-rpath-link,/workspace/destdir/lib/../lib64 /workspace/destdir/lib/libgio-2.0.so /workspace/destdir/lib/libgobject-2.0.so /workspace/destdir/lib/libglib-2.0.so -Wl,-rpath-link,/workspace/destdir/lib/../lib64 -Wl,-rpath-link,/workspace/destdir/lib/../lib64 -lm -Wl,--export-dynamic /workspace/destdir/lib/libgmodule-2.0.so -pthread -L/workspace/destdir/ -lcap -Wl,--end-group '-Wl,-rpath,$ORIGIN/../../../gst:/workspace/destdir/lib' -Wl,-rpath-link,/workspace/srcdir/gstreamer-1.18.3/build/gst -Wl,-rpath-link,/workspace/destdir/lib
/opt/powerpc64le-linux-gnu/bin/../lib/gcc/powerpc64le-linux-gnu/4.8.5/../../../../powerpc64le-linux-gnu/bin/ld: cannot find -lcap
collect2: error: ld returned 1 exit status
```

Otherwise, I think this looks pretty good!