### PR TITLE
[PETSc] Attempt to rebuild with good include files (and don't rename libpetsc)

### DIFF
--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -69,6 +69,12 @@ build_petsc()
         CFLAGS="${CFLAGS}" \
         FFLAGS="${FFLAGS}"
     make install
+    if [[ "${target}" == *-mingw* ]]; then
+        # changing the extension from so to dll.
+        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.so "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
+    else
+        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.${dlext} "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
+    fi
 }
 
 build_petsc double real Int32
@@ -86,15 +92,15 @@ platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686
 
 products = [
     # Current default build, equivalent to Float64_Real_Int32
-    LibraryProduct("libpetsc", :libpetsc, "\$libdir/petsc/double_real_Int32/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int32, "\$libdir/petsc/double_real_Int32/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, "\$libdir/petsc/double_real_Int64/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, "\$libdir/petsc/single_real_Int64/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int64, "\$libdir/petsc/double_complex_Int64/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int64, "\$libdir/petsc/single_complex_Int64/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int32, "\$libdir/petsc/single_real_Int32/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int32, "\$libdir/petsc/double_complex_Int32/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int32, "\$libdir/petsc/single_complex_Int32/lib")
+    LibraryProduct("libpetsc_double_real_Int32", :libpetsc, "\$libdir/petsc/double_real_Int32/lib")
+    LibraryProduct("libpetsc_double_real_Int32", :libpetsc_Float64_Real_Int32, "\$libdir/petsc/double_real_Int32/lib")
+    LibraryProduct("libpetsc_double_real_Int64", :libpetsc_Float64_Real_Int64, "\$libdir/petsc/double_real_Int64/lib")
+    LibraryProduct("libpetsc_single_real_Int64", :libpetsc_Float32_Real_Int64, "\$libdir/petsc/single_real_Int64/lib")
+    LibraryProduct("libpetsc_double_complex_Int64", :libpetsc_Float64_Complex_Int64, "\$libdir/petsc/double_complex_Int64/lib")
+    LibraryProduct("libpetsc_single_complex_Int64", :libpetsc_Float32_Complex_Int64, "\$libdir/petsc/single_complex_Int64/lib")
+    LibraryProduct("libpetsc_single_real_Int32", :libpetsc_Float32_Real_Int32, "\$libdir/petsc/single_real_Int32/lib")
+    LibraryProduct("libpetsc_double_complex_Int32", :libpetsc_Float64_Complex_Int32, "\$libdir/petsc/double_complex_Int32/lib")
+    LibraryProduct("libpetsc_single_complex_Int32", :libpetsc_Float32_Complex_Int32, "\$libdir/petsc/single_complex_Int32/lib")
 ]
 
 dependencies = [
@@ -105,4 +111,4 @@ dependencies = [
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"9")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"9")

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -69,12 +69,7 @@ build_petsc()
         CFLAGS="${CFLAGS}" \
         FFLAGS="${FFLAGS}"
     make install
-    if [[ "${target}" == *-mingw* ]]; then
-        # changing the extension from so to dll.
-        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.so "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
-    else
-        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.${dlext} "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
-    fi
+    mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.${dlext} "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
 }
 
 build_petsc double real Int32

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -70,10 +70,7 @@ build_petsc()
         FFLAGS="${FFLAGS}"
     make install
 
-    if [[ "${target}" == *-mingw* ]]; then
-        # changing the extension from so to dll.
-        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.so.*.*.* "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
-    elif [[ "${target}" == *-apple* ]]; then
+    if [[ "${target}" == *-apple* ]]; then
         mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.*.*.*.${dlext} "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
     else
         mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.${dlext}.*.*.* "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -69,7 +69,18 @@ build_petsc()
         CFLAGS="${CFLAGS}" \
         FFLAGS="${FFLAGS}"
     make install
-    mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.${dlext} "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
+
+    if [[ "${target}" == *-mingw* ]]; then
+        # changing the extension from so to dll.
+        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.so.*.*.* "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
+    elif [[ "${target}" == *-apple* ]]; then
+        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.*.*.*.${dlext} "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
+    else
+        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.${dlext}.*.*.* "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc_${1}_${2}_${3}.${dlext}"
+    fi
+
+    # Remove now broken(?) links
+    rm ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.*
 }
 
 build_petsc double real Int32

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -1,13 +1,13 @@
 using BinaryBuilder
 
 name = "PETSc"
