### PR TITLE
[CUDA] Fix handling of augmented platforms.

### DIFF
--- a/C/CUDA/CUDA_loader/build_10.0.jl
+++ b/C/CUDA/CUDA_loader/build_10.0.jl
@@ -149,6 +149,6 @@ products = [
     ExecutableProduct("nvlink", :nvlink),
 ]
 
-platforms = [Platform("x86_64", "linux"),
-             Platform("x86_64", "macos"),
-             Platform("x86_64", "windows")]
+platforms = [Platform("x86_64", "linux"; cuda="10.0"),
+             Platform("x86_64", "macos"; cuda="10.0"),
+             Platform("x86_64", "windows"; cuda="10.0")]

--- a/C/CUDA/CUDA_loader/build_10.1.jl
+++ b/C/CUDA/CUDA_loader/build_10.1.jl
@@ -159,6 +159,6 @@ products = [
     ExecutableProduct("nvlink", :nvlink),
 ]
 
-platforms = [Platform("x86_64", "linux"),
-             Platform("x86_64", "macos"),
-             Platform("x86_64", "windows")]
+platforms = [Platform("x86_64", "linux"; cuda="10.1"),
+             Platform("x86_64", "macos"; cuda="10.1"),
+             Platform("x86_64", "windows"; cuda="10.1")]

--- a/C/CUDA/CUDA_loader/build_10.2.jl
+++ b/C/CUDA/CUDA_loader/build_10.2.jl
@@ -120,5 +120,5 @@ products = [
     ExecutableProduct("nvlink", :nvlink),
 ]
 
-platforms = [Platform("x86_64", "linux"),
-             Platform("x86_64", "windows")]
+platforms = [Platform("x86_64", "linux"; cuda="10.2"),
+             Platform("x86_64", "windows"; cuda="10.2")]

--- a/C/CUDA/CUDA_loader/build_11.0.jl
+++ b/C/CUDA/CUDA_loader/build_11.0.jl
@@ -129,6 +129,6 @@ products = [
     ExecutableProduct("compute-sanitizer", :compute_sanitizer),
 ]
 
-platforms = [Platform("x86_64", "linux"),
-             Platform("powerpc64le", "linux"),
-             Platform("x86_64", "windows")]
+platforms = [Platform("x86_64", "linux"; cuda="11.0"),
+             Platform("powerpc64le", "linux"; cuda="11.0"),
+             Platform("x86_64", "windows"; cuda="11.0")]

--- a/C/CUDA/CUDA_loader/build_11.1.jl
+++ b/C/CUDA/CUDA_loader/build_11.1.jl
@@ -129,6 +129,6 @@ products = [
     ExecutableProduct("compute-sanitizer", :compute_sanitizer),
 ]
 
-platforms = [Platform("x86_64", "linux"),
-             Platform("powerpc64le", "linux"),
-             Platform("x86_64", "windows")]
+platforms = [Platform("x86_64", "linux"; cuda="11.1"),
+             Platform("powerpc64le", "linux"; cuda="11.1"),
+             Platform("x86_64", "windows"; cuda="11.1")]

--- a/C/CUDA/CUDA_loader/build_11.2.jl
+++ b/C/CUDA/CUDA_loader/build_11.2.jl
@@ -129,6 +129,6 @@ products = [
     ExecutableProduct("compute-sanitizer", :compute_sanitizer),
 ]
 
-platforms = [Platform("x86_64", "linux"),
-             Platform("powerpc64le", "linux"),
-             Platform("x86_64", "windows")]
+platforms = [Platform("x86_64", "linux"; cuda="11.2"),
+             Platform("powerpc64le", "linux"; cuda="11.2"),
+             Platform("x86_64", "windows"; cuda="11.2")]

--- a/C/CUDA/CUDA_loader/build_11.3.jl
+++ b/C/CUDA/CUDA_loader/build_11.3.jl
@@ -129,6 +129,6 @@ products = [
     ExecutableProduct("compute-sanitizer", :compute_sanitizer),
 ]
 
