### PR TITLE
XyceWrapper: hardcode non-aborting report handler

### DIFF
--- a/X/XyceWrapper/src/xycelib.cpp
+++ b/X/XyceWrapper/src/xycelib.cpp
@@ -2,9 +2,15 @@
 #include <Xyce_config.h>
 #include <N_CIR_GenCouplingSimulator.h>
 
-// CxxWrap doesn't like the return value
-void set_report_handler(Xyce::REH reh) {
-    Xyce::set_report_handler(reh);
+void report_handler(const char *m, unsigned i)
+{
+    std::cout << m;
+}
+
+// by default Xyce aborts on an error.
+// As a library we don't like that
+void set_report_handler() {
+    Xyce::set_report_handler(&report_handler);
 }
 
 class OutputHandler final : public Xyce::IO::ExternalOutputInterface


### PR DESCRIPTION
The `set_report_handler` function I added in the last minute in the previous PR is not actually usable from Julia. Very sorry about the noise.

The purpose of this function is simply to avoid Xyce aborting the Julia runtime on an error, so I just hardcoded it. I have now properly tested this in Xyce.jl: https://github.com/JuliaComputing/Xyce.jl/blob/7a2bff1f037dff2f4173e49bcdb60787a2daac61/src/Xyce.jl#L9