### PR TITLE
Set compat for packages using Lua_jll

### DIFF
--- a/F/flux_core/build_tarballs.jl
+++ b/F/flux_core/build_tarballs.jl
@@ -71,7 +71,7 @@ dependencies = [
     Dependency("Lz4_jll"),
     Dependency("Hwloc_jll"),
     Dependency("SQLite_jll"),
-    Dependency("Lua_jll"),
+    Dependency("Lua_jll"; compat="~5.3.6"),
     HostBuildDependency("Lua_jll"),
 ]
 

--- a/M/mpv/build_tarballs.jl
+++ b/M/mpv/build_tarballs.jl
@@ -57,7 +57,7 @@ dependencies = [
     Dependency(PackageSpec(name="SDL2_jll", uuid="ab825dc5-c88e-5901-9575-1e5e20358fcf"))
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
     Dependency(PackageSpec(name="FFMPEG_jll", uuid="b22a6f82-2f65-5046-a5b2-351ab43fb4e5"))
-    Dependency(PackageSpec(name="Lua_jll", uuid="a4086b1d-a96a-5d6b-8e4f-2030e6f25ba6"))
+    Dependency(PackageSpec(name="Lua_jll", uuid="a4086b1d-a96a-5d6b-8e4f-2030e6f25ba6"); compat="~5.3.6")
     Dependency(PackageSpec(name="JpegTurbo_jll", uuid="aacddb02-875f-59d6-b918-886e6ef4fbf8"))
     Dependency(PackageSpec(name="Xorg_libXrandr_jll", uuid="ec84b674-ba8e-5d96-8ba1-2a689ba10484"))
     Dependency(PackageSpec(name="Xorg_libXinerama_jll", uuid="d1454406-59df-5ea1-beac-c340f2130bc3"))


### PR DESCRIPTION
On Windows, Lua uses its major and minor version as part of the DLL name, so updating Lua_jll to use a newer version of Lua can break packages that depend on it.

[skip ci] [skip build]