### PR TITLE
bumping scip to 7.0.3 beta

### DIFF
--- a/S/SCIP/build_tarballs.jl
+++ b/S/SCIP/build_tarballs.jl
@@ -28,7 +28,16 @@ script = raw"""
 cd scipoptsuite*
 mkdir build
 cd build/
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DPAPILO=0 -DZIMPL=OFF -DGCG=0 -DREADLINE=OFF -DBOOST=off -DSYM=bliss ..
+cmake -DCMAKE_INSTALL_PREFIX=$prefix\
+  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}\
+  -DCMAKE_BUILD_TYPE=Release\
+  -DPAPILO=0\
+  -DZIMPL=OFF\
+  -DGCG=0\
+  -DREADLINE=OFF\
+  -DBOOST=off\
+  -DSYM=bliss\
+  -DIPOPT_DIR=${prefix} -DIPOPT_LIBRARIES=${libdir} ..
 make -j${nproc}
 make install
 """

--- a/S/SCIP/build_tarballs.jl
+++ b/S/SCIP/build_tarballs.jl
@@ -64,6 +64,7 @@ dependencies = [
     Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"), v"6.1.2"),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency(PackageSpec(name="Ipopt_jll", uuid="9cc047cb-c261-5740-88fc-0cf96f7bdcc7")),
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/SCIP/build_tarballs.jl
+++ b/S/SCIP/build_tarballs.jl
@@ -40,6 +40,11 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix\
   -DIPOPT_DIR=${prefix} -DIPOPT_LIBRARIES=${libdir} ..
 make -j${nproc}
 make install
+
+mkdir -p ${prefix}/share/licenses/SCIP
+for dir in papilo scip soplex; do
+    cp $WORKSPACE/srcdir/scipoptsuite*/${dir}/COPYING ${prefix}/share/licenses/SCIP/LICENSE_${dir}
+done
 """
 
 # These are the platforms we will build for by default, unless further

--- a/S/SCIP/build_tarballs.jl
+++ b/S/SCIP/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "SCIP"
-version = v"0.1.2"
+version = v"0.1.3"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://scip.zib.de/download/release/scipoptsuite-7.0.2.tgz", "f81b5a2c1c0eb949cf06bd50f42826e55284fa1269a6f28a92ac1a06d9c93a03"),
+    ArchiveSource("https://scip.zib.de/download/release/scipoptsuite-7.0.3.tgz", "5af5185a6e60cc62d1a89e3ac4fe22d32351a5158c2c04a95e180e76eb98cc07"),
 ]
 
 


### PR DESCRIPTION
There shouldn't be much surprise, preparing the SCIP_jll for 7.0.3