### PR TITLE
[SLICOT] Add builder

### DIFF
--- a/S/SLICOT/build_tarballs.jl
+++ b/S/SLICOT/build_tarballs.jl
@@ -1,0 +1,101 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "SLICOT"
+version = v"5.7.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com//SLICOT/SLICOT-Reference.git",
+              "7b96b6470ee0eaf75519a612d15d5e3e2857407d"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/SLICOT-Reference
+echo "cmake_minimum_required(VERSION 3.17)" >>CMakeLists.txt
+echo "project( cml )" >>CMakeLists.txt
+echo "enable_language( Fortran )" >>CMakeLists.txt
+echo "add_subdirectory( src )" >>CMakeLists.txt
+
+cd $WORKSPACE/srcdir/SLICOT-Reference/src
+
+echo "set( SLICOT_SOURCE_FILES" >source_files.cmake
+ls *.f >>source_files.cmake
+echo ")" >>source_files.cmake
+
+LAB_SYMBOLS=(
+DASUM DAXPY DBDSQR DCABS1 DCOPY DDOT DGEBAK DGEBAL DGEBRD DGECON
+DGEEQU DGEES DGEEV DGEGS DGEHRD DGELQ2 DGELQF DGELS DGELSS DGELSY
+DGEMM DGEMV DGEQLF DGEQP3 DGEQR2 DGEQRF DGER DGERFS DGERQ2 DGERQF
+DGESC2 DGESV DGESVD DGESVX DGETC2 DGETRF DGETRI DGETRS DGGBAK DGGBAL
+DGGES DGGEV DHGEQZ DHSEQR DLABAD DLACN2 DLACPY DLADIV DLAEXC DLAG2
+DLAGV2 DLAHQR DLAIC1 DLALN2 DLAMC3 DLAMCH DLANGE DLANHS DLANSY DLANTR
+DLANV2 DLAPMT DLAPY2 DLAPY3 DLAQGE DLARF DLARFB DLARFG DLARFT DLARFX
+DLARNV DLARTG DLAS2 DLASCL DLASET DLASR DLASRT DLASSQ DLASV2 DLASY2
+DLATRS DLATZM DNRM2 DORG2R DORGBR DORGHR DORGQR DORGR2 DORGRQ DORM2R
+DORMBR DORMHR DORMLQ DORMQL DORMQR DORMR2 DORMRQ DORMRZ DPOCON DPOSV
+DPOTRF DPOTRS DPPTRF DPPTRI DPPTRS DPTTRF DPTTRS DROT DROTG DRSCL
+DSCAL DSPMV DSPR DSWAP DSYCON DSYEV DSYEVX DSYMM DSYMV DSYR2 DSYR2K
+DSYRK DSYSV DSYTRF DSYTRI DSYTRS DTGEX2 DTGEXC DTGSEN DTGSYL DTPMV
+DTRCON DTREVC DTREXC DTRMM DTRMV DTRSEN DTRSM DTRSV DTRSYL DTRTRI
+DTRTRS DTZRZF DZASUM DZNRM2 IDAMAX ILAENV IZAMAX LSAME XERBLA ZAXPY
+ZCOPY ZDRSCL ZDSCAL ZGECON ZGEES ZGEMM ZGEMV ZGEQP3 ZGEQRF ZGESV
+ZGESVD ZGETRF ZGETRI ZGETRS ZHGEQZ ZLACGV ZLACON ZLACP2 ZLACPY ZLADIV
+ZLAHQR ZLAIC1 ZLANGE ZLANHS ZLANTR ZLAPMT ZLARF ZLARFG ZLARNV ZLARTG
+ZLASCL ZLASET ZLASSQ ZLATRS ZLATZM ZROT ZSCAL ZSWAP ZTRSM ZTZRZF
+ZUNGQR ZUNMQR ZUNMRQ ZUNMRZ
+)
+
+
+echo "include(source_files.cmake)" >>CMakeLists.txt
+echo "add_library( slicot_shared SHARED \${SLICOT_SOURCE_FILES} )" >> CMakeLists.txt
+echo "target_link_libraries( slicot_shared \${LAPACK_blas_LIBRARIES})" >> CMakeLists.txt
+echo "set_target_properties( slicot_shared PROPERTIES OUTPUT_NAME slicot )" >> CMakeLists.txt
+echo "install( TARGETS slicot_shared LIBRARY DESTINATION lib )" >> CMakeLists.txt
+
+FFLAGS="${FFLAGS} -O2 -fPIC -ffixed-line-length-none -cpp"
+
+SYMBOL_DEFS=()
+if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
+  for sym in ${LAB_SYMBOLS[@]}; do
+    SYMBOL_DEFS+=("-D${sym}=${sym}_64")
+  done
+  FFLAGS="${FFLAGS} -fdefault-integer-8 ${SYMBOL_DEFS[@]}"
+fi
+
+mkdir ../build
+cd ../build/
+# Above on the fly added CMake code builds shared library with specified LAPACK/BLAS
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DLAPACK_blas_LIBRARIES="-L/workspace/destdir/lib -lblastrampoline" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_Fortran_FLAGS="${FFLAGS}" \
+    ..
+make -j${nproc}
+make install
+
+install_license ../LICENSE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_gfortran_versions(supported_platforms())
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libslicot", :libslicot)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93")),
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+# For the time being need LLVM 11 because of <https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/158>.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_llvm_version=v"11")

