### PR TITLE
add asmjit

### DIFF
--- a/A/AsmJit/build_tarballs.jl
+++ b/A/AsmJit/build_tarballs.jl
@@ -2,7 +2,7 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-name = "asmjit"
+name = "AsmJit"
 version = v"0.1.0"
 
 # Collection of sources required to complete build


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [asmjit](https://github.com/asmjit/asmjit) library.
There are no tags and/or releases, so I am building from the most current commit on `master` here.

Tested on `x86_64-linux-*`, `x86_64-w64-mingw`, `powerpc` and `arm7l-linux-musabihf`.
The README notes ARM support is still TODO but it seemed to work? I tentatively left off the `;experimental=true` in platforms. There are a few open PRs/issues mentioning it so I am assuming it should be added at some point in the future.