### PR TITLE
Add a unified CUDA loader.

### DIFF
--- a/C/CUDA/CUDA_loader/build_10.0.jl
+++ b/C/CUDA/CUDA_loader/build_10.0.jl
@@ -157,6 +157,19 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
+products = [
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    LibraryProduct(["libcufft", "cufft64_100"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_100"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_100"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_100"], :libcusolver),
+    LibraryProduct(["libcurand", "curand64_100"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_100"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+]
+
 platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "macos"),
              Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_10.0.jl
+++ b/C/CUDA/CUDA_loader/build_10.0.jl
@@ -1,0 +1,162 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"10.0.130"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == x86_64-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib64/libnvblas.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # CUDA Accelerated Graph Library
+    mv lib64/libnvgraph.so* ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib64/libnpp*.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-apple-darwin* ]]; then
+    # CUDA Runtime
+    mv lib/libcudart.*dylib lib/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib/libcufft.*dylib lib/libcufftw.*dylib ${libdir}
+
+    # CUDA BLAS Library
+    mv lib/libcublas.*dylib ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib/libnvblas.*dylib ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib/libcusparse.*dylib ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib/libcusolver.*dylib ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib/libcurand.*dylib ${libdir}
+
+    # CUDA Accelerated Graph Library
+    mv lib/libnvgraph.*dylib ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib/libnpp*.*dylib ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib/libnvvm.*dylib ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib/libcupti.*dylib ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib/libnvToolsExt.*dylib ${libdir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll ${bindir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv bin/nvblas64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # CUDA Accelerated Graph Library
+    mv bin/nvgraph64_*.dll ${bindir}
+
+    # NVIDIA Performance Primitives Library
+    mv bin/npp*64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/libx64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/cuda-memcheck.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("x86_64", "macos"),
+             Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_10.2.jl
+++ b/C/CUDA/CUDA_loader/build_10.2.jl
@@ -119,5 +119,19 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
+products = [
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_10"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_10"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_10"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_102"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+]
+
 platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_10.2.jl
+++ b/C/CUDA/CUDA_loader/build_10.2.jl
@@ -1,0 +1,123 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"10.2.89"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == x86_64-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib64/libnvblas.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # CUDA Accelerated Graph Library
+    mv lib64/libnvgraph.so* ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib64/libnpp*.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv bin/nvblas64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Nulti GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # CUDA Accelerated Graph Library
+    mv bin/nvgraph64_*.dll ${bindir}
+
+    # NVIDIA Performance Primitives Library
+    mv bin/npp*64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/cuda-memcheck.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_11.0.jl
+++ b/C/CUDA/CUDA_loader/build_11.0.jl
@@ -121,6 +121,21 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
+products = [
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_10"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2020.1.1"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+]
+
 platforms = [Platform("x86_64", "linux"),
              Platform("powerpc64le", "linux"),
              Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_11.0.jl
+++ b/C/CUDA/CUDA_loader/build_11.0.jl
@@ -1,0 +1,126 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.0.3"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib64/libnvblas.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib64/libnpp*.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r Sanitizer/{docs,include}
+    mv Sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv bin/nvblas64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Performance Primitives Library
+    mv bin/npp*64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r Sanitizer/{docs,include}
+    mv Sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/cuda-memcheck.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("powerpc64le", "linux"),
+             Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_11.1.jl
+++ b/C/CUDA/CUDA_loader/build_11.1.jl
@@ -121,6 +121,21 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
+products = [
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2020.2.1"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+]
+
 platforms = [Platform("x86_64", "linux"),
              Platform("powerpc64le", "linux"),
              Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_11.1.jl
+++ b/C/CUDA/CUDA_loader/build_11.1.jl
@@ -1,0 +1,126 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.1.1"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib64/libnvblas.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib64/libnpp*.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv bin/nvblas64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Performance Primitives Library
+    mv bin/npp*64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/cuda-memcheck.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("powerpc64le", "linux"),
+             Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_11.2.jl
+++ b/C/CUDA/CUDA_loader/build_11.2.jl
@@ -121,6 +121,21 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
+products = [
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2020.3.1"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+]
+
 platforms = [Platform("x86_64", "linux"),
              Platform("powerpc64le", "linux"),
              Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_11.2.jl
+++ b/C/CUDA/CUDA_loader/build_11.2.jl
@@ -1,0 +1,126 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.2.2"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib64/libnvblas.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib64/libnpp*.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv bin/nvblas64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Performance Primitives Library
+    mv bin/npp*64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/cuda-memcheck.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("powerpc64le", "linux"),
+             Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_11.3.jl
+++ b/C/CUDA/CUDA_loader/build_11.3.jl
@@ -1,0 +1,126 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.3.0"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib64/libnvblas.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib64/libnpp*.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv bin/nvblas64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Performance Primitives Library
+    mv bin/npp*64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/cuda-memcheck.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("powerpc64le", "linux"),
+             Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_11.3.jl
+++ b/C/CUDA/CUDA_loader/build_11.3.jl
@@ -121,6 +121,21 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
+products = [
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2021.1.0"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+]
+
 platforms = [Platform("x86_64", "linux"),
              Platform("powerpc64le", "linux"),
              Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_9.0.jl
+++ b/C/CUDA/CUDA_loader/build_9.0.jl
@@ -157,6 +157,19 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
+products = [
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    LibraryProduct(["libcufft", "cufft64_90"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_90"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_90"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_90"], :libcusolver),
+    LibraryProduct(["libcurand", "curand64_90"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_90"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+]
+
 platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "macos"),
              Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_9.0.jl
+++ b/C/CUDA/CUDA_loader/build_9.0.jl
@@ -1,0 +1,162 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"9.0.176"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == x86_64-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib64/libnvblas.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # CUDA Accelerated Graph Library
+    mv lib64/libnvgraph.so* ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib64/libnpp*.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-apple-darwin* ]]; then
+    # CUDA Runtime
+    mv lib/libcudart.*dylib lib/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib/libcufft.*dylib lib/libcufftw.*dylib ${libdir}
+
+    # CUDA BLAS Library
+    mv lib/libcublas.*dylib ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib/libnvblas.*dylib ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib/libcusparse.*dylib ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib/libcusolver.*dylib ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib/libcurand.*dylib ${libdir}
+
+    # CUDA Accelerated Graph Library
+    mv lib/libnvgraph.*dylib ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib/libnpp*.*dylib ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib/libnvvm.*dylib ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib/libcupti.*dylib ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib/libnvToolsExt.*dylib ${libdir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll ${bindir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv bin/nvblas64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # CUDA Accelerated Graph Library
+    mv bin/nvgraph64_*.dll ${bindir}
+
+    # NVIDIA Performance Primitives Library
+    mv bin/npp*64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/libx64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/cuda-memcheck.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("x86_64", "macos"),
+             Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_9.2.jl
+++ b/C/CUDA/CUDA_loader/build_9.2.jl
@@ -157,6 +157,19 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
+products = [
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    LibraryProduct(["libcufft", "cufft64_92"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_92"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_92"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_92"], :libcusolver),
+    LibraryProduct(["libcurand", "curand64_92"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_92"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+]
+
 platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "macos"),
              Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_9.2.jl
+++ b/C/CUDA/CUDA_loader/build_9.2.jl
@@ -1,0 +1,162 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"9.2.148"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == x86_64-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib64/libnvblas.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # CUDA Accelerated Graph Library
+    mv lib64/libnvgraph.so* ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib64/libnpp*.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-apple-darwin* ]]; then
+    # CUDA Runtime
+    mv lib/libcudart.*dylib lib/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib/libcufft.*dylib lib/libcufftw.*dylib ${libdir}
+
+    # CUDA BLAS Library
+    mv lib/libcublas.*dylib ${libdir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv lib/libnvblas.*dylib ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib/libcusparse.*dylib ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib/libcusolver.*dylib ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib/libcurand.*dylib ${libdir}
+
+    # CUDA Accelerated Graph Library
+    mv lib/libnvgraph.*dylib ${libdir}
+
+    # NVIDIA Performance Primitives Library
+    mv lib/libnpp*.*dylib ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib/libnvvm.*dylib ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib/libcupti.*dylib ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib/libnvToolsExt.*dylib ${libdir}
+
+    # Additional binaries
+    mv bin/nvdisasm ${bindir}
+    mv bin/cuda-memcheck ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll ${bindir}
+
+    # NVIDIA "Drop-in" BLAS Library
+    mv bin/nvblas64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # CUDA Accelerated Graph Library
+    mv bin/nvgraph64_*.dll ${bindir}
+
+    # NVIDIA Performance Primitives Library
+    mv bin/npp*64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/libx64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Additional binaries
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/cuda-memcheck.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("x86_64", "macos"),
+             Platform("x86_64", "windows")]

--- a/C/CUDA/CUDA_loader/build_tarballs.jl
+++ b/C/CUDA/CUDA_loader/build_tarballs.jl
@@ -1,0 +1,35 @@
+using BinaryBuilder, Pkg
+
+name = "CUDA_loader"
+version = v"0.1"
+
+# NOTE: this only exports libraries that are used by CUDA.jl
+products = [
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    LibraryProduct(["libcufft", r"cufft64_.*"], :libcufft),
+    LibraryProduct(["libcublas", r"cublas64_.*"], :libcublas),
+    LibraryProduct(["libcusparse", r"cusparse64_.*"], :libcusparse),
+    LibraryProduct(["libcusolver", r"cusolver64_.*"], :libcusolver),
+    LibraryProduct(["libcurand", r"curand64_.*"], :libcurand),
+    LibraryProduct(["libcupti", r"cupti64_.*"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    # only on CUDA 10.2 or higher
+    LibraryProduct(["libcusolverMg", r"cusolverMg64_.*"], :libcusolverMg; optional=true),
+    # only on CUDA 11.0 or higher
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer; optional=true),
+]
+
+cuda_versions = [v"9.0", v"9.2", v"10.0", v"10.2", v"11.0", v"11.1", v"11.2", v"11.3"]
+for cuda_version in cuda_versions
+    cuda_tag = "$(cuda_version.major).$(cuda_version.minor)"
+    include("build_$(cuda_tag).jl")
+
+    for platform in platforms
+        platform.tags["cuda"] = cuda_tag
+    end
+
+    build_tarballs(ARGS, name, version, [], script, platforms, products, dependencies;
+                   lazy_artifacts=true)
+end

--- a/C/CUDA/CUDA_loader/build_tarballs.jl
+++ b/C/CUDA/CUDA_loader/build_tarballs.jl
@@ -1,25 +1,9 @@
 using BinaryBuilder, Pkg
 
+include("../../../fancy_toys.jl")
+
 name = "CUDA_loader"
 version = v"0.1"
-
-# NOTE: this only exports libraries that are used by CUDA.jl
-products = [
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    LibraryProduct(["libcufft", r"cufft64_.*"], :libcufft),
-    LibraryProduct(["libcublas", r"cublas64_.*"], :libcublas),
-    LibraryProduct(["libcusparse", r"cusparse64_.*"], :libcusparse),
-    LibraryProduct(["libcusolver", r"cusolver64_.*"], :libcusolver),
-    LibraryProduct(["libcurand", r"curand64_.*"], :libcurand),
-    LibraryProduct(["libcupti", r"cupti64_.*"], :libcupti),
-    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    # only on CUDA 10.2 or higher
-    LibraryProduct(["libcusolverMg", r"cusolverMg64_.*"], :libcusolverMg; optional=true),
-    # only on CUDA 11.0 or higher
-    ExecutableProduct("compute-sanitizer", :compute_sanitizer; optional=true),
-]
 
 cuda_versions = [v"9.0", v"9.2", v"10.0", v"10.2", v"11.0", v"11.1", v"11.2", v"11.3"]
 for cuda_version in cuda_versions
@@ -30,6 +14,8 @@ for cuda_version in cuda_versions
         platform.tags["cuda"] = cuda_tag
     end
 
+    any(should_build_platform.(triplet.(platforms))) || continue
     build_tarballs(ARGS, name, version, [], script, platforms, products, dependencies;
                    lazy_artifacts=true)
+
 end


### PR DESCRIPTION
This PR does some API exploration to figure out how a unified CUDA recipe would look; it's not intended to be functional (yet), as it needs additional features in BinaryBuilder.

IIUC, to use the new platform augmentation support, I need a single JLL that contains all the CUDA artifacts for each CUDA version (as opposed to the current CUDA_jll which attaches different artifacts to different versions of CUDA_jll), differentiated by the platform tag. There's a couple of problems with that:
- CUDA_jll pulls in the CUDA toolkit from CUDA_full_jll, which_does_ use package versions to select different versions of CUDA. I'd want to keep that, as it matches how we normally do this in Yggdrasil, but that means I can't have a single `dependencies` array (because it can't contain multiple versions of the same package).
- so instead of a single invocation, here I tried calling `build_tarballs` multiple times, each time with different arguments (changing the script, dependencies, and platforms). Is that OK?
- to simplify finding the CUDA Windows DLLs, whose name contains the CUDA version, it would be convenient if I could use regexes in the `LibraryProduct`s. Would that be OK?
- finally, since we support multiple versions of CUDA, some products aren't expected to be found for all versions. An `optional` keyword argument, resulting in e.g. `nothing` when requesting the product at run time, would be one solution.

Thoughts? cc @giordano @staticfloat 