### PR TITLE
[libcgal-julia] Update libcgal_julia for Julia 1.6

### DIFF
--- a/L/libcgal_julia/common.jl
+++ b/L/libcgal_julia/common.jl
@@ -69,11 +69,11 @@ dependencies = [
     BuildDependency(PackageSpec(name="GMP_jll", version=v"6.1.2")),
     BuildDependency(PackageSpec(name="MPFR_jll", version=v"4.0.2")),
 
-    Dependency(PackageSpec(name="CGAL_jll", version="5.2")),
+    Dependency("CGAL_jll", compat="5.2"),
     Dependency("libcxxwrap_julia_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version=v"8",
+               preferred_gcc_version=v"9",
                julia_compat = "$(julia_version.major).$(julia_version.minor)")

--- a/L/libcgal_julia/libcgal_julia@1.6/build_tarballs.jl
+++ b/L/libcgal_julia/libcgal_julia@1.6/build_tarballs.jl
@@ -1,0 +1,2 @@
+julia_version = v"1.6.0"
+include("../common.jl")


### PR DESCRIPTION
Since the preferred gcc version was bumped in libcxxwrap-julia, I
thought I'd bump it here too going forward.  One thought came to mind of
externalizing the version away much like the julia version is as well,
if it makes sense, but that could be for a later date.