### PR TITLE
[libpolymake_julia] bump to 0.4.3 (julia 1.3)

### DIFF
--- a/L/libpolymake_julia/common.jl
+++ b/L/libpolymake_julia/common.jl
@@ -5,13 +5,13 @@ import Pkg: PackageSpec
 import Pkg.Types: VersionSpec
 
 name = "libpolymake_julia"
-upstream_version = v"0.4.2"
+upstream_version = v"0.4.3"
 version = VersionNumber(upstream_version.major, upstream_version.minor, upstream_version.patch * 100 + julia_version.minor)
 
 # Collection of sources required to build libpolymake_julia
 sources = [
     ArchiveSource("https://github.com/oscar-system/libpolymake-julia/archive/v$(upstream_version).tar.gz",
-                  "2b9b75f80c14207f7377f2a093f22b46901f1f3de38bb2b3cb708584a1133982"),
+                  "dc1f727cadfe11529b66a6c592a780457e52492a83384f298f3bba8c28dc06ca"),
 ]
 
 # Bash recipe for building across all platforms

--- a/L/libpolymake_julia/libpolymake_julia@1.3/build_tarballs.jl
+++ b/L/libpolymake_julia/libpolymake_julia@1.3/build_tarballs.jl
@@ -1,3 +1,2 @@
 julia_version = v"1.3.1"
-
 include("../common.jl")


### PR DESCRIPTION
This version fixes the backwards compatibility issue that was introduced in the 0.4.2 version, which I have asked to be yanked: https://github.com/JuliaRegistries/General/pull/44719
I will update the PRs for the other julia versions when this is merged.