### PR TITLE
Bump OpenEXR: v3.0.1 -> v3.1.1.

### DIFF
--- a/O/OpenEXR/build_tarballs.jl
+++ b/O/OpenEXR/build_tarballs.jl
@@ -3,12 +3,13 @@
 using BinaryBuilder, Pkg
 
 name = "OpenEXR"
-version = v"3.0.1"
+version = v"3.1.1"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.0.1.tar.gz", "6d14a8df938bbbd55dd6e55b24c527fe9323fe6a45f704e56967dfbf477cecc1")
+    ArchiveSource("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.1.tar.gz", "045254e201c0f87d1d1a4b2b5815c4ae54845af2e6ec0ab88e979b5fdb30a86e")
 ]
+
 
 # Bash recipe for building across all platforms
 script = raw"""
@@ -34,15 +35,16 @@ platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libOpenEXRUtil-3_0", :libOpenEXRUtil),
-    LibraryProduct("libOpenEXR-3_0", :libOpenEXR),
-    LibraryProduct("libIlmThread-3_0", :libIlmThread),
-    LibraryProduct("libIex-3_0", :libIex)
+    LibraryProduct("libOpenEXRUtil-3_1", :libOpenEXRUtil),
+    LibraryProduct("libOpenEXRCore-3_1", :libOpenEXRCore),
+    LibraryProduct("libOpenEXR-3_1", :libOpenEXR),
+    LibraryProduct("libIlmThread-3_1", :libIlmThread),
+    LibraryProduct("libIex-3_1", :libIex)
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="Imath_jll", uuid="905a6f67-0a94-5f89-b386-d35d92009cd1")),
+    Dependency("Imath_jll"; compat="=3.1.2"),
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 


### PR DESCRIPTION
Provides a new, vastly richer C API on which https://github.com/twadleigh/OpenEXR.jl will be updated to depend.