### PR TITLE
Create a Xyce_jll with the latest commit on master

### DIFF
--- a/X/Xyce/build_tarballs.jl
+++ b/X/Xyce/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "Xyce"
-version = v"7.4"
+version = v"7.4.99"
 
 # Collection of sources required to complete build
 sources = [
-            GitSource("https://github.com/Xyce/Xyce.git", "82f96bbe05bac5921cd6fa1e8bb6a2983a797bf8"),
+            GitSource("https://github.com/Xyce/Xyce.git", "b7bb12d81f11d8b50141262537299b09d64b5565"),
             DirectorySource("./bundled")
           ]
 


### PR DESCRIPTION
- The master of Xyce has a lot improvements over v7.4
- This is for power users who want to use them already


----
- For people interested in v7.4 of Xyce this [Xyce_jll-v7.4.0+0](https://github.com/JuliaBinaryWrappers/Xyce_jll.jl/releases/tag/Xyce-v7.4.0%2B0) release can be used