### PR TITLE
Add a METIS4_jll

### DIFF
--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -1,6 +1,6 @@
 using BinaryBuilder, Pkg
 
-name = "METIS"
+name = "METIS4"
 version = v"4.0.3"
 
 # Collection of sources required to build METIS


### PR DESCRIPTION
@giordano @dpo @ViralBShah 

`HSL.jl` is the only Julia package to my knowledge that uses explicitly `METIS_jll` v4.0.3 in its `Project.toml`. Because `MA57` and `MA97` are not open source, we cannot build the libraries with Yggdrasil and use `METIS_jll` v4.0.3 as build dependency like it's done with the CoinOR `jll`. Therefore, `HSL.jl` is incompatible with other packages that require `METIS_jll` v5.1.0. `METIS_jll` v4.0.3 only contains static library whereas `METIS_jll` v5.1.0 contains dynamic one.

Related discussions :
- https://github.com/JuliaPackaging/Yggdrasil/pull/836
- https://github.com/JuliaPackaging/Yggdrasil/pull/530