### PR TITLE
[PETSc] Upgrades petsc to 3.15.2 and enables multiple precision, scalar, and int types

### DIFF
--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -14,7 +14,6 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/petsc*
-includedir="${prefix}/include"
 atomic_patch -p1 $WORKSPACE/srcdir/patches/petsc_name_mangle.patch
 
 BLAS_LAPACK_LIB="${libdir}/libopenblas.${dlext}"
@@ -88,4 +87,4 @@ dependencies = [
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"9")

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -23,7 +23,7 @@ if [[ "${target}" == *-mingw* ]]; then
     #atomic_patch -p1 $WORKSPACE/srcdir/patches/fix-header-cases.patch
     MPI_LIBS="${libdir}/msmpi.${dlext}"
 else
-    MPI_LIBS="[${libdir}/libmpi.${dlext},libmpifort.${dlext}]"
+    MPI_LIBS="[${libdir}/libmpifort.${dlext},${libdir}/libmpi.${dlext}]"
 fi
 
 ./configure --prefix=${prefix} \

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -85,6 +85,8 @@ build_petsc()
     fi
     # Remove useless links
     rm ${prefix}/lib/libpetsc.*
+    # Remove duplicated file
+    rm ${prefix}/lib/pkgconfig/PETSc.pc
 }
 
 build_petsc double real Int32

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -30,6 +30,7 @@ fi
     CC=${CC} \
     FC=${FC} \
     CXX=${CXX} \
+    CFLAGS='-fno-stack-protector' \
     COPTFLAGS='-O3' \
     CXXOPTFLAGS='-O3' \
     FOPTFLAGS='-O3' \

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -1,13 +1,13 @@
 using BinaryBuilder
 
 name = "PETSc"
-version = v"3.13.4"
+version = v"3.15.2"
 
 # Collection of sources required to build PETSc. Avoid using the git repository, it will
 # require building SOWING which fails in all non-linux platforms.
 sources = [
-    ArchiveSource("https://www.mcs.anl.gov/petsc/mirror/release-snapshots/petsc-3.13.4.tar.gz",
-    "2cf8abd70ec332510b17bff7dc8a465bf1eb053e17e2a0451a4a0256385657d8"),
+    ArchiveSource("https://www.mcs.anl.gov/petsc/mirror/release-snapshots/petsc-3.15.2.tar.gz",
+    "3b10c19c69fc42e01a38132668724a01f1da56f5c353105cd28f1120cc9041d8"),
     DirectorySource("./bundled"),
 ]
 

--- a/P/PETSc/bundled/patches/petsc_name_mangle.patch
+++ b/P/PETSc/bundled/patches/petsc_name_mangle.patch
@@ -2,7 +2,7 @@ diff --git a/config/BuildSystem/config/packages/BlasLapack.py b/config/BuildSyst
 index bbae50c096..9ad0a994eb 100644
 --- a/config/BuildSystem/config/packages/BlasLapack.py
 +++ b/config/BuildSystem/config/packages/BlasLapack.py
-@@ -118,7 +118,8 @@ class Configure(config.package.Package):
+@@ -121,7 +121,8 @@ class Configure(config.package.Package):
      foundLapack = 0
      self.f2c    = 0
      # allow a user-specified suffix to be appended to BLAS/LAPACK symbols


### PR DESCRIPTION
- Upgrades PETSc to 3.15.2
- Allows for 8 different build options:
  - Scalar Types: `complex` and `real`
  - Real Types: `Float64` and `Float32`
  - Int Types: `Int32` and `Int64`

The libraries named:
- `libpetsc_Float64_Real_Int64`
- `libpetsc_Float32_Real_Int64`
- `libpetsc_Float64_Complex_Int64`
- `libpetsc_Float32_Complex_Int64`
- `libpetsc_Float64_Real_Int32`
- `libpetsc_Float32_Real_Int32`
- `libpetsc_Float64_Complex_Int32`
- `libpetsc_Float32_Complex_Int32`

Additionally, there is a library `libpetsc` which is the same as `libpetsc_double_real_Int32` (the current default version of `PETSc_jll`).