### PR TITLE
[HELICS] update to v3.0.0

### DIFF
--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -15,8 +15,8 @@
 
 using BinaryBuilder
 
-HELICS_VERSION = v"2.7.1"
-HELICS_SHA = "872d415959e9d97069b06327410af00e7daae8dbeb9f050b26632eca924ea23c"
+HELICS_VERSION = v"3.0.0"
+HELICS_SHA = "928687e95d048f3f9f9d67cec4ac20866a98cbc00090a2d62abaa11c2a20958c"
 
 sources = [
     ArchiveSource("https://github.com/GMLC-TDC/HELICS/releases/download/v$HELICS_VERSION/Helics-v$HELICS_VERSION-source.tar.gz",


### PR DESCRIPTION
Adds a HELICS package for v3.0.0

If needed this one can be skipped and just v3.0.1 could be added -- though there are new maintenance releases being made in the 2.8.x series for bug fixes that will still need updating somehow. Is there a way to specify multiple versions or just open a new PR to Yggdrasil for each individual version if the result is not a monotonically increasing package version in the Yggdrasil commit history?