### PR TITLE
build Libtask for Julia 1.5.4

### DIFF
--- a/L/Libtask/build_tarballs.jl
+++ b/L/Libtask/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-julia_version = v"1.6.0"
+julia_version = v"1.5.4"
 
 name = "Libtask"
-version = v"0.4.3"
+version = v"0.4.4"
 
 # Collection of sources required to build Libtask
 sources = [


### PR DESCRIPTION
As discussed at https://github.com/TuringLang/Turing.jl/pull/1568#issuecomment-815368746, the memory layout of `struct jl_task_t` changed in v1.5.4, so we should build a new version for this version.