### PR TITLE
Hotfix for p4est output routines on Windows

### DIFF
--- a/P/P4est/build_tarballs.jl
+++ b/P/P4est/build_tarballs.jl
@@ -9,6 +9,7 @@ version = v"2.3.1"
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://p4est.github.io/release/p4est-2.3.1.tar.gz", "be66893b039fb3f27aca3d5d00acff42c67bfad5aa09cea9253cdd628b2bdc9a"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
@@ -38,6 +39,10 @@ if [[ "${target}" == *-mingw* ]]; then
   # Add manual definitions to fix missing `htonl` according to `INSTALL_WINDOWS` file
   # (see https://github.com/cburstedde/p4est/blob/master/INSTALL_WINDOWS)
   sed -i "1s/^/#define htonl(_val) ( ((uint16_t)(_val) \& 0xff00) >> 8 | ((uint16_t)(_val) \& 0xff) << 8 )\n/" src/p4est_algorithms.c src/p8est_algorithms.c src/p6est.c src/p4est_ghost.c
+
+  # Add patch to hotfix `p4est_save_ext`/`p6est_save_ext` until
+  # https://github.com/cburstedde/p4est/issues/113 is fixed and released
+  atomic_patch -p1 $WORKSPACE/srcdir/patches/fix-bad-ftell-return-value-windows.patch
 fi
 
 # Configure, build, install

--- a/P/P4est/bundled/patches/fix-bad-ftell-return-value-windows.patch
+++ b/P/P4est/bundled/patches/fix-bad-ftell-return-value-windows.patch
@@ -1,0 +1,30 @@
+diff --git a/src/p4est.c b/src/p4est.c
+index 834b70f6..9b71cc90 100644
+--- a/src/p4est.c
++++ b/src/p4est.c
+@@ -3522,6 +3522,10 @@ p4est_save_ext (const char *filename, p4est_t * p4est,
+     file = fopen (filename, "ab");
+     SC_CHECK_ABORT (file != NULL, "file open");
+ 
++    /* explicitly seek to end to avoid bad ftell return value on Windows */
++    retval = fseek(file, 0, SEEK_END);
++    SC_CHECK_ABORT (retval == 0, "file seek");
++
+     /* align the start of the header */
+     fpos = ftell (file);
+     SC_CHECK_ABORT (fpos > 0, "first file tell");
+diff --git a/src/p6est.c b/src/p6est.c
+index 9bb7b546..d115952f 100644
+--- a/src/p6est.c
++++ b/src/p6est.c
+@@ -756,6 +756,10 @@ p6est_save_ext (const char *filename, p6est_t * p6est,
+     file = fopen (filename, "ab");
+     SC_CHECK_ABORT (file != NULL, "file open");
+ 
++    /* explicitly seek to end to avoid bad ftell return value on Windows */
++    retval = fseek(file, 0, SEEK_END);
++    SC_CHECK_ABORT (retval == 0, "file seek");
++
+     /* align */
+     fpos = ftell (file);
+     SC_CHECK_ABORT (fpos > 0, "first file tell");


### PR DESCRIPTION
This adds a hotfix for the different behavior of `fopen`/`ftell` under Windows, resolving the issue reported in https://github.com/cburstedde/p4est/issues/113.

I realize that it's frowned upon to create new builds for an already released version, but it's a blocking issue for us at the moment (preventing us to use `P4est_jll` on Windows) and from what I can tell, no actual harm is done (it's not breaking any existing use of `P4est_jll` since the current version is unusable on Windows when trying to use the p4est output routines). Also, considering the past release frequency of the upstream project (approximately once every 2 years), I'd rather not wait for a proper patch release (at least in this particular case).