### PR TITLE
[New package] Add ROCmCompilerSupport 4.0.0

### DIFF
--- a/R/ROCmCompilerSupport/build_tarballs.jl
+++ b/R/ROCmCompilerSupport/build_tarballs.jl
@@ -1,0 +1,59 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ROCmCompilerSupport"
+version = v"4.0.0"
+
+# Collection of sources required to build
+sources = [
+    ArchiveSource("https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/archive/rocm-$(version).tar.gz",
+                  "f389601fb70b2d9a60d0e2798919af9ddf7b8376a2e460141507fe50073dfb31"), # 4.0.0
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+ln -s $WORKSPACE/destdir/tools/* $WORKSPACE/destdir/bin/
+
+cd ${WORKSPACE}/srcdir/ROCm-CompilerSupport*/lib/comgr
+atomic_patch -p1 $WORKSPACE/srcdir/patches/disable-1031.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/disable-tests.patch
+mkdir build && cd build
+export CC=clang
+export CXX=clang++
+# TODO: -DROCM_DIR=${prefix}
+cmake -DCMAKE_PREFIX_PATH=${prefix} \
+      -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_BUILD_TYPE=Release \
+      ..
+make -j${nproc}
+make install
+ldd $WORKSPACE/destdir/lib64/libamd_comgr.so
+
+find $WORKSPACE/destdir/bin -type l -delete
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="musl"),
+]
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct(["libamd_comgr"], :libamd_comgr),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("hsa_rocr_jll"),
+    Dependency("ROCmDeviceLibs_jll"),
+    Dependency("LLVM_full_jll", v"11.0.1"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies,
+               preferred_gcc_version=v"8", preferred_llvm_version=v"11")

--- a/R/ROCmCompilerSupport/build_tarballs.jl
+++ b/R/ROCmCompilerSupport/build_tarballs.jl
@@ -44,14 +44,15 @@ platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["libamd_comgr"], :libamd_comgr),
+    LibraryProduct(["libamd_comgr"], :libamd_comgr, dont_dlopen=true),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("hsa_rocr_jll"),
     Dependency("ROCmDeviceLibs_jll"),
-    Dependency("LLVM_full_jll", v"11.0.1"),
+    HostBuildDependency(PackageSpec(; name="LLVM_full_jll", version=v"11.0.1")),
+    BuildDependency(PackageSpec(; name="LLVM_full_jll", version=v"11.0.1")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/R/ROCmCompilerSupport/build_tarballs.jl
+++ b/R/ROCmCompilerSupport/build_tarballs.jl
@@ -14,18 +14,20 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-ln -s $WORKSPACE/destdir/tools/* $WORKSPACE/destdir/bin/
+ln -s ${bindir}/../tools/* ${bindir}/
 
 cd ${WORKSPACE}/srcdir/ROCm-CompilerSupport*/lib/comgr
 atomic_patch -p1 $WORKSPACE/srcdir/patches/disable-1031.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/disable-tests.patch
 mkdir build && cd build
-export CC=clang
-export CXX=clang++
 # TODO: -DROCM_DIR=${prefix}
 cmake -DCMAKE_PREFIX_PATH=${prefix} \
       -DCMAKE_INSTALL_PREFIX=${prefix} \
       -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake \
+      -DLLVM_DIR="${prefix}/lib/cmake/llvm" \
+      -DClang_DIR="${prefix}/lib/cmake/clang" \
+      -DLLD_DIR="${prefix}/lib/cmake/ldd" \
       ..
 make -j${nproc}
 make install
@@ -51,7 +53,7 @@ products = [
 dependencies = [
     Dependency("hsa_rocr_jll"),
     Dependency("ROCmDeviceLibs_jll"),
-    HostBuildDependency(PackageSpec(; name="LLVM_full_jll", version=v"11.0.1")),
+    # HostBuildsependency(PackageSpec(; name="LLVM_full_jll", version=v"11.0.1")),
     BuildDependency(PackageSpec(; name="LLVM_full_jll", version=v"11.0.1")),
 ]
 

--- a/R/ROCmCompilerSupport/bundled/patches/disable-1031.patch
+++ b/R/ROCmCompilerSupport/bundled/patches/disable-1031.patch
@@ -1,0 +1,23 @@
+diff --git a/src/comgr-metadata.cpp b/src/comgr-metadata.cpp
+index 239a759..0fb1df2 100644
+--- a/src/comgr-metadata.cpp
++++ b/src/comgr-metadata.cpp
+@@ -374,8 +374,6 @@ getNoteIsaName(StringRef VendorName, StringRef ArchitectureName,
+     NoteIsaName = "amdgcn-amd-amdhsa--gfx1012";
+   else if (OldName == "AMD:AMDGPU:10:3:0")
+     NoteIsaName = "amdgcn-amd-amdhsa--gfx1030";
+-  else if (OldName == "AMD:AMDGPU:10:3:1")
+-    NoteIsaName = "amdgcn-amd-amdhsa--gfx1031";
+   else
+     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+ 
+@@ -589,9 +587,6 @@ static amd_comgr_status_t getElfIsaNameV3(const ELFObjectFile<ELFT> *Obj,
+   case ELF::EF_AMDGPU_MACH_AMDGCN_GFX1030:
+     ElfIsaName += "gfx1030";
+     break;
+-  case ELF::EF_AMDGPU_MACH_AMDGCN_GFX1031:
+-    ElfIsaName += "gfx1031";
+-    break;
+   default:
+     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+   }

--- a/R/ROCmCompilerSupport/bundled/patches/disable-bc2h.patch
+++ b/R/ROCmCompilerSupport/bundled/patches/disable-bc2h.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bf38bfc..d8f68ec 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -149,7 +149,9 @@ configure_file(
+   ${CMAKE_CURRENT_SOURCE_DIR}/include/amd_comgr.h.in
+   ${CMAKE_CURRENT_BINARY_DIR}/include/amd_comgr.h @ONLY)
+ 
+-include(bc2h)
++#include(bc2h)
++add_executable(bc2h IMPORTED)
++set_target_properties(bc2h PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/bc2h)
+ include(opencl_pch)
+ include(DeviceLibs)
+ 

--- a/R/ROCmCompilerSupport/bundled/patches/disable-tests.patch
+++ b/R/ROCmCompilerSupport/bundled/patches/disable-tests.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bf38bfc..8cc6908 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -291,13 +291,6 @@ if (NOT UNIX)
+     PRIVATE version)
+ endif()
+ 
+-enable_testing()
+-add_custom_target(check-comgr COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS amd_comgr)
+-if (NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+-  set_property(GLOBAL APPEND PROPERTY LLVM_ADDITIONAL_TEST_TARGETS check-comgr)
+-endif()
+-add_subdirectory(test)
+-
+ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   # Add packaging directives for amd_comgr
+   set(CPACK_PACKAGE_NAME comgr)


### PR DESCRIPTION
In theory I don't need LLVM_full, but the other LLVM packages don't have LLD, which is needed for this package.