### PR TITLE
[libunwind] Add a separate builder for v1.3.2

### DIFF
--- a/L/LibUnwind/LibUnwind@1.3.2/build_tarballs.jl
+++ b/L/LibUnwind/LibUnwind@1.3.2/build_tarballs.jl
@@ -1,0 +1,59 @@
+using BinaryBuilder
+
+name = "LibUnwind"
+version = v"1.3.2"
+
+# Collection of sources required to build libffi
+sources = [
+    ArchiveSource("https://github.com/libunwind/libunwind/releases/download/v$(version)/libunwind-$(version).tar.gz",
+                  "0a4b5a78d8c0418dfa610245f75fa03ad45d8e5e4cc091915d2dbed34c01178e"),
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libunwind*/
+
+# We need to massage configure script to convince it to build the shared library
+# for PowerPC.
+if [[ "${target}" == powerpc64le-* ]]; then
+    autoreconf -vi
+fi
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/libunwind-prefer-extbl.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/libunwind-static-arm.patch
+atomic_patch -p0 ${WORKSPACE}/srcdir/patches/libunwind-configure-ppc64le.patch
+atomic_patch -p0 ${WORKSPACE}/srcdir/patches/libunwind-configure-static-lzma.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/libunwind-cfa-rsp.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/libunwind-dwarf-table.patch
+
+CFLAGS="${CFLAGS} -DPI -fPIC -I${prefix}/include"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} CFLAGS="${CFLAGS}" --libdir=${libdir} --enable-minidebuginfo --disable-tests
+make -j${nproc}
+make install
+
+# Shoe-horn liblzma.a into libunwind.a
+mkdir -p unpacked/{liblzma,libunwind}
+(cd unpacked/liblzma; ar -x ${prefix}/lib/liblzma.a)
+(cd unpacked/libunwind; ar -x ${prefix}/lib/libunwind.a)
+rm -f ${prefix}/lib/libunwind.a
+ar -qc ${prefix}/lib/libunwind.a unpacked/**/*
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line.  libunwind is only used
+# on Linux or FreeBSD (e.g. ELF systems)
+platforms = filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms(;experimental=true))
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libunwind", :libunwind),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    BuildDependency("XZ_jll"),
+]
+
+# Build the tarballs.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-cfa-rsp.patch
+++ b/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-cfa-rsp.patch
@@ -1,0 +1,393 @@
+commit c71298423c26b2143dc6f6ce554ec910ed882f8a
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Sat Feb 6 18:13:16 2021 -0500
+
+    x86_64: Stop aliasing RSP and CFA
+    
+    RSP and CFA are different concepts. RSP refers to the physical
+    register, CFA is a virtual register that serves as the base
+    address for various other saved registers. It is true that
+    in many frames these are set to alias, however this is not
+    a requirement. For example, a function that performs a stack
+    switch would likely change the rsp in the middle of the function,
+    but would keep the CFA at the original RSP such that saved registers
+    may be appropriately recovered.
+    
+    We are seeing incorrect unwinds in the Julia runtime when running
+    julia under rr. This is because injects code (with correct CFI)
+    that performs just such a stack switch [1]. GDB manages to unwind
+    this correctly, but libunwind incorrectly sets the rsp to the CFA
+    address, causing a misunwind.
+    
+    Tested on x86_64, patches for other architectures are ported, but
+    not tested.
+    
+    [1] https://github.com/rr-debugger/rr/blob/469c22059a4a1798d33a8a224457faf22b2c178c/src/preload/syscall_hook.S#L454
+
+diff --git a/include/dwarf.h b/include/dwarf.h
+index fab93c61..b845e2eb 100644
+--- a/include/dwarf.h
++++ b/include/dwarf.h
+@@ -227,6 +227,7 @@ typedef enum
+     DWARF_WHERE_REG,            /* register saved in another register */
+     DWARF_WHERE_EXPR,           /* register saved */
+     DWARF_WHERE_VAL_EXPR,       /* register has computed value */
++    DWARF_WHERE_CFA,            /* register is set to the computed cfa value */
+   }
+ dwarf_where_t;
+ 
+@@ -309,7 +310,7 @@ typedef struct dwarf_cursor
+     void *as_arg;               /* argument to address-space callbacks */
+     unw_addr_space_t as;        /* reference to per-address-space info */
+ 
+-    unw_word_t cfa;     /* canonical frame address; aka frame-/stack-pointer */
++    unw_word_t cfa;     /* canonical frame address; aka frame-pointer */
+     unw_word_t ip;              /* instruction pointer */
+     unw_word_t args_size;       /* size of arguments */
+     unw_word_t eh_args[UNW_TDEP_NUM_EH_REGS];
+diff --git a/include/libunwind_i.h b/include/libunwind_i.h
+index 36cf7a14..dcec1683 100644
+--- a/include/libunwind_i.h
++++ b/include/libunwind_i.h
+@@ -351,6 +351,10 @@ static inline void invalidate_edi (struct elf_dyn_info *edi)
+ 
+ #include "tdep/libunwind_i.h"
+ 
++#ifndef TDEP_DWARF_SP
++#define TDEP_DWARF_SP UNW_TDEP_SP
++#endif
++
+ #ifndef tdep_get_func_addr
+ # define tdep_get_func_addr(as,addr,v)          (*(v) = addr, 0)
+ #endif
+diff --git a/include/tdep-x86/dwarf-config.h b/include/tdep-x86/dwarf-config.h
+index f76f9c1c..11398e4e 100644
+--- a/include/tdep-x86/dwarf-config.h
++++ b/include/tdep-x86/dwarf-config.h
+@@ -43,9 +43,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+ typedef struct dwarf_loc
+   {
+     unw_word_t val;
+-#ifndef UNW_LOCAL_ONLY
+     unw_word_t type;            /* see X86_LOC_TYPE_* macros.  */
+-#endif
+   }
+ dwarf_loc_t;
+ 
+diff --git a/include/tdep-x86/libunwind_i.h b/include/tdep-x86/libunwind_i.h
+index 5231189a..1b59fe34 100644
+--- a/include/tdep-x86/libunwind_i.h
++++ b/include/tdep-x86/libunwind_i.h
+@@ -88,14 +88,28 @@ dwarf_get_uc(const struct dwarf_cursor *cursor)
+ 
+ #define DWARF_GET_LOC(l)        ((l).val)
+ 
+-#ifdef UNW_LOCAL_ONLY
++
++#define DWARF_GET_LOC(l)        ((l).val)
++# define DWARF_LOC_TYPE_MEM     (0 << 0)
++# define DWARF_LOC_TYPE_FP      (1 << 0)
++# define DWARF_LOC_TYPE_REG     (1 << 1)
++# define DWARF_LOC_TYPE_VAL     (1 << 2)
++
++# define DWARF_IS_REG_LOC(l)    (((l).type & DWARF_LOC_TYPE_REG) != 0)
++# define DWARF_IS_FP_LOC(l)     (((l).type & DWARF_LOC_TYPE_FP) != 0)
++# define DWARF_IS_MEM_LOC(l)    ((l).type == DWARF_LOC_TYPE_MEM)
++# define DWARF_IS_VAL_LOC(l)    (((l).type & DWARF_LOC_TYPE_VAL) != 0)
++
++# define DWARF_LOC(r, t)        ((dwarf_loc_t) { .val = (r), .type = (t) })
+ # define DWARF_NULL_LOC         DWARF_LOC (0, 0)
+-# define DWARF_IS_NULL_LOC(l)   (DWARF_GET_LOC (l) == 0)
+-# define DWARF_LOC(r, t)        ((dwarf_loc_t) { .val = (r) })
+-# define DWARF_IS_REG_LOC(l)    0
++# define DWARF_IS_NULL_LOC(l)                                           \
++                ({ dwarf_loc_t _l = (l); _l.val == 0 && _l.type == 0; })
++# define DWARF_VAL_LOC(c,v)     DWARF_LOC ((v), DWARF_LOC_TYPE_VAL)
++# define DWARF_MEM_LOC(c,m)     DWARF_LOC ((m), DWARF_LOC_TYPE_MEM)
++
++#ifdef UNW_LOCAL_ONLY
+ # define DWARF_REG_LOC(c,r)     (DWARF_LOC((unw_word_t)                      \
+                                  tdep_uc_addr(dwarf_get_uc(c), (r)), 0))
+-# define DWARF_MEM_LOC(c,m)     DWARF_LOC ((m), 0)
+ # define DWARF_FPREG_LOC(c,r)   (DWARF_LOC((unw_word_t)                      \
+                                  tdep_uc_addr(dwarf_get_uc(c), (r)), 0))
+ 
+@@ -117,35 +131,8 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
+   return 0;
+ }
+ 
+-static inline int
+-dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
+-{
+-  if (!DWARF_GET_LOC (loc))
+-    return -1;
+-  return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+-                                   0, c->as_arg);
+-}
+-
+-static inline int
+-dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
+-{
+-  if (!DWARF_GET_LOC (loc))
+-    return -1;
+-  return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+-                                   1, c->as_arg);
+-}
+-
+ #else /* !UNW_LOCAL_ONLY */
+-# define DWARF_LOC_TYPE_FP      (1 << 0)
+-# define DWARF_LOC_TYPE_REG     (1 << 1)
+-# define DWARF_NULL_LOC         DWARF_LOC (0, 0)
+-# define DWARF_IS_NULL_LOC(l)                                           \
+-                ({ dwarf_loc_t _l = (l); _l.val == 0 && _l.type == 0; })
+-# define DWARF_LOC(r, t)        ((dwarf_loc_t) { .val = (r), .type = (t) })
+-# define DWARF_IS_REG_LOC(l)    (((l).type & DWARF_LOC_TYPE_REG) != 0)
+-# define DWARF_IS_FP_LOC(l)     (((l).type & DWARF_LOC_TYPE_FP) != 0)
+ # define DWARF_REG_LOC(c,r)     DWARF_LOC((r), DWARF_LOC_TYPE_REG)
+-# define DWARF_MEM_LOC(c,m)     DWARF_LOC ((m), 0)
+ # define DWARF_FPREG_LOC(c,r)   DWARF_LOC((r), (DWARF_LOC_TYPE_REG      \
+                                                 | DWARF_LOC_TYPE_FP))
+ 
+@@ -195,38 +182,33 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
+                                    1, c->as_arg);
+ }
+ 
++#endif /* !UNW_LOCAL_ONLY */
++
+ static inline int
+ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
+ {
+   if (DWARF_IS_NULL_LOC (loc))
+     return -UNW_EBADREG;
+ 
+-  /* If a code-generator were to save a value of type unw_word_t in a
+-     floating-point register, we would have to support this case.  I
+-     suppose it could happen with MMX registers, but does it really
+-     happen?  */
+-  assert (!DWARF_IS_FP_LOC (loc));
+-
+   if (DWARF_IS_REG_LOC (loc))
+     return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+                                      0, c->as_arg);
+-  else
++  if (DWARF_IS_MEM_LOC (loc))
+     return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+                                      0, c->as_arg);
++  assert(DWARF_IS_VAL_LOC (loc));
++  *val = DWARF_GET_LOC (loc);
++  return 0;
+ }
+ 
+ static inline int
+ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
+ {
++  assert(!DWARF_IS_VAL_LOC (loc));
++
+   if (DWARF_IS_NULL_LOC (loc))
+     return -UNW_EBADREG;
+ 
+-  /* If a code-generator were to save a value of type unw_word_t in a
+-     floating-point register, we would have to support this case.  I
+-     suppose it could happen with MMX registers, but does it really
+-     happen?  */
+-  assert (!DWARF_IS_FP_LOC (loc));
+-
+   if (DWARF_IS_REG_LOC (loc))
+     return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+                                      1, c->as_arg);
+@@ -235,7 +217,9 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
+                                      1, c->as_arg);
+ }
+ 
+-#endif /* !UNW_LOCAL_ONLY */
++// For historical reasons, the DWARF numbering does not match the libunwind
++// numbering, necessitating this override
++#define TDEP_DWARF_SP 4
+ 
+ #define tdep_getcontext_trace           unw_getcontext
+ #define tdep_init_done                  UNW_OBJ(init_done)
+diff --git a/src/dwarf/Gparser.c b/src/dwarf/Gparser.c
+index 7d255aee..b1308d3c 100644
+--- a/src/dwarf/Gparser.c
++++ b/src/dwarf/Gparser.c
+@@ -28,6 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+ #include <stddef.h>
+ #include <limits.h>
+ 
++
+ #define alloc_reg_state()       (mempool_alloc (&dwarf_reg_state_pool))
+ #define free_reg_state(rs)      (mempool_free (&dwarf_reg_state_pool, rs))
+ 
+@@ -501,6 +502,9 @@ setup_fde (struct dwarf_cursor *c, dwarf_state_record_t *sr)
+   for (i = 0; i < DWARF_NUM_PRESERVED_REGS + 2; ++i)
+     set_reg (sr, i, DWARF_WHERE_SAME, 0);
+ 
++  // SP defaults to CFA (but is overridable)
++  set_reg (sr, TDEP_DWARF_SP, DWARF_WHERE_CFA, 0);
++
+   struct dwarf_cie_info *dci = c->pi.unwind_info;
+   sr->rs_current.ret_addr_column  = dci->ret_addr_column;
+   unw_word_t addr = dci->cie_instr_start;
+@@ -785,14 +789,14 @@ apply_reg_state (struct dwarf_cursor *c, struct dwarf_reg_state *rs)
+       /* As a special-case, if the stack-pointer is the CFA and the
+          stack-pointer wasn't saved, popping the CFA implicitly pops
+          the stack-pointer as well.  */
+-      if ((rs->reg.val[DWARF_CFA_REG_COLUMN] == UNW_TDEP_SP)
+-          && (UNW_TDEP_SP < ARRAY_SIZE(rs->reg.val))
+-          && (rs->reg.where[UNW_TDEP_SP] == DWARF_WHERE_SAME))
++      if ((rs->reg.val[DWARF_CFA_REG_COLUMN] == TDEP_DWARF_SP)
++          && (TDEP_DWARF_SP < ARRAY_SIZE(rs->reg.val))
++          && (DWARF_IS_NULL_LOC(c->loc[TDEP_DWARF_SP])))
+           cfa = c->cfa;
+       else
+         {
+           regnum = dwarf_to_unw_regnum (rs->reg.val[DWARF_CFA_REG_COLUMN]);
+-          if ((ret = unw_get_reg ((unw_cursor_t *) c, regnum, &cfa)) < 0)
++          if ((ret = unw_get_reg (dwarf_to_cursor(c), regnum, &cfa)) < 0)
+             return ret;
+         }
+       cfa += rs->reg.val[DWARF_CFA_OFF_COLUMN];
+@@ -826,6 +830,10 @@ apply_reg_state (struct dwarf_cursor *c, struct dwarf_reg_state *rs)
+         case DWARF_WHERE_SAME:
+           break;
+ 
++        case DWARF_WHERE_CFA:
++          new_loc[i] = DWARF_VAL_LOC (c, cfa);
++          break;
++
+         case DWARF_WHERE_CFAREL:
+           new_loc[i] = DWARF_MEM_LOC (c, cfa + rs->reg.val[i]);
+           break;
+diff --git a/src/x86/Gos-freebsd.c b/src/x86/Gos-freebsd.c
+index 7dd01404..1b251d02 100644
+--- a/src/x86/Gos-freebsd.c
++++ b/src/x86/Gos-freebsd.c
+@@ -138,6 +138,7 @@ x86_handle_signal_frame (unw_cursor_t *cursor)
+     c->dwarf.loc[ST0] = DWARF_NULL_LOC;
+   } else if (c->sigcontext_format == X86_SCF_FREEBSD_SYSCALL) {
+     c->dwarf.loc[EIP] = DWARF_LOC (c->dwarf.cfa, 0);
++    c->dwarf.loc[ESP] = DWARF_VAL_LOC (c, c->dwarf.cfa + 4);
+     c->dwarf.loc[EAX] = DWARF_NULL_LOC;
+     c->dwarf.cfa += 4;
+     c->dwarf.use_prev_instr = 1;
+diff --git a/src/x86/Gregs.c b/src/x86/Gregs.c
+index 4a959261..9446d6c6 100644
+--- a/src/x86/Gregs.c
++++ b/src/x86/Gregs.c
+@@ -53,7 +53,6 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
+       break;
+ 
+     case UNW_X86_CFA:
+-    case UNW_X86_ESP:
+       if (write)
+         return -UNW_EREADONLYREG;
+       *valp = c->dwarf.cfa;
+@@ -81,6 +80,7 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
+     case UNW_X86_ECX: loc = c->dwarf.loc[ECX]; break;
+     case UNW_X86_EBX: loc = c->dwarf.loc[EBX]; break;
+ 
++    case UNW_X86_ESP: loc = c->dwarf.loc[ESP]; break;
+     case UNW_X86_EBP: loc = c->dwarf.loc[EBP]; break;
+     case UNW_X86_ESI: loc = c->dwarf.loc[ESI]; break;
+     case UNW_X86_EDI: loc = c->dwarf.loc[EDI]; break;
+diff --git a/src/x86/Gstep.c b/src/x86/Gstep.c
+index 129b739a..061dcbaa 100644
+--- a/src/x86/Gstep.c
++++ b/src/x86/Gstep.c
+@@ -47,7 +47,7 @@ unw_step (unw_cursor_t *cursor)
+     {
+       /* DWARF failed, let's see if we can follow the frame-chain
+          or skip over the signal trampoline.  */
+-      struct dwarf_loc ebp_loc, eip_loc;
++      struct dwarf_loc ebp_loc, eip_loc, esp_loc;
+ 
+       /* We could get here because of missing/bad unwind information.
+          Validate all addresses before dereferencing. */
+@@ -77,6 +77,7 @@ unw_step (unw_cursor_t *cursor)
+                  c->dwarf.cfa);
+ 
+           ebp_loc = DWARF_LOC (c->dwarf.cfa, 0);
++          esp_loc = DWARF_VAL_LOC (c, c->dwarf.cfa + 8);
+           eip_loc = DWARF_LOC (c->dwarf.cfa + 4, 0);
+           c->dwarf.cfa += 8;
+ 
+@@ -87,6 +88,7 @@ unw_step (unw_cursor_t *cursor)
+             c->dwarf.loc[i] = DWARF_NULL_LOC;
+ 
+           c->dwarf.loc[EBP] = ebp_loc;
++          c->dwarf.loc[ESP] = esp_loc;
+           c->dwarf.loc[EIP] = eip_loc;
+           c->dwarf.use_prev_instr = 1;
+         }
+diff --git a/src/x86_64/Ginit.c b/src/x86_64/Ginit.c
+index b7e8e462..64b800af 100644
+--- a/src/x86_64/Ginit.c
++++ b/src/x86_64/Ginit.c
+@@ -49,8 +49,6 @@ static struct unw_addr_space local_addr_space;
+ 
+ unw_addr_space_t unw_local_addr_space = &local_addr_space;
+ 
+-HIDDEN unw_dyn_info_list_t _U_dyn_info_list;
+-
+ /* XXX fix me: there is currently no way to locate the dyn-info list
+        by a remote unwinder.  On ia64, this is done via a special
+        unwind-table entry.  Perhaps something similar can be done with
+@@ -66,7 +64,12 @@ static int
+ get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
+                         void *arg)
+ {
+-  *dyn_info_list_addr = (unw_word_t) &_U_dyn_info_list;
++#ifndef UNW_LOCAL_ONLY
++# pragma weak _U_dyn_info_list_addr
++  if (!_U_dyn_info_list_addr)
++    return -UNW_ENOINFO;
++#endif
++  *dyn_info_list_addr = _U_dyn_info_list_addr ();
+   return 0;
+ }
+ 
+diff --git a/src/x86_64/Gos-freebsd.c b/src/x86_64/Gos-freebsd.c
+index 883025c8..8bb101ea 100644
+--- a/src/x86_64/Gos-freebsd.c
++++ b/src/x86_64/Gos-freebsd.c
+@@ -133,6 +133,7 @@ x86_64_handle_signal_frame (unw_cursor_t *cursor)
+     c->dwarf.loc[RCX] = c->dwarf.loc[R10];
+     /*  rsp_loc = DWARF_LOC(c->dwarf.cfa - 8, 0);       */
+     /*  rbp_loc = c->dwarf.loc[RBP];                    */
++    c->dwarf.loc[RSP] = DWARF_VAL_LOC (c, c->dwarf.cfa + 8);
+     c->dwarf.loc[RIP] = DWARF_LOC (c->dwarf.cfa, 0);
+     ret = dwarf_get (&c->dwarf, c->dwarf.loc[RIP], &c->dwarf.ip);
+     Debug (1, "Frame Chain [RIP=0x%Lx] = 0x%Lx\n",
+diff --git a/src/x86_64/Gregs.c b/src/x86_64/Gregs.c
+index baf8a24f..dff5bcbe 100644
+--- a/src/x86_64/Gregs.c
++++ b/src/x86_64/Gregs.c
+@@ -79,7 +79,6 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
+       break;
+ 
+     case UNW_X86_64_CFA:
+-    case UNW_X86_64_RSP:
+       if (write)
+         return -UNW_EREADONLYREG;
+       *valp = c->dwarf.cfa;
+@@ -107,6 +106,7 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
+     case UNW_X86_64_RCX: loc = c->dwarf.loc[RCX]; break;
+     case UNW_X86_64_RBX: loc = c->dwarf.loc[RBX]; break;
+ 
++    case UNW_X86_64_RSP: loc = c->dwarf.loc[RSP]; break;
+     case UNW_X86_64_RBP: loc = c->dwarf.loc[RBP]; break;
+     case UNW_X86_64_RSI: loc = c->dwarf.loc[RSI]; break;
+     case UNW_X86_64_RDI: loc = c->dwarf.loc[RDI]; break;
+diff --git a/src/x86_64/Gstep.c b/src/x86_64/Gstep.c
+index 10498170..5425e3db 100644
+--- a/src/x86_64/Gstep.c
++++ b/src/x86_64/Gstep.c
+@@ -160,7 +160,7 @@ unw_step (unw_cursor_t *cursor)
+             {
+               unw_word_t rbp1 = 0;
+               rbp_loc = DWARF_LOC(rbp, 0);
+-              rsp_loc = DWARF_NULL_LOC;
++              rsp_loc = DWARF_VAL_LOC(c, rbp + 16);
+               rip_loc = DWARF_LOC (rbp + 8, 0);
+               ret = dwarf_get (&c->dwarf, rbp_loc, &rbp1);
+               Debug (1, "[RBP=0x%lx] = 0x%lx (cfa = 0x%lx) -> 0x%lx\n",

--- a/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-configure-ppc64le.patch
+++ b/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-configure-ppc64le.patch
@@ -1,0 +1,15 @@
+--- configure.orig	2019-03-26 03:46:55.540423566 -0400
++++ configure	2019-03-27 15:51:29.215795054 -0400
+@@ -17182,12 +17182,6 @@
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $use_dwarf" >&5
+ $as_echo "$use_dwarf" >&6; }
+ 
+-if test x$target_arch = xppc64; then
+-        libdir='${exec_prefix}/lib64'
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: PowerPC64 detected, lib will be installed ${libdir}" >&5
+-$as_echo "$as_me: PowerPC64 detected, lib will be installed ${libdir}" >&6;};
+-
+-fi
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to restrict build to remote support" >&5
+ $as_echo_n "checking whether to restrict build to remote support... " >&6; }

