### PR TITLE
[pciutils] init

### DIFF
--- a/P/pciutils/build_tarballs.jl
+++ b/P/pciutils/build_tarballs.jl
@@ -1,0 +1,35 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "pciutils"
+version = v"3.7.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/pciutils/pciutils.git", "864aecdea9c7db626856d8d452f6c784316a878c")
+]
+
+dependencies = [
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd pciutils
+make install PREFIX=${prefix} SHARED=yes SBINDIR=${prefix}/bin
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = filter!(p -> !Sys.iswindows(p) && !Sys.isapple(p), supported_platforms(;experimental=true))
+
+# The products that we will ensure are always built
+products = Product[
+    ExecutableProduct("lspci", :lspci),
+    ExecutableProduct("setpci", :setpci),
+    LibraryProduct("libpci", :libpci)
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+# gcc7 constraint from boost
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/P/pciutils/build_tarballs.jl
+++ b/P/pciutils/build_tarballs.jl
@@ -10,13 +10,13 @@ sources = [
     GitSource("https://github.com/pciutils/pciutils.git", "864aecdea9c7db626856d8d452f6c784316a878c")
 ]
 
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd pciutils
-make install PREFIX=${prefix} SHARED=yes SBINDIR=${prefix}/bin
+make install PREFIX=${prefix} SHARED=yes SBINDIR=${bindir}
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
This adds [pciutils](https://github.com/pciutils/pciutils).

>1. What's that?
>The PCI Utilities package contains a library for portable access to PCI bus
>configuration registers and several utilities based on this library.
>
>In runs on the following systems:
>
>	Linux		(via /sys/bus/pci, /proc/bus/pci or i386 ports)
>	FreeBSD		(via /dev/pci)
>	NetBSD		(via libpci)
>	OpenBSD		(via /dev/pci)
>	GNU/kFreeBSD	(via /dev/pci)
>	Solaris/i386	(direct port access)
>	Aix		(via /dev/pci and odmget)
>	GNU Hurd	(direct port access)
>	Windows		(direct port access, see README.Windows for caveats)
>	CYGWIN		(direct port access)
>	BeOS		(via syscalls)
>	Haiku		(via /dev/misc/poke)
>	Darwin		(via IOKit)
>	DOS/DJGPP	(via i386 ports)
>	SylixOS		(via /proc/pci)