### PR TITLE
add cpu_features

### DIFF
--- a/C/cpu_features/build_tarballs.jl
+++ b/C/cpu_features/build_tarballs.jl
@@ -1,0 +1,52 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "cpu_features"
+version = v"0.6.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/google/cpu_features/archive/refs/tags/v0.6.0.tar.gz", "95a1cf6f24948031df114798a97eea2a71143bd38a4d07d9a758dda3924c1932"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/cpu_features-*/
+
+if [[ ${target} == *-freebsd* ]]; then
+    #this is not in 0.6.0 release, but has been added on master, can probably remove after next release
+    atomic_patch -p1 "${WORKSPACE}/srcdir/patches/add-freebsd-macros.patch"
+fi
+
+
+mkdir build
+cd build/
+
+cmake .. \
+-DCMAKE_INSTALL_PREFIX=${prefix} \
+-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+-DCMAKE_BUILD_TYPE=Release
+
+make -j${nproc}
+make install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; experimental = true)
+
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("list_cpu_features", :list_cpu_features)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+#need at least gcc5 for Wincompatible-pointer-type flag
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")

--- a/C/cpu_features/bundled/patches/add-freebsd-macros.patch
+++ b/C/cpu_features/bundled/patches/add-freebsd-macros.patch
@@ -1,0 +1,74 @@
+diff --git a/include/cpu_features_macros.h b/include/cpu_features_macros.h
+index 4b231a1..59649b2 100644
+--- a/include/cpu_features_macros.h
++++ b/include/cpu_features_macros.h
+@@ -83,6 +83,10 @@
+ #define CPU_FEATURES_OS_DARWIN
+ #endif
+ 
++#if (defined(__freebsd__) || defined(__FreeBSD__))
++#define CPU_FEATURES_OS_FREEBSD
++#endif
++
+ ////////////////////////////////////////////////////////////////////////////////
+ // Compilers
+ ////////////////////////////////////////////////////////////////////////////////
+diff --git a/src/cpuinfo_x86.c b/src/cpuinfo_x86.c
+index 378ed05..33ddb63 100644
+--- a/src/cpuinfo_x86.c
++++ b/src/cpuinfo_x86.c
+@@ -97,7 +97,7 @@
+ // microarchitectures.
+ #if defined(CPU_FEATURES_OS_WINDOWS)
+ #include <windows.h>  // IsProcessorFeaturePresent
+-#elif defined(CPU_FEATURES_OS_LINUX_OR_ANDROID)
++#elif defined(CPU_FEATURES_OS_LINUX_OR_ANDROID) || defined(CPU_FEATURES_OS_FREEBSD)
+ #include "internal/filesystem.h"         // Needed to parse /proc/cpuinfo
+ #include "internal/stack_line_reader.h"  // Needed to parse /proc/cpuinfo
+ #include "internal/string_view.h"        // Needed to parse /proc/cpuinfo
+@@ -1239,6 +1239,45 @@ static void DetectSseViaOs(X86Features* features) {
+   features->ssse3 = GetDarwinSysCtlByName("hw.optional.supplementalsse3");
+   features->sse4_1 = GetDarwinSysCtlByName("hw.optional.sse4_1");
+   features->sse4_2 = GetDarwinSysCtlByName("hw.optional.sse4_2");
++  #elif defined(CPU_FEATURES_OS_FREEBSD)
++    // Handling FreeBSD platform through parsing /var/run/dmesg.boot.
++    const int fd = CpuFeatures_OpenFile("/var/run/dmesg.boot");
++    if (fd >= 0) {
++      StackLineReader reader;
++      StackLineReader_Initialize(&reader, fd);
++      for (;;) {
++        const LineResult result = StackLineReader_NextLine(&reader);
++        const StringView line = result.line;
++        const bool is_feature =
++            CpuFeatures_StringView_StartsWith(line, str("  Features="));
++        const bool is_feature2 =
++            CpuFeatures_StringView_StartsWith(line, str("  Features2="));
++        if (is_feature || is_feature2) {
++          // Lines of interests are of the following form:
++          // "  Features=0x1783fbff<PSE36,MMX,FXSR,SSE,SSE2,HTT>"
++          // We replace '<', '>' and ',' with space so we can search by
++          // whitespace separated word.
++          // TODO: Fix CpuFeatures_StringView_HasWord to allow for different
++          // separators.
++          for (size_t i = 0; i < line.size; ++i) {
++            char* c = (char*)(&(line.ptr[i]));
++            if (*c == '<' || *c == '>' || *c == ',') *c = ' ';
++          }
++          if (is_feature) {
++            features->sse = CpuFeatures_StringView_HasWord(line, "SSE");
++            features->sse2 = CpuFeatures_StringView_HasWord(line, "SSE2");
++          }
++          if (is_feature2) {
++            features->sse3 = CpuFeatures_StringView_HasWord(line, "SSE3");
++            features->ssse3 = CpuFeatures_StringView_HasWord(line, "SSSE3");
++            features->sse4_1 = CpuFeatures_StringView_HasWord(line, "SSE4.1");
++            features->sse4_2 = CpuFeatures_StringView_HasWord(line, "SSE4.2");
++          }
++        }
++        if (result.eof) break;
++      }
++      CpuFeatures_CloseFile(fd);
++    }
+ #elif defined(CPU_FEATURES_OS_LINUX_OR_ANDROID)
+   // Handling Linux platform through /proc/cpuinfo.
+   const int fd = CpuFeatures_OpenFile("/proc/cpuinfo");


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [cpu_features](https://github.com/google/cpu_features) library.

This  works for me on the regular platforms I test on, but there are a few commits on master that are not in the release that I may need to pull in still for the apple-* platforms.

The top level CMake file also [strongly recommends](https://github.com/google/cpu_features/blob/628c50e92d7b2223a3159fb53dbc49835233a84a/CMakeLists.txt#L20-L24) building as a static library, so I didn't mess with anything and just produce the executable currently.