### PR TITLE
[CI] Add check that there aren't projects with similar names

### DIFF
--- a/L/laz_perf/build_tarballs.jl
+++ b/L/laz_perf/build_tarballs.jl
@@ -1,0 +1,49 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "LAZperf"
+version = v"2.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/hobu/laz-perf/archive/refs/tags/$version.tar.gz", "0ea01f37dfa0e623d64846a58c3c2f0e77f8b17b9b8ba5721c3abcdbe14ac2d5"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+
+cd $WORKSPACE/srcdir/laz-perf-*
+
+if [[ "${target}" == *-mingw* ]]; then
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mingw-portable-endian.patch
+fi
+
+cmake . \
+-DCMAKE_INSTALL_PREFIX=$prefix \
+-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+-DCMAKE_BUILD_TYPE=Release \
+-DEMSCRIPTEN=OFF \
+-DWITH_TESTS=OFF
+
+make -j${nproc}
+make install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("liblazperf", :liblazperf)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/laz_perf/bundled/patches/mingw-portable-endian.patch
+++ b/L/laz_perf/bundled/patches/mingw-portable-endian.patch
@@ -1,0 +1,16 @@
+diff --git a/cpp/lazperf/portable_endian.hpp b/cpp/lazperf/portable_endian.hpp
+index b0e753f32..1883ad881 100644
+--- a/cpp/lazperf/portable_endian.hpp
++++ b/cpp/lazperf/portable_endian.hpp
+@@ -65,9 +65,9 @@
+ #       define be32toh ntohl
+ #       define le32toh(x) (x)
+
+-#       define htobe64 htonll
++#       define htobe64(x) ((((uint64_t)htonl(x&0xFFFFFFFF)) << 32) + htonl(x >> 32))
+ #       define htole64(x) (x)
+-#       define be64toh ntohll
++#       define be64toh(x) ((((uint64_t)ntohl(x&0xFFFFFFFF)) << 32) + ntohl(x >> 32))
+ #       define le64toh(x) (x)
+
+ #   elif BYTE_ORDER == BIG_ENDIAN

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,21 @@ jobs:
       # Be fragile, like a beautiful porcelain doll
       set -e
 
+      # Add check for projects with similar names
+      $(JULIA) -O0 -e '
+          # Collect all projects (== directories containing file called "build_tarballs.jl")
+          const projects = unique(split(basename(root), "@")[begin] for (root, dirs, files) in walkdir(".") if "build_tarballs.jl" ∈ files)
+          # Iterate over all projects
+          for project ∈ projects
+              # Iterate over all projects excluding the current one
+              for other ∈ filter(!=(project), projects)
+                  # Compare current project and the other, modulo case and underscores
+                  if lowercase(replace(project, "_" => "")) == lowercase(replace(other, "_" => ""))
+                      error("Projects $(project) and $(other) cannot coexist")
+                  end
+              end
+          end'
+
       # Normally we look at the last pushed commit
       COMPARE_AGAINST="HEAD~1"
       # Keyword to be used in the commit message to skip a rebuild


### PR DESCRIPTION
We recently had the curious case where #3546 was opened with name `laz_perf`,
just a few days after #3529 was merged, with name `LAZperf`.  This pull request
adds an automated check to prevent having projects which differ only by case
(this would be caught by the registry, but too late for us) and underscores.
Any other checks we can have?

Note: this pull request is also adding a project called `laz_perf` to simulate
the situation in #3546, to make sure the check is working as expected.  This
should be deleted before merging.