--- a/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-configure-static-lzma.patch
+++ b/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-configure-static-lzma.patch
@@ -1,0 +1,20 @@
+--- configure.orig	2019-03-27 16:18:36.485104445 -0400
++++ configure	2019-03-27 16:19:18.664745445 -0400
+@@ -17336,7 +17336,7 @@
+   $as_echo_n "(cached) " >&6
+ else
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-llzma  $LIBS"
++LIBS="-L/workspace/destdir/lib -l:liblzma.a $LIBS"
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -17367,7 +17367,7 @@
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_lzma_lzma_mf_is_supported" >&5
+ $as_echo "$ac_cv_lib_lzma_lzma_mf_is_supported" >&6; }
+ if test "x$ac_cv_lib_lzma_lzma_mf_is_supported" = xyes; then :
+-  LIBLZMA=-llzma
++  LIBLZMA="-L/workspace/destdir/lib -l:liblzma.a"
+ 
+ $as_echo "#define HAVE_LZMA 1" >>confdefs.h
+ 

--- a/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-dwarf-table.patch
+++ b/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-dwarf-table.patch
@@ -1,0 +1,36 @@
+From a5b5fd28ed03cb1ab524d24dc534c1fa167bf5a1 Mon Sep 17 00:00:00 2001
+From: Alex Arslan <ararslan@comcast.net>
+Date: Fri, 5 Nov 2021 16:58:41 -0700
+Subject: [PATCH] Fix table indexing in `dwarf_search_unwind_table`
+
+`table_len` is used as an index into `table`, assuming it represents the
+number of entries. However, it is defined as the number of entries
+multiplied by `sizeof(unw_word_t)`. This is accounted for in other
+places that use `table_len`, e.g. in `lookup`, which divides out the
+size of `unw_word_t`, but the indexing expression uses `table_len`
+directly. So when `table` has say 2 entries, we're actually looking at
+index 15 rather than 1 in the comparison. This can cause the conditional
+to erroneously evaluate to true, allowing the following line to
+segfault.
+
+This was observed with JIT compiled code from Julia with LLVM on
+FreeBSD.
+
+Co-Authored-By: Jameson Nash <vtjnash@gmail.com>
+---
+ src/dwarf/Gfind_proc_info-lsb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/dwarf/Gfind_proc_info-lsb.c b/src/dwarf/Gfind_proc_info-lsb.c
+index 5e27a501..af4cbce8 100644
+--- a/src/dwarf/Gfind_proc_info-lsb.c
++++ b/src/dwarf/Gfind_proc_info-lsb.c
+@@ -866,7 +866,7 @@ dwarf_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
+   if (as == unw_local_addr_space)
+     {
+       e = lookup (table, table_len, ip - ip_base);
+-      if (e && &e[1] < &table[table_len])
++      if (e && &e[1] < &table[table_len / sizeof (unw_word_t)])
+ 	last_ip = e[1].start_ip_offset + ip_base;
+       else
+ 	last_ip = di->end_ip;

--- a/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-prefer-extbl.patch
+++ b/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-prefer-extbl.patch
@@ -1,0 +1,144 @@
+From bc7b50355cb37cfa56f6131b2f9174b499053188 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sat, 1 Oct 2016 16:55:40 +0000
+Subject: [PATCH] Prefer EXTBL unwinding on ARM
+
+It is part of the C++ ABI so a EXTBL unwind info that's not `CANT_UNWIND`
+should always be reliable/correct.
+Ignore `ESTOPUNWIND` so that a `CANT_UNWIND` info can fallback to unwinding
+using the debug info instead.
+---
+ include/tdep-arm/libunwind_i.h |  4 ++++
+ src/arm/Gex_tables.c           | 18 ++++++++++++++----
+ src/arm/Gstep.c                | 35 +++++++++++++++++++++--------------
+ 3 files changed, 39 insertions(+), 18 deletions(-)
+
+diff --git a/include/tdep-arm/libunwind_i.h b/include/tdep-arm/libunwind_i.h
+index 2602f41c..074fc8cb 100644
+--- a/include/tdep-arm/libunwind_i.h
++++ b/include/tdep-arm/libunwind_i.h
+@@ -253,6 +253,7 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
+ #define tdep_init_done                  UNW_OBJ(init_done)
+ #define tdep_init                       UNW_OBJ(init)
+ #define arm_find_proc_info              UNW_OBJ(find_proc_info)
++#define arm_find_proc_info2             UNW_OBJ(find_proc_info2)
+ #define arm_put_unwind_info             UNW_OBJ(put_unwind_info)
+ /* Platforms that support UNW_INFO_FORMAT_TABLE need to define
+    tdep_search_unwind_table.  */
+@@ -294,6 +295,9 @@ extern void tdep_init (void);
+ extern int arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
+                                unw_proc_info_t *pi, int need_unwind_info,
+                                void *arg);
++extern int arm_find_proc_info2 (unw_addr_space_t as, unw_word_t ip,
++                                unw_proc_info_t *pi, int need_unwind_info,
++                                void *arg, int methods);
+ extern void arm_put_unwind_info (unw_addr_space_t as,
+                                   unw_proc_info_t *pi, void *arg);
+ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
+diff --git a/src/arm/Gex_tables.c b/src/arm/Gex_tables.c
+index d6573a65..a895e0cc 100644
+--- a/src/arm/Gex_tables.c
++++ b/src/arm/Gex_tables.c
+@@ -506,18 +506,20 @@ arm_phdr_cb (struct dl_phdr_info *info, size_t size, void *data)
+ }
+ 
+ HIDDEN int
+-arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
+-                    unw_proc_info_t *pi, int need_unwind_info, void *arg)
++arm_find_proc_info2 (unw_addr_space_t as, unw_word_t ip,
++                     unw_proc_info_t *pi, int need_unwind_info, void *arg,
++                     int methods)
+ {
+   int ret = -1;
+   intrmask_t saved_mask;
+ 
+   Debug (14, "looking for IP=0x%lx\n", (long) ip);
+ 
+-  if (UNW_TRY_METHOD(UNW_ARM_METHOD_DWARF))
++  if (UNW_TRY_METHOD (UNW_ARM_METHOD_DWARF) && (methods & UNW_ARM_METHOD_DWARF))
+     ret = dwarf_find_proc_info (as, ip, pi, need_unwind_info, arg);
+ 
+-  if (ret < 0 && UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX))
++  if (ret < 0 && UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX) &&
++      (methods & UNW_ARM_METHOD_EXIDX))
+     {
+       struct arm_cb_data cb_data;
+ 
+@@ -540,6 +542,14 @@ arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
+   return ret;
+ }
+ 
++HIDDEN int
++arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
++                    unw_proc_info_t *pi, int need_unwind_info, void *arg)
++{
++    return arm_find_proc_info2 (as, ip, pi, need_unwind_info, arg,
++                                UNW_ARM_METHOD_ALL);
++}
++
+ HIDDEN void
+ arm_put_unwind_info (unw_addr_space_t as, unw_proc_info_t *proc_info, void *arg)
+ {
+diff --git a/src/arm/Gstep.c b/src/arm/Gstep.c
+index adec02e0..c43daa1c 100644
+--- a/src/arm/Gstep.c
++++ b/src/arm/Gstep.c
+@@ -53,8 +53,15 @@ arm_exidx_step (struct cursor *c)
+                                      c->dwarf.as_arg);
+   if (ret == -UNW_ENOINFO)
+     {
++#ifdef UNW_LOCAL_ONLY
++        if ((ret = arm_find_proc_info2 (c->dwarf.as, ip, &c->dwarf.pi,
++                                        1, c->dwarf.as_arg,
++                                        UNW_ARM_METHOD_EXIDX)) < 0)
++        return ret;
++#else
+       if ((ret = tdep_find_proc_info (&c->dwarf, ip, 1)) < 0)
+         return ret;
++#endif
+     }
+ 
+   if (c->dwarf.pi.format != UNW_INFO_FORMAT_ARM_EXIDX)
+@@ -94,8 +101,21 @@ unw_step (unw_cursor_t *cursor)
+   if (unw_is_signal_frame (cursor) > 0)
+      return arm_handle_signal_frame (cursor);
+ 
++  /* First, try extbl-based unwinding. */
++  if (UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX))
++    {
++      Debug (13, "%s(ret=%d), trying extbl\n",
++             UNW_TRY_METHOD(UNW_ARM_METHOD_DWARF) ? "dwarf_step() failed " : "",
++             ret);
++      ret = arm_exidx_step (c);
++      if (ret > 0)
++        return 1;
++      if (ret == 0)
++        return ret;
++    }
++
+ #ifdef CONFIG_DEBUG_FRAME
+-  /* First, try DWARF-based unwinding. */
++  /* Second, try DWARF-based unwinding. */
+   if (UNW_TRY_METHOD(UNW_ARM_METHOD_DWARF))
+     {
+       ret = dwarf_step (&c->dwarf);
+@@ -114,16 +129,6 @@ unw_step (unw_cursor_t *cursor)
+     }
+ #endif /* CONFIG_DEBUG_FRAME */
+ 
+-  /* Next, try extbl-based unwinding. */
+-  if (UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX))
+-    {
+-      ret = arm_exidx_step (c);
+-      if (ret > 0)
+-        return 1;
+-      if (ret == -UNW_ESTOPUNWIND || ret == 0)
+-        return ret;
+-    }
+-
+   /* Fall back on APCS frame parsing.
+      Note: This won't work in case the ARM EABI is used. */
+ #ifdef __FreeBSD__
+-- 
+2.16.1
+

