### PR TITLE
[yosyswrapper] init

### DIFF
--- a/Y/YosysWrapper/build_tarballs.jl
+++ b/Y/YosysWrapper/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+julia_version = v"1.6.0"
+
+name = "YosysWrapper"
+version = v"0.9.0"
+
+# Collection of sources required to complete build
+sources = [
+    DirectorySource("./src"),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Yosys_jll", compat="0.9.0"),
+    Dependency("libcxxwrap_julia_jll"),
+    BuildDependency(PackageSpec(name="libjulia_jll", version=julia_version)),
+]
+
+
+# Bash recipe for building across all platforms
+script = raw"""
+mkdir -p build
+cd build
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_FIND_ROOT_PATH=${prefix} \
+    -DJulia_PREFIX=${prefix} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+cmake --build . --config Release --target install -- -j${nproc}
+"""
+
+include("../../L/libjulia/common.jl")
+platforms = libjulia_platforms(julia_version)
+platforms = filter!(p -> Sys.islinux(p), platforms)
+platforms = expand_cxxstring_abis(platforms)
+# building for CXX03 string ABI doesn't work with boost
+filter!(x -> cxxstring_abi(x) != "cxx03", platforms)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libyosyswrapper", :libyosyswrapper),
+]
+
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"9")

--- a/Y/YosysWrapper/src/CMakeLists.txt
+++ b/Y/YosysWrapper/src/CMakeLists.txt
@@ -1,0 +1,36 @@
+project(YosysWrapper)
+
+cmake_minimum_required(VERSION 2.8.12)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
+include_directories(${INTERFACE_INCLUDE_DIRECTORIES})
+
+find_package(JlCxx)
+get_target_property(JlCxx_location JlCxx::cxxwrap_julia LOCATION)
+get_filename_component(JlCxx_location ${JlCxx_location} DIRECTORY)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${JlCxx_location}")
+
+message(STATUS "Found JlCxx at ${JlCxx_location}")
+
+find_library(LIBYOSYS yosys PATH_SUFFIXES yosys REQUIRED)
+
+message(STATUS "Found Yosys at ${LIBYOSYS}")
+
+add_library(yosyswrapper SHARED yosyswrapper.cpp)
+
+include_directories(${CMAKE_INSTALL_PREFIX}/share/yosys/include)
+
+target_link_libraries(yosyswrapper
+  JlCxx::cxxwrap_julia
+  ${LIBYOSYS}
+)
+
+add_definitions(-D_YOSYS_)
+
+install(TARGETS
+  yosyswrapper
+LIBRARY DESTINATION lib
+ARCHIVE DESTINATION lib
+RUNTIME DESTINATION lib)

--- a/Y/YosysWrapper/src/LICENSE
+++ b/Y/YosysWrapper/src/LICENSE
@@ -1,0 +1,22 @@
+The YosysWrapper is licensed under the MIT "Expat" License:
+
+> Copyright (c) 2021: Steve Kelly
+>
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+> CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+> SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Y/YosysWrapper/src/yosyswrapper.cpp
+++ b/Y/YosysWrapper/src/yosyswrapper.cpp
@@ -1,0 +1,12 @@
+#include "jlcxx/jlcxx.hpp"
+#include <kernel/yosys.h>
+
+JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
+{
+    mod.method("run_command", &Yosys::run_command);
+    mod.method("yosys_setup", &Yosys::yosys_setup);
+    //mod.method("yosys_already_setup", &Yosys::yosys_already_setup);
+    mod.method("yosys_shutdown", &Yosys::yosys_shutdown);
+    //mod.method("run_frontend", &Yosys::run_frontend);
+    //mod.method("run_backend", &Yosys::run_backend);
+}


### PR DESCRIPTION
This is a minimal wrapper for Yosys using CXXwrap. Locally this works fine on every architecture *except* x86_64. I hope CI can confirm this. 

Draft, since I would like to test locally with Yosys.jl before merge and creating a bunch more noise.