### PR TITLE
add libunistring

### DIFF
--- a/L/libunistring/build_tarballs.jl
+++ b/L/libunistring/build_tarballs.jl
@@ -1,0 +1,43 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libunistring"
+version = v"0.9.10"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://ftp.gnu.org/gnu/libunistring/libunistring-$(version).tar.gz", "a82e5b333339a88ea4608e4635479a1cfb2e01aafb925e1290b65710d43f610b")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libunistring-*
+
+./configure \
+--prefix=${prefix} \
+--build=${MACHTYPE} \
+--host=${target}
+
+make -j${nproc}
+make install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; experimental = true)
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libunistring", :libunistring)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+    Dependency("Libiconv_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [libunistring](https://www.gnu.org/software/libunistring/) library.

Tested locally on:
`x86_64-linux-gnu`,
`x86_64-linux-musl`,
`x86_64-w64-mingw32`,
`powerpc64le-linux-gnu`,
`x86_64-unknown-freebsd`,
`x86_64-apple-darwin`