### PR TITLE
[ROCmOpenCLRuntime_jll] Disable initial-exec TLS model

### DIFF
--- a/R/ROCmOpenCLRuntime/build_tarballs.jl
+++ b/R/ROCmOpenCLRuntime/build_tarballs.jl
@@ -20,8 +20,11 @@ OPENCL_SRC=$(realpath $WORKSPACE/srcdir/ROCm-OpenCL-Runtime-*)
 ROCCLR_SRC=$(realpath $WORKSPACE/srcdir/ROCclr-*)
 
 cd $ROCCLR_SRC
-atomic_patch -p1 $WORKSPACE/srcdir/patches/musl-rocclr.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/rocclr-install-prefix.patch
+if [[ "${target}" == *-musl* ]]; then
+atomic_patch -p1 $WORKSPACE/srcdir/patches/musl-rocclr.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/rocclr-disable-initial-exec.patch
+fi
 mkdir build && cd build
 cmake -DCMAKE_PREFIX_PATH=${prefix} \
       -DCMAKE_INSTALL_PREFIX=${prefix} \
@@ -36,7 +39,9 @@ make -j${nproc}
 make install
 
 cd $OPENCL_SRC
+if [[ "${target}" == *-musl* ]]; then
 atomic_patch -p1 $WORKSPACE/srcdir/patches/musl-opencl.patch
+fi
 mkdir build && cd build
 cmake -DCMAKE_PREFIX_PATH=${prefix} \
       -DCMAKE_INSTALL_PREFIX=${prefix} \
@@ -68,8 +73,8 @@ platforms = [
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["libamdocl64"], :libamdocl; dont_dlopen=true),
-    LibraryProduct(["libOpenCL"], :libOpenCL; dont_dlopen=true),
+    LibraryProduct(["libamdocl64"], :libamdocl),
+    LibraryProduct(["libOpenCL"], :libOpenCL),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/R/ROCmOpenCLRuntime/bundled/patches/rocclr-disable-initial-exec.patch
+++ b/R/ROCmOpenCLRuntime/bundled/patches/rocclr-disable-initial-exec.patch
@@ -1,0 +1,26 @@
+diff --git a/thread/thread.cpp b/thread/thread.cpp
+index feb25765..92f47539 100644
+--- a/thread/thread.cpp
++++ b/thread/thread.cpp
+@@ -121,7 +121,7 @@ void Thread::resume() {
+ 
+ namespace details {
+ 
+-__thread Thread* thread_ __attribute__((tls_model("initial-exec")));
++__thread Thread* thread_;
+ 
+ }  // namespace details
+ 
+diff --git a/thread/thread.hpp b/thread/thread.hpp
+index 790bbfb3..8a9e0660 100644
+--- a/thread/thread.hpp
++++ b/thread/thread.hpp
+@@ -186,7 +186,7 @@ namespace details {
+ 
+ #if defined(__linux__)
+ 
+-extern __thread Thread* thread_ __attribute__((tls_model("initial-exec")));
++extern __thread Thread* thread_;
+ 
+ static inline Thread* currentThread() { return thread_; }
+ 


### PR DESCRIPTION
Since musl doesn't support it.