### PR TITLE
Add Libxc and Scalpack support to QuantumEspresso

### DIFF
--- a/Q/QuantumEspresso/build_tarballs.jl
+++ b/Q/QuantumEspresso/build_tarballs.jl
@@ -5,7 +5,6 @@ version = v"6.7.0"
 
 # TODO This build still suffers from some limitations:
 #      - Missing SCALAPACK support
-#      - Missing Libxc support
 
 sources = [
     ArchiveSource("https://github.com/QEF/q-e/releases/download/qe-6.7.0/qe-6.7-ReleasePack.tgz",
@@ -18,6 +17,7 @@ sources = [
 script = raw"""
     cd qe-*
     atomic_patch -p1 ../patches/0000-pass-host-to-configure.patch
+    atomic_patch -p1 ../patches/0001-libxc-prefix.patch
 
     export BLAS_LIBS="-L${libdir} -lopenblas"
     export LAPACK_LIBS="-L${libdir} -lopenblas"
@@ -26,7 +26,7 @@ script = raw"""
     export CC=mpicc
     ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
         --enable-parallel=yes --with-scalapack=no \
-        --with-libxc=no
+        --with-libxc=yes --with-libxc-prefix=${prefix}
     make all "${make_args[@]}" -j $nproc MPIF90=mpif90 CC=mpicc
     make install
 """
@@ -49,6 +49,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency("FFTW_jll"),
+    Dependency("Libxc_jll"),
     Dependency("MPICH_jll"),
     Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2")),
 ]

--- a/Q/QuantumEspresso/build_tarballs.jl
+++ b/Q/QuantumEspresso/build_tarballs.jl
@@ -3,9 +3,6 @@ using BinaryBuilder, Pkg
 name = "QuantumEspresso"
 version = v"6.7.0"
 
-# TODO This build still suffers from some limitations:
-#      - Missing SCALAPACK support
-
 sources = [
     ArchiveSource("https://github.com/QEF/q-e/releases/download/qe-6.7.0/qe-6.7-ReleasePack.tgz",
                   "8f06ea31ae52ad54e900a2f51afd5c70f78096d9dcf39c86c2b17dccb1ec9c87"),
@@ -17,25 +14,33 @@ sources = [
 script = raw"""
     cd qe-*
     atomic_patch -p1 ../patches/0000-pass-host-to-configure.patch
-    atomic_patch -p1 ../patches/0001-libxc-prefix.patch
 
     export BLAS_LIBS="-L${libdir} -lopenblas"
     export LAPACK_LIBS="-L${libdir} -lopenblas"
-    export FFTW_INCLUDE=${includedir} FFT_LIBS="-L${libdir} -lfftw3"
-    export MPIF90=mpif90
+    export SCALAPACK_LIBS="-L${libdir} -lscalapack"
+    export FFTW_INCLUDE=${includedir}
+    export FFT_LIBS="-L${libdir} -lfftw3"
+    export FC=mpif90
     export CC=mpicc
-    ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
-        --enable-parallel=yes --with-scalapack=no \
-        --with-libxc=yes --with-libxc-prefix=${prefix}
-    make all "${make_args[@]}" -j $nproc MPIF90=mpif90 CC=mpicc
+
+    flags=(--enable-parallel=yes --with-scalapack=yes)
+    if [ ${nbits} -eq 64 ]; then
+        # Enable Libxc support only on 64-bit platforms
+        atomic_patch -p1 ../patches/0001-libxc-prefix.patch
+        flags+=(--with-libxc=yes --with-libxc-prefix=${prefix})
+    fi
+
+    ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} ${flags[@]}
+    make all "${make_args[@]}" -j $nproc
     make install
+    exit 1
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_gfortran_versions(supported_platforms())
 platforms = filter!(!Sys.iswindows, platforms)
-platforms = filter!(!Sys.isapple, platforms)
+platforms = filter!(!Sys.isapple,   platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -52,6 +57,7 @@ dependencies = [
     Dependency("Libxc_jll"),
     Dependency("MPICH_jll"),
     Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2")),
+    Dependency("SCALAPACK_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well

--- a/Q/QuantumEspresso/build_tarballs.jl
+++ b/Q/QuantumEspresso/build_tarballs.jl
@@ -33,7 +33,6 @@ script = raw"""
     ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} ${flags[@]}
     make all "${make_args[@]}" -j $nproc
     make install
-    exit 1
 """
 
 # These are the platforms we will build for by default, unless further

--- a/Q/QuantumEspresso/build_tarballs.jl
+++ b/Q/QuantumEspresso/build_tarballs.jl
@@ -56,4 +56,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version=v"5", julia_compat="1.6")
+               preferred_gcc_version=v"5", julia_compat="1.6", preferred_llvm_version=v"11")

--- a/Q/QuantumEspresso/bundled/patches/0001-libxc-prefix.patch
+++ b/Q/QuantumEspresso/bundled/patches/0001-libxc-prefix.patch
@@ -1,0 +1,13 @@
+diff --git a/install/configure b/install/configure
+index 66337d1..95c3a48 100755
+--- a/install/configure
++++ b/install/configure
+@@ -6544,7 +6544,7 @@ if test "$with_libxc" -ne 0; then
+ lxcf="f03"
+ lxcf2="f03"
+ if test ! -z "$with_libxc_prefix"; then
+-lxc_version=`grep "XC_MAJOR_VERSION" "$with_libxc_prefix/xc_version.h" | tr -dc '1-9'`
++lxc_version=`grep "XC_MAJOR_VERSION" "$with_libxc_prefix/include/xc_version.h" | tr -dc '1-9'`
+ if test "$lxc_version" = 5; then
+   lxcf="f90"
+   lxcf2="f90"

--- a/Q/QuantumEspresso/bundled/patches/0001-libxc-prefix.patch
+++ b/Q/QuantumEspresso/bundled/patches/0001-libxc-prefix.patch
@@ -1,13 +1,18 @@
 diff --git a/install/configure b/install/configure
-index 66337d1..95c3a48 100755
+index 66337d1..4312b02 100755
 --- a/install/configure
 +++ b/install/configure
-@@ -6544,7 +6544,7 @@ if test "$with_libxc" -ne 0; then
+@@ -6544,10 +6544,10 @@ if test "$with_libxc" -ne 0; then
  lxcf="f03"
  lxcf2="f03"
  if test ! -z "$with_libxc_prefix"; then
 -lxc_version=`grep "XC_MAJOR_VERSION" "$with_libxc_prefix/xc_version.h" | tr -dc '1-9'`
 +lxc_version=`grep "XC_MAJOR_VERSION" "$with_libxc_prefix/include/xc_version.h" | tr -dc '1-9'`
  if test "$lxc_version" = 5; then
+-  lxcf="f90"
+-  lxcf2="f90"
++  lxcf="f03"
++  lxcf2="f03"
+ fi
+ if test "$lxc_version" -gt 5; then
    lxcf="f90"
-   lxcf2="f90"


### PR DESCRIPTION
Build currently fails due to mismatching FORTRAN versions, error message:
```
Fatal Error: Cannot read module file 'xc_f90_lib_m.mod' opened at (1), because it was created by a different version of GNU Fortran
```

I suppose the solution is to also bump the GCC version when building Libxc ... or is there something more clever that can be done @giordano ?