### PR TITLE
New Recipe: Modflow6 v6.2.2

### DIFF
--- a/M/Modflow6/build_tarballs.jl
+++ b/M/Modflow6/build_tarballs.jl
@@ -17,7 +17,7 @@ cd $WORKSPACE/srcdir/modflow6
 # lower the minimum required meson version
 sed -i s/0.59.0/0.58.0/ meson.build
 
-meson --debug=false --optimization=2 --cross-file=${MESON_TARGET_TOOLCHAIN} builddir
+meson -Ddebug=false -Doptimization=2 --cross-file=${MESON_TARGET_TOOLCHAIN} builddir
 meson compile -C builddir -j${nproc}
 meson install -C builddir
 """


### PR DESCRIPTION
Modflow is a groundwater modeling code written in Fortran by the USGS.

This requires a recent development commit for meson build support (thanks @Hofer-Julian!). From next release we can switch to tags. GCC 4.7 is not used due to a requirement on gfortran 4.9+ as mentioned in the [developer docs](https://github.com/MODFLOW-USGS/modflow6/blob/04ab9e1a9ccf428a16f84c477aa24ac76dd56224/DEVELOPER.md).