### PR TITLE
[faust] add Faust compiler v2.32.16

### DIFF
--- a/F/faust/build_tarballs.jl
+++ b/F/faust/build_tarballs.jl
@@ -178,6 +178,7 @@ dependencies = [
     Dependency("Ncurses_jll"),
     Dependency("Zlib_jll"),
     Dependency("libmicrohttpd_jll"),
+    Dependency("libsndfile_jll"),
     BuildDependency("XML2_jll"),
 ]
 

--- a/F/faust/build_tarballs.jl
+++ b/F/faust/build_tarballs.jl
@@ -53,20 +53,15 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
 CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
 CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
 
-if [[ "${target}" == "x86_64-linux-gnu" || "${target}" == "i686-linux-gnu" ]]; then
-    # Use llvm-config binary directly.
-    export PATH="$prefix/tools:$PATH"
-else
-    CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
-    CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
+CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
+CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
 
-    if [[ "${bb_full_target}" == x86_64-linux-musl-*-cxx03 ]]; then
-        # For some reason this target requires "-lLLVM-11jl"
-        # while others require "-lLLVM" to build.
-        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs_musl_cxx03.patch
-    else
-        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs.patch
-    fi
+if [[ "${bb_full_target}" == x86_64-linux-musl-*-cxx03 ]]; then
+    # For some reason this target requires "-lLLVM-11jl"
+    # while others require "-lLLVM" to build.
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs_musl_cxx03.patch
+else
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs.patch
 fi
 
 export CMAKEOPT="${CMAKE_FLAGS[@]}"
@@ -182,11 +177,11 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("LLVM_jll", v"11.0.1"),
-    Dependency("Ncurses_jll"),
-    Dependency("Zlib_jll"),
     Dependency("libmicrohttpd_jll"),
     Dependency("libsndfile_jll"),
+    BuildDependency("Ncurses_jll"),
     BuildDependency("XML2_jll"),
