### PR TITLE
[SHOT] first pass at a builder

### DIFF
--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -17,7 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/SHOT
 git submodule update --init --recursive
 atomic_patch -p1 ../patches/0001-Fix-whole-archive-linker-options-for-macOS.patch
-
+atomic_patch -p1 ../patches/0002-cmake.patch
 if [[ "${target}" == *-darwin* ]]; then
     # Work around the issue
     #     /workspace/srcdir/SHOT/src/Model/../Model/Simplifications.h:1370:26: error: 'value' is unavailable: introduced in macOS 10.14
@@ -58,6 +58,7 @@ make install
 
 products = [
     ExecutableProduct("SHOT", :amplexe),
+    LibraryProduct("libSHOTSolver", :libshotsolver),
 ]
 
 dependencies = [

--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -1,0 +1,55 @@
+include("../coin-or-common.jl")
+
+name = "SHOT"
+version = v"1.0.1"
+
+sources = [
+    GitSource(
+        "https://github.com/coin-or/SHOT.git",
+        "d2c99ba451689bd4a80b5e170855b94f0d300b05",
+    ),
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir/SHOT
+git submodule update --init --recursive
+mkdir -p build
+cd build
+
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DHAS_CBC=on \
+    -DCBC_DIR=${prefix} \
+    -DHAS_IPOPT=on \
+    -DIPOPT_DIR=${prefix} \
+    -DHAS_AMPL=on \
+    -DGENERATE_EXE=on \
+    ..
+
+make
+make install
+"""
+
+products = [
+    ExecutableProduct("SHOT", :amplexe),
+]
+
+dependencies = [
+    Dependency("Cbc_jll", Cbc_version),
+    Dependency("Ipopt_jll", Ipopt_version),
+    Dependency("CompilerSupportLibraries_jll"),
+]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    preferred_gcc_version = v"8",
+)

--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -8,11 +8,13 @@ sources = [
         "https://github.com/coin-or/SHOT.git",
         "d2c99ba451689bd4a80b5e170855b94f0d300b05",
     ),
+    DirectorySource("./bundled"),
 ]
 
 script = raw"""
 cd $WORKSPACE/srcdir/SHOT
 git submodule update --init --recursive
+atomic_patch -p1 ../patches/0001-Fix-whole-archive-linker-options-for-macOS.patch
 mkdir -p build
 cd build
 

--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -26,7 +26,7 @@ if [[ "${target}" == *-darwin* ]]; then
     #     /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/optional:947:27: note: 'value' has been explicitly marked unavailable here
     #         constexpr value_type& value() &
     #                               ^
-    export CXXFLAGS="-mmacosx-version-min=10.14"
+    export CXXFLAGS="-mmacosx-version-min=10.15"
 fi
 
 if [[ ${target} == *mingw* ]]; then

--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -51,5 +51,6 @@ build_tarballs(
     platforms,
     products,
     dependencies;
-    preferred_gcc_version = v"8",
+    julia_compat = "1.6",
+    preferred_gcc_version = v"9",
 )

--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -50,6 +50,7 @@ products = [
 ]
 
 dependencies = [
+    Dependency("ASL_jll", ASL_version),
     Dependency("Cbc_jll", Cbc_version),
     Dependency("Ipopt_jll", Ipopt_version),
     Dependency("CompilerSupportLibraries_jll"),

--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -54,6 +54,8 @@ cmake \
 
 make -j${nproc}
 make install
+
+install_license ../LICENSE
 """
 
 products = [

--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -28,7 +28,7 @@ cmake \
     -DGENERATE_EXE=on \
     ..
 
-make
+make -j${nproc}
 make install
 """
 

--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -16,6 +16,17 @@ git submodule update --init --recursive
 mkdir -p build
 cd build
 
+if [[ "${target}" == *-darwin* ]]; then
+    # Work around the issue
+    #     /workspace/srcdir/SHOT/src/Model/../Model/Simplifications.h:1370:26: error: 'value' is unavailable: introduced in macOS 10.14
+    #                     optional.value()->coefficient *= -1.0;
+    #                              ^
+    #     /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/optional:947:27: note: 'value' has been explicitly marked unavailable here
+    #         constexpr value_type& value() &
+    #                               ^
+    export CXXFLAGS="-mmacosx-version-min=10.14"
+fi
+
 cmake \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/C/Coin-OR/SHOT/build_tarballs.jl
+++ b/C/Coin-OR/SHOT/build_tarballs.jl
@@ -29,6 +29,10 @@ if [[ "${target}" == *-darwin* ]]; then
     export CXXFLAGS="-mmacosx-version-min=10.14"
 fi
 
+if [[ ${target} == *mingw* ]]; then
+    export LDFLAGS="-L${libdir}"
+fi
+
 cmake \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/C/Coin-OR/SHOT/bundled/patches/0001-Fix-whole-archive-linker-options-for-macOS.patch
+++ b/C/Coin-OR/SHOT/bundled/patches/0001-Fix-whole-archive-linker-options-for-macOS.patch
@@ -1,0 +1,26 @@
+From c38fbc46798b0d6538107474f5b3c51de035ea4c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mos=C3=A8=20Giordano?= <mose@gnu.org>
+Date: Tue, 6 Jul 2021 00:31:00 +0100
+Subject: [PATCH 1/1] Fix whole-archive linker options for macOS
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5c32d62a..fa5f660b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -582,6 +582,9 @@ target_link_libraries(SHOTSolver SHOTTasks)
+ if(MSYS OR MINGW)
+     # MinGW cross compilation will not work if "-Wl,--whole-archive" is defined below
+     target_link_libraries(SHOTSolver SHOTModelingInterfaces)
++elseif(APPLE)
++    # need these whole-archive flags to ensure that EntryPointGAMS symbols will be present in library
++    target_link_libraries(SHOTSolver "-Wl,-all_load" SHOTModelingInterfaces)
+ else()
+     # need these whole-archive flags to ensure that EntryPointGAMS symbols will be present in library
+     target_link_libraries(SHOTSolver "-Wl,--whole-archive" SHOTModelingInterfaces "-Wl,--no-whole-archive")
+-- 
+2.26.3
+

--- a/C/Coin-OR/SHOT/bundled/patches/0002-cmake.patch
+++ b/C/Coin-OR/SHOT/bundled/patches/0002-cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5c32d62a..e5e2ac25 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -451,6 +451,8 @@ target_link_libraries(SHOTDualStrategy SHOTModel)
+ 
+ # Creates the tasks library
+ file(GLOB_RECURSE TASK_SOURCES "${PROJECT_SOURCE_DIR}/src/Tasks/*.cpp")
++list(REMOVE_ITEM TASK_SOURCES "${PROJECT_SOURCE_DIR}/src/Tasks/TaskBase.h")
++list(REMOVE_ITEM TASK_SOURCES "${PROJECT_SOURCE_DIR}/src/Tasks/TaskBase.cpp")
+ add_library(SHOTTasks STATIC ${TASK_SOURCES})
+ target_link_libraries(SHOTTasks SHOTPrimalStrategy)
+ target_link_libraries(SHOTTasks SHOTDualStrategy)


### PR DESCRIPTION
## Failures

- [x] `apple-darwin`
```
[05:31:30] /workspace/srcdir/SHOT/src/Model/../Model/Simplifications.h:1370:26: error: 'value' is unavailable: introduced in macOS 10.14
[05:31:30]                 optional.value()->coefficient *= -1.0;
[05:31:30]                          ^
[05:31:30] /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/optional:947:27: note: 'value' has been explicitly marked unavailable here
[05:31:30]     constexpr value_type& value() &
[05:31:30]                           ^
```

- [x] `mingw`
```
[05:43:58] CMake Error at misc/FindFilesystem.cmake:61 (message):
[05:43:58]   No C++ support for std::filesystem
[05:43:58] Call Stack (most recent call first):
[05:43:58]   CMakeLists.txt:23 (find_package)
```