### PR TITLE
Minor version number bump (Minkowski sum & difference)

### DIFF
--- a/C/Clipper/build_tarballs.jl
+++ b/C/Clipper/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "Clipper"
-version = v"6.4.2"
+version = v"6.4.3"
 
 # Collection of sources required to build Clipper
 sources = [


### PR DESCRIPTION
@sjkelly To use the JLL with the new features in `Clipper.jl` we need a minor version bump.