### PR TITLE
[HiGHS] add version 1.1.0

### DIFF
--- a/H/HiGHS/build_tarballs.jl
+++ b/H/HiGHS/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder, Pkg
 
 name = "HiGHS"
 
-version = v"0.3.3"
+version = v"1.1.0"
 
 sources = [
     GitSource(
         "https://github.com/ERGO-Code/HiGHS.git",
-        "363dd4e8639f8f811ce031c9f6c8c35944e91615",
+        "bd9703cc1a896c68473144064011cc9d64246e07",
     ),
     DirectorySource("./bundled"),
 ]


### PR DESCRIPTION
This builds HiGHS off the latest commit: https://github.com/ERGO-Code/HiGHS/commit/bd9703cc1a896c68473144064011cc9d64246e07

Internally, they're calling it v1.1,  but there isn't a tagged release yet: https://github.com/ERGO-Code/HiGHS/issues/595.

cc @jajhall, @galabovaa 