### PR TITLE
add ParseGen

### DIFF
--- a/P/ParseGen/build_tarballs.jl
+++ b/P/ParseGen/build_tarballs.jl
@@ -44,4 +44,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 #this uses std filesystem, so we need gcc 8 at least
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"9")

--- a/P/ParseGen/build_tarballs.jl
+++ b/P/ParseGen/build_tarballs.jl
@@ -16,6 +16,8 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/parsegen-cpp*/
 
+install_license LICENSE
+
 mkdir build && cd build
 
 if [[ "${target}" == x86_64-apple-darwin* ]]; then

--- a/P/ParseGen/build_tarballs.jl
+++ b/P/ParseGen/build_tarballs.jl
@@ -1,0 +1,47 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ParseGen"
+version = v"2.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/sandialabs/parsegen-cpp/archive/refs/tags/v$(version).tar.gz", "c6c7c4958d1c6ab77bf0970b5aacae4b63603f702666492638ee8c0bdf3125c8")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/parsegen-cpp*/
+
+mkdir build && cd build
+
+cmake .. \
+-DCMAKE_INSTALL_PREFIX=${prefix} \
+-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+-DCMAKE_BUILD_TYPE=Release \
+-DBUILD_SHARED_LIBS=ON
+
+make -j${nproc}
+make install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libparsegen", :libparsegen)
+    ExecutableProduct("parsegen-calc", :parsegen_calc)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+#this uses std filesystem, so we need gcc 8 at least
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"8")

--- a/P/ParseGen/build_tarballs.jl
+++ b/P/ParseGen/build_tarballs.jl
@@ -7,7 +7,9 @@ version = v"2.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/sandialabs/parsegen-cpp/archive/refs/tags/v$(version).tar.gz", "c6c7c4958d1c6ab77bf0970b5aacae4b63603f702666492638ee8c0bdf3125c8")
+    ArchiveSource("https://github.com/sandialabs/parsegen-cpp/archive/refs/tags/v$(version).tar.gz", "c6c7c4958d1c6ab77bf0970b5aacae4b63603f702666492638ee8c0bdf3125c8"),
+    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
+    "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62")
 ]
 
 # Bash recipe for building across all platforms
@@ -15,6 +17,19 @@ script = raw"""
 cd $WORKSPACE/srcdir/parsegen-cpp*/
 
 mkdir build && cd build
+
+if [[ "${target}" == x86_64-apple-darwin* ]]; then
+    export CXXFLAGS="-mmacosx-version-min=10.15"
+    #install a newer SDK which supports `std::filesystem`
+    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
+    rm -rf /opt/${target}/${target}/sys-root/System
+    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
+    cp -ra System "/opt/${target}/${target}/sys-root/."
+    popd
+elif [[ "${target}" == aarch64-apple-darwin* ]]; then
+    # TODO: we need to fix this in the compiler wrappers
+    export CXXFLAGS="-mmacosx-version-min=11.0"
+fi
 
 cmake .. \
 -DCMAKE_INSTALL_PREFIX=${prefix} \


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [ParseGen](https://github.com/sandialabs/parsegen-cpp) library. This needs `C++17` and `std::filesystem`, so I am using `GCC 8` here.