### PR TITLE
[ECOS] copy include files

### DIFF
--- a/E/ECOS/build_tarballs.jl
+++ b/E/ECOS/build_tarballs.jl
@@ -15,6 +15,8 @@ make shared
 
 mkdir -p ${libdir}
 cp libecos.${dlext} ${libdir}
+mkdir -p ${prefix}/include
+cp -r include ${prefix}/include
 """
 
 # These are the platforms we will build for by default, unless further

--- a/E/ECOS/build_tarballs.jl
+++ b/E/ECOS/build_tarballs.jl
@@ -15,8 +15,7 @@ make shared
 
 mkdir -p ${libdir}
 cp libecos.${dlext} ${libdir}
-mkdir -p ${prefix}/include
-cp -r include ${prefix}/include
+cp -r include ${prefix}
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
ECOS_jll doesn't bundle the header files, which makes it difficult to automatically build a wrapper:
```Julia
julia> readdir(ECOS_jll.artifact_dir)
3-element Array{String,1}:
 "lib"
 "logs"
 "share"
```