### PR TITLE
[UserNSSandbox] Bump version

### DIFF
--- a/U/UserNSSandbox/build_tarballs.jl
+++ b/U/UserNSSandbox/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder
 
 name = "UserNSSandbox"
-version = v"2021.04.21"
+version = v"2021.04.22"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/staticfloat/Sandbox.jl",
-              "57ba97383793f775ba65722c28e3e6be885f795b"),
+              "0fc3812cd74a355e5a2c4d45d68fabb9fb059f55"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Turns out `musl`'s `realpath()` is not as flexible as `glibc`'s