### PR TITLE
GCC 4.8.5 for musl: tweak patch to match upstream

### DIFF
--- a/0_RootFS/GCCBootstrap@4/bundled/patches/gcc494_musl.patch
+++ b/0_RootFS/GCCBootstrap@4/bundled/patches/gcc494_musl.patch
@@ -184,7 +184,7 @@ Index: b/gcc/config/linux.h
  #else
  #error "Unsupported DEFAULT_LIBC"
  #endif /* DEFAULT_LIBC */
-@@ -82,23 +87,103 @@
+@@ -82,23 +87,104 @@
  #define BIONIC_DYNAMIC_LINKER64 "/system/bin/linker64"
  #define BIONIC_DYNAMIC_LINKERX32 "/system/bin/linkerx32"
  
@@ -280,6 +280,7 @@ Index: b/gcc/config/linux.h
 +#define INCLUDE_DEFAULTS				\
 +  {							\
 +    INCLUDE_DEFAULTS_MUSL_GPP				\
++    INCLUDE_DEFAULTS_MUSL_LOCAL			\
 +    INCLUDE_DEFAULTS_MUSL_PREFIX			\
 +    INCLUDE_DEFAULTS_MUSL_CROSS				\
 +    INCLUDE_DEFAULTS_MUSL_TOOL				\


### PR DESCRIPTION
The patch for using old GCC on musl defined INCLUDE_DEFAULTS_MUSL_LOCAL but
never used it in the definition of INCLUDE_DEFAULTS. Comparing the patch with
what is in mainline GCC these days suggest this patch. For reference, see:
<https://github.com/gcc-mirror/gcc/blob/master/gcc/config/linux.h#L190>

This is a first step towards addressing (parts of) issue #3949. Alas, since I only modify a .patch, nothing will actually be built -- which is good, as I am not sure how the correct way is to proceed with updating the RootFS / compiler shard. And in fact before doing that, it should be tested whether the patch even works as intended. So, baby steps:

1. Perform a test build and check if it has the correct default include paths
   - I tried this via `julia --color=yes  --proj=../../.ci build_tarballs.jl --verbose --debug=end x86_64-linux-musl` but I got `ERROR: LoadError: KeyError: key "CMAKE_TARGET_TOOLCHAIN" not found`
2. assuming this works... what next: modify `0_RootFS/GCCBootstrap@4/build_tarballs.jl` in this PR to force a rebuild?
3. finally... "update the rootfs" ?!? clearly I have no clue what I am talking about, so I hope to get some help here. But let's first do step 1 :-)