-version = v"3.15.2"
+version = v"3.16.5"
 
 # Collection of sources required to build PETSc. Avoid using the git repository, it will
 # require building SOWING which fails in all non-linux platforms.
 sources = [
     ArchiveSource("https://www.mcs.anl.gov/petsc/mirror/release-snapshots/petsc-$(version).tar.gz",
-    "3b10c19c69fc42e01a38132668724a01f1da56f5c353105cd28f1120cc9041d8"),
+    "7de8570eeb94062752d82a83208fc2bafc77b3f515023a4c14d8ff9440e66cac"),
     DirectorySource("./bundled"),
 ]
 

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -87,14 +87,14 @@ platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686
 products = [
     # Current default build, equivalent to Float64_Real_Int32
     LibraryProduct("libpetsc", :libpetsc, "$libdir/petsc/double_real_Int32/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int32, "$libdir/petsc/double_real_Int32/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, "$libdir/petsc/double_real_Int64/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, "$libdir/petsc/single_real_Int64/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int64, "$libdir/petsc/double_complex_Int64/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int64, "$libdir/petsc/single_complex_Int64/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int32, "$libdir/petsc/single_real_Int32/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int32, "$libdir/petsc/double_complex_Int32/lib")
-    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int32, "$libdir/petsc/single_complex_Int32/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int32, "\$libdir/petsc/double_real_Int32/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, "\$libdir/petsc/double_real_Int64/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, "\$libdir/petsc/single_real_Int64/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int64, "\$libdir/petsc/double_complex_Int64/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int64, "\$libdir/petsc/single_complex_Int64/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int32, "\$libdir/petsc/single_real_Int32/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int32, "\$libdir/petsc/double_complex_Int32/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int32, "\$libdir/petsc/single_complex_Int32/lib")
 ]
 
 dependencies = [

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -86,15 +86,15 @@ platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686
 
 products = [
     # Current default build, equivalent to Float64_Real_Int32
-    LibraryProduct("libpetsc", :libpetsc, ["lib/petsc/double_real_Int32/lib", "bin/petsc/double_real_Int32/lib"]),
-    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int32, ["lib/petsc/double_real_Int32/lib", "bin/petsc/double_real_Int32/lib"]),
-    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, ["lib/petsc/double_real_Int64/lib", "bin/petsc/double_real_Int64/lib"]),
-    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, ["lib/petsc/single_real_Int64/lib", "bin/petsc/single_real_Int64/lib"]),
-    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int64, ["lib/petsc/double_complex_Int64/lib", "bin/petsc/double_complex_Int64/lib"]),
-    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int64, ["lib/petsc/single_complex_Int64/lib", "bin/petsc/single_complex_Int64/lib"]),
-    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int32, ["lib/petsc/single_real_Int32/lib", "bin/petsc/single_real_Int32/lib"]),
-    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int32, ["lib/petsc/double_complex_Int32/lib", "bin/petsc/double_complex_Int32/lib"]),
-    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int32, ["lib/petsc/single_complex_Int32/lib", "bin/petsc/single_complex_Int32/lib"]),
+    LibraryProduct("libpetsc", :libpetsc, "$libdir/petsc/double_real_Int32/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int32, "$libdir/petsc/double_real_Int32/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, "$libdir/petsc/double_real_Int64/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, "$libdir/petsc/single_real_Int64/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int64, "$libdir/petsc/double_complex_Int64/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int64, "$libdir/petsc/single_complex_Int64/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int32, "$libdir/petsc/single_real_Int32/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int32, "$libdir/petsc/double_complex_Int32/lib")
+    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int32, "$libdir/petsc/single_complex_Int32/lib")
 ]
 
 dependencies = [

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -54,7 +54,8 @@ build_petsc()
         --with-mpi-include="${includedir}" \
         --with-sowing=0 \
         --with-precision=${1} \
-        --with-scalar-type=${2}
+        --with-scalar-type=${2} \
+        --PETSC_ARCH=${target}_${1}_${2}_${3}
 
     if [[ "${target}" == *-mingw* ]]; then
         export CPPFLAGS="-Dpetsc_EXPORTS"
@@ -68,10 +69,6 @@ build_petsc()
         CFLAGS="${CFLAGS}" \
         FFLAGS="${FFLAGS}"
     make install
-    if [[ "${target}" == *-mingw* ]]; then
-        # changing the extension from so to dll.
-        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.so "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.${dlext}"
-    fi
 }
 
 build_petsc double real Int32
