### PR TITLE
Update Singular_jll to latest version, second try

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -28,14 +28,14 @@ import Pkg.Types: VersionSpec
 #
 name = "Singular"
 upstream_version = v"4.2.1-1" # 4.2.1p1 plus some more changes
-version_offset = v"0.0.2"
+version_offset = v"0.1.0"
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,
                         upstream_version.patch * 100 + version_offset.minor,
                         Int(upstream_version.prerelease[1]) * 100 + version_offset.patch)
 
 # Collection of sources required to build normaliz
 sources = [
-    GitSource("https://github.com/Singular/Singular.git", "6f184ed5718756bb0410a3aebe5f372b76edd55f"),
+    GitSource("https://github.com/Singular/Singular.git", "92ee61126a6a0f5567914edd63e135fe85f86232"),
     #ArchiveSource("https://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/$(upstream_version.major)-$(upstream_version.minor)-$(upstream_version.patch)/singular-$(upstream_version).tar.gz",
     #              "5b0f6c036b4a6f58bf620204b004ec6ca3a5007acc8352fec55eade2fc9d63f6"),
     #DirectorySource("./bundled")


### PR DESCRIPTION
Unfortunately the result of PR #3794 had to be yanked as it introduced an unexpected ABI breakage.

This new PR thus increments the minor version to deal with that ABI break (which is enough, as all packages using this JLL use a `~...` compat string; also, incrementing the major part of the version would be annoying as we'd likely have to keep that increment around for a long time).

It also is made from a slightly newer git revision, which should fix a few other regressions.

However, this should only be merged once @tthsqe12 and @hannes14 had a chance to comment.