### PR TITLE
Add methods needed for Xyce 7.3 initialisation

### DIFF
--- a/X/XyceWrapper/build_tarballs.jl
+++ b/X/XyceWrapper/build_tarballs.jl
@@ -5,7 +5,7 @@ using BinaryBuilder, Pkg
 julia_version = v"1.6.0"
 
 name = "XyceWrapper"
-version = v"0.1.0"
+version = v"0.1.1"
 
 # Collection of sources required to complete build
 sources = [

--- a/X/XyceWrapper/src/xycelib.cpp
+++ b/X/XyceWrapper/src/xycelib.cpp
@@ -111,6 +111,8 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
 
     mod.add_type<Xyce::Circuit::GenCouplingSimulator>("GenCouplingSimulator")
         .method("initialize", &Xyce::Circuit::GenCouplingSimulator::initialize)
+        .method("initializeEarly", &Xyce::Circuit::GenCouplingSimulator::initializeEarly)
+        .method("initializeLate", &Xyce::Circuit::GenCouplingSimulator::initializeLate)
         .method("addOutputInterface", &Xyce::Circuit::GenCouplingSimulator::addOutputInterface)
         .method("runSimulation", &Xyce::Circuit::GenCouplingSimulator::runSimulation);
 


### PR DESCRIPTION
Since Xyce 7.3 it is no longer possible to add output handlers after calling `initialize` but this needs to be done with these methods that were added.

The corresponding CxxWrap change: https://github.com/JuliaComputing/Xyce.jl/commit/f0940ce24c6eaeda8b516e2d99d34e11dd1bff23