### PR TITLE
Update snappy to 1.1.9, add Apple M1 support

### DIFF
--- a/S/snappy/bundled/patches/snappy.patch
+++ b/S/snappy/bundled/patches/snappy.patch
@@ -1,0 +1,24 @@
+From f78dad304918275a38701b308eccbcf000d215a7 Mon Sep 17 00:00:00 2001
+From: Max Horn <max@quendi.de>
+Date: Fri, 22 Oct 2021 22:40:34 +0200
+Subject: [PATCH] Work around compiler not being able to inline
+
+---
+ snappy.cc | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/snappy.cc b/snappy.cc
+index 79dc0e8..48faad2 100644
+--- a/snappy.cc
++++ b/snappy.cc
+@@ -1013,7 +1013,6 @@ void MemMove(ptrdiff_t dst, const void* src, size_t size) {
+   (void)size;
+ }
+ 
+-SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+ size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
+   const uint8_t*& ip = *ip_p;
+   // This section is crucial for the throughput of the decompression loop.
+-- 
+2.21.1 (Apple Git-122.3)
+


### PR DESCRIPTION
This is needed for `Mongoc_jll` and hence ultimately `MongoC.jl`; I've asked whether they are OK with requiring Julia >= 1.6, and @felipenoris  confirmed that is the case, see https://github.com/felipenoris/Mongoc.jl/issues/86
