### PR TITLE
[ASL] bump and export .hd files

### DIFF
--- a/A/ASL/build_tarballs.jl
+++ b/A/ASL/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "ASL"
-version = v"0.1.1"
+version = v"0.1.2"
 
 # Collection of sources required to build ThinASLBuilder
 sources = [
     ArchiveSource("http://netlib.org/ampl/solvers.tgz",
-                  "775b92cadaf95af73fdeec3effba6b9c6ffdc518e5f628b575140fb170885903"),
+                  "65bb7dc72ce072bd4fa49578164a8430c03b458969cd4abe5ff6d8e9c09ad2dc"),
     DirectorySource("./bundled")
 ]
 
@@ -16,9 +16,8 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/solvers/
 head -17 asl.h > LICENSE.txt
+mkdir -p ${includedir}
 mkdir -p ${libdir}
-incdir=${prefix}/include
-mkdir -p ${incdir}
 
 all_load="--whole-archive"
 noall_load="--no-whole-archive"
@@ -47,8 +46,9 @@ fi
 
 make -f $makefile CC="$CC" CFLAGS="-O -fPIC $cflags"
 c++ -fPIC -shared -I$WORKSPACE/srcdir/asl-extra -I. $WORKSPACE/srcdir/asl-extra/aslinterface.cc -Wl,${all_load} amplsolver.a -Wl,${noall_load} -o libasl.${dlext}
-mv libasl.${dlext} ${libdir}
-cp *.h ${incdir}
+cp libasl.${dlext} ${libdir}
+cp *.h ${includedir}
+cp *.hd ${includedir}
 install_license LICENSE.txt
 """
 


### PR DESCRIPTION
I started to build Couenne, but it needed some `.hd` files like `opcodes.hd`.

@dpo is there a reason not to use https://github.com/ampl/asl? The archive from Netlib is semi-regularly updated, so it isn't reproducible.