### PR TITLE
[libpolymake_julia] bump for 4.4 (see #3057) for julia 1.6

### DIFF
--- a/L/libpolymake_julia/libpolymake_julia@1.6/build_tarballs.jl
+++ b/L/libpolymake_julia/libpolymake_julia@1.6/build_tarballs.jl
@@ -1,3 +1,2 @@
 const julia_version = v"1.6.0"
 include("../common.jl")
-


### PR DESCRIPTION
rebuild to make sure that this is really built with polymake 4.4
#3057 was built with 4.3 because the registry from the pkgserver was not up-to-date

after #3065