--- a/S/SLICOT/build_tarballs.jl
+++ b/S/SLICOT/build_tarballs.jl
@@ -9,6 +9,8 @@ version = v"5.7.0"
 sources = [
     GitSource("https://github.com//SLICOT/SLICOT-Reference.git",
               "7b96b6470ee0eaf75519a612d15d5e3e2857407d"),
+    ArchiveSource("https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.8.0.tar.gz",
+              "deb22cc4a6120bff72621155a9917f485f96ef8319ac074a7afbc68aab88bcf6"),
 ]
 
 # Bash recipe for building across all platforms
@@ -20,6 +22,8 @@ echo "enable_language( Fortran )" >>CMakeLists.txt
 echo "add_subdirectory( src )" >>CMakeLists.txt
 
 cd $WORKSPACE/srcdir/SLICOT-Reference/src
+cp ../../lapack-3.8.0/SRC/DEPRECATED/[dz]latzm.f .
+cp ../../lapack-3.8.0/SRC/DEPRECATED/dgegs.f .
 
 echo "set( SLICOT_SOURCE_FILES" >source_files.cmake
 ls *.f >>source_files.cmake
@@ -77,6 +81,11 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
 make -j${nproc}
 make install
 
+echo "" >>../LICENCE
+echo "DGEGS, DLATZM, and ZLATZM are extracted from LAPACK, with the following LICENSE:" >>../LICENCE
+echo "" >>../LICENSE
+cat ../../lapack-3.8.0/LICENSE >>../LICENSE
+
 install_license ../LICENSE
 """
 
@@ -97,5 +106,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-# For the time being need LLVM 11 because of <https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/158>.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_llvm_version=v"11")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/S/SLICOT/build_tarballs.jl
+++ b/S/SLICOT/build_tarballs.jl
@@ -49,7 +49,7 @@ ZCOPY ZDRSCL ZDSCAL ZGECON ZGEES ZGEMM ZGEMV ZGEQP3 ZGEQRF ZGESV
 ZGESVD ZGETRF ZGETRI ZGETRS ZHGEQZ ZLACGV ZLACON ZLACP2 ZLACPY ZLADIV
 ZLAHQR ZLAIC1 ZLANGE ZLANHS ZLANTR ZLAPMT ZLARF ZLARFG ZLARNV ZLARTG
 ZLASCL ZLASET ZLASSQ ZLATRS ZLATZM ZROT ZSCAL ZSWAP ZTRSM ZTZRZF
-ZUNGQR ZUNMQR ZUNMRQ ZUNMRZ
+ZUNGQR ZUNMQR ZUNMRQ ZUNMRZ ZGERC ZGERU DGGHRD
 )
 
 
@@ -106,4 +106,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.7")

--- a/S/SLICOT/build_tarballs.jl
+++ b/S/SLICOT/build_tarballs.jl
@@ -62,7 +62,7 @@ echo "install( TARGETS slicot_shared LIBRARY DESTINATION lib )" >> CMakeLists.tx
 FFLAGS="${FFLAGS} -O2 -fPIC -ffixed-line-length-none -cpp"
 
 SYMBOL_DEFS=()
-if [[ ${nbits} == 64 ]] && [[ ${target} != aarch64* ]]; then
+if [[ ${nbits} == 64 ]]; then
   for sym in ${LAB_SYMBOLS[@]}; do
     SYMBOL_DEFS+=("-D${sym}=${sym}_64")
   done


### PR DESCRIPTION
SLICOT - Subroutine Library In COntrol Theory - is a general purpose
basic mathematical library for control theoretical computations.

This commit adds the relicensed (BSD) version of SLICOT, linking
against libblastrampoline.