### PR TITLE
libffi: Stop messing with the install directory

### DIFF
--- a/L/Libffi/build_tarballs.jl
+++ b/L/Libffi/build_tarballs.jl
@@ -8,6 +8,7 @@ version = v"3.2.1"
 sources = [
     ArchiveSource("https://sourceware.org/pub/libffi/libffi-$(version).tar.gz",
                   "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37"),
+    DirectorySource("./bundled"),
 ]
 
 version = v"3.2.2" # <-- this is a lie, we need to bump the version to require julia v1.6
@@ -15,6 +16,7 @@ version = v"3.2.2" # <-- this is a lie, we need to bump the version to require j
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libffi-*/
+atomic_patch -p1 ../patches/*
 update_configure_scripts
 autoreconf -f -i
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static --enable-shared

--- a/L/Libffi/bundled/patches/0001-libdir-no-touchy.patch
+++ b/L/Libffi/bundled/patches/0001-libdir-no-touchy.patch
@@ -1,0 +1,31 @@
+--- libffi-3.2.1-orig/configure.ac	2021-11-18 00:13:42.753131022 -0500
++++ libffi-3.2.1/configure.ac	2021-11-18 00:14:43.014058771 -0500
+@@ -590,26 +590,7 @@
+     AC_DEFINE(USING_PURIFY, 1, [Define this if you are using Purify and want to suppress spurious messages.])
+   fi)
+ 
+-# These variables are only ever used when we cross-build to X86_WIN32.
+-# And we only support this with GCC, so...
+-if test "x$GCC" = "xyes"; then
+-  if test -n "$with_cross_host" &&
+-     test x"$with_cross_host" != x"no"; then
+-    toolexecdir="${exec_prefix}"/'$(target_alias)'
+-    toolexeclibdir="${toolexecdir}"/lib
+-  else
+-    toolexecdir="${libdir}"/gcc-lib/'$(target_alias)'
+-    toolexeclibdir="${libdir}"
+-  fi
+-  multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
+-  case $multi_os_directory in
+-    .) ;; # Avoid trailing /.
+-    ../*) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
+-  esac
+-  AC_SUBST(toolexecdir)
+-else
+-  toolexeclibdir="${libdir}"
+-fi
++toolexeclibdir="${libdir}"
+ AC_SUBST(toolexeclibdir)
+ 
+ AC_CONFIG_COMMANDS(include, [test -d include || mkdir include])
+


### PR DESCRIPTION
The libffi configure script tries to be "smart" and detect whether
the target platform uses the lib/lib64 split for its libraries even
though nobody asked it too. This causes libffi to not be linkable
because it doesn't get installed in the lib directory. Now, in theory
pkg-config would take care of that, because it does have the correct
directory, but in practice pkg-config does not work, so we really do
need everything in one directory. The last question may be why didn't
this cause trouble before? Well, the answer to that one is that on
many platforms, we have a copy of libffi in the sysroot, which
builds picked up instead of the correct dependency. We don't on
powerpc64 though, causing issues in #3903.

Fix all that by just patching the problematic code out of the
configure script. This seems to be a fairly common patch for
build systems to apply. E.g. there's a version of it in [1].

[1] https://github.com/chef/omnibus-software/blob/main/config/patches/libffi/libffi-3.2.1-disable-multi-os-directory.patch