### PR TITLE
SDL2: add more optional dependencies

### DIFF
--- a/S/SDL2/build_tarballs.jl
+++ b/S/SDL2/build_tarballs.jl
@@ -52,6 +52,9 @@ dependencies = [
     Dependency("Libglvnd_jll"),
     Dependency("alsa_jll"),
     Dependency("PulseAudio_jll"),
+    Dependency("Dbus_jll"),
+    Dependency("eudev_jll"),
+    Dependency("libsamplerate_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/SDL2/build_tarballs.jl
+++ b/S/SDL2/build_tarballs.jl
@@ -51,8 +51,8 @@ dependencies = [
     Dependency("Xorg_libXScrnSaver_jll"),
     Dependency("Libglvnd_jll"),
     Dependency("alsa_jll"),
+    Dependency("PulseAudio_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-


### PR DESCRIPTION
I think this is necessary for testing #https://github.com/JuliaPackaging/Yggdrasil/issues/1432.

Maybe I should do the same thing for SDL2_mixer, SDL2_tff, SDL2_image, and SDL2_gfx? I wonder why these libraries are not integrated into SDL2. 