### PR TITLE
[polymake] update patch to (temporarily) set sigchld before spawning subprocess

### DIFF
--- a/P/polymake/bundled/patches/sigchld.patch
+++ b/P/polymake/bundled/patches/sigchld.patch
@@ -14,3 +14,15 @@ index 607d9fa57f..523bd679b3 100644
  
     require DynaLoader;
     Polymake::Ext::bootstrap();
+diff --git a/perllib/Polymake/Interrupts.pm b/perllib/Polymake/Interrupts.pm
+index ca9cf3b6e3..fe9cff8a71 100644
+--- a/perllib/Polymake/Interrupts.pm
++++ b/perllib/Polymake/Interrupts.pm
+@@ -26,6 +26,7 @@ use Polymake::Ext;
+ 
+ # standard perl system() function can't be interrupted by a signal, but pipe write can.
+ sub system {
++   local $SIG{CHLD} = 'DEFAULT';
+    open my $dummy, join(" ", "|", @_)
+    or die "can't execute @_: $!\n";
+    close $dummy;


### PR DESCRIPTION
This should fix https://github.com/oscar-system/Oscar.jl/issues/831 (`No child processes`), even though I do not fully understand why this happens now and why only with 1.6.4 macos but I have spent way too much time trying to debug this.

Note: This is just a bugfix, an update to the latest Perl_jll will come later.