### PR TITLE
add RadeonProRender

### DIFF
--- a/R/RadeonProRender/build_tarballs.jl
+++ b/R/RadeonProRender/build_tarballs.jl
@@ -1,0 +1,71 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "RadeonProRender"
+version = v"2.2.7"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderSDK.git", "50200b1be97606e73b15baa17c568247e71d0116")
+]
+
+# TODO, also ship headers for Clang.jl generation!?
+script = raw"""
+echo ${target}
+cd $WORKSPACE/srcdir/RadeonProRenderSDK/RadeonProRender
+if [[ ${target} == x86_64-linux-gnu ]]; then
+    cp binUbuntu18/* ${libdir}/
+elif [[ ${target} == x86_64-apple-darwin* ]]; then
+    cp binMacOS/* ${libdir}/
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    cp binWin64/* ${libdir}/
+fi
+"""
+
+# TODO, can we add centos7?
+platforms = [
+    Platform("x86_64", "linux"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows")
+]
+
+# Fix warning in BinaryBuilder:
+platforms = expand_cxxstring_abis(platforms)
+
+# TODO, Hybrid doesn't exist on OSX, so I guess we can't include it?!
+products = [
+    # LibraryProduct("Hybrid", :Hybrid),
+    # LibraryProduct("HybridPro", :HybridPro),
+
+    # I don't think we need the executables:
+    # BinaryProduct("RprTextureCompiler64", :RprTextureCompiler64),
+    # BinaryProduct("RprsRender64", :RprsRender64),
+    LibraryProduct(["Northstar64", "libNorthstar64"], :libNorthstar64),
+    LibraryProduct(["ProRenderGLTF", "libProRenderGLTF"], :libProRenderGLTF),
+    LibraryProduct(["RadeonProRender64", "libRadeonProRender64"], :libRadeonProRender64),
+    LibraryProduct(["RprLoadStore64", "libRprLoadStore64"], :libRprLoadStore64),
+    LibraryProduct(["Tahoe64", "libTahoe64"], :libTahoe64),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+
+    # Not really needed for repacking, but if we ever want to
+    # build from scratch we'll need at least these:
+
+    # HostBuildDependency("GLEW_jll"),
+    # HostBuildDependency("GLU_jll"),
+    # HostBuildDependency("Lua_jll"),
+    # BuildDependency("Vulkan_Headers_jll"),
+    # BuildDependency("OpenCL_Headers_jll"),
+    # BuildDependency("ROCmDeviceLibs_jll"),
+    # BuildDependency("ROCmOpenCLRuntime_jll"),
+    # BuildDependency("ROCmCompilerSupport_jll"),
+
+    # fix warning from BinaryBuilder:
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This repackages the prebuild binaries from RadeonProRender...
I guess it would be nice to build them here, but since they don't seem to make cross-platform builds particularly easy and it depends on the entire GPU OpenCL/Vulkan/AMD stack, I didn't even try to build this.
If anyone expects this to be easy, let me know though ;) 

Also, they ship binaries for centos7, but I didn't see any BinaryBuilder Platform that matches that?