### PR TITLE
[Tectonic] Use pre-build binaries for 0.7.1

### DIFF
--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -9,6 +9,7 @@ sources = [
     ArchiveSource("$(url_prefix)-x86_64-unknown-linux-musl.tar.gz", "e46767ab9edc8cd83666a293020c290c984470d984f6f6e2f53454c0869c3dd4"; unpack_target="x86_64-linux-musl"),
     ArchiveSource("$(url_prefix)-x86_64-pc-windows-gnu.zip", "96659ede3eaeab5070bc518810a369d4113deaa53262b3d48d220c2f77c55072"; unpack_target="x86_64-w64-mingw32"),
     ArchiveSource("$(url_prefix)-x86_64-apple-darwin.tar.gz", "4311c5f77d89f11be2f56c14997c8b850f748038f679b8e73c5fe8601a50cba4"; unpack_target="x86_64-apple-darwin14"),
+    ArchiveSource("$(url_prefix)-arm-unknown-linux-musleabihf.tar.gz", "25ae41fdef59beef229f32114ebb15d3c1c1cd743535876965f4eef3a9292619"; unpack_target="aarch64-linux-gnu"),
     FileSource("https://raw.githubusercontent.com/tectonic-typesetting/tectonic/tectonic%40$(version)/LICENSE", "814a258f76e420b25cb3c07172eb2b3956f34cefbf0a650413b78e65c425f306")
 ]
 

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -9,7 +9,7 @@ sources = [
     ArchiveSource("$(url_prefix)-x86_64-unknown-linux-musl.tar.gz", "e46767ab9edc8cd83666a293020c290c984470d984f6f6e2f53454c0869c3dd4"; unpack_target="x86_64-linux-musl"),
     ArchiveSource("$(url_prefix)-x86_64-pc-windows-gnu.zip", "96659ede3eaeab5070bc518810a369d4113deaa53262b3d48d220c2f77c55072"; unpack_target="x86_64-w64-mingw32"),
     ArchiveSource("$(url_prefix)-x86_64-apple-darwin.tar.gz", "4311c5f77d89f11be2f56c14997c8b850f748038f679b8e73c5fe8601a50cba4"; unpack_target="x86_64-apple-darwin14"),
-    FileSource("https://raw.githubusercontent.com/tectonic-typesetting/tectonic/tectonic%40$(version)/LICENSE", "814a258f76e420b25cb3c07172eb2b3956f34cefbf0a650413b78e65c425f306"),
+    FileSource("https://raw.githubusercontent.com/tectonic-typesetting/tectonic/tectonic%40$(version)/LICENSE", "814a258f76e420b25cb3c07172eb2b3956f34cefbf0a650413b78e65c425f306")
 ]
 
 # Bash recipe for building across all platforms

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -7,6 +7,8 @@ url_prefix = "https://github.com/tectonic-typesetting/tectonic/releases/download
 sources = [
     ArchiveSource("$(url_prefix)-x86_64-unknown-linux-gnu.tar.gz", "3a128a4f2302033c350f9a18dc35a48f3034173d9e02b80c00ae4f83ee506cde"; unpack_target="x86_64-linux-gnu"),
     ArchiveSource("$(url_prefix)-x86_64-unknown-linux-musl.tar.gz", "e46767ab9edc8cd83666a293020c290c984470d984f6f6e2f53454c0869c3dd4"; unpack_target="x86_64-linux-musl"),
+    ArchiveSource("$(url_prefix)-x86_64-pc-windows-gnu.zip", "96659ede3eaeab5070bc518810a369d4113deaa53262b3d48d220c2f77c55072"; unpack_target="x86_64-w64-mingw32"),
+    ArchiveSource("$(url_prefix)-x86_64-apple-darwin.tar.gz", "4311c5f77d89f11be2f56c14997c8b850f748038f679b8e73c5fe8601a50cba4"; unpack_target="x86_64-apple-darwin14"),
     FileSource("https://raw.githubusercontent.com/tectonic-typesetting/tectonic/tectonic%40$(version)/LICENSE", "814a258f76e420b25cb3c07172eb2b3956f34cefbf0a650413b78e65c425f306"),
 ]
 
@@ -22,6 +24,8 @@ install_license LICENSE
 platforms = [
     Platform("x86_64", "linux"),
     Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "windows"),
+    Platform("x86_64", "macos")
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -1,40 +1,27 @@
-# Note that this script can accept some limited command-line arguments, run
-# `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder, Pkg
+using BinaryBuilder
 
 name = "tectonic"
-version = v"0.1.15"
+version = v"0.7.1"
 