@@ -89,15 +86,15 @@ platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686
 
 products = [
     # Current default build, equivalent to Float64_Real_Int32
-    LibraryProduct("libpetsc", :libpetsc, "lib/petsc/double_real_Int32/lib"),
-    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int32, "lib/petsc/double_real_Int32/lib"),
-    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, "lib/petsc/double_real_Int64/lib"),
-    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, "lib/petsc/single_real_Int64/lib"),
-    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int64, "lib/petsc/double_complex_Int64/lib"),
-    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int64, "lib/petsc/single_complex_Int64/lib"),
-    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int32, "lib/petsc/single_real_Int32/lib"),
-    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int32, "lib/petsc/double_complex_Int32/lib"),
-    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int32, "lib/petsc/single_complex_Int32/lib"),
+    LibraryProduct("libpetsc", :libpetsc, ["lib/petsc/double_real_Int32/lib", "bin/petsc/double_real_Int32/lib"]),
+    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int32, ["lib/petsc/double_real_Int32/lib", "bin/petsc/double_real_Int32/lib"]),
+    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, ["lib/petsc/double_real_Int64/lib", "bin/petsc/double_real_Int64/lib"]),
+    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, ["lib/petsc/single_real_Int64/lib", "bin/petsc/single_real_Int64/lib"]),
+    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int64, ["lib/petsc/double_complex_Int64/lib", "bin/petsc/double_complex_Int64/lib"]),
+    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int64, ["lib/petsc/single_complex_Int64/lib", "bin/petsc/single_complex_Int64/lib"]),
+    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int32, ["lib/petsc/single_real_Int32/lib", "bin/petsc/single_real_Int32/lib"]),
+    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int32, ["lib/petsc/double_complex_Int32/lib", "bin/petsc/double_complex_Int32/lib"]),
+    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int32, ["lib/petsc/single_complex_Int32/lib", "bin/petsc/single_complex_Int32/lib"]),
 ]
 
 dependencies = [

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -33,19 +33,19 @@ build_petsc()
     else
         USE_INT64=0
     fi
-    mkdir $libdir/petsc/${target}_${1}_${2}_${3}
-    ./configure --prefix=${libdir}/petsc/${target}_${1}_${2}_${3} \
+    mkdir $libdir/petsc/${1}_${2}_${3}
+    ./configure --prefix=${libdir}/petsc/${1}_${2}_${3} \
         CC=${CC} \
         FC=${FC} \
         CXX=${CXX} \
         COPTFLAGS='-O3' \
         CXXOPTFLAGS='-O3' \
         CFLAGS='-fno-stack-protector' \
+        LDFLAGS="-L${libdir}" \
         FOPTFLAGS='-O3' \
         --with-64-bit-indices=${USE_INT64} \
         --with-debugging=0 \
         --with-batch \
-        --PETSC_ARCH=${target}_${1}_${2}_${3} \
         --with-blaslapack-lib=$BLAS_LAPACK_LIB \
         --with-blaslapack-suffix="" \
         --known-64-bit-blas-indices=0 \
@@ -66,16 +66,11 @@ build_petsc()
     make -j${nproc} \
         CPPFLAGS="${CPPFLAGS}" \
         CFLAGS="${CFLAGS}" \
-        FFLAGS="${FFLAGS}" \
-        all
-
+        FFLAGS="${FFLAGS}"
     make install
-    # Sym link into the correct directory.
-    ln -s $libdir/petsc/${target}_${1}_${2}_${3}/lib/libpetsc.${dlext} $libdir/libpetsc_${1}_${2}_${3}.${dlext}
 }
 
 build_petsc double real Int32
