### PR TITLE
Bison: update to 3.8.2, enable more platforms

### DIFF
--- a/B/Bison/build_tarballs.jl
+++ b/B/Bison/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "Bison"
-version = v"3.5.2"
+version = v"3.8.2"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://ftp.gnu.org/gnu/bison/bison-3.5.2.tar.xz", "24e273db9eb6da8bbb6f0648284d0724a5cbd6268a163db402f961350a4e50dd"),
+    ArchiveSource("https://ftp.gnu.org/gnu/bison/bison-$(version).tar.xz", "9bba0214ccf7f1079c5d59210045227bcf619519840ebfa80cd3849cff5a5bf2"),
 ]
 
 # Bash recipe for building across all platforms
@@ -18,17 +18,19 @@ make -j${nproc}
 make install
 """
 
-# Disable windows for now
-platforms = filter(!Sys.iswindows, supported_platforms())
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("bison", :bison_exe)
+    ExecutableProduct("bison", :bison)
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
+    Dependency("Libiconv_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
As an experiment, I've also turned Windows back on, just to say if / how that fails.