### PR TITLE
[Clp] rebuild with MUMPS5 and modify version numbers

### DIFF
--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -39,7 +39,7 @@ CoinUtils_version = v"2.11.3"
 CoinUtils_gitsha = "ea66474879246f299e977802c94a0e45334e7afb"
 
 # Third-party packages needed by COIN-OR libraries.
-METIS_version = v"4.0.3"
+METIS_version = v"5.1.0"
 MUMPS_seq_version = v"5.2.1"
 OpenBLAS32_version = v"0.3.9"
 

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -1,45 +1,47 @@
 using BinaryBuilder, Pkg
 
+"""
+    offset_version(upstream, offset)
+
+Compute a version that allows distinguishing between changes in the upstream
+version and changes to the JLL which retain the same upstream version.
+
+When the `upstream` version is changed, `offset` version numbers should be reset
+to `v"0.0.0"` and incremented following semantic versioning.
+"""
+function offset_version(upstream, offset)
+    return VersionNumber(
+        upstream.major * 100 + offset.major,
+        upstream.minor * 100 + offset.minor,
+        upstream.patch * 100 + offset.patch,
+    )
+end
+
 # GCC version for building the whole system
 gcc_version = v"6"
 
-# Versions of various Coin-OR libraries
+# Versions of various COIN-OR libraries
 Cbc_version = v"2.10.5"
 Cbc_gitsha = "7b5ccc016f035f56614c8018b20d700978144e9f"
 
 Cgl_version = v"0.60.2"
 Cgl_gitsha = "6377b88754fafacf24baac28bb27c0623cc14457"
-Cgl_packagespec = PackageSpec(; name = "Cgl_jll",
-                              uuid = "3830e938-1dd0-5f3e-8b8e-b3ee43226782",
-                              version = Cgl_version)
 
-Clp_version = v"1.17.6"
+Clp_upstream_version = v"1.17.6"
 Clp_gitsha = "756ddd3ed813eb1fa8b2d1b4fe813e6a4d7aa1eb"
-Clp_packagespec = PackageSpec(; name = "Clp_jll",
-                              uuid = "06985876-5285-5a41-9fcb-8948a742cc53",
-                              version = Clp_version)
+Clp_version_offset = v"0.0.0"
+Clp_version = offset_version(Clp_upstream_version, Clp_version_offset)
 
 Osi_version = v"0.108.5"
 Osi_gitsha = "2bd34ae6b8c93d342d54fd19d4d773f07194583c"
-Osi_packagespec = PackageSpec(; name = "Osi_jll",
-                              uuid = "7da25872-d9ce-5375-a4d3-7a845f58efdd",
-                              version = Osi_version)
 
 CoinUtils_version = v"2.11.3"
 CoinUtils_gitsha = "ea66474879246f299e977802c94a0e45334e7afb"
-CoinUtils_packagespec = PackageSpec(; name = "CoinUtils_jll",
-                                    uuid = "be027038-0da8-5614-b30d-e42594cb92df",
-                                    version = CoinUtils_version)
 
-MUMPS_seq_version = v"4.10.0"
-MUMPS_seq_packagespec = PackageSpec(; name = "MUMPS_seq_jll",
-                                uuid = "d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d",
-                                version = MUMPS_seq_version)
-
+# Third-party packages needed by COIN-OR libraries.
 METIS_version = v"4.0.3"
-METIS_packagespec = PackageSpec(; name = "METIS_jll",
-                                uuid = "d00139f3-1899-568f-a2f0-47f597d42d70",
-                                version = METIS_version)
+MUMPS_seq_version = v"5.2.1"
+OpenBLAS32_version = v"0.3.9"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line


### PR DESCRIPTION
x-ref: https://github.com/JuliaPackaging/Yggdrasil/pull/2831 and https://github.com/JuliaPackaging/Yggdrasil/pull/2834.
cc @tkralphs.

This PR:
 * Rebuilds Clp with MUMPS5.2.1 to match Ipopt
 * Adds the `clp` executable
 * Modifies the version number to `v"100.1700.600"`.

Modifying the version number gives us some breathing room, because both Clp.jl and Cbc.jl use a version fixed to `v"1.17.6"`:
https://github.com/jump-dev/Clp.jl/blob/12542b098a901de55e44587966c11b563203fcd5/Project.toml#L17

Once this is merged, we should rebuild Cbc_jll to use the new version. I can also refactor #2834 to keep MUMPS5. Then rebuild Bonmin to use Cbc and Ipopt all using the same versions of things.