### PR TITLE
Initial setup for a Ghostscript package.

### DIFF
--- a/G/Ghostscript/build_tarballs.jl
+++ b/G/Ghostscript/build_tarballs.jl
@@ -1,0 +1,42 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Ghostscript"
+version = v"9.53.3"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9533/ghostscript-9.53.3.tar.gz", "6eaf422f26a81854a230b80fd18aaef7e8d94d661485bd2e97e695b9dce7bf7f")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd ghostscript-9.*/
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Linux(:i686, libc=:glibc),
+    Linux(:x86_64, libc=:glibc),
+    Linux(:i686, libc=:musl),
+    Linux(:x86_64, libc=:musl)
+]
+
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("gs", :gs)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This is the my first attempt at using BinaryBuilder. The wizard was used. Only these platforms worked:

```
platforms = [
    Linux(:i686, libc=:glibc),
    Linux(:x86_64, libc=:glibc),
    Linux(:i686, libc=:musl),
    Linux(:x86_64, libc=:musl)
]
```

All other platforms ended with the following error message:
![image](https://user-images.githubusercontent.com/705248/110073003-aee28780-7d4c-11eb-907d-8b857f4dbff5.png)

Any pointers on how to fix the cross compilation issues?