### PR TITLE
Build NodeJS v14.17.3 as a shared library.

### DIFF
--- a/L/libnode/build_tarballs.jl
+++ b/L/libnode/build_tarballs.jl
@@ -1,0 +1,72 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libnode"
+version = v"14.17.3"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://nodejs.org/dist/v14.17.3/node-v14.17.3.tar.gz", "dcbd156506ee79ee48439257626ca0a6db3d7eab8cb0208db6979125ae7d3a95"),
+]
+
+host_platform = HostPlatform()
+
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd node-*
+
+export CC_host=$HOSTCC
+export CXX_host=$HOSTCXX
+# Build & install libnode
+if [[ $target == $MACHTYPE ]]
+then
+    ./configure --prefix=${prefix} --shared --without-inspector --no-cross-compiling
+else
+    DEST_CPU=x86_64
+    if [[ $target == *aarch64* ]]; then DEST_CPU=arm64; fi
+    DEST_OS=linux
+    ./configure --prefix=${prefix} --shared --without-inspector --without-intl --cross-compiling --dest-cpu=$DEST_CPU --dest-os=$DEST_OS
+fi
+
+export LDFLAGS=-lrt
+export CPPFLAGS=-D__STDC_FORMAT_MACROS
+make -j`nproc`
+make install
+cp ./out/Release/node ${bindir}
+install_license ./LICENSE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+# Only 64-bit Linux platforms.
+# Requires XCode and MSVC to compile on Mac OS and Windows, respectively.
+# TODO: support FreeBSD/Mac/Windows
+platforms = [
+    x for x in supported_platforms()
+    if BinaryBuilder.os(x) ∉ ("freebsd", "windows", "macos") &&
+        nbits(x) ≡ 64 && !startswith(arch(x), "powerpc")
+]
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libnode", :libnode),
+    ExecutableProduct("node", :node),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+init_block = raw"""
+"""
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(
+    ARGS, name, version, sources, script,
+    platforms, products, dependencies;
+    preferred_gcc_version = v"10.2.0",
+    init_block = init_block
+)

--- a/L/libnode/build_tarballs.jl
+++ b/L/libnode/build_tarballs.jl
@@ -45,10 +45,18 @@ install_license ./LICENSE
 # Requires XCode and MSVC to compile on Mac OS and Windows, respectively.
 # TODO: support FreeBSD/Mac/Windows
 platforms = [
-    x for x in supported_platforms()
-    if BinaryBuilder.os(x) ∉ ("freebsd", "windows", "macos") &&
-        nbits(x) ≡ 64 && !startswith(arch(x), "powerpc")
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux"; libc="musl"),
+
+    # Platform("x86_64", "macos"),
+    # Platform("aarch64", "macos"),
+
+    # Platform("x86_64", "windows"),
 ]
+platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -67,6 +75,7 @@ init_block = raw"""
 build_tarballs(
     ARGS, name, version, sources, script,
     platforms, products, dependencies;
-    preferred_gcc_version = v"10.2.0",
+    julia_compat="1.6",
+    preferred_gcc_version = v"7",
     init_block = init_block
 )


### PR DESCRIPTION
NodeJS does not have an official distribution of shared libraries, so we have to compile it manually.

I mainly intend to use `libnode` in my attempt to embed NodeJS in Julia. There are two packages related:

- [`jlnode`](https://github.com/sunoru/jlnode) wraps some functions to let NodeJS and Julia communicate more easily.  I will submit another package `libjlnode_jll` after this PR is merged.
- [`NodeCall.jl`](https://github.com/sunoru/NodeCall.jl) makes use of `libjlnode_jll` to run an embedded NodeJS instance in the Julia's process, and we can then simply use javascript in julia. It will be very handy to use npm packages in Julia.

v14.17.3 is the latest one of LTS versions, which imo could be a good choice to be used here. I successfully build it on my own computer (x86_64-linux-glibc) for the four 64-bit Linux platforms (x86_64 and aarch64, glibc and musl), and the two packages above also work well.

Compiling node for Windows requires MSVC (and it takes a lot of work of patching sources to build a `libnode.dll`), and compiling `libnode.dylib` for macOS requires many Xcode-related tools. So they cannot be simply cross-compiled.

By the way, I have a question. Would it also be okay if we manually build the shared libraries, publish them somewhere (for example, on github), and only downloading them in the `build_tarballs.jl`? Thus it can also support the other platforms. I noticed [`NodeJS_16_jll`](https://github.com/JuliaPackaging/Yggdrasil/blob/60dbe065ebae7d787808635180b3e38e0626d54a/N/NodeJS/NodeJS_16/build_tarballs.jl) is depending on the official binaries of NodeJS. If so maybe we can use the binaries I build on my own computers? See: https://github.com/sunoru/node/releases/tag/v14.17.3
