### PR TITLE
add cif_api

### DIFF
--- a/C/cif_api/build_tarballs.jl
+++ b/C/cif_api/build_tarballs.jl
@@ -16,7 +16,8 @@ cd $WORKSPACE/srcdir/cif_api-*
 
 update_configure_scripts
 
-#CPP flags needed in configure statement to help *-musl-* builds configure scripts find sqlite3.h, unsure exactly why?
+#CPP flags needed to help *-musl-* builds configure scripts find sqlite3.h, unsure exactly why?
+export CPPFLAGS="-I${includedir}"
 
 ./configure \
     --prefix=${prefix} \
@@ -25,7 +26,6 @@ update_configure_scripts
     --build=${MACHTYPE} \
     --host=${target} \
     --with-docs=no \
-    CPPFLAGS="-I{includedir}"
 
 make -j${nproc}
 make install

--- a/C/cif_api/build_tarballs.jl
+++ b/C/cif_api/build_tarballs.jl
@@ -1,0 +1,47 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "cif_api"
+version = v"0.4.2"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/COMCIFS/cif_api/archive/refs/tags/v0.4.2.tar.gz", "803fa1d0525bb51407754fa63b9439ba350178f45372103e84773ed4871b3924")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/cif_api-*
+
+update_configure_scripts
+
+./configure \
+--prefix=${prefix} \
+--libdir=${libdir} \
+--includedir=${includedir} \
+--build=${MACHTYPE} \
+--host=${target}
+
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("libcif", :libcif)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="ICU_jll", uuid="a51ab1cf-af8e-5615-a023-bc2c838bba6b"))
+    Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/C/cif_api/build_tarballs.jl
+++ b/C/cif_api/build_tarballs.jl
@@ -44,7 +44,7 @@ platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("libcif", :libcif)
+    LibraryProduct("libcif", :libcif)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/C/cif_api/build_tarballs.jl
+++ b/C/cif_api/build_tarballs.jl
@@ -16,8 +16,7 @@ cd $WORKSPACE/srcdir/cif_api-*
 
 update_configure_scripts
 
-#export flags to help *-musl-* builds configure scripts find sqlite3.h
-export CPPFLAGS="-I{includedir}"
+#CPP flags needed in configure statement to help *-musl-* builds configure scripts find sqlite3.h, unsure exactly why?
 
 ./configure \
     --prefix=${prefix} \
@@ -25,7 +24,8 @@ export CPPFLAGS="-I{includedir}"
     --includedir=${includedir} \
     --build=${MACHTYPE} \
     --host=${target} \
-    --with-docs=no
+    --with-docs=no \
+    CPPFLAGS="-I{includedir}"
 
 make -j${nproc}
 make install
@@ -48,4 +48,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;preferred_gcc_version=v"5", julia_compat="1.6")

--- a/C/cif_api/build_tarballs.jl
+++ b/C/cif_api/build_tarballs.jl
@@ -31,7 +31,8 @@ fi
 --includedir=${includedir} \
 --build=${MACHTYPE} \
 --host=${target} \
---with-docs=no
+--with-docs=no \
+CPPFLAGS="-I/workspace/destdir/include"
 
 make -j${nproc}
 make install

