### PR TITLE
Update to latest BB, and test new compat field with Arb

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -28,7 +28,7 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilder]]
 deps = ["ArgParse", "BinaryBuilderBase", "Dates", "Downloads", "GitHub", "HTTP", "JLD2", "JSON", "LibGit2", "Libdl", "Logging", "LoggingExtras", "ObjectFile", "OutputCollectors", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Scratch", "Sockets", "UUIDs", "ghr_jll"]
-git-tree-sha1 = "0b7c92a7b8cfb5a251ffc001be4dcbe3de00997e"
+git-tree-sha1 = "ce0424c49f68f555d6181ca76f4a7a0026163202"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
@@ -36,7 +36,7 @@ version = "0.3.0"
 
 [[BinaryBuilderBase]]
 deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "4439b889da4d1131c014dcf94a9bd4b0a6564d06"
+git-tree-sha1 = "c3ceefb6a48993dd35514fac7f00f8e7b7addb2b"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"

--- a/A/Arb/build_tarballs.jl
+++ b/A/Arb/build_tarballs.jl
@@ -22,7 +22,7 @@ import Pkg.Types: VersionSpec
 # to all components.
 
 name = "Arb"
-version = v"200.1900.000"
+version = v"200.1900.001"
 upstream_version = v"2.19.0"
 
 # Collection of sources required to complete build
@@ -61,7 +61,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="FLINT_jll", version=VersionSpec("200.700"))),
+    Dependency(PackageSpec(name="FLINT_jll"), compat = "~200.700"),
     Dependency("GMP_jll", v"6.1.2"),
     Dependency("MPFR_jll", v"4.0.2"),
 ]


### PR DESCRIPTION
With https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1023 and https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/123 merged I'd like to use them (and thus also test them "in the field"). We have a bunch of packages that could use them, but I figure we should start with one and then see if it works (or if not, then the Manifest.toml change here can be reverted until we figure it out).

@giordano @staticfloat is that OK, or do you prefer another approach (which)?

CC @thofma @benlorenz 