### PR TITLE
[AZP] Update BinaryBuilderBase and BinaryBuilder

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -28,19 +28,19 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilder]]
 deps = ["ArgParse", "BinaryBuilderBase", "Dates", "Downloads", "GitHub", "HTTP", "JLD2", "JSON", "LibGit2", "Libdl", "Logging", "LoggingExtras", "ObjectFile", "OutputCollectors", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Scratch", "Sockets", "UUIDs", "ghr_jll"]
-git-tree-sha1 = "4b4c9a11f078a1c121505935b32befaed098ac71"
+git-tree-sha1 = "3412f6ef0e3dc3f4d4eda931f94f17a8cd9d1d3e"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
-version = "0.4.2"
+version = "0.4.4"
 
 [[BinaryBuilderBase]]
 deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "f1b3930333ac09c1ab1035390beff525124e45e9"
+git-tree-sha1 = "9f3b1dcfdd68214851417aded5f159557b4f27b7"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "1.0.4"
+version = "1.1.0"
 
 [[CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -316,10 +316,10 @@ uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 version = "1.2.9"
 
 [[RegistryTools]]
-deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
-git-tree-sha1 = "7f73c106c726171c3d8a9815fc7a1ff6548e12e6"
+deps = ["AutoHashEquals", "LibGit2", "Pkg", "SHA", "UUIDs"]
+git-tree-sha1 = "e5bc4ecbdd55f030b9f2644aa4a625f34a868ea0"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
-version = "1.5.7"
+version = "1.6.0"
 
 [[Requires]]
 deps = ["UUIDs"]


### PR DESCRIPTION
Changes:

* BinaryBuilderBase: https://github.com/JuliaPackaging/BinaryBuilderBase.jl/compare/v1.0.4...v1.1.0
* BinaryBuilder: https://github.com/JuliaPackaging/BinaryBuilder.jl/compare/v0.4.2...v0.4.4

Most notably, this includes a slightly less broken Rust toolchain, supporting
also experimental platforms, however 32-bit Windows (`i686-w64-mingw32`) is
completely unusable.