### PR TITLE
[polymake] add patch for SIGCHLD conflicts with other packages

### DIFF
--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -54,6 +54,9 @@ atomic_patch -p1 ../patches/relocatable.patch
 # to unbreak ctrl+c in julia
 atomic_patch -p1 ../patches/sigint.patch
 
+# work around sigchld-handler conflicts with other libraries
+atomic_patch -p1 ../patches/sigchld.patch
+
 # fix bug in minkowski_sum_fukuda (until 4.5)
 atomic_patch -p1 ../patches/minkowski_sum.patch
 

--- a/P/polymake/bundled/patches/sigchld.patch
+++ b/P/polymake/bundled/patches/sigchld.patch
@@ -1,0 +1,13 @@
+diff --git a/perllib/Polymake/Core/CPlusPlusGenerator.pm b/perllib/Polymake/Core/CPlusPlusGenerator.pm
+index 5c6a9781c2..5651027e11 100644
+--- a/perllib/Polymake/Core/CPlusPlusGenerator.pm
++++ b/perllib/Polymake/Core/CPlusPlusGenerator.pm
+@@ -913,7 +913,7 @@ sub build_temp_shared_module {
+ 
+    warn_print( "Compiling temporary shared module, please be patient..." ) if $Verbose::cpp;
+ 
+-   if (system(($Verbose::cpp>1 && "cat $dir/$cpperl_filename.cpperl >&2; ") .
++   if (Interrupts::system(($Verbose::cpp>1 && "cat $dir/$cpperl_filename.cpperl >&2; ") .
+               "ninja -C $dir $so_name ".($Verbose::cpp ? ">&2" : ">/dev/null")." 2>$dir/err.log")) {
+       if ($Verbose::cpp) {
+          die "C++/perl Interface module compilation failed; see the generated code and the error log below.\n\n",


### PR DESCRIPTION
This fixes `No child processes` errors with some subprocesses when both Polymake.jl and GAP.jl are active.