### PR TITLE
[Rootfs] Teach testsuite to be less headstrong about `CC`, `CXX` etc...

### DIFF
--- a/0_RootFS/Rootfs/bundled/testsuite/common.mk
+++ b/0_RootFS/Rootfs/bundled/testsuite/common.mk
@@ -55,11 +55,11 @@ PROJECT_BUILD := $(BUILD_ROOT)/$(target)/$(PROJECT_REL_DIR)
 
 # Define some compiler defaults (they are typically overridden by `export`'ed
 # variables in the BB shell)
-CC := $(target)-cc
-CXX := $(target)-c++
-FC := $(target)-f77
-GO := $(target)-go
-RUSTC := $(target)-rustc
+CC ?= $(target)-cc
+CXX ?= $(target)-c++
+FC ?= $(target)-f77
+GO ?= $(target)-go
+RUSTC ?= $(target)-rustc
 
 # Create default rule for that directory so it can be created, if need be:
 $(PROJECT_BUILD):


### PR DESCRIPTION
The testsuite should do what the comment says; it should not assume
values for `CC`, `CXX`, etc... this manifested as an incorrectly-set
`RUSTC`, which should not have been a problem in the first place, but
still is sub-optimal