### PR TITLE
[Cbc] expose cbc executable and add ASL interface

### DIFF
--- a/C/Coin-OR/Cbc/build_tarballs.jl
+++ b/C/Coin-OR/Cbc/build_tarballs.jl
@@ -41,11 +41,7 @@ fi
     --with-asl-lib="-lasl" \
     --with-blas-lib="-lopenblas" \
     --with-lapack-lib="-lopenblas" \
-    --with-metis-lib="-lmetis" \
-    --with-coinutils-lib="-lCoinUtils" \
-    --with-osi-lib="-lOsi" \
     --with-clp-lib="-lClp" \
-    --with-cgl-lib="-lCgl -lOsiClp " \
     --with-coindepend-lib="-lCgl -lOsiClp -lClp -lOsi -lCoinUtils" \
     --enable-cbc-parallel
 

--- a/C/Coin-OR/Cbc/build_tarballs.jl
+++ b/C/Coin-OR/Cbc/build_tarballs.jl
@@ -1,7 +1,3 @@
-# Note: editing coin-or-common.jl isn't sufficient to trigger a
-# build. You need to edit this one as well. 
-# Version 2.10.5+3
-
 include("../coin-or-common.jl")
 
 name = "Cbc"
@@ -9,8 +5,7 @@ version = Cbc_version
 
 # Collection of sources required to build CbcBuilder
 sources = [
-    GitSource("https://github.com/coin-or/Cbc.git",
-              Cbc_gitsha),
+    GitSource("https://github.com/coin-or/Cbc.git", Cbc_gitsha),
 ]
 
 # Bash recipe for building across all platforms
@@ -27,24 +22,32 @@ sed -i s/elf64ppc/elf64lppc/ configure
 mkdir build
 cd build/
 
-export CPPFLAGS="${CPPFLAGS} -DNDEBUG -I${prefix}/include -I$prefix/include/coin"
+export CPPFLAGS="${CPPFLAGS} -DNDEBUG -I${includedir} -I${includedir}/coin"
 if [[ ${target} == *mingw* ]]; then
     export LDFLAGS="-L$prefix/bin"
 elif [[ ${target} == *linux* ]]; then
     export LDFLAGS="-ldl -lrt"
 fi
 
-../configure --prefix=$prefix --build=${MACHTYPE} --host=${target} \
---with-pic --disable-pkg-config --disable-debug \
---enable-shared lt_cv_deplibs_check_method=pass_all \
---with-blas-lib="-lopenblas" --with-lapack-lib="-lopenblas" \
---with-metis-lib="-lmetis" \
---with-coinutils-lib="-lCoinUtils" \
---with-osi-lib="-lOsi -lCoinUtils" \
---with-clp-lib="-lClp -lOsiClp -lCoinUtils" \
---with-cgl-lib="-lCgl -lClp -lOsiClp -lOsi -lCoinUtils" \
---with-coindepend-lib="-lCgl -lClp -lOsiClp -lOsi -lCoinUtils" \
---enable-cbc-parallel
+../configure \
+    --prefix=${prefix} \
+    --build=${MACHTYPE} \
+    --host=${target} \
+    --with-pic \
+    --disable-pkg-config \
+    --disable-debug \
+    --enable-shared \
+    lt_cv_deplibs_check_method=pass_all \
+    --with-asl-lib="-lasl" \
+    --with-blas-lib="-lopenblas" \
+    --with-lapack-lib="-lopenblas" \
+    --with-metis-lib="-lmetis" \
+    --with-coinutils-lib="-lCoinUtils" \
+    --with-osi-lib="-lOsi" \
+    --with-clp-lib="-lClp" \
+    --with-cgl-lib="-lCgl -lOsiClp " \
+    --with-coindepend-lib="-lCgl -lOsiClp -lClp -lOsi -lCoinUtils" \
+    --enable-cbc-parallel
 
 make -j${nproc}
 make install
@@ -54,15 +57,17 @@ make install
 products = [
     LibraryProduct("libCbc", :libCbc),
     LibraryProduct("libCbcSolver", :libcbcsolver),
+    ExecutableProduct("cbc", :cbc),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(Clp_packagespec),
-    Dependency(Cgl_packagespec),
-    Dependency(Osi_packagespec),
-    Dependency(CoinUtils_packagespec),
-    Dependency("OpenBLAS32_jll"),
+    Dependency("ASL_jll", ASL_version),
+    Dependency("Cgl_jll", Cgl_version),
+    Dependency("Clp_jll", Clp_version),
+    Dependency("Osi_jll", Osi_version),
+    Dependency("CoinUtils_jll", CoinUtils_version),
+    Dependency("OpenBLAS32_jll", OpenBLAS32_version),
     Dependency("CompilerSupportLibraries_jll")
 ]
 

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -21,8 +21,10 @@ end
 gcc_version = v"6"
 
 # Versions of various COIN-OR libraries
-Cbc_version = v"2.10.5"
+Cbc_upstream_version = v"2.10.5"
 Cbc_gitsha = "7b5ccc016f035f56614c8018b20d700978144e9f"
+Cbc_version_offset = v"0.0.0"
+Cbc_version = offset_version(Cbc_upstream_version, Cbc_version_offset)
 
 Cgl_upstream_version = v"0.60.2"
 Cgl_gitsha = "6377b88754fafacf24baac28bb27c0623cc14457"


### PR DESCRIPTION
Talked to @tkralphs, who suggested some things to clean up the COIN-OR builds. 

Maybe a question for @giordano, what are the implications of adding new dependency? Do I have to bump a version? or can it be released as a `+N` version?

Ted: I had to add `--with-coindepend-lib` because it complained about missing Cgl otherwise, even though `--with-cgl-lib` was specified.

I tested this locally, and the AMPL Interface works:
```Julia
julia> model = Model(() -> AmplNLWriter.Optimizer(Cbc_jll.cbc))
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: AmplNLWriter

julia> @variable(model, x >= 1)
x

julia> @objective(model, Min, 2x)

2 x

julia> optimize!(model)
CBC 2.10.5: 
julia> value(x)
1.0

julia> objective_value(model)
2.0
```