### PR TITLE
libjulia 1.7: export two "missing" symbols

### DIFF
--- a/L/libjulia/libjulia@1.7/build_tarballs.jl
+++ b/L/libjulia/libjulia@1.7/build_tarballs.jl
@@ -1,2 +1,3 @@
 include("../common.jl")
 build_julia(ARGS, v"1.7.0-beta2")
+

--- a/L/libjulia/libjulia@1.7/bundled/patches/0003-exports.patch
+++ b/L/libjulia/libjulia@1.7/bundled/patches/0003-exports.patch
@@ -1,0 +1,19 @@
+diff --git a/src/jl_exported_funcs.inc b/src/jl_exported_funcs.inc
+index 82611bfb50..81e68f3b78 100644
+--- a/src/jl_exported_funcs.inc
++++ b/src/jl_exported_funcs.inc
+@@ -149,6 +149,7 @@
+     XX(jl_expand_with_loc) \
+     XX(jl_expand_with_loc_warn) \
+     XX(jl_extern_c) \
++    XX(jl_field_index) \
+     XX(jl_gc_add_finalizer) \
+     XX(jl_gc_add_finalizer_th) \
+     XX(jl_gc_add_ptr_finalizer) \
+@@ -540,4 +541,5 @@
+     XX(jl_vprintf) \
+     XX(jl_wakeup_thread) \
+     XX(jl_yield) \
+-    XX(jl_print_backtrace)
++    XX(jl_print_backtrace) \
++    XX(jl_get_pgcstack)


### PR DESCRIPTION
These symbols will be back in beta3. For now, adding them here should
allow us to build libcxxwrap for julia 1.7, and then proceed to adapt
dependent JLLs. Even though the resulting binaries won't work with
Julia 1.7-beta2, this still seems useful, as (a) it allows us to prepare
for -beta3 *now*, and (b) the resulting binaries probably will work
with Julia nightly builds.
