### PR TITLE
[Qt] Keep the static libraries

### DIFF
--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -149,8 +149,8 @@ esac
 make -j${nproc}
 make install
 
-# Delete static libraries
-rm ${prefix}/lib/*.a
+# Deleting static libraries is problematic: https://github.com/JuliaPackaging/Yggdrasil/pull/2713
+#rm ${prefix}/lib/*.a
 
 if [[ "${target}" == *-mingw* ]]; then
     # Make executables for Windows... executable


### PR DESCRIPTION
We need the Qt static libraries to build GR binaries. Refer to discussions in:

https://github.com/JuliaPackaging/Yggdrasil/pull/2713
https://github.com/JuliaPackaging/Yggdrasil/pull/2704