### PR TITLE
[Giflib] Upgrade to v5.2.1 and build for experimental platforms

### DIFF
--- a/G/Giflib/build_tarballs.jl
+++ b/G/Giflib/build_tarballs.jl
@@ -3,39 +3,26 @@
 using BinaryBuilder
 
 name = "Giflib"
-version = v"5.1.4"
+version = v"5.2.1"
 
 # Collection of sources required to build Giflib
 sources = [
-    ArchiveSource("https://downloads.sourceforge.net/project/giflib/giflib-$(version).tar.bz2",
-                  "df27ec3ff24671f80b29e6ab1c4971059c14ac3db95406884fc26574631ba8d5"),
-
-    # Apply security patch
-    ArchiveSource("https://deb.debian.org/debian/pool/main/g/giflib/giflib_5.1.4-3.debian.tar.xz",
-                  "767ea03c1948fa203626107ead3d8b08687a3478d6fbe4690986d545fb1d60bf"),
+    ArchiveSource("https://downloads.sourceforge.net/project/giflib/giflib-$(version).tar.gz",
+                  "31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/giflib-*/
-atomic_patch -p1 ../debian/patches/CVE-2016-3977.patch
-
-# We need to massage configure script to convince it to build the shared library
-# for PowerPC.
-if [[ "${target}" == powerpc64le-* ]]; then
-    autoreconf -vi
-fi
-
-update_configure_scripts
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
-make install
+make install PREFIX="${prefix}" LIBDIR="${libdir}"
+rm "${libdir}/libgif.a"
 install_license COPYING
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [
@@ -43,8 +30,8 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/G/Giflib/build_tarballs.jl
+++ b/G/Giflib/build_tarballs.jl
@@ -9,13 +9,17 @@ version = v"5.2.1"
 sources = [
     ArchiveSource("https://downloads.sourceforge.net/project/giflib/giflib-$(version).tar.gz",
                   "31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/giflib-*/
+# Apply patch to make it possible to build for non Linux-like platforms.
+# Adapted from also https://sourceforge.net/p/giflib/bugs/133/
+atomic_patch -p1 ../patches/makefile.patch
 make -j${nproc}
-make install PREFIX="${prefix}" LIBDIR="${libdir}"
+make install
 rm "${libdir}/libgif.a"
 install_license COPYING
 """

--- a/G/Giflib/bundled/patches/makefile.patch
+++ b/G/Giflib/bundled/patches/makefile.patch
@@ -1,0 +1,132 @@
+--- a/Makefile
++++ b/Makefile
+@@ -14,10 +14,10 @@
+ TAR = tar
+ INSTALL = install
+ 
+-PREFIX = /usr/local
+-BINDIR = $(PREFIX)/bin
+-INCDIR = $(PREFIX)/include
+-LIBDIR = $(PREFIX)/lib
++PREFIX = $(prefix)
++BINDIR = $(bindir)
++INCDIR = $(includedir)
++LIBDIR = $(libdir)
+ MANDIR = $(PREFIX)/share/man
+ 
+ # No user-serviceable parts below this line
+@@ -37,6 +37,8 @@
+ UHEADERS = getarg.h
+ UOBJECTS = $(USOURCES:.c=.o)
+ 
++UNAME:=$(shell uname)
++
+ # Some utilities are installed
+ INSTALLABLE = \
+ 	gif2rgb \
+@@ -61,27 +63,59 @@
+ 
+ LDLIBS=libgif.a -lm
+ 
+-all: libgif.so libgif.a libutil.so libutil.a $(UTILS)
++ifeq ($(UNAME), Darwin)
++LIBGIFSO        = libgif.$(dlext)
++LIBGIFSOMAJOR   = libgif.$(LIBMAJOR).$(dlext)
++LIBGIFSOVER	= libgif.$(LIBVER).$(dlext)
++LIBUTILSO	= libutil.$(dlext)
++LIBUTILSOMAJOR	= libutil.$(LIBMAJOR).$(dlext)
++else ifeq ($(UNAME), MSYS_NT-6.3)
++LIBGIFSO	= libgif.$(dlext)
++LIBGIFSOMAJOR	= libgif-$(LIBMAJOR).$(dlext)
++LIBGIFSOVER	= libgif-$(LIBMAJOR).$(dlext)
++LIBUTILSO	= libutil.$(dlext)
++LIBUTILSOMAJOR	= libutil-$(LIBMAJOR).$(dlext)
++else
++LIBGIFSO	= libgif.$(dlext)
++LIBGIFSOMAJOR	= libgif.$(dlext).$(LIBMAJOR)
++LIBGIFSOVER	= libgif.$(dlext).$(LIBVER)
++LIBUTILSO	= libutil.$(dlext)
++LIBUTILSOMAJOR	= libutil.$(dlext).$(LIBMAJOR)
++endif
++
++all: $(LIBGIFSO) libgif.a $(LIBUTILSO) libutil.a $(UTILS)
++ifeq ($(UNAME), Darwin)
++else ifeq ($(UNAME), MSYS_NT-6.3)
++else
+ 	$(MAKE) -C doc
++endif
+ 
+ $(UTILS):: libgif.a libutil.a
+ 
+-libgif.so: $(OBJECTS) $(HEADERS)
+-	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,libgif.so.$(LIBMAJOR) -o libgif.so $(OBJECTS)
++$(LIBGIFSO): $(OBJECTS) $(HEADERS)
++ifeq ($(UNAME), Darwin)
++	$(CC) $(CFLAGS) -shared $(LDFLAGS) -current_version 8.0 -Wl,-install_name,$(LIBGIFSOMAJOR) -compatibility_version 8.0 -o $(LIBGIFSO) $(OBJECTS)
++else
++	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,$(LIBGIFSOMAJOR) -o $(LIBGIFSO) $(OBJECTS)
++endif
+ 
+ libgif.a: $(OBJECTS) $(HEADERS)
+ 	$(AR) rcs libgif.a $(OBJECTS)
+ 
+-libutil.so: $(UOBJECTS) $(UHEADERS)
+-	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,libutil.so.$(LIBMAJOR) -o libutil.so $(UOBJECTS)
++$(LIBUTILSO): $(UOBJECTS) $(UHEADERS) $(LIBGIFSO)
++ifeq ($(UNAME), Darwin)
++	$(CC) $(CFLAGS) -shared $(LDFLAGS) -current_version 8.0 -Wl,-install_name,$(LIBUTILSOMAJOR) -compatibility_version 8.0 $(OBJECTS) -o $(LIBUTILSO) -lgif -L.
++else
++	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,$(LIBUTILSOMAJOR) -o $(LIBUTILSO) $(UOBJECTS) -lgif -L.
++endif
+ 
+ libutil.a: $(UOBJECTS) $(UHEADERS)
+ 	$(AR) rcs libutil.a $(UOBJECTS)
+ 
+ clean:
+-	rm -f $(UTILS) $(TARGET) libgetarg.a libgif.a libgif.so libutil.a libutil.so *.o
+-	rm -f libgif.so.$(LIBMAJOR).$(LIBMINOR).$(LIBPOINT)
+-	rm -f libgif.so.$(LIBMAJOR)
++	rm -f $(UTILS) $(TARGET) libgetarg.a libgif.a $(LIBGIFSO) libutil.a $(LIBUTILSO) *.o
++	rm -f $(LIBGIFSOVER)
++	rm -f $(LIBGIFSOMAJOR)
+ 	rm -fr doc/*.1 *.html doc/staging
+ 
+ check: all
+@@ -89,7 +123,12 @@
+ 
+ # Installation/uninstallation
+ 
++ifeq ($(UNAME), Darwin)
++install: all install-bin install-include install-lib
++else
+ install: all install-bin install-include install-lib install-man
++endif
++
+ install-bin: $(INSTALLABLE)
+ 	$(INSTALL) -d "$(DESTDIR)$(BINDIR)"
+ 	$(INSTALL) $^ "$(DESTDIR)$(BINDIR)"
+@@ -99,9 +138,12 @@
+ install-lib:
+ 	$(INSTALL) -d "$(DESTDIR)$(LIBDIR)"
+ 	$(INSTALL) -m 644 libgif.a "$(DESTDIR)$(LIBDIR)/libgif.a"
+-	$(INSTALL) -m 755 libgif.so "$(DESTDIR)$(LIBDIR)/libgif.so.$(LIBVER)"
+-	ln -sf libgif.so.$(LIBVER) "$(DESTDIR)$(LIBDIR)/libgif.so.$(LIBMAJOR)"
+-	ln -sf libgif.so.$(LIBMAJOR) "$(DESTDIR)$(LIBDIR)/libgif.so"
++	$(INSTALL) -m 755 $(LIBGIFSO) "$(DESTDIR)$(LIBDIR)/$(LIBGIFSOVER)"
++ifeq ($(UNAME), MSYS_NT-6.3)
++else
++	ln -sf $(LIBGIFSOVER) "$(DESTDIR)$(LIBDIR)/$(LIBGIFSOMAJOR)"
++endif
++	ln -sf $(LIBGIFSOMAJOR) "$(DESTDIR)$(LIBDIR)/$(LIBGIFSO)"
+ install-man:
+ 	$(INSTALL) -d "$(DESTDIR)$(MANDIR)/man1"
+ 	$(INSTALL) -m 644 doc/*.1 "$(DESTDIR)$(MANDIR)/man1"
+@@ -112,7 +154,7 @@
+ 	rm -f "$(DESTDIR)$(INCDIR)/gif_lib.h"
+ uninstall-lib:
+ 	cd "$(DESTDIR)$(LIBDIR)" && \
+-		rm -f libgif.a libgif.so libgif.so.$(LIBMAJOR) libgif.so.$(LIBVER)
++		rm -f libgif.a $(LIBGIFSO) $(LIBGIFSOMAJOR) $(LIBGIFSOVER)
+ uninstall-man:
+ 	cd "$(DESTDIR)$(MANDIR)/man1" && rm -f $(shell cd doc >/dev/null && echo *.1)
+ 


### PR DESCRIPTION
At the moment this only works on Linux and FreeBSD because upstream replaced the
previous autoconf-based build system with a hand-written Makefile which works
only on those platforms...

See https://sourceforge.net/p/giflib/bugs/133/ for inspiration about how to
patch the Makefile to build the library on the other platforms.