### PR TITLE
[ROCmCompilerSupport_jll] Disable -h flag in comgr-objdump

### DIFF
--- a/R/ROCmCompilerSupport/build_tarballs.jl
+++ b/R/ROCmCompilerSupport/build_tarballs.jl
@@ -57,7 +57,7 @@ platforms = [
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["libamd_comgr"], :libamd_comgr; dont_dlopen=true),
+    LibraryProduct(["libamd_comgr"], :libamd_comgr),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/R/ROCmCompilerSupport/build_tarballs.jl
+++ b/R/ROCmCompilerSupport/build_tarballs.jl
@@ -29,6 +29,7 @@ cd ../..
 atomic_patch -p1 $WORKSPACE/srcdir/patches/disable-1031.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/disable-tests.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/disable-bc2h.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/fix-objdump-clopt.patch
 mkdir build && cd build
 cp ../cmake/bc2h/bc2h .
 # TODO: -DROCM_DIR=${prefix}

--- a/R/ROCmCompilerSupport/bundled/patches/fix-objdump-clopt.patch
+++ b/R/ROCmCompilerSupport/bundled/patches/fix-objdump-clopt.patch
@@ -1,0 +1,16 @@
+diff --git a/src/comgr-objdump.cpp b/src/comgr-objdump.cpp
+index 1fdb1df..260db7e 100644
+--- a/src/comgr-objdump.cpp
++++ b/src/comgr-objdump.cpp
+@@ -174,9 +174,9 @@ cl::opt<bool> SectionHeaders("section-headers",
+ static cl::alias SectionHeadersShort("headers",
+                                      cl::desc("Alias for --section-headers"),
+                                      cl::aliasopt(SectionHeaders));
+-static cl::alias SectionHeadersShorter("h",
++/*static cl::alias SectionHeadersShorter("h",
+                                        cl::desc("Alias for --section-headers"),
+-                                       cl::aliasopt(SectionHeaders));
++                                       cl::aliasopt(SectionHeaders));*/
+ 
+ cl::list<std::string>
+     FilterSections("section",


### PR DESCRIPTION
Fixes an LLVM CommandLine conflict due to Julia's usage of LLVM.

Thanks to @staticfloat for helping solve this!