### PR TITLE
[Cgl] rebuild Cgl without fixed Clp version

### DIFF
--- a/C/Coin-OR/Cgl/build_tarballs.jl
+++ b/C/Coin-OR/Cgl/build_tarballs.jl
@@ -5,8 +5,7 @@ version = Cgl_version
 
 # Collection of sources required to build Cgl
 sources = [
-   GitSource("https://github.com/coin-or/Cgl.git",
-             Cgl_gitsha),
+   GitSource("https://github.com/coin-or/Cgl.git", Cgl_gitsha),
 ]
 
 # Bash recipe for building across all platforms
@@ -23,19 +22,25 @@ sed -i s/elf64ppc/elf64lppc/ configure
 mkdir build
 cd build/
 
-export CPPFLAGS="${CPPFLAGS} -DNDEBUG -I${prefix}/include -I$prefix/include/coin"
+export CPPFLAGS="${CPPFLAGS} -DNDEBUG -I${includedir} -I${includedir}/coin"
 if [[ ${target} == *mingw* ]]; then
     export LDFLAGS="-L$prefix/bin"
 elif [[ ${target} == *linux* ]]; then
     export LDFLAGS="-ldl -lrt"
 fi
 
-../configure --prefix=$prefix --build=${MACHTYPE} --host=${target} \
---with-pic --disable-pkg-config --disable-debug \
---enable-shared lt_cv_deplibs_check_method=pass_all \
---with-coinutils-lib="-lCoinUtils" \
---with-osi-lib="-lOsi -lCoinUtils" \
---with-osiclp-lib="-lOsiClp -lClp -lOsi -lCoinUtils"
+../configure \
+    --prefix=${prefix} \
+    --build=${MACHTYPE} \
+    --host=${target} \
+    --with-pic \
+    --disable-pkg-config \
+    --disable-debug \
+    --enable-shared \
+    lt_cv_deplibs_check_method=pass_all \
+    --with-coinutils-lib="-lCoinUtils" \
+    --with-osi-lib="-lOsi -lCoinUtils" \
+    --with-osiclp-lib="-lOsiClp -lClp -lOsi -lCoinUtils"
 
 make -j${nproc}
 make install
@@ -48,7 +53,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(Clp_packagespec),
+    Dependency("Clp_jll", Clp_version),
     Dependency("CompilerSupportLibraries_jll"),
 ]
 

--- a/C/Coin-OR/Cgl/build_tarballs.jl
+++ b/C/Coin-OR/Cgl/build_tarballs.jl
@@ -54,6 +54,8 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Clp_jll", Clp_version),
+    Dependency("Osi_jll", Osi_version),
+    Dependency("CoinUtils_jll", CoinUtils_version),
     Dependency("CompilerSupportLibraries_jll"),
 ]
 

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -24,8 +24,10 @@ gcc_version = v"6"
 Cbc_version = v"2.10.5"
 Cbc_gitsha = "7b5ccc016f035f56614c8018b20d700978144e9f"
 
-Cgl_version = v"0.60.2"
+Cgl_upstream_version = v"0.60.2"
 Cgl_gitsha = "6377b88754fafacf24baac28bb27c0623cc14457"
+Cgl_version_offset = v"0.0.0"
+Cgl_version = offset_version(Cgl_upstream_version, Cgl_version_offset)
 
 Clp_upstream_version = v"1.17.6"
 Clp_gitsha = "756ddd3ed813eb1fa8b2d1b4fe813e6a4d7aa1eb"


### PR DESCRIPTION
In order to rebuild https://github.com/JuliaPackaging/Yggdrasil/pull/2831 with the new Clp version, I had to bump Cgl.