### PR TITLE
Update Openresty to v1.19.9

### DIFF
--- a/O/Openresty/build_tarballs.jl
+++ b/O/Openresty/build_tarballs.jl
@@ -3,13 +3,13 @@
 using BinaryBuilder, Pkg
 
 name = "Openresty"
-version = v"1.19.3"
+version = v"1.19.9"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://openresty.org/download/openresty-1.19.3.1.tar.gz", "f36fcd9c51f4f9eb8aaab8c7f9e21018d5ce97694315b19cacd6ccf53ab03d5d"),
+    ArchiveSource("https://openresty.org/download/openresty-1.19.9.1.tar.gz", "576ff4e546e3301ce474deef9345522b7ef3a9d172600c62057f182f3a68c1f6"),
     ArchiveSource("https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz", "0b8e7465dc5e98c757cc3650a20a7843ee4c3edf50aaf60bb33fd879690d2c73"),
-    ArchiveSource("https://www.openssl.org/source/openssl-1.0.2t.tar.gz", "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc"),
+    ArchiveSource("https://www.openssl.org/source/openssl-1.1.1l.tar.gz", "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1"),
     ArchiveSource("https://www.zlib.net/zlib-1.2.11.tar.gz", "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1")
 ]
 
@@ -20,7 +20,7 @@ export SUPER_VERBOSE=1
 ./configure --prefix=${prefix} \
     --with-cc=$CC \
     --with-zlib=$WORKSPACE/srcdir/zlib-1.2.11 \
-    --with-openssl=$WORKSPACE/srcdir/openssl-1.0.2t \
+    --with-openssl=$WORKSPACE/srcdir/openssl-1.1.1l \
     --with-pcre=$WORKSPACE/srcdir/pcre-8.43 \
     --with-pcre-jit
 make
@@ -33,9 +33,7 @@ install_license $prefix/COPYRIGHT
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Platform("i686", "linux"; libc="glibc"),
     Platform("x86_64", "linux"; libc="glibc"),
-    Platform("i686", "linux"; libc="musl"),
     Platform("x86_64", "linux"; libc="musl"),
 ]
 


### PR DESCRIPTION
Update Openresty to v1.19.9 and use openssl v1.1.1l instead of v1.0.
Dropping 32bit build, it does not compile and is also not used.