### PR TITLE
Enable extra encodings for libiconv

### DIFF
--- a/L/Libiconv/build_tarballs.jl
+++ b/L/Libiconv/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = "VERSION=$(version.major).$(version.minor)\n" * raw"""
 cd $WORKSPACE/srcdir/libiconv-*/
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static --enable-extra-encodings
 make -j${nproc}
 make install
 


### PR DESCRIPTION
It'll enable more encodings with libiconv. Not sure if I need to bump version by adding metadata like `+20210614` to trigger a new package build on Yggdrasil.