### PR TITLE
Recompile MUMPS 5.4.1 with a patch update

### DIFF
--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 script = raw"""
 mkdir -p ${libdir}
 cd $WORKSPACE/srcdir/MUMPS*
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mumps_int64.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mumps_int32.patch
 
 OPENBLAS=(-lopenblas)
 FFLAGS=()

--- a/M/MUMPS/MUMPS@5/bundled/patches/mumps_int32.patch
+++ b/M/MUMPS/MUMPS@5/bundled/patches/mumps_int32.patch
@@ -7,7 +7,7 @@
 -	./build_mumps_int_def > $(incdir)/mumps_int_def.h
 +	echo "#if ! defined(MUMPS_INT_H)" > $(incdir)/mumps_int_def.h
 +	echo "#   define MUMPS_INT_H" >> $(incdir)/mumps_int_def.h
-+	echo "#   define MUMPS_INTSIZE64" >> $(incdir)/mumps_int_def.h
++	echo "#   define MUMPS_INTSIZE32" >> $(incdir)/mumps_int_def.h
 +	echo "#endif" >> $(incdir)/mumps_int_def.h
  build_mumps_int_def:build_mumps_int_def.o
  	$(CC) $(OPTC) $(OPTL) build_mumps_int_def.o -o build_mumps_int_def


### PR DESCRIPTION
Without Artifacts, MUMPS.jl works with MUMPS 5.4.1 but I have some errors with the Artifact `MUMPS_jll` and the only difference is `MUMPS_INT` (Int64 instead of Int32) .