### PR TITLE
[Glib] Use release build type

### DIFF
--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -30,6 +30,7 @@ fi
 
 mkdir build_glib && cd build_glib
 meson --cross-file="${MESON_TARGET_TOOLCHAIN}" \
+    --buildtype=release \
     -Dman=false \
     -Diconv=external \
     "${MESON_FLAGS[@]}" \


### PR DESCRIPTION
Following https://github.com/JuliaPackaging/Yggdrasil/pull/3989, hopefully Glib goes down from 32.7 MB.

cc @giordano 