### PR TITLE
[CGAL] Update to v5.3

### DIFF
--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -50,4 +50,4 @@ dependencies = [
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"9")

--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -3,13 +3,13 @@
 using BinaryBuilder
 
 name     = "CGAL"
-rversion = "5.2.1"
+rversion = "5.3"
 version  = VersionNumber(rversion)
 
 # Collection of sources required to build CGAL
 sources = [
     ArchiveSource("https://github.com/CGAL/cgal/releases/download/v$rversion/CGAL-$rversion-library.tar.xz",
-                  "390aa87c4f21609c19397c4b14abb5ccad3edd1e33933a0089b266f67ce7b111"),
+                  "1c9c32814eb9b0abfd368c8145194b49d7c6ade76eec613b1eac6ebb93470bdb"),
 ]
 
 # Bash recipe for building across all platforms
@@ -25,7 +25,6 @@ cmake -B build \
   -DCMAKE_INSTALL_PREFIX=$prefix \
   -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TARGET_TOOLCHAIN \
   `# cgal specific` \
-  -DCGAL_HEADER_ONLY=OFF \
   -DWITH_CGAL_Core=ON \
   -DWITH_CGAL_ImageIO=ON \
   -DWITH_CGAL_Qt5=OFF \
@@ -41,19 +40,19 @@ install_license CGAL-*/LICENSE*
 platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
-products = [
-    LibraryProduct("libCGAL", :libCGAL),
-    LibraryProduct("libCGAL_Core", :libCGAL_Core),
-    LibraryProduct("libCGAL_ImageIO", :libCGAL_ImageIO),
+# CGAL is, as of 5.0, a header-only library, removing support for lib
+# compilation in 5.3
+products = Product[
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    # Essential dependencies
     Dependency("boost_jll"; compat="=1.71.0"),
-    Dependency("GMP_jll", v"6.1.2"),
-    Dependency("MPFR_jll", v"4.0.2"),
+    Dependency("GMP_jll", v"6.1.2"; compat=">=4.2"),
+    Dependency("MPFR_jll", v"4.0.2"; compat=">=2.2.1"),
     Dependency("Zlib_jll"),
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8")

--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -8,8 +8,8 @@ version  = VersionNumber(rversion)
 
 # Collection of sources required to build CGAL
 sources = [
-    ArchiveSource("https://github.com/CGAL/cgal/releases/download/v$rversion/CGAL-$rversion-library.tar.xz",
-                  "1c9c32814eb9b0abfd368c8145194b49d7c6ade76eec613b1eac6ebb93470bdb"),
+    ArchiveSource("https://github.com/CGAL/cgal/releases/download/v$rversion/CGAL-$rversion.tar.xz",
+                  "2c242e3f27655bc80b34e2fa5e32187a46003d2d9cd7dbec8fbcbc342cea2fb6"),
 ]
 
 # Bash recipe for building across all platforms
@@ -24,10 +24,6 @@ cmake -B build \
   -DCMAKE_FIND_ROOT_PATH=$prefix \
   -DCMAKE_INSTALL_PREFIX=$prefix \
   -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TARGET_TOOLCHAIN \
-  `# cgal specific` \
-  -DWITH_CGAL_Core=ON \
-  -DWITH_CGAL_ImageIO=ON \
-  -DWITH_CGAL_Qt5=OFF \
   CGAL-*/
 
 ## and away we go..
@@ -42,8 +38,7 @@ platforms = expand_cxxstring_abis(supported_platforms())
 # The products that we will ensure are always built
 # CGAL is, as of 5.0, a header-only library, removing support for lib
 # compilation in 5.3
-products = Product[
-]
+products = Product[]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [

--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -44,8 +44,8 @@ products = Product[]
 dependencies = [
     # Essential dependencies
     Dependency("boost_jll"; compat="=1.71.0"),
-    Dependency("GMP_jll", v"6.1.2"; compat=">=4.2"),
-    Dependency("MPFR_jll", v"4.0.2"; compat=">=2.2.1"),
+    Dependency("GMP_jll"; compat="6.1.2"),
+    Dependency("MPFR_jll"; compat="4.0.2"),
     Dependency("Zlib_jll"),
 ]
 

--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -33,7 +33,7 @@ install_license CGAL-*/LICENSE*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms())
+platforms = [AnyPlatform()]
 
 # The products that we will ensure are always built
 # CGAL is, as of 5.0, a header-only library, removing support for lib


### PR DESCRIPTION
CGAL is now purely header-only, producing no shared libraries anymore.
Additionally, it now only supports GCC/G++ >=8.3, leading to a change in
the preferred gcc version.  Furthermore, I also opted for adding
`compat` entries to GMP and MPFR in accordance to CGAL's manual despite
it not mattering much since the specified versions are well within
acceptable bounds.

Furthermore, I was looking into pulling more optional dependencies such
as Eigen.  However, if they're optional and CGAL is now header-only, I'm
assuming these will mostly matter when building whatever depends on
CGAL, having that specific dependent pull in the optional dependencies.
This, alas, leads to every dependent pulling optional dependencies over
and over again, but it also means one isn't pulling a tree of
unnecessary things with CGAL if they just want the core library.

Forgive the rambling thoughts, I'm monologuing.  Though if anyone reads
this and finds it a curious thing to discuss, contact me.