### PR TITLE
Add LRSLib_PolyhedraFork_jll

### DIFF
--- a/L/LRSLib_PolyhedraFork/build_tarballs.jl
+++ b/L/LRSLib_PolyhedraFork/build_tarballs.jl
@@ -1,0 +1,54 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "LRS_PolyhedraFork"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/JuliaPolyhedra/lrslib.git", "d8b723a2c315614979a8354f9e768d273d14a215"),
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd lrslib
+install_license COPYING
+
+if [ $(uname) = "Darwin" ]; then
+    atomic_patch -p1 ../makefile.osx.patch
+fi
+
+make liblrs.${dlext}.0 SONAME=liblrs.${dlext} SHLIB=liblrs.${dlext}.0
+cp liblrs.${dlext}.0 ${libdir}/liblrs.${dlext}
+
+cp ../makefile.liblrsnash .
+make -f makefile.liblrsnash SHLIB=liblrsnash.${dlext} LIBLRSDIR=${libdir}
+cp liblrsnash.${dlext} ${libdir}/liblrsnash.${dlext}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Linux(:x86_64, libc=:glibc),
+    Linux(:aarch64, libc=:glibc),
+    Linux(:powerpc64le, libc=:glibc),
+    MacOS(:x86_64)
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("liblrsnash", :liblrsnash),
+    LibraryProduct("liblrs", :liblrs)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/L/LRSLib_PolyhedraFork/build_tarballs.jl
+++ b/L/LRSLib_PolyhedraFork/build_tarballs.jl
@@ -32,10 +32,10 @@ cp liblrsnash.${dlext} ${libdir}/liblrsnash.${dlext}
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:powerpc64le, libc=:glibc),
-    MacOS(:x86_64)
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
 ]
 
 

--- a/L/LRSLib_PolyhedraFork/bundled/makefile.liblrsnash
+++ b/L/LRSLib_PolyhedraFork/bundled/makefile.liblrsnash
@@ -1,0 +1,7 @@
+INCLUDEDIR = /usr/include
+LIBDIR     = /usr/lib
+SHLIB = liblrsnash.so
+# LIBLRSDIR = /path/to/liblrs.so
+
+all:lrsnashlib.c lrsnashlib.h
+	$(CC) -shared -fPIC -O3 -o $(SHLIB) lrsnashlib.c -L$(LIBLRSDIR) -llrs -L${LIBDIR} -lgmp -Wl,-rpath,$(LIBLRSDIR) -DGMP -DMA -DLRS_QUIET -I${INCLUDEDIR}

--- a/L/LRSLib_PolyhedraFork/bundled/makefile.osx.patch
+++ b/L/LRSLib_PolyhedraFork/bundled/makefile.osx.patch
@@ -1,0 +1,11 @@
+--- a/makefile	2018-07-03 13:37:36.000000000 +0900
++++ b/makefile
+@@ -204,7 +204,7 @@ SHLIBBIN=lrs-shared redund-shared lrsnas
+ # Building (linking) the shared library, and relevant symlinks.
+ 
+ ${SHLIB}: ${SHLIBOBJ}
+-	$(CC) -shared -Wl,-soname=$(SONAME) $(SHLIBFLAGS) -o $@ ${SHLIBOBJ} -lgmp
++	$(CC) -shared -Wl,-install_name,$(SONAME) $(SHLIBFLAGS) -o $@ ${SHLIBOBJ} -L${LIBDIR} -lgmp
+ 
+ ${SONAME}: ${SHLIB}
+ 	ln -sf ${SHLIB} ${SONAME}


### PR DESCRIPTION
Adds a JLL package for [JuliaPolyhedra/lrslib](https://github.com/JuliaPolyhedra/lrslib), a fork of lrslib that is modified to be suitable for use in [LRSLib.jl](https://github.com/JuliaPolyhedra/LRSLib.jl).  (By contrast, the existing [`lrslib_jll`](https://github.com/JuliaBinaryWrappers/lrslib_jll.jl) is based on the vanilla version of lrslib.)

cc @blegat, x-ref https://github.com/JuliaPolyhedra/LRSLib.jl/issues/39.