### PR TITLE
[libcgal-julia] Update to v0.17 (julia 1.6)

### DIFF
--- a/L/libcgal_julia/libcgal_julia@1.6/build_tarballs.jl
+++ b/L/libcgal_julia/libcgal_julia@1.6/build_tarballs.jl
@@ -1,3 +1,2 @@
 julia_version = v"1.6.0"
-gcc_version = v"9"
 include("../common.jl")


### PR DESCRIPTION
Should be merged after #3335 and consecutive jll (JuliaRegistries/General#40883) is registered.