### PR TITLE
Make ADIOS2 build on macOS and Windows

### DIFF
--- a/A/ADIOS2/build_tarballs.jl
+++ b/A/ADIOS2/build_tarballs.jl
@@ -43,6 +43,7 @@ fi
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_gcc.cmake -DCMAKE_BUILD_TYPE=Release -DADIOS2_USE_Fortran=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ${mpiopts} ${winopts} ..
 make -j${nproc}
 make -j${nproc} install
+install_license ../Copyright.txt ../LICENSE
 """
 
 # These are the platforms we will build for by default, unless further
@@ -84,15 +85,16 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="Blosc_jll")),
-    Dependency(PackageSpec(name="Bzip2_jll")),
+    # We don't want to use Bzip2 because this would lock us into Julia ≥1.6
+    # Dependency(PackageSpec(name="Bzip2_jll")),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency(PackageSpec(name="MPICH_jll")),
     Dependency(PackageSpec(name="MicrosoftMPI_jll")),
-    Dependency(PackageSpec(name="Python_jll")),
     Dependency(PackageSpec(name="ZeroMQ_jll")),
     Dependency(PackageSpec(name="libpng_jll")),
     Dependency(PackageSpec(name="zfp_jll")),
-    # (HDF5: cannot do; we would need HDF5 with MPI support)
+    # We cannot use HDF5 because we need a HDF5 configurion with MPI support
+    # Dependency(PackageSpec(name="HDF5_jll")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/ADIOS2/build_tarballs.jl
+++ b/A/ADIOS2/build_tarballs.jl
@@ -15,27 +15,32 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd ADIOS2-2.7.1
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/shlwapi.patch
 mkdir build
 cd build
 if [[ "$target" == *-apple-* ]]; then
-    # Set up a wrapper script for the assembler
+    # Set up a wrapper script for the assembler. GCC's assembler
+    # output isn't accepted by the LLVM assembler.
     as=$(which as)
     mv "$as" "$as.old"
     export AS="$as.old"
     ln -s "$WORKSPACE/srcdir/scripts/as.llvm" "$as"
 fi
 mpiopts=
-sstopts=
-# if [[ "$target" == x86_64-w64-mingw32 ]]; then
-#     mpiopts="-DMPI_HOME=$prefix -DMPI_GUESS_LIBRARY_NAME=MSMPI -DMPI_C_LIBRARIES=msmpi64 -DMPI_CXX_LIBRARIES=msmpi64"
-#     sstopts="-DADIOS2_USE_SST=OFF"
-# elif [[ "$target" == *-mingw* ]]; then
-#     mpiopts="-DMPI_HOME=$prefix -DMPI_GUESS_LIBRARY_NAME=MSMPI"
-#     sstopts="-DADIOS2_USE_SST=OFF"
-# fi
+winopts=
+if [[ "$target" == x86_64-w64-mingw32 ]]; then
+    # cmake's auto-detection doesn't work on Windows.
+    # The SST and Table ADIOS2 components don't build on Windows
+    # (reported in <https://github.com/ornladios/ADIOS2/issues/2705>)
+    mpiopts="-DMPI_HOME=$prefix -DMPI_GUESS_LIBRARY_NAME=MSMPI -DMPI_C_LIBRARIES=msmpi64 -DMPI_CXX_LIBRARIES=msmpi64"
+    winopts="-DADIOS2_USE_SST=OFF -DADIOS2_USE_Table=OFF"
+elif [[ "$target" == *-mingw* ]]; then
+    mpiopts="-DMPI_HOME=$prefix -DMPI_GUESS_LIBRARY_NAME=MSMPI"
+    winopts="-DADIOS2_USE_SST=OFF -DADIOS2_USE_Table=OFF"
+fi
 # We disable Fortran because this would require building many more
 # versions of the library
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_gcc.cmake -DCMAKE_BUILD_TYPE=Release -DADIOS2_USE_Fortran=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ${mpiopts} ${sstopts} ..
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_gcc.cmake -DCMAKE_BUILD_TYPE=Release -DADIOS2_USE_Fortran=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ${mpiopts} ${winopts} ..
 make -j${nproc}
 make -j${nproc} install
 """
@@ -49,6 +54,7 @@ platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
     Platform("x86_64", "linux"; libc="musl"),
     Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
 
     # These platforms fail:
 
