### PR TITLE
[RDKit] update git commit

### DIFF
--- a/R/RDKit/build_tarballs.jl
+++ b/R/RDKit/build_tarballs.jl
@@ -6,7 +6,7 @@ name = "RDKit"
 version = v"2021.09.1pre"
 
 sources = [
-    GitSource("https://github.com/rdkit/rdkit.git", "af3bb3e78b24ed8d92211d9c047ddbcf5c04afc8"),
+    GitSource("https://github.com/rdkit/rdkit.git", "ccb805b46790ec497ed9eac538e880060c2693bc"),
 ]
 
 script = raw"""


### PR DESCRIPTION
updating only the git commit for the new build (memory leak fixed) since this is building dev functionality that won't be stable until Setp/Oct when the 2021.09 version will be released. We'll then replace the GitSource by an ArchiveSource.

So the auto build number the BinaryBuilder adds will work for now.

More info: 
https://greglandrum.github.io/rdkit-blog/technical/2021/05/01/rdkit-cffi-part1.html
https://chembl.blogspot.com/2021/05/julia-meets-rdkit.html

Thanks!
