### PR TITLE
[BLIS]Include a Recent Upstream Fix + Switch BLAS Interface to ILP64

### DIFF
--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -31,26 +31,26 @@ case ${target} in
     *"x86_64"*"linux"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
-        export BLI_F77TYPE=64
+        export BLI_F77BITS=64
         ;;
     *"x86_64"*"w64"*) 
         # MinGW doesn't support savexmm instructions
         # Build only for AMD processors.
         export BLI_CONFIG=amd64
         export BLI_THREAD=openmp
-        export BLI_F77TYPE=64
+        export BLI_F77BITS=64
         ;;
     *"x86_64"*"apple"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
-        export BLI_F77TYPE=64
+        export BLI_F77BITS=64
         export CC=gcc
         export CXX=g++
         ;;
     *"x86_64"*"freebsd"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
-        export BLI_F77TYPE=64
+        export BLI_F77BITS=64
         export CC=gcc
         export CXX=g++
         ;;
@@ -59,30 +59,30 @@ case ${target} in
         # Use Cortex-A57 for the moment.
         export BLI_CONFIG=cortexa57
         export BLI_THREAD=openmp
-        export BLI_F77TYPE=64
+        export BLI_F77BITS=64
         ;;
     *"arm"*"linux"*) 
         export BLI_CONFIG=cortexa9
         export BLI_THREAD=none
         # Keep 32-bit BLAS interface for 32-bit processors.
-        export BLI_F77TYPE=32
+        export BLI_F77BITS=32
         ;;
     *)
         # Default (Generic) configuration without optimized kernel.
         export BLI_CONFIG=generic
         export BLI_THREAD=none
-        export BLI_F77TYPE=64
+        export BLI_F77BITS=64
         ;; 
 
 esac
 
 # For 64-bit builds, add _64 suffix to exported BLAS routines.
 # This corresponds to ILP64 handling of OpenBLAS thus Julia.
-if [ ${BLI_F77TYPE} = 64 ]; then
+if [ ${BLI_F77BITS} = 64 ]; then
     patch frame/include/bli_macro_defs.h < ${WORKSPACE}/srcdir/patches/bli_macro_defs.h.f77suffix64.patch
 fi
 
-./configure -p ${prefix} -t ${BLI_THREAD} -b ${BLI_F77TYPE} ${BLI_CONFIG}
+./configure -p ${prefix} -t ${BLI_THREAD} -b ${BLI_F77BITS} ${BLI_CONFIG}
 make -j${nproc}
 make install
 

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -7,7 +7,8 @@ version = v"0.8.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/flame/blis.git", "8a3066c315358d45d4f5b710c54594455f9e8fc6")
+    GitSource("https://github.com/flame/blis.git", "8a3066c315358d45d4f5b710c54594455f9e8fc6"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
@@ -74,6 +75,12 @@ case ${target} in
         ;; 
 
 esac
+
+# For 64-bit builds, add _64 suffix to exported BLAS routines.
+# This corresponds to ILP64 handling of OpenBLAS thus Julia.
+if [ ${BLI_F77TYPE} = 64 ]; then
+    patch frame/include/bli_macro_defs.h < ${WORKSPACE}/srcdir/patches/bli_macro_defs.h.f77suffix64.patch
+fi
 
 ./configure -p ${prefix} -t ${BLI_THREAD} -b ${BLI_F77TYPE} ${BLI_CONFIG}
 make -j${nproc}

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -79,6 +79,9 @@ export BLI_F77BITS=${nbits}
 make -j${nproc}
 make install
 
+# Static library is not needed.
+rm ${prefix}/lib/libblis.a
+
 # Rename .dll for Windows targets.
 if [[ "${target}" == *"x86_64"*"w64"* ]]; then
     mkdir -p ${prefix}/bin

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -31,26 +31,22 @@ case ${target} in
     *"x86_64"*"linux"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
-        export nbits=64
         ;;
     *"x86_64"*"w64"*) 
         # MinGW doesn't support savexmm instructions
         # Build only for AMD processors.
         export BLI_CONFIG=amd64
         export BLI_THREAD=openmp
-        export nbits=64
         ;;
     *"x86_64"*"apple"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
-        export nbits=64
         export CC=gcc
         export CXX=g++
         ;;
     *"x86_64"*"freebsd"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
-        export nbits=64
         export CC=gcc
         export CXX=g++
         ;;
@@ -59,19 +55,16 @@ case ${target} in
         # Use Cortex-A57 for the moment.
         export BLI_CONFIG=cortexa57
         export BLI_THREAD=openmp
-        export nbits=64
         ;;
     *"arm"*"linux"*) 
         export BLI_CONFIG=cortexa9
         export BLI_THREAD=none
         # Keep 32-bit BLAS interface for 32-bit processors.
-        export nbits=32
         ;;
     *)
         # Default (Generic) configuration without optimized kernel.
         export BLI_CONFIG=generic
         export BLI_THREAD=none
-        export nbits=64
         ;; 
 
 esac

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -30,22 +30,26 @@ case ${target} in
     *"x86_64"*"linux"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
+        export BLI_F77TYPE=64
         ;;
     *"x86_64"*"w64"*) 
         # MinGW doesn't support savexmm instructions
         # Build only for AMD processors.
         export BLI_CONFIG=amd64
         export BLI_THREAD=openmp
