### PR TITLE
[soapyrtlsdr] init

### DIFF
--- a/S/soapyrtlsdr/build_tarballs.jl
+++ b/S/soapyrtlsdr/build_tarballs.jl
@@ -1,0 +1,42 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "soapyrtlsdr"
+version = v"0.3.2"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/pothosware/SoapyRTLSDR.git", "e4b963926012399904aceb57690df3a4f293ce67")
+]
+
+dependencies = [
+    Dependency("librtlsdr_jll"; compat="0.6.0"),
+    Dependency("soapysdr_jll"; compat="0.8.0")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd SoapyRTLSDR
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_BUILD_TYPE=Release \
+      ..
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(;experimental=true)
+
+# The products that we will ensure are always built
+products = Product[
+    LibraryProduct("librtlsdrSupport", :librtlsdrSupport, ["lib/SoapySDR/modules0.8/"])
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+# gcc7 constraint from boost
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
This adds the functional module for #3544 for use with [SoapySDR.jl](https://github.com/JuliaTelecom/SoapySDR.jl). Such that one can do:
```
julia> using SoapySDR, soapyrtlsdr_jll

julia> Devices()
Found Rafael Micro R820T tuner
[1] :driver => "rtlsdr", :label => "Generic RTL2832U OEM :: 00000001", :manufacturer => "Realtek", :product => "RTL2838UHIDIR", :serial => "00000001", :tuner => "Rafael Micro R820T"
```
