### PR TITLE
Fix julia_compat for GAP_jll for Julia 1.7

### DIFF
--- a/G/GAP/GAP@1.7/build_tarballs.jl
+++ b/G/GAP/GAP@1.7/build_tarballs.jl
@@ -13,4 +13,4 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version=v"7", init_block=init_block, julia_compat="1.6")
+               preferred_gcc_version=v"7", init_block=init_block, julia_compat="1.7")


### PR DESCRIPTION
[skip build]
[skip ci]

I'm trying to fix this in the registry in https://github.com/JuliaRegistries/General/pull/41585 so this PR is just meant to ensure the next time I update this JLL, it is done right.