### PR TITLE
[lrslib] Bump version

### DIFF
--- a/L/lrslib/build_tarballs.jl
+++ b/L/lrslib/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "lrslib"
-version = v"0.1.0"
+version = v"0.2.0"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
https://github.com/JuliaPolyhedra/LRSLib.jl/pull/40 CI is passing on version [0.1.0+3](https://github.com/JuliaPackaging/Yggdrasil/pull/2862) of `lrslib_jll`, and fails on earlier versions due to the lack of an `liblrsnash` LibraryProduct.  AFAIK, Julia package compatibility [specifiers](https://pkgdocs.julialang.org/v1/compatibility/) don't have a way of saying "version 0.1.0+3 or above," so we need a version bump to be able to require at least this version in LRSLib.jl's `Project.toml` (see https://github.com/JuliaPolyhedra/LRSLib.jl/pull/40).  Since this release adds more API (in the form of the new LibraryProduct), I think a bump to the [minor version](https://semver.org/#spec-item-7) makes sense, i.e., to `v"0.2.0"`.