### PR TITLE
[New package] Add rocminfo_jll 4.0.0

### DIFF
--- a/R/rocminfo/build_tarballs.jl
+++ b/R/rocminfo/build_tarballs.jl
@@ -1,0 +1,47 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "rocminfo"
+version = v"4.0.0"
+
+# Collection of sources required to build
+sources = [
+    ArchiveSource("https://github.com/RadeonOpenCompute/rocminfo/archive/rocm-$(version).tar.gz",
+                  "0b3d692959dd4bc2d1665ab3a838592fcd08d2b5e373593b9192ca369e2c4aa7"), # 4.0.0
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/rocminfo*/
+
+mkdir build && cd build
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_PREFIX_PATH=${prefix} \
+    ..
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="musl"),
+]
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("rocminfo", :rocminfo),
+    ExecutableProduct("rocm_agent_enumerator", :rocm_agent_enumerator),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("hsa_rocr_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")


### PR DESCRIPTION
ROCm tool used when building with hipcc (ref #3338 ), and just generally useful for system monitoring.