### PR TITLE
FGlT v1.0.0 

### DIFF
--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -7,14 +7,18 @@ version = v"1.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/fcdimitr/fglt.git", "b91e1b3f4ed05eca69f342f7319faedb9d358257")
+    GitSource("https://github.com/fcdimitr/fglt.git", "c3c0c683a76fef56473314527760b74ffd271455")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
 cd fglt/
-meson --cross-file=${MESON_TARGET_TOOLCHAIN} build
+if [[ "${target}" == *-i686* ]] || [[ "${target}" == *-armv7l-linux-musl* ]] || [[ "${target}" == *-x86_64-linux-musl* ]]; then
+  meson --cross-file=${MESON_TARGET_TOOLCHAIN} -Dprefer_openmp=true build
+else
+  meson --cross-file=${MESON_TARGET_TOOLCHAIN} build
+fi
 cd build/
 ninja
 ninja install
@@ -24,8 +28,8 @@ ninja install
 # platforms are passed in on the command line
 platforms = supported_platforms()
 
-# FGlT contains std::string values!  This causes incompatibilities across the GCC 4/5 version boundary.
-platforms = expand_cxxstring_abis(platforms)
+# [FIXED!] FGlT contains std::string values!  This causes incompatibilities across the GCC 4/5 version boundary.
+# platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -13,10 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/fglt/
-#if [[ "${target}" == *-linux-* ]]; then
-#    FLAGS="-Dprefer_openmp=true"
-#fi
-meson --cross-file=${MESON_TARGET_TOOLCHAIN} ${FLAGS} build
+meson --cross-file=${MESON_TARGET_TOOLCHAIN} build
 cd build/
 ninja -j${nproc}
 ninja install

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd fglt/
-if [[ "${target}" == *-i686* ]] || [[ "${target}" == *-armv7l-linux-musl* ]] || [[ "${target}" == *-x86_64-linux-musl* ]]; then
+if [[ "${target}" == *-i686* ]] || [[ "${target}" == *-armv7l-linux-musl* ]] || [[ "${target}" == *-x86_64-linux-musl* || [[ "${target}" == *-x86_64-linux-gnu* ]]; then
   meson --cross-file=${MESON_TARGET_TOOLCHAIN} -Dprefer_openmp=true build
 else
   meson --cross-file=${MESON_TARGET_TOOLCHAIN} build

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -37,7 +37,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
-    Dependency(PackageSpec(name="cilkrts_jll", uuid="71772805-00bc-5a29-9044-a26d819b7806""))
+    Dependency(PackageSpec(name="cilkrts_jll", uuid="71772805-00bc-5a29-9044-a26d819b7806")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -12,21 +12,19 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd fglt/
-if [[ "${target}" == *i686* ]] || [[ "${target}" == *armv7l-linux-musl* ]] || [[ "${target}" == *x86_64-linux-musl* ]] || [[ "${target}" == *x86_64-linux-gnu* ]]; then
-  meson --cross-file=${MESON_TARGET_TOOLCHAIN} -Dprefer_openmp=true build
-else
-  meson --cross-file=${MESON_TARGET_TOOLCHAIN} build
+cd $WORKSPACE/srcdir/fglt/
+if [[ "${target}" == *-linux-* ]]; then
+    FLAGS="-Dprefer_openmp=true"
 fi
+meson --cross-file=${MESON_TARGET_TOOLCHAIN} ${FLAGS} build
 cd build/
-ninja
+ninja -j${nproc}
 ninja install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # [FIXED!] FGlT contains std::string values!  This causes incompatibilities across the GCC 4/5 version boundary.
 # platforms = expand_cxxstring_abis(platforms)

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd fglt/
-if [[ "${target}" == *-i686* ]] || [[ "${target}" == *-armv7l-linux-musl* ]] || [[ "${target}" == *-x86_64-linux-musl* || [[ "${target}" == *-x86_64-linux-gnu* ]]; then
+if [[ "${target}" == *-i686* ]] || [[ "${target}" == *-armv7l-linux-musl* ]] || [[ "${target}" == *-x86_64-linux-musl* ]] || [[ "${target}" == *-x86_64-linux-gnu* ]]; then
   meson --cross-file=${MESON_TARGET_TOOLCHAIN} -Dprefer_openmp=true build
 else
   meson --cross-file=${MESON_TARGET_TOOLCHAIN} build

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -1,0 +1,37 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "FGlT"
+version = v"1.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/fcdimitr/fglt.git", "b91e1b3f4ed05eca69f342f7319faedb9d358257")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd fglt/
+meson --cross-file=${MESON_TARGET_TOOLCHAIN} build
+cd build/
+ninja
+ninja install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libfglt", :libfglt)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -24,6 +24,9 @@ ninja install
 # platforms are passed in on the command line
 platforms = supported_platforms()
 
+# FGlT contains std::string values!  This causes incompatibilities across the GCC 4/5 version boundary.
+platforms = expand_cxxstring_abis(platforms)
+
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libfglt", :libfglt)

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -35,7 +35,8 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
+dependencies = [
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -37,6 +37,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+    Dependency(PackageSpec(name="cilkrts_jll", uuid="71772805-00bc-5a29-9044-a26d819b7806""))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -37,4 +37,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7.1.0")  # CILK support

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd fglt/
-if [[ "${target}" == *-i686* ]] || [[ "${target}" == *-armv7l-linux-musl* ]] || [[ "${target}" == *-x86_64-linux-musl* ]] || [[ "${target}" == *-x86_64-linux-gnu* ]]; then
+if [[ "${target}" == *i686* ]] || [[ "${target}" == *armv7l-linux-musl* ]] || [[ "${target}" == *x86_64-linux-musl* ]] || [[ "${target}" == *x86_64-linux-gnu* ]]; then
   meson --cross-file=${MESON_TARGET_TOOLCHAIN} -Dprefer_openmp=true build
 else
   meson --cross-file=${MESON_TARGET_TOOLCHAIN} build

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -13,9 +13,9 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/fglt/
-if [[ "${target}" == *-linux-* ]]; then
-    FLAGS="-Dprefer_openmp=true"
-fi
+#if [[ "${target}" == *-linux-* ]]; then
+#    FLAGS="-Dprefer_openmp=true"
+#fi
 meson --cross-file=${MESON_TARGET_TOOLCHAIN} ${FLAGS} build
 cd build/
 ninja -j${nproc}


### PR DESCRIPTION
Hello! This pull-request contains the recipe needed for building the [Fast Graphlet Transform](https://github.com/fcdimitr/fglt) implementation. The binaries are required for [FGLT.jl](https://github.com/nsailor/FGLT.jl).

The source code takes advantage of `cilk` or `openMP` for parallelism. These are "optional" dependencies in the FGlT package, the code can be compiled for sequential execution if none is available.

What is the best way to check on which framework is used on each platform?

Many thanks in advance!