### PR TITLE
ngspice: Add some custom extensions

### DIFF
--- a/N/ngspice/build_tarballs.jl
+++ b/N/ngspice/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"34"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/imr/ngspice.git", "279edff5d9877b13ddd7708285553ea20d6f14cd"),
+    GitSource("https://github.com/JuliaSky130/ngspice.git", "a034b9a2bafcc218aba92c911a6425953f0bda28"),
     DirectorySource("./bundled")
 ]
 


### PR DESCRIPTION
This is part of an experiment to use the julia package manager to
manage SPICE library files. The patches being included here allow
NgSpice.jl to register a callback to have julia resolve SPICE-side
library and include references using regular code loading.