### PR TITLE
Only set julia_version in libjulia_platforms if it is >= 1.6

### DIFF
--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -17,8 +17,10 @@ function libjulia_platforms(julia_version)
         filter!(p -> !(Sys.islinux(p) && arch(p) == "powerpc64le"), platforms)
     end
 
-    for p in platforms
-        p["julia_version"] = string(julia_version)
+    if julia_version >= v"1.6"
+        for p in platforms
+            p["julia_version"] = string(julia_version)
+        end
     end
 
     # While the "official" Julia kernel ABI itself does not involve any C++


### PR DESCRIPTION
... as older Julia versions get confused by the `julia_version` in the artifact names.

For example, compare 
1. <https://github.com/JuliaBinaryWrappers/libsingular_julia_jll.jl/releases/tag/libsingular_julia-v0.17.5%2B0>
2. <https://github.com/JuliaBinaryWrappers/libsingular_julia_jll.jl/releases/tag/libsingular_julia-v0.18.5%2B0>

The first one was made before we started adding in `julia_version` (which happened in PR #3411). The second was made a few days ago.

I also wonder if we really should be setting `julia_version` to the *full* version, such as  "1.5.3" -- or instead to e.g. `1.5` or `1.5.0`, considering that Julia does this anyway (from `base/binaryplatforms.jl` in Julia 1.6):
>  `By default, we compare julia_version only against major and minor versions:`

On the other hand, function `host_triplet` in the same file does this:
```julia
    # Add on julia_version extended tag
    if !occursin("-julia_version+", str)
        str = string(str, "-julia_version+", VersionNumber(VERSION.major, VERSION.minor, VERSION.patch))
    end
```
so I get this:
```
julia> Base.BinaryPlatforms.host_triplet()
"x86_64-apple-darwin-libgfortran5-cxx11-julia_version+1.6.2"
```



CC @thofma @benlorenz @barche