### PR TITLE
[Eigen] Build for Experimental Platforms

### DIFF
--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -39,4 +39,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.7")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "Eigen"
-version = v"3.3.7"
+version = v"3.3.8" #Version number artificially bumped by 1.
 
 sources = [
     ArchiveSource("https://gitlab.com/libeigen/eigen/-/archive/$(version)/eigen-$(version).tar.bz2",

--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -1,11 +1,11 @@
 using BinaryBuilder
 
 name = "Eigen"
-version = v"3.3.7" #Version number artificially bumped by 1.
+version = v"3.3.9"
 
 sources = [
     ArchiveSource("https://gitlab.com/libeigen/eigen/-/archive/$(version)/eigen-$(version).tar.bz2",
-                  "685adf14bd8e9c015b78097c1dc22f2f01343756f196acdc76a678e1ae352e11")
+                  "0fa5cafe78f66d2b501b43016858070d52ba47bd9b1016b0165a7b8e04675677")
 ]
 
 # Bash recipe for building across all platforms

--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -27,7 +27,7 @@ install_license COPYING.*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 # No products: Eigen is a pure header library
@@ -39,4 +39,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.7")

--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "Eigen"
-version = v"3.3.8" #Version number artificially bumped by 1.
+version = v"3.3.7" #Version number artificially bumped by 1.
 
 sources = [
     ArchiveSource("https://gitlab.com/libeigen/eigen/-/archive/$(version)/eigen-$(version).tar.bz2",

--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -27,7 +27,7 @@ install_license COPYING.*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = [AnyPlatform()]
 
 # The products that we will ensure are always built
 # No products: Eigen is a pure header library
@@ -39,4 +39,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
Let's see what happens. I got `LoadError: Unable to automatically install 'GCCBootstrap-x86_64-linux-musl.v10.2.0.x86_64-linux-musl.unpacked` so let's see what this does. 

Also is empty products intentional?