### PR TITLE
[GnuPG] Add builder

### DIFF
--- a/G/GnuPG/build_tarballs.jl
+++ b/G/GnuPG/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [
 # Tried -no-undefined but still couldn't build for windows
 script = raw"""
 cd $WORKSPACE/srcdir/gnupg-*/
-./configure --prefix=${prefix} --host=${target} --build=${MACHTYPE} LDFLAGS=-Wl,-rpath-link=${prefix}
+./configure --prefix=${prefix} --host=${target} --build=${MACHTYPE}
 make -j${nproc}
 make install
 """
@@ -33,6 +33,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    # We need this to run a host yat2m executable
+    HostBuildDependency("Libgpg_error_jll"),
     Dependency("GnuTLS_jll"),
     Dependency("Libksba_jll"),
     Dependency("Libgcrypt_jll"),
@@ -43,7 +45,8 @@ dependencies = [
     Dependency("OpenLDAPClient_jll"),
     Dependency("Bzip2_jll"),
     Dependency("SQLite_jll"),
-    Dependency("libusb_jll")
+    Dependency("libusb_jll"),
+    Dependency("Nettle_jll", v"3.4.1", compat="~3.4.1"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GnuPG/build_tarballs.jl
+++ b/G/GnuPG/build_tarballs.jl
@@ -19,6 +19,7 @@ if [[ "${target}" != ${MACHTYPE} ]]; then
     # Delete `gpg-error-config` of the host to prevent it from being picked up
     # when configuring the package
     rm "${host_bindir}/gpg-error-config"
+    export LDFLAGS="-L${libdir}"
 fi
 if [[ "${target}" == *86*-linux-gnu ]]; then
     # We have an old glibc which doesn't have `IN_EXCL_UNLINK`

--- a/G/GnuPG/build_tarballs.jl
+++ b/G/GnuPG/build_tarballs.jl
@@ -15,6 +15,11 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/gnupg-*/
+if [[ "${target}" != ${MACHTYPE} ]]; then
+    # Delete `gpg-error-config` of the host to prevent it from being picked up
+    # when configuring the package
+    rm "${host_bindir}/gpg-error-config"
+fi
 if [[ "${target}" == *86*-linux-gnu ]]; then
     # We have an old glibc which doesn't have `IN_EXCL_UNLINK`
     FLAGS=(ac_cv_func_inotify_init=no)

--- a/G/GnuPG/build_tarballs.jl
+++ b/G/GnuPG/build_tarballs.jl
@@ -1,0 +1,50 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "GnuPG"
+version = v"2.2.27"
+
+# Collection of sources required to build libgcrypt
+sources = [
+    ArchiveSource("https://gnupg.org/ftp/gcrypt/gnupg/gnupg-$(version).tar.bz2",
+                  "34e60009014ea16402069136e0a5f63d9b65f90096244975db5cea74b3d02399"),
+]
+
+# Bash recipe for building across all platforms
+
+# Tried -no-undefined but still couldn't build for windows
+script = raw"""
+cd $WORKSPACE/srcdir/gnupg-*/
+./configure --prefix=${prefix} --host=${target} --build=${MACHTYPE} LDFLAGS=-Wl,-rpath-link=${prefix}
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line.  We are manually disabling
+# many platforms that do not seem to work.
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct(["libgnupg"], :libgnupg),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("GnuTLS_jll"),
+    Dependency("Libksba_jll"),
+    Dependency("Libgcrypt_jll"),
+    Dependency("Libgpg_error_jll"),
+    Dependency("nPth_jll"),
+    Dependency("Zlib_jll"),
+    Dependency("Libassuan_jll"),
+    Dependency("OpenLDAPClient_jll"),
+    Dependency("Bzip2_jll"),
+    Dependency("SQLite_jll"),
+    Dependency("libusb_jll")
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/G/GnuPG/build_tarballs.jl
+++ b/G/GnuPG/build_tarballs.jl
@@ -28,7 +28,21 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["libgnupg"], :libgnupg),
+    ExecutableProduct("dirmngr", :dirmngr),
+    ExecutableProduct("dirmngr-client", :dirmngr_client),
+    ExecutableProduct("gpg", :gpg),
+    ExecutableProduct("gpg-agent", :gpg_agent),
+    ExecutableProduct("gpgconf", :gpgconf),
+    ExecutableProduct("gpg-connect-agent", :gpg_connect_agent),
+    ExecutableProduct("gpgparsemail", :gpgparsemail),
+    ExecutableProduct("gpgscm", :gpgscm),
+    ExecutableProduct("gpgsm", :gpgsm),
+    ExecutableProduct("gpgsplit", :gpgsplit),
+    ExecutableProduct("gpgtar", :gpgtar),
+    ExecutableProduct("gpgv", :gpgv),
+    ExecutableProduct("gpg-wks-server", :gpg_wks_server),
+    ExecutableProduct("kbxutil", :kbxutil),
+    ExecutableProduct("watchgnupg", :watchgnupg),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/G/GnuPG/bundled/patches/intel-linux-gnu-add-rt-lib.patch
+++ b/G/GnuPG/bundled/patches/intel-linux-gnu-add-rt-lib.patch
@@ -1,0 +1,20 @@
+--- a/agent/Makefile.in
++++ b/agent/Makefile.in
+@@ -574,7 +574,7 @@
+ 	$(INCICONV)
+ 
+ gpg_protect_tool_LDADD = $(common_libs) $(LIBGCRYPT_LIBS) $(LIBASSUAN_LIBS) \
+-         $(GPG_ERROR_LIBS) $(LIBINTL) $(NETLIBS) $(LIBICONV)
++         $(GPG_ERROR_LIBS) $(LIBINTL) $(NETLIBS) $(LIBICONV) -lrt
+ 
+ gpg_preset_passphrase_SOURCES = \
+ 	preset-passphrase.c
+@@ -586,7 +586,7 @@
+ 	 $(LIBGCRYPT_LIBS) $(GPG_ERROR_LIBS) $(LIBINTL) $(NETLIBS) $(LIBICONV)
+ 
+ t_common_ldadd = $(common_libs)  $(LIBGCRYPT_LIBS) $(GPG_ERROR_LIBS) \
+-	          $(LIBINTL) $(LIBICONV) $(NETLIBS)
++	          $(LIBINTL) $(LIBICONV) $(NETLIBS) -lrt
+ 
+ t_protect_SOURCES = t-protect.c protect.c
+ t_protect_LDADD = $(t_common_ldadd)


### PR DESCRIPTION
```
[18:13:59] /workspace/destdir/lib/libgnutls.so: undefined reference to `nettle_des_decrypt@NETTLE_6'
[18:13:59] /workspace/destdir/lib/libgnutls.so: undefined reference to `nettle_dsa_params_clear@HOGWEED_4'
[18:13:59] /workspace/destdir/lib/libgnutls.so: undefined reference to `nettle_ecc_size_a@HOGWEED_4'
[18:13:59] /workspace/destdir/lib/libgnutls.so: undefined reference to `nettle_ccm_encrypt_message@NETTLE_6'
[18:13:59] /workspace/destdir/lib/libgnutls.so: undefined reference to `nettle_dsa_generate_params@HOGWEED_4'
[18:13:59] /workspace/destdir/lib/libgnutls.so: undefined reference to `nettle_rsa_pkcs1_verify@HOGWEED_4'
[18:13:59] /workspace/destdir/lib/libgnutls.so: undefined reference to `nettle_sha256_digest@NETTLE_6'
[18:13:59] /workspace/destdir/lib/libgnutls.so: undefined reference to `nettle_hmac_sha1_digest@NETTLE_6'
[18:13:59] collect2: error: ld returned 1 exit status
[18:13:59] make[2]: *** [Makefile:913: dirmngr] Error 1
[18:13:59] make[2]: *** Waiting for unfinished jobs....
[18:13:59] mv -f .deps/t_http_basic-dns.Tpo .deps/t_http_basic-dns.Po
[18:14:00] mv -f .deps/t_ldap_parse_uri-dns.Tpo .deps/t_ldap_parse_uri-dns.Po
[18:14:00] make[2]: Leaving directory '/workspace/srcdir/gnupg-2.2.27/dirmngr'
[18:14:00] make[1]: *** [Makefile:619: all-recursive] Error 1
[18:14:00] make[1]: Leaving directory '/workspace/srcdir/gnupg-2.2.27'
[18:14:00] make: *** [Makefile:539: all] Error 2
[18:14:00]  ---> make -j${nproc}
[18:14:00] Previous command exited with 2
[18:14:00] Child Process exited, exit code 2
```