### PR TITLE
Xyce: Expand supported platforms

### DIFF
--- a/X/Xyce/build_tarballs.jl
+++ b/X/Xyce/build_tarballs.jl
@@ -17,6 +17,7 @@ export TMPDIR=${WORKSPACE}/tmpdir
 mkdir ${TMPDIR}
 cd $WORKSPACE/srcdir
 apk add flex-dev
+update_configure_scripts --reconf
 install_license ${WORKSPACE}/srcdir/Xyce/COPYING
 cd Xyce
 for f in ${WORKSPACE}/srcdir/patches/*.patch; do
@@ -37,7 +38,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 
-platforms = filter(Sys.islinux, supported_platforms())
+platforms = supported_platforms()
 
 platforms = expand_cxxstring_abis(platforms)
 platforms = expand_gfortran_versions(platforms)

--- a/X/Xyce/build_tarballs.jl
+++ b/X/Xyce/build_tarballs.jl
@@ -41,7 +41,6 @@ make install
 platforms = supported_platforms()
 
 platforms = expand_cxxstring_abis(platforms)
-platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/X/Xyce/bundled/patches/no-undefined.patch
+++ b/X/Xyce/bundled/patches/no-undefined.patch
@@ -1,0 +1,35 @@
+diff --git a/configure.ac b/configure.ac
+index d3453a72..0bf380d1 100755
+--- a/configure.ac
++++ b/configure.ac
+@@ -479,13 +479,6 @@ if test "x$F77" = "xg95"; then
+   LDFLAGS="-Wl,-framework,Accelerate $LDFLAGS"
+ fi
+ 
+-dnl *********************************************************************
+-dnl checks for libraries now
+-dnl Replace `main' with a function in -lm:
+-if test "$FORTRAN_BLAS" != "no"; then
+-  AC_F77_LIBRARY_LDFLAGS
+-fi
+-
+ AC_SEARCH_LIBS(sqrt, [m])
+ 
+ dnl find a valid blas and lapack library
+diff --git a/src/Makefile.am b/src/Makefile.am
+index b60a533d..a4d24e5d 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -82,8 +82,10 @@ XYCELINK = $(MSLINK)
+ # build library (static & shared) for linking (w/libtool) into other codes
+ lib_LTLIBRARIES = libxyce.la
+ libxyce_la_SOURCES = $(XYCESOURCES)
+-libxyce_la_LIBADD = $(XYCELINK)
+-libxyce_la_LDFLAGS = $(AM_LDFLAGS) @XYCELIBS@
++libxyce_la_LIBADD = $(XYCELINK) @XYCELIBS@
++libxyce_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined
++# XYCESOURCE may be empty - make sure libtool still knows that this is a C++ link
++libxyce_la_LIBTOOLFLAGS = --tag=CXX
+ 
+ if BUILD_XYCE_BINARY
+ 


### PR DESCRIPTION
The AC_F77_LIBRARY_LDFLAGS flag is required when linking C++ and
Fortran *source files* into the same (shared) object. However,
here we're merely linking a Fortran library, so it is not required.
Unfortunately, while it in theory should do no harm, in practice
the AC_F77_LIBRARY_LDFLAGS macro is broken when targeting Windows
(which I will attempt to fix separately in upstream autoconf),
so remove it here.