-# Collection of sources required to build tar
+url_prefix = "https://github.com/tectonic-typesetting/tectonic/releases/download/tectonic%40$(version)/tectonic-$(version)"
 sources = [
-    ArchiveSource(
-        "https://github.com/tectonic-typesetting/tectonic/archive/tectonic@$(version).tar.gz",
-        "0e55188eafc1b58f3660a303fcdd6adc071051b9eb728119837fbeed2309914f"
-    )
+    ArchiveSource("$(url_prefix)-x86_64-unknown-linux-gnu.tar.gz", "3a128a4f2302033c350f9a18dc35a48f3034173d9e02b80c00ae4f83ee506cde"; unpack_target="x86_64-linux-gnu"),
+    ArchiveSource("$(url_prefix)-x86_64-unknown-linux-musl.tar.gz", "e46767ab9edc8cd83666a293020c290c984470d984f6f6e2f53454c0869c3dd4"; unpack_target="x86_64-linux-musl"),
+    FileSource("https://raw.githubusercontent.com/tectonic-typesetting/tectonic/tectonic%40$(version)/LICENSE", "814a258f76e420b25cb3c07172eb2b3956f34cefbf0a650413b78e65c425f306"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/tectonic-*/
-cargo build --release -j${nproc}
-cp target/${rust_target}/release/tectonic${exeext} ${bindir}/
+cd ${WORKSPACE}/srcdir/
+mkdir -p "${bindir}"
+dirprefix="${target}/"
+install -m 755 "${dirprefix}tectonic${exeext}" "${bindir}/tectonic${exeext}"
+install_license LICENSE
 """
 
-# Some platforms disabled for now due issues with rust and musl cross compilation. See #1673.
 platforms = [
-    Platform("x86_64", "freebsd"),
-    Platform("aarch64", "linux"; libc="glibc"),
-    # Platform("aarch64", "linux"; libc="musl"),
-    Platform("armv7l", "linux"; libc="glibc"),
-    # Platform("armv7l", "linux"; libc="musl"),
-    Platform("i686", "linux"; libc="glibc"),
-    # Platform("i686", "linux"; libc="musl"),
-    Platform("powerpc64le", "linux"; libc="glibc"),
-    Platform("x86_64", "linux"; libc="glibc"),
-    # Platform("x86_64", "linux"; libc="musl"),
-    Platform("x86_64", "macos"),
-    # Platform("i686", "windows"),
-    Platform("x86_64", "windows"),
+    Platform("x86_64", "linux"),
+    Platform("x86_64", "linux"; libc="musl"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 
@@ -45,15 +32,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Fontconfig_jll"),
-    Dependency("FreeType2_jll"),
-    Dependency("Graphite2_jll"),
-    Dependency("HarfBuzz_jll"),
-    Dependency(PackageSpec(; name="ICU_jll", version=v"67.1.0")),
-    Dependency("OpenSSL_jll"),
-    Dependency("Zlib_jll"),
-    Dependency("libpng_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers=[:c, :rust], preferred_gcc_version=v"7", lock_microarchitecture=false)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -7,9 +7,9 @@ url_prefix = "https://github.com/tectonic-typesetting/tectonic/releases/download
 sources = [
     ArchiveSource("$(url_prefix)-x86_64-unknown-linux-gnu.tar.gz", "3a128a4f2302033c350f9a18dc35a48f3034173d9e02b80c00ae4f83ee506cde"; unpack_target="x86_64-linux-gnu"),
     ArchiveSource("$(url_prefix)-x86_64-unknown-linux-musl.tar.gz", "e46767ab9edc8cd83666a293020c290c984470d984f6f6e2f53454c0869c3dd4"; unpack_target="x86_64-linux-musl"),
+    ArchiveSource("$(url_prefix)-arm-unknown-linux-musleabihf.tar.gz", "25ae41fdef59beef229f32114ebb15d3c1c1cd743535876965f4eef3a9292619"; unpack_target="aarch64-linux-gnu"),
     ArchiveSource("$(url_prefix)-x86_64-pc-windows-gnu.zip", "96659ede3eaeab5070bc518810a369d4113deaa53262b3d48d220c2f77c55072"; unpack_target="x86_64-w64-mingw32"),
     ArchiveSource("$(url_prefix)-x86_64-apple-darwin.tar.gz", "4311c5f77d89f11be2f56c14997c8b850f748038f679b8e73c5fe8601a50cba4"; unpack_target="x86_64-apple-darwin14"),
-    ArchiveSource("$(url_prefix)-arm-unknown-linux-musleabihf.tar.gz", "25ae41fdef59beef229f32114ebb15d3c1c1cd743535876965f4eef3a9292619"; unpack_target="aarch64-linux-gnu"),
     FileSource("https://raw.githubusercontent.com/tectonic-typesetting/tectonic/tectonic%40$(version)/LICENSE", "814a258f76e420b25cb3c07172eb2b3956f34cefbf0a650413b78e65c425f306")
 ]
 
@@ -25,8 +25,9 @@ install_license LICENSE
 platforms = [
     Platform("x86_64", "linux"),
     Platform("x86_64", "linux"; libc="musl"),
+    Platform("aarch64", "linux")
     Platform("x86_64", "windows"),
-    Platform("x86_64", "macos")
+    Platform("x86_64", "macos"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -25,9 +25,9 @@ install_license LICENSE
 platforms = [
     Platform("x86_64", "linux"),
     Platform("x86_64", "linux"; libc="musl"),
-    Platform("aarch64", "linux")
+    Platform("aarch64", "linux"),
     Platform("x86_64", "windows"),
-    Platform("x86_64", "macos"),
+    Platform("x86_64", "macos")
 ]
 platforms = expand_cxxstring_abis(platforms)
 


### PR DESCRIPTION
In #3616, a recent attempt is made to build Tectonic from source. In this PR, I suggest to use the released binaries instead. 

Note that, unlike https://github.com/MichaelHatherly/Tectonic.jl, this doesn't include `biber`, so 

```
\documentclass{article}
\usepackage[autostyle]{csquotes}

\begin{document}

test

\end{document}
```

**can** be build with `./tectonic` and

```
\documentclass{article}
\usepackage[autostyle]{csquotes}
\usepackage[
    backend=bibtex
]{biblatex}
\addbibresource{references.bib}

\begin{document}

Lorem ipsum dolor sit amet~\cite{orwell1945animal}.

\printbibliography

\end{document}
```
can be build too. However, the `biber` backend won't work when changing `backend=bibtex` to `backend=biber` unless the `biber` executable is available on the system. In https://github.com/MichaelHatherly/Tectonic.jl, this is solved by manually also including the `biber` executables.

But, I think it would make more sense to add `biber` as a separate binary to Yggdrasil. Users who want `biber` can then write:

```
biber() do biber_bin
     tectonic() do tectonic_bin
          run(`$tectonic_bin myfile.tex`)
     end
end
```