+        export BLI_F77TYPE=64
         ;;
     *"x86_64"*"apple"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
+        export BLI_F77TYPE=64
         export CC=gcc
         export CXX=g++
         ;;
     *"x86_64"*"freebsd"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
+        export BLI_F77TYPE=64
         export CC=gcc
         export CXX=g++
         ;;
@@ -54,17 +58,24 @@ case ${target} in
         # Use Cortex-A57 for the moment.
         export BLI_CONFIG=cortexa57
         export BLI_THREAD=openmp
+        export BLI_F77TYPE=64
         ;;
     *"arm"*"linux"*) 
         export BLI_CONFIG=cortexa9
         export BLI_THREAD=none
+        # Keep 32-bit BLAS interface for 32-bit processors.
+        export BLI_F77TYPE=32
         ;;
     *)
+        # Default (Generic) configuration without optimized kernel.
+        export BLI_CONFIG=generic
+        export BLI_THREAD=none
+        export BLI_F77TYPE=64
         ;; 
 
 esac
 
-./configure -p ${prefix} -t ${BLI_THREAD} ${BLI_CONFIG}
+./configure -p ${prefix} -t ${BLI_THREAD} -b ${BLI_F77TYPE} ${BLI_CONFIG}
 make -j${nproc}
 make install
 

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -84,8 +84,8 @@ rm ${prefix}/lib/libblis.a
 
 # Rename .dll for Windows targets.
 if [[ "${target}" == *"x86_64"*"w64"* ]]; then
-    mkdir -p ${prefix}/bin
-    mv ${prefix}/lib/libblis.3.dll ${prefix}/bin/libblis.dll
+    mkdir -p ${libdir}
+    mv ${prefix}/lib/libblis.3.dll ${libdir}/libblis.dll
 fi
 """
 

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -59,7 +59,6 @@ case ${target} in
     *"arm"*"linux"*) 
         export BLI_CONFIG=cortexa9
         export BLI_THREAD=none
-        # Keep 32-bit BLAS interface for 32-bit processors.
         ;;
     *)
         # Default (Generic) configuration without optimized kernel.

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -31,26 +31,26 @@ case ${target} in
     *"x86_64"*"linux"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
-        export BLI_F77BITS=64
+        export nbits=64
         ;;
     *"x86_64"*"w64"*) 
         # MinGW doesn't support savexmm instructions
         # Build only for AMD processors.
         export BLI_CONFIG=amd64
         export BLI_THREAD=openmp
-        export BLI_F77BITS=64
+        export nbits=64
         ;;
     *"x86_64"*"apple"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
-        export BLI_F77BITS=64
+        export nbits=64
         export CC=gcc
         export CXX=g++
         ;;
     *"x86_64"*"freebsd"*) 
         export BLI_CONFIG=x86_64
         export BLI_THREAD=openmp
-        export BLI_F77BITS=64
+        export nbits=64
         export CC=gcc
         export CXX=g++
         ;;
@@ -59,29 +59,30 @@ case ${target} in
         # Use Cortex-A57 for the moment.
         export BLI_CONFIG=cortexa57
         export BLI_THREAD=openmp
-        export BLI_F77BITS=64
+        export nbits=64
         ;;
     *"arm"*"linux"*) 
         export BLI_CONFIG=cortexa9
         export BLI_THREAD=none
         # Keep 32-bit BLAS interface for 32-bit processors.
-        export BLI_F77BITS=32
+        export nbits=32
         ;;
     *)
         # Default (Generic) configuration without optimized kernel.
         export BLI_CONFIG=generic
         export BLI_THREAD=none
-        export BLI_F77BITS=64
+        export nbits=64
         ;; 
 
 esac
 
 # For 64-bit builds, add _64 suffix to exported BLAS routines.
 # This corresponds to ILP64 handling of OpenBLAS thus Julia.
-if [ ${BLI_F77BITS} = 64 ]; then
+if [ ${nbits} = 64 ]; then
     patch frame/include/bli_macro_defs.h < ${WORKSPACE}/srcdir/patches/bli_macro_defs.h.f77suffix64.patch
 fi
 
+export BLI_F77BITS=${nbits}
 ./configure -p ${prefix} -t ${BLI_THREAD} -b ${BLI_F77BITS} ${BLI_CONFIG}
 make -j${nproc}
 make install

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"0.8.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/flame/blis.git", "9b387f6d5a010969727ec583c0cdd067a5274ed8")
+    GitSource("https://github.com/flame/blis.git", "8a3066c315358d45d4f5b710c54594455f9e8fc6")
 ]
 
 # Bash recipe for building across all platforms

--- a/B/blis/bundled/patches/bli_macro_defs.h.f77suffix64.patch
+++ b/B/blis/bundled/patches/bli_macro_defs.h.f77suffix64.patch
@@ -1,0 +1,4 @@
+160c160
+< #define PASTEF77(ch1,name)                     ch1        ## name ## _
+---
+> #define PASTEF77(ch1,name)                     ch1        ## name ## _64_


### PR DESCRIPTION
A recent upstream fix (flame/blis@8a3066c) addresses generic-stride problems (flame/blis#484) for configurations with gemmsup enabled.

Including this fix in our binary would address JuliaLinearAlgebra/BLIS.jl#1 and let the package pass all CI tests.