### PR TITLE
add librttopo

### DIFF
--- a/L/librttopo/build_tarballs.jl
+++ b/L/librttopo/build_tarballs.jl
@@ -3,18 +3,16 @@
 using BinaryBuilder, Pkg
 
 name = "librttopo"
-version = v"0.1.0"
+version = v"1.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://git.osgeo.org/gitea/rttopo/librttopo.git", "ffcdc7ee67375c5874b09101dca3fc9fc98ecc08")
+    ArchiveSource("https://download.osgeo.org/librttopo/src/librttopo-$(version).tar.gz", "a77d8b787ba13f685de819348d5146f9f6ec56fd3bcf71e880dfc5e0086d4cb0")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/librttopo/
-
-./autogen.sh
+cd $WORKSPACE/srcdir/librttopo*
 
 if [[ ${target} == *-freebsd* ]]; then
     export CPPFLAGS="-I${includedir}"

--- a/L/librttopo/build_tarballs.jl
+++ b/L/librttopo/build_tarballs.jl
@@ -1,0 +1,49 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "librttopo"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://git.osgeo.org/gitea/rttopo/librttopo.git", "ffcdc7ee67375c5874b09101dca3fc9fc98ecc08")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/librttopo/
+
+./autogen.sh
+
+if [[ ${target} == *-freebsd* ]]; then
+    export CPPFLAGS="-I${includedir}"
+fi
+
+./configure \
+--prefix=${prefix} \
+--build=${MACHTYPE} \
+--host=${target}
+
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("librttopo", :librttopo)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="GEOS_jll", uuid="d604d12d-fa86-5845-992e-78dc15976526"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+#GEOS uses gcc6
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"6")


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [librttopo](https://git.osgeo.org/gitea/rttopo/librttopo) library. They don't seem to have releases, so I am building from current `master` here.

Tested locally on `linux-gnu`, `linux-musl`, `mingw`, `powerpc`, `freebsd`, and `apple-darwin` with no issues.