### PR TITLE
Bump MagicVLSI

### DIFF
--- a/M/MagicVLSI/build_tarballs.jl
+++ b/M/MagicVLSI/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"8.3.160"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/Keno/magic.git", "7e68c94744cd36c193536ba8a5cc3a931b640b8b")
+    GitSource("https://github.com/Keno/magic.git", "8ab1743be8f6e0d7ab95e0c2e86688379fca1aad")
 ]
 
 # Bash recipe for building across all platforms

--- a/M/MagicVLSI/build_tarballs.jl
+++ b/M/MagicVLSI/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "MagicVLSI"
-version = v"8.3.61"
+version = v"8.3.160"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/Keno/magic.git", "a58100a14cdb57462cf75691532d01c5733fb59b")
+    GitSource("https://github.com/Keno/magic.git", "7e68c94744cd36c193536ba8a5cc3a931b640b8b")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bumps MagicVLSI to 8.3.160 and fixes a relocation-related problem
that caused `magic --version` to hang rather than printing the
version, breaking downstream tooling.