### PR TITLE
add HYPRE

### DIFF
--- a/H/HYPRE/build_tarballs.jl
+++ b/H/HYPRE/build_tarballs.jl
@@ -52,7 +52,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [HYPRE](https://github.com/hypre-space/hypre) library. This is fairly close to default, I did turn off some of the CUDA functionality that is normally enabled by default to be able to finish the wizard.

Tested locally on `x86_64-linux-*`, `x86_64-w64-mingw` and `powerpc`