### PR TITLE
Add Aria2-1.36.0

### DIFF
--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -21,7 +21,7 @@ export LDFLAGS="-L${libdir}"
 ./configure \
     --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-pic --enable-shared --enable-libaria2 \
-    --with-openssl --with-libxml2 --with-libz
+    --with-openssl --with-libxml2 --with-libz --with-libssh2
 
 make -j${nproc}
 make install
@@ -45,6 +45,12 @@ products = [
 dependencies = [
     # TODO
     # - libcares https://github.com/c-ares/c-ares
+    Dependency(PackageSpec(name="LibSSH2_jll")),
+    # `MbedTLS_jll` is a dependency of `LibSSH2_jll`.  Strangely, we
+    # are getting a newer version in the build than the one
+    # `LibSSH2_jll` was compiled with.  So we explicitly select the
+    # right version here.
+    BuildDependency(PackageSpec(name="MbedTLS_jll", version="2.24")),
     Dependency(PackageSpec(name="OpenSSL_jll")),
     Dependency(PackageSpec(name="XML2_jll")),
     Dependency(PackageSpec(name="Zlib_jll")),

--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -1,0 +1,56 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Aria2"
+version = v"1.36.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/aria2/aria2/releases/download/release-$(version)/aria2-$(version).tar.xz",
+                  "58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/aria2-*/
+
+export CPPFLAGS="-I${includedir}"
+export LDFLAGS="-L${libdir}"
+
+./configure \
+    --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
+    --with-pic --enable-shared --enable-libaria2 \
+    --with-openssl --with-libxml2 --with-libz --with-libssh2
+
+make -j${nproc}
+make install
+
+install_license COPYING
+install_license LICENSE.OpenSSL
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; experimental=true)
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("aria2c", :aria2c),
+    LibraryProduct("libaria2", :libaria2)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    # TODO
+    # - libcares https://github.com/c-ares/c-ares
+    Dependency(PackageSpec(name="LibSSH2_jll")),
+    Dependency(PackageSpec(name="OpenSSL_jll")),
+    Dependency(PackageSpec(name="XML2_jll")),
+    Dependency(PackageSpec(name="Zlib_jll")),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version = v"7")

--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -21,7 +21,7 @@ export LDFLAGS="-L${libdir}"
 ./configure \
     --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-pic --enable-shared --enable-libaria2 \
-    --with-openssl --with-libxml2 --with-libz --with-libssh2
+    --with-openssl --with-libxml2 --with-libz
 
 make -j${nproc}
 make install
@@ -45,7 +45,6 @@ products = [
 dependencies = [
     # TODO
     # - libcares https://github.com/c-ares/c-ares
-    Dependency(PackageSpec(name="LibSSH2_jll")),
     Dependency(PackageSpec(name="OpenSSL_jll")),
     Dependency(PackageSpec(name="XML2_jll")),
     Dependency(PackageSpec(name="Zlib_jll")),


### PR DESCRIPTION
Add aria2 https://github.com/aria2/aria2

I had a strange linking error when adding `Dependency(PackageSpec(name="LibSSH2_jll"))` to the dependencies, due to LibSSH in turn using mbedtls. So for now i removed libssh2 functionality. When adding libssh2 to the build deps, the build works fine but the executable and library are linked to `libmbedcrypto.so.7` which can't be found.

I think it's due to `LibSSH2_jll v1.10.1+0` pulling in `MbedTLS_jll v2.27.0+0` for the build, even though according to the [build script](https://github.com/JuliaPackaging/Yggdrasil/blob/7a834c853005098bf8a8f0817e7fa93be2525e40/L/LibSSH2/build_tarballs.jl#L45) it should use 2.24.0.