### PR TITLE
[libpolymake_julia] update to 0.4.1, use compat (for julia 1.4)

### DIFF
--- a/L/libpolymake_julia/libpolymake_julia@1.4/build_tarballs.jl
+++ b/L/libpolymake_julia/libpolymake_julia@1.4/build_tarballs.jl
@@ -1,2 +1,3 @@
 const julia_version = v"1.4.2"
 include("../common.jl")
+


### PR DESCRIPTION
Tests with julia 1.3 (using #2745) seem fine, so lets continue.