### PR TITLE
Enable fortran interface for Libxc

### DIFF
--- a/L/Libxc/build_tarballs.jl
+++ b/L/Libxc/build_tarballs.jl
@@ -22,12 +22,12 @@ if [[ "${target}" = *-mingw* ]]; then
     mkdir libxc_build
     cd libxc_build
     cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-        -DCMAKE_BUILD_TYPE=Release -DENABLE_FORTRAN=OFF -DENABLE_XHOST=OFF -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=Release -DENABLE_FORTRAN=ON -DENABLE_XHOST=OFF -DBUILD_SHARED_LIBS=ON \
         -DDISABLE_VXC=OFF -DDISABLE_FXC=OFF -DDISABLE_KXC=ON -DDISABLE_LXC=ON ..
 else
     autoreconf -vi
     export CFLAGS="$CFLAGS -std=c99"
-    ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-fortran \
+    ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-fortran \
         --disable-static --enable-shared \
         --enable-vxc=yes --enable-fxc=yes --enable-kxc=no --enable-lxc=no
 fi
@@ -40,6 +40,7 @@ make install
 # platforms are passed in on the command line
 # Disable armv7l because the build seems to fill /tmp.
 platforms = [p for p in supported_platforms() if arch(p) != :armv7l]
+platforms = expand_gfortran_versions(platforms)
 
 
 # The products that we will ensure are always built

--- a/L/Libxc/build_tarballs.jl
+++ b/L/Libxc/build_tarballs.jl
@@ -50,7 +50,9 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[]
+dependencies = [
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/L/Libxc/build_tarballs.jl
+++ b/L/Libxc/build_tarballs.jl
@@ -27,7 +27,7 @@ if [[ "${target}" = *-mingw* ]]; then
 else
     autoreconf -vi
     export CFLAGS="$CFLAGS -std=c99"
-    ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-fortran \
+    ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
         --disable-static --enable-shared \
         --enable-vxc=yes --enable-fxc=yes --enable-kxc=no --enable-lxc=no
 fi

--- a/L/Libxc/build_tarballs.jl
+++ b/L/Libxc/build_tarballs.jl
@@ -27,6 +27,7 @@ if [[ "${target}" = *-mingw* ]]; then
 else
     autoreconf -vi
     export CFLAGS="$CFLAGS -std=c99"
+    export FCFLAGS="-pipe -O3"
     ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
         --disable-static --enable-shared \
         --enable-vxc=yes --enable-fxc=yes --enable-kxc=no --enable-lxc=no


### PR DESCRIPTION
Needed for Libxc support in Quantum Espresso (see https://github.com/JuliaPackaging/Yggdrasil/pull/3229).