### PR TITLE
[UserNSSandbox] Add `--persist` option

### DIFF
--- a/U/UserNSSandbox/build_tarballs.jl
+++ b/U/UserNSSandbox/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "UserNSSandbox"
-version = v"2021.01.19"
+version = v"2021.03.04"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
With the `--persist` option, it is now possible to persist changes made
to the root fs between runs.  This is showcased in the new release of
`Sandbox.jl`, which allows much easier breakpointing and debugging of
build systems.