### PR TITLE
[libpng] Go back to building with CMake

### DIFF
--- a/L/libpng/build_tarballs.jl
+++ b/L/libpng/build_tarballs.jl
@@ -16,10 +16,17 @@ version = v"1.6.38" # <--- This version number is a lie, we need to bump it to b
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libpng-*/
-export CPPFLAGS="-I${includedir}"
-export CFLAGS="-O3"
-export LDFLAGS="-L${libdir}"
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
+mkdir build && cd build
+if [[ "${target}" == aarch64-apple-darwin* ]]; then
+    # Let CMake know this platform supports NEON extension
+    FLAGS=(-DPNG_ARM_NEON=on)
+fi
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPNG_STATIC=OFF \
+    "${FLAGS[@]}" \
+    ..
 make -j${nproc}
 make install
 """


### PR DESCRIPTION
Pass option `PNG_ARM_NEON=on` to CMake when targeting `aarch64-apple-darwin` to
let it know the platforms has the NEON extension.

Additionally, this should avoid breaking the ABI of the library on Windows by changing its soname, as it happened when [switching to Autoconf](https://github.com/JuliaBinaryWrappers/libpng_jll.jl/commit/b778f2a3aa2c3b32142f3fb519ecf5ad45edca2a#diff-7b45cff429f8c49eb84a6a0cb9f24cf87ab0923b409bb51ba9172d49aa44e1b6)