### PR TITLE
[OpenBLAS] Use 512 threads as max threads for OpenBLAS

### DIFF
--- a/O/OpenBLAS/common.jl
+++ b/O/OpenBLAS/common.jl
@@ -38,7 +38,7 @@ function openblas_sources(version::VersionNumber; kwargs...)
     ]
 end
 
-function openblas_script(;num_64bit_threads::Integer=4096, openblas32::Bool=false, aarch64_ilp64::Bool=false, kwargs...)
+function openblas_script(;num_64bit_threads::Integer=512, openblas32::Bool=false, aarch64_ilp64::Bool=false, kwargs...)
     # Allow some basic configuration
     script = """
     NUM_64BIT_THREADS=$(num_64bit_threads)


### PR DESCRIPTION
4096 is too high. Moving to 512 as discussed in https://github.com/JuliaLang/LinearAlgebra.jl/issues/877, which should be quite sufficient.

Note that this is not yet going to rebuild the openblas packages, which should come next.

cc @chriselrod @staticfloat 