### PR TITLE
[LLVM_full] Include libunwind on 11.0.1 and 12.0.1

### DIFF
--- a/L/LLVM/LLVM_full@11.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@11.0.1/build_tarballs.jl
@@ -2,5 +2,6 @@ version = v"11.0.1"
 
 include("../common.jl")
 
+# Go forth and build
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"7", preferred_llvm_version=v"8", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@11.0.1/bundled/patches/0801-unwind-prologue-epilogue.patch
+++ b/L/LLVM/LLVM_full@11.0.1/bundled/patches/0801-unwind-prologue-epilogue.patch
@@ -1,0 +1,183 @@
+An updated version of this libosxunwind commit:
+
+commit ca57a5b60de4cd1daa42ed2e5d1d4aa3e96a09d1
+Author: Keno Fischer <kfischer@college.harvard.edu>
+Date:   Mon Aug 26 15:28:08 2013 -0400
+
+    Add support for unwinding during prologue/epilogue
+
+---
+diff --git a/libunwind/src/CompactUnwinder.hpp b/libunwind/src/CompactUnwinder.hpp
+index 1c3175dff50a..78a658ccbc27 100644
+--- a/libunwind/src/CompactUnwinder.hpp
++++ b/libunwind/src/CompactUnwinder.hpp
+@@ -310,6 +310,50 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingRBPFrame(
+   uint32_t savedRegistersLocations =
+       EXTRACT_BITS(compactEncoding, UNWIND_X86_64_RBP_FRAME_REGISTERS);
+ 
++  // If we have not stored EBP yet
++  if (functionStart == registers.getIP()) {
++    uint64_t rsp = registers.getSP();
++    // old esp is ebp less return address
++    registers.setSP(rsp+8);
++    // pop return address into eip
++    registers.setIP(addressSpace.get64(rsp));
++
++    return UNW_STEP_SUCCESS;
++  } else if (functionStart + 1 == registers.getIP()) {
++    uint64_t rsp = registers.getSP();
++    // old esp is ebp less return address
++    registers.setSP(rsp + 16);
++    // pop return address into eip
++    registers.setIP(addressSpace.get64(rsp + 8));
++
++    return UNW_STEP_SUCCESS;
++  }
++
++  // If we're about to return, we've already popped the base pointer
++  uint8_t b = addressSpace.get8(registers.getIP());
++
++  // This is a hack to detect VZEROUPPER but in between popq rbp and ret
++  // It's not pretty but it works
++  if (b == 0xC5) {
++    if ((b = addressSpace.get8(registers.getIP() + 1)) == 0xF8 &&
++        (b = addressSpace.get8(registers.getIP() + 2)) == 0x77)
++      b = addressSpace.get8(registers.getIP() + 3);
++    else
++      goto skip_ret;
++  }
++
++  if (b == 0xC3 || b == 0xCB || b == 0xC2 || b == 0xCA) {
++    uint64_t rbp = registers.getSP();
++    // old esp is ebp less return address
++    registers.setSP(rbp + 16);
++    // pop return address into eip
++    registers.setIP(addressSpace.get64(rbp + 8));
++
++    return UNW_STEP_SUCCESS;
++  }
++
++  skip_ret:
++
+   uint64_t savedRegisters = registers.getRBP() - 8 * savedRegistersOffset;
+   for (int i = 0; i < 5; ++i) {
+     switch (savedRegistersLocations & 0x7) {
+@@ -430,6 +474,118 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingFrameless(
+       }
+     }
+   }
++
++  // Note that the order of these registers is so that
++  // registersSaved[0] is the one that will be pushed onto the stack last.
++  // Thus, if we want to walk this from the top, we need to go in reverse.
++  assert(regCount <= 6);
++
++  // check whether we are still in the prologue
++  uint64_t curAddr = functionStart;
++  if (regCount > 0) {
++    for (int8_t i = (int8_t)(regCount) - 1; i >= 0; --i) {
++      if (registers.getIP() == curAddr) {
++        // None of the registers have been modified yet, so we don't need to reload them
++        framelessUnwind(addressSpace, registers.getSP() + 8 * (regCount - (uint64_t)(i + 1)), registers);
++        return UNW_STEP_SUCCESS;
++      } else {
++        assert(curAddr < registers.getIP());
++      }
++
++
++      // pushq %rbp and pushq %rbx is 1 byte. Everything else 2
++      if ((UNWIND_X86_64_REG_RBP == registersSaved[i]) ||
++          (UNWIND_X86_64_REG_RBX == registersSaved[i]))
++        curAddr += 1;
++      else
++        curAddr += 2;
++    }
++  }
++  if (registers.getIP() == curAddr) {
++    // None of the registers have been modified yet, so we don't need to reload them
++    framelessUnwind(addressSpace, registers.getSP() + 8*regCount, registers);
++    return UNW_STEP_SUCCESS;
++  } else {
++    assert(curAddr < registers.getIP());
++  }
++
++
++  // And now for the epilogue
++  {
++    uint8_t  i  = 0;
++    uint64_t p  = registers.getIP();
++    uint8_t  b  = 0;
++
++    while (true) {
++      b = addressSpace.get8(p++);
++      // This is a hack to detect VZEROUPPER but in between the popq's and ret
++      // It's not pretty but it works
++      if (b == 0xC5) {
++        if ((b = addressSpace.get8(p++)) == 0xF8 && (b = addressSpace.get8(p++)) == 0x77)
++          b = addressSpace.get8(p++);
++        else
++          break;
++      }
++      //  popq %rbx    popq %rbp
++      if (b == 0x5B || b == 0x5D) {
++        i++;
++      } else if (b == 0x41) {
++        b = addressSpace.get8(p++);
++        if (b == 0x5C || b == 0x5D || b == 0x5E || b == 0x5F)
++          i++;
++        else
++          break;
++      } else if (b == 0xC3 || b == 0xCB || b == 0xC2 || b == 0xCA) {
++        // i pop's haven't happened yet
++        uint64_t savedRegisters = registers.getSP() + 8 * i;
++        if (regCount > 0) {
++          for (int8_t j = (int8_t)(regCount) - 1; j >= (int8_t)(regCount) - i; --j) {
++            uint64_t addr = savedRegisters - 8 * (regCount - (uint64_t)(j));
++            switch (registersSaved[j]) {
++              case UNWIND_X86_64_REG_RBX:
++                registers.setRBX(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_R12:
++                registers.setR12(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_R13:
++                registers.setR13(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_R14:
++                registers.setR14(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_R15:
++                registers.setR15(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_RBP:
++                registers.setRBP(addressSpace.get64(addr));
++                break;
++              default:
++                _LIBUNWIND_DEBUG_LOG("bad register for frameless, encoding=%08X for "
++                             "function starting at 0x%llX",
++                              encoding, functionStart);
++                _LIBUNWIND_ABORT("invalid compact unwind encoding");
++            }
++          }
++        }
++        framelessUnwind(addressSpace, savedRegisters, registers);
++        return UNW_STEP_SUCCESS;
++      } else {
++        break;
++      }
++    }
++  }
++
++  /*
++   0x10fe2733a:  5b                             popq   %rbx
++   0x10fe2733b:  41 5c                          popq   %r12
++   0x10fe2733d:  41 5d                          popq   %r13
++   0x10fe2733f:  41 5e                          popq   %r14
++   0x10fe27341:  41 5f                          popq   %r15
++   0x10fe27343:  5d                             popq   %rbp
++   */
++
++
+   uint64_t savedRegisters = registers.getSP() + stackSize - 8 - 8 * regCount;
+   for (uint32_t i = 0; i < regCount; ++i) {
+     switch (registersSaved[i]) {

--- a/L/LLVM/LLVM_full@11.0.1/bundled/patches/0802-force-dwarf.patch
+++ b/L/LLVM/LLVM_full@11.0.1/bundled/patches/0802-force-dwarf.patch
@@ -1,0 +1,181 @@
+An updated version of this libosxunwind commit:
+
+Author: Keno Fischer <kfischer@college.harvard.edu>
+Date:   Tue Aug 27 15:01:22 2013 -0400
+
+    Add option to step with DWARF
+
+---
+diff --git a/libunwind/include/libunwind.h b/libunwind/include/libunwind.h
+index 23ef47f4ac83..ea6c5cb86438 100644
+--- a/libunwind/include/libunwind.h
++++ b/libunwind/include/libunwind.h
+@@ -102,6 +102,7 @@ extern "C" {
+ 
+ extern int unw_getcontext(unw_context_t *) LIBUNWIND_AVAIL;
+ extern int unw_init_local(unw_cursor_t *, unw_context_t *) LIBUNWIND_AVAIL;
++extern int unw_init_local_dwarf(unw_cursor_t *, unw_context_t *) LIBUNWIND_AVAIL;
+ extern int unw_step(unw_cursor_t *) LIBUNWIND_AVAIL;
+ extern int unw_get_reg(unw_cursor_t *, unw_regnum_t, unw_word_t *) LIBUNWIND_AVAIL;
+ extern int unw_get_fpreg(unw_cursor_t *, unw_regnum_t, unw_fpreg_t *) LIBUNWIND_AVAIL;
+diff --git a/libunwind/src/UnwindCursor.hpp b/libunwind/src/UnwindCursor.hpp
+index f346c720d22c..e44f22a91513 100644
+--- a/libunwind/src/UnwindCursor.hpp
++++ b/libunwind/src/UnwindCursor.hpp
+@@ -436,6 +436,9 @@ public:
+   virtual bool isSignalFrame() {
+     _LIBUNWIND_ABORT("isSignalFrame not implemented");
+   }
++  virtual void setForceDWARF(bool) {
++    _LIBUNWIND_ABORT("setForceDWARF not implemented");
++  }
+   virtual bool getFunctionName(char *, size_t, unw_word_t *) {
+     _LIBUNWIND_ABORT("getFunctionName not implemented");
+   }
+@@ -891,6 +894,7 @@ public:
+   virtual void        getInfo(unw_proc_info_t *);
+   virtual void        jumpto();
+   virtual bool        isSignalFrame();
++  virtual void        setForceDWARF(bool force);
+   virtual bool        getFunctionName(char *buf, size_t len, unw_word_t *off);
+   virtual void        setInfoBasedOnIPRegister(bool isReturnAddress = false);
+   virtual const char *getRegisterName(int num);
+@@ -938,7 +942,7 @@ private:
+                                             const UnwindInfoSections &sects);
+   int stepWithCompactEncoding() {
+   #if defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
+-    if ( compactSaysUseDwarf() )
++    if ( _forceDwarf || compactSaysUseDwarf() )
+       return stepWithDwarfFDE();
+   #endif
+     R dummy;
+@@ -1173,13 +1177,14 @@ private:
+   unw_proc_info_t  _info;
+   bool             _unwindInfoMissing;
+   bool             _isSignalFrame;
++  bool             _forceDwarf;
+ };
+ 
+ 
+ template <typename A, typename R>
+ UnwindCursor<A, R>::UnwindCursor(unw_context_t *context, A &as)
+     : _addressSpace(as), _registers(context), _unwindInfoMissing(false),
+-      _isSignalFrame(false) {
++      _isSignalFrame(false), _forceDwarf(false) {
+   static_assert((check_fit<UnwindCursor<A, R>, unw_cursor_t>::does_fit),
+                 "UnwindCursor<> does not fit in unw_cursor_t");
+   memset(&_info, 0, sizeof(_info));
+@@ -1187,7 +1192,8 @@ UnwindCursor<A, R>::UnwindCursor(unw_context_t *context, A &as)
+ 
+ template <typename A, typename R>
+ UnwindCursor<A, R>::UnwindCursor(A &as, void *)
+-    : _addressSpace(as), _unwindInfoMissing(false), _isSignalFrame(false) {
++    : _addressSpace(as), _unwindInfoMissing(false), _isSignalFrame(false),
++    _forceDwarf(false) {
+   memset(&_info, 0, sizeof(_info));
+   // FIXME
+   // fill in _registers from thread arg
+@@ -1243,6 +1249,10 @@ template <typename A, typename R> bool UnwindCursor<A, R>::isSignalFrame() {
+   return _isSignalFrame;
+ }
+ 
++template <typename A, typename R> void UnwindCursor<A, R>::setForceDWARF(bool force) {
++  _forceDwarf = force;
++}
++
+ #endif // defined(_LIBUNWIND_SUPPORT_SEH_UNWIND)
+ 
+ #if defined(_LIBUNWIND_ARM_EHABI)
+@@ -1895,7 +1905,13 @@ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
+         // record that we have no unwind info.
+         if (_info.format == 0)
+           _unwindInfoMissing = true;
++  #if defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
++        if (!(_forceDwarf || compactSaysUseDwarf(&dwarfOffset)))
++          return;
++  #else
+         return;
++  #endif
++
+       }
+     }
+ #endif // defined(_LIBUNWIND_SUPPORT_COMPACT_UNWIND)
+diff --git a/libunwind/src/libunwind.cpp b/libunwind/src/libunwind.cpp
+index fd079da30895..206afcbbaf78 100644
+--- a/libunwind/src/libunwind.cpp
++++ b/libunwind/src/libunwind.cpp
+@@ -69,6 +69,7 @@ _LIBUNWIND_HIDDEN int __unw_init_local(unw_cursor_t *cursor,
+   new (reinterpret_cast<UnwindCursor<LocalAddressSpace, REGISTER_KIND> *>(cursor))
+       UnwindCursor<LocalAddressSpace, REGISTER_KIND>(
+           context, LocalAddressSpace::sThisAddressSpace);
++  static_assert(sizeof(unw_cursor_t) >= sizeof(UnwindCursor<LocalAddressSpace,REGISTER_KIND>), "libunwind header outdated");
+ #undef REGISTER_KIND
+   AbstractUnwindCursor *co = (AbstractUnwindCursor *)cursor;
+   co->setInfoBasedOnIPRegister();
+@@ -77,6 +78,54 @@ _LIBUNWIND_HIDDEN int __unw_init_local(unw_cursor_t *cursor,
+ }
+ _LIBUNWIND_WEAK_ALIAS(__unw_init_local, unw_init_local)
+ 
++_LIBUNWIND_HIDDEN int __unw_init_local_dwarf(unw_cursor_t *cursor,
++                                       unw_context_t *context) {
++  _LIBUNWIND_TRACE_API("__unw_init_local_dwarf(cursor=%p, context=%p)",
++                       static_cast<void *>(cursor),
++                       static_cast<void *>(context));
++#if defined(__i386__)
++# define REGISTER_KIND Registers_x86
++#elif defined(__x86_64__)
++# define REGISTER_KIND Registers_x86_64
++#elif defined(__powerpc64__)
++# define REGISTER_KIND Registers_ppc64
++#elif defined(__ppc__)
++# define REGISTER_KIND Registers_ppc
++#elif defined(__aarch64__)
++# define REGISTER_KIND Registers_arm64
++#elif defined(__arm__)
++# define REGISTER_KIND Registers_arm
++#elif defined(__or1k__)
++# define REGISTER_KIND Registers_or1k
++#elif defined(__hexagon__)
++# define REGISTER_KIND Registers_hexagon
++#elif defined(__mips__) && defined(_ABIO32) && _MIPS_SIM == _ABIO32
++# define REGISTER_KIND Registers_mips_o32
++#elif defined(__mips64)
++# define REGISTER_KIND Registers_mips_newabi
++#elif defined(__mips__)
++# warning The MIPS architecture is not supported with this ABI and environment!
++#elif defined(__sparc__)
++# define REGISTER_KIND Registers_sparc
++#elif defined(__riscv) && __riscv_xlen == 64
++# define REGISTER_KIND Registers_riscv
++#else
++# error Architecture not supported
++#endif
++  // Use "placement new" to allocate UnwindCursor in the cursor buffer.
++  new (reinterpret_cast<UnwindCursor<LocalAddressSpace, REGISTER_KIND> *>(cursor))
++      UnwindCursor<LocalAddressSpace, REGISTER_KIND>(
++          context, LocalAddressSpace::sThisAddressSpace);
++  static_assert(sizeof(unw_cursor_t) >= sizeof(UnwindCursor<LocalAddressSpace,REGISTER_KIND>), "libunwind header outdated");
++#undef REGISTER_KIND
++  AbstractUnwindCursor *co = (AbstractUnwindCursor *)cursor;
++  co->setForceDWARF(true);
++  co->setInfoBasedOnIPRegister();
++
++  return UNW_ESUCCESS;
++}
++_LIBUNWIND_WEAK_ALIAS(__unw_init_local_dwarf, unw_init_local_dwarf)
++
+ /// Get value of specified register at cursor position in stack frame.
+ _LIBUNWIND_HIDDEN int __unw_get_reg(unw_cursor_t *cursor, unw_regnum_t regNum,
+                                     unw_word_t *value) {
+diff --git a/libunwind/src/libunwind_ext.h b/libunwind/src/libunwind_ext.h
+index 316dee298246..5b9f7e2f56cd 100644
+--- a/libunwind/src/libunwind_ext.h
++++ b/libunwind/src/libunwind_ext.h
+@@ -25,6 +25,7 @@ extern "C" {
+ 
+ extern int __unw_getcontext(unw_context_t *);
+ extern int __unw_init_local(unw_cursor_t *, unw_context_t *);
++extern int __unw_init_local_dwarf(unw_cursor_t *, unw_context_t *);
+ extern int __unw_step(unw_cursor_t *);
+ extern int __unw_get_reg(unw_cursor_t *, unw_regnum_t, unw_word_t *);
+ extern int __unw_get_fpreg(unw_cursor_t *, unw_regnum_t, unw_fpreg_t *);

--- a/L/LLVM/LLVM_full@12.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@12.0.1/build_tarballs.jl
@@ -2,5 +2,6 @@ version = v"12.0.1"
 
 include("../common.jl")
 
+# Go forth and build
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.7")

--- a/L/LLVM/LLVM_full@12.0.1/bundled/patches/0801-unwind-prologue-epilogue.patch
+++ b/L/LLVM/LLVM_full@12.0.1/bundled/patches/0801-unwind-prologue-epilogue.patch
@@ -1,0 +1,183 @@
+An updated version of this libosxunwind commit:
+
+commit ca57a5b60de4cd1daa42ed2e5d1d4aa3e96a09d1
+Author: Keno Fischer <kfischer@college.harvard.edu>
+Date:   Mon Aug 26 15:28:08 2013 -0400
+
+    Add support for unwinding during prologue/epilogue
+
+---
+diff --git a/libunwind/src/CompactUnwinder.hpp b/libunwind/src/CompactUnwinder.hpp
+index 1c3175dff50a..78a658ccbc27 100644
+--- a/libunwind/src/CompactUnwinder.hpp
++++ b/libunwind/src/CompactUnwinder.hpp
+@@ -310,6 +310,50 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingRBPFrame(
+   uint32_t savedRegistersLocations =
+       EXTRACT_BITS(compactEncoding, UNWIND_X86_64_RBP_FRAME_REGISTERS);
+ 
++  // If we have not stored EBP yet
++  if (functionStart == registers.getIP()) {
++    uint64_t rsp = registers.getSP();
++    // old esp is ebp less return address
++    registers.setSP(rsp+8);
++    // pop return address into eip
++    registers.setIP(addressSpace.get64(rsp));
++
++    return UNW_STEP_SUCCESS;
++  } else if (functionStart + 1 == registers.getIP()) {
++    uint64_t rsp = registers.getSP();
++    // old esp is ebp less return address
++    registers.setSP(rsp + 16);
++    // pop return address into eip
++    registers.setIP(addressSpace.get64(rsp + 8));
++
++    return UNW_STEP_SUCCESS;
++  }
++
++  // If we're about to return, we've already popped the base pointer
++  uint8_t b = addressSpace.get8(registers.getIP());
++
++  // This is a hack to detect VZEROUPPER but in between popq rbp and ret
++  // It's not pretty but it works
++  if (b == 0xC5) {
++    if ((b = addressSpace.get8(registers.getIP() + 1)) == 0xF8 &&
++        (b = addressSpace.get8(registers.getIP() + 2)) == 0x77)
++      b = addressSpace.get8(registers.getIP() + 3);
++    else
++      goto skip_ret;
++  }
++
++  if (b == 0xC3 || b == 0xCB || b == 0xC2 || b == 0xCA) {
++    uint64_t rbp = registers.getSP();
++    // old esp is ebp less return address
++    registers.setSP(rbp + 16);
++    // pop return address into eip
++    registers.setIP(addressSpace.get64(rbp + 8));
++
++    return UNW_STEP_SUCCESS;
++  }
++
++  skip_ret:
++
+   uint64_t savedRegisters = registers.getRBP() - 8 * savedRegistersOffset;
+   for (int i = 0; i < 5; ++i) {
+     switch (savedRegistersLocations & 0x7) {
+@@ -430,6 +474,118 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingFrameless(
+       }
+     }
+   }
++
++  // Note that the order of these registers is so that
++  // registersSaved[0] is the one that will be pushed onto the stack last.
++  // Thus, if we want to walk this from the top, we need to go in reverse.
++  assert(regCount <= 6);
++
++  // check whether we are still in the prologue
++  uint64_t curAddr = functionStart;
++  if (regCount > 0) {
++    for (int8_t i = (int8_t)(regCount) - 1; i >= 0; --i) {
++      if (registers.getIP() == curAddr) {
++        // None of the registers have been modified yet, so we don't need to reload them
++        framelessUnwind(addressSpace, registers.getSP() + 8 * (regCount - (uint64_t)(i + 1)), registers);
++        return UNW_STEP_SUCCESS;
++      } else {
++        assert(curAddr < registers.getIP());
++      }
++
++
++      // pushq %rbp and pushq %rbx is 1 byte. Everything else 2
++      if ((UNWIND_X86_64_REG_RBP == registersSaved[i]) ||
++          (UNWIND_X86_64_REG_RBX == registersSaved[i]))
++        curAddr += 1;
++      else
++        curAddr += 2;
++    }
++  }
++  if (registers.getIP() == curAddr) {
++    // None of the registers have been modified yet, so we don't need to reload them
++    framelessUnwind(addressSpace, registers.getSP() + 8*regCount, registers);
++    return UNW_STEP_SUCCESS;
++  } else {
++    assert(curAddr < registers.getIP());
++  }
++
++
++  // And now for the epilogue
++  {
++    uint8_t  i  = 0;
++    uint64_t p  = registers.getIP();
++    uint8_t  b  = 0;
++
++    while (true) {
++      b = addressSpace.get8(p++);
++      // This is a hack to detect VZEROUPPER but in between the popq's and ret
++      // It's not pretty but it works
++      if (b == 0xC5) {
++        if ((b = addressSpace.get8(p++)) == 0xF8 && (b = addressSpace.get8(p++)) == 0x77)
++          b = addressSpace.get8(p++);
++        else
++          break;
++      }
++      //  popq %rbx    popq %rbp
++      if (b == 0x5B || b == 0x5D) {
++        i++;
++      } else if (b == 0x41) {
++        b = addressSpace.get8(p++);
++        if (b == 0x5C || b == 0x5D || b == 0x5E || b == 0x5F)
++          i++;
++        else
++          break;
++      } else if (b == 0xC3 || b == 0xCB || b == 0xC2 || b == 0xCA) {
++        // i pop's haven't happened yet
++        uint64_t savedRegisters = registers.getSP() + 8 * i;
++        if (regCount > 0) {
++          for (int8_t j = (int8_t)(regCount) - 1; j >= (int8_t)(regCount) - i; --j) {
++            uint64_t addr = savedRegisters - 8 * (regCount - (uint64_t)(j));
++            switch (registersSaved[j]) {
++              case UNWIND_X86_64_REG_RBX:
++                registers.setRBX(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_R12:
++                registers.setR12(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_R13:
++                registers.setR13(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_R14:
++                registers.setR14(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_R15:
++                registers.setR15(addressSpace.get64(addr));
++                break;
++              case UNWIND_X86_64_REG_RBP:
++                registers.setRBP(addressSpace.get64(addr));
++                break;
++              default:
++                _LIBUNWIND_DEBUG_LOG("bad register for frameless, encoding=%08X for "
++                             "function starting at 0x%llX",
++                              encoding, functionStart);
++                _LIBUNWIND_ABORT("invalid compact unwind encoding");
++            }
++          }
++        }
++        framelessUnwind(addressSpace, savedRegisters, registers);
++        return UNW_STEP_SUCCESS;
++      } else {
++        break;
++      }
++    }
++  }
++
++  /*
++   0x10fe2733a:  5b                             popq   %rbx
++   0x10fe2733b:  41 5c                          popq   %r12
++   0x10fe2733d:  41 5d                          popq   %r13
++   0x10fe2733f:  41 5e                          popq   %r14
++   0x10fe27341:  41 5f                          popq   %r15
++   0x10fe27343:  5d                             popq   %rbp
++   */
++
++
+   uint64_t savedRegisters = registers.getSP() + stackSize - 8 - 8 * regCount;
+   for (uint32_t i = 0; i < regCount; ++i) {
+     switch (registersSaved[i]) {

--- a/L/LLVM/LLVM_full@12.0.1/bundled/patches/0802-force-dwarf.patch
+++ b/L/LLVM/LLVM_full@12.0.1/bundled/patches/0802-force-dwarf.patch
@@ -1,0 +1,180 @@
+An updated version of this libosxunwind commit:
+
+Author: Keno Fischer <kfischer@college.harvard.edu>
+Date:   Tue Aug 27 15:01:22 2013 -0400
+
+    Add option to step with DWARF
+
+---
+diff --git a/libunwind/include/libunwind.h b/libunwind/include/libunwind.h
+index 5bae8d0..dac4095 100644
+--- a/libunwind/include/libunwind.h
++++ b/libunwind/include/libunwind.h
+@@ -108,6 +108,7 @@ extern "C" {
+
+ extern int unw_getcontext(unw_context_t *) LIBUNWIND_AVAIL;
+ extern int unw_init_local(unw_cursor_t *, unw_context_t *) LIBUNWIND_AVAIL;
++extern int unw_init_local_dwarf(unw_cursor_t *, unw_context_t *) LIBUNWIND_AVAIL;
+ extern int unw_step(unw_cursor_t *) LIBUNWIND_AVAIL;
+ extern int unw_get_reg(unw_cursor_t *, unw_regnum_t, unw_word_t *) LIBUNWIND_AVAIL;
+ extern int unw_get_fpreg(unw_cursor_t *, unw_regnum_t, unw_fpreg_t *) LIBUNWIND_AVAIL;
+diff --git a/libunwind/src/UnwindCursor.hpp b/libunwind/src/UnwindCursor.hpp
+index e537ed8..b009558 100644
+--- a/libunwind/src/UnwindCursor.hpp
++++ b/libunwind/src/UnwindCursor.hpp
+@@ -437,6 +437,9 @@ public:
+   virtual bool isSignalFrame() {
+     _LIBUNWIND_ABORT("isSignalFrame not implemented");
+   }
++  virtual void setForceDWARF(bool) {
++    _LIBUNWIND_ABORT("setForceDWARF not implemented");
++  }
+   virtual bool getFunctionName(char *, size_t, unw_word_t *) {
+     _LIBUNWIND_ABORT("getFunctionName not implemented");
+   }
+@@ -894,6 +897,7 @@ public:
+   virtual void        getInfo(unw_proc_info_t *);
+   virtual void        jumpto();
+   virtual bool        isSignalFrame();
++  virtual void        setForceDWARF(bool force);
+   virtual bool        getFunctionName(char *buf, size_t len, unw_word_t *off);
+   virtual void        setInfoBasedOnIPRegister(bool isReturnAddress = false);
+   virtual const char *getRegisterName(int num);
+@@ -963,7 +967,7 @@ private:
+                                             const UnwindInfoSections &sects);
+   int stepWithCompactEncoding() {
+   #if defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
+-    if ( compactSaysUseDwarf() )
++    if ( _forceDwarf || compactSaysUseDwarf() )
+       return stepWithDwarfFDE();
+   #endif
+     R dummy;
+@@ -1201,13 +1205,14 @@ private:
+ #if defined(_LIBUNWIND_TARGET_LINUX) && defined(_LIBUNWIND_TARGET_AARCH64)
+   bool             _isSigReturn = false;
+ #endif
++  bool             _forceDwarf;
+ };
+
+
+ template <typename A, typename R>
+ UnwindCursor<A, R>::UnwindCursor(unw_context_t *context, A &as)
+     : _addressSpace(as), _registers(context), _unwindInfoMissing(false),
+-      _isSignalFrame(false) {
++      _isSignalFrame(false), _forceDwarf(false) {
+   static_assert((check_fit<UnwindCursor<A, R>, unw_cursor_t>::does_fit),
+                 "UnwindCursor<> does not fit in unw_cursor_t");
+   static_assert((alignof(UnwindCursor<A, R>) <= alignof(unw_cursor_t)),
+@@ -1217,7 +1222,8 @@ UnwindCursor<A, R>::UnwindCursor(unw_context_t *context, A &as)
+
+ template <typename A, typename R>
+ UnwindCursor<A, R>::UnwindCursor(A &as, void *)
+-    : _addressSpace(as), _unwindInfoMissing(false), _isSignalFrame(false) {
++    : _addressSpace(as), _unwindInfoMissing(false), _isSignalFrame(false),
++    _forceDwarf(false) {
+   memset(&_info, 0, sizeof(_info));
+   // FIXME
+   // fill in _registers from thread arg
+@@ -1273,6 +1279,10 @@ template <typename A, typename R> bool UnwindCursor<A, R>::isSignalFrame() {
+   return _isSignalFrame;
+ }
+
++template <typename A, typename R> void UnwindCursor<A, R>::setForceDWARF(bool force) {
++  _forceDwarf = force;
++}
++
+ #endif // defined(_LIBUNWIND_SUPPORT_SEH_UNWIND)
+ 
+ #if defined(_LIBUNWIND_ARM_EHABI)
+@@ -1941,7 +1951,12 @@ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
+         // record that we have no unwind info.
+         if (_info.format == 0)
+           _unwindInfoMissing = true;
++  #if defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
++        if (!(_forceDwarf || compactSaysUseDwarf(&dwarfOffset)))
++          return;
++  #else
+         return;
++  #endif
+       }
+     }
+ #endif // defined(_LIBUNWIND_SUPPORT_COMPACT_UNWIND)
+diff --git a/libunwind/src/libunwind.cpp b/libunwind/src/libunwind.cpp
+index c21461b..3e17573 100644
+--- a/libunwind/src/libunwind.cpp
++++ b/libunwind/src/libunwind.cpp
+@@ -71,6 +71,7 @@ _LIBUNWIND_HIDDEN int __unw_init_local(unw_cursor_t *cursor,
+   new (reinterpret_cast<UnwindCursor<LocalAddressSpace, REGISTER_KIND> *>(cursor))
+       UnwindCursor<LocalAddressSpace, REGISTER_KIND>(
+           context, LocalAddressSpace::sThisAddressSpace);
++  static_assert(sizeof(unw_cursor_t) >= sizeof(UnwindCursor<LocalAddressSpace,REGISTER_KIND>), "libunwind header outdated");
+ #undef REGISTER_KIND
+   AbstractUnwindCursor *co = (AbstractUnwindCursor *)cursor;
+   co->setInfoBasedOnIPRegister();
+@@ -94,6 +95,54 @@ _LIBUNWIND_HIDDEN int __unw_get_reg(unw_cursor_t *cursor, unw_regnum_t regNum,
+ }
+ _LIBUNWIND_WEAK_ALIAS(__unw_get_reg, unw_get_reg)
+
++_LIBUNWIND_HIDDEN int __unw_init_local_dwarf(unw_cursor_t *cursor,
++                                       unw_context_t *context) {
++  _LIBUNWIND_TRACE_API("__unw_init_local_dwarf(cursor=%p, context=%p)",
++                       static_cast<void *>(cursor),
++                       static_cast<void *>(context));
++#if defined(__i386__)
++# define REGISTER_KIND Registers_x86
++#elif defined(__x86_64__)
++# define REGISTER_KIND Registers_x86_64
++#elif defined(__powerpc64__)
++# define REGISTER_KIND Registers_ppc64
++#elif defined(__ppc__)
++# define REGISTER_KIND Registers_ppc
++#elif defined(__aarch64__)
++# define REGISTER_KIND Registers_arm64
++#elif defined(__arm__)
++# define REGISTER_KIND Registers_arm
++#elif defined(__or1k__)
++# define REGISTER_KIND Registers_or1k
++#elif defined(__hexagon__)
++# define REGISTER_KIND Registers_hexagon
++#elif defined(__mips__) && defined(_ABIO32) && _MIPS_SIM == _ABIO32
++# define REGISTER_KIND Registers_mips_o32
++#elif defined(__mips64)
++# define REGISTER_KIND Registers_mips_newabi
++#elif defined(__mips__)
++# warning The MIPS architecture is not supported with this ABI and environment!
++#elif defined(__sparc__)
++# define REGISTER_KIND Registers_sparc
++#elif defined(__riscv) && __riscv_xlen == 64
++# define REGISTER_KIND Registers_riscv
++#else
++# error Architecture not supported
++#endif
++  // Use "placement new" to allocate UnwindCursor in the cursor buffer.
++  new (reinterpret_cast<UnwindCursor<LocalAddressSpace, REGISTER_KIND> *>(cursor))
++      UnwindCursor<LocalAddressSpace, REGISTER_KIND>(
++          context, LocalAddressSpace::sThisAddressSpace);
++  static_assert(sizeof(unw_cursor_t) >= sizeof(UnwindCursor<LocalAddressSpace,REGISTER_KIND>), "libunwind header outdated");
++#undef REGISTER_KIND
++  AbstractUnwindCursor *co = (AbstractUnwindCursor *)cursor;
++  co->setForceDWARF(true);
++  co->setInfoBasedOnIPRegister();
++
++  return UNW_ESUCCESS;
++}
++_LIBUNWIND_WEAK_ALIAS(__unw_init_local_dwarf, unw_init_local_dwarf)
++
+ /// Set value of specified register at cursor position in stack frame.
+ _LIBUNWIND_HIDDEN int __unw_set_reg(unw_cursor_t *cursor, unw_regnum_t regNum,
+                                     unw_word_t value) {
+diff --git a/libunwind/src/libunwind_ext.h b/libunwind/src/libunwind_ext.h
+index 316dee2..5b9f7e2 100644
+--- a/libunwind/src/libunwind_ext.h
++++ b/libunwind/src/libunwind_ext.h
+@@ -25,6 +25,7 @@ extern "C" {
+
+ extern int __unw_getcontext(unw_context_t *);
+ extern int __unw_init_local(unw_cursor_t *, unw_context_t *);
++extern int __unw_init_local_dwarf(unw_cursor_t *, unw_context_t *);
+ extern int __unw_step(unw_cursor_t *);
+ extern int __unw_get_reg(unw_cursor_t *, unw_regnum_t, unw_word_t *);
+ extern int __unw_get_fpreg(unw_cursor_t *, unw_regnum_t, unw_fpreg_t *);

--- a/L/LLVM/LLVM_full@12.0.1/bundled/patches/0803-freebsd-libgcc-api-compat.patch
+++ b/L/LLVM/LLVM_full@12.0.1/bundled/patches/0803-freebsd-libgcc-api-compat.patch
@@ -1,0 +1,107 @@
+Modification of the following patch in the FreeBSD source tree, which
+includes LLVM libunwind in contrib/llvm-project/libunwind.
+
+From 9f287522cec9feac040d7cb845a440a8f6b7b90e Mon Sep 17 00:00:00 2001
+From: Dimitry Andric <dim@FreeBSD.org>
+Date: Sun, 2 Aug 2020 18:12:14 +0000
+Subject: [PATCH] Reapply r310365 (by emaste):
+
+libunwind: make __{de,}register_frame compatible with libgcc API
+
+The libgcc __register_frame and __deregister_frame functions take a
+pointer to a set of FDE/CIEs, terminated by an entry where length is 0.
+
+In Apple's libunwind implementation the pointer is taken to be to a
+single FDE. I suspect this was just an Apple bug, compensated by Apple-
+specific code in LLVM.
+
+See lib/ExecutionEngine/RuntimeDyld/RTDyldMemoryManager.cpp and
+http://lists.llvm.org/pipermail/llvm-dev/2013-April/061737.html
+for more detail.
+
+This change is based on the LLVM RTDyldMemoryManager.cpp. It should
+later be changed to be alignment-safe.
+
+Reported by:	dim
+Reviewed by:	dim
+Sponsored by:	The FreeBSD Foundation
+Differential Revision:	https://reviews.freebsd.org/D8869
+
+Reapply r351610:
+
+Update libunwind custom frame register and deregister functions for
+FreeBSD: use the new doubly underscored names for unw_add_dynamic_fde
+and unw_remove_dynamic_fde.
+
+NOTE: this should be upstreamed...
+---
+ .../libunwind/src/UnwindLevel1-gcc-ext.c      | 42 ++++++++++++++++++-
+ 1 file changed, 41 insertions(+), 1 deletion(-)
+
+diff --git a/libunwind/src/UnwindLevel1-gcc-ext.c b/libunwind/src/UnwindLevel1-gcc-ext.c
+index 310b836d129e5..30f9cabf241f2 100644
+--- a/libunwind/src/UnwindLevel1-gcc-ext.c
++++ b/libunwind/src/UnwindLevel1-gcc-ext.c
+@@ -234,6 +234,46 @@ _LIBUNWIND_EXPORT uintptr_t _Unwind_GetIPInfo(struct _Unwind_Context *context,
+ 
+ #if defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
+ 
++#if defined(__FreeBSD__)
++
++// Based on LLVM's lib/ExecutionEngine/RuntimeDyld/RTDyldMemoryManager.cpp
++// and XXX should be fixed to be alignment-safe.
++static void processFDE(const char *addr, bool isDeregister) {
++  uint64_t length;
++  while ((length = *((const uint32_t *)addr)) != 0) {
++    const char *p = addr + 4;
++    if (length == 0xffffffff) {
++      length = *((const uint64_t *)p);
++      p += 8;
++    }
++    uint32_t offset = *((const uint32_t *)p);
++    if (offset != 0) {
++      if (isDeregister)
++        __unw_remove_dynamic_fde((unw_word_t)(uintptr_t)addr);
++      else
++        __unw_add_dynamic_fde((unw_word_t)(uintptr_t)addr);
++    }
++    addr = p + length;
++  }
++}
++
++/// Called by programs with dynamic code generators that want to register
++/// dynamically generated FDEs, with a libgcc-compatible API.
++
++_LIBUNWIND_EXPORT void __register_frame(const void *addr) {
++  _LIBUNWIND_TRACE_API("__register_frame(%p)", addr);
++  processFDE(addr, false);
++}
++
++/// Called by programs with dynamic code generators that want to unregister
++/// dynamically generated FDEs, with a libgcc-compatible API.
++_LIBUNWIND_EXPORT void __deregister_frame(const void *addr) {
++  _LIBUNWIND_TRACE_API("__deregister_frame(%p)", addr);
++  processFDE(addr, true);
++}
++
++#else // defined(__FreeBSD__)
++
+ /// Called by programs with dynamic code generators that want
+ /// to register a dynamically generated FDE.
+ /// This function has existed on Mac OS X since 10.4, but
+@@ -243,7 +283,6 @@ _LIBUNWIND_EXPORT void __register_frame(const void *fde) {
+   __unw_add_dynamic_fde((unw_word_t)(uintptr_t)fde);
+ }
+ 
+-
+ /// Called by programs with dynamic code generators that want
+ /// to unregister a dynamically generated FDE.
+ /// This function has existed on Mac OS X since 10.4, but
+@@ -253,6 +292,7 @@ _LIBUNWIND_EXPORT void __deregister_frame(const void *fde) {
+   __unw_remove_dynamic_fde((unw_word_t)(uintptr_t)fde);
+ }
+ 
++#endif // defined(__FreeBSD__)
+ 
+ // The following register/deregister functions are gcc extensions.
+ // They have existed on Mac OS X, but have never worked because Mac OS X

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -122,8 +122,10 @@ LLVM_TARGETS=$(IFS=';' ; echo "${TARGETS[*]}")
 CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD:STRING=$LLVM_TARGETS)
 
 # We mostly care about clang and LLVM
-if [[ "${LLVM_MAJ_VER}" -gt "11" ]]; then
-    CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld;mlir')
+if [[ "${LLVM_MAJ_VER}" -ge "12" ]]; then
+    CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld;mlir;libcxx;libunwind')
+elif [[ "${LLVM_MAJ_VER}" -eq "11" ]]; then
+    CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld;libunwind')
 else
     CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld')
 fi
@@ -243,6 +245,16 @@ fi
 CMAKE_FLAGS+=(-DCMAKE_C_COMPILER_TARGET=${CMAKE_TARGET})
 CMAKE_FLAGS+=(-DCMAKE_CXX_COMPILER_TARGET=${CMAKE_TARGET})
 CMAKE_FLAGS+=(-DCMAKE_ASM_COMPILER_TARGET=${CMAKE_TARGET})
+
+# Some libunwind-specific things
+if [[ "${LLVM_MAJ_VER}" -ge "11" ]]; then
+    CMAKE_FLAGS+=(-DLIBUNWIND_INCLUDE_DOCS=OFF)
+    CMAKE_FLAGS+=(-DLIBUNWIND_ENABLE_PEDANTIC=OFF)
+    if [[ ${target} == x86_64-w64-mingw32 ]]; then
+        # Support for threading requires Windows Vista
+        export CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -D_WIN32_WINNT=0x0600"
+    fi
+fi
 
 cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]} -DCMAKE_CXX_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS}" -DCMAKE_C_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS}"
 ninja -j${nproc} -vv


### PR DESCRIPTION
This is a first step toward integrating LLVMLibUnwind alongside Clang, MLIR, et al. so that we can drop the LLVMLibUnwind patch that allows building without the monorepo.