### PR TITLE
[CryptoMiniSat] Add Builder

### DIFF
--- a/C/CryptoMiniSat/build_tarballs.jl
+++ b/C/CryptoMiniSat/build_tarballs.jl
@@ -1,0 +1,46 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "CryptoMiniSat"
+version = v"5.8.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/msoos/cryptominisat.git", "e7079937ed2bfe9160a104378e5a344028e4ab78")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/cryptominisat
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+make -j${nproc}
+make install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("cryptominisat5", :cryptominisat5),
+    ExecutableProduct("cryptominisat5_simple", :cryptominisat5_simple),
+    LibraryProduct("libcryptominisat5", :libcryptominisat5)
+    
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("boost_jll"),
+    Dependency("Zlib_jll"),
+    Dependency("SQLite_jll")
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/C/CryptoMiniSat/build_tarballs.jl
+++ b/C/CryptoMiniSat/build_tarballs.jl
@@ -16,6 +16,7 @@ script = raw"""
 
 cd $WORKSPACE/srcdir/cryptominisat
 atomic_patch -p1 ../Yalsatpatch.patch
+atomic_patch -p1 ../feenablepatch.patch
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
@@ -23,6 +24,7 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     -DENABLE_PYTHON_INTERFACE=OFF \
     -DIPASIR=ON \
     -DNOM4RI=ON \
+    -DBoost_USE_STATIC_LIBS=OFF \
     ..
 make -j${nproc}
 make install

--- a/C/CryptoMiniSat/build_tarballs.jl
+++ b/C/CryptoMiniSat/build_tarballs.jl
@@ -37,7 +37,7 @@ platforms = expand_cxxstring_abis(supported_platforms())
 products = Product[
     ExecutableProduct("cryptominisat5", :cryptominisat5),
     ExecutableProduct("cryptominisat5_simple", :cryptominisat5_simple),
-    LibraryProduct("libcryptominisat5", :libcryptominisat5),
+    LibraryProduct(["libcryptominisat5", "libcryptominisat5win"], :libcryptominisat5),
     LibraryProduct("libipasircryptominisat5", :libipasircryptominisat5)
 ]
 

--- a/C/CryptoMiniSat/build_tarballs.jl
+++ b/C/CryptoMiniSat/build_tarballs.jl
@@ -35,7 +35,7 @@ platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = Product[
-    ExecutableProduct("cryptominisat5", :cryptominisat5),
+    ExecutableProduct(["cryptominisat5", "cryptominisat5win"], :cryptominisat5),
     ExecutableProduct("cryptominisat5_simple", :cryptominisat5_simple),
     LibraryProduct(["libcryptominisat5", "libcryptominisat5win"], :libcryptominisat5),
     LibraryProduct("libipasircryptominisat5", :libipasircryptominisat5)

--- a/C/CryptoMiniSat/build_tarballs.jl
+++ b/C/CryptoMiniSat/build_tarballs.jl
@@ -7,20 +7,26 @@ version = v"5.8.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/msoos/cryptominisat.git", "e7079937ed2bfe9160a104378e5a344028e4ab78")
+    GitSource("https://github.com/msoos/cryptominisat.git", "e7079937ed2bfe9160a104378e5a344028e4ab78"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
+
 cd $WORKSPACE/srcdir/cryptominisat
+atomic_patch -p1 ../Yalsatpatch.patch
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_PYTHON_INTERFACE=OFF \
+    -DIPASIR=ON \
+    -DNOM4RI=ON \
     ..
 make -j${nproc}
 make install
-
+install_license ${WORKSPACE}/srcdir/cryptominisat/LICENSE.txt
 """
 
 # These are the platforms we will build for by default, unless further
@@ -28,18 +34,20 @@ make install
 platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
