### PR TITLE
[GR] Try using ZeroMQ and Qhull from BB.

### DIFF
--- a/G/GR/build_tarballs.jl
+++ b/G/GR/build_tarballs.jl
@@ -22,7 +22,7 @@ fi
 
 update_configure_scripts
 
-make -C 3rdparty/qhull -j${nproc}
+#make -C 3rdparty/qhull -j${nproc}
 
 if [[ $target == *"mingw"* ]]; then
     winflags=-DCMAKE_C_FLAGS="-D_WIN32_WINNT=0x0f00"
@@ -41,7 +41,8 @@ fi
 
 mkdir build
 cd build
-cmake $winflags -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DGR_USE_BUNDLED_LIBRARIES=ON $tifflags -DCMAKE_BUILD_TYPE=Release ..
+#cmake $winflags -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DGR_USE_BUNDLED_LIBRARIES=ON $tifflags -DCMAKE_BUILD_TYPE=Release ..
+cmake $winflags -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} $tifflags -DCMAKE_BUILD_TYPE=Release ..
 
 VERBOSE=ON cmake --build . --config Release --target install -- -j${nproc}
 cp ../../gr.js ${libdir}/
@@ -94,7 +95,7 @@ dependencies = [
     Dependency("Qt5Base_jll"),
     Dependency("Zlib_jll"),
     Dependency("ZeroMQ_jll"),
-#    Dependency("Qhull_jll"),
+    Dependency("Qhull_jll"),
     BuildDependency("Xorg_libX11_jll"),
     BuildDependency("Xorg_xproto_jll"),
 ]

--- a/G/GR/build_tarballs.jl
+++ b/G/GR/build_tarballs.jl
@@ -31,9 +31,9 @@ else
     tifflags=-DTIFF_LIBRARY=${libdir}/libtiff.${dlext}
 fi
 
-if [[ "${target}" == *apple* ]]; then
-    make -C 3rdparty/zeromq ZEROMQ_EXTRA_CONFIGURE_FLAGS="--host=${target}"
-fi
+#if [[ "${target}" == *apple* ]]; then
+#    make -C 3rdparty/zeromq ZEROMQ_EXTRA_CONFIGURE_FLAGS="--host=${target}"
+#fi
 
 if [[ "${target}" == arm-* ]]; then
     export CXXFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib"
@@ -91,11 +91,12 @@ dependencies = [
     Dependency("libpng_jll"),
     Dependency("Libtiff_jll"; compat="4.3.0"),
     Dependency("Pixman_jll"),
-#    Dependency("Qhull_jll"),
     Dependency("Qt5Base_jll"),
+    Dependency("Zlib_jll"),
+    Dependency("ZeroMQ_jll"),
+#    Dependency("Qhull_jll"),
     BuildDependency("Xorg_libX11_jll"),
     BuildDependency("Xorg_xproto_jll"),
-    Dependency("Zlib_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Let's see if we can have GR use the ZeroMQ and Qhull that we have in BB. The build goes through fine with ZeroMQ. It seems that GR is trying to link against the libqhullstatic.a, which should be compiled with `-fpic` (based on the messages), or GR should perhaps is not linking right.

Qhull does not have a build for Apple M1. We need a new Qhull build that includes support for Apple M1, before we can build GR against it.