### PR TITLE
Update XyceWrapper to build everywhere Xyce is built

### DIFF
--- a/X/XyceWrapper/build_tarballs.jl
+++ b/X/XyceWrapper/build_tarballs.jl
@@ -29,7 +29,6 @@ install_license /usr/share/licenses/MIT
 
 include("../../L/libjulia/common.jl")
 platforms = libjulia_platforms(julia_version)
-platforms = filter!(Sys.islinux, platforms) # Xyce only supports Linux
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/X/XyceWrapper/src/CMakeLists.txt
+++ b/X/XyceWrapper/src/CMakeLists.txt
@@ -1,8 +1,6 @@
 project(XyceLib)
 
-cmake_policy(SET CMP0025 NEW)
-
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.14)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
@@ -26,8 +24,4 @@ target_link_libraries(xycelib
   teuchoscore 
 )
 
-install(TARGETS
-  xycelib
-LIBRARY DESTINATION lib
-ARCHIVE DESTINATION lib
-RUNTIME DESTINATION lib)
+install(TARGETS xycelib LIBRARY)

--- a/X/XyceWrapper/src/CMakeLists.txt
+++ b/X/XyceWrapper/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(XyceLib)
 
+cmake_policy(SET CMP0025 NEW)
+
 cmake_minimum_required(VERSION 2.8.12)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
After the recent PRs, Trillinos and Xyce now build on Windows and such. This is the last missing piece to actually use it on Windows.