### PR TITLE
[HiGHS] add exectuable build

### DIFF
--- a/H/HiGHS/build_tarballs.jl
+++ b/H/HiGHS/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder, Pkg
 
 name = "HiGHS"
 
-version = v"0.3.2"
+version = v"0.3.3"
 
 sources = [
     GitSource(
         "https://github.com/ERGO-Code/HiGHS.git",
-        "4a5dd7499522f1fa730a31c59bba419b2bcc6839",
+        "363dd4e8639f8f811ce031c9f6c8c35944e91615",
     ),
     DirectorySource("./bundled"),
 ]
@@ -49,10 +49,12 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
+platforms = filter!(!Sys.isfreebsd, platforms)
 
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libhighs", :libhighs),
+    ExecutableProduct("highs", :highs),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
Closes #3431

cc @galabovaa 

The error was because of this use of `target_link_libraries`:
https://github.com/ERGO-Code/HiGHS/pull/369/commits/086b075aa8854f41b0c65c3283bee8bdd3b9b2dd

but even when I fixed that, I ran into another error
```
[ 99%] Linking CXX shared library ../lib/libhighs.so
cd /workspace/srcdir/HiGHS/build/src && /usr/bin/cmake -E cmake_link_script CMakeFiles/libhighs.dir/link.txt --verbose=true
/opt/bin/x86_64-unknown-freebsd11.1-libgfortran3-cxx03/x86_64-unknown-freebsd11.1-clang++ --sysroot=/opt/x86_64-unknown-freebsd11.1/x86_64-unknown-freebsd11.1/sys-root/ -fPIC -O3 -DNDEBUG  -shared -Wl,-soname,libhighs.so -o ../lib/libhighs.so CMakeFiles/libhighs.dir/__/extern/filereaderlp/reader.cpp.o CMakeFiles/libhighs.dir/io/Filereader.cpp.o CMakeFiles/libhighs.dir/io/FilereaderLp.cpp.o CMakeFiles/libhighs.dir/io/FilereaderEms.cpp.o CMakeFiles/libhighs.dir/io/FilereaderMps.cpp.o CMakeFiles/libhighs.dir/io/HighsIO.cpp.o CMakeFiles/libhighs.dir/io/HMPSIO.cpp.o CMakeFiles/libhighs.dir/io/HMpsFF.cpp.o CMakeFiles/libhighs.dir/io/LoadOptions.cpp.o CMakeFiles/libhighs.dir/lp_data/Highs.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsDebug.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsDeprecated.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsInfo.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsInfoDebug.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsInterface.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsLp.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsLpUtils.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsModelUtils.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsRanging.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsSolution.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsSolutionDebug.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsSolve.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsStatus.cpp.o CMakeFiles/libhighs.dir/lp_data/HighsOptions.cpp.o CMakeFiles/libhighs.dir/mip/HighsMipSolver.cpp.o CMakeFiles/libhighs.dir/mip/HighsMipSolverData.cpp.o CMakeFiles/libhighs.dir/mip/HighsDomain.cpp.o CMakeFiles/libhighs.dir/mip/HighsDynamicRowMatrix.cpp.o CMakeFiles/libhighs.dir/mip/HighsLpRelaxation.cpp.o CMakeFiles/libhighs.dir/mip/HighsSeparation.cpp.o CMakeFiles/libhighs.dir/mip/HighsSeparator.cpp.o CMakeFiles/libhighs.dir/mip/HighsTableauSeparator.cpp.o CMakeFiles/libhighs.dir/mip/HighsModkSeparator.cpp.o CMakeFiles/libhighs.dir/mip/HighsPathSeparator.cpp.o CMakeFiles/libhighs.dir/mip/HighsCutGeneration.cpp.o CMakeFiles/libhighs.dir/mip/HighsSearch.cpp.o CMakeFiles/libhighs.dir/mip/HighsConflictPool.cpp.o CMakeFiles/libhighs.dir/mip/HighsCutPool.cpp.o CMakeFiles/libhighs.dir/mip/HighsCliqueTable.cpp.o CMakeFiles/libhighs.dir/mip/HighsGFkSolve.cpp.o CMakeFiles/libhighs.dir/mip/HighsTransformedLp.cpp.o CMakeFiles/libhighs.dir/mip/HighsLpAggregator.cpp.o CMakeFiles/libhighs.dir/mip/HighsDebugSol.cpp.o CMakeFiles/libhighs.dir/mip/HighsImplications.cpp.o CMakeFiles/libhighs.dir/mip/HighsPrimalHeuristics.cpp.o CMakeFiles/libhighs.dir/mip/HighsPseudocost.cpp.o CMakeFiles/libhighs.dir/mip/HighsNodeQueue.cpp.o CMakeFiles/libhighs.dir/mip/HighsRedcostFixing.cpp.o CMakeFiles/libhighs.dir/model/HighsHessian.cpp.o CMakeFiles/libhighs.dir/model/HighsHessianUtils.cpp.o CMakeFiles/libhighs.dir/model/HighsModel.cpp.o CMakeFiles/libhighs.dir/presolve/ICrashX.cpp.o CMakeFiles/libhighs.dir/presolve/HAggregator.cpp.o CMakeFiles/libhighs.dir/presolve/HighsLpPropagator.cpp.o CMakeFiles/libhighs.dir/presolve/HighsPostsolveStack.cpp.o CMakeFiles/libhighs.dir/presolve/HighsSymmetry.cpp.o CMakeFiles/libhighs.dir/presolve/HPreData.cpp.o CMakeFiles/libhighs.dir/presolve/HPresolve.cpp.o CMakeFiles/libhighs.dir/presolve/PresolveAnalysis.cpp.o CMakeFiles/libhighs.dir/presolve/PresolveComponent.cpp.o CMakeFiles/libhighs.dir/presolve/Presolve.cpp.o CMakeFiles/libhighs.dir/presolve/PresolveUtils.cpp.o CMakeFiles/libhighs.dir/qpsolver/basis.cpp.o CMakeFiles/libhighs.dir/qpsolver/solver.cpp.o CMakeFiles/libhighs.dir/qpsolver/ratiotest.cpp.o CMakeFiles/libhighs.dir/simplex/HCrash.cpp.o CMakeFiles/libhighs.dir/simplex/HEkk.cpp.o CMakeFiles/libhighs.dir/simplex/HEkkControl.cpp.o CMakeFiles/libhighs.dir/simplex/HEkkDebug.cpp.o CMakeFiles/libhighs.dir/simplex/HEkkPrimal.cpp.o CMakeFiles/libhighs.dir/simplex/HEkkDual.cpp.o CMakeFiles/libhighs.dir/simplex/HEkkDualRHS.cpp.o CMakeFiles/libhighs.dir/simplex/HEkkDualRow.cpp.o CMakeFiles/libhighs.dir/simplex/HEkkDualMulti.cpp.o CMakeFiles/libhighs.dir/simplex/HEkkInterface.cpp.o CMakeFiles/libhighs.dir/simplex/HFactor.cpp.o CMakeFiles/libhighs.dir/simplex/HFactorDebug.cpp.o CMakeFiles/libhighs.dir/simplex/HighsSimplexAnalysis.cpp.o CMakeFiles/libhighs.dir/simplex/HMatrix.cpp.o CMakeFiles/libhighs.dir/simplex/HSimplex.cpp.o CMakeFiles/libhighs.dir/simplex/HSimplexDebug.cpp.o CMakeFiles/libhighs.dir/simplex/HSimplexReport.cpp.o CMakeFiles/libhighs.dir/simplex/HVector.cpp.o CMakeFiles/libhighs.dir/test/KktCh2.cpp.o CMakeFiles/libhighs.dir/test/DevKkt.cpp.o CMakeFiles/libhighs.dir/util/HighsHash.cpp.o CMakeFiles/libhighs.dir/util/HighsLinearSumBounds.cpp.o CMakeFiles/libhighs.dir/util/HighsMatrixPic.cpp.o CMakeFiles/libhighs.dir/util/HighsSort.cpp.o CMakeFiles/libhighs.dir/util/HighsUtils.cpp.o CMakeFiles/libhighs.dir/util/HSet.cpp.o CMakeFiles/libhighs.dir/util/stringutil.cpp.o CMakeFiles/libhighs.dir/interfaces/highs_c_api.cpp.o CMakeFiles/libhighs.dir/ipm/basiclu/src/basiclu_factorize.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/basiclu_solve_dense.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_build_factors.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_factorize_bump.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_initialize.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_markowitz.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_setup_bump.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_solve_sparse.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/basiclu_get_factors.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/basiclu_solve_for_update.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_condest.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_file.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_internal.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_matrix_norm.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_singletons.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_solve_symbolic.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_update.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/basiclu_initialize.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/basiclu_solve_sparse.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_pivot.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_solve_dense.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_solve_triangular.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/basiclu_object.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/basiclu_update.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_dfs.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_garbage_perm.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_residual_test.c.o CMakeFiles/libhighs.dir/ipm/basiclu/src/lu_solve_for_update.c.o CMakeFiles/libhighs.dir/ipm/ipx/src/basiclu_kernel.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/basiclu_wrapper.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/basis.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/conjugate_residuals.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/control.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/crossover.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/diagonal_precond.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/forrest_tomlin.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/guess_basis.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/indexed_vector.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/info.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/ipm.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/ipx_c.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/iterate.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/kkt_solver.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/kkt_solver_basis.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/kkt_solver_diag.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/linear_operator.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/lp_solver.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/lu_factorization.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/lu_update.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/maxvolume.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/model.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/normal_matrix.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/sparse_matrix.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/sparse_utils.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/splitted_normal_matrix.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/starting_basis.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/symbolic_invert.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/timer.cc.o CMakeFiles/libhighs.dir/ipm/ipx/src/utils.cc.o CMakeFiles/libhighs.dir/ipm/IpxWrapper.cpp.o  -Wl,-rpath,:::::::::::::::::::::: -lpthread /opt/x86_64-unknown-freebsd11.1/x86_64-unknown-freebsd11.1/sys-root/usr/lib/libomp.so 
/opt/x86_64-unknown-freebsd11.1/bin/x86_64-unknown-freebsd11.1-ld: CMakeFiles/libhighs.dir/__/extern/filereaderlp/reader.cpp.o: unrecognized relocation (0x2a) in section `.text'
/opt/x86_64-unknown-freebsd11.1/bin/x86_64-unknown-freebsd11.1-ld: final link failed: Bad value
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
```

For now let's just skip the FreeBSD build. We can solve the issue once everything else is working.