### PR TITLE
[ImarisWriter] Add initial ImarisWriter build_tarballs.jl

### DIFF
--- a/I/ImarisWriter/build_tarballs.jl
+++ b/I/ImarisWriter/build_tarballs.jl
@@ -15,7 +15,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/ImarisWriter/
 mkdir build && cd build
 if [[ "${target}" == *-mingw* ]]; then
-    FLAGS = "-DHDF5_FALLBACK_LIBRARIES=${libdir}/libhdf5-0.dll"
+    FLAGS="-DHDF5_FALLBACK_LIBRARIES=${libdir}/libhdf5-0.dll"
 fi
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/I/ImarisWriter/build_tarballs.jl
+++ b/I/ImarisWriter/build_tarballs.jl
@@ -33,8 +33,7 @@ platforms = [
     Platform("i686", "windows"),
     Platform("x86_64", "windows"),
 ]
-# Too buggy at the moment
-# platforms = collect(Iterators.flatten(expand_cxxstring_abis.(platforms)))
+platforms = expand_cxxstring_abis(platforms)
 
 
 # The products that we will ensure are always built

--- a/I/ImarisWriter/build_tarballs.jl
+++ b/I/ImarisWriter/build_tarballs.jl
@@ -12,10 +12,17 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd ImarisWriter/
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DHDF5_FALLBACK_LIBRARIES=$prefix/bin/libhdf5-0.dll
-make
+cd $WORKSPACE/srcdir/ImarisWriter/
+mkdir build && cd build
+if [[ "${target}" == *-mingw* ]]; then
+    FLAGS = "-DHDF5_FALLBACK_LIBRARIES=${libdir}/libhdf5-0.dll"
+fi
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    "${FLAGS}" \
+    ..
+make -j${nproc}
 make install
 exit
 """

--- a/I/ImarisWriter/build_tarballs.jl
+++ b/I/ImarisWriter/build_tarballs.jl
@@ -33,7 +33,8 @@ platforms = [
     Windows(:i686),
     Windows(:x86_64)
 ]
-platforms = collect(Iterators.flatten(expand_cxxstring_abis.(platforms)))
+# Too buggy at the moment
+# platforms = collect(Iterators.flatten(expand_cxxstring_abis.(platforms)))
 
 
 # The products that we will ensure are always built

--- a/I/ImarisWriter/build_tarballs.jl
+++ b/I/ImarisWriter/build_tarballs.jl
@@ -28,10 +28,10 @@ exit
 # /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/local/include/H5public.h
 #
 platforms = [
-    Linux(:x86_64),
-    Linux(:aarch64, libc=:glibc),
-    Windows(:i686),
-    Windows(:x86_64)
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("i686", "windows"),
+    Platform("x86_64", "windows"),
 ]
 # Too buggy at the moment
 # platforms = collect(Iterators.flatten(expand_cxxstring_abis.(platforms)))
@@ -51,4 +51,3 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5.2.0")
-

--- a/I/ImarisWriter/build_tarballs.jl
+++ b/I/ImarisWriter/build_tarballs.jl
@@ -33,7 +33,7 @@ platforms = [
     Windows(:i686),
     Windows(:x86_64)
 ]
-platforms = expand_cxxstring_abis(platforms)
+platforms = expand_cxxstring_abis(platforms; skip=Sys.isbsd)
 
 
 # The products that we will ensure are always built

--- a/I/ImarisWriter/build_tarballs.jl
+++ b/I/ImarisWriter/build_tarballs.jl
@@ -28,7 +28,7 @@ exit
 # /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/local/include/H5public.h
 #
 platforms = [
-    Linux(:x86_64, libc=:glibc),
+    Linux(:x86_64),
     Linux(:aarch64, libc=:glibc),
     Windows(:i686),
     Windows(:x86_64)

--- a/I/ImarisWriter/build_tarballs.jl
+++ b/I/ImarisWriter/build_tarballs.jl
@@ -1,0 +1,53 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ImarisWriter"
+version = v"0.0.1"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/JaneliaSciComp/ImarisWriter.git", "da070d3fce8a1da4ca739c9e91054261d2df79a7")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd ImarisWriter/
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DHDF5_FALLBACK_LIBRARIES=$prefix/bin/libhdf5-0.dll
+make
+make install
+exit
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+#
+# Mac build fails due to lack of features.h. See H5_HAVE_FEATURES_H in
+# /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/local/include/H5pubconf.h
+# /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/local/include/H5public.h
+#
+platforms = [
+    Linux(:x86_64, libc=:glibc),
+    Linux(:aarch64, libc=:glibc),
+    Windows(:i686),
+    Windows(:x86_64)
+]
+platforms = expand_cxxstring_abis(platforms)
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libbpImarisWriter96", :libbpImarisWriter96)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="HDF5_jll", uuid="0234f1f7-429e-5d53-9886-15a909be8d59"))
+    Dependency(PackageSpec(name="Lz4_jll", uuid="5ced341a-0733-55b8-9ab6-a4889d929147"))
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5.2.0")
+

--- a/I/ImarisWriter/build_tarballs.jl
+++ b/I/ImarisWriter/build_tarballs.jl
@@ -33,7 +33,7 @@ platforms = [
     Windows(:i686),
     Windows(:x86_64)
 ]
-platforms = expand_cxxstring_abis(platforms; skip=Sys.isbsd)
+platforms = collect(Iterators.flatten(expand_cxxstring_abis.(platforms)))
 
 
 # The products that we will ensure are always built


### PR DESCRIPTION
ImarisWriter is a high performance file writer for microscopy images

Add ImarisWriter build_tarballs.jl with sources from https://github.com/JaneliaSciComp/ImarisWriter/tree/binarybuilder

The original source is from https://github.com/imaris/ImarisWriter under Apache License Version 2.0 by Imaris (fma Bitplane) of Oxford Instruments

This package depends on HDF5 and is thus limited by cross compilation issues there.

Mac build fails due to lack of features.h. See H5_HAVE_FEATURES_H in
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/local/include/H5pubconf.h
/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/local/include/H5public.h

CMake cannot locate libhdf5 on Windows which is located in `$prefix/bin/libhdf5-0.dll`. A custom CMake variable is provided as a fallback in order to locate that library.
