### PR TITLE
Update libserialport to latest master

### DIFF
--- a/L/libserialport/build_tarballs.jl
+++ b/L/libserialport/build_tarballs.jl
@@ -6,7 +6,7 @@ version = v"0.1.2"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/sigrokproject/libserialport.git",
-        "6f9b03e597ea7200eb616a4e410add3dd1690cb1"
+        "6f9b03e597ea7200eb616a4e410add3dd1690cb1")
 ]
 
 # Bash recipe for building across all platforms

--- a/L/libserialport/build_tarballs.jl
+++ b/L/libserialport/build_tarballs.jl
@@ -6,14 +6,14 @@ version = v"0.1.2"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/sigrokproject/libserialport.git",
-        "ffbfc5c76ba8100d21d0141478a6c0d761ecfb2f")
+        "6f9b03e597ea7200eb616a4e410add3dd1690cb1"
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libserialport/
 ./autogen.sh
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-include-path=$prefix/include
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """


### PR DESCRIPTION
Use lastest master to fix https://github.com/JuliaIO/LibSerialPort.jl/issues/84

I'm not sure why/when the `--with-include-path=` was added, but the build complains that this isn't used, so I removed it.
