### PR TITLE
[yosys] loosen zlib compat

### DIFF
--- a/Y/Yosys/build_tarballs.jl
+++ b/Y/Yosys/build_tarballs.jl
@@ -14,7 +14,7 @@ dependencies = [
     Dependency("boost_jll"; compat="=1.76.0"), # max gcc7
     Dependency("Readline_jll"),
     Dependency("Tcl_jll"),
-    Dependency("Zlib_jll"; compat="1.2.12"),
+    Dependency("Zlib_jll"),
     Dependency("Libffi_jll"; compat="~3.2.2"),
 ]
 


### PR DESCRIPTION
It seems to be making the latest Yosys version impossible to install through Pkg.