### PR TITLE
add APR

### DIFF
--- a/A/APR/build_tarballs.jl
+++ b/A/APR/build_tarballs.jl
@@ -28,6 +28,7 @@ export CPPFLAGS="-DAPR_IOVEC_DEFINED"
 --prefix=${prefix} \
 --build=${MACHTYPE} \
 --host=${target} \
+--with-installbuilddir=$(mktemp -d) \
 --enable-shared=yes \
 --enable-static=no \
 --disable-libtool-lock \

--- a/A/APR/build_tarballs.jl
+++ b/A/APR/build_tarballs.jl
@@ -8,44 +8,50 @@ version = v"1.7.0"
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://dlcdn.apache.org//apr/apr-$(version).tar.gz", "48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2"),
-    DirectorySource("./bundled/")
+    DirectorySource("./bundled/"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/apr-*
 
-#stop libtool from building gen_test_char for non-native host
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/remove-libtool-compile-gen_test_char.patch
+# Add `usigned long long` as option for size of `size_t`, and `long long` for `ssize_t`.
+atomic_patch -p1 ../patches/size_t_fmt_long_long.patch
 
-#compile it with host compiler manually
-${HOSTCC} -Wall -O2 -DCROSS_COMPILE tools/gen_test_char.c -s -o tools/gen_test_char
+# stop libtool from building gen_test_char for non-native host
+atomic_patch -p1 ../patches/remove-libtool-compile-gen_test_char.patch
 
-#CPPFLAGS trick and configure hints are from https://bz.apache.org/bugzilla/show_bug.cgi?id=50146
+# compile it with host compiler manually
+${HOSTCC} -Wall -O2 -DCROSS_COMPILE tools/gen_test_char.c -s -o tools/gen_test_char${exeext}
+
+# CPPFLAGS trick and configure hints are from https://bz.apache.org/bugzilla/show_bug.cgi?id=50146
 export CPPFLAGS="-DAPR_IOVEC_DEFINED"
 
+# Need to rebuild configure script after applying `size_t` patch.
+autoreconf -fiv
+
 ./configure \
---prefix=${prefix} \
---build=${MACHTYPE} \
---host=${target} \
---with-installbuilddir=$(mktemp -d) \
---enable-shared=yes \
---enable-static=no \
---disable-libtool-lock \
---disable-lfs \
---disable-dso \
---disable-ipv6 \
-ac_cv_file__dev_zero=no \
-ac_cv_func_setpgrp_void=no \
-apr_cv_tcp_nodelay_with_cork=no \
-cross_compiling=yes \
-apr_cv_process_shared_works=no
+    --prefix=${prefix} \
+    --build=${MACHTYPE} \
+    --host=${target} \
+    --with-installbuilddir=$(mktemp -d) \
+    --enable-shared=yes \
+    --enable-static=no \
+    --disable-libtool-lock \
+    --disable-lfs \
+    --disable-dso \
+    --disable-ipv6 \
+    ac_cv_file__dev_zero=no \
+    ac_cv_func_setpgrp_void=no \
+    apr_cv_tcp_nodelay_with_cork=no \
+    cross_compiling=yes \
+    apr_cv_process_shared_works=no \
+    apr_cv_mutex_robust_shared=no
 
 make -j${nproc}
 make install
 
 install_license LICENSE
-
 """
 
 # These are the platforms we will build for by default, unless further
@@ -59,7 +65,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = []
+dependencies = Dependency[]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/A/APR/build_tarballs.jl
+++ b/A/APR/build_tarballs.jl
@@ -7,12 +7,19 @@ version = v"1.7.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://dlcdn.apache.org//apr/apr-$(version).tar.gz", "48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2")
+    ArchiveSource("https://dlcdn.apache.org//apr/apr-$(version).tar.gz", "48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2"),
+    DirectorySource("./bundled/")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/apr-*
+
+#stop libtool from building gen_test_char for non-native host
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/remove-libtool-compile-gen_test_char.patch
+
+#compile it with host compiler manually
+${HOSTCC} -Wall -O2 -DCROSS_COMPILE tools/gen_test_char.c -s -o tools/gen_test_char
 
 #CPPFLAGS trick and configure hints are from https://bz.apache.org/bugzilla/show_bug.cgi?id=50146
 export CPPFLAGS="-DAPR_IOVEC_DEFINED"

--- a/A/APR/bundled/patches/remove-libtool-compile-gen_test_char.patch
+++ b/A/APR/bundled/patches/remove-libtool-compile-gen_test_char.patch
@@ -1,0 +1,18 @@
+diff --git a/Makefile.in b/Makefile.in
+index 7aeefd0..e1b2ce4 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -131,13 +131,6 @@ check: $(TARGET_LIB)
+ etags:
+ 	etags `find . -name '*.[ch]'`
+ 
+-OBJECTS_gen_test_char = tools/gen_test_char.lo $(LOCAL_LIBS)
+-tools/gen_test_char.lo: tools/gen_test_char.c
+-	$(APR_MKDIR) tools
+-	$(LT_COMPILE)
+-
+-tools/gen_test_char@EXEEXT@: $(OBJECTS_gen_test_char)
+-	$(LINK_PROG) $(OBJECTS_gen_test_char) $(ALL_LIBS)
+ 
+ include/private/apr_escape_test_char.h: tools/gen_test_char@EXEEXT@
+ 	$(APR_MKDIR) include/private

--- a/A/APR/bundled/patches/size_t_fmt_long_long.patch
+++ b/A/APR/bundled/patches/size_t_fmt_long_long.patch
@@ -1,0 +1,19 @@
+--- a/configure.in
++++ b/configure.in
+@@ -1864,10 +1864,14 @@
+ 
+ dnl I would expect much of the above to go away with new compile test
+ APR_CHECK_TYPES_FMT_COMPATIBLE(ssize_t, long, ld, [ssize_t_fmt="ld"], [
+-APR_CHECK_TYPES_FMT_COMPATIBLE(ssize_t, int, d, [ssize_t_fmt="d"])
++APR_CHECK_TYPES_FMT_COMPATIBLE(ssize_t, int, d, [ssize_t_fmt="d"],
++APR_CHECK_TYPES_FMT_COMPATIBLE(ssize_t, long long, d, [ssize_t_fmt="zd"])
++)
+ ])
+ APR_CHECK_TYPES_FMT_COMPATIBLE(size_t, unsigned long, lu, [size_t_fmt="lu"], [
+-APR_CHECK_TYPES_FMT_COMPATIBLE(size_t, unsigned int, u, [size_t_fmt="u"])
++APR_CHECK_TYPES_FMT_COMPATIBLE(size_t, unsigned int, u, [size_t_fmt="u"],
++APR_CHECK_TYPES_FMT_COMPATIBLE(size_t, unsigned long long, u, [size_t_fmt="zu"])
++)
+ ])
+ 
+ APR_CHECK_SIZEOF_EXTENDED([#include <sys/types.h>], ssize_t, 8)


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` script for the [Apache Portable Runtime (APR)](http://apr.apache.org/) project.
As far as I can tell, `APR-util` was once a source dependency but has been merged into `APR` at some point (?) so I am not downloading that source here.

I am using the download mirror link provided on the project website, it looks weird to me but seems to work without issue?
This completes the wizard and build locally for me on `x86_64-linux-gnu` and `x86_64-linux-musl`.

Quoting from the bugzilla link because it made me laugh: 
>Good luck. May these problems in the Apache *PORTABLE* Runtime library be fixed one glorious day.