### PR TITLE
add poly2tri

### DIFF
--- a/P/poly2tri/build_tarballs.jl
+++ b/P/poly2tri/build_tarballs.jl
@@ -1,0 +1,46 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "poly2tri"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/jhasse/poly2tri.git", "136fa7acfc95cf06a3488102f0cff039b7f3485c"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+
+cd $WORKSPACE/srcdir/poly2tri/
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/cmake-edits.patch
+
+cmake -GNinja . \
+-DCMAKE_INSTALL_PREFIX=${prefix} \
+-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+-DCMAKE_BUILD_TYPE=Release \
+-DP2T_BUILD_TESTS=OFF \
+-DP2T_BUILD_TESTBED=OFF
+
+cmake --build .
+ninja install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libpoly2tri", :libpoly2tri)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/P/poly2tri/build_tarballs.jl
+++ b/P/poly2tri/build_tarballs.jl
@@ -26,13 +26,12 @@ cmake -GNinja . \
 -DP2T_BUILD_TESTBED=OFF
 
 cmake --build .
-ninja install
-
+ninja -j${nproc} install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms())
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
 
 # The products that we will ensure are always built
 products = [

--- a/P/poly2tri/bundled/patches/cmake-edits.patch
+++ b/P/poly2tri/bundled/patches/cmake-edits.patch
@@ -1,0 +1,20 @@
+diff --git before/CMakeLists.txt after/CMakeLists.txt
+index 50d6e31..0961a45 100644
+--- before/CMakeLists.txt
++++ after/CMakeLists.txt
+@@ -8,7 +8,7 @@ option(P2T_BUILD_TESTBED "Build the testbed application" OFF)
+ 
+ file(GLOB SOURCES poly2tri/common/*.cc poly2tri/sweep/*.cc)
+ file(GLOB HEADERS poly2tri/*.h poly2tri/common/*.h poly2tri/sweep/*.h)
+-add_library(poly2tri ${SOURCES} ${HEADERS})
++add_library(poly2tri SHARED ${SOURCES} ${HEADERS})
+ target_include_directories(poly2tri INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+ 
+ if(P2T_BUILD_TESTS)
+@@ -19,3 +19,6 @@ endif()
+ if(P2T_BUILD_TESTBED)
+     add_subdirectory(testbed)
+ endif()
++
++install(FILES ${HEADERS} DESTINATION include)
++install(TARGETS poly2tri DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [poly2tri](https://github.com/jhasse/poly2tri) library.
They don't have any tagged releases on the GitHub page, so this builds from the most recent commit on master.

Tested locally on the usual platforms with no issues