### PR TITLE
[Imath] build with gcc5

### DIFF
--- a/I/Imath/build_tarballs.jl
+++ b/I/Imath/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/Imath
+cd $WORKSPACE/srcdir/Imath*
 mkdir build
 cd build/
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/I/Imath/build_tarballs.jl
+++ b/I/Imath/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"3.0.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/AcademySoftwareFoundation/Imath.git", "73c2cdfcaf2a22880ddf42a866ebd4614d424410")
+    ArchiveSource("https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.0.1.tar.gz", "9cd984bb6b0a9572dd4a373b1fab60bc4c992a52ec5c68328fe0f48f194ba3c0")
 ]
 
 # Bash recipe for building across all platforms

--- a/I/Imath/build_tarballs.jl
+++ b/I/Imath/build_tarballs.jl
@@ -12,13 +12,16 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
+cd $WORKSPACE/srcdir/Imath
 mkdir build
 cd build/
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../Imath
-make -j
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DBUILD_TESTING=OFF \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+make -j${nproc}
 make install
-install_license ../Imath/LICENSE.md 
 exit
 """
 
@@ -36,4 +39,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7.1.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5.2.0")


### PR DESCRIPTION
Build with gcc5. As it is, openexr support can't be built into ImageMagick_jll.