### PR TITLE
Patch categorical support for mlpack

### DIFF
--- a/M/mlpack/build_tarballs.jl
+++ b/M/mlpack/build_tarballs.jl
@@ -186,7 +186,7 @@ products = [
 dependencies = [
     Dependency("boost_jll"; compat="=1.71.0"),
     Dependency("armadillo_jll"),
-    Dependency("OpenBLAS_jll")
+    Dependency("OpenBLAS_jll", v"0.3.10")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/mlpack/build_tarballs.jl
+++ b/M/mlpack/build_tarballs.jl
@@ -9,11 +9,18 @@ name = "mlpack"
 version = v"3.4.2"
 sources = [
     ArchiveSource("https://www.mlpack.org/files/mlpack-$(version).tar.gz",
-                  "9e5c4af5c276c86a0dcc553289f6fe7b1b340d61c1e59844b53da0debedbb171")
+                  "9e5c4af5c276c86a0dcc553289f6fe7b1b340d61c1e59844b53da0debedbb171"),
+    DirectorySource("./bundled"),
 ]
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/mlpack-*/
+
+# Apply any patches that are needed.
+for f in ${WORKSPACE}/srcdir/patches/*.patch;
+do
+    atomic_patch -p1 ${f};
+done
 
 mkdir build && cd build
 

--- a/M/mlpack/bundled/patches/count-categories.patch
+++ b/M/mlpack/bundled/patches/count-categories.patch
@@ -1,0 +1,54 @@
+From 2763a4656b4ccfd86677b31c85149dff2d70d27f Mon Sep 17 00:00:00 2001
+From: Ryan Curtin <ryan@ratml.org>
+Date: Mon, 7 Jun 2021 16:34:30 -0400
+Subject: [PATCH] Compute number of categories in categorical data.
+
+---
+ src/mlpack/bindings/julia/julia_util.cpp | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/src/mlpack/bindings/julia/julia_util.cpp b/src/mlpack/bindings/julia/julia_util.cpp
+index ac8663eab..e50252782 100644
+--- a/src/mlpack/bindings/julia/julia_util.cpp
++++ b/src/mlpack/bindings/julia/julia_util.cpp
+@@ -193,13 +193,37 @@ void IO_SetParamMatWithInfo(const char* paramName,
+                             const bool pointsAreRows)
+ {
+   data::DatasetInfo d(pointsAreRows ? cols : rows);
++  bool hasCategoricals = false;
+   for (size_t i = 0; i < d.Dimensionality(); ++i)
+   {
+     d.Type(i) = (dimensions[i]) ? data::Datatype::categorical :
+         data::Datatype::numeric;
++    if (dimensions[i])
++      hasCategoricals = true;
+   }
+ 
+   arma::mat m(memptr, arma::uword(rows), arma::uword(cols), false, true);
++
++  // Do we need to find how many categories we have?
++  if (hasCategoricals)
++  {
++    arma::vec maxs = arma::max(m, 1) + 1;
++
++    for (size_t i = 0; i < d.Dimensionality(); ++i)
++    {
++      if (dimensions[i])
++      {
++        // Map the right number of objects.
++        for (size_t j = 0; j < (size_t) maxs[i]; ++j)
++        {
++          std::ostringstream oss;
++          oss << j;
++          d.MapString<double>(oss.str(), i);
++        }
++      }
++    }
++  }
++
+   std::get<0>(IO::GetParam<std::tuple<data::DatasetInfo, arma::mat>>(
+       paramName)) = std::move(d);
+   std::get<1>(IO::GetParam<std::tuple<data::DatasetInfo, arma::mat>>(
+-- 
+2.31.1
+


### PR DESCRIPTION
It was recently discovered in mlpack/mlpack#2973 that mlpack's Julia bindings segfault when a user is trying to learn a model on categorical data.  This was traced to a fairly simple patch, but, a new mlpack release is not coming soon since the library is currently in a heavy state of refactoring to reduce its dependencies.

Therefore, I took the relevant patch from that PR and backported it into the `mlpack_jll` package here.

One thing I am not sure of is whether I need to bump the package version from 3.4.2 so that Julia will automatically update the package.  If so, I'd bump it to something like 3.4.2-1, but I think that is not a valid Julia version number... someone please correct me with whatever the right thing is here. :)