### PR TITLE
[New package] Add rocm_cmake_jll 4.0.0

### DIFF
--- a/R/rocm_cmake/build_tarballs.jl
+++ b/R/rocm_cmake/build_tarballs.jl
@@ -1,0 +1,42 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "rocm_cmake"
+version = v"4.0.0"
+
+# Collection of sources required to build
+sources = [
+    ArchiveSource("https://github.com/RadeonOpenCompute/rocm-cmake/archive/rocm-$(version).tar.gz",
+                  "4577487acaa6e041a1316145867584f31caaf0d4aa2dd8fd7f82f81c269cada6"), # 4.0.0
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/rocm-cmake*/
+
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} ..
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="musl"),
+]
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+    FileProduct("share/rocm/cmake", :cmake_dir),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
Needed to locate ROCm components when building HIP-derived libraries