### PR TITLE
[PTSCOTCH] Add Builder

### DIFF
--- a/C/Ccluster/build_tarballs.jl
+++ b/C/Ccluster/build_tarballs.jl
@@ -1,0 +1,53 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Ccluster"
+version = v"1.1.6"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/rimbach/Ccluster/archive/refs/tags/v1.1.6.tar.gz", "85b866a5485403d8af944965c531645709c21ee0810adfe720258e5c509332e1")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/Ccluster*/
+if [[ ${target} == *musl* ]]; then
+    export CFLAGS="-D_GNU_SOURCE=1 -std=c99 -O2 -funroll-loops -g"
+elif [[ ${target} == *mingw* ]]; then
+    sed -i -e "s#/lib\>#/$(basename ${libdir})#g" configure; extraflags=--build=MINGW${nbits}
+fi
+./configure --prefix=$prefix \
+    --disable-pthread \
+    --disable-static \
+    --enable-shared \
+    --with-gmp=$prefix \
+    --with-mpfr=$prefix \
+    --with-flint=$prefix \
+    --with-arb=$prefix \
+    ${extraflags}
+make library -j${nproc}
+make install LIBDIR=$(basename ${libdir})
+exit
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libccluster", :libccluster)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="Arb_jll", uuid="d9960996-1013-53c9-9ba4-74a4155039c3"))
+    Dependency(PackageSpec(name="FLINT_jll", uuid="e134572f-a0d5-539d-bddf-3cad8db41a82"))
+    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"), v"6.1.2"; compat="6.1.2")
+    Dependency(PackageSpec(name="MPFR_jll", uuid="3a97d323-0669-5f0c-9066-3539efd106a3"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/P/PTSCOTCH/build_tarballs.jl
+++ b/P/PTSCOTCH/build_tarballs.jl
@@ -2,7 +2,7 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-name = "SCOTCH"
+name = "PTSCOTCH"
 version = v"6.1.0"
 
 # Collection of sources required to complete build
@@ -25,8 +25,8 @@ fi
 cd src
 make ptscotch
 cp ../lib/libpt* ${libdir}
+cp ../include/p* ${includedir}
 install_license ../LICENSE_en.txt
-exit
 """
 
 # These are the platforms we will build for by default, unless further
@@ -37,7 +37,7 @@ platforms = filter!(p -> !Sys.iswindows(p), supported_platforms(; experimental=t
 products = [
     LibraryProduct("libptscotcherr", :libptscotcherr),
     LibraryProduct("libptscotcherrexit", :libptscotcherrexit),
-    LibraryProduct("libptscotchparmetis", :libptscotchmetis),
+    LibraryProduct("libptscotchparmetis", :libptscotchparmetis),
     LibraryProduct("libptscotch", :libptscotch)
 ]
 

--- a/P/PTSCOTCH/build_tarballs.jl
+++ b/P/PTSCOTCH/build_tarballs.jl
@@ -44,7 +44,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
-    Dependency("OpenMPI_jll"),
+    Dependency("MPICH_jll"),
     Dependency("SCOTCH_jll")
 ]
 

--- a/P/PTSCOTCH/build_tarballs.jl
+++ b/P/PTSCOTCH/build_tarballs.jl
@@ -38,7 +38,7 @@ products = [
     LibraryProduct("libptscotcherr", :libptscotcherr),
     LibraryProduct("libptscotcherrexit", :libptscotcherrexit),
     LibraryProduct("libptscotchparmetis", :libptscotchparmetis),
-    LibraryProduct("libptscotch", :libptscotch)
+    LibraryProduct("libptscotch", :libptscotch, dont_dlopen=true)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/P/PTSCOTCH/build_tarballs.jl
+++ b/P/PTSCOTCH/build_tarballs.jl
@@ -31,7 +31,7 @@ install_license ../LICENSE_en.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(!Sys.iswindows, supported_platforms(; experimental=true))
+platforms = filter!(!Sys.iswindows, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/P/PTSCOTCH/build_tarballs.jl
+++ b/P/PTSCOTCH/build_tarballs.jl
@@ -1,0 +1,52 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "SCOTCH"
+version = v"6.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://gitlab.inria.fr/scotch/scotch/-/archive/v6.1.0/scotch-v6.1.0.tar.gz","4fe537f608f0fe39ec78807f90203f9cca1181deb16bfa93b7d4cd440e01bbd1"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/scotch*
+atomic_patch -p1 "${WORKSPACE}/srcdir/patches/native_build.patch"
+atomic_patch -p1 "${WORKSPACE}/srcdir/patches/Makefile.patch"
+if [[ "${target}" == *apple* || "${target}" == *freebsd* ]]; then
+    atomic_patch -p1 "${WORKSPACE}/srcdir/patches/OSX_FreeBSD.patch"
+fi
+if [[ "${target}" == *mingw* ]]; then
+    atomic_patch -p1 "${WORKSPACE}/srcdir/patches/Windows.patch"
+fi
+cd src
+make ptscotch
+cp ../lib/libpt* ${libdir}
+install_license ../LICENSE_en.txt
+exit
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = filter!(p -> !Sys.iswindows(p), supported_platforms(; experimental=true))
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libptscotcherr", :libptscotcherr),
+    LibraryProduct("libptscotcherrexit", :libptscotcherrexit),
+    LibraryProduct("libptscotchparmetis", :libptscotchmetis),
+    LibraryProduct("libptscotch", :libptscotch)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
+    Dependency("OpenMPI_jll"),
+    Dependency("SCOTCH_jll")
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"9.1.0", julia_compat="1.6")

--- a/P/PTSCOTCH/bundled/patches/Makefile.patch
+++ b/P/PTSCOTCH/bundled/patches/Makefile.patch
@@ -11,8 +11,8 @@
 +CAT             = cat
 +CCS             = $(CC)
 +CCP             = mpicc
-+CCD             = $(CC)
-+CFLAGS          = -O3 -fPIC -Drestrict=__restrict -DCOMMON_PTHREAD_BARRIER -DCOMMON_PTHREAD -DSCOTCH_CHECK_AUTO -DCOMMON_RANDOM_FIXED_SEED -DCOMMON_TIMING_OLD -DSCOTCH_RENAME -DCOMMON_FILE_COMPRESS_GZ -DIDXSIZE64 -DSCOTCH_PTHREAD
++CCD             = $(CC) -I$(prefix)/include/
++CFLAGS          = -O3 -fPIC -Drestrict=__restrict -DCOMMON_PTHREAD_BARRIER -DCOMMON_PTHREAD -DSCOTCH_CHECK_AUTO -DCOMMON_RANDOM_FIXED_SEED -DCOMMON_TIMING_OLD -DSCOTCH_RENAME -DCOMMON_FILE_COMPRESS_GZ -DIDXSIZE64
 +CLIBFLAGS       = -shared -fPIC
 +LDFLAGS         = -lz -lm -pthread
 +CP              = cp

--- a/P/PTSCOTCH/bundled/patches/Makefile.patch
+++ b/P/PTSCOTCH/bundled/patches/Makefile.patch
@@ -1,0 +1,24 @@
+--- /dev/null
++++ b/src/Makefile.inc
+@@ -0,0 +1,21 @@
++EXE             =
++LIB             = .$(dlext)
++OBJ             = .o
++
++MAKE            = make
++AR              = $(CC)
++ARFLAGS         = -shared -o
++CAT             = cat
++CCS             = $(CC)
++CCP             = mpicc
++CCD             = $(CC)
++CFLAGS          = -O3 -fPIC -Drestrict=__restrict -DCOMMON_PTHREAD_BARRIER -DCOMMON_PTHREAD -DSCOTCH_CHECK_AUTO -DCOMMON_RANDOM_FIXED_SEED -DCOMMON_TIMING_OLD -DSCOTCH_RENAME -DCOMMON_FILE_COMPRESS_GZ -DIDXSIZE64 -DSCOTCH_PTHREAD
++CLIBFLAGS       = -shared -fPIC
++LDFLAGS         = -lz -lm -pthread
++CP              = cp
++LEX             = flex -Pscotchyy -olex.yy.c
++LN              = ln
++MKDIR           = mkdir -p
++MV              = mv
++RANLIB          = echo
++YACC            = bison -pscotchyy -y -b y

--- a/P/PTSCOTCH/bundled/patches/OSX_FreeBSD.patch
+++ b/P/PTSCOTCH/bundled/patches/OSX_FreeBSD.patch
@@ -1,0 +1,11 @@
+--- a/src/Makefile.inc
++++ b/src/Makefile.inc
+@@ -4,7 +4,7 @@
+ 
+ MAKE            = make
+ AR              = $(CC)
+-ARFLAGS         = -shared -o
++ARFLAGS         = -shared -o -dynamic -undefined dynamic_lookup -o
+ CAT             = cat
+ CCS             = $(CC)
+ CCP             = mpicc

--- a/P/PTSCOTCH/bundled/patches/Windows.patch
+++ b/P/PTSCOTCH/bundled/patches/Windows.patch
@@ -1,0 +1,14 @@
+--- a/src/Makefile.inc
++++ b/src/Makefile.inc
+@@ -9,9 +9,9 @@
+ CCS             = $(CC)
+ CCP             = mpicc
+ CCD             = $(CC)
+-CFLAGS          = -O3 -fPIC -Drestrict=__restrict -DCOMMON_PTHREAD_BARRIER -DCOMMON_PTHREAD -DSCOTCH_CHECK_AUTO -DCOMMON_RANDOM_FIXED_SEED -DCOMMON_TIMING_OLD -DSCOTCH_RENAME -DCOMMON_FILE_COMPRESS_GZ -DIDXSIZE64
++CFLAGS          = -O3 -fPIC -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -DCOMMON_STUB_FORK -DCOMMON_WINDOWS -DIDXSIZE64
+ CLIBFLAGS       = -shared -fPIC
+-LDFLAGS         = -lz -lm -pthread
++LDFLAGS         = -lz -lm
+ CP              = cp
+ LEX             = flex -Pscotchyy -olex.yy.c
+ LN              = ln

--- a/P/PTSCOTCH/bundled/patches/native_build.patch
+++ b/P/PTSCOTCH/bundled/patches/native_build.patch
@@ -1,0 +1,19 @@
+--- a/src/libscotch/Makefile
++++ b/src/libscotch/Makefile
+@@ -3096,14 +3096,14 @@
+ 					mapping.h				\
+ 					order.h					\
+ 					parser.h
+-			 		$(CCD) $(CCDFLAGS) -DSCOTCH_VERSION_NUM=$(VERSION) -DSCOTCH_RELEASE_NUM=$(RELEASE) -DSCOTCH_PATCHLEVEL_NUM=$(PATCHLEVEL) $(<) -o $(@) $(LDFLAGS)
++			 		$(CC_BUILD) -DSCOTCH_VERSION_NUM=$(VERSION) -DSCOTCH_RELEASE_NUM=$(RELEASE) -DSCOTCH_PATCHLEVEL_NUM=$(PATCHLEVEL) $(<) -o $(@) $(LDFLAGS)
+ 
+ ptdummysizes$(EXE)		:	dummysizes.c				\
+ 					module.h				\
+ 					common.h				\
+ 					dgraph.h				\
+ 					dorder.h
+-			 		$(CCD) $(CCDFLAGS) -DSCOTCH_VERSION_NUM=$(VERSION) -DSCOTCH_RELEASE_NUM=$(RELEASE) -DSCOTCH_PATCHLEVEL_NUM=$(PATCHLEVEL) $(<) -o $(@) $(LDFLAGS)
++			 		$(CC_BUILD) -DSCOTCH_VERSION_NUM=$(VERSION) -DSCOTCH_RELEASE_NUM=$(RELEASE) -DSCOTCH_PATCHLEVEL_NUM=$(PATCHLEVEL) $(<) -o $(@) $(LDFLAGS)
+ 
+ scotch.h			:	dummysizes$(EXE)			\
+ 					library.h


### PR DESCRIPTION
I'm not sure this is the best way to do this, if we had multi-jll builders that would be best. Right now I just build scotch and ptscotch but only copy ptscotch to the prefix.  The build script is otherwise exactly the same as SCOTCH_jll.