### PR TITLE
New Recipe: libcleri v0.12.1

### DIFF
--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -27,19 +27,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("i686", "linux"; libc = "glibc"),
-    Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("aarch64", "linux"; libc = "glibc"),
-    Platform("powerpc64le", "linux"; libc = "glibc"),
-    Platform("i686", "linux"; libc = "musl"),
-    Platform("x86_64", "linux"; libc = "musl"),
-    Platform("aarch64", "linux"; libc = "musl"),
-    Platform("x86_64", "macos"; ),
-    Platform("x86_64", "freebsd"; ),
-    Platform("i686", "windows"; ),
-    Platform("x86_64", "windows"; )
-]
+platforms = supported_platforms(; experimental=true)
 
 
 # The products that we will ensure are always built

--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -53,4 +53,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")

--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -16,8 +16,8 @@ export CFLAGS=$(pcre2-config --cflags)
 export LDFLAGS=$(pcre2-config --libs8)
 cd $WORKSPACE/srcdir
 cd libcleri/
-make -C Release -f makefile
-make -C Release -f makefile install INSTALL_PATH=${prefix}
+make -C Release FN="libcleri.${dlext}"
+make -C Release FN="libcleri.${dlext}" install INSTALL_PATH=${prefix}
 if [[ ${target} == *-mingw-* ]]; then
    for f in ${prefix}/lib/libcleri.so*; do
        ln -s $f $(echo $f | sed -e 's/.so/.dll/')

--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -18,11 +18,6 @@ cd $WORKSPACE/srcdir
 cd libcleri/
 make -C Release FN="libcleri.${dlext}"
 make -C Release FN="libcleri.${dlext}" install INSTALL_PATH=${prefix}
-if [[ ${target} == *-mingw-* ]]; then
-   for f in ${prefix}/lib/libcleri.so*; do
-       ln -s $f $(echo $f | sed -e 's/.so/.dll/')
-   done
-fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libcleri"
+version = v"0.12.1"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/transceptor-technology/libcleri.git", "a8a1adc9dcf4e889a4d44c17acb20d74d0c6cfe5")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+export CFLAGS=$(pcre2-config --cflags)
+export LDFLAGS=$(pcre2-config --libs8)
+cd $WORKSPACE/srcdir
+cd libcleri/
+make -C Release -f makefile
+make -C Release -f makefile install INSTALL_PATH=${prefix}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("i686", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("powerpc64le", "linux"; libc = "glibc"),
+    Platform("i686", "linux"; libc = "musl"),
+    Platform("x86_64", "linux"; libc = "musl"),
+    Platform("aarch64", "linux"; libc = "musl"),
+    Platform("x86_64", "macos"; ),
+    Platform("x86_64", "freebsd"; ),
+    Platform("i686", "windows"; ),
+    Platform("x86_64", "windows"; )
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libcleri", :libcleri)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="PCRE2_jll", uuid="efcefdf7-47ab-520b-bdef-62a2eaa19f15"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -18,6 +18,11 @@ cd $WORKSPACE/srcdir
 cd libcleri/
 make -C Release -f makefile
 make -C Release -f makefile install INSTALL_PATH=${prefix}
+if [[ ${target} == *-mingw-* ]]; then
+   for f in ${prefix}/lib/libcleri.so*; do
+       ln -s $f $(echo $f | sed -e 's/.so/.dll/')
+   done
+fi
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Hello, this PR adds a new recipe for the libcleri C library, currently directed to v0.12.1 from https://github.com/transceptor-technology/libcleri/tree/0.12.1. I am adding it as a build dependency of my repo at https://github.com/libAtoms/extxyz, for which a build recipe will be coming shortly, since I understood that it was preferable to have a single library in each recipe.

This recipe builds correctly on all but two platforms:
 - Linux armv7l {call_abi=eabihf, libc=musl}
 - Linux armv7l {call_abi=eabihf, libc=glibc}
 
The error on armv71 is an internal compiler error, details pasted below. For now I simply skipped these platforms, but I'm happy to revisit, for example with newer compiler versions, if that would be preferable.

```
[22:19:03] make: Entering directory '/workspace/srcdir/libcleri/Release'
[22:19:03] Building file: ../src/children.c
[22:19:03] Invoking: Cross GCC Compiler
[22:19:03] gcc -DNDEBUG -I../inc -O3 -Winline -Wall  -I/workspace/destdir/include -c -fmessage-length=0 -fPIC -MMD -MP -MF"src/children.d" -MT"src/children.o" -o "src/children.o" "../src/children.c"
[22:19:04] arm-linux-musleabihf-gcc: internal compiler error: Illegal instruction (program as)
[22:19:04] mmap: Bad file descriptor
[22:19:04] close: Bad file descriptor
[22:19:04] Please submit a full bug report,
[22:19:04] with preprocessed source if appropriate.
[22:19:04] See <http://gcc.gnu.org/bugs.html> for instructions.
[22:19:04] make: *** [src/subdir.mk:80: src/children.o] Error 4
[22:19:04] make: Leaving directory '/workspace/srcdir/libcleri/Release'
```
