### PR TITLE
Add pandoc-crossref

### DIFF
--- a/P/pandoc_crossref/build_tarballs.jl
+++ b/P/pandoc_crossref/build_tarballs.jl
@@ -1,19 +1,18 @@
 using BinaryBuilder
 
 # Collection of pre-build pandoc binaries
-name = "pandoc-crossref"
+name = "pandoc_crossref"
 
 # Actually, this should be v"0.3.6.4".
 version = v"0.3.6"
 crossref_ver = "0.3.6.4"
 pandoc_ver = "2.9.2.1"
 
-url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v$crossref_ver/pandoc-crossref"
+url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v$(crossref_ver)/pandoc-crossref"
 sources = [
-    ArchiveSource("$url_prefix-Linux-$pandoc_ver.tar.xz", "57e8f71d46c401daf0a3247b7405b49503b836e93893730e6e5907f6cb2c0885"; unpack_target = "x86_64-linux-gnu"),
-    ArchiveSource("$url_prefix-macOS-$pandoc_ver.tar.xz", "b63ac830d7164279eb80041cd5f793e6b611ce1a701a86308ce5b2a3a99d33b2"; unpack_target = "x86_64-apple-darwin14"),
-    # Unknown archive format.
-    # ArchiveSource("$url_prefix-Windows-$pandoc_ver.7z", "3e943fcdd3f91951fe18f9900e136ccb9ea810b2582f4bd929760357eaf83ef4"; unpack_target = "x86_64-w64-mingw32"),
+    ArchiveSource("$(url_prefix)-Linux-$(pandoc_ver).tar.xz", "57e8f71d46c401daf0a3247b7405b49503b836e93893730e6e5907f6cb2c0885"; unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$(url_prefix)-macOS-$(pandoc_ver).tar.xz", "b63ac830d7164279eb80041cd5f793e6b611ce1a701a86308ce5b2a3a99d33b2"; unpack_target = "x86_64-apple-darwin14"),
+    FileSource("$(url_prefix)-Windows-$(pandoc_ver).7z", "3e943fcdd3f91951fe18f9900e136ccb9ea810b2582f4bd929760357eaf83ef4"; filename = "x86_64-w64-mingw32"),
     FileSource("https://raw.githubusercontent.com/lierdakil/pandoc-crossref/65858c01a76f75990e7e30bcdb571cd84a69d47c/LICENSE", "39db8f9acf036595a2566ea3fe560bc7bd65d8749f088e0f4a4ef2f8a6cb4b34"),
 ]
 
@@ -21,11 +20,12 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/
 mkdir -p "${bindir}"
-if [[ "${target}" != *-mingw* ]]; then
-    subdir="bin/"
+subdir="${target}"
+if [[ "${target}" == *-mingw* ]]; then
+    7z x "${target}"
+    subdir="windows-build"
 fi
-cp ${target}/pandoc-crossref/${subdir}pandoc-crossref${exeext} ${bindir}
-chmod +x ${bindir}/pandoc-crossref
+install -m 755 "${subdir}/pandoc-crossref${exeext}" "${bindir}/pandoc-crossref${exeext}"
 install_license LICENSE
 """
 
@@ -34,7 +34,7 @@ install_license LICENSE
 platforms = [
     Platform("x86_64", "linux"),
     Platform("x86_64", "macos"),
-    # Platform("x86_64", "windows"),
+    Platform("x86_64", "windows"),
 ]
 
 # The products that we will ensure are always built
@@ -43,7 +43,8 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
+dependencies = [
+    HostBuildDependency("p7zip_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/P/pandoc_crossref/build_tarballs.jl
+++ b/P/pandoc_crossref/build_tarballs.jl
@@ -6,12 +6,14 @@ name = "pandoc-crossref"
 # Actually, this should be v"0.3.6.4".
 version = v"0.3.6"
 crossref_ver = "0.3.6.4"
+pandoc_ver = "2.9.2.1"
 
-url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v0.3.6.4/pandoc-crossref-"
+url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v$crossref_ver/pandoc-crossref"
 sources = [
-    ArchiveSource("$url_prefix-Linux-$crossref_ver.tar.xz", "57e8f71d46c401daf0a3247b7405b49503b836e93893730e6e5907f6cb2c0885"; unpack_target = "x86_64-linux-gnu"),
-    ArchiveSource("$url_prefix-macOS-$crossref_ver.tar.xz", "b63ac830d7164279eb80041cd5f793e6b611ce1a701a86308ce5b2a3a99d33b2"; unpack_target = "x86_64-apple-darwin14"),
-    ArchiveSource("$url_prefix-Windows-$crossref_ver.tar.xz", "3e943fcdd3f91951fe18f9900e136ccb9ea810b2582f4bd929760357eaf83ef4"; unpack_target = "x86_64-w64-mingw32"),
+    ArchiveSource("$url_prefix-Linux-$pandoc_ver.tar.xz", "57e8f71d46c401daf0a3247b7405b49503b836e93893730e6e5907f6cb2c0885"; unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$url_prefix-macOS-$pandoc_ver.tar.xz", "b63ac830d7164279eb80041cd5f793e6b611ce1a701a86308ce5b2a3a99d33b2"; unpack_target = "x86_64-apple-darwin14"),
+    # Unknown archive format.
+    # ArchiveSource("$url_prefix-Windows-$pandoc_ver.7z", "3e943fcdd3f91951fe18f9900e136ccb9ea810b2582f4bd929760357eaf83ef4"; unpack_target = "x86_64-w64-mingw32"),
     FileSource("https://raw.githubusercontent.com/lierdakil/pandoc-crossref/65858c01a76f75990e7e30bcdb571cd84a69d47c/LICENSE", "39db8f9acf036595a2566ea3fe560bc7bd65d8749f088e0f4a4ef2f8a6cb4b34"),
 ]
 
@@ -32,7 +34,7 @@ install_license LICENSE
 platforms = [
     Platform("x86_64", "linux"),
     Platform("x86_64", "macos"),
-    Platform("x86_64", "windows"),
+    # Platform("x86_64", "windows"),
 ]
 
 # The products that we will ensure are always built

--- a/P/pandoc_crossref/build_tarballs.jl
+++ b/P/pandoc_crossref/build_tarballs.jl
@@ -1,0 +1,48 @@
+using BinaryBuilder
+
+# Collection of pre-build pandoc binaries
+name = "pandoc-crossref"
+
+# Actually, this should be v"0.3.6.4".
+version = v"0.3.6"
+crossref_ver = "0.3.6.4"
+
+url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v0.3.6.4/pandoc-crossref-"
+sources = [
+    ArchiveSource("$url_prefix-Linux-$crossref_ver.tar.xz", "57e8f71d46c401daf0a3247b7405b49503b836e93893730e6e5907f6cb2c0885"; unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$url_prefix-macOS-$crossref_ver.tar.xz", "b63ac830d7164279eb80041cd5f793e6b611ce1a701a86308ce5b2a3a99d33b2"; unpack_target = "x86_64-apple-darwin14"),
+    ArchiveSource("$url_prefix-Windows-$crossref_ver.tar.xz", "3e943fcdd3f91951fe18f9900e136ccb9ea810b2582f4bd929760357eaf83ef4"; unpack_target = "x86_64-w64-mingw32"),
+    FileSource("https://raw.githubusercontent.com/lierdakil/pandoc-crossref/65858c01a76f75990e7e30bcdb571cd84a69d47c/LICENSE", "39db8f9acf036595a2566ea3fe560bc7bd65d8749f088e0f4a4ef2f8a6cb4b34"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/
+mkdir -p "${bindir}"
+if [[ "${target}" != *-mingw* ]]; then
+    subdir="bin/"
+fi
+cp ${target}/pandoc-crossref/${subdir}pandoc-crossref${exeext} ${bindir}
+chmod +x ${bindir}/pandoc-crossref
+install_license LICENSE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
+]
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("pandoc-crossref", :pandoc_crossref),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
I would like to add `pandoc-crossref`. This version supports [Pandoc version 2.9](https://github.com/lierdakil/pandoc-crossref/releases/tag/v0.3.6.4), which is contained in [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil/blob/master/P/pandoc/build_tarballs.jl) at the moment.

After reading the documentation, I'm still unsure how to test the changes. Instead, I've used the Pandoc Yggdrasil script as a template. Some pointers on how I can improve the changes are welcome.

EDIT: I've got it working via the devcontainer. I am now fixing some issues in the file.