-cp -a $libdir/petsc/${target}_double_real_Int32/include/*.h $includedir/
 build_petsc single real Int32
 build_petsc double complex Int32
 build_petsc single complex Int32
@@ -89,15 +84,15 @@ build_petsc single complex Int64
 platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686", "windows")]))
 
 products = [
-    LibraryProduct("libpetsc_double_real_Int32", :libpetsc), # Current default build
-    LibraryProduct("libpetsc_double_real_Int64", :libpetsc_Float64_Real_Int64),
-    LibraryProduct("libpetsc_single_real_Int64", :libpetsc_Float32_Real_Int64),
-    LibraryProduct("libpetsc_double_complex_Int64", :libpetsc_Float64_Complex_Int64),
-    LibraryProduct("libpetsc_single_complex_Int64", :libpetsc_Float32_Complex_Int64),
-    LibraryProduct("libpetsc_double_real_Int32", :libpetsc_Float64_Real_Int32),
-    LibraryProduct("libpetsc_single_real_Int32", :libpetsc_Float32_Real_Int32),
-    LibraryProduct("libpetsc_double_complex_Int32", :libpetsc_Float64_Complex_Int32),
-    LibraryProduct("libpetsc_single_complex_Int32", :libpetsc_Float32_Complex_Int32),
+    # Current default build, equivalent to Float64_Real_Int32
+    LibraryProduct("libpetsc", :libpetsc, "lib/petsc/double_real_Int32/lib"),
+    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, "lib/petsc/double_real_Int64/lib"),
+    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, "lib/petsc/single_real_Int64/lib"),
+    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int64, "lib/petsc/double_complex_Int64/lib"),
+    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int64, "lib/petsc/single_complex_Int64/lib"),
+    LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int32, "lib/petsc/single_real_Int32/lib"),
+    LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int32, "lib/petsc/double_complex_Int32/lib"),
+    LibraryProduct("libpetsc", :libpetsc_Float32_Complex_Int32, "lib/petsc/single_complex_Int32/lib"),
 ]
 
 dependencies = [

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -64,13 +64,11 @@ build_petsc()
     fi
 
     make -j${nproc} \
-        PETSC_DIR="${PWD}" \
-        PETSC_ARCH="${target}_${1}_${2}_${3}" \
         CPPFLAGS="${CPPFLAGS}" \
         CFLAGS="${CFLAGS}" \
         FFLAGS="${FFLAGS}" \
         all
-    
+
     make install
     # Sym link into the correct directory.
     ln -s $libdir/petsc/${target}_${1}_${2}_${3}/lib/libpetsc.${dlext} $libdir/libpetsc_${1}_${2}_${3}.${dlext}

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -73,7 +73,7 @@ build_petsc()
     
     make install
     # Sym link into the correct directory.
-    ln -s $libdir/petsc/${target}_${1}_${2}_${3}/lib/libpetsc.${dlext} $libdir/libpetsc_${target}_${1}_${2}_${3}.${dlext}
+    ln -s $libdir/petsc/${target}_${1}_${2}_${3}/lib/libpetsc.${dlext} $libdir/libpetsc_${1}_${2}_${3}.${dlext}
 }
 
 build_petsc double real Int32

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -24,7 +24,7 @@ if [[ "${target}" == *-mingw* ]]; then
 else
     MPI_LIBS="[${libdir}/libmpifort.${dlext},${libdir}/libmpi.${dlext}]"
 fi
-
+mkdir $libdir/petsc
 build_petsc()
 {
 
@@ -33,8 +33,8 @@ build_petsc()
     else
         USE_INT64=0
     fi
-
-    ./configure --prefix=${prefix} \
+    mkdir $libdir/petsc/${target}_${1}_${2}_${3}
+    ./configure --prefix=${libdir}/petsc/${target}_${1}_${2}_${3} \
         CC=${CC} \
         FC=${FC} \
         CXX=${CXX} \
@@ -69,27 +69,15 @@ build_petsc()
         CPPFLAGS="${CPPFLAGS}" \
         CFLAGS="${CFLAGS}" \
         FFLAGS="${FFLAGS}" \
-        DEST_DIR="${prefix}" \
         all
-
-    make PETSC_DIR=$PWD PETSC_ARCH=${target}_${1}_${2}_${3} DEST_DIR=$prefix install
-
-    # add suffix to library name
-    if [[ "${target}" == *-mingw* ]]; then
-        # changing the extension from so to dll.
-        mv ${prefix}/lib/libpetsc.so.*.*.* "${libdir}/libpetsc_${1}_${2}_${3}.${dlext}"
-    elif [[ "${target}" == *-apple* ]]; then
-        mv ${prefix}/lib/libpetsc.*.*.*.${dlext} "${libdir}/libpetsc_${1}_${2}_${3}.${dlext}"
-    else
-        mv ${prefix}/lib/libpetsc.${dlext}.*.*.* "${libdir}/libpetsc_${1}_${2}_${3}.${dlext}"
-    fi
-    # Remove useless links
-    rm ${prefix}/lib/libpetsc.*
-    # Remove duplicated file
-    rm ${prefix}/lib/pkgconfig/PETSc.pc
+    
+    make install
+    # Sym link into the correct directory.
+    ln -s $libdir/petsc/${target}_${1}_${2}_${3}/lib/libpetsc.${dlext} $libdir/libpetsc_${target}_${1}_${2}_${3}.${dlext}
 }
 
 build_petsc double real Int32
+cp -a $libdir/petsc/x86_64-linux-gnu_double_real_Int32/include/*.h $includedir/
 build_petsc single real Int32
 build_petsc double complex Int32
 build_petsc single complex Int32

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -77,7 +77,7 @@ build_petsc()
 }
 
 build_petsc double real Int32
-cp -a $libdir/petsc/x86_64-linux-gnu_double_real_Int32/include/*.h $includedir/
+cp -a $libdir/petsc/${target}-gnu_double_real_Int32/include/*.h $includedir/
 build_petsc single real Int32
 build_petsc double complex Int32
 build_petsc single complex Int32

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -68,6 +68,10 @@ build_petsc()
         CFLAGS="${CFLAGS}" \
         FFLAGS="${FFLAGS}"
     make install
+    if [[ "${target}" == *-mingw* ]]; then
+        # changing the extension from so to dll.
+        mv ${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.so "${libdir}/petsc/${1}_${2}_${3}/lib/libpetsc.${dlext}"
+    fi
 }
 
 build_petsc double real Int32
@@ -86,6 +90,7 @@ platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686
 products = [
     # Current default build, equivalent to Float64_Real_Int32
     LibraryProduct("libpetsc", :libpetsc, "lib/petsc/double_real_Int32/lib"),
+    LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int32, "lib/petsc/double_real_Int32/lib"),
     LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, "lib/petsc/double_real_Int64/lib"),
     LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, "lib/petsc/single_real_Int64/lib"),
     LibraryProduct("libpetsc", :libpetsc_Float64_Complex_Int64, "lib/petsc/double_complex_Int64/lib"),

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -86,7 +86,7 @@ platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686
 
 products = [
     # Current default build, equivalent to Float64_Real_Int32
-    LibraryProduct("libpetsc", :libpetsc, "$libdir/petsc/double_real_Int32/lib")
+    LibraryProduct("libpetsc", :libpetsc, "\$libdir/petsc/double_real_Int32/lib")
     LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int32, "\$libdir/petsc/double_real_Int32/lib")
     LibraryProduct("libpetsc", :libpetsc_Float64_Real_Int64, "\$libdir/petsc/double_real_Int64/lib")
     LibraryProduct("libpetsc", :libpetsc_Float32_Real_Int64, "\$libdir/petsc/single_real_Int64/lib")

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -77,7 +77,7 @@ build_petsc()
 }
 
 build_petsc double real Int32
-cp -a $libdir/petsc/${target}-gnu_double_real_Int32/include/*.h $includedir/
+cp -a $libdir/petsc/${target}_double_real_Int32/include/*.h $includedir/
 build_petsc single real Int32
 build_petsc double complex Int32
 build_petsc single complex Int32


### PR DESCRIPTION
This is just a first attempt at building PETSc a little differently. It may be totally the wrong way to do it, but it achieves two things: keeps generated include files for each scalar type version, and avoids renaming.

I'm not sure the latter is necessary, but it helps me avoid symlinking/digging into build systems for packages that depend on `-lpetsc`. 