### PR TITLE
Remove constraint on macOS of `QuantumEspresso_jll`

### DIFF
--- a/Q/QuantumEspresso/build_tarballs.jl
+++ b/Q/QuantumEspresso/build_tarballs.jl
@@ -46,7 +46,6 @@ script = raw"""
 # platforms are passed in on the command line
 platforms = expand_gfortran_versions(supported_platforms())
 platforms = filter!(!Sys.iswindows, platforms)
-platforms = filter!(!Sys.isapple,   platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/Q/QuantumEspresso/build_tarballs.jl
+++ b/Q/QuantumEspresso/build_tarballs.jl
@@ -41,6 +41,8 @@ fi
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} ${flags[@]}
 make all "${make_args[@]}" -j $nproc
 make install
+# Manually make all binary executables...executable.  Sigh
+chmod +x "${bindir}"/*
 """
 
 # These are the platforms we will build for by default, unless further

--- a/Q/QuantumEspresso/build_tarballs.jl
+++ b/Q/QuantumEspresso/build_tarballs.jl
@@ -12,34 +12,35 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-    cd qe-*
-    atomic_patch -p1 ../patches/0000-pass-host-to-configure.patch
+cd qe-*
+atomic_patch -p1 ../patches/0000-pass-host-to-configure.patch
 
-    export BLAS_LIBS="-L${libdir} -lopenblas"
-    export LAPACK_LIBS="-L${libdir} -lopenblas"
-    export FFTW_INCLUDE=${includedir}
-    export FFT_LIBS="-L${libdir} -lfftw3"
-    export FC=mpif90
-    export CC=mpicc
+export BLAS_LIBS="-L${libdir} -lopenblas"
+export LAPACK_LIBS="-L${libdir} -lopenblas"
+export FFTW_INCLUDE=${includedir}
+export FFT_LIBS="-L${libdir} -lfftw3"
+export FC=mpif90
+export CC=mpicc
+export LD=
 
-    flags=(--enable-parallel=yes)
-    if [ "${nbits}" == 64 ]; then
-        # Enable Libxc support only on 64-bit platforms
-        atomic_patch -p1 ../patches/0001-libxc-prefix.patch
-        flags+=(--with-libxc=yes --with-libxc-prefix=${prefix})
-    fi
+flags=(--enable-parallel=yes)
+if [ "${nbits}" == 64 ]; then
+    # Enable Libxc support only on 64-bit platforms
+    atomic_patch -p1 ../patches/0001-libxc-prefix.patch
+    flags+=(--with-libxc=yes --with-libxc-prefix=${prefix})
+fi
 
-    if [[ "${target}" == powerpc64le-linux-gnu ]]; then
-        # No scalapack binary available on PowerPC
-        flags+=(--with-scalapack=no)
-    else
-        export SCALAPACK_LIBS="-L${libdir} -lscalapack"
-        flags+=(--with-scalapack=yes)
-    fi
+if [[ "${target}" == powerpc64le-linux-gnu ]]; then
+    # No scalapack binary available on PowerPC
+    flags+=(--with-scalapack=no)
+else
+    export SCALAPACK_LIBS="-L${libdir} -lscalapack"
+    flags+=(--with-scalapack=yes)
+fi
 
-    ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} ${flags[@]}
-    make all "${make_args[@]}" -j $nproc
-    make install
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} ${flags[@]}
+make all "${make_args[@]}" -j $nproc
+make install
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Can the restriction be removed for `QuantumEspresso` now since https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/156 was merged? I am no expert in building this, but I really need to install it on macOS. If so, please merge this.