### PR TITLE
Fix EOF detection for p4est on Windows

### DIFF
--- a/P/P4est/build_tarballs.jl
+++ b/P/P4est/build_tarballs.jl
@@ -43,6 +43,10 @@ if [[ "${target}" == *-mingw* ]]; then
   # Add patch to hotfix `p4est_save_ext`/`p6est_save_ext` until
   # https://github.com/cburstedde/p4est/issues/113 is fixed and released
   atomic_patch -p1 $WORKSPACE/srcdir/patches/fix-bad-ftell-return-value-windows.patch
+
+  # Add patch to hotfix `p4est_connectivity_getline_upper` until
+  # https://github.com/cburstedde/p4est/pull/115 is merged and released
+  atomic_patch -p1 $WORKSPACE/srcdir/patches/fix-end-of-file-detection-windows.patch
 fi
 
 # Configure, build, install

--- a/P/P4est/bundled/patches/fix-end-of-file-detection-windows.patch
+++ b/P/P4est/bundled/patches/fix-end-of-file-detection-windows.patch
@@ -1,0 +1,17 @@
+diff --git a/src/p4est_connectivity.c b/src/p4est_connectivity.c
+index e8267437..51360e8e 100644
+--- a/src/p4est_connectivity.c
++++ b/src/p4est_connectivity.c
+@@ -4596,11 +4596,11 @@ p4est_connectivity_getline_upper (FILE * stream)
+ 
+   for (;;) {
+     c = fgetc (stream);
+-    c = toupper (c);
+     if (c == EOF && linep == line) {
+       P4EST_FREE (linep);
+       return NULL;
+     }
++    c = toupper (c);
+ 
+     if (--len == 0) {
+       char               *linen;


### PR DESCRIPTION
This fixes https://github.com/cburstedde/p4est/pull/115 until a new release of the upstream library with the fix is available.
It's a bug that can only appear on Windows due to `toupper(EOF)` being undefined behavior, whereas on Linux/macOS/BSD, `toupper(EOF) == EOF`.

By moving the check for `EOF` before the conversion `toupper`, the relevant code section works as intended and independent of the platform.