### PR TITLE
[CUDNN] make Windows binaries executable

### DIFF
--- a/C/CUDNN/common.jl
+++ b/C/CUDNN/common.jl
@@ -32,6 +32,9 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     mv bin/cudnn*64_*.dll ${libdir}
     mv include/* ${prefix}/include
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
 fi
 """
 


### PR DESCRIPTION
To fix the issues that arise in https://github.com/JuliaGPU/CUDA.jl/issues/757.

This is already done in the CUDA build as well: https://github.com/JuliaPackaging/Yggdrasil/blob/221a3f61bbd7604dc5ae2cbbdd0023a7198a60a3/C/CUDA/CUDA%4011.3/build_tarballs.jl#L124-L125