### PR TITLE
[New package] Add ROCm-OpenCL-Runtime and ROCclr 4.0.0

### DIFF
--- a/R/ROCmOpenCLRuntime/build_tarballs.jl
+++ b/R/ROCmOpenCLRuntime/build_tarballs.jl
@@ -1,0 +1,88 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ROCmOpenCLRuntime"
+version = v"4.0.0"
+
+# Collection of sources required to build
+sources = [
+    ArchiveSource("https://github.com/ROCm-Developer-Tools/ROCclr/archive/rocm-$(version).tar.gz",
+                  "8db502d0f607834e3b882f939d33e8abe2f9b55ddafaf1b0c2cd29a0425ed76a"), # 4.0.0
+    ArchiveSource("https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/archive/rocm-$(version).tar.gz",
+                  "d43ea5898c6b9e730b5efabe8367cc136a9260afeac5d0fe85b481d625dd7df1"), # 4.0.0
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+OPENCL_SRC=$(realpath $WORKSPACE/srcdir/ROCm-OpenCL-Runtime-*)
+ROCCLR_SRC=$(realpath $WORKSPACE/srcdir/ROCclr-*)
+
+cd $ROCCLR_SRC
+atomic_patch -p1 $WORKSPACE/srcdir/patches/musl-rocclr.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/rocclr-install-prefix.patch
+mkdir build && cd build
+cmake -DCMAKE_PREFIX_PATH=${prefix} \
+      -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DOPENCL_DIR=$OPENCL_SRC \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake \
+      -DLLVM_DIR="${prefix}/lib/cmake/llvm" \
+      -DClang_DIR="${prefix}/lib/cmake/clang" \
+      -DLLD_DIR="${prefix}/lib/cmake/ldd" \
+      ..
+make -j${nproc}
+make install
+
+cd $OPENCL_SRC
+atomic_patch -p1 $WORKSPACE/srcdir/patches/musl-opencl.patch
+mkdir build && cd build
+cmake -DCMAKE_PREFIX_PATH=${prefix} \
+      -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DUSE_COMGR_LIBRARY=ON \
+      -DBUILD_TESTS:BOOL=OFF \
+      -DBUILD_TESTING:BOOL=OFF \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake \
+      -DLLVM_DIR="${prefix}/lib/cmake/llvm" \
+      -DClang_DIR="${prefix}/lib/cmake/clang" \
+      -DLLD_DIR="${prefix}/lib/cmake/ldd" \
+      ..
+make -j${nproc}
+make install
+install_license ../LICENSE.txt
+
+# fix paths to point from src dir to install dir
+sed -i "s#$ROCCLR_SRC/build#$WORKSPACE/destdir/lib#" $WORKSPACE/destdir/lib/cmake/rocclr/rocclr-targets.cmake
+sed -i "s#$ROCCLR_SRC/include\;##" $WORKSPACE/destdir/lib/cmake/rocclr/rocclr-targets.cmake
+sed -i "s#$ROCCLR_SRC#$WORKSPACE/destdir/include#g;s#$OPENCL_SRC.*\;##g" $WORKSPACE/destdir/lib/cmake/rocclr/rocclr-targets.cmake
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc="glibc", cxxstring_abi="cxx11"),
+    Platform("x86_64", "linux"; libc="musl", cxxstring_abi="cxx11"),
+]
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct(["libamdocl64"], :libamdocl; dont_dlopen=true),
+    LibraryProduct(["libOpenCL"], :libOpenCL; dont_dlopen=true),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("hsa_rocr_jll"),
+    Dependency("ROCmDeviceLibs_jll"),
+    Dependency("ROCmCompilerSupport_jll"),
+    BuildDependency(PackageSpec(; name="LLVM_full_jll", version=v"11.0.1")),
+    Dependency("Libglvnd_jll"),
+    Dependency("Xorg_libX11_jll"),
+    Dependency("Xorg_xorgproto_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies,
+               preferred_gcc_version=v"8", preferred_llvm_version=v"11")

