### PR TITLE
Xyce wrapper

### DIFF
--- a/X/XyceWrapper/build_tarballs.jl
+++ b/X/XyceWrapper/build_tarballs.jl
@@ -1,4 +1,3 @@
-using Base: DirectOrdering
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg

--- a/X/XyceWrapper/build_tarballs.jl
+++ b/X/XyceWrapper/build_tarballs.jl
@@ -28,7 +28,6 @@ cmake --build . --config Release --target install -- -j${nproc}
 
 platforms = filter(Sys.islinux, supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
-platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/X/XyceWrapper/build_tarballs.jl
+++ b/X/XyceWrapper/build_tarballs.jl
@@ -1,8 +1,9 @@
+using Base: DirectOrdering
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-julia_version = "1.6.0"
+julia_version = v"1.6.0"
 
 name = "XyceWrapper"
 version = v"0.1.0"
@@ -24,9 +25,12 @@ cmake \
     -DCMAKE_BUILD_TYPE=Release \
     ..
 cmake --build . --config Release --target install -- -j${nproc}
+install_license /usr/share/licenses/MIT
 """
 
-platforms = filter(Sys.islinux, supported_platforms())
+include("../../L/libjulia/common.jl")
+platforms = libjulia_platforms(julia_version)
+platforms = filter!(Sys.islinux, platforms) # Xyce only supports Linux
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/X/XyceWrapper/build_tarballs.jl
+++ b/X/XyceWrapper/build_tarballs.jl
@@ -1,0 +1,46 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+julia_version = "1.6.0"
+
+name = "XyceWrapper"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    DirectorySource("./src"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+mkdir -p build
+cd build
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_FIND_ROOT_PATH=${prefix} \
+    -DJulia_PREFIX=${prefix} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+cmake --build . --config Release --target install -- -j${nproc}
+"""
+
+platforms = filter(Sys.islinux, supported_platforms())
+platforms = expand_cxxstring_abis(platforms)
+platforms = expand_gfortran_versions(platforms)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libxycelib", :xycelib),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Xyce_jll"),
+    Dependency("libcxxwrap_julia_jll"),
+    BuildDependency(PackageSpec(name="libjulia_jll", version=julia_version)),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"7")

--- a/X/XyceWrapper/src/CMakeLists.txt
+++ b/X/XyceWrapper/src/CMakeLists.txt
@@ -1,0 +1,31 @@
+project(XyceLib)
+
+cmake_minimum_required(VERSION 2.8.12)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
+find_package(JlCxx)
+get_target_property(JlCxx_location JlCxx::cxxwrap_julia LOCATION)
+get_filename_component(JlCxx_location ${JlCxx_location} DIRECTORY)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${JlCxx_location}")
+
+message(STATUS "Found JlCxx at ${JlCxx_location}")
+
+find_library(XYCE_LIBRARY xyce REQUIRED)
+
+message(STATUS "Found Xyce at ${XYCE_LIBRARY}")
+
+add_library(xycelib SHARED xycelib.cpp)
+
+target_link_libraries(xycelib
+  JlCxx::cxxwrap_julia
+  ${XYCE_LIBRARY}
+  teuchoscore 
+)
+
+install(TARGETS
+  xycelib
+LIBRARY DESTINATION lib
+ARCHIVE DESTINATION lib
+RUNTIME DESTINATION lib)

--- a/X/XyceWrapper/src/xycelib.cpp
+++ b/X/XyceWrapper/src/xycelib.cpp
@@ -2,7 +2,10 @@
 #include <Xyce_config.h>
 #include <N_CIR_GenCouplingSimulator.h>
 
-typedef void (*func_t)(int);
+// CxxWrap doesn't like the return value
+void set_report_handler(Xyce::REH reh) {
+    Xyce::set_report_handler(reh);
+}
 
 class OutputHandler final : public Xyce::IO::ExternalOutputInterface
 {
@@ -104,4 +107,6 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         .method("initialize", &Xyce::Circuit::GenCouplingSimulator::initialize)
         .method("addOutputInterface", &Xyce::Circuit::GenCouplingSimulator::addOutputInterface)
         .method("runSimulation", &Xyce::Circuit::GenCouplingSimulator::runSimulation);
+
+    mod.method("set_report_handler", &set_report_handler);
 }

