### PR TITLE
[CGAL] Remove unnecessary dependency

### DIFF
--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -46,7 +46,6 @@ dependencies = [
     Dependency("boost_jll"; compat="=1.71.0"),
     Dependency("GMP_jll"; compat="6.1.2"),
     Dependency("MPFR_jll"; compat="4.0.2"),
-    Dependency("Zlib_jll"),
 ]
 
 # Build the tarballs.


### PR DESCRIPTION
Zlib is not required by CGAL unless one is interested in image I/O
functionality.  As such, it should be required by dependants who need it
instead of further blowing up CGAL_jll's dependency graph.