### PR TITLE
[libcgal-julia] Update to v0.17 (julia 1.7)

### DIFF
--- a/L/libcgal_julia/common.jl
+++ b/L/libcgal_julia/common.jl
@@ -57,7 +57,7 @@ install_license $jlcgaldir/LICENSE
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 include("../../L/libjulia/common.jl")
-platforms = libjulia_platforms(julia_version)
+platforms = libjulia_platforms(v"1.6") # HACK: filter out experimental platforms
 # generates an abundance of linker errors and notes about using older versions
 # of GCC.  Among many things, this could be related to boost as well.  However,
 # requiring newer versions would, much like libsingular_julia, require the

--- a/L/libcgal_julia/libcgal_julia@1.7/build_tarballs.jl
+++ b/L/libcgal_julia/libcgal_julia@1.7/build_tarballs.jl
@@ -1,0 +1,2 @@
+julia_version = v"1.7.0"
+include("../common.jl")


### PR DESCRIPTION
Should be merged after #3336 and consecutive jll (JuliaRegistries/General#40888) is registered.