### PR TITLE
add libpointmatcher

### DIFF
--- a/L/libpointmatcher/build_tarballs.jl
+++ b/L/libpointmatcher/build_tarballs.jl
@@ -32,6 +32,8 @@ cmake .. \
 make -j${nproc}
 make install
 
+install_license ../debian/copyright
+
 """
 
 # These are the platforms we will build for by default, unless further

--- a/L/libpointmatcher/build_tarballs.jl
+++ b/L/libpointmatcher/build_tarballs.jl
@@ -38,6 +38,8 @@ make install
 # platforms are passed in on the command line
 
 platforms = expand_cxxstring_abis(supported_platforms())
+#only supports 64 bit compilers
+filter!(p -> nbits(p) != 32, platforms)
 
 
 

--- a/L/libpointmatcher/build_tarballs.jl
+++ b/L/libpointmatcher/build_tarballs.jl
@@ -44,7 +44,7 @@ rm ${prefix}/share/libnabo/cmake/libnaboConfig.cmake
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 
-platforms = expand_cxxstring_abis(supported_platforms())
+platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
 #only supports 64 bit compilers
 filter!(p -> nbits(p) != 32, platforms)
 

--- a/L/libpointmatcher/build_tarballs.jl
+++ b/L/libpointmatcher/build_tarballs.jl
@@ -1,0 +1,57 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libpointmatcher"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/ethz-asl/libpointmatcher.git", "fc7cd5da39b24665d65e6a570124621b4e1d3ef2"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libpointmatcher/
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/comment-cmake-alias.patch
+
+mkdir build && cd build
+
+cmake .. \
+-DCMAKE_INSTALL_PREFIX=${prefix} \
+-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+-DCMAKE_BUILD_TYPE=Release \
+-DBUILD_TESTS=OFF \
+-DPOINTMATCHER_BUILD_EXAMPLES=OFF \
+-DPOINTMATCHER_BUILD_EVALUATIONS=OFF \
+-DBUILD_PYTHON_MODULE=OFF \
+-DBUILD_SHARED_LIBS=ON
+
+make -j${nproc}
+make install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+
+platforms = expand_cxxstring_abis(supported_platforms())
+
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libpointmatcher", :libpointmatcher)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    BuildDependency(PackageSpec(name="Eigen_jll", uuid="bc6bbf8a-a594-5541-9c57-10b0d0312c70"))
+    Dependency("boost_jll"; compat="=1.76.0")
+    Dependency(PackageSpec(name="libnabo_jll", uuid="569caa04-3db7-54b1-b5fe-10f3ec93054b"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/libpointmatcher/build_tarballs.jl
+++ b/L/libpointmatcher/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"0.1.0"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/ethz-asl/libpointmatcher.git", "fc7cd5da39b24665d65e6a570124621b4e1d3ef2"),
-    DirectorySource("./bundled")
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
@@ -19,21 +19,26 @@ atomic_patch -p1 ${WORKSPACE}/srcdir/patches/comment-cmake-alias.patch
 
 mkdir build && cd build
 
+# Fix path of libnabo.  TODO: This has to be fixed in libnabo_jll.
+sed -i "s?${prefix}/lib?${libdir}?" ${prefix}/share/libnabo/cmake/libnaboConfig.cmake
+
 cmake .. \
--DCMAKE_INSTALL_PREFIX=${prefix} \
--DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
--DCMAKE_BUILD_TYPE=Release \
--DBUILD_TESTS=OFF \
--DPOINTMATCHER_BUILD_EXAMPLES=OFF \
--DPOINTMATCHER_BUILD_EVALUATIONS=OFF \
--DBUILD_PYTHON_MODULE=OFF \
--DBUILD_SHARED_LIBS=ON
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTS=OFF \
+    -DPOINTMATCHER_BUILD_EXAMPLES=OFF \
+    -DPOINTMATCHER_BUILD_EVALUATIONS=OFF \
+    -DBUILD_PYTHON_MODULE=OFF \
+    -DBUILD_SHARED_LIBS=ON
 
 make -j${nproc}
 make install
 
 install_license ../debian/copyright
 
+# Delete modified file from libnabo
+rm ${prefix}/share/libnabo/cmake/libnaboConfig.cmake
 """
 
 # These are the platforms we will build for by default, unless further
@@ -42,7 +47,6 @@ install_license ../debian/copyright
 platforms = expand_cxxstring_abis(supported_platforms())
 #only supports 64 bit compilers
 filter!(p -> nbits(p) != 32, platforms)
-
 
 
 # The products that we will ensure are always built
@@ -55,6 +59,7 @@ dependencies = [
     BuildDependency(PackageSpec(name="Eigen_jll", uuid="bc6bbf8a-a594-5541-9c57-10b0d0312c70"))
     Dependency("boost_jll"; compat="=1.76.0")
     Dependency(PackageSpec(name="libnabo_jll", uuid="569caa04-3db7-54b1-b5fe-10f3ec93054b"))
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libpointmatcher/bundled/patches/comment-cmake-alias.patch
+++ b/L/libpointmatcher/bundled/patches/comment-cmake-alias.patch
@@ -1,0 +1,13 @@
+diff --git before/CMakeLists.txt after/CMakeLists.txt
+index 7d78484..f3391bc 100644
+--- before/CMakeLists.txt
++++ after/CMakeLists.txt
+@@ -166,7 +166,7 @@ endif()
+ # This cmake target alias will be defined by either: 
+ # a) libnabo sources if built as a git submodule in the same project than this library, or
+ # b) by libnabo-targets.cmake, included by find_package(libnabo) above.
+-set(libnabo_LIBRARIES libnabo::nabo)
++#set(libnabo_LIBRARIES libnabo::nabo)
+ 
+ #--------------------
+ # DEPENDENCY: OpenMP (optional)


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [libpointmatcher](https://github.com/ethz-asl/libpointmatcher) library.
While the repo does have releases listed, the latest release is a few hundred commits behind `master` and I had trouble getting it to work so I am building from `master` here. I don't quite understand the whole CMake alias thing I had to patch, but it works locally.

I don't think this is an issue for the big CI machines, but I had some issues with this hanging on me when running any level of `make -j` and I had to restart a couple times... I did most of my wizard/testing with just serial `make`.


