### PR TITLE
Always pass --build with --host to configure

### DIFF
--- a/A/Attr/build_tarballs.jl
+++ b/A/Attr/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/attr-*/
-./configure --prefix=${prefix} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/A/adwaita_icon_theme/build_tarballs.jl
+++ b/A/adwaita_icon_theme/build_tarballs.jl
@@ -17,8 +17,8 @@ cd $WORKSPACE/srcdir/adwaita-icon-theme-*/
 
 # Install native gtk+3.0 so that we get `gtk-encode-symbolic-svg`
 apk add gtk+3.0 librsvg
-./autogen.sh --prefix=$prefix --host=$target
-./configure --prefix=$prefix --host=$target
+./autogen.sh --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/A/argp_standalone/build_tarballs.jl
+++ b/A/argp_standalone/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/argp-*/
-CFLAGS="-fPIC" ./configure --prefix=${prefix} --host=${target}
+CFLAGS="-fPIC" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 install_license $WORKSPACE/srcdir/LICENSE
 install -D -m644 argp.h ${includedir}/argp.h

--- a/C/CFITSIO/build_tarballs.jl
+++ b/C/CFITSIO/build_tarballs.jl
@@ -24,7 +24,7 @@ if [[ "${target}" == *-mingw* ]]; then
     # renames `TBYTE` to `_TBYTE`.
     atomic_patch -p1 ../patches/tbyte.patch
 fi
-./configure --prefix=$prefix --host=$target --enable-reentrant
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-reentrant
 make -j${nproc} shared
 make install
 # Delete the static library

--- a/C/Cairo/build_tarballs.jl
+++ b/C/Cairo/build_tarballs.jl
@@ -24,7 +24,7 @@ elif [[ "${target}" == *-linux-* ]] || [[ "${target}" == *freebsd* ]]; then
     BACKEND_OPTIONS="--enable-xlib --enable-xcb --enable-xlib-xcb"
 fi
 
-./configure --prefix=${prefix} --host=${target} \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --disable-static \
     --enable-ft \
     --enable-tee \

--- a/C/Cuba/build_tarballs.jl
+++ b/C/Cuba/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/cuba/
 
-./configure --prefix=${prefix} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make shared
 make install
 rm "${prefix}/lib/libcuba.a" "${prefix}/share/cuba.pdf"

--- a/C/capnproto/build_tarballs.jl
+++ b/C/capnproto/build_tarballs.jl
@@ -28,7 +28,7 @@ atomic_patch -p2 ${WORKSPACE}/srcdir/patches/aligned-alloc.patch
     make -j${nproc}
 )
 export CAPNP=build_native/capnp
-./configure --prefix=$prefix --host=$target --with-external-capnp
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-external-capnp
 make -j${nproc}
 make install
 if [[ "${target}" == *-mingw* ]]; then

