### PR TITLE
Update libcleri recipe: manually make library executable on Windows

### DIFF
--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -21,6 +21,9 @@ make -C Release FN="libcleri.${dlext}" install INSTALL_PATH=${prefix}
 if [[ "${target}" == *-apple-* ]]; then
     install_name_tool -id @rpath/libcleri.dylib.0 ${prefix}/lib/libcleri.dylib
 fi
+if [[ "${target}" == *-mingw* ]]; then
+    chmod a+x ${prefix}/lib/libcleri.${dlext}
+fi
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
This was reported in https://github.com/libAtoms/ExtXYZ.jl/issues/6, and now shows up directly in the CI for ExtXYZ.jl, which tries and fails to import `libcleri.dll`  on Windows with an access error.

https://github.com/libAtoms/ExtXYZ.jl/runs/3351081827?check_suite_focus=true#step:6:58. 

The manual fix to add execute permissions to the built libraries should not be necessary since JuliaPackaging/BinaryBuilder.jl#992 has been merged, but somehow does seem to be.

