### PR TITLE
Update LAMMPS to include most packages

### DIFF
--- a/L/LAMMPS/build_tarballs.jl
+++ b/L/LAMMPS/build_tarballs.jl
@@ -11,17 +11,22 @@ sources = [
 ]
 
 # Bash recipe for building across all platforms
+# LAMMPS DPD packages do not work on all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/lammps/
 mkdir build && cd build/
-cmake ../cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+cmake -C ../cmake/presets/most.cmake -C ../cmake/presets/nolib.cmake ../cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
     -DLAMMPS_EXCEPTIONS=ON \
-    -DPKG_SNAP=ON \
-    -DBUILD_MPI=ON
-
+    -DPKG_MPI=ON \
+	-DPKG_SNAP=ON \
+    -DPKG_DPD-BASIC=OFF \
+	-DPKG_DPD-MESO=OFF \
+	-DPKG_DPD-REACT=OFF \
+	-DPKG_DPD-SMOOTH=OFF 
+	
 make -j${nproc}
 make install
 

--- a/L/LAMMPS/build_tarballs.jl
+++ b/L/LAMMPS/build_tarballs.jl
@@ -25,6 +25,9 @@ cmake -C ../cmake/presets/most.cmake -C ../cmake/presets/nolib.cmake ../cmake -D
     -DPKG_DPD-BASIC=OFF \
 	-DPKG_DPD-MESO=OFF \
 	-DPKG_DPD-REACT=OFF \
+        -DPKG_USER-MESODPD=OFF \
+        -DPKG_USER-DPD=OFF \
+        -DPKG_USER-SDPD=OFF \
 	-DPKG_DPD-SMOOTH=OFF 
 	
 make -j${nproc}


### PR DESCRIPTION
Modified to build LAMMPS with "most" packages cmake preset.
LAMMPS packages requiring extra libraries were disabled to simplify the process.

The LAMMPS packages containing DPD style potentials caused issues while cross compiling and have been disabled.