### PR TITLE
add libpsl

### DIFF
--- a/L/libpsl/build_tarballs.jl
+++ b/L/libpsl/build_tarballs.jl
@@ -40,7 +40,9 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[]
+dependencies = Dependency[
+    Dependency("Libiconv_jll"),
+]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/libpsl/build_tarballs.jl
+++ b/L/libpsl/build_tarballs.jl
@@ -1,0 +1,46 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libpsl"
+version = v"0.21.1"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/rockdaboot/libpsl/releases/download/$(version)/libpsl-$(version).tar.gz", "ac6ce1e1fbd4d0254c4ddb9d37f1fa99dec83619c1253328155206b896210d4c")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libpsl*
+
+./configure \
+--prefix=${prefix} \
+--build=${MACHTYPE} \
+--host=${target} \
+--enable-gtk-doc-html=no \
+--enable-static=no \
+--enable-shared=yes \
+--enable-man=no
+
+make -j${nproc}
+make install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; experimental = true)
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libpsl", :libpsl),
+    ExecutableProduct("psl", :psl)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [libpsl](https://github.com/rockdaboot/libpsl) library.
This library doesn't have any dependencies, so I felt it was safe to add the `experimental=true` flag without breaking anything.

Tested locally on `linux-gnu`, `mingw`, `linux-musl` with no issues.