### PR TITLE
add build recipe for the tracy profiler

### DIFF
--- a/T/TracyProfiler/build_tarballs.jl
+++ b/T/TracyProfiler/build_tarballs.jl
@@ -86,7 +86,8 @@ dependencies = [
     Dependency("GLFW_jll"),
     Dependency("FreeType2_jll"),
     Dependency("Capstone_jll"),
-    Dependency("GTK3_jll"),
+    # GTK3 is only needed for the system file dialog on Linux
+    Dependency("GTK3_jll", platforms=filter(Sys.islinux, platforms)),
     BuildDependency("Xorg_xorgproto_jll"),
 ]
 

--- a/T/TracyProfiler/build_tarballs.jl
+++ b/T/TracyProfiler/build_tarballs.jl
@@ -62,6 +62,8 @@ cp -v ./csvexport/build/unix/csvexport-release* $bindir
 # Build / install import-chrome utility
 make -j${nproc} -C import-chrome/build/unix release
 cp -v ./import-chrome/build/unix/import-chrome-release* $bindir
+
+install_license LICENSE
 """
 
 # Only supports x86_64 builds for Linux / Unix

--- a/T/TracyProfiler/build_tarballs.jl
+++ b/T/TracyProfiler/build_tarballs.jl
@@ -19,8 +19,9 @@ mkdir -vp $libdir
 cd ${WORKSPACE}/srcdir/tracy*
 
 # Apply patches to disable forcing -march
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/unix_library_release.patch
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/unix_common_make.patch
+atomic_patch -p1 ../patches/unix_library_release.patch
+atomic_patch -p1 ../patches/unix_common_make.patch
+atomic_patch -p1 ../patches/library_extension.patch
 
 # Need full c++17 support so upgrade min osx version and install newer SDK
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
@@ -40,7 +41,7 @@ fi
 
 # Build / install the library
 make -j${nproc} -C library/unix release
-cp -v ./library/unix/libtracy-release* $libdir
+cp -v "./library/unix/libtracy-release.${dlext}" ${libdir}
 
 # Build / install the profiler GUI
 make -j${nproc} -C profiler/build/unix release

--- a/T/TracyProfiler/build_tarballs.jl
+++ b/T/TracyProfiler/build_tarballs.jl
@@ -19,21 +19,23 @@ mkdir -vp $libdir
 cd ${WORKSPACE}/srcdir/tracy*
 
 # Apply patches to disable forcing -march
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/unix_library_release.patch 
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/unix_library_release.patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/unix_common_make.patch
 
 # Need full c++17 support so upgrade min osx version and install newer SDK
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
     echo "Installing newer MacOS 10.15 SDK"
- 
-    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk 
-    rm -rf /opt/${target}/${target}/sys-root/System 
-    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/." 
-    cp -ra System "/opt/${target}/${target}/sys-root/." 
+
+    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
+    rm -rf /opt/${target}/${target}/sys-root/System
+    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
+    cp -ra System "/opt/${target}/${target}/sys-root/."
     popd
 
     # append flag to mkfile for macos target min version
     echo "CFLAGS += -mmacosx-version-min=10.15" >> common/unix-release.mk
+    # Disable link-time optimization, we have some mess in our macOS toolchain.
+    sed -i 's/ -flto//' {profiler,update,capture,csvexport,import-chrome}/build/unix/release.mk
 fi
 
 # Build / install the library
@@ -65,7 +67,7 @@ cp -v ./import-chrome/build/unix/import-chrome-release* $bindir
 platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
     Platform("x86_64", "macos"),
-] 
+]
 
 products = Product[
     LibraryProduct("libtracy-release", :libtracy),

--- a/T/TracyProfiler/build_tarballs.jl
+++ b/T/TracyProfiler/build_tarballs.jl
@@ -1,0 +1,89 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "TracyProfiler"
+version = v"0.7.8"
+sources = [
+    ArchiveSource("https://github.com/wolfpld/tracy/archive/refs/tags/v$(version).tar.gz",
+		  "4021940a2620570ac767eee84e58d572a3faf1570edfaf5309c609752146e950"),
+    DirectorySource("./bundled")
+]
+
+script = raw"""
+mkdir -vp $bindir
+mkdir -vp $libdir
+
+cd ${WORKSPACE}/srcdir/tracy*
+
+# Apply patches to disable forcing -march
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/unix_library_release.patch 
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/unix_common_make.patch
+
+if [[ "${target}" == *-apple-* ]]; then
+    CC=gcc
+    CXX=g++
+fi
+
+# Build / install the library
+make -j -C library/unix release
+cp -v ./library/unix/libtracy-release* $libdir
+
+# Build / install the profiler GUI
+make -j${nproc} -C profiler/build/unix release
+cp -v ./profiler/build/unix/Tracy-release* $bindir
+
+# Build / install update utility
+make -j${nproc} -C update/build/unix release
+cp -v ./update/build/unix/update-release* $bindir
+
+# Build / install capture utility
+make -j${nproc} -C capture/build/unix release
+cp -v ./capture/build/unix/capture-release* $bindir
+
+# Build / install csvexport utility
+make -j${nproc} -C csvexport/build/unix release
+cp -v ./csvexport/build/unix/csvexport-release* $bindir
+
+# Build / install import-chrome utility
+make -j${nproc} -C import-chrome/build/unix release
+cp -v ./import-chrome/build/unix/import-chrome-release* $bindir
+"""
+
+# Only supports x86_64 builds for Linux / Unix
+# TODO: There are issues with cross compiling the libbacktrace libtracy on MacOS
+platforms = [
+    Platform("x86_64", "linux"; libc="glibc"),
+] 
+
+products = Product[
+    LibraryProduct("libtracy-release", :libtracy),
+    ExecutableProduct("Tracy-release", :tracy_profiler_exe),
+    ExecutableProduct("update-release", :tracy_update_exe),
+    ExecutableProduct("capture-release", :tracy_capture_exe),
+    ExecutableProduct("csvexport-release", :tracy_csvexport_exe),
+    ExecutableProduct("import-chrome-release", :tracy_import_chrome_exe),
+]
+
+dependencies = [
+    Dependency("GLFW_jll"),
+    Dependency("FreeType2_jll"),
+    Dependency("Capstone_jll"),
+    Dependency("GTK3_jll"),
+    BuildDependency("Xorg_compositeproto_jll"),
+    BuildDependency("Xorg_damageproto_jll"),
+    BuildDependency("Xorg_fixesproto_jll"),
+    BuildDependency("Xorg_inputproto_jll"),
+    BuildDependency("Xorg_kbproto_jll"),
+    BuildDependency("Xorg_randrproto_jll"),
+    BuildDependency("Xorg_renderproto_jll"),
+    BuildDependency("Xorg_xextproto_jll"),
+    BuildDependency("Xorg_xineramaproto_jll"),
+    BuildDependency("Xorg_xproto_jll"),
+]
+
+# requires std-c++17, full support in gcc 7+, clang 8+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    julia_compat="1.6",
+    preferred_gcc_version=v"8",
+)

--- a/T/TracyProfiler/build_tarballs.jl
+++ b/T/TracyProfiler/build_tarballs.jl
@@ -71,6 +71,7 @@ platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
     Platform("x86_64", "macos"),
 ]
+platforms = expand_cxxstring_abis(platforms)
 
 products = Product[
     LibraryProduct("libtracy-release", :libtracy),

--- a/T/TracyProfiler/bundled/patches/library_extension.patch
+++ b/T/TracyProfiler/bundled/patches/library_extension.patch
@@ -1,0 +1,11 @@
+--- library/unix/build.mk.orig	2022-01-04 23:27:34.172524112 +0100
++++ library/unix/build.mk	2022-01-04 23:27:41.192405438 +0100
+@@ -4,7 +4,7 @@
+ INCLUDES :=
+ LIBS := -lpthread -ldl
+ PROJECT := libtracy
+-IMAGE := $(PROJECT)-$(BUILD).so
++IMAGE := $(PROJECT)-$(BUILD).$(dlext)
+ SHARED_LIBRARY := yes
+ 
+ SRC := ../../TracyClient.cpp

--- a/T/TracyProfiler/bundled/patches/library_extension.patch
+++ b/T/TracyProfiler/bundled/patches/library_extension.patch
@@ -1,5 +1,5 @@
---- library/unix/build.mk.orig	2022-01-04 23:27:34.172524112 +0100
-+++ library/unix/build.mk	2022-01-04 23:27:41.192405438 +0100
+--- a/library/unix/build.mk
++++ b/library/unix/build.mk
 @@ -4,7 +4,7 @@
  INCLUDES :=
  LIBS := -lpthread -ldl

--- a/T/TracyProfiler/bundled/patches/unix_common_make.patch
+++ b/T/TracyProfiler/bundled/patches/unix_common_make.patch
@@ -1,0 +1,13 @@
+--- a/common/unix-release.mk
++++ b/common/unix-release.mk
+@@ -5,9 +5,4 @@
+ else
+ LDFLAGS := -s
+ endif
+-
++DEFINES += -D__STDC_FORMAT_MACROS
+-ifneq (,$(filter $(ARCH),aarch64 arm64))
+-CFLAGS += -mcpu=native
+-else
+-CFLAGS += -march=native
+-endif

--- a/T/TracyProfiler/bundled/patches/unix_library_release.patch
+++ b/T/TracyProfiler/bundled/patches/unix_library_release.patch
@@ -1,0 +1,11 @@
+--- a/library/unix/release.mk
++++ b/library/unix/release.mk
+@@ -1,7 +1,7 @@
+ ARCH := $(shell uname -m)
+ 
+ CFLAGS := -O3 -s
+-DEFINES := -DNDEBUG
++DEFINES := -DNDEBUG -D__STDC_FORMAT_MACROS
+ BUILD := release
+ 
+ ifeq ($(ARCH),x86_64)


### PR DESCRIPTION
More info here: https://github.com/wolfpld/tracy

This builds the profiler gui, instrumentation library and utilities.  The only issue on OSX is with the instrumentation library with libbacktrace, I don't think the MACHO defines are correct with cross compilation and needs someone better versed to debug but everything on linux x64 should work to get started.