### PR TITLE
[Cbc] Export libOsiCbc library

### DIFF
--- a/C/Coin-OR/Cbc/build_tarballs.jl
+++ b/C/Coin-OR/Cbc/build_tarballs.jl
@@ -52,6 +52,7 @@ make install
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libCbc", :libCbc),
+    LibraryProduct("libOsiCbc", :libOsiCbc),
     LibraryProduct("libCbcSolver", :libcbcsolver),
     ExecutableProduct("cbc", :cbc),
 ]


### PR DESCRIPTION
MibS failed to install because it was missing this library: https://github.com/JuliaRegistries/General/pull/39121