### PR TITLE
add libLAS

### DIFF
--- a/L/libLAS/build_tarballs.jl
+++ b/L/libLAS/build_tarballs.jl
@@ -48,7 +48,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/L/libLAS/build_tarballs.jl
+++ b/L/libLAS/build_tarballs.jl
@@ -20,9 +20,7 @@ atomic_patch -p1 ${WORKSPACE}/srcdir/patches/comment-out-FixupOrdering.patch
 
 if [[ "${target}" == *-mingw* ]]; then
     atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mingw-rename-libs.patch
-fi
-
-if [[ "${target}" == aarch64-linux-musl* ]] || [[ "${target}" == arm-linux-musleabihf ]]; then
+elif [[ "${target}" == aarch64-linux-musl* ]] || [[ "${target}" == arm-linux-musleabihf ]]; then
     atomic_patch -p1 ${WORKSPACE}/srcdir/patches/add-arch-macros.patch
 fi
 

--- a/L/libLAS/build_tarballs.jl
+++ b/L/libLAS/build_tarballs.jl
@@ -22,6 +22,10 @@ if [[ "${target}" == *-mingw* ]]; then
     atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mingw-rename-libs.patch
 fi
 
+if [[ "${target}" == aarch64-linux-musl* ]] || [[ "${target}" == arm-linux-musleabihf ]]; then
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/add-arch-macros.patch
+fi
+
 mkdir build && cd build
 
 cmake .. \

--- a/L/libLAS/build_tarballs.jl
+++ b/L/libLAS/build_tarballs.jl
@@ -1,0 +1,78 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libLAS"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/libLAS/libLAS.git", "e6a1aaed412d638687b8aec44f7b12df7ca2bbbb"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+
+cd $WORKSPACE/srcdir/libLAS/
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/comment-out-FixupOrdering.patch
+
+if [[ "${target}" == *-mingw* ]]; then
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mingw-rename-libs.patch
+fi
+
+mkdir build && cd build
+
+cmake .. \
+-DCMAKE_INSTALL_PREFIX=${prefix} \
+-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+-DCMAKE_BUILD_TYPE=Release \
+-DWITH_UTILITIES=FALSE \
+-DWITH_TESTS=FALSE \
+-DBUILD_OSGEO4W=FALSE \
+-DWITH_LASZIP=TRUE \
+-DWITH_GDAL=TRUE \
+-DWITH_GEOTIFF=TRUE
+
+make -j${nproc}
+make install
+
+if [[ "${target}" == *-mingw* ]]; then
+#cmake install only grabs the .dll.a and leaves the actual .dll behind, manually move it 
+mv bin/Release/*.dll ${libdir}
+fi
+
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("liblas", :liblas),
+    LibraryProduct("liblas_c", :liblas_c)
+    #ExecutableProduct("las2txt", :las2txt),
+    #ExecutableProduct("lasinfo", :lasinfo),
+    #ExecutableProduct("ts2las", :ts2las),
+    #ExecutableProduct("las2col", :las2col),
+    #ExecutableProduct("las2pg", :las2pg),
+    #ExecutableProduct("lasblock", :lasblock),
+    #ExecutableProduct("las2las", :las2las),
+    #ExecutableProduct("txt2las", :txt2las),
+    #ExecutableProduct("las2ogr", :las2ogr)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("boost_jll"; compat="=1.76.0")
+    Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"))
+    Dependency(PackageSpec(name="PROJ_jll", uuid="58948b4f-47e0-5654-a9ad-f609743f8632"))
+    Dependency(PackageSpec(name="libgeotiff_jll", uuid="06c338fa-64ff-565b-ac2f-249532af990e"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"5")

--- a/L/libLAS/bundled/patches/add-arch-macros.patch
+++ b/L/libLAS/bundled/patches/add-arch-macros.patch
@@ -1,0 +1,13 @@
+diff --git a/include/liblas/detail/endian.hpp b/include/liblas/detail/endian.hpp
+index cd94997c..946bcb5a 100644
+--- a/include/liblas/detail/endian.hpp
++++ b/include/liblas/detail/endian.hpp
+@@ -88,7 +88,7 @@
+    || defined(_M_ALPHA) || defined(__amd64) \
+    || defined(__amd64__) || defined(_M_AMD64) \
+    || defined(__x86_64) || defined(__x86_64__) \
+-   || defined(_M_X64)
++   || defined(_M_X64) || defined(__aarch64__) || defined(__arm__)
+ 
+ # define LIBLAS_LITTLE_ENDIAN
+ # define LIBLAS_BYTE_ORDER 1234

--- a/L/libLAS/bundled/patches/comment-out-FixupOrdering.patch
+++ b/L/libLAS/bundled/patches/comment-out-FixupOrdering.patch
@@ -1,0 +1,31 @@
+diff --git before/src/gt_wkt_srs.cpp after/src/gt_wkt_srs.cpp
+index 8a73c75..fe04716 100755
+--- before/src/gt_wkt_srs.cpp
++++ after/src/gt_wkt_srs.cpp
+@@ -299,7 +299,7 @@ char *GTIFGetOGISDefn( GTIF *hGTIF, GTIFDefn * psDefn )
+                 oSRS.SetFromUserInput(pszWKT);
+                 oSRS.SetExtension( "PROJCS", "PROJ4",
+                                    "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs" );
+-                oSRS.FixupOrdering();
++            // oSRS.FixupOrdering();
+                 CPLFree(pszWKT);
+                 pszWKT = NULL;
+                 oSRS.exportToWkt(&pszWKT);
+@@ -505,7 +505,7 @@ char *GTIFGetOGISDefn( GTIF *hGTIF, GTIFDefn * psDefn )
+         {
+             char	*pszWKT;
+             oSRS.morphFromESRI();
+-            oSRS.FixupOrdering();
++            //oSRS.FixupOrdering();
+             if( oSRS.exportToWkt( &pszWKT ) == OGRERR_NONE )
+                 return pszWKT;
+         }
+@@ -1107,7 +1107,7 @@ char *GTIFGetOGISDefn( GTIF *hGTIF, GTIFDefn * psDefn )
+ /* ==================================================================== */
+     char	*pszWKT;
+ 
+-    oSRS.FixupOrdering();
++    //oSRS.FixupOrdering();
+ 
+     if( oSRS.exportToWkt( &pszWKT ) == OGRERR_NONE )
+         return pszWKT;

--- a/L/libLAS/bundled/patches/mingw-rename-libs.patch
+++ b/L/libLAS/bundled/patches/mingw-rename-libs.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4df28710..0ff6abeb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,10 +23,10 @@ SET(OSGEO4W_UPSTREAM_RELEASE "1")
+ 
+ if(WIN32)
+   # Name of C++ library
+-  set(LIBLAS_LIB_NAME liblas)
++  set(LIBLAS_LIB_NAME las)
+ 
+   # Name of C library
+-  set(LIBLAS_C_LIB_NAME liblas_c)
++  set(LIBLAS_C_LIB_NAME las_c)
+ 
+ else()
+   # Name of C++ library


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [libLAS](https://github.com/libLAS/libLAS) library (not to be confused with the [LASlib](https://github.com/LAStools/LAStools/tree/master/LASlib) library....). This project is semi-deprecated (?) but I still see it as a dependency for a number of projects floating around. The last release was in 2016, they mention in an issue that there are no plans to cut a new release and it's basically managed as a rolling release now. I am building from latest master here.

Many of the dependencies are newer than what the project is written for so I had to fix some things. Otherwise tested on the usual subset of platforms with no issues. :crossed_fingers: 

FYI: @visr @evetion 

