### PR TITLE
[Cairo] Build for aarch64-apple-darwin

### DIFF
--- a/C/Cairo/bundled/patches/mingw-libssp.patch
+++ b/C/Cairo/bundled/patches/mingw-libssp.patch
@@ -1,0 +1,11 @@
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -44,7 +44,7 @@
+ 	$(enabled_cairo_private) \
+ 	$(enabled_cairo_sources) \
+ 	$(NULL)
+-libcairo_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(CAIRO_LIBTOOL_VERSION_INFO) -no-undefined $(export_symbols)
++libcairo_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(CAIRO_LIBTOOL_VERSION_INFO) -no-undefined $(export_symbols) -lssp
+ libcairo_la_LIBADD = $(CAIRO_LIBS) \
+ 	$(cairo_cxx_lib)
+ libcairo_la_DEPENDENCIES = $(cairo_def_dependency) $(cairo_cxx_lib)


### PR DESCRIPTION
Note to self: Windows builds were failing with
```
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: .libs/cairo-output-stream.o: in function `memcpy':
[01:33:47] /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:202: undefined reference to `__memcpy_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: .libs/cairo-win32-font.o: in function `memcpy':
[01:33:47] /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:202: undefined reference to `__memcpy_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: .libs/cairo-pdf-interchange.o: in function `strcat':
[01:33:47] /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:234: undefined reference to `__strcat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:234: undefined reference to `__strcat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:234: undefined reference to `__strcat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:234: undefined reference to `__strcat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: .libs/cairo-pdf-interchange.o: in function `strncat':
[01:33:47] /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:246: undefined reference to `__strncat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:246: undefined reference to `__strncat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: .libs/cairo-pdf-interchange.o: in function `strcat':
[01:33:47] /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:234: undefined reference to `__strcat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: .libs/cairo-pdf-interchange.o: in function `strncat':
[01:33:47] /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:246: undefined reference to `__strncat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:246: undefined reference to `__strncat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: .libs/cairo-pdf-interchange.o: in function `strcat':
[01:33:47] /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:234: undefined reference to `__strcat_chk'
[01:33:47] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: .libs/cairo-pdf-interchange.o: in function `strncat':
[01:33:47] /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/include/string.h:246: undefined reference to `__strncat_chk'
[01:33:47] collect2: error: ld returned 1 exit status
```
Added `-lssp` to `LDFLAGS`, as suggested by past-me in https://github.com/JuliaPackaging/Yggdrasil/pull/2744