### PR TITLE
[AZP] Update BinaryBuilderBase and BinaryBuilder

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -28,19 +28,19 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilder]]
 deps = ["ArgParse", "BinaryBuilderBase", "Dates", "Downloads", "GitHub", "HTTP", "JLD2", "JSON", "LibGit2", "Libdl", "Logging", "LoggingExtras", "ObjectFile", "OutputCollectors", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Scratch", "Sockets", "UUIDs", "ghr_jll"]
-git-tree-sha1 = "839b214a6ed80aa694472bbf9d1d9fed9db7f435"
+git-tree-sha1 = "8acb1c4caf51b51fc44f5e947bbde0135531d922"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
-version = "0.4.5"
+version = "0.4.6"
 
 [[BinaryBuilderBase]]
 deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "1d3e476094c1da44ffae26c4e9714065b6ce8744"
+git-tree-sha1 = "a7d9c9f209f47a86622ec2bc019359b41db33d0b"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "1.2.1"
+version = "1.3.0"
 
 [[CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -93,9 +93,9 @@ version = "0.1.6"
 
 [[FileIO]]
 deps = ["Pkg", "Requires", "UUIDs"]
-git-tree-sha1 = "2db648b6712831ecb333eae76dbfd1c156ca13bb"
+git-tree-sha1 = "67551df041955cc6ee2ed098718c8fcd7fc7aebe"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.11.2"
+version = "1.12.0"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -254,9 +254,9 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
 
 [[OutputCollectors]]
-git-tree-sha1 = "d86c19b7fa8ad6a4dc8ec2c726642cc6291b2941"
+git-tree-sha1 = "5d3f2b3b2e2a9d7d6f1774c78e94530ac7f360cc"
 uuid = "6c11c7d4-943b-4e2b-80de-f2cfc2930a8c"
-version = "0.1.0"
+version = "0.1.1"
 
 [[Parsers]]
 deps = ["Dates"]


### PR DESCRIPTION
Changes:

* https://github.com/JuliaPackaging/BinaryBuilderBase.jl/compare/v1.2.1...v1.3.0
* https://github.com/JuliaPackaging/BinaryBuilder.jl/compare/v0.4.5...v0.4.6


Note: `supported_platforms()` now includes platforms which so far were marked as
experimental.  You hay have to manually filter them out in some recipes if you
don't  to build for them.  Remember constraints detailed #2763 when including
these platforms in recipes.