-products = [
+products = Product[
     ExecutableProduct("cryptominisat5", :cryptominisat5),
     ExecutableProduct("cryptominisat5_simple", :cryptominisat5_simple),
-    LibraryProduct("libcryptominisat5", :libcryptominisat5)
-    
+    LibraryProduct("libcryptominisat5", :libcryptominisat5),
+    LibraryProduct("libipasircryptominisat5", :libipasircryptominisat5)
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("boost_jll"),
     Dependency("Zlib_jll"),
-    Dependency("SQLite_jll")
+    Dependency("SQLite_jll"),
+    Dependency("MPICH_jll"),
+    Dependency("MicrosoftMPI_jll")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CryptoMiniSat/build_tarballs.jl
+++ b/C/CryptoMiniSat/build_tarballs.jl
@@ -52,4 +52,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7")

--- a/C/CryptoMiniSat/build_tarballs.jl
+++ b/C/CryptoMiniSat/build_tarballs.jl
@@ -48,9 +48,8 @@ dependencies = [
     Dependency("boost_jll"),
     Dependency("Zlib_jll"),
     Dependency("SQLite_jll"),
-    Dependency("MPICH_jll"),
-    Dependency("MicrosoftMPI_jll")
+    Dependency("MPICH_jll")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/C/CryptoMiniSat/build_tarballs.jl
+++ b/C/CryptoMiniSat/build_tarballs.jl
@@ -51,4 +51,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7")

--- a/C/CryptoMiniSat/bundled/Yalsatpatch.patch
+++ b/C/CryptoMiniSat/bundled/Yalsatpatch.patch
@@ -1,0 +1,24 @@
+--- a/CMakeLists.txt	2021-04-28 11:29:14.157223857 -0400
++++ b/CMakeLists.txt	2021-04-28 11:30:48.141922745 -0400
+@@ -572,14 +572,15 @@
+     endif()
+ endif()
+ 
+-include(CheckFloatPrecision)
+-check_float_precision()
+-if (HAVE__FPU_SETCW)
+-    add_definitions(-DYALSAT_FPU)
+-    message(STATUS "Found FPU code for yalsat: fpu_control.h, _FPU_SINGLE, _FPU_DOUBLE")
++if (NOT CMAKE_CROSSCOMPILING)
++    include(CheckFloatPrecision)
++    check_float_precision()
++    if (HAVE__FPU_SETCW)
++        add_definitions(-DYALSAT_FPU)
++        message(STATUS "Found FPU code for yalsat: fpu_control.h, _FPU_SINGLE, _FPU_DOUBLE")
++    endif()
+ endif()
+ 
+-
+ option(WEIGHTED_SAMPLING "Allow for weighted sampling" OFF)
+ if (WEIGHTED_SAMPLING)
+     add_definitions( -DWEIGHTED_SAMPLING )

--- a/C/CryptoMiniSat/bundled/feenablepatch.patch
+++ b/C/CryptoMiniSat/bundled/feenablepatch.patch
@@ -5,7 +5,7 @@
  int main(int argc, char** argv)
  {
 -    #if defined(__GNUC__) && defined(__linux__)
-+    #if defined(__GLIBC__) && defined(__linux__)
++    #if defined(_GNU_SOURCE) && defined(__linux__)
      feenableexcept(FE_INVALID   |
                     FE_DIVBYZERO |
                     FE_OVERFLOW

--- a/C/CryptoMiniSat/bundled/feenablepatch.patch
+++ b/C/CryptoMiniSat/bundled/feenablepatch.patch
@@ -5,7 +5,7 @@
  int main(int argc, char** argv)
  {
 -    #if defined(__GNUC__) && defined(__linux__)
-+    #if defined(_GNU_SOURCE) && defined(__linux__)
++    #if defined(__GLIBC__) && defined(__linux__)
      feenableexcept(FE_INVALID   |
                     FE_DIVBYZERO |
                     FE_OVERFLOW

--- a/C/CryptoMiniSat/bundled/feenablepatch.patch
+++ b/C/CryptoMiniSat/bundled/feenablepatch.patch
@@ -1,0 +1,11 @@
+--- a/src/main_exe.cpp	2021-04-28 19:37:49.840225279 -0400
++++ b/src/main_exe.cpp	2021-04-28 19:53:18.474122721 -0400
+@@ -27,7 +27,7 @@
+ 
+ int main(int argc, char** argv)
+ {
+-    #if defined(__GNUC__) && defined(__linux__)
++    #if defined(__GLIBC__) && defined(__linux__)
+     feenableexcept(FE_INVALID   |
+                    FE_DIVBYZERO |
+                    FE_OVERFLOW


### PR DESCRIPTION
There's a weird issue I can't really figure. On musl I get `/workspace/srcdir/cryptominisat/src/main_exe.cpp:34:5: error: ‘feenableexcept’ was not declared in this scope`. But if I inspect that section of the code I see it's in an `#if defined(__GNUC__) && defined(__linux__)` block. That seems like it shouldn't be defined on musl then to me?