### PR TITLE
libjulia 1.7: turn libuv into a dependency

### DIFF
--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -21,7 +21,7 @@ function libjulia_platforms(julia_version)
 end
 
 # Collection of sources required to build Julia
-function build_julia(ARGS, version)
+function build_julia(ARGS, version::VersionNumber)
     name = "libjulia"
 
     checksums = Dict(
@@ -269,9 +269,9 @@ function build_julia(ARGS, version)
 
     dependencies = BinaryBuilder.AbstractDependency[
         Dependency("LibUnwind_jll"),
+        Dependency("LibUV_jll"),
         BuildDependency("OpenLibm_jll"),
         BuildDependency("dSFMT_jll"),
-        BuildDependency("LibUV_jll"),
         BuildDependency("utf8proc_jll"),
         BuildDependency("MbedTLS_jll"),
         BuildDependency("LibSSH2_jll"),

--- a/L/libjulia/libjulia@1.7/build_tarballs.jl
+++ b/L/libjulia/libjulia@1.7/build_tarballs.jl
@@ -1,3 +1,2 @@
 include("../common.jl")
 build_julia(ARGS, v"1.7.0-beta2")
-


### PR DESCRIPTION
... not just a build dependency, so that `uv.h` is present when including
`julia.h`, which is necessary.

<s>Also add an option third argument to build_julia to allow us to decouple
the Julia version (such as 1.7.0-beta2) from the version of the
JLL (which must not contain a prerelease part).

We then use this to assign the version 1.7.1 to this latest libjulia_kll build.
</s>