### PR TITLE
[RootFS] Include gofmt in Go compiler shard

### DIFF
--- a/0_RootFS/Go/build_tarballs.jl
+++ b/0_RootFS/Go/build_tarballs.jl
@@ -29,6 +29,7 @@ dependencies = []
 # The products that we will ensure are always built
 products = [
     ExecutableProduct("go", :go, "go/bin"),
+    ExecutableProduct("gofmt", :gofmt, "go/bin"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Minor follow up to https://github.com/JuliaPackaging/Yggdrasil/pull/2781.

After getting farther in compiling Kubernetes from source I discovered that part of the build process expected `gofmt` to be present. It is strange that a build process would require this but it's harmless to add.