### PR TITLE
[LLVM] Fix name of versioned symlink for macOS

### DIFF
--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -260,8 +260,8 @@ fi
 # Work around llvm-config bug by creating versioned symlink to libLLVM
 # https://github.com/JuliaLang/julia/pull/30033
 if [[ "${target}" == *darwin* ]]; then
-    LLVM_VER=$(basename $(echo ${prefix}/tools/clang-*.*))
-    ln -s libLLVM.dylib ${prefix}/lib/libLLVM-${LLVM_VER##*-}.dylib
+    LLVM_VER=$(${WORKSPACE}/bootstrap/bin/llvm-config --version | cut -d. -f1-2)
+    ln -s libLLVM.dylib ${prefix}/lib/libLLVM-${LLVM_VER}.dylib
 fi
 
 # Lit is a python dependency and there is no proper install target


### PR DESCRIPTION
Fix #3548.

Note: I don't want to rebuild LLVM just to fix this (we've just built LLVM, it has been broken for 1.5 years, can wait more), the commit contains `[skip ci]`