--- a/R/ROCmOpenCLRuntime/bundled/patches/musl-opencl.patch
+++ b/R/ROCmOpenCLRuntime/bundled/patches/musl-opencl.patch
@@ -1,0 +1,18 @@
+diff --git a/amdocl/glibc_functions.cpp b/amdocl/glibc_functions.cpp
+index 908ed75..8187a43 100644
+--- a/amdocl/glibc_functions.cpp
++++ b/amdocl/glibc_functions.cpp
+@@ -27,11 +27,11 @@ extern "C" {
+ #endif // __cplusplus
+ 
+ #if defined(_LP64)
+-asm (".symver memcpy, memcpy@GLIBC_2.2.5");
++/*asm (".symver memcpy, memcpy@GLIBC_2.2.5");
+ void *__wrap_memcpy(void *dest, const void *src, size_t n)
+ {
+     return memcpy(dest, src, n);
+-}
++}*/
+ #endif // _LP64
+ 
+ #if defined(__cplusplus)

--- a/R/ROCmOpenCLRuntime/bundled/patches/musl-rocclr.patch
+++ b/R/ROCmOpenCLRuntime/bundled/patches/musl-rocclr.patch
@@ -1,0 +1,56 @@
+commit f8cabb0212d052cd8409ab18fcd1861465ba84c5
+Author: Julian P Samaroo <jpsamaroo@jpsamaroo.me>
+Date:   Mon Jan 4 14:17:32 2021 -0600
+
+    Fixes for musl support
+
+diff --git a/os/os.hpp b/os/os.hpp
+index 82879dee..1bc01309 100755
+--- a/os/os.hpp
++++ b/os/os.hpp
+@@ -29,12 +29,17 @@
+ 
+ #if defined(__linux__)
+ #include <sched.h>
++#include <libgen.h>
+ #endif
+ 
+ #ifdef _WIN32
+ #include <Basetsd.h>  // For KAFFINITY
+ #endif                // _WIN32
+ 
++#ifndef __cpu_mask
++typedef unsigned long __cpu_mask;
++#endif
++
+ // Smallest supported VM page size.
+ #define MIN_PAGE_SHIFT 12
+ #define MIN_PAGE_SIZE (1UL << MIN_PAGE_SHIFT)
+
+diff --git a/os/os_posix.cpp b/os/os_posix.cpp
+index 91d08bc3..5527ee79 100755
+--- a/os/os_posix.cpp
++++ b/os/os_posix.cpp
+@@ -374,15 +374,22 @@ const void* Os::createOsThread(amd::Thread* thread) {
+     for (int i = 0; i < processorCount_; i++) {
+       CPU_SET(i, &cpuset);
+     }
++#ifdef pthread_attr_setaffinity_np
+     if (0 != pthread_attr_setaffinity_np(&threadAttr, sizeof(cpu_set_t), &cpuset)) {
+       fatal("pthread_attr_setaffinity_np failed to set affinity");
+     }
++#endif
+   }
+ 
+   pthread_t handle = 0;
+   if (0 != ::pthread_create(&handle, &threadAttr, (void* (*)(void*)) & Thread::entry, thread)) {
+     thread->setState(Thread::FAILED);
+   }
++#ifndef pthread_attr_setaffinity_np
++  if (0 != pthread_setaffinity_np(handle, sizeof(cpu_set_t), &cpuset)) {
++    fatal("pthread_attr_setaffinity_np failed to set affinity");
++  }
++#endif
+ 
+   ::pthread_attr_destroy(&threadAttr);
+   return reinterpret_cast<const void*>(handle);

--- a/R/ROCmOpenCLRuntime/bundled/patches/rocclr-install-prefix.patch
+++ b/R/ROCmOpenCLRuntime/bundled/patches/rocclr-install-prefix.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 93955582..0e07a8d7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,9 +17,9 @@ set(ROCCLR_VERSION_NAME rocclr-config-version.cmake)
+ set(ROCCLR_PACKAGE_PREFIX lib/cmake/rocclr)
+ set(ROCCLR_PREFIX_CODE)
+ set(ROCCLR_TARGETS_PATH
+-  "${CMAKE_CURRENT_BINARY_DIR}/${ROCCLR_PACKAGE_PREFIX}/${ROCCLR_TARGETS_NAME}")
++  "${CMAKE_INSTALL_PREFIX}/${ROCCLR_PACKAGE_PREFIX}/${ROCCLR_TARGETS_NAME}")
+ set(ROCCLR_VERSION_PATH
+-  "${CMAKE_CURRENT_BINARY_DIR}/${ROCCLR_PACKAGE_PREFIX}/${ROCCLR_VERSION_NAME}")
++  "${CMAKE_INSTALL_PREFIX}/${ROCCLR_PACKAGE_PREFIX}/${ROCCLR_VERSION_NAME}")
+ 
+ # Generate the build-tree package.
+ configure_file("cmake/${ROCCLR_CONFIG_NAME}.in"


### PR DESCRIPTION
These packages are the last dependencies of ROCm's HIP. I'm building both in the same build script because they are pretty tightly intertwined, and were too annoying to split up. I'd be happy to split them in the future if for some reason people want one and not the other.