--- a/C/cif_api/build_tarballs.jl
+++ b/C/cif_api/build_tarballs.jl
@@ -7,7 +7,8 @@ version = v"0.4.2"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/COMCIFS/cif_api/archive/refs/tags/v0.4.2.tar.gz", "803fa1d0525bb51407754fa63b9439ba350178f45372103e84773ed4871b3924")
+    ArchiveSource("https://github.com/COMCIFS/cif_api/archive/refs/tags/v0.4.2.tar.gz", "803fa1d0525bb51407754fa63b9439ba350178f45372103e84773ed4871b3924"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
@@ -15,6 +16,12 @@ script = raw"""
 cd $WORKSPACE/srcdir/cif_api-*
 
 update_configure_scripts
+
+if [[ ${target} == *mingw* ]]; then
+    #remove win32 if branch to prevent file not found errors on make install?
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mingw-remove-install-hook.patch
+    autoreconf -vi
+fi
 
 #CPP flags needed to help *-musl-* builds configure scripts find sqlite3.h, unsure exactly why?
 export CPPFLAGS="-I${includedir}"

--- a/C/cif_api/build_tarballs.jl
+++ b/C/cif_api/build_tarballs.jl
@@ -48,4 +48,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;preferred_gcc_version=v"5", julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;preferred_gcc_version=v"7", julia_compat="1.6")

--- a/C/cif_api/build_tarballs.jl
+++ b/C/cif_api/build_tarballs.jl
@@ -16,23 +16,16 @@ cd $WORKSPACE/srcdir/cif_api-*
 
 update_configure_scripts
 
-if [[ "${target}" == *-linux-* ]]; then
-# Hint to find libstdc++, required to link against C++ libs when using C compiler
-    if [[ "${nbits}" == 32 ]]; then
-        export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib"
-    else
-        export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib64"
-    fi
-fi
+#export flags to help *-musl-* builds configure scripts find sqlite3.h
+export CPPFLAGS="-I{includedir}"
 
 ./configure \
---prefix=${prefix} \
---libdir=${libdir} \
---includedir=${includedir} \
---build=${MACHTYPE} \
---host=${target} \
---with-docs=no \
-CPPFLAGS="-I/workspace/destdir/include"
+    --prefix=${prefix} \
+    --libdir=${libdir} \
+    --includedir=${includedir} \
+    --build=${MACHTYPE} \
+    --host=${target} \
+    --with-docs=no
 
 make -j${nproc}
 make install
@@ -50,9 +43,9 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="ICU_jll", uuid="a51ab1cf-af8e-5615-a023-bc2c838bba6b"))
+    Dependency("ICU_jll"; compat="69.1")
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.6")

--- a/C/cif_api/build_tarballs.jl
+++ b/C/cif_api/build_tarballs.jl
@@ -16,12 +16,22 @@ cd $WORKSPACE/srcdir/cif_api-*
 
 update_configure_scripts
 
+if [[ "${target}" == *-linux-* ]]; then
+# Hint to find libstdc++, required to link against C++ libs when using C compiler
+    if [[ "${nbits}" == 32 ]]; then
+        export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib"
+    else
+        export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib64"
+    fi
+fi
+
 ./configure \
 --prefix=${prefix} \
 --libdir=${libdir} \
 --includedir=${includedir} \
 --build=${MACHTYPE} \
---host=${target}
+--host=${target} \
+--with-docs=no
 
 make -j${nproc}
 make install

--- a/C/cif_api/bundled/patches/mingw-remove-install-hook.patch
+++ b/C/cif_api/bundled/patches/mingw-remove-install-hook.patch
@@ -1,0 +1,26 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 3f9794b..9ffde74 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -57,17 +57,10 @@ LIB_CURRENT = 2
+ LIB_REVISION = 0
+ LIB_AGE = 1
+ 
+-if win32
+-  LIB_VERSION_FLAGS = -avoid-version
+-  INSTALL_HOOKS = install_import_lib
+-  UNINSTALL_HOOKS = uninstall_import_lib
+-  CLEANFILES = libcif.def
+-else
+-  LIB_VERSION_FLAGS = -version-info $(LIB_CURRENT):$(LIB_REVISION):$(LIB_AGE)
+-  INSTALL_HOOKS = 
+-  UNINSTALL_HOOKS = 
+-  CLEANFILES =
+-endif
++LIB_VERSION_FLAGS = -version-info $(LIB_CURRENT):$(LIB_REVISION):$(LIB_AGE)
++INSTALL_HOOKS = 
++UNINSTALL_HOOKS = 
++CLEANFILES =
+ 
+ BUILT_SOURCES = internal/schema.h internal/version.h
+ EXTRA_DIST = notes.txt style.txt


### PR DESCRIPTION
This PR adds a `build_tarball.jl` for [cif_api](https://github.com/COMCIFS/cif_api).

This is what comes out of the wizard for me on a `x86_64-mingw-*` platform, `*-linux-*` still needs some tinkering but I wanted to see how the other platforms do as well.

Closes #2680 