### PR TITLE
[CoinUtils] rebuild 2.11.4

### DIFF
--- a/C/Coin-OR/CoinUtils/build_tarballs.jl
+++ b/C/Coin-OR/CoinUtils/build_tarballs.jl
@@ -5,8 +5,7 @@ version = CoinUtils_version
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/coin-or/CoinUtils.git",
-              CoinUtils_gitsha),
+    GitSource("https://github.com/coin-or/CoinUtils.git", CoinUtils_gitsha),
 ]
 
 # Bash recipe for building across all platforms
@@ -25,18 +24,24 @@ sed -i s/elf64ppc/elf64lppc/ configure
 mkdir build
 cd build/
 
-export CPPFLAGS="${CPPFLAGS} -I${prefix}/include -I${prefix}/include/coin"
+export CPPFLAGS="${CPPFLAGS} -I${includedir} -I${includedir}/coin"
 if [[ ${target} == *mingw* ]]; then
-    export LDFLAGS="-L$prefix/bin"
+    export LDFLAGS="-L${libdir}"
 elif [[ ${target} == *linux* ]]; then
     export LDFLAGS="-ldl -lrt"
 fi
 
-../configure --prefix=$prefix --build=${MACHTYPE} --host=${target} \
---with-pic --disable-pkg-config --disable-debug \
---enable-shared lt_cv_deplibs_check_method=pass_all \
---with-blas --with-blas-lib="-lopenblas" \
---with-lapack --with-lapack-lib="-lopenblas"
+../configure \
+    --prefix=${prefix} \
+    --build=${MACHTYPE} \
+    --host=${target} \
+    --with-pic \
+    --disable-pkg-config \
+    --disable-debug \
+    --enable-shared \
+    lt_cv_deplibs_check_method=pass_all \
+    --with-blas --with-blas-lib="-lopenblas" \
+    --with-lapack --with-lapack-lib="-lopenblas"
 
 make -j${nproc}
 make install
@@ -49,7 +54,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
-    Dependency("OpenBLAS32_jll"),
+    Dependency("OpenBLAS32_jll", OpenBLAS32_version),
     Dependency("CompilerSupportLibraries_jll"),
 ]
 

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -39,8 +39,8 @@ Clp_version = offset_version(Clp_upstream_version, Clp_version_offset)
 Osi_version = v"0.108.5"
 Osi_gitsha = "2bd34ae6b8c93d342d54fd19d4d773f07194583c"
 
-CoinUtils_version = v"2.11.3"
-CoinUtils_gitsha = "ea66474879246f299e977802c94a0e45334e7afb"
+CoinUtils_version = v"2.11.4"
+CoinUtils_gitsha = "f709081c9b57cc2dd32579d804b30689ca789982"
 
 Ipopt_version = v"3.13.4"
 Ipopt_gitsha = "3fbc0d29427d4290d15fb8842f78ddfbb929278f"


### PR DESCRIPTION
With the ExecutableProduct in `Clp_jll` and the existing `CoinUtils_jll@2.11.4`, I get:
```Julia
julia> Clp_jll.clp() do exe
       run(`$exe`)
       end
dyld: Library not loaded: @rpath/libc++.1.dylib
  Referenced from: /Users/oscar/.julia/artifacts/38d2a3c2c3ee4e798cb6bf60940d69f19ff59070/lib/libCoinUtils.3.11.4.dylib
  Reason: image not found
```
However with `CoinUtils_jll@2.11.3` it works as expected. The LibraryProducts work with both 2.11.3 and 2.11.4.

Viral added 2.11.4 https://github.com/JuliaPackaging/Yggdrasil/pull/771, but then a few days later changed back to 2.11.3 https://github.com/JuliaPackaging/Yggdrasil/pull/783, I think just to sync things up with the old CoinUtilsBuilder package to get something working.

I would second https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/1012, and that it would be nice to check if the executable is actually executable (i.e., executes with an exit code of 0). Something like:
```Julia
ExecutableProduct("clp", :clp; test_script="-v")

 # Auditor would run

run(`$(Clp_jll.clp()) $(test_script)`)
```