### PR TITLE
[VOLK] specify boost_jll compat

### DIFF
--- a/V/VOLK/build_tarballs.jl
+++ b/V/VOLK/build_tarballs.jl
@@ -62,7 +62,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"))
+    Dependency("boost_jll"; compat="=1.76.0")
     HostBuildDependency(PackageSpec(name="ORC_jll", uuid="fb41591b-4dee-5dae-bf56-d83afd04fbc0"))
 ]
 


### PR DESCRIPTION
This specifies the compat version of the `boost_jll` dependency. I missed this initially in #3718