### PR TITLE
Unpin Mbed TLS from version 2.24

### DIFF
--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -49,7 +49,7 @@ dependencies = [
     # are getting a newer version in the build than the one
     # `LibSSH2_jll` was compiled with.  So we explicitly select the
     # right version here.
-    BuildDependency(PackageSpec(name="MbedTLS_jll", version="2.24")),
+    BuildDependency(PackageSpec(name="MbedTLS_jll")),
     Dependency(PackageSpec(name="OpenSSL_jll")),
     Dependency(PackageSpec(name="XML2_jll")),
     Dependency(PackageSpec(name="Zlib_jll")),

--- a/A/AzStorage/build_tarballs.jl
+++ b/A/AzStorage/build_tarballs.jl
@@ -44,7 +44,7 @@ dependencies = [
     # MbedTLS is only an indirect dependency (through LibCURL), but we want to
     # be sure to have the right version of MbedTLS for the corresponding version
     # of Julia.
-    BuildDependency(PackageSpec(; name="MbedTLS_jll", version="2.24.0")),
+    BuildDependency(PackageSpec(; name="MbedTLS_jll")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GDAL/common.jl
+++ b/G/GDAL/common.jl
@@ -132,7 +132,7 @@ function configure(version_offset, min_julia_version, proj_jll_version)
             # The following libraries are dependencies of LibCURL_jll which is now a
             # stdlib, but the stdlib doesn't explicitly list its dependencies
             Dependency("LibSSH2_jll"),
-            Dependency("MbedTLS_jll", v"2.24.0"),
+            Dependency("MbedTLS_jll"),
             Dependency("nghttp2_jll"),
         ]
     )

--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -76,7 +76,7 @@ dependencies = [
     Dependency("nghttp2_jll"),
     # Note that while we unconditionally list MbedTLS as a dependency,
     # we default to schannel/SecureTransport on Windows/MacOS.
-    Dependency("MbedTLS_jll", v"2.24.0"),
+    Dependency("MbedTLS_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -59,7 +59,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("MbedTLS_jll", v"2.24.0"),
+    Dependency("MbedTLS_jll"),
     Dependency("LibSSH2_jll"),
 ]
 

--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -42,7 +42,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("MbedTLS_jll", v"2.24.0"),
+    Dependency("MbedTLS_jll"),
 ]
 
 # Note: we explicitly lie about this because we don't have the new

--- a/N/NetCDF/common.jl
+++ b/N/NetCDF/common.jl
@@ -98,7 +98,7 @@ nc-config --all
             # The following libraries are dependencies of LibCURL_jll which is now a
             # stdlib, but the stdlib doesn't explicitly list its dependencies
             Dependency("LibSSH2_jll"),
-            Dependency("MbedTLS_jll", v"2.24.0"),
+            Dependency("MbedTLS_jll"),
             Dependency("nghttp2_jll"),
         ]
     )

--- a/S/samtools/build_tarballs.jl
+++ b/S/samtools/build_tarballs.jl
@@ -42,7 +42,7 @@ dependencies = [
     # `MbedTLS_jll`).  For some reasons that aren't clear to me at the moment, we are
     # getting a version of `MbedTLS_jll` which doesn't match the one `LibCURL_jll` was
     # compiled with.
-    BuildDependency(PackageSpec(; name="MbedTLS_jll", version="2.24"))
+    BuildDependency(PackageSpec(; name="MbedTLS_jll"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -82,7 +82,7 @@ dependencies = Dependency[
     # The following libraries are dependencies of LibCURL_jll which is now a
     # stdlib, but the stdlib doesn't explicitly list its dependencies
     Dependency("LibSSH2_jll"),
-    Dependency("MbedTLS_jll", v"2.24.0"),
+    Dependency("MbedTLS_jll"),
     Dependency("nghttp2_jll"),
 ]
 


### PR DESCRIPTION
Currently Mbed TLS is pinned to 2.24, including in some julia dependencies:

1. [LibSSH2](https://github.com/JuliaPackaging/Yggdrasil/blob/f81c3d85a7c911c796cefa08091210d1810cac80/L/LibSSH2/build_tarballs.jl#L45
)
2. [LibGit2](https://github.com/JuliaPackaging/Yggdrasil/blob/f81c3d85a7c911c796cefa08091210d1810cac80/L/LibGit2/build_tarballs.jl#L62)
3. [Curl](https://github.com/JuliaPackaging/Yggdrasil/blob/f81c3d85a7c911c796cefa08091210d1810cac80/L/LibCURL/build_tarballs.jl#L79)

This creates an issue when trying to update Mbed TLS in Julia: https://github.com/JuliaLang/julia/pull/42311

We need to remove the pin, which should be possible with Julia 1.6.

This should allow Mbed TLS to be upgraded to 2.27 or 2.28 in response to security advisories.

Note that GDAL and NetCDF use a configure function that I'm not familiar with. Perhaps these need a Julia 1.6 compat declaration.