### PR TITLE
Updated DuckDB to version 0.2.9

### DIFF
--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-cd duckdb-0.2.9/
+cd duckdb*/
 if [[ "${target}" == *-mingw32 ]]; then
     sed -i -E "/add_executable\(duckdb_rest_server server.cpp\)$/aif\(\$\{WIN32\}\)\n  set\(LINK_EXTRA -lwsock32 -lws2_32\)\nendif\(\)\n" tools/rest/CMakeLists.txt
 fi

--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "DuckDB"
-version = v"0.2.1"
+version = v"0.2.9"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/cwida/duckdb.git", "d9bceddc7209a7e0b5c0402958d1191e19a491e7")
+    ArchiveSource("https://github.com/duckdb/duckdb/archive/refs/tags/v0.2.9.tar.gz", "ede74256ca8811ae37001d238c4ffb156861c408453e95e02096773465619ccf")
 ]
 
 # Bash recipe for building across all platforms

--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-cd duckdb/
+cd duckdb-0.2.9/
 if [[ "${target}" == *-mingw32 ]]; then
     sed -i -E "/add_executable\(duckdb_rest_server server.cpp\)$/aif\(\$\{WIN32\}\)\n  set\(LINK_EXTRA -lwsock32 -lws2_32\)\nendif\(\)\n" tools/rest/CMakeLists.txt
 fi


### PR DESCRIPTION
The latest version of Duckdb.
[Release notes](https://github.com/duckdb/duckdb/releases/tag/v0.2.9)