### PR TITLE
Bump (Lib)CURL to 7.81.0

### DIFF
--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -23,7 +23,7 @@ FLAGS=(
     --without-nss --without-polarssl
     --without-spnego --without-libpsl --disable-ares --disable-manual
     --disable-ldap --disable-ldaps --without-zsh-functions-dir
-    --disable-static --disable-libgsasl
+    --disable-static --without-libgsasl
 
     # A few things we actually enable
     --with-libssh2=${prefix} --with-zlib=${prefix} --with-nghttp2=${prefix}

--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -76,7 +76,7 @@ dependencies = [
     Dependency("nghttp2_jll"),
     # Note that while we unconditionally list MbedTLS as a dependency,
     # we default to schannel/SecureTransport on Windows/MacOS.
-    Dependency("MbedTLS_jll", v"2.28.0"),
+    Dependency("MbedTLS_jll"; compat="~2.28.0"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -80,4 +80,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.8")

--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "LibCURL"
-version = v"7.78.0"
+version = v"7.81.0"
 
 # Collection of sources required to build LibCURL
 sources = [
-    ArchiveSource("https://curl.haxx.se/download/curl-$(version).tar.gz",
-                  "ed936c0b02c06d42cf84b39dd12bb14b62d77c7c4e875ade022280df5dcc81d7"),
+    ArchiveSource("https://curl.se/download/curl-$(version).tar.gz",
+                  "ac8e1087711084548d788ef18b9b732c8de887457b81f616fc681d1044b32f98"),
 ]
 
 # Bash recipe for building across all platforms
@@ -76,7 +76,7 @@ dependencies = [
     Dependency("nghttp2_jll"),
     # Note that while we unconditionally list MbedTLS as a dependency,
     # we default to schannel/SecureTransport on Windows/MacOS.
-    Dependency("MbedTLS_jll", v"2.24.0"),
+    Dependency("MbedTLS_jll", v"2.28.0"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
URL has changed permanently from curl.haxx.se to curl.se. Also note to depends on MbedTLS 2.28 in this script.

I would consider holding this for a bit as some potential issues between LibCURL 7.81 and Julia are investigated:
https://github.com/JuliaLang/julia/issues/43682

However, I have built Julia master with curl 7.81.0 and MbedTLS 2.28 just fine locally on Linux.