### PR TITLE
[libpolymake_julia] build for julia 1.7

### DIFF
--- a/L/libpolymake_julia/common.jl
+++ b/L/libpolymake_julia/common.jl
@@ -10,8 +10,9 @@ version = VersionNumber(upstream_version.major, upstream_version.minor, upstream
 
 # Collection of sources required to build libpolymake_julia
 sources = [
-    ArchiveSource("https://github.com/oscar-system/libpolymake-julia/archive/v$(upstream_version).tar.gz",
-                  "f7733a8eb2b2e75d63db6cb6b035b9fae24ce7f6c2992253a3df0529a914ad37"),
+#    ArchiveSource("https://github.com/oscar-system/libpolymake-julia/archive/v$(upstream_version).tar.gz",
+#                  "f7733a8eb2b2e75d63db6cb6b035b9fae24ce7f6c2992253a3df0529a914ad37"),
+    GitSource("https://github.com/oscar-system/libpolymake-julia.git", "ae511cfa548044a81918fe885af5226bd4bb8cfc"),
 ]
 
 # Bash recipe for building across all platforms
@@ -30,7 +31,7 @@ cmake libpolymake-j*/ -B build \
 
 VERBOSE=ON cmake --build build --config Release --target install -- -j${nproc}
 
-install_license $WORKSPACE/srcdir/libpolymake-j*/LICENSE.md
+install_license libpolymake-j*/LICENSE.md
 """
 
 # These are the platforms we will build for by default, unless further

--- a/L/libpolymake_julia/libpolymake_julia@1.7/build_tarballs.jl
+++ b/L/libpolymake_julia/libpolymake_julia@1.7/build_tarballs.jl
@@ -1,0 +1,3 @@
+const julia_version = v"1.7.0"
+include("../common.jl")
+


### PR DESCRIPTION
Changed to gitsource to include one small change for julia 1.7, but we can keep that `0.4.(1*100+10+julia.minor)` version number.