### PR TITLE
[CompilerSupportLibraries] Don't eliminate `.so` symlinks

### DIFF
--- a/C/CompilerSupportLibraries/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/build_tarballs.jl
@@ -80,8 +80,8 @@ rm -f ${libdir}/*.a ${libdir}/*.py
 
 # Delete any `.so` files that are not ELF files, since they're mostly likely linker scripts
 for f in ${libdir}/*.so; do
-    if [[ "$(file -b "$f")" != ELF* ]]; then
-        rm -f "$f"
+    if [[ "$(file -b "$(realpath "$f")")" != ELF* ]]; then
+        rm -vf "$f"
     fi
 done
 


### PR DESCRIPTION
We want the symlinks such as `libatomic.so -> libatomic.so.1`.  This
symlink was being eliminated in the `rm` pass that was trying to drop
all linker scripts, but because the check (which was attempting to
determine whether a library is a proper `ELF` file or not) did not
dereference symlinks, it was rejecting all symlinks as non-`ELF` files.