### PR TITLE
add SISL

### DIFF
--- a/S/SISL/build_tarballs.jl
+++ b/S/SISL/build_tarballs.jl
@@ -1,0 +1,53 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "SISL"
+version = v"4.6.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/SINTEF-Geometry/SISL/archive/refs/tags/SISL-$(version).tar.gz", "b207fe6b4b20775e3064168633256fddd475ff98573408f6f5088a938c086f86"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/SISL-*
+
+if [[ "${target}" == *-mingw* ]]; then
+    #this is derived directly from https://github.com/SINTEF-Geometry/SISL/pull/6, if that ever get merged this can be removed
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mingw-cmake-patch.patch
+fi
+
+mkdir build
+cd build
+
+cmake .. \
+-DCMAKE_INSTALL_PREFIX=${prefix} \
+-Dsisl_INSTALL_PREFIX=${prefix} \
+-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+-DCMAKE_BUILD_TYPE=Release \
+-DBUILD_SHARED_LIBS=ON
+
+make -j${nproc}
+make install
+
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; experimental = true)
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libsisl", :libsisl)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/S/SISL/bundled/patches/mingw-cmake-patch.patch
+++ b/S/SISL/bundled/patches/mingw-cmake-patch.patch
@@ -1,0 +1,28 @@
+From 57a0f4d30976c75b910868341f8d8171f18ba246 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nick=20=C3=98stergaard?= <oe.nick@gmail.com>
+Date: Sun, 7 Jun 2015 14:44:17 +0200
+Subject: [PATCH] Fix compiler detection for windows
+
+GCC cross compilation will use the compiler arguments that was only
+intended for MSVC. Replace the if(WIN32) with if(MSVC).
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 47643a0..1c27394 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,10 +32,10 @@ IF(CMAKE_COMPILER_IS_GNUXX)
+   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-but-set-variable -fPIC")
+   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-but-set-variable -fPIC")
+ ENDIF(CMAKE_COMPILER_IS_GNUXX)
+-IF(WIN32)
++IF(MSVC)
+   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP8 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS")
+   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP8 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS")
+-ENDIF(WIN32)
++ENDIF(MSVC)
+ 
+ 
+ # Apps, examples, tests, ...?


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` script for the [SISL](https://github.com/SINTEF-Geometry/SISL) library. Tested locally on `linux-gnu`, `linux-musl`, and `mingw` with no issues