### PR TITLE
[ALSA] Bump version

### DIFF
--- a/A/alsa/build_tarballs.jl
+++ b/A/alsa/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder
 
 name = "alsa"
-version = v"1.2.1-1"
+version = v"1.2.4"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.1.1.tar.bz2",
+    ArchiveSource("https://www.alsa-project.org/files/pub/lib/alsa-lib-$version.tar.bz2",
                   "c95ac63c0aad43a6ac457d960569096b0b2ef72dc4e3737e77e3e2de87022cec"),
 ]
 

--- a/A/alsa/build_tarballs.jl
+++ b/A/alsa/build_tarballs.jl
@@ -9,11 +9,14 @@ version = v"1.2.4"
 sources = [
     ArchiveSource("https://www.alsa-project.org/files/pub/lib/alsa-lib-$version.tar.bz2",
                   "f7554be1a56cdff468b58fc1c29b95b64864c590038dd309c7a978c7116908f7"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/alsa-lib*/
+# TODO: remove for version >= 1.2.5
+atomic_patch -p1 $WORKSPACE/srcdir/patches/plugin_dir_no_DL.patch
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make
 make install

--- a/A/alsa/build_tarballs.jl
+++ b/A/alsa/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"1.2.4"
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://www.alsa-project.org/files/pub/lib/alsa-lib-$version.tar.bz2",
-                  "c95ac63c0aad43a6ac457d960569096b0b2ef72dc4e3737e77e3e2de87022cec"),
+                  "f7554be1a56cdff468b58fc1c29b95b64864c590038dd309c7a978c7116908f7"),
 ]
 
 # Bash recipe for building across all platforms

--- a/A/alsa/bundled/patches/plugin_dir_no_DL.patch
+++ b/A/alsa/bundled/patches/plugin_dir_no_DL.patch
@@ -1,0 +1,29 @@
+From ad8c8e5503980295dd8e5e54a6285d2d7e32eb1e Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Thu, 22 Oct 2020 20:57:32 +0200
+Subject: [PATCH] dlmisc: the snd_plugin_dir_set / snd_plugin_dir must be
+ declared even for \!DL_ORIGIN_AVAILABLE
+
+Fixes: 8580c081c2 ("dlsym: add support for ALSA_PLUGIN_DIR environment variable")
+BugLink: https://github.com/alsa-project/alsa-lib/issues/91
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/dlmisc.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/dlmisc.c b/src/dlmisc.c
+index c9517c55..f20eb593 100644
+--- a/src/dlmisc.c
++++ b/src/dlmisc.c
+@@ -42,11 +42,9 @@
+ #ifndef PIC
+ struct snd_dlsym_link *snd_dlsym_start = NULL;
+ #endif
+-#ifdef DL_ORIGIN_AVAILABLE
+ static int snd_plugin_dir_set = 0;
+ static char *snd_plugin_dir = NULL;
+ #endif
+-#endif
+ 
+ #if defined(DL_ORIGIN_AVAILABLE) && defined(HAVE_LIBPTHREAD)
+ static pthread_mutex_t snd_dlpath_mutex = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
I've getting a segfault when I try running the "runtests_local.jl" file in PortAudio...I'm hoping this might help?

```
julia> stream = PortAudioStream(2, 0)

signal (11): Segmentation fault
in expression starting at REPL[6]:1
snd_pcm_avail_update at /workspace/srcdir/alsa-lib-1.2.1.1/src/pcm/pcm.c:2929
unknown function (ip: 0x7ffc138e52df)
Allocations: 14490140 (Pool: 14484196; Big: 5944); GC: 13
fish: “/home/brandon/julia-1.6.0/bin/j…” terminated by signal SIGSEGV (Address boundary error)
```