### PR TITLE
[libcgal-julia] Fix gcc version (julia 1.5)

### DIFF
--- a/L/libcgal_julia/libcgal_julia@1.5/build_tarballs.jl
+++ b/L/libcgal_julia/libcgal_julia@1.5/build_tarballs.jl
@@ -1,2 +1,3 @@
 julia_version = v"1.5.3"
+gcc_version = v"8"
 include("../common.jl")


### PR DESCRIPTION
Should not be merged before #3344 and subsequent jll registry.