### PR TITLE
add alternative recipe for wxWidgets

### DIFF
--- a/W/wxWidgets/build_tarballs.jl
+++ b/W/wxWidgets/build_tarballs.jl
@@ -1,0 +1,82 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "wxWidgets"
+version = v"3.1.5"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/wxWidgets/wxWidgets/archive/refs/tags/v$version.tar.gz", "e8fd5f9fbff864562aa4d9c094f898c97f5e1274c90f25beb0bfd5cb61319dea")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+
+cd $WORKSPACE/srcdir/wxWidgets-*
+
+if [[ "${target}" == *-linux-musl ]]; then
+    
+    #help find zlib for some reason
+    export CPPFLAGS="-I${includedir}"
+
+    # Delete libexpat to prevent it from being picked up by mistake
+    rm /usr/lib/libexpat.so*
+fi
+
+./configure \
+--prefix=${prefix} \
+--build=${MACHTYPE} \
+--host=${target} \
+--includedir=${includedir} \
+--libdir=${libdir} \
+--with-gtk=3 \
+--with-libiconv=ON \
+--with-libcurl=ON \
+--with-libpng=sys \
+--with-libjpeg=sys \
+--with-libtiff=sys \
+--with-zlib=sys \
+--disable-tests
+
+make -j${nproc}
+make install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("wxrc-$(version.major).$(version.minor)", :wxrc),
+    LibraryProduct("libwx_gtk3u_adv-$(version.major).$(version.minor)", :libwx_gtk3u_adv),
+    LibraryProduct("libwx_gtk3u_core-$(version.major).$(version.minor)", :libwx_gtk3u_core),
+    LibraryProduct("libwx_gtk3u_richtext-$(version.major).$(version.minor)", :libwx_gtk3u_richtext),
+    LibraryProduct("libwx_gtk3u_html-$(version.major).$(version.minor)", :libwx_gtk3u_html),
+    LibraryProduct("libwx_baseu_xml-$(version.major).$(version.minor)", :libwx_baseu_xml),
+    LibraryProduct("libwx_gtk3u_aui-$(version.major).$(version.minor)", :libwx_gtk3u_aui),
+    LibraryProduct("libwx_gtk3u_stc-$(version.major).$(version.minor)", :libwx_gtk3u_stc),
+    LibraryProduct("libwx_baseu-$(version.major).$(version.minor)", :libwx_baseu),
+    LibraryProduct("libwx_gtk3u_qa-$(version.major).$(version.minor)", :libwx_gtk3u_qa),
+    LibraryProduct("libwx_gtk3u_ribbon-$(version.major).$(version.minor)", :libwx_gtk3u_ribbon),
+    LibraryProduct("libwx_gtk3u_propgrid-$(version.major).$(version.minor)", :libwx_gtk3u_propgrid),
+    LibraryProduct("libwx_gtk3u_xrc-$(version.major).$(version.minor)", :libwx_gtk3u_xrc),
+    LibraryProduct("libwx_baseu_net-$(version.major).$(version.minor)", :libwx_baseu_net)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f"))
+    Dependency(PackageSpec(name="JpegTurbo_jll", uuid="aacddb02-875f-59d6-b918-886e6ef4fbf8"))
+    Dependency(PackageSpec(name="Libtiff_jll", uuid="89763e89-9b03-5906-acba-b20f662cd828"))
+    Dependency(PackageSpec(name="LibCURL_jll", uuid="deac9b47-8bc7-5906-a0fe-35ac56dc84c0"))
+    Dependency(PackageSpec(name="GTK3_jll", uuid="77ec8976-b24b-556a-a1bf-49a033a670a6"))
+    Dependency(PackageSpec(name="Zlib_jll", uuid = "83775a58-1f1d-513f-b197-d71354ab007a"))
+    BuildDependency(PackageSpec(name="Xorg_xorgproto_jll", uuid="c4d99508-4286-5418-9131-c86396af500b"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
Posting as an alternative to https://github.com/JuliaPackaging/Yggdrasil/pull/2345. That PR seemed to have a lot going on, so I didn't want to try to add the chain of commits. 

This PR adds a builder for [wxWidgets](https://github.com/wxWidgets/wxWidgets). I would like to have this available as a dependency for a different project.

This works locally on `x86_64-linux-gnu` at the very least. I took some pieces from the other PR, but the dependencies seemed strange to me vs reading through some of the wiki and `configure` scripts.

I am still working on `minGW` platforms. It seems to build but the naming scheme of the libraries changes and I have not quite found where that gets decided/assigned.

for example:
`libwx_gtk3u_adv-3.1` for `linux` turns into `wxgtk3315u_adv_gcc_custom.dll` on `minGW`

```
[ Info: Found a valid dl path libxml2-2.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path libxslt-1.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path libz.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path libzstd-1.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxbase315u_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxbase315u_net_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxbase315u_xml_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_adv_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_aui_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_core_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_html_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_propgrid_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_qa_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_ribbon_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_richtext_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_stc_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Found a valid dl path wxgtk3315u_xrc_gcc_custom.dll while looking for libwx_gtk3u_html-3.1
[ Info: Could not locate libwx_gtk3u_html-3.1 inside ["/home/scrap/Documents/wxwidgets/build/x86_64-w64-mingw32-cxx11/9T5o3IfS/x86_64-w64-mingw32-libgfortran3-cxx11/destdir/bin"]
┌ Error: Built wxWidgets but libwx_gtk3u_html still unsatisfied:

```