### PR TITLE
[Readline] fix linkage on freebsd

### DIFF
--- a/R/Readline/build_tarballs.jl
+++ b/R/Readline/build_tarballs.jl
@@ -26,6 +26,8 @@ export CPPFLAGS="-I${includedir}"
 if [[ "${target}" == *-mingw* ]]; then
     # Only on Windows the library name embeds the ABI version
     export NCURSES_ABI_VER=6
+fi
+if [[ "${target}" == *-mingw* ]] || [[ "${target}" == *-freebsd* ]]; then
     export LDFLAGS="-L${libdir}"
 fi
 


### PR DESCRIPTION
Add linker flag to point to correct `$libdir` for FreeBSD (this is often needed for FreeBSD and can lead to failures as mentioned in the [Build Troubleshooting](https://docs.binarybuilder.org/dev/troubleshooting/#Libraries-of-the-dependencies-can't-be-found), but in this case the failure was hidden because of a similar library existing in the Rootfs). With this change running the build with `--debug=end` produces:
```console
sandbox:${WORKSPACE}/srcdir/readline-8.1 # patchelf --print-needed $libdir/libhistory.so
libncursesw.so.6
libc.so.7
```

Without that change we get this on FreeBSD:
```julia
root@freebsd:~ # /root/julia-1.6.4/bin/julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.4 (2021-11-19)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using Readline_jll
ERROR: InitError: could not load library "/root/.julia/artifacts/ad33f7b809e8fc6bba556f463eb13047c718400f/lib/libhistory.so"
Shared object "libncurses.so.8" not found, required by "libhistory.so"
Stacktrace:
 [1] dlopen(s::String, flags::UInt32; throw_error::Bool)
   @ Base.Libc.Libdl ./libdl.jl:114
 [2] dlopen(s::String, flags::UInt32)
   @ Base.Libc.Libdl ./libdl.jl:114
 [3] macro expansion
   @ ~/.julia/packages/JLLWrappers/bkwIo/src/products/library_generators.jl:54 [inlined]
 [4] __init__()
   @ Readline_jll ~/.julia/packages/Readline_jll/qAxER/src/wrappers/x86_64-unknown-freebsd.jl:10
 [5] _include_from_serialized(path::String, depmods::Vector{Any})
   @ Base ./loading.jl:696
 [6] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String)
   @ Base ./loading.jl:782
 [7] _require(pkg::Base.PkgId)
   @ Base ./loading.jl:1020
 [8] require(uuidkey::Base.PkgId)
   @ Base ./loading.jl:936
 [9] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:923
during initialization of module Readline_jll
```
It is linked with a libncurses.so.8 which seems to come from the rootfs as no such library exists here:
```julia
julia> using Ncurses_jll

julia> run(`ls -la $(Ncurses_jll.artifact_dir)/lib`)
total 1852
drwxr-xr-x  3 root  wheel    1024 Nov 19 23:37 .
drwxr-xr-x  7 root  wheel     512 Nov 19 23:37 ..
lrwxr-xr-x  1 root  wheel      11 Nov 19 23:37 libform.so -> libformw.so
-r--r--r--  1 root  wheel  153012 Nov 19 23:37 libformw.a
lrwxr-xr-x  1 root  wheel      13 Nov 19 23:37 libformw.so -> libformw.so.6
lrwxr-xr-x  1 root  wheel      15 Nov 19 23:37 libformw.so.6 -> libformw.so.6.2
-r-xr-xr-x  1 root  wheel  104400 Nov 19 23:37 libformw.so.6.2
lrwxr-xr-x  1 root  wheel      11 Nov 19 23:37 libmenu.so -> libmenuw.so
-r--r--r--  1 root  wheel   72686 Nov 19 23:37 libmenuw.a
lrwxr-xr-x  1 root  wheel      13 Nov 19 23:37 libmenuw.so -> libmenuw.so.6
lrwxr-xr-x  1 root  wheel      15 Nov 19 23:37 libmenuw.so.6 -> libmenuw.so.6.2
-r-xr-xr-x  1 root  wheel   46424 Nov 19 23:37 libmenuw.so.6.2
lrwxr-xr-x  1 root  wheel      14 Nov 19 23:37 libncurses.so -> libncursesw.so
-r--r--r--  1 root  wheel  845074 Nov 19 23:37 libncursesw.a
lrwxr-xr-x  1 root  wheel      16 Nov 19 23:37 libncursesw.so -> libncursesw.so.6
lrwxr-xr-x  1 root  wheel      18 Nov 19 23:37 libncursesw.so.6 -> libncursesw.so.6.2
-r-xr-xr-x  1 root  wheel  498599 Nov 19 23:37 libncursesw.so.6.2
lrwxr-xr-x  1 root  wheel      12 Nov 19 23:37 libpanel.so -> libpanelw.so
-r--r--r--  1 root  wheel   29098 Nov 19 23:37 libpanelw.a
lrwxr-xr-x  1 root  wheel      14 Nov 19 23:37 libpanelw.so -> libpanelw.so.6
lrwxr-xr-x  1 root  wheel      16 Nov 19 23:37 libpanelw.so.6 -> libpanelw.so.6.2
-r-xr-xr-x  1 root  wheel   20944 Nov 19 23:37 libpanelw.so.6.2
drwxr-xr-x  2 root  wheel     512 Nov 19 23:37 pkgconfig
lrwxr-xr-x  1 root  wheel      17 Nov 19 23:37 terminfo -> ../share/terminfo
```

The command in the log also does not contain any `-L$libdir` argument:
```
cc -shared -Wl,-soname,libreadline.so.8.1 -Wl,-rpath,/workspace/destdir/lib -Wl,-soname,`basename libreadline.so.8.1 .1` -o libreadline.so.8.1 readline.so vi_mode.so funmap.so keymaps.so parens.so search.so rltty.so complete.so bind.so isearch.so display.so signals.so util.so kill.so undo.so macro.so input.so callback.so terminal.so text.so nls.so misc.so history.so histexpand.so histfile.so histsearch.so shell.so mbutil.so tilde.so colors.so parse-colors.so xmalloc.so xfree.so compat.so -lncurses
```