### PR TITLE
[Chuffed] add new build recipe for Chuffed solver

### DIFF
--- a/C/Chuffed/build_tarballs.jl
+++ b/C/Chuffed/build_tarballs.jl
@@ -26,7 +26,7 @@ make -j ${nproc}
 make install
 """
 
-platforms = supported_platforms()
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
 
 products = [
     ExecutableProduct("fzn-chuffed", :fznchuffed),

--- a/C/Chuffed/build_tarballs.jl
+++ b/C/Chuffed/build_tarballs.jl
@@ -1,0 +1,50 @@
+using BinaryBuilder, Pkg
+
+name = "Chuffed"
+
+version = v"0.10.4"
+
+sources = [
+    GitSource(
+        "https://github.com/chuffed/chuffed.git",
+        "23b9fcee3bb30b11f68d82ef4534040ebae1a8fb",
+    ),
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir/chuffed
+mkdir -p build
+cd build
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+# https://github.com/chuffed/chuffed/issues/75
+rm ../chuffed/flatzinc/parser.tab.h
+make -j ${nproc}
+make install
+"""
+
+platforms = supported_platforms()
+
+products = [
+    ExecutableProduct("fzn-chuffed", :fznchuffed),
+]
+
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
+]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    preferred_gcc_version = v"4.8",
+    julia_compat = "1.6",
+)


### PR DESCRIPTION
cc @dourouc05

I haven't build all platforms locally, only Mac:
```
(base) oscar@Oscars-MBP ~ % /Users/oscar/Documents/Code/Yggdrasil/C/Chuffed/products/Chuffed.v0.10.4.x86_64-apple-darwin/bin/fzn-chuffed -h
Usage: /Users/oscar/Documents/Code/Yggdrasil/C/Chuffed/products/Chuffed.v0.10.4.x86_64-apple-darwin/bin/fzn-chuffed [options] <file>.fzn
Options:
  -h, --help
     Print help for common options.
  --help-all
     Print help for all options.
  -a
     Satisfaction problems: Find and print all solutions.
     Optimisation problems: Print all (sub-optimal) intermediate solutions.
  -n <n>, --n-of-solutions <n>
     An upper bound on the number of solutions (default 1).
  -v, --verbose
     Verbose mode (default off).
  -t, --time-out <n>
     Time out in milliseconds (default 0, 0 = run indefinitely).
  --rnd-seed <n>
     Set random seed (default 0). If 0 then the current time
     via std::time(0) is used.

Search Options:
  -f [on|off]
     Free search. Alternates between user-specified and activity-based
     search when search is restarted. Restart base is set to 100.
```