### PR TITLE
[libcgal-julia] Update to v0.17 (julia 1.5)

### DIFF
--- a/L/libcgal_julia/libcgal_julia@1.5/build_tarballs.jl
+++ b/L/libcgal_julia/libcgal_julia@1.5/build_tarballs.jl
@@ -1,3 +1,2 @@
 julia_version = v"1.5.3"
-gcc_version = v"8"
 include("../common.jl")


### PR DESCRIPTION
Should be merged after #3334 and consecutive jll (JuliaRegistries/General#40879) is registered.