### PR TITLE
[Pandoc] Version 2.14

### DIFF
--- a/P/pandoc/build_tarballs.jl
+++ b/P/pandoc/build_tarballs.jl
@@ -2,16 +2,17 @@ using BinaryBuilder
 
 # Collection of pre-build pandoc binaries
 name = "pandoc"
-version = v"2.11.4"
-pandoc_ver = "2.11.4"
+version = v"2.14"
+pandoc_ver = "2.14"
 
 url_prefix = "https://github.com/jgm/pandoc/releases/download/$(pandoc_ver)/pandoc-$(pandoc_ver)"
 sources = [
-    ArchiveSource("$(url_prefix)-linux-amd64.tar.gz", "b15ce6009ab833fb51fc472bf8bb9683cd2bd7f8ac948f3ddeb6b8f9a366d69a"; unpack_target = "x86_64-linux-gnu"),
-    ArchiveSource("$(url_prefix)-macOS.zip", "13b8597860afa6ab802993a684b340be3f31f4d2a06c50b6601f9e726cf76f71"; unpack_target = "x86_64-apple-darwin14"),
-    ArchiveSource("$(url_prefix)-windows-x86_64.zip", "ee1b0c4d0f539ee8316d6cebb29f6aa709aa3a72be2b2b4ab6e9e4a77a01a50b"; unpack_target = "x86_64-w64-mingw32"),
-    FileSource("https://raw.githubusercontent.com/jgm/pandoc/54d8c6959cc53e78cfea2093b33504672f81ed74/COPYING.md", "2b0d4dda4bf8034e1506507a67f80f982131137afe62bf144d248f9faea31da4"),
-    FileSource("https://raw.githubusercontent.com/jgm/pandoc/54d8c6959cc53e78cfea2093b33504672f81ed74/COPYRIGHT", "7087ebeaa4c3131b7a989ea4310da1442610e9e2874c3bc9d3e8a52d618fd97a"),
+    ArchiveSource("$(url_prefix)-linux-amd64.tar.gz", "e24cca7d241d907d690428a296861cbcbdaf4686ef887ac65581a930b2e6038c"; unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$(url_prefix)-macOS.zip", "630564487c30602ee299b463efc4fb48b418a6f254c123a11f3748426b2007b3"; unpack_target = "x86_64-apple-darwin14"),
+    ArchiveSource("$(url_prefix)-windows-x86_64.zip", "341935e8de2bc58153b6aabcced8bf73d753bc6b97efdf0128f52da82841b0c5"; unpack_target = "x86_64-w64-mingw32"),
+    ArchiveSource("$(url_prefix)-linux-arm64.tar.gz", "fd334f48c12b17ec264b2c49a554c584cdb29828c29fbbde7c1f57232a30975d"; unpack_target = "aarch64-linux-gnu"),
+    FileSource("https://raw.githubusercontent.com/jgm/pandoc/$(pandoc_ver)/COPYRIGHT", "adcfa50add0dd23fda4937830ee6401a45638cffa15b9b33b1932f833f4fab75"),
+    FileSource("https://raw.githubusercontent.com/jgm/pandoc/$(pandoc_ver)/COPYING.md", "e7ea3adeab955103a837b692ca0017cb3abbed0d3dccbfa499d6b2b825d698c3"),
 ]
 
 # Bash recipe for building across all platforms
@@ -33,6 +34,7 @@ platforms = [
     Platform("x86_64", "linux"),
     Platform("x86_64", "macos"),
     Platform("x86_64", "windows"),
+    Platform("aarch64", "linux")
 ]
 
 # The products that we will ensure are always built


### PR DESCRIPTION
Since the newer versions use `2.14.0.1` instead of `2.14.1`, I decided to just go for a slightly older version, that is, `2.14`.