### PR TITLE
[MPItrampoline] Update to version 2.7.0

### DIFF
--- a/M/MPICH/build_tarballs.jl
+++ b/M/MPICH/build_tarballs.jl
@@ -6,8 +6,8 @@ version = v"3.4.2"
 sources = [
     ArchiveSource("https://www.mpich.org/static/downloads/$(version)/mpich-$(version).tar.gz",
                   "5c19bea8b84e8d74cca5f047e82b147ff3fba096144270e3911ad623d6c587bf"),
-    ArchiveSource("https://github.com/eschnett/MPIconstants/archive/refs/tags/v1.3.2.tar.gz",
-                  "3437eb7913cf213de80cef4ade7d73f0b3adfe9eadabe993b923dc50a21bd65e"),
+    ArchiveSource("https://github.com/eschnett/MPIconstants/archive/refs/tags/v1.4.0.tar.gz",
+                  "610d816c22cd05e16e17371c6384e0b6f9d3a2bdcb311824d0d40790812882fc"),
 ]
 
 script = raw"""

--- a/M/MPItrampoline/build_tarballs.jl
+++ b/M/MPItrampoline/build_tarballs.jl
@@ -13,8 +13,8 @@ sources = [
                   "610d816c22cd05e16e17371c6384e0b6f9d3a2bdcb311824d0d40790812882fc"),
     ArchiveSource("https://www.mpich.org/static/downloads/3.4.2/mpich-3.4.2.tar.gz",
                   "5c19bea8b84e8d74cca5f047e82b147ff3fba096144270e3911ad623d6c587bf"),
-    ArchiveSource("https://github.com/eschnett/MPIwrapper/archive/refs/tags/v2.2.0.tar.gz",
-                  "9cc9cda6f09288b8694a82cb3a64cf8457e408eee01a612e669fee749c1cb0b8"),
+    ArchiveSource("https://github.com/eschnett/MPIwrapper/archive/refs/tags/v2.2.1.tar.gz",
+                  "4ce058d47e515ff3dc62a6e175a9b1f402d25cc3037be0d9c26add2d78ba8da9"),
 ]
 
 # Bash recipe for building across all platforms
@@ -97,17 +97,6 @@ if [[ "${target}" != i686-linux-gnu ]] || [[ "${target}" != x86_64-linux-* ]]; t
     fi
 fi
 
-if [[ "${target}" == aarch64-apple-* ]]; then
-    export FFLAGS=-fallow-argument-mismatch
-fi
-
-if [[ "${target}" == *-apple-* ]]; then
-    # MPICH uses the link options `-flat_namespace` on Darwin. This
-    # conflicts with MPItrampoline, which requires the option
-    # `-twolevel_namespace`.
-    EXTRA_FLAGS+=(--enable-two-level-namespace)
-fi
-
 # Building with an external hwloc leads to problems loading the
 # resulting libraries and executable via MPIwrapper, because this
 # happens outside of Julia's control.
@@ -125,6 +114,17 @@ export CFLAGS='-fPIC -DPIC'
 export CXXFLAGS='-fPIC -DPIC'
 export FFLAGS='-fPIC -DPIC'
 export FCFLAGS='-fPIC -DPIC'
+
+if [[ "${target}" == aarch64-apple-* ]]; then
+    export FFLAGS="$FFLAGS -fallow-argument-mismatch"
+fi
+
+if [[ "${target}" == *-apple-* ]]; then
+    # MPICH uses the link options `-flat_namespace` on Darwin. This
+    # conflicts with MPItrampoline, which requires the option
+    # `-twolevel_namespace`.
+    EXTRA_FLAGS+=(--enable-two-level-namespace)
+fi
 
 ./configure \
     --build=${MACHTYPE} \

--- a/M/MPItrampoline/build_tarballs.jl
+++ b/M/MPItrampoline/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "MPItrampoline"
-version = v"2.6.0"
+version = v"2.7.0"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://github.com/eschnett/MPItrampoline/archive/refs/tags/v$(version).tar.gz",
-                  "5425085f4b8772990b28a643b7dfc7ac37a399ee35ffa3d6113a06e5b508dfac"),
+                  "b188657e41b240bba663ce5b3d7b73377a27a64edcc1e0aaa7c924cf00e30b42"),
     ArchiveSource("https://github.com/eschnett/MPIconstants/archive/refs/tags/v1.4.0.tar.gz",
                   "610d816c22cd05e16e17371c6384e0b6f9d3a2bdcb311824d0d40790812882fc"),
     ArchiveSource("https://www.mpich.org/static/downloads/3.4.2/mpich-3.4.2.tar.gz",

--- a/M/MicrosoftMPI/build_tarballs.jl
+++ b/M/MicrosoftMPI/build_tarballs.jl
@@ -7,8 +7,8 @@ sources = [
                   "c305ce3f05d142d519f8dd800d83a4b894fc31bcad30512cefb557feaccbe8b4"),
     FileSource("https://download.microsoft.com/download/a/5/2/a5207ca5-1203-491a-8fb8-906fd68ae623/msmpisdk.msi",
                   "f9174c54feda794586ebd83eea065be4ad38b36f32af6e7dd9158d8fd1c08433"),
-    ArchiveSource("https://github.com/eschnett/MPIconstants/archive/refs/tags/v1.3.2.tar.gz",
-                  "3437eb7913cf213de80cef4ade7d73f0b3adfe9eadabe993b923dc50a21bd65e"),
+    ArchiveSource("https://github.com/eschnett/MPIconstants/archive/refs/tags/v1.4.0.tar.gz",
+                  "610d816c22cd05e16e17371c6384e0b6f9d3a2bdcb311824d0d40790812882fc"),
 ]
 
 script = raw"""

--- a/O/OpenMPI/build_tarballs.jl
+++ b/O/OpenMPI/build_tarballs.jl
@@ -5,8 +5,8 @@ version = v"4.1.1"
 sources = [
     ArchiveSource("https://download.open-mpi.org/release/open-mpi/v$(version.major).$(version.minor)/openmpi-$(version).tar.gz",
                   "d80b9219e80ea1f8bcfe5ad921bd9014285c4948c5965f4156a3831e60776444"),
-    ArchiveSource("https://github.com/eschnett/MPIconstants/archive/refs/tags/v1.3.2.tar.gz",
-                  "3437eb7913cf213de80cef4ade7d73f0b3adfe9eadabe993b923dc50a21bd65e"),
+    ArchiveSource("https://github.com/eschnett/MPIconstants/archive/refs/tags/v1.4.0.tar.gz",
+                  "610d816c22cd05e16e17371c6384e0b6f9d3a2bdcb311824d0d40790812882fc"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
Also improve the way in which the fall-back MPICH library is built. It is now a static library which simplifies `dlopen`ing the MPIwrapper library.