### PR TITLE
Manually disable `clock_gettime` in GCC builds for Darwin

### DIFF
--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -357,6 +357,9 @@ function gcc_script(compiler_target::Platform)
 
         # On darwin, cilk doesn't build on 5.X-7.X.  :(
         export enable_libcilkrts=no
+
+        # GCC doesn't know how to use availability macros properly, so tell it not to use `clock_gettime()`
+        export ac_cv_func_clock_gettime=no
     fi
 
     # Link dependent packages into gcc build root:


### PR DESCRIPTION
GCC on Darwin can't properly deal with certain feature detection macros,
so we'll help it out by manually disabling them for it.