### PR TITLE
[MibS] add a build script for coin-or/Mibs

### DIFF
--- a/C/Coin-OR/MibS/build_tarballs.jl
+++ b/C/Coin-OR/MibS/build_tarballs.jl
@@ -1,0 +1,66 @@
+include("../coin-or-common.jl")
+
+sources = [
+    GitSource("https://github.com/coin-or/MibS.git", MibS_gitsha),
+]
+
+script = raw"""
+export CPPFLAGS="${CPPFLAGS} -I${includedir} -I${includedir}/coin"
+if [[ "${target}" == *mingw* ]]; then
+    export LDFLAGS="-L${bindir}"
+elif [[ "${target}" == *linux* ]]; then
+    export LDFLAGS="-ldl -lrt"
+fi
+
+cd $WORKSPACE/srcdir/MibS
+rm -f ${prefix}/lib/*.la
+update_configure_scripts
+sed -i s/elf64ppc/elf64lppc/ configure
+mkdir build
+cd build
+../configure \
+    --prefix=${prefix} \
+    --build=${MACHTYPE} \
+    --host=${target} \
+    --with-pic \
+    --disable-pkg-config \
+    --disable-debug \
+    --disable-dependency-tracking \
+    --enable-shared \
+    lt_cv_deplibs_check_method=pass_all \
+    --with-cbc-lib="-lOsiCbc -lCbc" \
+    --with-symphony-lib="-lOsiSym -lSym" \
+    --with-coindepend-lib="-lBlis -lBcps -lAlps -lCgl -lOsiClp -lClp -lOsi -lCoinUtils"
+make -j${nproc}
+make install
+"""
+
+products = [
+    ExecutableProduct("mibs", :mibs),
+]
+
+dependencies = [
+    Dependency("CoinUtils_jll", CoinUtils_version),
+    Dependency("Osi_jll", Osi_version),
+    Dependency("Clp_jll", Clp_version),
+    Dependency("Cgl_jll", Cgl_version),
+    Dependency("Cbc_jll", Cbc_version),
+    Dependency("SYMPHONY_jll", SYMPHONY_version),
+    Dependency("ALPS_jll", ALPS_version),
+    Dependency("BiCePS_jll", BiCePS_version),
+    Dependency("CHiPPS_BLIS_jll", CHiPPS_BLIS_version),
+    Dependency("CompilerSupportLibraries_jll"),
+]
+
+build_tarballs(
+    ARGS,
+    "MibS",
+    MibS_version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    preferred_gcc_version = gcc_version,
+    julia_compat = "1.6",
+)

--- a/C/Coin-OR/MibS/build_tarballs.jl
+++ b/C/Coin-OR/MibS/build_tarballs.jl
@@ -11,7 +11,6 @@ if [[ "${target}" == *mingw* ]]; then
 elif [[ "${target}" == *linux* ]]; then
     export LDFLAGS="-ldl -lrt"
 fi
-
 cd $WORKSPACE/srcdir/MibS
 rm -f ${prefix}/lib/*.la
 update_configure_scripts
@@ -37,6 +36,7 @@ make install
 
 products = [
     ExecutableProduct("mibs", :mibs),
+    ExecutableProduct("libMibs", :libmibs),
 ]
 
 dependencies = [

--- a/C/Coin-OR/MibS/build_tarballs.jl
+++ b/C/Coin-OR/MibS/build_tarballs.jl
@@ -36,7 +36,7 @@ make install
 
 products = [
     ExecutableProduct("mibs", :mibs),
-    ExecutableProduct("libMibs", :libmibs),
+    LibraryProduct("libMibs", :libmibs),
 ]
 
 dependencies = [

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -70,6 +70,9 @@ CHiPPS_BLIS_version =
 SYMPHONY_version = v"5.6.17"
 SYMPHONY_gitsha = "f917d42e6655a82ea4e9290aa7d41b0f60a91f20"
 
+MibS_version = v"1.1.3"
+MibS_gitsha = "4b7ec93c4bd1d6a978deff9987cf1df74f6598d3"
+
 # Third-party packages needed by COIN-OR libraries.
 ASL_version = v"0.1.2"
 METIS_version = v"5.1.0"


### PR DESCRIPTION
Probably still a WIP, but let's see what the damage is on some other platforms.

This targets 
- MibS 1.1.3 https://github.com/coin-or/MibS/commit/4b7ec93c4bd1d6a978deff9987cf1df74f6598d3
- SYMPHONY https://github.com/coin-or/SYMPHONY/commit/c0a755011ea2430f3465927ef29820933ddf3f2f
- CHiPPS-ALPS https://github.com/coin-or/CHiPPS-ALPS/commit/5b1a0b524979764d6ca929446762762712c035bb
- CHiPPS-BiCePS https://github.com/coin-or/CHiPPS-BiCePS/commit/bb7c56ef1bc91624a1dbee8c2f7da7246a0933ed
- CHiPPS-BLIS https://github.com/SaTahernejad/CHiPPS-BLIS/commit/b714e6af651704d0b019ad4495cbbe7529fbdb17

<s>It's probably easiest to keep them bundled together like this for now. We can split of SYMPHONY as a separate solver at some point if there is interest, or if we start building other COIN software with the same dependency.</s>

## Unbundling

- [x] SYMPHONY https://github.com/JuliaPackaging/Yggdrasil/pull/3160
- [x] ALPS https://github.com/JuliaPackaging/Yggdrasil/pull/3161
- [x] BiCePS https://github.com/JuliaPackaging/Yggdrasil/pull/3164
- [x] BLIS https://github.com/JuliaPackaging/Yggdrasil/pull/3183

cc @matbesancon 
cc @joaquimg
cc @tkralphs
cc @hesamshaelaie