### PR TITLE
[libpng] Build for experimental platforms

### DIFF
--- a/L/libpng/build_tarballs.jl
+++ b/L/libpng/build_tarballs.jl
@@ -11,18 +11,22 @@ sources = [
                   "daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4"),
 ]
 
+version = v"1.6.38" # <--- This version number is a lie, we need to bump it to build for experimental platforms
+
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libpng-*/
-mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" ..
-make -j${ncore}
+export CPPFLAGS="-I${includedir}"
+export CFLAGS="-O3"
+export LDFLAGS="-L${libdir}"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
+make -j${nproc}
 make install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [
@@ -35,4 +39,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
Switch the build system from CMake to Autoconf because the autodetection of ARM NEON for `aarch64-apple-darwin` (Apple Silicon, M1 CPU) at build time works with the latter but not the former system.