### PR TITLE
qhull semver for v2020.2 is actually v8.0.2

### DIFF
--- a/Q/Qhull/build_tarballs.jl
+++ b/Q/Qhull/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"8.0.2"
 # Collection of sources required to build
 sources = [
     ArchiveSource(
-        "https://github.com/qhull/qhull/archive/$(version.major).$(version.minor).tar.gz", # URL
+        "https://github.com/qhull/qhull/archive/2020.2.tar.gz", # URL
         "59356b229b768e6e2b09a701448bfa222c37b797a84f87f864f97462d8dbc7c5"                 # sha256 hash
     ),
 ]

--- a/Q/Qhull/build_tarballs.jl
+++ b/Q/Qhull/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "Qhull"
-version = v"2020.2"
+version = v"8.0.2"
 
 # Collection of sources required to build
 sources = [


### PR DESCRIPTION
As [explained in #3657](https://github.com/JuliaPackaging/Yggdrasil/pull/3657#issuecomment-930666102), we should really rename this to the [semver version](http://www.qhull.org/news/qhull-news.html).  (Or semver-like, at least; I don't know if they are strictly following semantic versioning.)

Then [dependents of `qhull_jll`](https://juliahub.com/ui/Packages/Qhull_jll/nBD85/2020.2.0+0?t=2) can update their compatibility section to list `qhull_jll = "8"` and it should do the right thing, since Pkg assumes that differing major versions are incompatible.

Once 8.0.2 is released, we can then merge #3657 to release 8.1-alpha1.