### PR TITLE
[libsodium] Build for experimental platforms

### DIFF
--- a/L/libsodium/build_tarballs.jl
+++ b/L/libsodium/build_tarballs.jl
@@ -6,7 +6,7 @@ name = "libsodium"
 # Note: upstream stopped giving version numbers to new releases.  "Releases" are
 # commits to the "stable" branch.  Here we just invent new versions numbers
 # because we need having different versions.
-version = v"1.0.19"
+version = v"1.0.20"
 
 # Collection of sources required to complete build
 sources = [
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [
@@ -37,4 +37,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.6")


### PR DESCRIPTION
This tries to copy #2732 for another library. 

This one, because running `julia build_tarballs.jl --help` on an ARM mac gives failures in BinaryBuilder > GitHub > SodiumSeal > libsodium. And because its version numbers aren't tied to those of the upstream source. 

See if this works?