### PR TITLE
Update FLINT to 2.8.4, for Julia >= 1.6

### DIFF
--- a/F/FLINT/build_tarballs.jl
+++ b/F/FLINT/build_tarballs.jl
@@ -26,7 +26,7 @@ using BinaryBuilder, Pkg
 # and possibly other packages.
 name = "FLINT"
 upstream_version = v"2.8.4"
-build_for_julia16_or_newer = false
+build_for_julia16_or_newer = true
 version_offset = build_for_julia16_or_newer ? v"0.0.1" : v"0.0.0"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,


### PR DESCRIPTION
Should be only merged after #3911 was merged and we had a chance to update LoadFlint.jl