### PR TITLE
build against OpenBLAS version 0.3.13

### DIFF
--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -43,7 +43,7 @@ dependencies = [
 #     OpenBLAS_jll-0.3.13-3 opted into using ILP64 on aarch64
 #     (see https://github.com/JuliaPackaging/Yggdrasil/pull/2590)
 #     but we still try to compile with `-lopenblas` there.
-    Dependency("OpenBLAS_jll", v"0.3.13", compat=">=0.3.13")
+    Dependency("OpenBLAS_jll"; compat="0.3.13")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well

--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -14,7 +14,7 @@ cd $WORKSPACE/srcdir/scs*
 flags="DLONG=1 USE_OPENMP=0"
 blasldflags="-L${prefix}/lib"
 # see https://github.com/JuliaPackaging/Yggdrasil/blob/0bc1abd56fa176e3d2cc2e48e7bf85a26c948c40/OpenBLAS/build_tarballs.jl#L23
-if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
+if [[ ${nbits} == 64 ]]; then
     flags="${flags} BLAS64=1 BLASSUFFIX=_64_"
     blasldflags+=" -lopenblas64_"
 else
@@ -43,7 +43,7 @@ dependencies = [
 #     OpenBLAS_jll-0.3.13-3 opted into using ILP64 on aarch64
 #     (see https://github.com/JuliaPackaging/Yggdrasil/pull/2590)
 #     but we still try to compile with `-lopenblas` there.
-    Dependency("OpenBLAS_jll", v"0.3.12", compat="<0.3.13")
+    Dependency("OpenBLAS_jll", v"0.3.13", compat=">=0.3.13")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well


### PR DESCRIPTION
I'm actually not sure how to proceed with this;

on julia-1.7 SCS pulls `SCS_jll-2.1.2` which is the latest version that doesn't have compat in OpenBLAS.

see https://github.com/jump-dev/SCS.jl/issues/235