### PR TITLE
[libfive] init

### DIFF
--- a/L/libfive/build_tarballs.jl
+++ b/L/libfive/build_tarballs.jl
@@ -1,0 +1,50 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libfive"
+version = v"0.1.0" # not yet tagged
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/sjkelly/libfive.git", "ce9a35f8b22dafd260bdd521c7773b25026433e7")
+]
+
+dependencies = [
+    Dependency("boost_jll"; compat="=1.76.0"),
+    Dependency("Eigen_jll"),
+    Dependency("libpng_jll")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libfive/
+
+# Eigen Hack
+ln -sf ${includedir}/eigen3/Eigen ${includedir}/Eigen
+
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_STUDIO_APP=OFF \
+    -DBUILD_GUILE_BINDINGS=OFF \
+    -DBUILD_PYTHON_BINDINGS=OFF \
+    ..
+make -j${nproc}
+make install
+install_license /usr/share/licenses/MPL2 #libfive is MPL2, studio is GPL3 (not distributed here)
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(;experimental=true)
+platforms = expand_cxxstring_abis(platforms) #auditor requested
+
+# The products that we will ensure are always built
+products = Product[
+    LibraryProduct("libfive", :libfive),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"7",lock_microarchitecture=false)

--- a/L/libfive/build_tarballs.jl
+++ b/L/libfive/build_tarballs.jl
@@ -38,7 +38,7 @@ install_license /usr/share/licenses/MPL2 #libfive is MPL2, studio is GPL3 (not d
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expansupported_platforms(;experimental=true)
+platforms = supported_platforms(;experimental=true)
 platforms = expand_cxxstring_abis(platforms) #auditor requested
 
 # The products that we will ensure are always built

--- a/L/libfive/build_tarballs.jl
+++ b/L/libfive/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"0.1.0" # not yet tagged
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/sjkelly/libfive.git", "919ae1a3265915724c6e04309dc95a2582ba9930")
+    GitSource("https://github.com/sjkelly/libfive.git", "68d1c4c6c4e8bde5a1281ffb6695ffb377680c8c")
 ]
 
 dependencies = [

--- a/L/libfive/build_tarballs.jl
+++ b/L/libfive/build_tarballs.jl
@@ -38,7 +38,7 @@ install_license /usr/share/licenses/MPL2 #libfive is MPL2, studio is GPL3 (not d
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = expansupported_platforms(;experimental=true)
 platforms = expand_cxxstring_abis(platforms) #auditor requested
 
 # The products that we will ensure are always built
@@ -47,4 +47,4 @@ products = Product[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"7",lock_microarchitecture=false)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8",lock_microarchitecture=false)

--- a/L/libfive/build_tarballs.jl
+++ b/L/libfive/build_tarballs.jl
@@ -47,4 +47,4 @@ products = Product[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8",lock_microarchitecture=false)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"7")

--- a/L/libfive/build_tarballs.jl
+++ b/L/libfive/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"0.1.0" # not yet tagged
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/sjkelly/libfive.git", "ce9a35f8b22dafd260bdd521c7773b25026433e7")
+    GitSource("https://github.com/sjkelly/libfive.git", "919ae1a3265915724c6e04309dc95a2582ba9930")
 ]
 
 dependencies = [


### PR DESCRIPTION
This adds [libfive](https://libfive.com/):

>libfive is a software library and set of tools for solid modeling, especially suited for parametric and procedural design. It is infrastructure for generative design, mass customization, and domain-specific CAD tools.
Your browser does not support the video tag.

>The geometry kernel is based on functional representations, which have several benefits over traditional triangle meshes:

>    Constructive solid geometry is trivial, and scales well to large models
    Resolution can be arbitrarily high (down to floating-point accuracy)
    Many unusual operations (e.g. blends and warps) are robust and easy to express

>The libfive stack includes a low-level geometry kernel, bindings in higher-level languages, a standard library of shapes and transforms, and a desktop application for script-based design.

Bindings: https://github.com/JuliaGeometry/Libfive.jl