### PR TITLE
[AzStorage] bump version for libcurl and mbedtls deps

### DIFF
--- a/A/AzStorage/build_tarballs.jl
+++ b/A/AzStorage/build_tarballs.jl
@@ -1,6 +1,6 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder
+using BinaryBuilder, Pkg
 
 name = "AzStorage"
 version = v"0.4.0"
@@ -29,7 +29,7 @@ cp libAzStorage.so ${libdir}/libAzStorage.${dlext}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 # TODO - add libgomp dependency
@@ -40,16 +40,12 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
-    # libcurl changed compatibility version for macOS from v7.71 to v7.73 (v11
-    # to v12)
     Dependency("LibCURL_jll", v"7.73.0"),
-    # The following libraries are dependencies of LibCURL_jll which is now a
-    # stdlib, but the stdlib doesn't explicitly list its dependencies
-    Dependency("LibSSH2_jll"),
-    Dependency("MbedTLS_jll", v"2.24.0"),
-    Dependency("nghttp2_jll"),
-    Dependency("Zlib_jll"),
+    # MbedTLS is only an indirect dependency (through LibCURL), but we want to
+    # be sure to have the right version of MbedTLS for the corresponding version
+    # of Julia.
+    BuildDependency(PackageSpec(; name="MbedTLS_jll", version="2.24.0")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
If I understand correctly, this will make things compatible with Julia 1.6, but break compatibility with older version of julia.

see: https://github.com/ChevronETC/AzStorage.jl/issues/26

cc: @mloubout 