### PR TITLE
[CompilerSupportLibraries] Remove extraneous libraries

### DIFF
--- a/C/CompilerSupportLibraries/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/build_tarballs.jl
@@ -3,7 +3,7 @@ using BinaryBuilder, SHA
 include("../../fancy_toys.jl")
 
 name = "CompilerSupportLibraries"
-version = v"0.4.3"
+version = v"0.4.4"
 
 # We are going to need to extract the latest libstdc++ and libgomp from BB
 # So let's grab them into tarballs by using preferred_gcc_version:
@@ -56,9 +56,9 @@ tar -zxvf ${WORKSPACE}/srcdir/LatestLibraries*.tar.gz -C ${prefix}
 
 echo ***********************************************************
 echo LatestLibraries logs, reproduced here for debuggability:
-zcat ${prefix}/logs/LatestLibraries.log.gz
+zcat ${prefix}/logs/LatestLibraries/LatestLibraries.log.gz
 echo ***********************************************************
-rm -f ${prefix}/logs/LatestLibraries.log.gz
+rm -f ${prefix}/logs/LatestLibraries/LatestLibraries.log.gz
 
 # Make sure expansions aren't empty
 shopt -s nullglob
@@ -97,6 +97,9 @@ if [[ ${target} == *apple* ]]; then
     LIBGCC_NAME=$(basename $(echo ${libdir}/libgcc_s.*.dylib))
     install_name_tool -id @rpath/${LIBGCC_NAME} ${libdir}/${LIBGCC_NAME}
 fi
+
+# Remove extraneous libraries
+rm -f ${libdir}/{libiconv,libxml2,libz}*.${dlext}*
 
 # Install license (we license these all as GPL3, since they're from GCC)
 install_license /usr/share/licenses/GPL3


### PR DESCRIPTION
At the moment, some tarballs include extraneous libraries, for example

```console
% tar tzvf CompilerSupportLibraries.v0.4.3.x86_64-linux-musl-libgfortran5.tar.gz|grep 'lib/'
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libatomic.so -> libatomic.so.1.2.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libatomic.so.1 -> libatomic.so.1.2.0
-rwxr-xr-x 0/0          121584 1970-01-01 01:00 lib/libatomic.so.1.2.0
-rwxr-xr-x 0/0          580536 1970-01-01 01:00 lib/libgcc_s.so.1
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libgfortran.so -> libgfortran.so.5.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libgfortran.so.5 -> libgfortran.so.5.0.0
-rwxr-xr-x 0/0        11681536 1970-01-01 01:00 lib/libgfortran.so.5.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libgomp.so -> libgomp.so.1.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libgomp.so.1 -> libgomp.so.1.0.0
-rwxr-xr-x 0/0         1528424 1970-01-01 01:00 lib/libgomp.so.1.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libiconv.so -> libiconv.so.2.6.1
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libiconv.so.2 -> libiconv.so.2.6.1
-rwxr-xr-x 0/0         1391307 1970-01-01 01:00 lib/libiconv.so.2.6.1
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libitm.so -> libitm.so.1.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libitm.so.1 -> libitm.so.1.0.0
-rwxr-xr-x 0/0         1323728 1970-01-01 01:00 lib/libitm.so.1.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libobjc.so -> libobjc.so.4.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libobjc.so.4 -> libobjc.so.4.0.0
-rwxr-xr-x 0/0          399096 1970-01-01 01:00 lib/libobjc.so.4.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libquadmath.so -> libquadmath.so.0.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libquadmath.so.0 -> libquadmath.so.0.0.0
-rwxr-xr-x 0/0         1270032 1970-01-01 01:00 lib/libquadmath.so.0.0.0
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libstdc++.so -> libstdc++.so.6.0.28
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libstdc++.so.6 -> libstdc++.so.6.0.28
-rwxr-xr-x 0/0        20420808 1970-01-01 01:00 lib/libstdc++.so.6.0.28
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libxml2.so -> libxml2.so.2.9.10
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libxml2.so.2 -> libxml2.so.2.9.10
-rwxr-xr-x 0/0         5361416 1970-01-01 01:00 lib/libxml2.so.2.9.10
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libz.so -> libz.so.1.2.11
lrwxr-xr-x 0/0               0 1970-01-01 01:00 lib/libz.so.1 -> libz.so.1.2.11
-rwxr-xr-x 0/0          115443 1970-01-01 01:00 lib/libz.so.1.2.11
```