### PR TITLE
[libcxxwrap-julia] Update for Julia 1.6

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-julia_version = v"1.5.3"
+julia_version = v"1.6.0"
 
 name = "libcxxwrap_julia"
-version = v"0.8.5"
+version = v"0.8.6"
 
 is_yggdrasil = haskey(ENV, "BUILD_BUILDNUMBER")
 git_repo = is_yggdrasil ? "https://github.com/JuliaInterop/libcxxwrap-julia.git" : joinpath(ENV["HOME"], "src/julia/libcxxwrap-julia/")
@@ -13,7 +13,7 @@ unpack_target = is_yggdrasil ? "" : "libcxxwrap-julia"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource(git_repo, "2bba0c81ea00d58d3321540a0526098aa9eb3c8b", unpack_target=unpack_target),
+    GitSource(git_repo, "15d30a1d5952ebacc6bb16a297a236b8be63b763", unpack_target=unpack_target),
 ]
 
 # Bash recipe for building across all platforms
@@ -51,4 +51,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    preferred_gcc_version = v"8", julia_compat = "^$(julia_version.major).$(julia_version.minor)")
+    preferred_gcc_version = v"9", julia_compat = "^$(julia_version.major).$(julia_version.minor)")


### PR DESCRIPTION
New build based on Julia 1.6 (requires PR #1987 first). This also removes a call to `jlbacktrace`, which is not exported anymore in Julia 1.6 and therefore fails on Windows.