### PR TITLE
[FFTW] Build for experimental platforms

### DIFF
--- a/F/FFTW/build_tarballs.jl
+++ b/F/FFTW/build_tarballs.jl
@@ -1,12 +1,11 @@
 using BinaryBuilder
 
 name = "FFTW"
-version = v"3.3.10" # <-- this is a lie, we're building v3.3.8, but we need to bump version to build for julia v1.6
-source_version = v"3.3.9"
+version = v"3.3.10"
 
 # Collection of sources required to build FFTW
 sources = [
-   ArchiveSource("http://fftw.org/fftw-$(source_version).tar.gz",	
+   ArchiveSource("http://fftw.org/fftw-$(version).tar.gz",	
                   "bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d"),
 ]
 

--- a/F/FFTW/build_tarballs.jl
+++ b/F/FFTW/build_tarballs.jl
@@ -1,11 +1,12 @@
 using BinaryBuilder
 
 name = "FFTW"
-version = v"3.3.9"
+version = v"3.3.10" # <-- this is a lie, we're building v3.3.8, but we need to bump version to build for julia v1.6
+source_version = v"3.3.9"
 
 # Collection of sources required to build FFTW
 sources = [
-   ArchiveSource("http://fftw.org/fftw-$(version).tar.gz",	
+   ArchiveSource("http://fftw.org/fftw-$(source_version).tar.gz",	
                   "bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d"),
 ]
 
@@ -70,7 +71,7 @@ install_license COPYING COPYRIGHT
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms() # build on all supported platforms
+platforms = supported_platforms(; experimental=true) # build on all supported platforms
 
 # The products that we will ensure are always built
 products = [
@@ -83,4 +84,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")

--- a/F/FFTW/build_tarballs.jl
+++ b/F/FFTW/build_tarballs.jl
@@ -6,7 +6,7 @@ version = v"3.3.10"
 # Collection of sources required to build FFTW
 sources = [
    ArchiveSource("http://fftw.org/fftw-$(version).tar.gz",	
-                  "bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d"),
+                  "56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
FFTW.jl now [requires](https://github.com/JuliaMath/FFTW.jl/blob/9a9239f4eabb2656cf6c90dcdbbdcd345d4fdc09/Project.toml#L19) Julia 1.6. In order to support experimental platforms like Apple Silicon, a new FFTW_jll needs to be built with an updated version number and then FFTW.jl can be updated. This PR seeks to resolve the open point for FFTW in https://github.com/JuliaPackaging/Yggdrasil/issues/2763.