### PR TITLE
[OpenMPI] Expand gfortran versions and use LLVM 11

### DIFF
--- a/O/OpenMPI/build_tarballs.jl
+++ b/O/OpenMPI/build_tarballs.jl
@@ -45,7 +45,8 @@ products = [
     ExecutableProduct("mpiexec", :mpiexec)
 ]
 
-dependencies = Dependency[
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/O/OpenMPI/build_tarballs.jl
+++ b/O/OpenMPI/build_tarballs.jl
@@ -30,6 +30,8 @@ make -j${nproc}
 
 # Install the library
 make install
+
+install_license LICENSE
 """
 
 # These are the platforms we will build for by default, unless further

--- a/O/OpenMPI/build_tarballs.jl
+++ b/O/OpenMPI/build_tarballs.jl
@@ -36,7 +36,8 @@ make install
 # platforms are passed in on the command line.
 #platforms = supported_platforms()
 platforms = filter(p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc"), supported_platforms(; experimental=true))
-
+platforms = expand_gfortran_versions(platforms)
+    
 products = [
     LibraryProduct("libmpi", :libmpi)
     ExecutableProduct("mpiexec", :mpiexec)
@@ -46,4 +47,7 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+# For the time being we need to use LLVM 11 because LLVM 12 has troubles with GCC 4-5
+# on FreeBSD: https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/158
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_llvm_version=v"11")

--- a/O/OpenMPI/bundled/aarch64-linux-gnu
+++ b/O/OpenMPI/bundled/aarch64-linux-gnu
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/aarch64-linux-musl
+++ b/O/OpenMPI/bundled/aarch64-linux-musl
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/arm-linux-gnueabihf
+++ b/O/OpenMPI/bundled/arm-linux-gnueabihf
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/arm-linux-musleabihf
+++ b/O/OpenMPI/bundled/arm-linux-musleabihf
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/i686-linux-gnu
+++ b/O/OpenMPI/bundled/i686-linux-gnu
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/i686-linux-musl
+++ b/O/OpenMPI/bundled/i686-linux-musl
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/powerpc64le-linux-gnu
+++ b/O/OpenMPI/bundled/powerpc64le-linux-gnu
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/x86_64-apple-darwin14
+++ b/O/OpenMPI/bundled/x86_64-apple-darwin14
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/x86_64-linux-gnu
+++ b/O/OpenMPI/bundled/x86_64-linux-gnu
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/x86_64-linux-musl
+++ b/O/OpenMPI/bundled/x86_64-linux-musl
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'

--- a/O/OpenMPI/bundled/x86_64-unknown-freebsd11.1
+++ b/O/OpenMPI/bundled/x86_64-unknown-freebsd11.1
@@ -61,3 +61,6 @@ ompi_cv_fortran_sizeof_REALp8='8'
 ompi_cv_fortran_true_value='1'
 
 ompi_cv_real16_c_equiv='yes'
+
+ompi_cv_fortran_alignment_type_test_mpi_handle_='    4'
+ompi_cv_fortran_sizeof_type_test_mpi_handle_='4'


### PR DESCRIPTION
On FreeBSD we're hitting https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/158, so registration of this package actually failed on `master`