### PR TITLE
NodeJS_14

### DIFF
--- a/N/NodeJS/NodeJS_14/build_tarballs.jl
+++ b/N/NodeJS/NodeJS_14/build_tarballs.jl
@@ -38,14 +38,14 @@ install_license LICENSE
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Platform("x86_64", "linux"; libc="glibc"),
-    Platform("aarch64", "linux"; libc="glibc"),
-    Platform("powerpc64le", "linux"; libc="glibc"),
-    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc", cxxstring_abi="cxx11"),
+    Platform("aarch64", "linux"; libc="glibc", cxxstring_abi="cxx11"),
+    Platform("powerpc64le", "linux"; libc="glibc", cxxstring_abi="cxx11"),
+    Platform("armv7l", "linux"; libc="glibc", cxxstring_abi="cxx11"),
 
-    Platform("x86_64", "linux"; libc="musl"),
-    Platform("aarch64", "linux"; libc="musl"),
-    Platform("armv7l", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11"),
+    Platform("aarch64", "linux"; libc="musl", cxxstring_abi="cxx11"),
+    Platform("armv7l", "linux"; libc="musl", cxxstring_abi="cxx11"),
 
     Platform("x86_64", "macos"),
     Platform("aarch64", "macos"),

--- a/N/NodeJS/NodeJS_14/build_tarballs.jl
+++ b/N/NodeJS/NodeJS_14/build_tarballs.jl
@@ -15,6 +15,7 @@ sources = [
     ArchiveSource("$(url_prefix)-linux-armv7l.tar.gz", "54efe997dbeff971b1e39c8eb910566ecb68cfd6140a6b5c738265d4b5842d24"; unpack_target = "arm-linux-musleabihf"),
 
     ArchiveSource("$(url_prefix)-darwin-x64.tar.gz", "b762b72fc149629b7e394ea9b75a093cad709a9f2f71480942945d8da0fc1218"; unpack_target = "x86_64-apple-darwin14"),
+    ArchiveSource("$(url_prefix)-darwin-x64.tar.gz", "b762b72fc149629b7e394ea9b75a093cad709a9f2f71480942945d8da0fc1218"; unpack_target = "aarch64-apple-darwin20"),
 
     ArchiveSource("$(url_prefix)-win-x64.zip", "e469db37b4df74627842d809566c651042d86f0e6006688f0f5fe3532c6dfa41"; unpack_target = "x86_64-w64-mingw32"),
     ArchiveSource("$(url_prefix)-win-x86.zip", "cfb3535a172fb792a63814deffde405466902359bedfbd884188f6fc56f97d64"; unpack_target = "i686-w64-mingw32"),
@@ -61,8 +62,8 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/N/NodeJS/build_tarballs.jl
+++ b/N/NodeJS/build_tarballs.jl
@@ -9,6 +9,8 @@ sources = [
     ArchiveSource("$(url_prefix)-linux-arm64.tar.gz", "2b78771550f8a3e6e990d8e60e9ade82c7a9e2738b6222e92198bcd5ea857ea6"; unpack_target = "aarch64-linux-gnu"),
     ArchiveSource("$(url_prefix)-linux-ppc64le.tar.gz", "2339b4b1a8db39348cb1877b0cfdee3b2ef2b730f461ef7263610cbaaea5232a"; unpack_target = "powerpc64le-linux-gnu"),
     ArchiveSource("$(url_prefix)-darwin-x64.tar.gz", "14ec767e376d1e2e668f997065926c5c0086ec46516d1d45918af8ae05bd4583"; unpack_target = "x86_64-apple-darwin14"),
+]
+win_sources = [
     ArchiveSource("$(url_prefix)-win-x64.zip", "716045c2f16ea10ca97bd04cf2e5ef865f9c4d6d677a9bc25e2ea522b594af4f"; unpack_target = "x86_64-w64-mingw32"),
     ArchiveSource("$(url_prefix)-win-x86.zip", "9699067581e0d333b13158d4ebb27b6357444564548aaa220d821cdc6d840bd2"; unpack_target = "i686-w64-mingw32"),
 ]
@@ -17,12 +19,11 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/
 cp -r ${target}/*/* ${prefix}/.
+cd ${prefix}
 if [[ "${target}" == *-mingw* ]]; then
-    mkdir ${prefix}/bin
-    mv ${prefix}/node.exe ${prefix}/bin
-    chmod +x ${prefix}/bin/node.exe
+    chmod +x {node.exe,npm,npm.cmd,npx,npx.cmd}
 fi
-install_license ${prefix}/LICENSE
+install_license LICENSE
 """
 
 # These are the platforms we will build for by default, unless further
@@ -32,6 +33,8 @@ platforms = [
     Platform("aarch64", "linux"),
     Platform("powerpc64le", "linux"),
     Platform("x86_64", "macos"),
+]
+win_platforms =  [
     Platform("x86_64", "windows"),
     Platform("i686", "windows"),
 ]
@@ -39,11 +42,23 @@ platforms = [
 # The products that we will ensure are always built
 products = [
     ExecutableProduct("node", :node),
+    ExecutableProduct("npm", :npm),
+    ExecutableProduct("npx", :npx),
+]
+win_products = [
+    ExecutableProduct("node", :node, "."),
+    ExecutableProduct("npm", :npm, "."),
+    ExecutableProduct("npx", :npx, "."),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
 ]
 
+include("../../fancy_toys.jl")
+
 # Build the tarballs, and possibly a `build.jl` as well.
+if should_build_platform("x86_64-w64-mingw32") || should_build_platform("i686-w64-mingw32")
+    build_tarballs(ARGS, name, version, win_sources, script, win_platforms, win_products, dependencies)
+end
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/N/NodeJS/build_tarballs.jl
+++ b/N/NodeJS/build_tarballs.jl
@@ -18,7 +18,9 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/
 cp -r ${target}/*/* ${prefix}/.
 if [[ "${target}" == *-mingw* ]]; then
-    chmod +x ${prefix}/{node.exe,npm,npx}
+    mkdir ${prefix}/bin
+    mv ${prefix}/node.exe ${prefix}/bin
+    chmod +x ${prefix}/bin/node.exe
 fi
 install_license ${prefix}/LICENSE
 """

--- a/N/NodeJS/build_tarballs.jl
+++ b/N/NodeJS/build_tarballs.jl
@@ -1,0 +1,47 @@
+using BinaryBuilder
+
+name = "NodeJS"
+version = v"14.16.0"
+
+url_prefix = "https://nodejs.org/dist/v$version/node-v$version"
+sources = [
+    ArchiveSource("$(url_prefix)-linux-x64.tar.gz", "7212031d7468718d7c8f5e1766380daaabe09d54611675338e7a88a97c3e31b6"; unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$(url_prefix)-linux-arm64.tar.gz", "2b78771550f8a3e6e990d8e60e9ade82c7a9e2738b6222e92198bcd5ea857ea6"; unpack_target = "aarch64-linux-gnu"),
+    ArchiveSource("$(url_prefix)-linux-ppc64le.tar.gz", "2339b4b1a8db39348cb1877b0cfdee3b2ef2b730f461ef7263610cbaaea5232a"; unpack_target = "powerpc64le-linux-gnu"),
+    ArchiveSource("$(url_prefix)-darwin-x64.tar.gz", "14ec767e376d1e2e668f997065926c5c0086ec46516d1d45918af8ae05bd4583"; unpack_target = "x86_64-apple-darwin14"),
+    ArchiveSource("$(url_prefix)-win-x64.zip", "716045c2f16ea10ca97bd04cf2e5ef865f9c4d6d677a9bc25e2ea522b594af4f"; unpack_target = "x86_64-w64-mingw32"),
+    ArchiveSource("$(url_prefix)-win-x86.zip", "9699067581e0d333b13158d4ebb27b6357444564548aaa220d821cdc6d840bd2"; unpack_target = "i686-w64-mingw32"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/
+cp -r ${target}/*/* ${prefix}/.
+if [[ "${target}" == *-mingw* ]]; then
+    chmod +x ${prefix}/{node.exe,npm,npx}
+fi
+install_license ${prefix}/LICENSE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"),
+    Platform("aarch64", "linux"),
+    Platform("powerpc64le", "linux"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
+    Platform("i686", "windows"),
+]
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("node", :node),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/N/NodeJS/build_tarballs.jl
+++ b/N/NodeJS/build_tarballs.jl
@@ -9,8 +9,6 @@ sources = [
     ArchiveSource("$(url_prefix)-linux-arm64.tar.gz", "2b78771550f8a3e6e990d8e60e9ade82c7a9e2738b6222e92198bcd5ea857ea6"; unpack_target = "aarch64-linux-gnu"),
     ArchiveSource("$(url_prefix)-linux-ppc64le.tar.gz", "2339b4b1a8db39348cb1877b0cfdee3b2ef2b730f461ef7263610cbaaea5232a"; unpack_target = "powerpc64le-linux-gnu"),
     ArchiveSource("$(url_prefix)-darwin-x64.tar.gz", "14ec767e376d1e2e668f997065926c5c0086ec46516d1d45918af8ae05bd4583"; unpack_target = "x86_64-apple-darwin14"),
-]
-win_sources = [
     ArchiveSource("$(url_prefix)-win-x64.zip", "716045c2f16ea10ca97bd04cf2e5ef865f9c4d6d677a9bc25e2ea522b594af4f"; unpack_target = "x86_64-w64-mingw32"),
     ArchiveSource("$(url_prefix)-win-x86.zip", "9699067581e0d333b13158d4ebb27b6357444564548aaa220d821cdc6d840bd2"; unpack_target = "i686-w64-mingw32"),
 ]
@@ -21,7 +19,10 @@ cd ${WORKSPACE}/srcdir/
 cp -r ${target}/*/* ${prefix}/.
 cd ${prefix}
 if [[ "${target}" == *-mingw* ]]; then
+    mkdir bin
     chmod +x {node.exe,npm,npm.cmd,npx,npx.cmd}
+    mv {node.exe,npm,npm.cmd,npx,npx.cmd} bin
+    mv node_modules bin
 fi
 install_license LICENSE
 """
@@ -33,8 +34,6 @@ platforms = [
     Platform("aarch64", "linux"),
     Platform("powerpc64le", "linux"),
     Platform("x86_64", "macos"),
-]
-win_platforms =  [
     Platform("x86_64", "windows"),
     Platform("i686", "windows"),
 ]
@@ -42,23 +41,13 @@ win_platforms =  [
 # The products that we will ensure are always built
 products = [
     ExecutableProduct("node", :node),
-    ExecutableProduct("npm", :npm),
-    ExecutableProduct("npx", :npx),
-]
-win_products = [
-    ExecutableProduct("node", :node, "."),
-    ExecutableProduct("npm", :npm, "."),
-    ExecutableProduct("npx", :npx, "."),
+    FileProduct("bin/npm", :npm),
+    FileProduct("bin/npx", :npx),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
 ]
 
-include("../../fancy_toys.jl")
-
 # Build the tarballs, and possibly a `build.jl` as well.
-if should_build_platform("x86_64-w64-mingw32") || should_build_platform("i686-w64-mingw32")
-    build_tarballs(ARGS, name, version, win_sources, script, win_platforms, win_products, dependencies)
-end
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
First, I'm aware of `NodeJS.jl` 😄. I think it might predate Yggdrasil perhaps, hence why it wasn't just written up as a build script here? This is mostly just to reduce the maintenance burden on @davidanthoff, if you don't mind?

- Node version is bumped from `12.13.1` to the latest LTS `14.16.0`.
- `chmod +x` appears to be needed (like it was with [Kaleido](https://github.com/JuliaPackaging/Yggdrasil/pull/2699)) on Windows for Julia 1.6. I was getting `permission denied (EACCES)` when using `NodeJS.jl` on windows CIs.
- `ExecutableProduct("node", :node),` wasn't picking up the binary on Windows when I was trying this locally, perhaps it'll work on CI. Or is there something special I need to do to correctly pick up `.exe`s?