### PR TITLE
[Graphene] Upgrade to v1.10.6 and build for experimental platforms

### DIFF
--- a/G/Graphene/build_tarballs.jl
+++ b/G/Graphene/build_tarballs.jl
@@ -3,23 +3,22 @@
 using BinaryBuilder
 
 name = "Graphene"
-version = v"1.10.0"
+version = v"1.10.6"
 
 # Collection of sources required to build Graphene
 sources = [
     ArchiveSource("https://github.com/ebassi/graphene/releases/download/$(version)/graphene-$(version).tar.xz",
-                  "406d97f51dd4ca61e91f84666a00c3e976d3e667cd248b76d92fdb35ce876499")
+                  "80ae57723e4608e6875626a88aaa6f56dd25df75024bd16e9d77e718c3560b25"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/graphene-*/
 mkdir build && cd build
-
 meson .. \
     -Dgtk_doc=false \
     -Dgobject_types=true \
-    -Dintrospection=false \
+    -Dintrospection=disabled \
     -Dtests=false \
     -Dinstalled_tests=false \
     --cross-file="${MESON_TARGET_TOOLCHAIN}"
@@ -29,7 +28,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = Product[
@@ -38,8 +37,8 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Glib_jll", v"2.59.0"; compat="2.59"),
+    Dependency("Glib_jll"; compat="2.68.3"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
Need to build a new version of Glib because we need https://gitlab.gnome.org/GNOME/glib/-/commit/2c97526c006b22110f013dfc13ddf55e032e4ec8.  Sigh