--- a/C/cddlib/build_tarballs.jl
+++ b/C/cddlib/build_tarballs.jl
@@ -16,7 +16,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/*
 sed -i '/^libcddgmp_la_LDFLAGS/ s/$/  $(CDD_LDFLAGS)/' lib-src/Makefile.gmp.am
 ./bootstrap # needed because we are building a commit and not a release
-CPPFLAGS=-I${prefix}/include ./configure --prefix=${prefix} --host=${target}
+CPPFLAGS=-I${prefix}/include ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 cd lib-src # Call make in the lib-src subfolder to avoid building the doc folder since pdflatex is not installed
 make -j${nproc}
 make install

--- a/C/czmq/build_tarballs.jl
+++ b/C/czmq/build_tarballs.jl
@@ -26,6 +26,7 @@ fi
 atomic_patch -p1 ../patches/ntohll.patch
 
 ./configure --prefix=$prefix \
+    --build=${MACHTYPE} \
     --host=${target} \
     --enable-drafts \
     --disable-static \

--- a/D/Dbus/build_tarballs.jl
+++ b/D/Dbus/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/dbus-*
-./configure --prefix=${prefix} --host=${target} \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-xml=expat \
     --with-dbus-user=messagebus \
     --with-system-pid-file=/var/run/dbus.pid \

--- a/E/Elfutils/build_tarballs.jl
+++ b/E/Elfutils/build_tarballs.jl
@@ -33,6 +33,7 @@ export CC=gcc
 export CXX=g++
 CFLAGS="-Wno-error=unused-result" CPPFLAGS="-I${prefix}/include" ./configure \
     --prefix=${prefix} \
+    --build=${MACHTYPE} \
     --host=${target} \
     --disable-debuginfod
 make -j${nproc}

--- a/E/Expat/build_tarballs.jl
+++ b/E/Expat/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/expat-*/
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/F/FFTW/build_tarballs.jl
+++ b/F/FFTW/build_tarballs.jl
@@ -16,6 +16,7 @@ cd $WORKSPACE/srcdir/fftw*
 # Base configure flags
 FLAGS=(
     --prefix="$prefix"
+    --build=${MACHTYPE}
     --host="${target}"
     --enable-shared
     --disable-static

--- a/F/FreeType2/build_tarballs.jl
+++ b/F/FreeType2/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/freetype-*/
-./configure --prefix=${prefix} --host=${target} --enable-shared --disable-static
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-shared --disable-static
 make -j${nproc}
 make install
 """

--- a/F/flux_core/build_tarballs.jl
+++ b/F/flux_core/build_tarballs.jl
@@ -34,7 +34,7 @@ export LUA_LIB=-llua
 
 export PYTHON=python3
 
-./configure --prefix=$prefix --host=${target} --without-python
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --without-python
 
 make -j${nproc}
 make install

--- a/F/fts/build_tarballs.jl
+++ b/F/fts/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/musl-fts-*/
 ./bootstrap.sh
-CFLAGS="-fPIC" ./configure --prefix=${prefix} --host=${target}
+CFLAGS="-fPIC" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/G/GDAL/common.jl
+++ b/G/GDAL/common.jl
@@ -53,7 +53,7 @@ function configure(version_offset, min_julia_version, proj_jll_version)
     rm -f ${prefix}/lib/*.la
 
     ./configure --help
-    ./configure --prefix=$prefix --host=$target \
+    ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
         --with-geos=${bindir}/geos-config \
         --with-proj=$prefix \
         --with-tiff=$prefix \

--- a/G/GSL/GSL@1/build_tarballs.jl
+++ b/G/GSL/GSL@1/build_tarballs.jl
@@ -22,7 +22,7 @@ if [[ "${target}" == powerpc64le-* ]]; then
     autoreconf -vi
 fi
 
-./configure --prefix=$prefix --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/G/Gettext/build_tarballs.jl
+++ b/G/Gettext/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/gettext-*/
 export CFLAGS="-O2"
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/G/Giflib/build_tarballs.jl
+++ b/G/Giflib/build_tarballs.jl
@@ -27,7 +27,7 @@ if [[ "${target}" == powerpc64le-* ]]; then
 fi
 
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 install_license COPYING

--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -40,7 +40,7 @@ elif [[ ${target} == *-freebsd* ]]; then
     LDFLAGS="-L${prefix}/lib -lcharset"
 fi
 
-./configure --prefix=$prefix --host=$target \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-curl \
     --with-expat \
     --with-openssl \

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -37,7 +37,7 @@ if [[ "${target}" == i686-linux-musl ]]; then
     sed -i 's/cross_compiling=no/cross_compiling=yes/' configure
 fi
 
-./configure --cache-file=glib.cache --with-libiconv=gnu --prefix=${prefix} --host=${target}
+./configure --cache-file=glib.cache --with-libiconv=gnu --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 find -name Makefile -exec sed -i 's?/workspace/destdir/bin/msgfmt?/usr/bin/msgfmt?g' '{}' \;
 
 make -j${nproc}

--- a/G/Glibc/build_tarballs.jl
+++ b/G/Glibc/build_tarballs.jl
@@ -23,6 +23,7 @@ atomic_patch -p1 $WORKSPACE/srcdir/patches/glibc_sunrpc_uchar.patch
 mkdir -p $WORKSPACE/srcdir/glibc_build
 cd $WORKSPACE/srcdir/glibc_build
 $WORKSPACE/srcdir/glibc-*/configure --prefix=/usr \
+	--build=${MACHTYPE} \
 	--host=${target} \
 	--disable-multilib \
 	--disable-werror

--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -18,7 +18,7 @@ cd $WORKSPACE/srcdir/gnutls-*/
 #    export AR=/opt/${target}/bin/ar
 #fi
 
-GMP_CFLAGS="-I${prefix}/include" ./configure --prefix=${prefix} --host=${target} \
+GMP_CFLAGS="-I${prefix}/include" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-included-libtasn1 \
     --with-included-unistring \
     --without-p11-kit 

--- a/H/HarfBuzz/build_tarballs.jl
+++ b/H/HarfBuzz/build_tarballs.jl
@@ -17,7 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/harfbuzz-*/
 atomic_patch -p1 ../patches/Remove-HB_ICU_STMT.patch
 autoreconf -i -f
-./configure --prefix=$prefix --host=$target \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-gobject=yes \
     --with-graphite2=yes \
     --with-glib=yes \

--- a/H/Help2man/build_tarballs.jl
+++ b/H/Help2man/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/help2man*/
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/H/Hwloc/build_tarballs.jl
+++ b/H/Hwloc/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/hwloc-*
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/H/hicolor_icon_theme/build_tarballs.jl
+++ b/H/hicolor_icon_theme/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/hicolor-icon-theme-*/
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make install
 """
 

--- a/I/ImageMagick/build_tarballs.jl
+++ b/I/ImageMagick/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/ImageMagick6*/
-./configure --prefix=$prefix --host=$target --without-x --disable-openmp --disable-installed --disable-dependency-tracking --without-frozenpaths --without-perl --disable-docs --disable-static
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --without-x --disable-openmp --disable-installed --disable-dependency-tracking --without-frozenpaths --without-perl --disable-docs --disable-static
 make -j${nproc}
 make install
 """

--- a/I/Ipopt/build_tarballs.jl
+++ b/I/Ipopt/build_tarballs.jl
@@ -28,6 +28,7 @@ fi
             --with-mumps-lflags="-L${libdir} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord" \
             --with-asl-cflags="-I${prefix}/include" \
             --with-asl-lflags="${LIBASL[*]}" \
+            --build=${MACHTYPE} \
             --host=${target}
 
 # parallel build fails

--- a/I/IpoptMKL/build_tarballs.jl
+++ b/I/IpoptMKL/build_tarballs.jl
@@ -31,6 +31,7 @@ fi
             --with-lapack="${libmkl[*]}" \
             --with-asl-cflags="-I${prefix}/include" \
             --with-asl-lflags="${LIBASL[*]}" \
+            --build=${MACHTYPE} \
             --host=${target}
 
 # parallel build fails

--- a/I/iso_codes/build_tarballs.jl
+++ b/I/iso_codes/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/iso-codes-*/
 apk add gettext
-./configure --prefix=${prefix} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/L/LAME/build_tarballs.jl
+++ b/L/LAME/build_tarballs.jl
@@ -19,7 +19,7 @@ apk add nasm
 if [[ $(uname -m) == i?86 ]]; then
     sed -i -e 's/<xmmintrin.h/&.nouse/' configure
 fi
-./configure --prefix=$prefix --host=$target --disable-static
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
 make -j${nproc}
 make install
 """

--- a/L/LZO/build_tarballs.jl
+++ b/L/LZO/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/lzo-*/
-./configure --prefix=$prefix --host=$target --enable-shared --disable-static
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-shared --disable-static
 make -j${nproc}
 make install
 """

--- a/L/Leptonica/build_tarballs.jl
+++ b/L/Leptonica/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/leptonica-*/
 export CPPFLAGS="-I$prefix/include"
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 install_license leptonica-license.txt

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -34,7 +34,7 @@ if [[ "${target}" == i686-linux-musl ]]; then
     # other tests.
     sed -i 's/cross_compiling=no/cross_compiling=yes/' configure
 fi
-./configure --prefix=$prefix --host=$target --with-includes=$prefix/include --with-libraries=$prefix/lib --without-readline --without-zlib --with-openssl
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-includes=$prefix/include --with-libraries=$prefix/lib --without-readline --without-zlib --with-openssl
 make -C src/interfaces/libpq install
 install_license COPYRIGHT
 """

--- a/L/LibUV/build_tarballs.jl
+++ b/L/LibUV/build_tarballs.jl
@@ -20,7 +20,7 @@ touch -c configure
 
 # `--with-pic` isn't enough; we really really need -fPIC and -DPIC everywhere...
 # everywhere, especially on FreeBSD
-./configure --prefix=$prefix --host=$target --with-pic CFLAGS="${CFLAGS} -DPIC -fPIC" CXXFLAGS="${CXXFLAGS} -DPIC -fPIC"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-pic CFLAGS="${CFLAGS} -DPIC -fPIC" CXXFLAGS="${CXXFLAGS} -DPIC -fPIC"
 make -j${nproc} V=1
 make install
 """

--- a/L/LibUnwind/build_tarballs.jl
+++ b/L/LibUnwind/build_tarballs.jl
@@ -27,7 +27,7 @@ atomic_patch -p0 ${WORKSPACE}/srcdir/patches/libunwind-configure-static-lzma.pat
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/libunwind-cfa-rsp.patch
 
 CFLAGS="${CFLAGS} -DPI -fPIC -I${prefix}/include"
-./configure --prefix=$prefix --host=$target CFLAGS="${CFLAGS}" --libdir=${libdir} --enable-minidebuginfo --disable-tests
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} CFLAGS="${CFLAGS}" --libdir=${libdir} --enable-minidebuginfo --disable-tests
 make -j${nproc}
 make install
 

--- a/L/Libcap_Ng/build_tarballs.jl
+++ b/L/Libcap_Ng/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libcap-ng-*/
-./configure --prefix=${prefix} --host=${target} \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --enable-static=no \
     -with-python=no \
     CFLAGS="${CFLAGS} -pthread"

--- a/L/Libcroco/build_tarballs.jl
+++ b/L/Libcroco/build_tarballs.jl
@@ -21,7 +21,7 @@ if [[ "${target}" == *-apple-* ]]; then
     FLAGS+=(--disable-Bsymbolic)
 fi
 
-./configure --prefix=$prefix --host=$target --disable-gtk-doc "${FLAGS[@]}"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-gtk-doc "${FLAGS[@]}"
 make -j${nproc}
 make install
 """

--- a/L/Libffi/build_tarballs.jl
+++ b/L/Libffi/build_tarballs.jl
@@ -15,7 +15,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/libffi-*/
 update_configure_scripts
 autoreconf -f -i
-./configure --prefix=$prefix --host=$target --disable-static --enable-shared
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static --enable-shared
 make -j${nproc}
 make install
 """

--- a/L/Libgcrypt/build_tarballs.jl
+++ b/L/Libgcrypt/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libgcrypt-*/
-./configure --prefix=${prefix} --host=${target} \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --disable-padlock-support \
     --disable-asm
 make -j${nproc}

--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -19,7 +19,7 @@ FLAGS=()
 if [[ "${target}" == *musl* ]]; then
     FLAGS=(--disable-tls)
 fi
-./configure --prefix=${prefix} --host=${target} "${FLAGS[@]}"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} "${FLAGS[@]}"
 make -j${nproc}
 make install
 # The license is embedded in the README file

--- a/L/Libiconv/build_tarballs.jl
+++ b/L/Libiconv/build_tarballs.jl
@@ -11,7 +11,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libiconv-*/
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/L/Libmount/build_tarballs.jl
+++ b/L/Libmount/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/util-linux-*/
-./configure --prefix=$prefix --host=$target --disable-all-programs --enable-libblkid --enable-libmount
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-all-programs --enable-libblkid --enable-libmount
 make -j${nproc}
 make install
 """

--- a/L/Librsvg/build_tarballs.jl
+++ b/L/Librsvg/build_tarballs.jl
@@ -35,7 +35,7 @@ fi
 sed -i.bak -e 's&cssparser = "0.23"&cssparser = "0.25"&' rust/Cargo.toml
 (cd rust && cargo vendor)
 
-LDFLAGS="-L${prefix}/lib -L${prefix}/lib64 -Wl,-rpath,${prefix}/lib -Wl,-rpath,${prefix}/lib64" ./configure --prefix=$prefix --host=$target \
+LDFLAGS="-L${prefix}/lib -L${prefix}/lib64 -Wl,-rpath,${prefix}/lib -Wl,-rpath,${prefix}/lib64" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --disable-static \
     --enable-pixbuf-loader \
     --disable-introspection \

--- a/L/Libtiff/build_tarballs.jl
+++ b/L/Libtiff/build_tarballs.jl
@@ -16,7 +16,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/tiff-*/
 export CPPFLAGS="-I${prefix}/include"
 
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/L/Libuuid/build_tarballs.jl
+++ b/L/Libuuid/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/util-linux-*/
-./configure --prefix=$prefix --host=$target --disable-all-programs --enable-libuuid
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-all-programs --enable-libuuid
 make -j${nproc}
 make install
 """

--- a/L/LoopTools/build_tarballs.jl
+++ b/L/LoopTools/build_tarballs.jl
@@ -17,7 +17,7 @@ cd ${WORKSPACE}/srcdir/LoopTools-*
 atomic_patch -p1 ../patches/simplify-configure.patch
 export AR=ar
 export RANLIB=ranlib
-./configure --prefix=$prefix --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install EXE="${exeext}"
 # Now let's build the shared library

--- a/L/libass/build_tarballs.jl
+++ b/L/libass/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/libass-*
 apk add nasm
-./configure --prefix=$prefix --host=$target --disable-require-system-font-provider --disable-static
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-require-system-font-provider --disable-static
 make -j${nproc}
 make install
 """

--- a/L/libfdk_aac/build_tarballs.jl
+++ b/L/libfdk_aac/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/fdk-aac-*
-./configure --prefix=$prefix --host=$target --disable-static
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
 make -j${nproc}
 make install
 install_license NOTICE

--- a/L/libmodplug/build_tarballs.jl
+++ b/L/libmodplug/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libmodplug-*/
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/L/libsndfile/build_tarballs.jl
+++ b/L/libsndfile/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libsndfile-*/
-CFLAGS="-I${prefix}/include" ./configure --prefix=$prefix --host=$target --disable-static
+CFLAGS="-I${prefix}/include" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
 make -j${nproc}
 make install
 """

--- a/L/libwebp/build_tarballs.jl
+++ b/L/libwebp/build_tarballs.jl
@@ -19,7 +19,7 @@ export CPPFLAGS="-I${prefix}/include"
 if [[ "${target}" == *-freebsd* ]]; then
     export LDFLAGS="-L${libdir}"
 fi
-./configure --prefix=${prefix} --host=${target} \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --enable-swap-16bit-csp \
     --enable-experimental \
     --enable-libwebp{mux,demux,decoder,extras} \

--- a/M/MPC/build_tarballs.jl
+++ b/M/MPC/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/mpc-*
-./configure --prefix=$prefix --host=$target --enable-shared --disable-static --with-gmp=${prefix} --with-mpfr=${prefix}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-shared --disable-static --with-gmp=${prefix} --with-mpfr=${prefix}
 make -j${nproc}
 make install
 

--- a/M/MPFR/build_tarballs.jl
+++ b/M/MPFR/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/mpfr-*
-./configure --prefix=$prefix --host=$target --enable-shared --disable-static --with-gmp=${prefix} --enable-thread-safe --enable-shared-cache --disable-float128 --disable-decimal-float
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-shared --disable-static --with-gmp=${prefix} --enable-thread-safe --enable-shared-cache --disable-float128 --disable-decimal-float
 make -j${nproc}
 make install
 

--- a/M/MPICH/build_tarballs.jl
+++ b/M/MPICH/build_tarballs.jl
@@ -57,7 +57,7 @@ if [[ "${target}" != i686-linux-gnu ]] || [[ "${target}" != x86_64-linux-* ]]; t
     fi
 fi
 
-./configure --prefix=$prefix --host=$target \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --enable-shared=yes \
     --enable-static=no \
     --disable-dependency-tracking \

--- a/M/MPIR/build_tarballs.jl
+++ b/M/MPIR/build_tarballs.jl
@@ -18,7 +18,7 @@ cd $WORKSPACE/srcdir/mpir-*
 # We need `yasm`
 apk add yasm
 
-./configure --enable-cxx --prefix=$prefix --host=${target} --disable-static --enable-shared
+./configure --enable-cxx --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static --enable-shared
 make -j
 make install
 """

--- a/M/Mingw/build_tarballs.jl
+++ b/M/Mingw/build_tarballs.jl
@@ -40,6 +40,7 @@ fi
 
 $WORKSPACE/srcdir/mingw-*/mingw-w64-crt/configure \
     --prefix=/ \
+    --build=${MACHTYPE} \
     --host=${target} \
     ${MINGW_CONF_ARGS}
 make -j${nproc} 
@@ -51,6 +52,7 @@ mkdir -p $WORKSPACE/srcdir/mingw_winpthreads_build
 cd $WORKSPACE/srcdir/mingw_winpthreads_build
 $WORKSPACE/srcdir/mingw-*/mingw-w64-libraries/winpthreads/configure \
     --prefix=/ \
+    --build=${MACHTYPE} \
     --host=${target} \
     --enable-static \
     --enable-shared

--- a/M/Musl/build_tarballs.jl
+++ b/M/Musl/build_tarballs.jl
@@ -27,6 +27,7 @@ musl_arch()
 
 export LDFLAGS="${LDFLAGS} -Wl,-soname,libc.musl-$(musl_target).so.1"
 ${WORKSPACE}/srcdir/musl-*/configure --prefix=/usr \
+    --build=${MACHTYPE} \
     --host=${target} \
     --disable-multilib \
     --disable-werror \

--- a/M/mpg123/build_tarballs.jl
+++ b/M/mpg123/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/mpg123-*/
-./configure --prefix=$prefix --host=$target --enable-int-quality
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-int-quality
 make -j${nproc}
 make install
 """

--- a/N/Nettle/build_tarballs.jl
+++ b/N/Nettle/build_tarballs.jl
@@ -18,7 +18,7 @@ atomic_patch -p1 ../patches/alloca.patch
 export CFLAGS="${CFLAGS} -std=c99"
 
 update_configure_scripts
-./configure --prefix=$prefix --host=$target --with-include-path=$prefix/include
+./configure --prefix=$prefix --build=${MACHTYPE} --host=${target} --with-include-path=$prefix/include
 make -j${nproc}
 make install
 install_license COPYING*

--- a/O/OpenMPI/build_tarballs.jl
+++ b/O/OpenMPI/build_tarballs.jl
@@ -11,7 +11,7 @@ script = raw"""
 # Enter the funzone
 cd ${WORKSPACE}/srcdir/openmpi-*
 
-./configure --prefix=$prefix --host=$target --enable-shared=yes --enable-static=no --disable-mpi-fortran --without-cs-fs
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-shared=yes --enable-static=no --disable-mpi-fortran --without-cs-fs
 
 # Build the library
 make "${flags[@]}" -j${nproc}

--- a/O/OptimPack/build_tarballs.jl
+++ b/O/OptimPack/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/optimpack-*
-./configure --prefix=$prefix --host=$target --enable-shared=yes --enable-static=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-shared=yes --enable-static=no
 FLAGS=()
 if [[ "${target}" == *-mingw* ]]; then
     # This is needed in order to build the shared library on Windows

--- a/O/obstack/build_tarballs.jl
+++ b/O/obstack/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/musl-obstack-*/
 ./bootstrap.sh
-CFLAGS="-fPIC" ./configure --prefix=${prefix} --host=${target}
+CFLAGS="-fPIC" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/P/PCRE/build_tarballs.jl
+++ b/P/PCRE/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/pcre-*/
-./configure --prefix=$prefix --host=$target --enable-utf8 --enable-unicode-properties
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-utf8 --enable-unicode-properties
 make -j${nproc} VERBOSE=1
 make install VERBOSE=1
 """

--- a/P/PCRE2/build_tarballs.jl
+++ b/P/PCRE2/build_tarballs.jl
@@ -26,7 +26,7 @@ export CFLAGS="${CFLAGS} -O3"
 atomic_patch -d src/sljit -p2 ${WORKSPACE}/srcdir/patches/sljit-apple-silicon-support.patch
 atomic_patch -d src/sljit -p2 ${WORKSPACE}/srcdir/patches/sljit-nomprotect.patch
 
-./configure --prefix=${prefix} --host=${target} \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --disable-static \
     --enable-jit \
     --enable-pcre2-16 \

--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -23,7 +23,7 @@ if [[ ${target} == powerpc64le* ]]; then
     export LDFLAGS="${LDFLAGS} -Wl,-rpath-link,${prefix}/lib64"
 fi
 
-./configure --prefix=$prefix --host=$target \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --disable-introspection \
     --disable-gtk-doc-html
 

--- a/P/Pixman/build_tarballs.jl
+++ b/P/Pixman/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/pixman-*/
 
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/S/SDL2/build_tarballs.jl
+++ b/S/SDL2/build_tarballs.jl
@@ -23,7 +23,7 @@ fi
 export CPPFLAGS="-I${prefix}/include"
 export LDFLAGS="-L${libdir}"
 
-./configure --prefix=${prefix} --host=${target} \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --enable-shared \
     --disable-static \
     "${FLAGS[@]}"

--- a/S/SDL2_ttf/build_tarballs.jl
+++ b/S/SDL2_ttf/build_tarballs.jl
@@ -23,7 +23,7 @@ touch NEWS README AUTHORS ChangeLog
 # but with some encouragement it can do it
 autoreconf -vi || autoreconf -vi
 export CPPFLAGS="-I${prefix}/include/SDL2"
-./configure --prefix=${prefix} --host=${target} \
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --enable-shared \
     --disable-static \
     "${FLAGS[@]}"

--- a/T/Tar/build_tarballs.jl
+++ b/T/Tar/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/tar-*/
 export FORCE_UNSAFE_CONFIGURE=1
-./configure --prefix=${prefix} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/T/Tcl/build_tarballs.jl
+++ b/T/Tcl/build_tarballs.jl
@@ -25,7 +25,7 @@ FLAGS=()
 if [[ "${target}" == x86_64-* ]]; then
     FLAGS+=(--enable-64bit)
 fi
-./configure --prefix=${prefix} --host=${target} "${FLAGS[@]}"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} "${FLAGS[@]}"
 make -j${nproc}
 make install
 # Tk needs private headers

--- a/T/Tesseract/build_tarballs.jl
+++ b/T/Tesseract/build_tarballs.jl
@@ -21,7 +21,7 @@ if [[ "${target}" == *-musl* ]] || [[ "${target}" == *-freebsd* ]]; then
 fi
 atomic_patch -p1 "$WORKSPACE/srcdir/patches/disable_fast_math.patch"
 ./autogen.sh
-./configure --prefix=$prefix --host=$target
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/T/Tk/build_tarballs.jl
+++ b/T/Tk/build_tarballs.jl
@@ -41,7 +41,7 @@ if [[ "${target}" == *mingw* ]]; then
     atomic_patch -p2 "${WORKSPACE}/srcdir/patches/win_tk_rc_include.patch"
 fi
 
-./configure --prefix=${prefix} --host=${target} "${FLAGS[@]}"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} "${FLAGS[@]}"
 make -j${nproc}
 make install
 make install-private-headers

--- a/W/WCS/build_tarballs.jl
+++ b/W/WCS/build_tarballs.jl
@@ -18,7 +18,7 @@ if [[ "${target}" == *mingw* ]]; then
     autoconf
     export CFLAGS="${CFLAGS} -DNO_OLDNAMES"
 fi
-./configure --prefix=$prefix --host=$target --disable-fortran --without-cfitsio --without-pgplot --disable-utils
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-fortran --without-cfitsio --without-pgplot --disable-utils
 make -j${nproc}
 make install
 

--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -20,7 +20,7 @@ cd $WORKSPACE/srcdir/wayland-*/
 apk add wayland-dev
 
 atomic_patch -p1 ../patches/Makefile_in.patch
-./configure --prefix=${prefix} --host=${target} --disable-documentation --with-host-scanner
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-documentation --with-host-scanner
 make -j${nproc}
 make install
 """

--- a/W/Wayland_protocols/build_tarballs.jl
+++ b/W/Wayland_protocols/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/wayland-protocols-*/
-./configure --prefix=${prefix} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/W/Wine/build_tarballs.jl
+++ b/W/Wine/build_tarballs.jl
@@ -35,7 +35,7 @@ wine64_build_script = raw"""
 # First, build wine64, making the actual build directory itself the thing we will install.
 mkdir $WORKSPACE/destdir/wine64
 cd $WORKSPACE/destdir/wine64
-$WORKSPACE/srcdir/wine/configure --prefix=${prefix} --host=${target} --without-x --without-freetype --enable-win64
+$WORKSPACE/srcdir/wine/configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --without-x --without-freetype --enable-win64
 make -j${nproc}
 """
 

--- a/X/XML2/build_tarballs.jl
+++ b/X/XML2/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd ${WORKSPACE}/srcdir/libxml2-*
-./autogen.sh --prefix=${prefix} --host=${target} \
+./autogen.sh --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --without-python \
     --disable-static \
     --with-zlib=${prefix} \

--- a/X/XSLT/build_tarballs.jl
+++ b/X/XSLT/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/libxslt-*/
 
-./configure --prefix=${prefix} --host=${target} --disable-static
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
 make -j${nproc}
 make install
 

--- a/X/Xorg_compositeproto/build_tarballs.jl
+++ b/X/Xorg_compositeproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/compositeproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_damageproto/build_tarballs.jl
+++ b/X/Xorg_damageproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/damageproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_dri2proto/build_tarballs.jl
+++ b/X/Xorg_dri2proto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/dri2proto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_dri3proto/build_tarballs.jl
+++ b/X/Xorg_dri3proto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/dri3proto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_fixesproto/build_tarballs.jl
+++ b/X/Xorg_fixesproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/fixesproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_glproto/build_tarballs.jl
+++ b/X/Xorg_glproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/glproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_inputproto/build_tarballs.jl
+++ b/X/Xorg_inputproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/inputproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_kbproto/build_tarballs.jl
+++ b/X/Xorg_kbproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/kbproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libICE/build_tarballs.jl
+++ b/X/Xorg_libICE/build_tarballs.jl
@@ -18,7 +18,7 @@ cd $WORKSPACE/srcdir/libICE-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libSM/build_tarballs.jl
+++ b/X/Xorg_libSM/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libSM-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libX11/build_tarballs.jl
+++ b/X/Xorg_libX11/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libX11-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 # For some obscure reason, this Makefile may not get the value of CPPFLAGS
 sed -i "s?CPPFLAGS = ?CPPFLAGS = ${CPPFLAGS}?" src/util/Makefile
 make -j${nproc}

--- a/X/Xorg_libXScrnSaver/build_tarballs.jl
+++ b/X/Xorg_libXScrnSaver/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXScrnSaver-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXau/build_tarballs.jl
+++ b/X/Xorg_libXau/build_tarballs.jl
@@ -18,7 +18,7 @@ cd $WORKSPACE/srcdir/libXau-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXcomposite/build_tarballs.jl
+++ b/X/Xorg_libXcomposite/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXcomposite-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXcursor/build_tarballs.jl
+++ b/X/Xorg_libXcursor/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXcursor-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXdamage/build_tarballs.jl
+++ b/X/Xorg_libXdamage/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXdamage-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXdmcp/build_tarballs.jl
+++ b/X/Xorg_libXdmcp/build_tarballs.jl
@@ -18,7 +18,7 @@ cd $WORKSPACE/srcdir/libXdmcp-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXext/build_tarballs.jl
+++ b/X/Xorg_libXext/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXext-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXfixes/build_tarballs.jl
+++ b/X/Xorg_libXfixes/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXfixes-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXft/build_tarballs.jl
+++ b/X/Xorg_libXft/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXft-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXi/build_tarballs.jl
+++ b/X/Xorg_libXi/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXi-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXinerama/build_tarballs.jl
+++ b/X/Xorg_libXinerama/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXinerama-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXmu/build_tarballs.jl
+++ b/X/Xorg_libXmu/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXmu-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXrandr/build_tarballs.jl
+++ b/X/Xorg_libXrandr/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXrandr-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXrender/build_tarballs.jl
+++ b/X/Xorg_libXrender/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXrender-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXt/build_tarballs.jl
+++ b/X/Xorg_libXt/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXt-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXtst/build_tarballs.jl
+++ b/X/Xorg_libXtst/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libXtst-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libXxf86vm/build_tarballs.jl
+++ b/X/Xorg_libXxf86vm/build_tarballs.jl
@@ -24,7 +24,7 @@ update_configure_scripts
 #
 # and I don't have the time to investigate it.
 sed -i -e 's/elf64ppc/elf64lppc/g' configure
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libpciaccess/build_tarballs.jl
+++ b/X/Xorg_libpciaccess/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libpciaccess-*/
-./configure --prefix=${prefix} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libpthread_stubs/build_tarballs.jl
+++ b/X/Xorg_libpthread_stubs/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libpthread-stubs-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libxcb/build_tarballs.jl
+++ b/X/Xorg_libxcb/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libxcb-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libxkbfile/build_tarballs.jl
+++ b/X/Xorg_libxkbfile/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libxkbfile-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_libxshmfence/build_tarballs.jl
+++ b/X/Xorg_libxshmfence/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/libxshmfence-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_randrproto/build_tarballs.jl
+++ b/X/Xorg_randrproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/randrproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_recordproto/build_tarballs.jl
+++ b/X/Xorg_recordproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/recordproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_renderproto/build_tarballs.jl
+++ b/X/Xorg_renderproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/renderproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_scrnsaverproto/build_tarballs.jl
+++ b/X/Xorg_scrnsaverproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/scrnsaverproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_util_macros/build_tarballs.jl
+++ b/X/Xorg_util_macros/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/util-macros-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xcb_proto/build_tarballs.jl
+++ b/X/Xorg_xcb_proto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/xcb-proto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xcb_util/build_tarballs.jl
+++ b/X/Xorg_xcb_util/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/xcb-util-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xcb_util_image/build_tarballs.jl
+++ b/X/Xorg_xcb_util_image/build_tarballs.jl
@@ -19,7 +19,7 @@ CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
 
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xcb_util_keysyms/build_tarballs.jl
+++ b/X/Xorg_xcb_util_keysyms/build_tarballs.jl
@@ -21,7 +21,7 @@ CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
 
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 install_license ../LICENSE

--- a/X/Xorg_xcb_util_renderutil/build_tarballs.jl
+++ b/X/Xorg_xcb_util_renderutil/build_tarballs.jl
@@ -19,7 +19,7 @@ CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
 
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xcb_util_wm/build_tarballs.jl
+++ b/X/Xorg_xcb_util_wm/build_tarballs.jl
@@ -19,7 +19,7 @@ CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
 
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xextproto/build_tarballs.jl
+++ b/X/Xorg_xextproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/xextproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xf86vidmodeproto/build_tarballs.jl
+++ b/X/Xorg_xf86vidmodeproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/xf86vidmodeproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xineramaproto/build_tarballs.jl
+++ b/X/Xorg_xineramaproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/xineramaproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xkbcomp/build_tarballs.jl
+++ b/X/Xorg_xkbcomp/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/xkbcomp-*
-./configure --prefix=${prefix} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xkeyboard_config/build_tarballs.jl
+++ b/X/Xorg_xkeyboard_config/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/xkeyboard-config-*
 apk add libxslt
-./configure --prefix=${prefix} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xorgproto/build_tarballs.jl
+++ b/X/Xorg_xorgproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/xorgproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 install_license COPYING-*

--- a/X/Xorg_xproto/build_tarballs.jl
+++ b/X/Xorg_xproto/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/xproto-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xorg_xtrans/build_tarballs.jl
+++ b/X/Xorg_xtrans/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/xtrans-*/
 CPPFLAGS="-I${prefix}/include"
 # When compiling for things like ppc64le, we need newer `config.sub` files
 update_configure_scripts
-./configure --prefix=${prefix} --host=${target} --enable-malloc0returnsnull=no
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-malloc0returnsnull=no
 make -j${nproc}
 make install
 """

--- a/X/Xyce/build_tarballs.jl
+++ b/X/Xyce/build_tarballs.jl
@@ -27,7 +27,10 @@ fi
 cd ..
 mkdir buildx
 cd buildx
-/workspace/srcdir/Xyce/./configure --enable-shared --disable-mpi --prefix=${prefix} LDFLAGS="-L${libdir} -lopenblas" CPPFLAGS="-I/${includedir} -I/usr/include" --host=${target}
+/workspace/srcdir/Xyce/./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
+    --enable-shared --disable-mpi \
+    LDFLAGS="-L${libdir} -lopenblas" \
+    CPPFLAGS="-I/${includedir} -I/usr/include"
 make -j${nprocs}
 make install
 """

--- a/X/x264/build_tarballs.jl
+++ b/X/x264/build_tarballs.jl
@@ -20,7 +20,7 @@ if [[ "${target}" == x86_64* ]] || [[ "${target}" == i686* ]]; then
 else
     export AS="${CC}"
 fi
-./configure --prefix=$prefix --host=$target --enable-shared --enable-pic --disable-static
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-shared --enable-pic --disable-static
 # Remove unsafe compilation flag
 sed -i 's/ -ffast-math//g' config.mak
 make -j${nproc}

--- a/Z/ZeroMQ/build_tarballs.jl
+++ b/Z/ZeroMQ/build_tarballs.jl
@@ -25,6 +25,7 @@ elif [[ "${target}" == *86*-linux-musl* ]]; then
 fi
 sh autogen.sh
 ./configure --prefix=$prefix \
+    --build=${MACHTYPE} \
     --host=${target} \
     --without-docs \
     --enable-drafts \


### PR DESCRIPTION
From the autoconf manual:

> If you specify --host, but not --build, when configure performs the first
> compiler test it tries to run an executable produced by the compiler. If the
> execution fails, it enters cross-compilation mode. This is fragile. Moreover,
> by the time the compiler test is performed, it may be too late to modify the
> build-system type: other tests may have already been performed. Therefore,
> whenever you specify --host, be sure to specify --build too.

[skip build]
[skip ci]