### PR TITLE
Remove Julia compat from LLVM_full.

### DIFF
--- a/L/LLVM/LLVM_full@12.0.0/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@12.0.0/build_tarballs.jl
@@ -3,4 +3,4 @@ version = v"12.0.0"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.7")
+                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@12.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@12.0.1/build_tarballs.jl
@@ -3,4 +3,4 @@ version = v"12.0.1"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.7")
+               preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@13.0.0/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@13.0.0/build_tarballs.jl
@@ -3,4 +3,4 @@ version = v"13.0.0"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.8")
+               preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@12.0.0/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@12.0.0/build_tarballs.jl
@@ -3,4 +3,4 @@ version = v"12.0.0"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true, assert=true)...;
-                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.7")
+                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@12.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@12.0.1/build_tarballs.jl
@@ -3,5 +3,5 @@ version = v"12.0.1"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true, assert=true)...;
-                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.7")
+                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")
 

--- a/L/LLVM/LLVM_full_assert@13.0.0/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@13.0.0/build_tarballs.jl
@@ -3,5 +3,5 @@ version = v"13.0.0"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true, assert=true)...;
-                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.8")
+                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")
 


### PR DESCRIPTION
LLVM_full is intended as a build tool, so we want to be able to use it from different Julia versions. Since the JLL doesn't dlopen anything, it doesn't make sense to me to have Julia compat bounds on it.

Use case: I'm generating LLVM 13 headers for LLVM.jl, but Clang.jl doesn't work on 1.8.