--- a/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-static-arm.patch
+++ b/L/LibUnwind/LibUnwind@1.3.2/bundled/patches/libunwind-static-arm.patch
@@ -1,0 +1,13 @@
+diff --git a/src/arm/Gex_tables.c b/src/arm/Gex_tables.c
+index d6573a65..1d64803e 100644
+--- a/src/arm/Gex_tables.c
++++ b/src/arm/Gex_tables.c
+@@ -381,7 +381,7 @@ arm_exidx_extract (struct dwarf_cursor *c, uint8_t *buf)
+   return nbuf;
+ }
+ 
+-int
++static int
+ arm_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
+ 			 unw_dyn_info_t *di, unw_proc_info_t *pi,
+ 			 int need_unwind_info, void *arg)


### PR DESCRIPTION
PR #3856 refactored the previous master into a builder specifically for libunwind v1.5.0. To avoid issues with automated JLL registration, it only did that version. This PR now adds a separate builder for v1.3.2, the version of libunwind currently in use by Julia, based on the state of the builder as of commit e9a0bfdaf1947867eafde7c8472389fdf60ccdc6 but with https://github.com/libunwind/libunwind/pull/308 as an added patch.

Note that to avoid said issues with registration, this commit does not refactor the other builder to use a common setup; that can be done separately to reduce duplication.