### PR TITLE
[Bonmin] rebuild using latest versions

### DIFF
--- a/C/Coin-OR/Bonmin/build_tarballs.jl
+++ b/C/Coin-OR/Bonmin/build_tarballs.jl
@@ -36,7 +36,7 @@ fi
     --prefix=${prefix} \
     --build=${MACHTYPE} \
     --host=${target} \
-    --disable-pkgconfig \
+    --disable-pkg-config \
     --disable-debug \
     --enable-shared \
     lt_cv_deplibs_check_method=pass_all \

--- a/C/Coin-OR/Bonmin/build_tarballs.jl
+++ b/C/Coin-OR/Bonmin/build_tarballs.jl
@@ -1,11 +1,10 @@
-using BinaryBuilder, Pkg
+include("../coin-or-common.jl")
 
 name = "Bonmin"
-version = v"1.8.8"
+version = Bonmin_version
 
 sources = [
-    GitSource("https://github.com/coin-or/Bonmin.git",
-              "65c56cea1e7c40acd9897a2667c11f91d845bb7b"),
+    GitSource("https://github.com/coin-or/Bonmin.git", Bonmin_gitsha),
     DirectorySource("./bundled")
 ]
 
@@ -37,11 +36,12 @@ fi
     --prefix=${prefix} \
     --build=${MACHTYPE} \
     --host=${target} \
-    --disable-pthread-mumps \
-    --enable-static \
+    --disable-pkgconfig \
+    --disable-debug \
     --enable-shared \
     lt_cv_deplibs_check_method=pass_all \
-    --with-asl-lib="-lipoptamplinterface -lasl"
+    --with-asl-lib="-lasl" \
+    --with-coindepend-lib="-lCbc -lCgl -lOsiClp -lClp -lOsi -lCoinUtils -lipoptamplinterface -lipopt"
 
 make -j${nproc}
 make install
@@ -50,10 +50,6 @@ make install
 rm "${includedir}/coin-or/IpoptConfig.h"
 """
 
-
-platforms = supported_platforms()
-filter!(!Sys.isfreebsd, platforms)
-platforms = expand_cxxstring_abis(platforms)
 filter!(x -> cxxstring_abi(x) != "cxx03", platforms)
 platforms = expand_gfortran_versions(platforms)
 
@@ -66,9 +62,14 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Cbc_jll", v"2.10.5"),
+    Dependency("ASL_jll", ASL_version),
+    Dependency("Cbc_jll", Cbc_version, compat="=$(Cbc_version)"),
+    Dependency("Cgl_jll", Cgl_version),
+    Dependency("Clp_jll", Clp_version),
+    Dependency("Osi_jll", Osi_version),
+    Dependency("CoinUtils_jll", CoinUtils_version),
+    Dependency("Ipopt_jll", Ipopt_version, compat="=$(Ipopt_version)"),
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("Ipopt_jll", v"3.13.4", compat="~3.13.4"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/Coin-OR/Bonmin/build_tarballs.jl
+++ b/C/Coin-OR/Bonmin/build_tarballs.jl
@@ -51,7 +51,6 @@ rm "${includedir}/coin-or/IpoptConfig.h"
 """
 
 filter!(x -> cxxstring_abi(x) != "cxx03", platforms)
-platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -21,6 +21,12 @@ end
 gcc_version = v"6"
 
 # Versions of various COIN-OR libraries
+
+Bonmin_upstream_version = v"1.8.8"
+Bonmin_gitsha = "65c56cea1e7c40acd9897a2667c11f91d845bb7b"
+Bonmin_version_offset = v"0.0.0"
+Bonmin_version = offset_version(Bonmin_upstream_version, Bonmin_version_offset)
+
 Cbc_upstream_version = v"2.10.5"
 Cbc_gitsha = "7b5ccc016f035f56614c8018b20d700978144e9f"
 Cbc_version_offset = v"0.0.0"


### PR DESCRIPTION
@tkralphs that seems to have done the trick:

```Julia
julia> using JuMP, AmplNLWriter, Bonmin_jll

julia> model = Model(() -> AmplNLWriter.Optimizer(Bonmin_jll.amplexe))
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: AmplNLWriter

julia> @variable(model, x >= 0)
x

julia> @objective(model, Min, x)
x

julia> optimize!(model)
Bonmin 1.8.8 using Cbc 2.10.5 and Ipopt 3.13.4
bonmin: 
Cbc3007W No integer variables - nothing to do

******************************************************************************
This program contains Ipopt, a library for large-scale nonlinear optimization.
 Ipopt is released as open source code under the Eclipse Public License (EPL).
         For more information visit https://github.com/coin-or/Ipopt
******************************************************************************

NLP0012I 
              Num      Status      Obj             It       time                 Location
NLP0014I             1         OPT 0        2 0.004643
Cbc3007W No integer variables - nothing to do

 	"Finished"

julia> value(x)
0.0
```