@@ -58,18 +64,13 @@ platforms = [
     #FAIL Platform("armv7l", "linux"; libc="glibc"),
     #FAIL Platform("i686", "linux"; libc="glibc"),
     #TODO Platform("i686", "linux"; libc="musl"),
+    #TODO Platform("i686", "windows"),
 
     # [22:40:43] /workspace/srcdir/ADIOS2-2.7.1/source/adios2/toolkit/profiling/taustubs/tautimer.cpp:208:31: error: ‘__NR_gettid’ was not declared in this scope
     # [22:40:43]      mytid = (uint64_t)syscall(__NR_gettid);
     # (Likely the respective syscall does not exist on FreeBSD;
     # reported as <https://github.com/ornladios/ADIOS2/issues/2705>.)
     #FAIL Platform("x86_64", "freebsd"),
-
-    # [13:22:26] /workspace/srcdir/ADIOS2-2.7.1/source/adios2/engine/table/TableWriter.cpp:201:16: error: ‘AvailableIpAddresses’ is not a member of ‘adios2::helper’
-    # [13:22:26]      auto ips = helper::AvailableIpAddresses();
-    # (Reported as <https://github.com/ornladios/ADIOS2/issues/2705>.)
-    #FAIL Platform("x86_64", "windows"),
-    #TODO Platform("i686", "windows"),
 ]
 # Apparently, macOS doesn't use different C++ string APIs
 platforms = expand_cxxstring_abis(platforms; skip=Sys.isapple)
@@ -86,7 +87,7 @@ dependencies = [
     Dependency(PackageSpec(name="Bzip2_jll")),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency(PackageSpec(name="MPICH_jll")),
-    # Dependency(PackageSpec(name="MicrosoftMPI_jll")),
+    Dependency(PackageSpec(name="MicrosoftMPI_jll")),
     Dependency(PackageSpec(name="Python_jll")),
     Dependency(PackageSpec(name="ZeroMQ_jll")),
     Dependency(PackageSpec(name="libpng_jll")),
@@ -95,4 +96,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+# GCC 4 is too old for Windows; it doesn't have <regex.h>
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5")

--- a/A/ADIOS2/bundled/patches/shlwapi.patch
+++ b/A/ADIOS2/bundled/patches/shlwapi.patch
@@ -1,0 +1,15 @@
+--- a/source/utils/CMakeLists.txt
++++ b/source/utils/CMakeLists.txt
+@@ -11,7 +11,11 @@
+ 
+ # BPLS
+ add_executable(bpls ./bpls/bpls.cpp)
+-target_link_libraries(bpls adios2_core adios2sys adios2::thirdparty::pugixml)
++if(WIN32 AND (NOT MSVC))
++  target_link_libraries(bpls adios2_core adios2sys adios2::thirdparty::pugixml shlwapi)
++else()
++  target_link_libraries(bpls adios2_core adios2sys adios2::thirdparty::pugixml)
++endif()
+ target_include_directories(bpls PRIVATE ${PROJECT_BINARY_DIR})
+ set_property(TARGET bpls PROPERTY OUTPUT_NAME bpls${ADIOS2_EXECUTABLE_SUFFIX})
+ install(TARGETS bpls EXPORT adios2

--- a/A/ADIOS2/bundled/scripts/as.llvm
+++ b/A/ADIOS2/bundled/scripts/as.llvm
@@ -1,0 +1,50 @@
+#! /bin/sh
+
+# GCC and Clang disagree about the exact names for certain mnemonics:
+#    GCC:          Clang:
+#    fild          fildl
+#    fildlll       fildq (?)
+#    fildlq        fildq
+#    fisttp        fisttpl
+#    fisttplll     fisttpq (?)
+#    fisttplq      fisttpq
+#    vcvtsd2siq    vcvtsd2si
+#    vcvttsd2siq   vcvttsd2si
+#    vcvttss2siq   vcvttss2si
+# We don't really care who is right, but we need to convert the syntax.
+
+for arg in $@; do
+    if [ -f "$arg" ]; then
+        perl -pi -e 's{\bfild\b}{fildl}g; s{\bfildlll\b}{fildq}g; s{\bfildlq\b}{fildq}g; s{\bfisttp\b}{fisttpl}g; s{\bfisttplll\b}{fisttpq}g; s{\bfisttplq\b}{fisttpq}g; s{\bvcvtsd2siq\b}{vcvtsd2si}g; s{\bvcvttsd2siq\b}{vcvttsd2si}g; s{\bvcvttss2siq\b}{vcvttss2si}g' $arg
+    fi
+done
+exec "$AS" "$@"
+# Taken and adapted from
+# https://lists.macosforge.org/pipermail/macports-dev/2011-October/016335.html
+# by Vincent Habchi <vince@macports.org>
+
+# To be installed in /opt/local/bin
+
+unset DYLD_LIBRARY_PATH
+
+have_input_file=
+ARGS=$@
+while [[ $# -ne 0 ]]; do
+    ARG=$1
+    # Skip options
+    if [[ $ARG == -arch || $ARG == -[FILRYlouz] ]]; then
+        # Skip next token
+        shift
+        shift
+        continue
+    fi
+
+    if [[ $ARG == -* ]]; then
+        shift
+        continue
+    fi
+
+    input_file=$ARG
+    have_input_file=1
+    break
+done


### PR DESCRIPTION
I realized that I do need macOS support, and I found a work-around.

With the help of the ADIOS2 developers, Windows is now also working.

I don't intend to work on this any further in the near future (assuming that the created binary works).