### PR TITLE
Bump SPIRV-Tools to v2021.2, vendor SPIRV-Headers.

### DIFF
--- a/S/SPIRV_Tools/build_tarballs.jl
+++ b/S/SPIRV_Tools/build_tarballs.jl
@@ -3,14 +3,15 @@
 using BinaryBuilder, Pkg
 
 name = "SPIRV_Tools"
-version = v"2020.6"
+version = v"2021.2"
 
 # Collection of sources required to build SPIRV-Tools
 sources = [
-    GitSource("https://github.com/KhronosGroup/SPIRV-Tools.git", "4c2f34a504817cc96d3e8b0435265a743cb2038a"),
-    # vendored dependencies
-    GitSource("https://github.com/google/effcee.git", "33d438fb1939e94e5507d38dee9d999f60a03d96"), # 2019.1
-    GitSource("https://github.com/google/re2.git", "166dbbeb3b0ab7e733b278e8f42a84f6882b8a25"), # 2020-11-01
+    GitSource("https://github.com/KhronosGroup/SPIRV-Tools.git", "5775a63ab44f6ffef2978de424062eb92719bdd0"),
+    # vendored dependencies, see the DEPS file
+    GitSource("https://github.com/google/effcee.git", "2ec8f8738118cc483b67c04a759fee53496c5659"),
+    GitSource("https://github.com/google/re2.git", "f8e389f3acdc2517562924239e2a188037393683"),
+    GitSource("https://github.com/KhronosGroup/SPIRV-Headers.git", "07f259e68af3a540038fa32df522554e74f53ed5"),
 ]
 
 # Bash recipe for building across all platforms
@@ -18,6 +19,7 @@ script = raw"""
 # put vendored dependencies in places they will be picked up by the build system
 mv effcee SPIRV-Tools/external/effcee
 mv re2 SPIRV-Tools/external/re2
+mv SPIRV-Headers SPIRV-Tools/external/spirv-headers
 
 cd SPIRV-Tools
 install_license LICENSE
@@ -38,9 +40,6 @@ CMAKE_FLAGS+=(-DSPIRV_SKIP_TESTS=ON)
 
 # Don't use -Werror
 CMAKE_FLAGS+=(-DSPIRV_WERROR=OFF)
-
-# Point to the SPIRV Headers JLL
-CMAKE_FLAGS+=(-DSPIRV-Headers_SOURCE_DIR=${prefix})
 
 cmake -B build -S . -GNinja ${CMAKE_FLAGS[@]}
 ninja -C build -j ${nproc} install
@@ -64,8 +63,6 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
-    BuildDependency(PackageSpec(name="SPIRV_Headers_jll", version=v"1.5.4"))
-]
+dependencies = []
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
Upstream doesn't bother tagging a release of SPIRV-Headers (https://github.com/KhronosGroup/SPIRV-Headers/issues/199), so vendor own own copy (https://github.com/KhronosGroup/SPIRV-Tools/pull/4444) so that we can finally upgrade SPIRV-Tools (it doesn't compile with the tagged headers). 