### PR TITLE
Update Armadillo and use ILP64 on aarch64

### DIFF
--- a/A/armadillo/build_tarballs.jl
+++ b/A/armadillo/build_tarballs.jl
@@ -5,10 +5,10 @@ using BinaryBuilder
 
 
 name = "armadillo"
-version = v"9.850.1"
+version = v"10.5.1"
 sources = [
-    ArchiveSource("http://sourceforge.net/projects/arma/files/armadillo-9.850.1.tar.xz",
-                  "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f")
+    ArchiveSource("http://sourceforge.net/projects/arma/files/armadillo-10.5.1.tar.xz",
+                  "96ad6e1cbcf28f3d1c1ff972de2c40dadddbd7683256bad502d3c463d2f64cdf")
 ]
 
 script = raw"""
@@ -20,7 +20,7 @@ FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
        -DCMAKE_BUILD_TYPE=Release
        -DBUILD_SHARED_LIBS=ON)
 
-if [[ "${nbits}" == 64 ]] && [[ "${target}" != aarch64* ]]; then
+if [[ "${nbits}" == 64 ]]; then
     FLAGS+=(-Dopenblas_LIBRARY="${libdir}/libopenblas64_.${dlext}")
     # Force Armadillo's CMake configuration to accept OpenBLAS as a LAPACK
     # replacement.

--- a/M/mlpack/build_tarballs.jl
+++ b/M/mlpack/build_tarballs.jl
@@ -179,7 +179,7 @@ products = [
 dependencies = [
     Dependency("boost_jll"; compat="=1.71.0"),
     Dependency("armadillo_jll"),
-    Dependency("OpenBLAS_jll", v"0.3.10")
+    Dependency("OpenBLAS_jll")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/mlpack/build_tarballs.jl
+++ b/M/mlpack/build_tarballs.jl
@@ -179,7 +179,7 @@ products = [
 dependencies = [
     Dependency("boost_jll"; compat="=1.71.0"),
     Dependency("armadillo_jll"),
-    Dependency("OpenBLAS_jll")
+    Dependency("OpenBLAS_jll", v"0.3.10")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This is a follow-up to #3144 (and in turn #2465).  It updates the version of Armadillo, and also tries to make Armadillo use correct OpenBLAS symbols.