### PR TITLE
[libunwind] Add upstream PR for DWARF parsing as a patch

### DIFF
--- a/L/LibUnwind/build_tarballs.jl
+++ b/L/LibUnwind/build_tarballs.jl
@@ -29,6 +29,7 @@ atomic_patch -p1 ${WORKSPACE}/srcdir/patches/libunwind-static-arm.patch
 atomic_patch -p0 ${WORKSPACE}/srcdir/patches/libunwind-configure-ppc64le.patch
 atomic_patch -p0 ${WORKSPACE}/srcdir/patches/libunwind-configure-static-lzma.patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/libunwind-cfa-rsp.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/libunwind-dwarf4-cie.patch
 
 CFLAGS="${CFLAGS} -DPI -fPIC -I${prefix}/include"
 ./configure \

--- a/L/LibUnwind/bundled/patches/libunwind-dwarf4-cie.patch
+++ b/L/LibUnwind/bundled/patches/libunwind-dwarf4-cie.patch
@@ -1,0 +1,38 @@
+From 59f4736785d3619838399cf14a1f61cff2172940 Mon Sep 17 00:00:00 2001
+From: Dave Watson <dade.watson@gmail.com>
+Date: Fri, 25 Jun 2021 11:12:17 -0700
+Subject: [PATCH] DWARF: dwarf4 fix cie parsing
+
+dwarf 4 addds address_size and segment_size fields. Read these before code/data align fields.
+---
+ src/dwarf/Gfde.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/dwarf/Gfde.c b/src/dwarf/Gfde.c
+index 9250b895e..3d3edaac1 100644
+--- a/src/dwarf/Gfde.c
++++ b/src/dwarf/Gfde.c
+@@ -48,6 +48,7 @@ parse_cie (unw_addr_space_t as, unw_accessors_t *a, unw_word_t addr,
+            int is_debug_frame, void *arg)
+ {
+   uint8_t version, ch, augstr[5], fde_encoding, handler_encoding;
++  uint8_t address_size, segment_size;
+   unw_word_t len, cie_end_addr, aug_size;
+   uint32_t u32val;
+   uint64_t u64val;
+@@ -138,6 +139,15 @@ parse_cie (unw_addr_space_t as, unw_accessors_t *a, unw_word_t addr,
+         augstr[i++] = ch;
+     }
+ 
++  if (version > 3)
++    {
++      if((ret = dwarf_readu8(as, a, &addr, &address_size, arg)) < 0) 
++	return ret;
++
++      if((ret = dwarf_readu8(as, a, &addr, &segment_size, arg)) < 0) 
++	return ret;
++    }
++
+   if ((ret = dwarf_read_uleb128 (as, a, &addr, &dci->code_align, arg)) < 0
+       || (ret = dwarf_read_sleb128 (as, a, &addr, &dci->data_align, arg)) < 0)
+     return ret;


### PR DESCRIPTION
DWARF v4 added fields to CIE that were not previously being parsed correctly by libunwind. See https://github.com/libunwind/libunwind/pull/266.

~This fixes the Julia test failures on FreeBSD for me (https://github.com/JuliaLang/julia/issues/41943).~ 😭 it doesn't reliably