+    BuildDependency("Zlib_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/faust/build_tarballs.jl
+++ b/F/faust/build_tarballs.jl
@@ -53,20 +53,15 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
 CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
 CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
 
-if [[ "${target}" == "x86_64-linux-gnu" || "${target}" == "i686-linux-gnu" ]]; then
-    # Use llvm-config binary directly.
-    export PATH="$prefix/tools:$PATH"
-else
-    CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
-    CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
+CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
+CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
 
-    if [[ "${bb_full_target}" == x86_64-linux-musl-*-cxx03 ]]; then
-        # For some reason this target requires "-lLLVM-11jl"
-        # while others require "-lLLVM" to build.
-        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs_musl_cxx03.patch
-    else
-        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs.patch
-    fi
+if [[ "${bb_full_target}" == x86_64-linux-musl-*-cxx03 ]]; then
+    # For some reason this target requires "-lLLVM-11jl"
+    # while others require "-lLLVM" to build.
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs_musl_cxx03.patch
+else
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs.patch
 fi
 
 export CMAKEOPT="${CMAKE_FLAGS[@]}"
@@ -181,12 +176,12 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("LLVM_jll", v"11.0.1"),
-    Dependency("Ncurses_jll"),
-    Dependency("Zlib_jll"),
+    Dependency("libLLVM_jll", v"11.0.1"),
     Dependency("libmicrohttpd_jll"),
     Dependency("libsndfile_jll"),
+    BuildDependency("Ncurses_jll"),
     BuildDependency("XML2_jll"),
+    BuildDependency("Zlib_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/faust/build_tarballs.jl
+++ b/F/faust/build_tarballs.jl
@@ -60,7 +60,7 @@ else
     CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
     CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
 
-    if [[ "${target}" == "x86_64-linux-musl-cxx03*"]]; then
+    if [[ "${target}" == "x86_64-linux-musl-cxx03*" ]]; then
         # For some reason this target requires "-lLLVM-11jl"
         # while others require "-lLLVM" to build.
         atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs_musl_cxx03.patch

--- a/F/faust/build_tarballs.jl
+++ b/F/faust/build_tarballs.jl
@@ -59,7 +59,14 @@ if [[ "${target}" == "x86_64-linux-gnu" || "${target}" == "i686-linux-gnu" ]]; t
 else
     CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
     CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
-    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs.patch
+
+    if [[ "${target}" == "x86_64-linux-musl-cxx03*"]]; then
+        # For some reason this target requires "-lLLVM-11jl"
+        # while others require "-lLLVM" to build.
+        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs_musl_cxx03.patch
+    else
+        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs.patch
+    fi
 fi
 
 export CMAKEOPT="${CMAKE_FLAGS[@]}"

--- a/F/faust/build_tarballs.jl
+++ b/F/faust/build_tarballs.jl
@@ -60,7 +60,7 @@ else
     CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
     CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
 
-    if [[ "${target}" == "x86_64-linux-musl-cxx03*" ]]; then
+    if [[ "${bb_full_target}" == x86_64-linux-musl-*-cxx03 ]]; then
         # For some reason this target requires "-lLLVM-11jl"
         # while others require "-lLLVM" to build.
         atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs_musl_cxx03.patch

--- a/F/faust/build_tarballs.jl
+++ b/F/faust/build_tarballs.jl
@@ -53,15 +53,20 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
 CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
 CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
 
-CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
-CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
-
-if [[ "${bb_full_target}" == x86_64-linux-musl-*-cxx03 ]]; then
-    # For some reason this target requires "-lLLVM-11jl"
-    # while others require "-lLLVM" to build.
-    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs_musl_cxx03.patch
+if [[ "${target}" == "x86_64-linux-gnu" || "${target}" == "i686-linux-gnu" ]]; then
+    # Use llvm-config binary directly.
+    export PATH="$prefix/tools:$PATH"
 else
-    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs.patch
+    CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
+    CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
+
+    if [[ "${bb_full_target}" == x86_64-linux-musl-*-cxx03 ]]; then
+        # For some reason this target requires "-lLLVM-11jl"
+        # while others require "-lLLVM" to build.
+        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs_musl_cxx03.patch
+    else
+        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs.patch
+    fi
 fi
 
 export CMAKEOPT="${CMAKE_FLAGS[@]}"
@@ -176,12 +181,12 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("libLLVM_jll", v"11.0.1"),
+    Dependency("LLVM_jll", v"11.0.1"),
+    Dependency("Ncurses_jll"),
+    Dependency("Zlib_jll"),
     Dependency("libmicrohttpd_jll"),
     Dependency("libsndfile_jll"),
-    BuildDependency("Ncurses_jll"),
     BuildDependency("XML2_jll"),
-    BuildDependency("Zlib_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/faust/build_tarballs.jl
+++ b/F/faust/build_tarballs.jl
@@ -1,0 +1,185 @@
+
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "faust"
+version = v"2.32.16"
+
+# Collection of sources required to build faust
+sources = [
+    GitSource("https://github.com/grame-cncm/faust.git",
+              "53055b47f0ac81bee92b32db3c12729759e005f4"),
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/faust
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/disable_interp.patch
+CMAKE_FLAGS=()
+CMAKE_TARGET=${target}
+
+if [[ "${target}" == *musl* ]]; then
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/execinfo.patch
+    export CXXFLAGS="-DALPINE"
+fi
+
+if [[ "${target}" == *apple* ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=10.9
+    export LDFLAGS="${LDFLAGS} -mmacosx-version-min=10.9"
+    # If we're building for Apple, CMake gets confused with `aarch64-apple-darwin` and instead prefers
+    # `arm64-apple-darwin`.  If this issue persists, we may have to change our triplet printing.
+    if [[ "${target}" == aarch64* ]]; then
+        CMAKE_TARGET=arm64-${target#*-}
+    fi
+fi
+
+if [[ "${target}" == *mingw* ]]; then
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/ws2.patch
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/windows-microhttpd.patch
+    export LDFLAGS="${LDFLAGS} -lws2_32 -lmicrohttpd"
+fi
+
+if [[ "${target}" == *freebsd* ]]; then
+    export LDFLAGS="${LDFLAGS} -lexecinfo"
+fi
+
+CMAKE_FLAGS+=(-DCMAKE_C_COMPILER_TARGET=${CMAKE_TARGET})
+CMAKE_FLAGS+=(-DCMAKE_CXX_COMPILER_TARGET=${CMAKE_TARGET})
+
+CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+
+if [[ "${target}" == "x86_64-linux-gnu" || "${target}" == "i686-linux-gnu" ]]; then
+    # Use llvm-config binary directly.
+    export PATH="$prefix/tools:$PATH"
+else
+    CMAKE_FLAGS+=(-DUSE_LLVM_CONFIG=OFF)
+    CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/set_llvm_libs.patch
+fi
+
+export CMAKEOPT="${CMAKE_FLAGS[@]}"
+export PREFIX=$prefix
+
+make -j$(nproc) all
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("faust", :faust),
+    LibraryProduct("libfaust", :libfaust),
+    LibraryProduct("libHTTPDFaust", :libHTTPDFaust),
+    LibraryProduct("libOSCFaust", :libOSCFaust),
+
+    # Generated list of Faust scripts using:
+    # find $prefix/bin -maxdepth 1 -name 'faust2*' -printf '    FileProduct(joinpath("bin", "%f"), :%f),\n' | sort
+    FileProduct(joinpath("bin", "faust2alqt"), :faust2alqt),
+    FileProduct(joinpath("bin", "faust2alsaconsole"), :faust2alsaconsole),
+    FileProduct(joinpath("bin", "faust2alsa"), :faust2alsa),
+    FileProduct(joinpath("bin", "faust2android"), :faust2android),
+    FileProduct(joinpath("bin", "faust2androidunity"), :faust2androidunity),
+    FileProduct(joinpath("bin", "faust2api"), :faust2api),
+    FileProduct(joinpath("bin", "faust2atomsnippets"), :faust2atomsnippets),
+    FileProduct(joinpath("bin", "faust2au"), :faust2au),
+    FileProduct(joinpath("bin", "faust2bela"), :faust2bela),
+    FileProduct(joinpath("bin", "faust2caqt"), :faust2caqt),
+    FileProduct(joinpath("bin", "faust2caqtios"), :faust2caqtios),
+    FileProduct(joinpath("bin", "faust2csound"), :faust2csound),
+    FileProduct(joinpath("bin", "faust2csvplot"), :faust2csvplot),
+    FileProduct(joinpath("bin", "faust2dplug"), :faust2dplug),
+    FileProduct(joinpath("bin", "faust2dssi"), :faust2dssi),
+    FileProduct(joinpath("bin", "faust2dummy"), :faust2dummy),
+    FileProduct(joinpath("bin", "faust2dummymem"), :faust2dummymem),
+    FileProduct(joinpath("bin", "faust2eps"), :faust2eps),
+    FileProduct(joinpath("bin", "faust2esp32"), :faust2esp32),
+    FileProduct(joinpath("bin", "faust2faustvst"), :faust2faustvst),
+    FileProduct(joinpath("bin", "faust2firefox"), :faust2firefox),
+    FileProduct(joinpath("bin", "faust2gen"), :faust2gen),
+    FileProduct(joinpath("bin", "faust2graph"), :faust2graph),
+    FileProduct(joinpath("bin", "faust2graphviewer"), :faust2graphviewer),
+    FileProduct(joinpath("bin", "faust2ios"), :faust2ios),
+    FileProduct(joinpath("bin", "faust2jackconsole"), :faust2jackconsole),
+    FileProduct(joinpath("bin", "faust2jack"), :faust2jack),
+    FileProduct(joinpath("bin", "faust2jackrust"), :faust2jackrust),
+    FileProduct(joinpath("bin", "faust2jackserver"), :faust2jackserver),
+    FileProduct(joinpath("bin", "faust2jaqtchain"), :faust2jaqtchain),
+    FileProduct(joinpath("bin", "faust2jaqt"), :faust2jaqt),
+    FileProduct(joinpath("bin", "faust2juce"), :faust2juce),
+    FileProduct(joinpath("bin", "faust2ladspa"), :faust2ladspa),
+    FileProduct(joinpath("bin", "faust2linuxunity"), :faust2linuxunity),
+    FileProduct(joinpath("bin", "faust2lv2"), :faust2lv2),
+    FileProduct(joinpath("bin", "faust2mathdoc"), :faust2mathdoc),
+    FileProduct(joinpath("bin", "faust2mathviewer"), :faust2mathviewer),
+    FileProduct(joinpath("bin", "faust2max6"), :faust2max6),
+    FileProduct(joinpath("bin", "faust2md"), :faust2md),
+    FileProduct(joinpath("bin", "faust2msp"), :faust2msp),
+    FileProduct(joinpath("bin", "faust2netjackconsole"), :faust2netjackconsole),
+    FileProduct(joinpath("bin", "faust2netjackqt"), :faust2netjackqt),
+    FileProduct(joinpath("bin", "faust2nodejs"), :faust2nodejs),
+    FileProduct(joinpath("bin", "faust2octave"), :faust2octave),
+    FileProduct(joinpath("bin", "faust2osxiosunity"), :faust2osxiosunity),
+    FileProduct(joinpath("bin", "faust2owl"), :faust2owl),
+    FileProduct(joinpath("bin", "faust2paqt"), :faust2paqt),
+    FileProduct(joinpath("bin", "faust2pdf"), :faust2pdf),
+    FileProduct(joinpath("bin", "faust2plot"), :faust2plot),
+    FileProduct(joinpath("bin", "faust2png"), :faust2png),
+    FileProduct(joinpath("bin", "faust2portaudiorust"), :faust2portaudiorust),
+    FileProduct(joinpath("bin", "faust2puredata"), :faust2puredata),
+    FileProduct(joinpath("bin", "faust2pure"), :faust2pure),
+    FileProduct(joinpath("bin", "faust2raqt"), :faust2raqt),
+    FileProduct(joinpath("bin", "faust2ros"), :faust2ros),
+    FileProduct(joinpath("bin", "faust2rosgtk"), :faust2rosgtk),
+    FileProduct(joinpath("bin", "faust2rpialsaconsole"), :faust2rpialsaconsole),
+    FileProduct(joinpath("bin", "faust2rpinetjackconsole"), :faust2rpinetjackconsole),
+    FileProduct(joinpath("bin", "faust2sam"), :faust2sam),
+    FileProduct(joinpath("bin", "faust2sc"), :faust2sc),
+    FileProduct(joinpath("bin", "faust2sig"), :faust2sig),
+    FileProduct(joinpath("bin", "faust2sigviewer"), :faust2sigviewer),
+    FileProduct(joinpath("bin", "faust2smartkeyb"), :faust2smartkeyb),
+    FileProduct(joinpath("bin", "faust2sndfile"), :faust2sndfile),
+    FileProduct(joinpath("bin", "faust2soul"), :faust2soul),
+    FileProduct(joinpath("bin", "faust2supercollider"), :faust2supercollider),
+    FileProduct(joinpath("bin", "faust2svg"), :faust2svg),
+    FileProduct(joinpath("bin", "faust2svgviewer"), :faust2svgviewer),
+    FileProduct(joinpath("bin", "faust2teensy"), :faust2teensy),
+    FileProduct(joinpath("bin", "faust2unity"), :faust2unity),
+    FileProduct(joinpath("bin", "faust2vcvrack"), :faust2vcvrack),
+    FileProduct(joinpath("bin", "faust2vst"), :faust2vst),
+    FileProduct(joinpath("bin", "faust2vsti"), :faust2vsti),
+    FileProduct(joinpath("bin", "faust2w32max6"), :faust2w32max6),
+    FileProduct(joinpath("bin", "faust2w32msp"), :faust2w32msp),
+    FileProduct(joinpath("bin", "faust2w32puredata"), :faust2w32puredata),
+    FileProduct(joinpath("bin", "faust2w32vst"), :faust2w32vst),
+    FileProduct(joinpath("bin", "faust2w64max6"), :faust2w64max6),
+    FileProduct(joinpath("bin", "faust2w64vst"), :faust2w64vst),
+    FileProduct(joinpath("bin", "faust2wasm"), :faust2wasm),
+    FileProduct(joinpath("bin", "faust2webaudiowasm"), :faust2webaudiowasm),
+    FileProduct(joinpath("bin", "faust2webaudiowast"), :faust2webaudiowast),
+    FileProduct(joinpath("bin", "faust2winunity"), :faust2winunity), 
+
+    FileProduct(joinpath("bin","faustoptflags"), :faustoptflags),
+    FileProduct(joinpath("bin","usage.sh"), :usage_sh),
+
+    FileProduct(joinpath("share", "faust", "stdfaust.lib"), :stdfaust_lib),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("LLVM_jll", v"11.0.1"),
+    Dependency("Ncurses_jll"),
+    Dependency("Zlib_jll"),
+    Dependency("libmicrohttpd_jll"),
+    BuildDependency("XML2_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, preferred_gcc_version=v"8", julia_compat="1.6")

--- a/F/faust/bundled/patches/disable_interp.patch
+++ b/F/faust/bundled/patches/disable_interp.patch
@@ -1,0 +1,12 @@
+diff --git a/build/targets/all.cmake b/build/targets/all.cmake
+index 4b4473824..ff05d7769 100644
+--- a/build/targets/all.cmake
++++ b/build/targets/all.cmake
+@@ -11,5 +11,5 @@ set ( INCLUDE_HTTP        ON  CACHE STRING  "Include Faust HTTPD static library"
+ set ( OSCDYNAMIC          ON  CACHE STRING  "Include Faust OSC dynamic library" FORCE )
+ set ( HTTPDYNAMIC         ON  CACHE STRING  "Include Faust HTTP dynamic library" FORCE )
+ 
+-set ( INCLUDE_ITP         ON  CACHE STRING  "Include Faust Machine library" FORCE )
+-set ( ITPDYNAMIC          ON  CACHE STRING  "Include Faust Machine library" FORCE )
++set ( INCLUDE_ITP         OFF  CACHE STRING  "Include Faust Machine library" FORCE )
++set ( ITPDYNAMIC          OFF  CACHE STRING  "Include Faust Machine library" FORCE )

--- a/F/faust/bundled/patches/execinfo.patch
+++ b/F/faust/bundled/patches/execinfo.patch
@@ -1,0 +1,13 @@
+diff --git a/compiler/errors/exception.hh b/compiler/errors/exception.hh
+index 2a295092e..b7aa18574 100644
+--- a/compiler/errors/exception.hh
++++ b/compiler/errors/exception.hh
+@@ -29,7 +29,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ //#include <io.h>
+ #endif
+ 
+-#if !defined(EMCC) && !defined(WIN32) && !defined(ANDROID)
++#if !defined(EMCC) && !defined(WIN32) && !defined(ANDROID) && !defined(ALPINE)
+ #include <execinfo.h>
+ #endif
+ 

--- a/F/faust/bundled/patches/rt.patch
+++ b/F/faust/bundled/patches/rt.patch
@@ -1,0 +1,14 @@
+diff --git a/build/misc/llvm.cmake b/build/misc/llvm.cmake
+index a285f6249..a9e97c31e 100644
+--- a/build/misc/llvm.cmake
++++ b/build/misc/llvm.cmake
+@@ -101,6 +101,9 @@ macro (llvm_cmake)
+ 		message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+ 		# Find the libraries that correspond to the LLVM components that we wish to use
+ 		llvm_map_components_to_libnames(LLVM_LIBS all)
++		set_target_properties(LLVMSupport PROPERTIES
++			INTERFACE_LINK_LIBRARIES "dl;m;LLVMDemangle"
++		)
+ #		list(REMOVE_ITEM LLVM_LIBS LTO)
+ 	else()
+ 		llvm_config()

--- a/F/faust/bundled/patches/set_llvm_libs.patch
+++ b/F/faust/bundled/patches/set_llvm_libs.patch
@@ -1,0 +1,14 @@
+diff --git a/build/misc/llvm.cmake b/build/misc/llvm.cmake
+index a285f6249..46423a5b7 100644
+--- a/build/misc/llvm.cmake
++++ b/build/misc/llvm.cmake
+@@ -99,8 +99,7 @@ macro (llvm_cmake)
+ 	if (COMMAND llvm_map_components_to_libnames)
+ 		message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+ 		message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+-		# Find the libraries that correspond to the LLVM components that we wish to use
+-		llvm_map_components_to_libnames(LLVM_LIBS all)
++		set(LLVM_LIBS "-lLLVM -lstdc++")
+ #		list(REMOVE_ITEM LLVM_LIBS LTO)
+ 	else()
+ 		llvm_config()

--- a/F/faust/bundled/patches/set_llvm_libs_musl_cxx03.patch
+++ b/F/faust/bundled/patches/set_llvm_libs_musl_cxx03.patch
@@ -1,0 +1,14 @@
+diff --git a/build/misc/llvm.cmake b/build/misc/llvm.cmake
+index a285f6249..e445111fa 100644
+--- a/build/misc/llvm.cmake
++++ b/build/misc/llvm.cmake
+@@ -99,8 +99,7 @@ macro (llvm_cmake)
+ 	if (COMMAND llvm_map_components_to_libnames)
+ 		message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+ 		message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+-		# Find the libraries that correspond to the LLVM components that we wish to use
+-		llvm_map_components_to_libnames(LLVM_LIBS all)
++		set(LLVM_LIBS "-lLLVM-11jl -lstdc++")
+ #		list(REMOVE_ITEM LLVM_LIBS LTO)
+ 	else()
+ 		llvm_config()

--- a/F/faust/bundled/patches/windows-microhttpd.patch
+++ b/F/faust/bundled/patches/windows-microhttpd.patch
@@ -1,0 +1,12 @@
+diff --git a/build/http/CMakeLists.txt b/build/http/CMakeLists.txt
+index 63e5b06c8..ac94ef74f 100644
+--- a/build/http/CMakeLists.txt
++++ b/build/http/CMakeLists.txt
+@@ -165,6 +165,7 @@ if (HTTPDYNAMIC)
+ 	elseif(MSYS)
+ 		target_link_libraries (httpdynamic ${LIBMICROHTTPD__LDFLAGS})
+ 	else()
++		target_link_libraries (httpdynamic ws2_32 microhttpd)
+ 		set_target_properties (httpdynamic PROPERTIES 
+ 			COMPILE_FLAGS  "${LIBMICROHTTPD__CFLAGS}"
+ 			LINK_FLAGS     "${LIBMICROHTTPD__LDFLAGS}")

--- a/F/faust/bundled/patches/ws2.patch
+++ b/F/faust/bundled/patches/ws2.patch
@@ -1,0 +1,13 @@
+diff --git a/build/CMakeLists.txt b/build/CMakeLists.txt
+index 34c6df065..6e73ef352 100644
+--- a/build/CMakeLists.txt
++++ b/build/CMakeLists.txt
+@@ -141,7 +141,7 @@ elseif(WIN32 OR MSYS)
+ 		set (FAUST_DEFINITIONS ${FAUST_DEFINITIONS} -DWIN32 -D__MINGW32__)
+ 	endif()
+ 	set (FAUST_DEFINITIONS ${FAUST_DEFINITIONS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES)
+-	set (FAUST_LIBS ${FAUST_LIBS} Ws2_32) #.lib)
++	set (FAUST_LIBS ${FAUST_LIBS} ws2_32) #.lib)
+ elseif(NOT ANDROID)
+ 	set (FAUST_LIBS -lpthread ${FAUST_LIBS})
+ endif()


### PR DESCRIPTION
This adds the [Faust](https://faust.grame.fr/) DSP compiler. I endeavored to get all platforms building successfully; am currently in the process of developing a wrapper [Faust.jl](https://github.com/corajr/Faust.jl) around Faust's LLVM IR generation.