### PR TITLE
Relax glib constraints for [BlueZ]

### DIFF
--- a/B/BlueZ/build_tarballs.jl
+++ b/B/BlueZ/build_tarballs.jl
@@ -58,7 +58,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="Dbus_jll", uuid="ee1fde0b-3d02-5ea6-8484-8dfef6360eab"))
     Dependency(PackageSpec(name="eudev_jll", uuid="35ca27e7-8b34-5b7f-bca9-bdc33f59eb06"))
-    Dependency(PackageSpec(name="Glib_jll", uuid="7746bdde-850d-59dc-9ae8-88ece973131d"), v"2.68.1"; compat="2.68.1")
+    Dependency(PackageSpec(name="Glib_jll", uuid="7746bdde-850d-59dc-9ae8-88ece973131d"); compat="2.28")
     Dependency(PackageSpec(name="Libical_jll", uuid="bce108ef-3f60-5dd0-bcd6-e13a096cb796"))
     Dependency(PackageSpec(name="Readline_jll", uuid="05236dd9-4125-5232-aa7c-9ec0c9b2c25a"))
 ]


### PR DESCRIPTION
configure only seems to be checking if glib is greater than or equal to 2.28