### PR TITLE
Fix install_name of libcleri.dylib on MacOS builds

### DIFF
--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -18,6 +18,9 @@ cd $WORKSPACE/srcdir
 cd libcleri/
 make -C Release FN="libcleri.${dlext}"
 make -C Release FN="libcleri.${dlext}" install INSTALL_PATH=${prefix}
+if [[ "${target}" == *-apple-* ]]; then
+    install_name_tool -id @rpath/libcleri.dylib.0 ${prefix}/lib/libcleri.dylib
+fi
 """
 
 # These are the platforms we will build for by default, unless further
@@ -36,4 +39,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
My initial build, merged in #3382, did not include `@rpath` in its `install_name`, so was not easy to link to in dependent libraries.

I've also removed the change to GCC v5 since this proved to be unnecessary, so better to stick with the older and more compatible default GCC v4.8.5.