--- a/X/XyceWrapper/src/xycelib.cpp
+++ b/X/XyceWrapper/src/xycelib.cpp
@@ -1,0 +1,107 @@
+#include "jlcxx/jlcxx.hpp"
+#include <Xyce_config.h>
+#include <N_CIR_GenCouplingSimulator.h>
+
+typedef void (*func_t)(int);
+
+class OutputHandler final : public Xyce::IO::ExternalOutputInterface
+{
+public:
+    OutputHandler(std::string name,
+    Xyce::IO::OutputType::OutputType type,
+    std::vector<std::string> outputs)
+        : requested_fieldnames(outputs), type(type), name(name) { }
+
+    std::string getName()
+    {
+        return name;
+    }
+
+    Xyce::IO::OutputType::OutputType getOutputType()
+    {
+        return type;
+    }
+
+    void requestedOutputs(std::vector<std::string> &outputVars)
+    {
+        outputVars = requested_fieldnames;
+    }
+
+    void outputFieldNames(std::vector<std::string> &outputNames)
+    {
+        fieldnames = outputNames;
+        real_data.resize(outputNames.size());
+    }
+
+    std::vector<std::string> getFieldnames() {
+        return fieldnames;
+    }
+
+    std::vector<double> getRealData(unsigned int idx) {
+        return real_data[idx];
+    }
+
+    void outputReal(std::vector<double> &outputData)
+    {
+        for(int i=0;i<outputData.size();i++) {
+            real_data[i].push_back(outputData[i]);
+        }
+    }
+
+    void outputComplex(std::vector<std::complex<double>> &outputData)
+    {
+        // TODO: how to expose std::complex to julia?
+    }
+
+    std::string name;
+    Xyce::IO::OutputType::OutputType type;
+    std::vector<std::string> requested_fieldnames;
+    std::vector<std::string> fieldnames;
+    std::vector<std::vector<double>> real_data;
+};
+
+namespace jlcxx
+{
+  // Needed for upcasting
+  template<> struct SuperType<OutputHandler> { typedef Xyce::IO::ExternalOutputInterface type; };
+}
+
+JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
+{
+    mod.add_bits<Xyce::IO::OutputType::OutputType>("OutputType", jlcxx::julia_type("CppEnum"));
+    mod.set_const("DC", Xyce::IO::OutputType::OutputType::DC);
+    mod.set_const("TRAN", Xyce::IO::OutputType::OutputType::TRAN);
+    mod.set_const("AC", Xyce::IO::OutputType::OutputType::AC);
+    mod.set_const("AC_IC", Xyce::IO::OutputType::OutputType::AC_IC);
+    mod.set_const("HB_FD", Xyce::IO::OutputType::OutputType::HB_FD);
+    mod.set_const("HB_TD", Xyce::IO::OutputType::OutputType::HB_TD);
+    mod.set_const("HB_IC", Xyce::IO::OutputType::OutputType::HB_IC);
+    mod.set_const("HB_STARTUP", Xyce::IO::OutputType::OutputType::HB_STARTUP);
+    mod.set_const("DCOP", Xyce::IO::OutputType::OutputType::DCOP);
+    mod.set_const("HOMOTOPY", Xyce::IO::OutputType::OutputType::HOMOTOPY);
+    mod.set_const("MPDE", Xyce::IO::OutputType::OutputType::MPDE);
+    mod.set_const("MPDE_IC", Xyce::IO::OutputType::OutputType::MPDE_IC);
+    mod.set_const("MPDE_STARTUP", Xyce::IO::OutputType::OutputType::MPDE_STARTUP);
+    mod.set_const("SENS", Xyce::IO::OutputType::OutputType::SENS);
+    mod.set_const("TRANADJOINT", Xyce::IO::OutputType::OutputType::TRANADJOINT);
+    mod.set_const("NOISE", Xyce::IO::OutputType::OutputType::NOISE);
+    mod.set_const("SPARAM", Xyce::IO::OutputType::OutputType::SPARAM);
+    mod.set_const("ES", Xyce::IO::OutputType::OutputType::ES);
+    mod.set_const("PCE", Xyce::IO::OutputType::OutputType::ES);
+
+    mod.add_bits<Xyce::Circuit::Simulator::RunStatus>("RunStatus", jlcxx::julia_type("CppEnum"));
+    mod.set_const("ERROR", Xyce::Circuit::Simulator::RunStatus::ERROR);
+    mod.set_const("SUCCESS", Xyce::Circuit::Simulator::RunStatus::SUCCESS);
+    mod.set_const("DONE", Xyce::Circuit::Simulator::RunStatus::DONE);
+
+    mod.add_type<Xyce::IO::ExternalOutputInterface>("ExternalOutputInterface");
+    mod.add_type<OutputHandler>("OutputHandler", jlcxx::julia_base_type<Xyce::IO::ExternalOutputInterface>())
+        .constructor<std::string, Xyce::IO::OutputType::OutputType, std::vector<std::string>>()
+        .method("getFieldnames", &OutputHandler::getFieldnames)
+        .method("getRealData", &OutputHandler::getRealData);
+
+    mod.add_type<Xyce::Circuit::GenCouplingSimulator>("GenCouplingSimulator")
+        .method("initialize", &Xyce::Circuit::GenCouplingSimulator::initialize)
+        .method("addOutputInterface", &Xyce::Circuit::GenCouplingSimulator::addOutputInterface)
+        .method("runSimulation", &Xyce::Circuit::GenCouplingSimulator::runSimulation);
+}


### PR DESCRIPTION
We are working on a high-level Julia wrapper over Xyce, to complement Xyce_jll that is part of Yggdrasil already. However, the Xyce API is C++ so using CxxWrap requires building a native extension that can be used from Julia.

This extension currently requires manual building inside https://github.com/JuliaComputing/Xyce.jl/ which is not user friendly at all. So we'd like to get this wrapper in Yggdrasil as well so people can just `] add Xyce.jl` and start simulating.