### PR TITLE
Add MMseqs2 build script

### DIFF
--- a/M/MMseqs2/build_tarballs.jl
+++ b/M/MMseqs2/build_tarballs.jl
@@ -71,8 +71,7 @@ cmake .. \
 make -j${nproc}
 make install
 
-cd ..
-install_license LICENSE.md
+install_license ../LICENSE.md
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/MMseqs2/build_tarballs.jl
+++ b/M/MMseqs2/build_tarballs.jl
@@ -3,7 +3,13 @@
 using BinaryBuilder, Pkg
 
 name = "MMseqs2"
-version = v"13.45111.0"
+version = v"13"
+
+# MMseqs2 seem to use as versioning scheme of "major version + first 5
+# characters of the tagged commit"
+# https://github.com/soedinglab/MMseqs2/releases
+version_commitprefix = "45111"
+
 
 # Possible build variants
 # - OpenMP (default)
@@ -33,7 +39,7 @@ version = v"13.45111.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/soedinglab/MMseqs2/archive/refs/tags/$(version.major)-$(version.minor).tar.gz",
+    ArchiveSource("https://github.com/soedinglab/MMseqs2/archive/refs/tags/$(version.major)-$(version_commitprefix).tar.gz",
                   "6444bb682ebf5ced54b2eda7a301fa3e933c2a28b7661f96ef5bdab1d53695a2")
 ]
 

--- a/M/MMseqs2/build_tarballs.jl
+++ b/M/MMseqs2/build_tarballs.jl
@@ -74,7 +74,7 @@ install_license ../LICENSE.md
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(exclude = p -> Sys.iswindows(p) || arch(p) == "i686")
+platforms = supported_platforms(; experimental=true, exclude = p -> Sys.iswindows(p) || arch(p) == "i686")
 # also expand cxxstring abis on macos because we use g++
 platforms = expand_cxxstring_abis(platforms; skip=Sys.isfreebsd)
 

--- a/M/MMseqs2/build_tarballs.jl
+++ b/M/MMseqs2/build_tarballs.jl
@@ -20,10 +20,6 @@ version_commitprefix = "45111"
 # - built-in zstd, replace with Zstd_jll? (-DUSE_SYSTEM_ZSTD=1 cmake option)
 # - os-specific build script examples under util/build_{osx,windows}
 
-# Auditor warnings
-# - freebsd (x86_64-unknown-freebsd)
-#   Warning: Linked library libomp.so could not be resolved and could not be auto-mapped
-
 # Build failures
 # - windows:
 #   - cmake can't find openmp, this check can be avoided by passing -DREQUIRE_OPENMP=0 to cmake

