### PR TITLE
Add Conduit

### DIFF
--- a/C/Conduit/build_tarballs.jl
+++ b/C/Conduit/build_tarballs.jl
@@ -5,13 +5,13 @@ using BinaryBuilder, Pkg
 name = "Conduit"
 version = v"0.8.0"
 sources = [
-    ArchiveSource("https://github.com/LLNL/conduit/releases/download/v0.8.0/conduit-v0.8.0-src-with-blt.tar.gz",
+    ArchiveSource("https://github.com/LLNL/conduit/releases/download/v$(version)/conduit-v$(version)-src-with-blt.tar.gz",
 		  "0607dcf9ced44f95e0b9549f5bbf7a332afd84597c52e293d7ca8d83117b5119")
 ]
 
 # Note: we need to build the (optional) webserver by default until v0.8.1 is released
 script = raw"""
-cd ${WORKSPACE}/srcdir/conduit-v0.8.0
+cd ${WORKSPACE}/srcdir/conduit*
 rm -rf build && mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
@@ -39,7 +39,7 @@ products = [
     LibraryProduct("libconduit_relay", :libconduit_relay),
 ]
 
-dependencies = [
+dependencies = Dependency[
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; 

--- a/C/Conduit/build_tarballs.jl
+++ b/C/Conduit/build_tarballs.jl
@@ -1,0 +1,46 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Conduit"
+version = v"0.8.0"
+sources = [
+    ArchiveSource("https://github.com/LLNL/conduit/releases/download/v0.8.0/conduit-v0.8.0-src-with-blt.tar.gz",
+		  "0607dcf9ced44f95e0b9549f5bbf7a332afd84597c52e293d7ca8d83117b5119")
+]
+
+# Note: we need to build the (optional) webserver by default until v0.8.1 is released
+script = raw"""
+cd ${WORKSPACE}/srcdir/conduit-v0.8.0
+rm -rf build && mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
+      -DENABLE_TESTS=OFF \
+      -DENABLE_EXAMPLES=OFF \
+      -DENABLE_UTILS=OFF \
+      -DENABLE_DOCS=OFF \
+      -DENABLE_RELAY_WEBSERVER=ON \
+      -DENABLE_COVERAGE=OFF \
+      -DENABLE_PYTHON=OFF \
+      -DENABLE_FORTRAN=OFF \
+      -DENABLE_MPI=OFF \
+      ../src
+make -j${nproc}
+make install
+"""
+
+platforms = expand_cxxstring_abis(supported_platforms())
+
+products = [
+    LibraryProduct("libconduit", :libconduit),
+    LibraryProduct("libconduit_blueprint", :libconduit_blueprint),
+    LibraryProduct("libconduit_relay", :libconduit_relay),
+]
+
+dependencies = [
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; 
+	       julia_compat="1.6", preferred_gcc_version=v"5")


### PR DESCRIPTION
Adds a new build recipe for LLNL's conduit mesh data exhange library
https://github.com/LLNL/conduit

This does not include MPI support for the time being, but that should be
a strict addition in the future (when the default Julia MPI ABI issues get
resolved).