### PR TITLE
[unpaper] build for experimental platforms

### DIFF
--- a/U/unpaper/build_tarballs.jl
+++ b/U/unpaper/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "unpaper"
-version = v"6.1"
+version = v"6.1.100" # <--- This version number is a lie, (it is v6.1) we just need to bump it to build for experimental platforms
 
 # Collection of sources required to complete build
 sources = [
@@ -30,7 +30,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [
@@ -44,4 +44,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 # FFMPEG uses `preferred_gcc_version=v"8"`.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")

--- a/U/unpaper/build_tarballs.jl
+++ b/U/unpaper/build_tarballs.jl
@@ -27,7 +27,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
 
 # The products that we will ensure are always built
 products = [

--- a/U/unpaper/build_tarballs.jl
+++ b/U/unpaper/build_tarballs.jl
@@ -11,11 +11,8 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/unpaper-6.1/
-apk add libxslt
-if [[ "${target}" == *-linux-* ]]; then
-    export LDFLAGS="-lstdc++"
-elif [[ "${target}" == *-mingw* ]]; then
+cd $WORKSPACE/srcdir/unpaper-*/
+if [[ "${target}" == *-mingw* ]]; then
     # FFMPEG_jll installs the pkgconfig files in the wrong directory for Windows
     export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${libdir}/pkgconfig"
     # Give some hints to the linker
@@ -38,7 +35,9 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
+dependencies = [
+    # Offer a native xsltproc
+    HostBuildDependency("XSLT_jll"),
     Dependency("FFMPEG_jll"),
 ]
 


### PR DESCRIPTION
and get the threadsafe method. 6.1 is still the latest release, or I'd just upgrade it for real.