### PR TITLE
[hsa_rocr] Do not install legacy symlinks

### DIFF
--- a/H/hsa_rocr/build_tarballs.jl
+++ b/H/hsa_rocr/build_tarballs.jl
@@ -8,12 +8,16 @@ version = v"4.2.0"
 # Collection of sources required to build
 sources = [
     ArchiveSource("https://github.com/RadeonOpenCompute/ROCR-Runtime/archive/rocm-$(version).tar.gz",
-                  "fa0e7bcd64e97cbff7c39c9e87c84a49d2184dc977b341794770805ec3f896cc")
+                  "fa0e7bcd64e97cbff7c39c9e87c84a49d2184dc977b341794770805ec3f896cc"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd ${WORKSPACE}/srcdir/ROCR-Runtime*/
+
+# Do not install legacy symlinks which only creates confusion with RUNPATHs
+atomic_patch -p1 ../patches/no-symlinks.patch
 
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release \

--- a/H/hsa_rocr/bundled/patches/no-symlinks.patch
+++ b/H/hsa_rocr/bundled/patches/no-symlinks.patch
@@ -1,0 +1,42 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -134,9 +134,6 @@
+   ${CMAKE_CURRENT_SOURCE_DIR}
+   ${CMAKE_CURRENT_SOURCE_DIR}/libamdhsacode )
+ 
+-## Set RUNPATH - ../../lib covers use of the legacy symlink in /hsa/lib/
+-set_property(TARGET ${CORE_RUNTIME_TARGET} PROPERTY INSTALL_RPATH "$ORIGIN;$ORIGIN/../../lib;$ORIGIN/../../lib64;$ORIGIN/../lib64" )
+-
+ ## ------------------------- Linux Compiler and Linker options -------------------------
+ set ( HSA_CXX_FLAGS ${HSA_COMMON_CXX_FLAGS} -Werror -fexceptions -fno-rtti -fvisibility=hidden -Wno-error=missing-braces -Wno-error=sign-compare -Wno-sign-compare -Wno-write-strings -Wno-conversion-null -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -Wno-error=comment -Wno-comment -Wno-error=pointer-arith -Wno-pointer-arith -Wno-error=unused-variable -Wno-error=unused-function )
+ 
+@@ -295,13 +292,6 @@
+   install ( TARGETS ${CORE_RUNTIME_NAME} EXPORT ${CORE_RUNTIME_NAME}Targets )
+ endif()
+ 
+-## Create symlinks for legacy packaging and install
+-add_custom_target ( hsa_include_link ALL WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${CMAKE_COMMAND} -E create_symlink ../../include/hsa hsa_include_link )
+-if ( ${BUILD_SHARED_LIBS} )
+-    add_custom_target ( hsa_lib_link ALL WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${CMAKE_COMMAND} -E create_symlink ../../lib/${CORE_RUNTIME_LIBRARY}.so ${CORE_RUNTIME_LIBRARY}-link.so )
+-    add_custom_target ( hsa_lib_link2 ALL WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${CMAKE_COMMAND} -E create_symlink ../../lib/${CORE_RUNTIME_LIBRARY}.so.${VERSION_MAJOR} ${CORE_RUNTIME_LIBRARY}-link.so.${VERSION_MAJOR} )
+-endif()
+-
+ ## Set install information
+ # Installs binaries and exports the library usage data to ${HSAKMT_TARGET}Targets
+ # TODO: Fix me for flat directory layout.  Should be ${CMAKE_INSTALL_LIBDIR}
+@@ -315,15 +305,6 @@
+ # Install public headers
+ # TODO: Fix me for flat directory layout.  Should be ${CMAKE_INSTALL_INCLUDEDIR}
+ install ( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc/ DESTINATION include/hsa COMPONENT dev )
+-
+-# Legacy symlink.
+-install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/hsa_include_link DESTINATION hsa/include PERMISSIONS OWNER_WRITE OWNER_READ RENAME hsa COMPONENT dirlink)
+-
+-# Legacy symlinks.
+-if ( ${BUILD_SHARED_LIBS} )
+-    install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/${CORE_RUNTIME_LIBRARY}-link.so DESTINATION hsa/lib PERMISSIONS OWNER_WRITE OWNER_READ RENAME ${CORE_RUNTIME_LIBRARY}.so COMPONENT binary)
+-    install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/${CORE_RUNTIME_LIBRARY}-link.so.${VERSION_MAJOR} DESTINATION hsa/lib PERMISSIONS OWNER_WRITE OWNER_READ RENAME ${CORE_RUNTIME_LIBRARY}.so.${VERSION_MAJOR} COMPONENT binary)
+-endif ()
+ 
+ ## Configure and install package config file
+ # Record our usage data for clients find_package calls.


### PR DESCRIPTION
The symlinks are created for legacy reasons we don't care about, for us they
only cause confusions with RUNPATHs:
https://github.com/JuliaPackaging/Yggdrasil/pull/4077#issuecomment-1000500072

CC: @jpsamaroo