### PR TITLE
put back the default threads for OpenBLAS to 32

### DIFF
--- a/O/OpenBLAS/OpenBLAS@0.3.17/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS@0.3.17/build_tarballs.jl
@@ -7,7 +7,7 @@ name = "OpenBLAS"
 version = v"0.3.17"
 
 sources = openblas_sources(version)
-script = openblas_script(;aarch64_ilp64=true)
+script = openblas_script(;aarch64_ilp64=true, num_64bit_threads=512)
 platforms = openblas_platforms(;experimental=true)
 products = openblas_products()
 dependencies = openblas_dependencies()

--- a/O/OpenBLAS/common.jl
+++ b/O/OpenBLAS/common.jl
@@ -38,7 +38,9 @@ function openblas_sources(version::VersionNumber; kwargs...)
     ]
 end
 
-function openblas_script(;num_64bit_threads::Integer=512, openblas32::Bool=false, aarch64_ilp64::Bool=false, kwargs...)
+# Do not override the default `num_64bit_threads` here, instead pass a custom from specific OpenBLAS versions
+# that should opt into a higher thread count.
+function openblas_script(;num_64bit_threads::Integer=32, openblas32::Bool=false, aarch64_ilp64::Bool=false, kwargs...)
     # Allow some basic configuration
     script = """
     NUM_64BIT_THREADS=$(num_64bit_threads)


### PR DESCRIPTION
After this we should rebuild the OpenBLAS libraries used on 1.6.4 and 1.7.0 with this.

Ref https://github.com/JuliaPackaging/Yggdrasil/issues/3996