### PR TITLE
Update p4est to v2.3.1 and enable Windows build

### DIFF
--- a/P/P4est/build_tarballs.jl
+++ b/P/P4est/build_tarballs.jl
@@ -49,7 +49,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 
 # The products that we will ensure are always built
@@ -64,4 +64,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8.1.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8.1.0", julia_compat="1.6")


### PR DESCRIPTION
This `build_tarballs.jl` is quite a mess, mainly due to adding support for Windows. p4est is being restructured these days, and will get a CMake build system. I hope once it is released, it'll reduce the amount of special cases present here.