### PR TITLE
[Qt] Remove static libraries from tarballs

### DIFF
--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -148,6 +148,15 @@ esac
 
 make -j${nproc}
 make install
+
+# Delete static libraries
+rm ${prefix}/lib/*.a
+
+if [[ "${target}" == *-mingw* ]]; then
+    # Make executables for Windows... executable
+    chmod 755 ${bindir}/*${exeext}
+fi
+
 install_license $WORKSPACE/srcdir/qt-everywhere-src-*/LICENSE.LGPLv3
 """
 


### PR DESCRIPTION
@barche any issues with removing static libraries from the tarballs?  Is it
possible some libraries want to static link Qt?  It'd save some space on disk.