--- a/M/MMseqs2/build_tarballs.jl
+++ b/M/MMseqs2/build_tarballs.jl
@@ -1,0 +1,96 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "MMseqs2"
+version = v"13.45111.0"
+
+# Possible build variants
+# - OpenMP (default)
+# - MPI (-DHAVE_MPI=1)
+# - single-threaded (-DREQUIRE_OPENMP=0)
+
+# TODO
+# - built-in zstd, replace with Zstd_jll? (-DUSE_SYSTEM_ZSTD=1 cmake option)
+# - os-specific build script examples under util/build_{osx,windows}
+
+# Auditor warnings
+# - freebsd (x86_64-unknown-freebsd)
+#   Warning: Linked library libomp.so could not be resolved and could not be auto-mapped
+
+# Build failures
+# - windows:
+#   - cmake can't find openmp, this check can be avoided by passing -DREQUIRE_OPENMP=0 to cmake
+#   - compile error afterwards
+#     error: ‘posix_memalign’ was not declared in this scope
+#     (and more following errors)
+# - i686: compile error due to bitwidth issues, haven't investigated more
+# - aarch64-linux with cmake option -DHAVE_ARM8=1, had to deactivate
+#   - compile wants to set -march=armv8-a+simd, but BinaryBuild
+#     wrappers don't allow that
+# - powerpc build fails with gcc-7.x
+
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/soedinglab/MMseqs2/archive/refs/tags/$(version.major)-$(version.minor).tar.gz",
+                  "6444bb682ebf5ced54b2eda7a301fa3e933c2a28b7661f96ef5bdab1d53695a2")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd MMseqs2-*/
+
+# macos, freebsd: use gcc/g++ so we can use openmp
+if [[ "${target}" == *-darwin* || "${target}" == -freebsd* ]]; then
+    CMAKE_TARGET_TOOLCHAIN="${CMAKE_TARGET_TOOLCHAIN/%.cmake/_gcc.cmake}"
+    echo "[INFO] setting CMAKE_TARGET_TOOLCHAIN = ${CMAKE_TARGET_TOOLCHAIN}"
+fi
+
+# architecture extensions
+ARCH_FLAGS=
+if [[ "${target}" == x86_64-* || "${target}" == i686-* ]]; then
+    ARCH_FLAGS="-DHAVE_SSE2=1 -DHAVE_SSE4_1=1 -DHAVE_AVX2=1"
+elif [[ "${target}" == powerpc64le-* ]]; then
+    ARCH_FLAGS="-DHAVE_POWER8=1 -DHAVE_POWER9=1"
+elif [[ "${target}" == aarch64-* ]]; then
+    # TODO: commented out because this causes -march=armv8-a+simd to be added to CFLAGS
+    #       which is not allowed by the BinaryBuilder toolchain
+    # ARCH_FLAGS="-DHAVE_ARM8=1"
+    ARCH_FLAGS=
+fi
+
+mkdir build
+cd build
+cmake .. \
+    -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=RELEASE \
+    -DNATIVE_ARCH=0 ${ARCH_FLAGS}
+make -j${nproc}
+make install
+
+cd ..
+install_license LICENSE.md
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(exclude = p -> Sys.iswindows(p) || arch(p) == "i686")
+# also expand cxxstring abis on macos because we use g++
+platforms = expand_cxxstring_abis(platforms; skip=Sys.isfreebsd)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("mmseqs", :mmseqs)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+    Dependency(PackageSpec(name="Zlib_jll")),
+    Dependency(PackageSpec(name="Bzip2_jll")),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version = v"8")

--- a/M/MMseqs2/bundled/patches/arm-simd-march-cmakefile.patch
+++ b/M/MMseqs2/bundled/patches/arm-simd-march-cmakefile.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1a677e3..fd56c05 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,7 +70,11 @@ elseif (HAVE_POWER8)
+     set(MMSEQS_ARCH "${MMSEQS_ARCH} -mcpu=power8 -mvsx")
+     set(PPC64 1)
+ elseif (HAVE_ARM8)
+-    set(MMSEQS_ARCH "${MMSEQS_ARCH} -march=armv8-a+simd")
++    # Commented out for BinaryBuilder
++    # -march=armv8-a already implies -march=armv8-a+simd, and
++    # BinaryBuilder compiler wrappers don't accept -march
++    # Ref: https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
++    #set(MMSEQS_ARCH "${MMSEQS_ARCH} -march=armv8-a+simd")
+     set(ARM 1)
+ elseif (HAVE_S390X)
+     set(MMSEQS_ARCH "${MMSEQS_ARCH} -mzarch -march=z14")


### PR DESCRIPTION
This is a build script for mmseqs2, a many-to-many sequence searching tool for bioinformatics:

https://github.com/soedinglab/MMseqs2

Notes:

- not sure if the way i switched `CMAKE_TARGET_TOOLCHAIN` on macos and freebsd is the right way to do it
- I added the dependencies Zlib and Bzip2 by hand, so i don't have any uuids there. Is this a problem?
- ARM doesn't have vectorization acceleration due to the -march issues noted in the build script
- I chose g++-8, because g++-7 didn't compile on powerpc. A build with g++-11 resulted in binaries that didn't work on Ubuntu 20.04 due to newer GLIBCXX symbols used
- freebsd has a warning from the BinaryBuilder auditor: `Warning: Linked library libomp.so could not be resolved and could not be auto-mapped`. I don't have a freebsd system so i can't test if the built binary actually works there