### PR TITLE
[Sundials] Build for Julia v1.7

### DIFF
--- a/S/Sundials/Sundials@5/build_tarballs.jl
+++ b/S/Sundials/Sundials@5/build_tarballs.jl
@@ -19,6 +19,11 @@ if [[ "${target}" == *-mingw* ]]; then
     atomic_patch -p1 $WORKSPACE/srcdir/patches/Sundials_windows.patch
     # Work around https://github.com/LLNL/sundials/issues/29
     export CFLAGS="-DBUILD_SUNDIALS_LIBRARY"
+    # See https://github.com/LLNL/sundials/issues/35
+    atomic_patch -p1 ../patches/Sundials_lapackband.patch
+    # When looking for KLU libraries, CMake searches only for import libraries,
+    # this patch ensures we look also for shared libraries.
+    atomic_patch -p1 ../patches/Sundials_findklu_suffixes.patch
 elif [[ "${target}" == powerpc64le-* ]]; then
     export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib64"
 fi

--- a/S/Sundials/Sundials@5/build_tarballs.jl
+++ b/S/Sundials/Sundials@5/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "Sundials"
-version = v"5.2.0"
+version = v"5.2.1" # <-- There is no version 5.2.1, but we need to change version to build for Julia v1.7
 
 # Collection of sources required to build Sundials
 sources = [
@@ -18,14 +18,14 @@ cd $WORKSPACE/srcdir/sundials*
 if [[ "${target}" == *-mingw* ]]; then
     atomic_patch -p1 $WORKSPACE/srcdir/patches/Sundials_windows.patch
     # Work around https://github.com/LLNL/sundials/issues/29
-    export CFLAGS="${CFLAGS} -DBUILD_SUNDIALS_LIBRARY"
+    export CFLAGS="-DBUILD_SUNDIALS_LIBRARY"
 elif [[ "${target}" == powerpc64le-* ]]; then
     export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib64"
 fi
 
 # Set up LAPACK
 LAPACK_LIBRARIES="-lgfortran"
-if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
+if [[ ${nbits} == 64 ]]; then
     atomic_patch -p1 $WORKSPACE/srcdir/patches/Sundials_Fortran.patch
     LAPACK_LIBRARIES="${LAPACK_LIBRARIES} ${libdir}/libopenblas64_.${dlext}"
 else
@@ -43,8 +43,11 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
     -DEXAMPLES_ENABLE_C=OFF \
-    -DKLU_ENABLE=ON -DKLU_INCLUDE_DIR="$prefix/include" -DKLU_LIBRARY_DIR="$libdir" \
-    -DLAPACK_ENABLE=ON -DLAPACK_LIBRARIES:STRING="${LAPACK_LIBRARIES}" \
+    -DKLU_ENABLE=ON \
+    -DKLU_INCLUDE_DIR="${includedir}" \
+    -DKLU_LIBRARY_DIR="${libdir}" \
+    -DLAPACK_ENABLE=ON \
+    -DLAPACK_LIBRARIES:STRING="${LAPACK_LIBRARIES}" \
     ..
 make -j${nproc}
 make install
@@ -56,9 +59,8 @@ fi
 """
 
 # We attempt to build for all defined platforms
-platforms = supported_platforms()
+platforms = filter!(p -> arch(p) != "powerpc64le", supported_platforms(; experimental=true))
 platforms = expand_gfortran_versions(platforms)
-platforms = [p for p in platforms if !(arch(p) == :powerpc64le)]
 
 products = [
     LibraryProduct("libsundials_arkode", :libsundials_arkode),
@@ -89,8 +91,8 @@ products = [
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
     Dependency("OpenBLAS_jll"),
-    Dependency("SuiteSparse_jll"),
+    Dependency("SuiteSparse_jll"; compat="~5.10.1"),
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"6", julia_compat="1.7")

--- a/S/Sundials/bundled@5/patches/Sundials_findklu_suffixes.patch
+++ b/S/Sundials/bundled@5/patches/Sundials_findklu_suffixes.patch
@@ -1,0 +1,13 @@
+--- a/config/FindKLU.cmake
++++ b/config/FindKLU.cmake
+@@ -19,6 +19,10 @@
+   set(CMAKE_FIND_LIBRARY_PREFIXES lib ${CMAKE_FIND_LIBRARY_PREFIXES})
+ endif()
+ 
++# Ensure on Windows we look for shared libraries `*.dll`, instead of just import
++# libraries (we don't have those for suitesparseconfig).
++set(CMAKE_FIND_LIBRARY_SUFFIXES ".$ENV{dlext}" ${CMAKE_FIND_LIBRARY_SUFFIXES})
++
+ ### Find include dir
+ find_path(temp_KLU_INCLUDE_DIR klu.h ${KLU_INCLUDE_DIR})
+ if (temp_KLU_INCLUDE_DIR)

--- a/S/Sundials/bundled@5/patches/Sundials_lapackband.patch
+++ b/S/Sundials/bundled@5/patches/Sundials_lapackband.patch
@@ -1,0 +1,19 @@
+From 887af4374af2271db9310d31eaa9b5aeff49e829 Mon Sep 17 00:00:00 2001
+From: "Balos, Cody Joe" <balos1@llnl.gov>
+Date: Thu, 21 May 2020 10:27:40 -0700
+Subject: [PATCH] SUNDIALS Release v5.3.0
+
+diff --git a/src/sunlinsol/lapackband/CMakeLists.txt b/src/sunlinsol/lapackband/CMakeLists.txt
+index 2bb5a4ef..b736ed09 100644
+--- a/src/sunlinsol/lapackband/CMakeLists.txt
++++ b/src/sunlinsol/lapackband/CMakeLists.txt
+@@ -74,6 +74,9 @@ if(BUILD_SHARED_LIBS)
+   target_link_libraries(sundials_sunlinsollapackband_shared
+     PUBLIC sundials_sunmatrixband_shared ${LAPACK_LIBRARIES})
+ 
++  target_compile_definitions(sundials_sunlinsollapackband_shared
++    PUBLIC -DBUILD_SUNDIALS_LIBRARY)
++
+   install(TARGETS sundials_sunlinsollapackband_shared
+     DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 


### PR DESCRIPTION
~@staticfloat since this is for Julia v1.7 only, we might actually target
libblastrampoline instead of OpenBLAS.  Do we only need to use that as
dependency instead of OpenBLAS and point the build system to
`libblastrampoline.${dlext}` and that's it?~  nevermind, I think this needs lapack more than blas

CC: @ChrisRackauckas