-platforms = [Platform("x86_64", "linux"),
-             Platform("powerpc64le", "linux"),
-             Platform("x86_64", "windows")]
+platforms = [Platform("x86_64", "linux"; cuda="11.3"),
+             Platform("powerpc64le", "linux"; cuda="11.3"),
+             Platform("x86_64", "windows"; cuda="11.3")]

--- a/C/CUDA/CUDA_loader/build_9.0.jl
+++ b/C/CUDA/CUDA_loader/build_9.0.jl
@@ -149,6 +149,6 @@ products = [
     ExecutableProduct("nvlink", :nvlink),
 ]
 
-platforms = [Platform("x86_64", "linux"),
-             Platform("x86_64", "macos"),
-             Platform("x86_64", "windows")]
+platforms = [Platform("x86_64", "linux"; cuda="9.0"),
+             Platform("x86_64", "macos"; cuda="9.0"),
+             Platform("x86_64", "windows"; cuda="9.0")]

--- a/C/CUDA/CUDA_loader/build_9.2.jl
+++ b/C/CUDA/CUDA_loader/build_9.2.jl
@@ -149,6 +149,6 @@ products = [
     ExecutableProduct("nvlink", :nvlink),
 ]
 
-platforms = [Platform("x86_64", "linux"),
-             Platform("x86_64", "macos"),
-             Platform("x86_64", "windows")]
+platforms = [Platform("x86_64", "linux"; cuda="9.2"),
+             Platform("x86_64", "macos"; cuda="9.2"),
+             Platform("x86_64", "windows"; cuda="9.2")]

--- a/C/CUDA/CUDA_loader/build_tarballs.jl
+++ b/C/CUDA/CUDA_loader/build_tarballs.jl
@@ -10,12 +10,7 @@ for cuda_version in cuda_versions
     cuda_tag = "$(cuda_version.major).$(cuda_version.minor)"
     include("build_$(cuda_tag).jl")
 
-    for platform in platforms
-        platform.tags["cuda"] = cuda_tag
-    end
-
     any(should_build_platform.(triplet.(platforms))) || continue
     build_tarballs(ARGS, name, version, [], script, platforms, products, dependencies;
                    lazy_artifacts=true)
-
 end

--- a/C/CUDNN/build_tarballs.jl
+++ b/C/CUDNN/build_tarballs.jl
@@ -1,4 +1,5 @@
 using BinaryBuilder, Pkg
+using Base.BinaryPlatforms: arch, os
 
 include("../../fancy_toys.jl")
 
@@ -54,10 +55,9 @@ for cuda_version in cuda_versions
     include("build_$(cuda_tag).jl")
 
     for (platform, sources) in platforms_and_sources
-        should_build_platform(triplet(platform)) || continue
-        platform.tags["cuda"] = cuda_tag
-
-        build_tarballs(ARGS, name, version, sources, script, [platform], products, dependencies;
-                       lazy_artifacts=true)
+        augmented_platform = Platform(arch(platform), os(platform); cuda=cuda_tag)
+        should_build_platform(triplet(augmented_platform)) || continue
+        build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
+                       products, dependencies; lazy_artifacts=true)
     end
 end

--- a/C/CUTENSOR/build_tarballs.jl
+++ b/C/CUTENSOR/build_tarballs.jl
@@ -1,4 +1,5 @@
 using BinaryBuilder, Pkg
+using Base.BinaryPlatforms: arch, os
 
 include("../../fancy_toys.jl")
 
@@ -36,10 +37,9 @@ for cuda_version in cuda_versions
     include("build_$(cuda_tag).jl")
 
     for (platform, sources) in platforms_and_sources
-        should_build_platform(triplet(platform)) || continue
-        platform.tags["cuda"] = cuda_tag
-
-        build_tarballs(ARGS, name, version, sources, script, [platform], products, dependencies;
-                       lazy_artifacts=true)
+        augmented_platform = Platform(arch(platform), os(platform); cuda=cuda_tag)
+        should_build_platform(triplet(augmented_platform)) || continue
+        build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
+                       products, dependencies; lazy_artifacts=true)
     end
 end


### PR DESCRIPTION
Something fishy was going on; either because of changing the Platform objects in-place, or by calling `should_build_platform` on a non-augmented triple.