### PR TITLE
GDB: Enable XML support

### DIFF
--- a/G/GDB/build_tarballs.jl
+++ b/G/GDB/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 script = raw"""
 apk add texinfo
 cd $WORKSPACE/srcdir/gdb-10.1/
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} 
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-expat
 make -j${nproc} all
 make install
 """
@@ -40,7 +40,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"), v"6.1.2")
+    Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d")),
+    Dependency("Expat_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Without this, GDB is incompatible with rr:

```
warning: Can not parse XML target description; XML support was disabled at compile time
Remote 'g' packet reply is too long (expected 560 bytes, got 816 bytes): [snip]
```

cc @ianatol