### PR TITLE
notcurses: stop building the cxx libraries

### DIFF
--- a/N/Notcurses/build_tarballs.jl
+++ b/N/Notcurses/build_tarballs.jl
@@ -38,6 +38,7 @@ FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
        -DBUILD_BINARIES=off
        -DUSE_POC=off
        -DUSE_MULTIMEDIA=none
+       -DUSE_CXX=off
        )
 
 cmake .. "${FLAGS[@]}"


### PR DESCRIPTION
I noticed we are currently building the cxx library for notcurses which isn't really useful. Disable it.