### PR TITLE
libjulia: update to 1.7.0 final and also a newer master snapshot

### DIFF
--- a/L/libjulia/build_tarballs.jl
+++ b/L/libjulia/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("common.jl")
 jllversion=v"1.7.0"
 build_julia(ARGS, v"1.6.3"; jllversion)
-build_julia(ARGS, v"1.7.0-rc1"; jllversion)
+build_julia(ARGS, v"1.7.0"; jllversion)
 build_julia(ARGS, v"1.8.0-DEV"; jllversion)

--- a/L/libjulia/bundled/patches/1.8.0-DEV/0001-Don-t-set-HAVE_SSP-unconditionally-on-aarch64.patch
+++ b/L/libjulia/bundled/patches/1.8.0-DEV/0001-Don-t-set-HAVE_SSP-unconditionally-on-aarch64.patch
@@ -1,0 +1,30 @@
+From dd925de72b46a1982cb5515c2e90d67b1744f0bf Mon Sep 17 00:00:00 2001
+From: Max Horn <max@quendi.de>
+Date: Sun, 26 Dec 2021 17:28:46 +0100
+Subject: [PATCH] Don't set HAVE_SSP unconditionally on aarch64
+
+There is no plausible reason for this. And indeed, this patch fixes
+compilation for the libjulia_jll builder on Yggdrasil which currently fails
+due to the absence of libssp.
+
+The removed line was introduced in PR #41936 but without any justification
+that I could discern, so it might have just slipped in there accidentally.
+---
+ Make.inc | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Make.inc b/Make.inc
+index 9706b1f929..b73d9033ca 100644
+--- a/Make.inc
++++ b/Make.inc
+@@ -891,7 +891,6 @@ OPENBLAS_DYNAMIC_ARCH:=0
+ OPENBLAS_TARGET_ARCH:=ARMV8
+ USE_BLAS64:=1
+ BINARY:=64
+-HAVE_SSP:=1
+ ifeq ($(OS),Darwin)
+ # Apple Chips are all at least A12Z
+ MCPU:=apple-a12
+-- 
+2.34.0.7.g0ea906d205
+

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -46,12 +46,12 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         v"1.5.3" => "be19630383047783d6f314ebe0bf5e3f95f82b0c203606ec636dced405aab1fe",
         v"1.5.4" => "852122bf1bdefd39307b1dd2aa546e3885d76ede7c07cb04d90814b9510ea9f9",
         v"1.6.3" => "2593def8cc9ef81663d1c6bfb8addc3f10502dd9a1d5a559728316a11dea2594",
-        v"1.7.0-rc1" => "0da8a3597ab3841457877ad1e4740e9ee49c08f55a00c10a2a21c8165e68f1aa",
+        v"1.7.0" => "8e870dbef71bc72469933317a1a18214fd1b4b12f1080784af7b2c56177efcb4",
     )
 
     if version == v"1.8.0-DEV"
         sources = [
-            GitSource("https://github.com/JuliaLang/julia", "5b7bb084d478050b5265f66a571969c7df280f6b"),
+            GitSource("https://github.com/JuliaLang/julia", "00646634c6a73998eaae3785eb78fea881c39502"),
             DirectorySource("./bundled"),
         ]
     else
@@ -177,7 +177,9 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
     override BUILD_OS=Linux
 
     #llvm-config-host is not available
-    override LLVMLINK=${LLVMLINK}
+    override LLVMLINK=${LLVMLINK}    # For Julia <= 1.7
+    override RT_LLVMLINK=${LLVMLINK} # For Julia >= 1.8
+    override CG_LLVMLINK=${LLVMLINK} # For Julia >= 1.8
     override LLVM_CXXFLAGS=${LLVM_CXXFLAGS}
     override LLVM_LDFLAGS=${LLVM_LDFLAGS}
 
@@ -348,12 +350,12 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         # So we use get_addable_spec below to "fake it" for now.
         # This means the resulting package has fewer dependencies declared, but at least it
         # will work and allow people to build JLL binaries ready for Julia 1.7
-        push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"12.0.1+2")))
+        push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"12.0.1+3")))
 
         # starting with Julia 1.7, we need LLVMLibUnwind_jll
         push!(dependencies, BuildDependency(get_addable_spec("LLVMLibUnwind_jll", v"11.0.1+1")))
     elseif version.major == 1 && version.minor == 8
-        push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"12.0.1+2")))
+        push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"12.0.1+4")))
         push!(dependencies, BuildDependency(get_addable_spec("LLVMLibUnwind_jll", v"12.0.1+0")))
     else
         error("Unsupported Julia version")


### PR DESCRIPTION
Note that this *hopefully* doesn't matter, namely if 1.7.0-rc3 and 1.7.0 are 100% ABI compatible, which they should be, but better safe than sorry? Same goes for the master branch, which is far more likely to have breaking ABI changes. I figure it's a good idea to at least rebuild this once with the final releases, anyhow. Thoughts?