### PR TITLE
[lrslib] Add LibraryProduct for `liblrsnash`

### DIFF
--- a/L/lrslib/build_tarballs.jl
+++ b/L/lrslib/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/lrslib*
 extraargs=""
-cflags="-O3 -Wall"
+cflags="-fPIC -O3 -Wall"
 
 # 32bit linux, arm and windows:
 if [[ $target == i686* ]] || [[ $target == arm* ]]; then
@@ -40,6 +40,10 @@ if [[ $target == *mingw* ]]; then
   for file in ${bindir}/{lrs,lrsnash,redund}; do mv $file $file.exe; done
   mv ${prefix}/lib/*lrs*.dll ${libdir}/
 fi
+
+nash_shlib="liblrsnash.${dlext}"
+${CC} -shared ${cflags} -o ${nash_shlib} lrsnashlib.c -L${libdir} -llrs -lgmp -Wl,-rpath,${libdir} -DMA -DGMP -DLRS_QUIET -I${includedir}
+mv ${nash_shlib} ${libdir}
 """
 
 # These are the platforms we will build for by default, unless further
@@ -52,6 +56,7 @@ products = [
     ExecutableProduct("lrsnash", :lrsnash)
     ExecutableProduct("redund", :redund)
     LibraryProduct("liblrs", :liblrs)
+    LibraryProduct("liblrsnash", :liblrsnash)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/L/lrslib/build_tarballs.jl
+++ b/L/lrslib/build_tarballs.jl
@@ -25,10 +25,11 @@ if [[ $target == i686* ]] || [[ $target == arm* ]]; then
 fi
 
 if [[ $target == *apple* ]]; then
+  export CC=gcc
   sed -i -e 's#-Wl,-soname=#-install_name #' makefile
   extraargs="SONAME=liblrs.0.dylib SHLINK=liblrs.dylib SHLIB=liblrs.0.0.0.dylib"
 elif [[ $target == *freebsd* ]]; then
-  export CC="$CC $LDFLAGS"
+  export CC="gcc $LDFLAGS"
 elif [[ $target == *mingw* ]]; then
   extraargs="SONAME=liblrs-0.dll SHLINK=liblrs.dll SHLIB=liblrs-0-0-0.dll"
   cflags="$cflags -DSIGNALS -DTIMES"

--- a/L/lrslib/build_tarballs.jl
+++ b/L/lrslib/build_tarballs.jl
@@ -29,7 +29,7 @@ if [[ $target == *apple* ]]; then
   sed -i -e 's#-Wl,-soname=#-install_name #' makefile
   extraargs="SONAME=liblrs.0.dylib SHLINK=liblrs.dylib SHLIB=liblrs.0.0.0.dylib"
 elif [[ $target == *freebsd* ]]; then
-  export CC="gcc $LDFLAGS"
+  export CC="gcc"
 elif [[ $target == *mingw* ]]; then
   extraargs="SONAME=liblrs-0.dll SHLINK=liblrs.dll SHLIB=liblrs-0-0-0.dll"
   cflags="$cflags -DSIGNALS -DTIMES"


### PR DESCRIPTION
Adds a `LibraryProduct` for `liblrsnash`, which will allow this JLL to be used by [JuliaPolyhedra/LRSLib.jl](https://github.com/JuliaPolyhedra/LRSLib.jl).

x-ref: https://github.com/JuliaPolyhedra/LRSLib.jl/issues/39