### PR TITLE
[patch] libsixel: export required missing symbol for the windows target

### DIFF
--- a/L/libsixel/build_tarballs.jl
+++ b/L/libsixel/build_tarballs.jl
@@ -7,12 +7,19 @@ version = v"1.8.6"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/saitoha/libsixel.git", "5db717dfef6fa327cd4025e7352550f63d20699c")
+    GitSource("https://github.com/saitoha/libsixel.git", "5db717dfef6fa327cd4025e7352550f63d20699c"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libsixel/
+
+# This patch fixes https://github.com/johnnychen94/Sixel.jl/issues/5
+if [[ "${target}" == *-mingw* ]]; then
+    atomic_patch -p1 ../patches/01-libsixel-win32.patch
+fi
+
 ./configure --prefix=${prefix} \
     --build=${MACHTYPE} \
     --host=${target} \

--- a/L/libsixel/bundled/patches/01-libsixel-win32.patch
+++ b/L/libsixel/bundled/patches/01-libsixel-win32.patch
@@ -1,0 +1,16 @@
+# This patch exports `sixel_allocator_new` to the generated dll library for the windows target
+# as bug fix. Upstream PR in https://github.com/saitoha/libsixel/pull/151
+
+diff --git a/include/sixel.h.in b/include/sixel.h.in
+index bcdb66c..cf61715 100644
+--- a/include/sixel.h.in
++++ b/include/sixel.h.in
+@@ -506,7 +506,7 @@ extern "C" {
+ #endif
+ 
+ /* create allocator object */
+-SIXELSTATUS
++SIXELAPI SIXELSTATUS
+ sixel_allocator_new(
+     sixel_allocator_t   /* out */ **ppallocator,  /* allocator object to be created */
+     sixel_malloc_t      /* in */  fn_malloc,      /* custom malloc() function */


### PR DESCRIPTION
`sixel_allocator_new` is expected to be a part of libsixel API

I've manually tested that it fixes the symbol issue in https://github.com/johnnychen94/Sixel.jl/issues/5 with `Libdl.dlsym` so should be a good patch. The upstream patch is in https://github.com/saitoha/libsixel/pull/151