### PR TITLE
Add ONNX v1.10.2.

### DIFF
--- a/O/ONNX/build_tarballs.jl
+++ b/O/ONNX/build_tarballs.jl
@@ -1,0 +1,55 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ONNX"
+version = v"1.10.2"
+
+sources = [
+    ArchiveSource(
+        "https://github.com/onnx/onnx/archive/refs/tags/v1.10.2.tar.gz",
+        "520b3aa34272cc215e2eb41385f58adf01750d88858d4722563edca8410c5dc9",
+    ),
+]
+
+script = raw"""
+cd onnx*
+mkdir build
+cd build
+cmake \
+    -DBUILD_ONNX_PYTHON=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DONNX_USE_LITE_PROTO=ON \
+    -DONNX_USE_PROTOBUF_SHARED_LIBS=ON \
+    -DProtobuf_PROTOC_EXECUTABLE=${host_bindir}/protoc \
+    ..
+cmake --build . --config Release --target install -- -j${nproc}
+"""
+
+#=
+Sadly, no windows support yet. It looks to me like the upstream treats
+`defined(_WIN32)` as synonymous with `build with MSVC`.
+=#
+platforms = filter(p -> p.tags["os"] != "windows", supported_platforms())
+
+products = [
+    FileProduct("lib/libonnx.a", :libonnx),
+    LibraryProduct("libonnxifi", :libonnxifi),
+    LibraryProduct("libonnxifi_dummy", :libonnxifi_dummy),
+]
+
+dependencies = [HostBuildDependency("protoc_jll"), Dependency("protoc_jll")]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    preferred_gcc_version = v"9",
+)

--- a/O/ONNX/build_tarballs.jl
+++ b/O/ONNX/build_tarballs.jl
@@ -32,8 +32,7 @@ cmake --build . --config Release --target install -- -j${nproc}
 Sadly, no windows support yet. It looks to me like the upstream treats
 `defined(_WIN32)` as synonymous with `build with MSVC`.
 =#
-platforms =
-    filter(p -> p.tags["os"] != "windows", expand_cxxstring_abis(supported_platforms()))
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true, exclude=Sys.iswindows))
 
 products = [
     FileProduct("lib/libonnx.a", :libonnx),

--- a/O/ONNX/build_tarballs.jl
+++ b/O/ONNX/build_tarballs.jl
@@ -32,7 +32,8 @@ cmake --build . --config Release --target install -- -j${nproc}
 Sadly, no windows support yet. It looks to me like the upstream treats
 `defined(_WIN32)` as synonymous with `build with MSVC`.
 =#
-platforms = filter(p -> p.tags["os"] != "windows", supported_platforms())
+platforms =
+    filter(p -> p.tags["os"] != "windows", expand_cxxstring_abis(supported_platforms()))
 
 products = [
     FileProduct("lib/libonnx.a", :libonnx),

--- a/O/ONNX/build_tarballs.jl
+++ b/O/ONNX/build_tarballs.jl
@@ -52,4 +52,5 @@ build_tarballs(
     products,
     dependencies;
     preferred_gcc_version = v"9",
+    julia_compat = "1.6",
 )

--- a/O/ONNX/build_tarballs.jl
+++ b/O/ONNX/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"1.10.2"
 
 sources = [
     ArchiveSource(
-        "https://github.com/onnx/onnx/archive/refs/tags/v1.10.2.tar.gz",
+        "https://github.com/onnx/onnx/archive/refs/tags/v$(version).tar.gz",
         "520b3aa34272cc215e2eb41385f58adf01750d88858d4722563edca8410c5dc9",
     ),
 ]


### PR DESCRIPTION
As of now, this build recipe excludes building for the windows platform. The upstream code includes many instances of conditional compilation guarded by `#ifdef _WIN32` that selects between targeting a Win32 API vs. POSIX. The cross compilers don't seem to like building against the Win32 interface. I don't know if the mingw compilers provide the full POSIX interface. And, if they actually do, I haven't yet been able to convince the build system to treat this case as POSIX. (All I've tried on that front to this point is to pass `-U_WIN32` to cmake.)