### PR TITLE
add compat bounds for GEOS_jll

### DIFF
--- a/G/GDAL/common.jl
+++ b/G/GDAL/common.jl
@@ -106,7 +106,7 @@ function configure(version_offset, min_julia_version, proj_jll_version)
 
     # Dependencies that must be installed before this package can be built
     dependencies = [
-        Dependency("GEOS_jll"),
+        Dependency("GEOS_jll"; compat="~3.9"),
         Dependency(PackageSpec(name="PROJ_jll", version=proj_jll_version)),
         Dependency("Zlib_jll"),
         Dependency("SQLite_jll"),

--- a/L/librttopo/build_tarballs.jl
+++ b/L/librttopo/build_tarballs.jl
@@ -39,7 +39,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GEOS_jll", uuid="d604d12d-fa86-5845-992e-78dc15976526"))
+    Dependency("GEOS_jll"; compat="~3.9")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libspatialite/build_tarballs.jl
+++ b/L/libspatialite/build_tarballs.jl
@@ -88,7 +88,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("SQLite_jll")
-    Dependency(PackageSpec(name="GEOS_jll", uuid="d604d12d-fa86-5845-992e-78dc15976526"))
+    Dependency("GEOS_jll"; compat="~3.9")
     Dependency(PackageSpec(name="PROJ_jll", uuid="58948b4f-47e0-5654-a9ad-f609743f8632"))
     Dependency(PackageSpec(name="Libiconv_jll", uuid="94ce4f54-9a6c-5748-9c1c-f9c7231a4531"))
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))


### PR DESCRIPTION
This brings the build scripts back in line with the already merged registry edit of https://github.com/JuliaRegistries/General/pull/47879

The GEOS 3.10 build works as well, but its dependencies will need a new build, since the SONAME of the GEOS build changed.

[skip ci] [skip build]
