### PR TITLE
[libgeotiff] build 1.7.0

### DIFF
--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -1,11 +1,12 @@
 using BinaryBuilder, Pkg
 
 name = "libgeotiff"
-version = v"1.6.0"
+version = v"1.7.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/OSGeo/libgeotiff/releases/download/$version/libgeotiff-$version.tar.gz", "9311017e5284cffb86f2c7b7a9df1fb5ebcdc61c30468fb2e6bca36e4272ebca"),
+    ArchiveSource("https://github.com/OSGeo/libgeotiff/releases/download/$version/libgeotiff-$version.tar.gz",
+                  "fc304d8839ca5947cfbeb63adb9d1aa47acef38fc6d6689e622926e672a99a7e"),
     DirectorySource("./bundled"),
 ]
 
@@ -27,6 +28,11 @@ if [[ "${target}" == *-linux-* ]]; then
     else
         export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib64"
     fi
+fi
+
+# same fix as used for PROJ
+if [[ "${target}" == x86_64-linux-musl* ]]; then
+    export LDFLAGS="$LDFLAGS -lcurl"
 fi
 
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
@@ -54,10 +60,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="PROJ_jll", uuid="58948b4f-47e0-5654-a9ad-f609743f8632")),
-    # TODO: v4.3.0 is available, use that next time
-    Dependency("Libtiff_jll"; compat="4.1.0"),
+    Dependency("PROJ_jll"; compat="~800.200"),
+    Dependency("Libtiff_jll"; compat="4.3"),
+    Dependency("LibCURL_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
Needed to progress with #4193, since both have a PROJ dependency.

Had to add LibCURL_jll as a direct dependency (rather than through PROJ), to avoid this issue:

```
/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root//usr/local/lib/libcurl.so.4: undefined reference to `mbedtls_net_recv'
/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/local/lib/libproj.so.22.2.0: undefined reference to `curl_easy_perform@CURL_4'
```