### PR TITLE
[openblas] Build for 128 threads by default

### DIFF
--- a/O/OpenBLAS/common.jl
+++ b/O/OpenBLAS/common.jl
@@ -38,7 +38,7 @@ function openblas_sources(version::VersionNumber; kwargs...)
     ]
 end
 
-function openblas_script(;num_64bit_threads::Integer=32, openblas32::Bool=false, aarch64_ilp64::Bool=false, kwargs...)
+function openblas_script(;num_64bit_threads::Integer=128, openblas32::Bool=false, aarch64_ilp64::Bool=false, kwargs...)
     # Allow some basic configuration
     script = """
     NUM_64BIT_THREADS=$(num_64bit_threads)


### PR DESCRIPTION
Core counts are going up a lot nowadays - I suggest we use 128 max threads by default.