### PR TITLE
[libsndfile] adding Opus dependency

### DIFF
--- a/L/libsndfile/build_tarballs.jl
+++ b/L/libsndfile/build_tarballs.jl
@@ -15,8 +15,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/libsndfile-*/
 export CFLAGS="-I${includedir}" 
-autoreconf -fvi
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
 make -j${nproc}
 make install
 """


### PR DESCRIPTION
Fixing the build script for libsndfile. The current script is causing problems with FLAC and OGG files, see [this issue](https://github.com/JuliaAudio/LibSndFile.jl/issues/47)