### PR TITLE
add TinyXML

### DIFF
--- a/T/TinyXML/build_tarballs.jl
+++ b/T/TinyXML/build_tarballs.jl
@@ -1,0 +1,49 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "TinyXML"
+version = v"2.6.2"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://downloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz", "15bdfdcec58a7da30adc87ac2b078e4417dbe5392f3afb719f9ba6d062645593")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+
+cd $WORKSPACE/srcdir/tinyxml
+
+g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3   tinyxml.cpp -o tinyxml.o
+g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinyxmlparser.cpp -o tinyxmlparser.o
+g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 xmltest.cpp -o xmltest.o
+g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3   tinyxmlerror.cpp -o tinyxmlerror.o
+g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3   tinystr.cpp -o tinystr.o
+g++ -o xmltest tinyxml.o tinyxmlparser.o xmltest.o tinyxmlerror.o tinystr.o  
+
+mkdir -p ${bindir}
+cp xmltest ${bindir}
+
+install_license readme.txt
+
+mkdir -p ${includedir}
+cp *.h ${includedir}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("xmltest", :xmltest)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/T/TinyXML/build_tarballs.jl
+++ b/T/TinyXML/build_tarballs.jl
@@ -15,27 +15,28 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/tinyxml
 
-c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinyxml.cpp -o tinyxml.o
-c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinyxmlparser.cpp -o tinyxmlparser.o
-c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 xmltest.cpp -o xmltest.o
-c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinyxmlerror.cpp -o tinyxmlerror.o
-c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinystr.cpp -o tinystr.o
-mkdir -p "${bindir}"
-c++ -o "${bindir}/xmltest${exeext}" tinyxml.o tinyxmlparser.o xmltest.o tinyxmlerror.o tinystr.o  
-
-install_license readme.txt
+CPPFLAGS="-DTIXML_USE_STL"
+CXXFLAGS="-fPIC -Wall -Wno-unknown-pragmas -Wno-format -O3"
+c++ -c "${CPPFLAGS}" ${CXXFLAGS} tinyxml.cpp -o tinyxml.o
+c++ -c "${CPPFLAGS}" ${CXXFLAGS} tinyxmlparser.cpp -o tinyxmlparser.o
+c++ -c "${CPPFLAGS}" ${CXXFLAGS} tinyxmlerror.cpp -o tinyxmlerror.o
+c++ -c "${CPPFLAGS}" ${CXXFLAGS} tinystr.cpp -o tinystr.o
+mkdir -p "${libdir}"
+c++ -shared -o "${libdir}/libtinyxml.${dlext}" tinyxml.o tinyxmlparser.o tinyxmlerror.o tinystr.o
 
 mkdir -p "${includedir}"
 cp *.h "${includedir}/."
+
+install_license readme.txt
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("xmltest", :xmltest)
+    LibraryProduct("libtinyxml", :libtinyxml),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/T/TinyXML/build_tarballs.jl
+++ b/T/TinyXML/build_tarballs.jl
@@ -38,7 +38,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("xmltest", :xmltest)
+    FileProduct("bin/xmltest", :xmltest)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/T/TinyXML/build_tarballs.jl
+++ b/T/TinyXML/build_tarballs.jl
@@ -7,38 +7,35 @@ version = v"2.6.2"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://downloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz", "15bdfdcec58a7da30adc87ac2b078e4417dbe5392f3afb719f9ba6d062645593")
+    ArchiveSource("https://downloads.sourceforge.net/project/tinyxml/tinyxml/$(version)/tinyxml_$(version.major)_$(version.minor)_$(version.patch).tar.gz",
+                  "15bdfdcec58a7da30adc87ac2b078e4417dbe5392f3afb719f9ba6d062645593"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-
 cd $WORKSPACE/srcdir/tinyxml
 
-g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3   tinyxml.cpp -o tinyxml.o
-g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinyxmlparser.cpp -o tinyxmlparser.o
-g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 xmltest.cpp -o xmltest.o
-g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3   tinyxmlerror.cpp -o tinyxmlerror.o
-g++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3   tinystr.cpp -o tinystr.o
-g++ -o xmltest tinyxml.o tinyxmlparser.o xmltest.o tinyxmlerror.o tinystr.o  
-
-mkdir -p ${bindir}
-cp xmltest ${bindir}
+c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinyxml.cpp -o tinyxml.o
+c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinyxmlparser.cpp -o tinyxmlparser.o
+c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 xmltest.cpp -o xmltest.o
+c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinyxmlerror.cpp -o tinyxmlerror.o
+c++ -c -Wall -Wno-unknown-pragmas -Wno-format -O3 tinystr.cpp -o tinystr.o
+mkdir -p "${bindir}"
+c++ -o "${bindir}/xmltest${exeext}" tinyxml.o tinyxmlparser.o xmltest.o tinyxmlerror.o tinystr.o  
 
 install_license readme.txt
 
-mkdir -p ${includedir}
-cp *.h ${includedir}
+mkdir -p "${includedir}"
+cp *.h "${includedir}/."
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [
-    FileProduct("bin/xmltest", :xmltest)
+    ExecutableProduct("xmltest", :xmltest)
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
This PR adds a `build tarballs.jl` for [TinyXML](https://sourceforge.net/projects/tinyxml/). I would like to have this available as a dependency for another project. 

The project does come with a small `Makefile`, but it seemed simple enough to just skip it and write it in the bash commands.
I picked `supported_platforms()` somewhat arbitrarily, I didn't see anything weird so I thought it would be safe for everything. 