### PR TITLE
[skip build] Drop experimental=true usage from supported_platforms

### DIFF
--- a/0_RootFS/PlatformSupport/build_tarballs.jl
+++ b/0_RootFS/PlatformSupport/build_tarballs.jl
@@ -1,5 +1,6 @@
 ### Instructions for adding a new version
 #
+#
 # Check out a branch of BinaryBuilderBase from the current master of that repo.
 # Run this script for each target platform. The following will do the job:
 # ```

--- a/0_RootFS/PlatformSupport/build_tarballs.jl
+++ b/0_RootFS/PlatformSupport/build_tarballs.jl
@@ -5,7 +5,7 @@
 # ```
 # using BinaryBuilder
 # using BinaryBuilder: aatriplet
-# for platform in supported_platforms(; experimental=true)
+# for platform in supported_platforms()
 #     # Append version numbers for BSD systems
 #     if Sys.isapple(platform)
 #         suffix = arch(platform) == "aarch64" ? "20" : "14"

--- a/0_RootFS/Rust/build_tarballs.jl
+++ b/0_RootFS/Rust/build_tarballs.jl
@@ -85,7 +85,7 @@ mega_rust_path = artifact_path(first(values(build_info))[3])
 rust_host = Platform("x86_64", "linux"; libc="musl")
 rust_host_triplet = map_rust_target(rust_host)
 
-for target_platform in supported_platforms(; experimental=true)
+for target_platform in supported_platforms()
     rust_target_triplet = map_rust_target(target_platform)
     @info("Generating artifacts for $(rust_target_triplet)...")
     unpacked_hash = create_artifact() do dir
@@ -121,7 +121,7 @@ unpacked_hash = create_artifact() do dir
     cp(joinpath(mega_rust_path, "toolchains"), joinpath(dir, "toolchains"))
     rm(joinpath(dir, "toolchains", "$(version)-$(rust_host_triplet)", "share"); recursive=true)
     rm(joinpath(dir, "toolchains", "$(version)-$(rust_host_triplet)", "etc"); recursive=true)
-    for rust_target_triplet in map_rust_target.(supported_platforms(; experimental=true))
+    for rust_target_triplet in map_rust_target.(supported_platforms())
         rm(joinpath(dir, "toolchains", "$(version)-$(rust_host_triplet)", "lib", "rustlib", rust_target_triplet); recursive=true)
     end
 end

--- a/A/ASL/build_tarballs.jl
+++ b/A/ASL/build_tarballs.jl
@@ -54,7 +54,7 @@ install_license LICENSE.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/A/ATK/build_tarballs.jl
+++ b/A/ATK/build_tarballs.jl
@@ -24,7 +24,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/A/ATKmm/build_tarballs.jl
+++ b/A/ATKmm/build_tarballs.jl
@@ -22,7 +22,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/A/AlgRemez/build_tarballs.jl
+++ b/A/AlgRemez/build_tarballs.jl
@@ -20,7 +20,7 @@ make INCLIST=-I${includedir} LDFLAGS="-L${libdir} -lmpfr -lgmp" BIN=${bindir}/al
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -32,7 +32,7 @@ install_license LICENSE.OpenSSL
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/A/Atomsk/build_tarballs.jl
+++ b/A/Atomsk/build_tarballs.jl
@@ -21,7 +21,7 @@ make install INSTPATH=${prefix} BIN="atomsk${exeext}"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built

--- a/A/Attr/build_tarballs.jl
+++ b/A/Attr/build_tarballs.jl
@@ -23,7 +23,7 @@ install_license doc/COPYING*
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.  We are manually disabling
 # many platforms that do not seem to work.
-platforms = filter!(Sys.islinux, supported_platforms(; experimental=true))
+platforms = filter!(Sys.islinux, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/A/AzStorage/build_tarballs.jl
+++ b/A/AzStorage/build_tarballs.jl
@@ -29,7 +29,7 @@ cp libAzStorage.so ${libdir}/libAzStorage.${dlext}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 # TODO - add libgomp dependency

--- a/A/acl/build_tarballs.jl
+++ b/A/acl/build_tarballs.jl
@@ -23,7 +23,7 @@ install_license doc/COPYING*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(Sys.islinux, supported_platforms(; experimental=true))
+platforms = filter!(Sys.islinux, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/A/alsa/build_tarballs.jl
+++ b/A/alsa/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter(Sys.islinux, supported_platforms(;experimental=true))
+platforms = filter(Sys.islinux, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/A/argp_standalone/build_tarballs.jl
+++ b/A/argp_standalone/build_tarballs.jl
@@ -23,7 +23,7 @@ install -D -m755 libargp.a ${libdir}/libargp.a
 """
 
 # Select Unix platforms
-platforms = filter(p->Sys.islinux(p) && libc(p) == "musl", supported_platforms(;experimental=true))
+platforms = filter(p->Sys.islinux(p) && libc(p) == "musl", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/B/BWA/build_tarballs.jl
+++ b/B/BWA/build_tarballs.jl
@@ -25,7 +25,7 @@ cp "libbwa.${dlext}" "${libdir}/libbwa.${dlext}"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 # The package uses Intel intrinsics, so we can build only for Intel platforms.
 filter!(p -> BinaryBuilder.proc_family(p) == "intel", platforms)
 # ...and uses some Unix header files not available on Windows.

--- a/B/Bison/build_tarballs.jl
+++ b/B/Bison/build_tarballs.jl
@@ -20,7 +20,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/B/Blosc/build_tarballs.jl
+++ b/B/Blosc/build_tarballs.jl
@@ -36,7 +36,7 @@ install_license ../LICENSES/*.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/B/Blosc2/build_tarballs.jl
+++ b/B/Blosc2/build_tarballs.jl
@@ -33,7 +33,7 @@ install_license ../LICENSES/*.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/B/Bzip2/build_tarballs.jl
+++ b/B/Bzip2/build_tarballs.jl
@@ -63,7 +63,7 @@ EOF
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/B/basiclu/build_tarballs.jl
+++ b/B/basiclu/build_tarballs.jl
@@ -27,7 +27,7 @@ cp include/* "${includedir}/."
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/B/bliss/build_tarballs.jl
+++ b/B/bliss/build_tarballs.jl
@@ -36,7 +36,7 @@ install_license ../COPYING.LESSER
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/B/boost/build_tarballs.jl
+++ b/B/boost/build_tarballs.jl
@@ -64,7 +64,7 @@ install_license LICENSE_1_0.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/C/CFITSIO/build_tarballs.jl
+++ b/C/CFITSIO/build_tarballs.jl
@@ -38,7 +38,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/CImGuiPack/build_tarballs.jl
+++ b/C/CImGuiPack/build_tarballs.jl
@@ -24,7 +24,7 @@ install_license ../cimgui/LICENSE ../cimgui/imgui/LICENSE.txt ../cimplot/LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/CLIME/build_tarballs.jl
+++ b/C/CLIME/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/CRlibm/build_tarballs.jl
+++ b/C/CRlibm/build_tarballs.jl
@@ -30,7 +30,7 @@ cc -L. -shared -o ${libdir}/libcrlibm.${dlext} *.o scs_lib/*.o
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/CVRPSEP/build_tarballs.jl
+++ b/C/CVRPSEP/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/Cairo/build_tarballs.jl
+++ b/C/Cairo/build_tarballs.jl
@@ -55,7 +55,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/C/Cairomm/build_tarballs.jl
+++ b/C/Cairomm/build_tarballs.jl
@@ -22,7 +22,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/C/Cares/build_tarballs.jl
+++ b/C/Cares/build_tarballs.jl
@@ -29,7 +29,7 @@ install_license ../LICENSE.md
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/Chuffed/build_tarballs.jl
+++ b/C/Chuffed/build_tarballs.jl
@@ -26,7 +26,7 @@ make -j ${nproc}
 make install
 """
 
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 products = [
     ExecutableProduct("fzn-chuffed", :fznchuffed),

--- a/C/Coin-OR/CSDP/build_tarballs.jl
+++ b/C/Coin-OR/CSDP/build_tarballs.jl
@@ -44,7 +44,7 @@ ${CC} -fopenmp -fPIC -shared -Wl,${all_load} libsdp.a -Wl,${noall_load} -o ${lib
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/Coin-OR/Ipopt/build_tarballs.jl
+++ b/C/Coin-OR/Ipopt/build_tarballs.jl
@@ -43,7 +43,7 @@ make
 make install
 """
 
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 platforms = expand_gfortran_versions(platforms)
 

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -94,5 +94,5 @@ OpenBLAS32_version = v"0.3.10"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 platforms = filter!(!Sys.isfreebsd, platforms)

--- a/C/CompilerSupportLibraries/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/build_tarballs.jl
@@ -18,7 +18,7 @@ for d in /opt/${target}/${target}/lib*; do
 done
 """
 
-extraction_platforms = supported_platforms(;experimental=true)
+extraction_platforms = supported_platforms()
 extraction_products = [
     LibraryProduct("libstdc++", :libstdcxx),
     LibraryProduct("libgomp", :libgomp),
@@ -107,7 +107,7 @@ install_license /usr/share/licenses/GPL3
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_gfortran_versions(supported_platforms(;experimental=true))
+platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
 common_products = [

--- a/C/Cuba/build_tarballs.jl
+++ b/C/Cuba/build_tarballs.jl
@@ -23,7 +23,7 @@ rm "${prefix}/lib/libcuba.a" "${prefix}/share/cuba.pdf"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/Cubature/build_tarballs.jl
+++ b/C/Cubature/build_tarballs.jl
@@ -18,7 +18,7 @@ ${CC} ${LDFLAGS} -shared -fPIC -O3 hcubature.c pcubature.c -o ${libdir}/libcubat
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/cargo_license/build_tarballs.jl
+++ b/C/cargo_license/build_tarballs.jl
@@ -21,7 +21,7 @@ install_license $WORKSPACE/srcdir/cargo-license/LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 # Rust toolchain for i686 Windows is unusable
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
 

--- a/C/cddlib/build_tarballs.jl
+++ b/C/cddlib/build_tarballs.jl
@@ -24,7 +24,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/C/cilantro/build_tarballs.jl
+++ b/C/cilantro/build_tarballs.jl
@@ -37,7 +37,7 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 
- platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+ platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/C/cohomCalg/build_tarballs.jl
+++ b/C/cohomCalg/build_tarballs.jl
@@ -26,7 +26,7 @@ install_license LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 filter!(!Sys.iswindows, platforms)
 
 # The products that we will ensure are always built

--- a/D/DecFP/build_tarballs.jl
+++ b/D/DecFP/build_tarballs.jl
@@ -45,7 +45,7 @@ install_license ../eula.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/D/Dierckx/build_tarballs.jl
+++ b/D/Dierckx/build_tarballs.jl
@@ -22,7 +22,7 @@ gfortran -o "${libdir}/libddierckx.${dlext}" -O3 -shared -fPIC *.f
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_gfortran_versions(supported_platforms(; experimental=true))
+platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/D/Doxygen/build_tarballs.jl
+++ b/D/Doxygen/build_tarballs.jl
@@ -32,7 +32,7 @@ install_license ../LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/D/DynarePreprocessor/build_tarballs.jl
+++ b/D/DynarePreprocessor/build_tarballs.jl
@@ -55,7 +55,7 @@ cp "src/dynare-preprocessor${exeext}" "${bindir}"
 install_license COPYING
 """
 
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 products = [
     ExecutableProduct("dynare-preprocessor", :dynare_preprocessor),

--- a/D/dSFMT/build_tarballs.jl
+++ b/D/dSFMT/build_tarballs.jl
@@ -29,7 +29,7 @@ ${CC} ${FLAGS[@]} ${CFLAGS} ${CPPFLAGS} ${LDFLAGS} -o "${libdir}/libdSFMT.${dlex
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/E/ECOS/build_tarballs.jl
+++ b/E/ECOS/build_tarballs.jl
@@ -22,7 +22,7 @@ cp -r include ${prefix}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/E/ERFA/build_tarballs.jl
+++ b/E/ERFA/build_tarballs.jl
@@ -26,7 +26,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/E/EarCut/build_tarballs.jl
+++ b/E/EarCut/build_tarballs.jl
@@ -21,7 +21,7 @@ ${CXX} -std=c++11 -fPIC -shared -o "${libdir}/libearcut.${dlext}" cwrapper.cpp
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/E/Exiv2/build_tarballs.jl
+++ b/E/Exiv2/build_tarballs.jl
@@ -45,7 +45,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/E/Expat/build_tarballs.jl
+++ b/E/Expat/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/E/extxyz/build_tarballs.jl
+++ b/E/extxyz/build_tarballs.jl
@@ -20,7 +20,7 @@ make -C libextxyz install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/F/FFMPEG/common.jl
+++ b/F/FFMPEG/common.jl
@@ -127,6 +127,6 @@ end
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 preferred_gcc_version = v"8"

--- a/F/FFTW/build_tarballs.jl
+++ b/F/FFTW/build_tarballs.jl
@@ -70,7 +70,7 @@ install_license COPYING COPYRIGHT
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true) # build on all supported platforms
+platforms = supported_platforms() # build on all supported platforms
 
 # The products that we will ensure are always built
 products = [

--- a/F/FGlT/build_tarballs.jl
+++ b/F/FGlT/build_tarballs.jl
@@ -21,7 +21,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # [FIXED!] FGlT contains std::string values!  This causes incompatibilities across the GCC 4/5 version boundary.
 # platforms = expand_cxxstring_abis(platforms)

--- a/F/FMM3D/build_tarballs.jl
+++ b/F/FMM3D/build_tarballs.jl
@@ -75,7 +75,7 @@ exit
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_gfortran_versions(supported_platforms(; experimental=true))
+platforms = expand_gfortran_versions(supported_platforms())
 filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
 
 # The products that we will ensure are always built

--- a/F/FastJet/build_tarballs.jl
+++ b/F/FastJet/build_tarballs.jl
@@ -48,7 +48,7 @@ done
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/F/Fontconfig/build_tarballs.jl
+++ b/F/Fontconfig/build_tarballs.jl
@@ -50,7 +50,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/F/FreeType2/build_tarballs.jl
+++ b/F/FreeType2/build_tarballs.jl
@@ -22,7 +22,7 @@ install_license docs/{FTL,GPLv2,LICENSE}.TXT
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/F/FriBidi/build_tarballs.jl
+++ b/F/FriBidi/build_tarballs.jl
@@ -23,7 +23,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/F/faust/build_tarballs.jl
+++ b/F/faust/build_tarballs.jl
@@ -73,7 +73,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/F/ffts/build_tarballs.jl
+++ b/F/ffts/build_tarballs.jl
@@ -32,7 +32,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 # filter failing ARM targets
 filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
 

--- a/F/flex/build_tarballs.jl
+++ b/F/flex/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;exclude=Sys.iswindows, experimental=true)
+platforms = supported_platforms(;exclude=Sys.iswindows)
 
 # The products that we will ensure are always built
 products = [

--- a/F/fzf/build_tarballs.jl
+++ b/F/fzf/build_tarballs.jl
@@ -20,7 +20,7 @@ go build -o ${bindir}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/common.jl
+++ b/G/GAP_pkg/common.jl
@@ -30,7 +30,7 @@ end
 
 function setup_gap_package(gap_version::VersionNumber, gap_lib_version::VersionNumber = gap_version; uses_cxx::Bool = false)
 
-    platforms = supported_platforms(; experimental=true)
+    platforms = supported_platforms()
     filter!(p -> nbits(p) == 64, platforms) # we only care about 64bit builds
     filter!(!Sys.iswindows, platforms)      # Windows is not supported
 

--- a/G/GEOS/build_tarballs.jl
+++ b/G/GEOS/build_tarballs.jl
@@ -34,7 +34,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/G/GLFW/build_tarballs.jl
+++ b/G/GLFW/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/G/GLPK/build_tarballs.jl
+++ b/G/GLPK/build_tarballs.jl
@@ -24,7 +24,7 @@ make install
 """
 
 # Build for all platforms
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/GMP/common.jl
+++ b/G/GMP/common.jl
@@ -51,7 +51,7 @@ install_license COPYING*
 """
 
     # We enable experimental platforms as this is a core Julia dependency
-    platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+    platforms = expand_cxxstring_abis(supported_platforms())
 
     # The products that we will ensure are always built
     products = [

--- a/G/GSL/GSL@2/build_tarballs.jl
+++ b/G/GSL/GSL@2/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/GTK3/build_tarballs.jl
+++ b/G/GTK3/build_tarballs.jl
@@ -58,7 +58,7 @@ rm ${prefix}/bin/gdk-pixbuf-pixdata ${prefix}/bin/glib-compile-{resources,schema
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/G/Gama/build_tarballs.jl
+++ b/G/Gama/build_tarballs.jl
@@ -30,7 +30,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/G/Geant4/build_tarballs.jl
+++ b/G/Geant4/build_tarballs.jl
@@ -30,7 +30,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 filter!(p -> !Sys.iswindows(p) && arch(p) != "armv6l", platforms)
 
 # The products that we will ensure are always built

--- a/G/Gettext/build_tarballs.jl
+++ b/G/Gettext/build_tarballs.jl
@@ -39,7 +39,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/G/Giflib/build_tarballs.jl
+++ b/G/Giflib/build_tarballs.jl
@@ -26,7 +26,7 @@ install_license COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/Gingko/build_tarballs.jl
+++ b/G/Gingko/build_tarballs.jl
@@ -33,7 +33,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
- platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+ platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -41,7 +41,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/Glibmm/build_tarballs.jl
+++ b/G/Glibmm/build_tarballs.jl
@@ -23,7 +23,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -44,7 +44,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # Disable windows because O_NONBLOCK isn't defined
 filter!(!Sys.iswindows, platforms)

--- a/G/Graphene/build_tarballs.jl
+++ b/G/Graphene/build_tarballs.jl
@@ -28,7 +28,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = Product[

--- a/G/Graphite2/build_tarballs.jl
+++ b/G/Graphite2/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/Gumbo/build_tarballs.jl
+++ b/G/Gumbo/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/gdk_pixbuf/build_tarballs.jl
+++ b/G/gdk_pixbuf/build_tarballs.jl
@@ -37,7 +37,7 @@ find ${prefix}/lib -name loaders.cache -delete
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/gh_cli/build_tarballs.jl
+++ b/G/gh_cli/build_tarballs.jl
@@ -20,7 +20,7 @@ mv gh${exeext} ${bindir}/gh${exeext}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/gocloc/build_tarballs.jl
+++ b/G/gocloc/build_tarballs.jl
@@ -20,7 +20,7 @@ mv bin/gocloc ${bindir}/gocloc${exeext}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/G/grep/build_tarballs.jl
+++ b/G/grep/build_tarballs.jl
@@ -20,7 +20,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/gsasl/build_tarballs.jl
+++ b/G/gsasl/build_tarballs.jl
@@ -26,7 +26,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/H/H3/build_tarballs.jl
+++ b/H/H3/build_tarballs.jl
@@ -33,7 +33,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/H/HYPRE/build_tarballs.jl
+++ b/H/HYPRE/build_tarballs.jl
@@ -52,7 +52,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/H/Hanabi/build_tarballs.jl
+++ b/H/Hanabi/build_tarballs.jl
@@ -27,7 +27,7 @@ install_license ../../LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/H/HarfBuzz/common.jl
+++ b/H/HarfBuzz/common.jl
@@ -47,7 +47,7 @@ fi
 
     # These are the platforms we will build for by default, unless further
     # platforms are passed in on the command line
-    platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+    platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
     # The products that we will ensure are always built
     products = if icu

--- a/H/HelloWorldC/build_tarballs.jl
+++ b/H/HelloWorldC/build_tarballs.jl
@@ -23,7 +23,7 @@ install_license /usr/share/licenses/MIT
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/H/HiGHS/build_tarballs.jl
+++ b/H/HiGHS/build_tarballs.jl
@@ -48,7 +48,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 platforms = filter!(!Sys.isfreebsd, platforms)
 
 # The products that we will ensure are always built

--- a/H/Hwloc/build_tarballs.jl
+++ b/H/Hwloc/build_tarballs.jl
@@ -20,7 +20,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/H/htslib/build_tarballs.jl
+++ b/H/htslib/build_tarballs.jl
@@ -36,7 +36,7 @@ fi
 # platforms are passed in on the command line
 # NOTE: Configuring i686-w64-mingw32 fails due to 'unable to find the recv()
 # function' error. So we skip it for now.
-platforms = supported_platforms(; experimental=true, exclude=Sys.iswindows)
+platforms = supported_platforms(; exclude=Sys.iswindows)
 
 # The products that we will ensure are always built
 products = [

--- a/I/ICU/build_tarballs.jl
+++ b/I/ICU/build_tarballs.jl
@@ -64,7 +64,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/I/ITSOL_2/build_tarballs.jl
+++ b/I/ITSOL_2/build_tarballs.jl
@@ -26,7 +26,7 @@ install_license ../{COPYRIGHT,LGPL}
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 # FreeBSD build failed with libgfortran_version=3.0.0
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built

--- a/I/Icestorm/build_tarballs.jl
+++ b/I/Icestorm/build_tarballs.jl
@@ -22,7 +22,7 @@ make install PREFIX=${prefix} ICEPROG=0
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> !Sys.iswindows(p), supported_platforms(;experimental=true))
+platforms = filter!(p -> !Sys.iswindows(p), supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/I/ImageMagick/build_tarballs.jl
+++ b/I/ImageMagick/build_tarballs.jl
@@ -39,7 +39,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/I/ipx/build_tarballs.jl
+++ b/I/ipx/build_tarballs.jl
@@ -26,7 +26,7 @@ cp include/* "${includedir}/."
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> (Sys.islinux(p) || Sys.isfreebsd(p)) && nbits(p) == 64, supported_platforms(;experimental=true))
+platforms = filter!(p -> (Sys.islinux(p) || Sys.isfreebsd(p)) && nbits(p) == 64, supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/J/JonkerVolgenant/build_tarballs.jl
+++ b/J/JonkerVolgenant/build_tarballs.jl
@@ -19,7 +19,7 @@ cc -I -Wall -std=c99 -shared -fPIC -O3 -o "${libdir}/bipartite_assignement.${dle
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/J/JpegTurbo/build_tarballs.jl
+++ b/J/JpegTurbo/build_tarballs.jl
@@ -23,7 +23,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/J/jemalloc/build_tarballs.jl
+++ b/J/jemalloc/build_tarballs.jl
@@ -28,7 +28,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/J/jq/build_tarballs.jl
+++ b/J/jq/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/K/Kissat/build_tarballs.jl
+++ b/K/Kissat/build_tarballs.jl
@@ -23,7 +23,7 @@ cp build/libkissat.so "$libdir/libkissat.${dlext}"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude=Sys.iswindows, experimental=true)
+platforms = supported_platforms(; exclude=Sys.iswindows)
 # The products that we will ensure are always built
 products = [
     ExecutableProduct("kissat", :kissat),

--- a/K/Kokkos/build_tarballs.jl
+++ b/K/Kokkos/build_tarballs.jl
@@ -48,7 +48,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 #Kokkos assumes a 64-bit build, remove 32-bit platforms
 filter!(p -> nbits(p) != 32, platforms)
 

--- a/L/LAME/build_tarballs.jl
+++ b/L/LAME/build_tarballs.jl
@@ -28,7 +28,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/LAMMPS/build_tarballs.jl
+++ b/L/LAMMPS/build_tarballs.jl
@@ -40,7 +40,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-# platforms = supported_platforms(; experimental=true)
+# platforms = supported_platforms()
 platforms = supported_platforms()
 platforms = filter(p -> !(Sys.isfreebsd(p) || libc(p) == "musl"), platforms)
 

--- a/L/LAPACK/build_tarballs.jl
+++ b/L/LAPACK/build_tarballs.jl
@@ -27,7 +27,7 @@ VERBOSE=ON cmake --build . --config Release --target install -- -j${nproc}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_gfortran_versions(supported_platforms(;experimental=true))
+platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/LAZperf/build_tarballs.jl
+++ b/L/LAZperf/build_tarballs.jl
@@ -34,7 +34,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/L/LCIO/build_tarballs.jl
+++ b/L/LCIO/build_tarballs.jl
@@ -23,7 +23,7 @@ cmake --build . --target install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 filter!(!Sys.isfreebsd, platforms)
 filter!(!Sys.iswindows, platforms)
 filter!(p -> arch(p) ∉ ("armv7l", "armv6l"), platforms)

--- a/L/LHAPDF/build_tarballs.jl
+++ b/L/LHAPDF/build_tarballs.jl
@@ -31,7 +31,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/LLVMExtra/build_tarballs.jl
+++ b/L/LLVMExtra/build_tarballs.jl
@@ -37,7 +37,7 @@ ninja -C build -j ${nproc} install
 function configure(julia_version, llvm_version)
     # These are the platforms we will build for by default, unless further
     # platforms are passed in on the command line
-    platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+    platforms = expand_cxxstring_abis(supported_platforms())
 
     foreach(platforms) do p
         BinaryPlatforms.add_tag!(p.tags, "julia_version", string(julia_version))

--- a/L/LZO/build_tarballs.jl
+++ b/L/LZO/build_tarballs.jl
@@ -23,7 +23,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = Product[

--- a/L/Leptonica/build_tarballs.jl
+++ b/L/Leptonica/build_tarballs.jl
@@ -23,7 +23,7 @@ install_license leptonica-license.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/LevelDB/build_tarballs.jl
+++ b/L/LevelDB/build_tarballs.jl
@@ -29,7 +29,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/build_tarballs.jl
@@ -61,7 +61,7 @@ install_license COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -50,7 +50,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibMPDec/build_tarballs.jl
+++ b/L/LibMPDec/build_tarballs.jl
@@ -33,7 +33,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibOSXUnwind/build_tarballs.jl
+++ b/L/LibOSXUnwind/build_tarballs.jl
@@ -35,7 +35,7 @@ cp -aR include ${prefix}/
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter(Sys.isapple, supported_platforms(;experimental=true))
+platforms = filter(Sys.isapple, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -41,7 +41,7 @@ install_license COPYRIGHT
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -33,7 +33,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibUV/build_tarballs.jl
+++ b/L/LibUV/build_tarballs.jl
@@ -26,7 +26,7 @@ make install
 """
 
 # We enable experimental platforms as this is a core Julia dependency
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibUnwind/LibUnwind@1.3.2/build_tarballs.jl
+++ b/L/LibUnwind/LibUnwind@1.3.2/build_tarballs.jl
@@ -43,7 +43,7 @@ ar -qc ${prefix}/lib/libunwind.a unpacked/**/*
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.  libunwind is only used
 # on Linux or FreeBSD (e.g. ELF systems)
-platforms = filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms(;experimental=true))
+platforms = filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibUnwind/LibUnwind@1.5.0/build_tarballs.jl
+++ b/L/LibUnwind/LibUnwind@1.5.0/build_tarballs.jl
@@ -55,7 +55,7 @@ ar -qc ${prefix}/lib/libunwind.a unpacked/**/*
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.  libunwind is only used
 # on Linux or FreeBSD (e.g. ELF systems)
-platforms = filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms(;experimental=true))
+platforms = filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/LibVPX/build_tarballs.jl
+++ b/L/LibVPX/build_tarballs.jl
@@ -77,7 +77,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/Libepoxy/build_tarballs.jl
+++ b/L/Libepoxy/build_tarballs.jl
@@ -22,7 +22,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/Libffi/build_tarballs.jl
+++ b/L/Libffi/build_tarballs.jl
@@ -26,7 +26,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/Libgcrypt/build_tarballs.jl
+++ b/L/Libgcrypt/build_tarballs.jl
@@ -24,7 +24,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.  We are manually disabling
 # many platforms that do not seem to work.
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/Libgpg_error/build_tarballs.jl
+++ b/L/Libgpg_error/build_tarballs.jl
@@ -44,7 +44,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.  We are manually disabling
 # many platforms that do not seem to work.
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/Libiconv/build_tarballs.jl
+++ b/L/Libiconv/build_tarballs.jl
@@ -38,7 +38,7 @@ EOF
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/Libmount/build_tarballs.jl
+++ b/L/Libmount/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(Sys.islinux, supported_platforms(; experimental=true))
+platforms = filter!(Sys.islinux, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/Librsvg/build_tarballs.jl
+++ b/L/Librsvg/build_tarballs.jl
@@ -48,7 +48,7 @@ install_license COPYING.LIB
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 # We dont have all dependencies for armv6l
 filter!(p -> arch(p) != "armv6l", platforms)
 # Rust toolchain for i686 Windows is unusable

--- a/L/Libtiff/build_tarballs.jl
+++ b/L/Libtiff/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/Libuuid/build_tarballs.jl
+++ b/L/Libuuid/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> !(Sys.iswindows(p) || Sys.isapple(p)), supported_platforms(; experimental=true))
+platforms = filter!(p -> !(Sys.iswindows(p) || Sys.isapple(p)), supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/Libxc/build_tarballs.jl
+++ b/L/Libxc/build_tarballs.jl
@@ -39,7 +39,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_gfortran_versions(supported_platforms(; experimental=true))
+platforms = expand_gfortran_versions(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/L/LittleCMS/build_tarballs.jl
+++ b/L/LittleCMS/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/Lua/build_tarballs.jl
+++ b/L/Lua/build_tarballs.jl
@@ -43,7 +43,7 @@ make install INSTALL_TOP="${prefix}" INSTALL_LIB="${libdir}" TO_BIN="${TO_BIN}" 
 install_license "${WORKSPACE}/srcdir/LICENSE"
 """
 
-platforms = supported_platforms(experimental=true)
+platforms = supported_platforms()
 
 products = [
     ExecutableProduct("lua", :lua),

--- a/L/Lz4/build_tarballs.jl
+++ b/L/Lz4/build_tarballs.jl
@@ -25,7 +25,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/lib4ti2/build_tarballs.jl
+++ b/L/lib4ti2/build_tarballs.jl
@@ -59,7 +59,7 @@ fi
 """
 
 # Build for all platforms
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # 4ti2 contains std::string values; to avoid incompatibilities across
 # the GCC 4/5 version boundary, we need the following:

--- a/L/libad9361_iio/build_tarballs.jl
+++ b/L/libad9361_iio/build_tarballs.jl
@@ -42,8 +42,8 @@ include("../../fancy_toys.jl")
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> !Sys.isapple(p), supported_platforms(;experimental=true))
-platforms_macos = filter!(p -> Sys.isapple(p), supported_platforms(;experimental=true))
+platforms = filter!(p -> !Sys.isapple(p), supported_platforms())
+platforms_macos = filter!(p -> Sys.isapple(p), supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/libaio/build_tarballs.jl
+++ b/L/libaio/build_tarballs.jl
@@ -21,7 +21,7 @@ make -j${nproc} install prefix=${prefix}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> Sys.islinux(p), supported_platforms(;experimental=true))
+platforms = filter!(p -> Sys.islinux(p), supported_platforms())
 
 # The products that we will ensure are always built
 products = Product[

--- a/L/libass/build_tarballs.jl
+++ b/L/libass/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -21,7 +21,7 @@ install_license /usr/share/licenses/MIT
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libclangex/build_tarballs.jl
+++ b/L/libclangex/build_tarballs.jl
@@ -32,7 +32,7 @@ install_license ../COPYRIGHT ../LICENSE-APACHE ../LICENSE-MIT
 function configure(julia_version, llvm_version)
     # These are the platforms we will build for by default, unless further
     # platforms are passed in on the command line
-    platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+    platforms = expand_cxxstring_abis(supported_platforms())
 
     foreach(platforms) do p
         BinaryPlatforms.add_tag!(p.tags, "julia_version", string(julia_version))

--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -28,7 +28,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/L/libdeflate/build_tarballs.jl
+++ b/L/libdeflate/build_tarballs.jl
@@ -22,7 +22,7 @@ make PROG_SUFFIX=$exeext PREFIX=${prefix} LIBDIR=${libdir} install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libevdev/build_tarballs.jl
+++ b/L/libevdev/build_tarballs.jl
@@ -25,7 +25,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(Sys.islinux, supported_platforms(; experimental=true))
+platforms = filter!(Sys.islinux, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/libevent/build_tarballs.jl
+++ b/L/libevent/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 # FIXME: Name is `libevent-2-1-7.dll` but `parse_dl_name_version` strips the trailing `-7`

--- a/L/libfdk_aac/build_tarballs.jl
+++ b/L/libfdk_aac/build_tarballs.jl
@@ -22,7 +22,7 @@ install_license NOTICE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libgraphicsmagic/build_tarballs.jl
+++ b/L/libgraphicsmagic/build_tarballs.jl
@@ -20,7 +20,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(!Sys.iswindows, supported_platforms(; experimental=true))
+platforms = filter!(!Sys.iswindows, supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 

--- a/L/libidn/build_tarballs.jl
+++ b/L/libidn/build_tarballs.jl
@@ -30,7 +30,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental = true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/L/libidn2/build_tarballs.jl
+++ b/L/libidn2/build_tarballs.jl
@@ -29,7 +29,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental = true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/L/libiio/build_tarballs.jl
+++ b/L/libiio/build_tarballs.jl
@@ -39,8 +39,8 @@ include("../../fancy_toys.jl")
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> !Sys.isapple(p), supported_platforms(;experimental=true))
-platforms_macos = filter!(p -> Sys.isapple(p), supported_platforms(;experimental=true))
+platforms = filter!(p -> !Sys.isapple(p), supported_platforms())
+platforms_macos = filter!(p -> Sys.isapple(p), supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/libmicrohttpd/build_tarballs.jl
+++ b/L/libmicrohttpd/build_tarballs.jl
@@ -20,7 +20,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libnabo/build_tarballs.jl
+++ b/L/libnabo/build_tarballs.jl
@@ -30,7 +30,7 @@ install_license ../debian/copyright
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/L/libpng/build_tarballs.jl
+++ b/L/libpng/build_tarballs.jl
@@ -33,7 +33,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libportaudio/build_tarballs.jl
+++ b/L/libportaudio/build_tarballs.jl
@@ -50,7 +50,7 @@ install_license "../LICENSE.txt"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libpsl/build_tarballs.jl
+++ b/L/libpsl/build_tarballs.jl
@@ -30,7 +30,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental = true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/L/librtlsdr/build_tarballs.jl
+++ b/L/librtlsdr/build_tarballs.jl
@@ -29,7 +29,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p-> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p-> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = Product[

--- a/L/libsharp2/build_tarballs.jl
+++ b/L/libsharp2/build_tarballs.jl
@@ -32,7 +32,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libsigcpp/build_tarballs.jl
+++ b/L/libsigcpp/build_tarballs.jl
@@ -23,7 +23,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/libsixel/build_tarballs.jl
+++ b/L/libsixel/build_tarballs.jl
@@ -32,7 +32,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libsodium/build_tarballs.jl
+++ b/L/libsodium/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libtirpc/build_tarballs.jl
+++ b/L/libtirpc/build_tarballs.jl
@@ -38,7 +38,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental = true)
+platforms = supported_platforms()
 #this is really only supported for linux platforms
 filter!(Sys.islinux, platforms)
 

--- a/L/libtree/build_tarballs.jl
+++ b/L/libtree/build_tarballs.jl
@@ -13,7 +13,7 @@ make CFLAGS="-Os -fwhole-program" LDFLAGS="-Wl,-s" "PREFIX=$prefix" install
 """
 
 # Build only on platforms where ELF objects are usually used.
-platforms = filter!(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms(; experimental=true))
+platforms = filter!(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
 
 products = [
     ExecutableProduct("libtree", :libtree)

--- a/L/libudfread/build_tarballs.jl
+++ b/L/libudfread/build_tarballs.jl
@@ -22,7 +22,7 @@ install_license COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(!Sys.iswindows, supported_platforms(; experimental=true))
+platforms = filter!(!Sys.iswindows, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/L/libunistring/build_tarballs.jl
+++ b/L/libunistring/build_tarballs.jl
@@ -26,7 +26,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental = true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/L/libusb/build_tarballs.jl
+++ b/L/libusb/build_tarballs.jl
@@ -24,7 +24,7 @@ install_license COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [p for p in supported_platforms(;experimental=true) if !Sys.isfreebsd(p)]
+platforms = [p for p in supported_platforms() if !Sys.isfreebsd(p)]
 
 # The products that we will ensure are always built
 products = [

--- a/L/libvofi/build_tarballs.jl
+++ b/L/libvofi/build_tarballs.jl
@@ -24,7 +24,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libvorbis/build_tarballs.jl
+++ b/L/libvorbis/build_tarballs.jl
@@ -33,7 +33,7 @@ rm -r "${prefix}/share/doc"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libwebp/build_tarballs.jl
+++ b/L/libwebp/build_tarballs.jl
@@ -28,7 +28,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/lrslib/build_tarballs.jl
+++ b/L/lrslib/build_tarballs.jl
@@ -53,7 +53,7 @@ ${CC} -shared ${cflags} -o "${libdir}/liblrsnash.${dlext}" lrsnashlib.c -L${libd
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/M/MAFFT/build_tarballs.jl
+++ b/M/MAFFT/build_tarballs.jl
@@ -50,7 +50,7 @@ install_license extensions/mxscarna_src/vienna/COPYING-ViennaRNA
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true, exclude=Sys.iswindows)
+platforms = supported_platforms(; exclude=Sys.iswindows)
 platforms = expand_cxxstring_abis(platforms)
 
 

--- a/M/METIS/METIS@5/build_tarballs.jl
+++ b/M/METIS/METIS@5/build_tarballs.jl
@@ -33,7 +33,7 @@ make -j${nproc} install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/M/MMseqs2/build_tarballs.jl
+++ b/M/MMseqs2/build_tarballs.jl
@@ -85,7 +85,7 @@ install_license ../LICENSE.md
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true, exclude = p -> Sys.iswindows(p) || arch(p) == "i686")
+platforms = supported_platforms(; exclude = p -> Sys.iswindows(p) || arch(p) == "i686")
 # expand cxxstring abis on platforms where we use g++
 platforms = expand_cxxstring_abis(platforms; skip = p -> Sys.isfreebsd(p) || (Sys.isapple(p) && arch(p) == "aarch64"))
 

--- a/M/MPC/build_tarballs.jl
+++ b/M/MPC/build_tarballs.jl
@@ -33,7 +33,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/M/MPFI/build_tarballs.jl
+++ b/M/MPFI/build_tarballs.jl
@@ -28,7 +28,7 @@ script = raw"""
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/M/MPFR/build_tarballs.jl
+++ b/M/MPFR/build_tarballs.jl
@@ -25,7 +25,7 @@ fi
 """
 
 # We enable experimental platforms as this is a core Julia dependency
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/M/MPICH/build_tarballs.jl
+++ b/M/MPICH/build_tarballs.jl
@@ -113,7 +113,7 @@ cmake --build . --config RelWithDebInfo --parallel $nproc --target install
 install_license $WORKSPACE/srcdir/mpich*/COPYRIGHT $WORKSPACE/srcdir/MPIconstants-*/LICENSE.md
 """
 
-platforms = expand_gfortran_versions(filter!(!Sys.iswindows, supported_platforms(; experimental=true)))
+platforms = expand_gfortran_versions(filter!(!Sys.iswindows, supported_platforms()))
 
 products = [
     # MPICH

--- a/M/MPItrampoline/build_tarballs.jl
+++ b/M/MPItrampoline/build_tarballs.jl
@@ -206,7 +206,7 @@ install_license $WORKSPACE/srcdir/MPItrampoline-*/LICENSE.md $WORKSPACE/srcdir/m
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # MPItrampoline requires `RTLD_DEEPBIND` for `dlopen`,
 # and thus does not support musl or BSD.

--- a/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
@@ -79,7 +79,7 @@ cp include/* ${prefix}/include/mumps_seq
 cp libseq/*.h ${prefix}/include/mumps_seq
 """
 
-platforms = expand_gfortran_versions(supported_platforms(;experimental=true))
+platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/M/MbedTLS/common.jl
+++ b/M/MbedTLS/common.jl
@@ -79,7 +79,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/M/Modflow6/build_tarballs.jl
+++ b/M/Modflow6/build_tarballs.jl
@@ -24,7 +24,7 @@ meson install -C builddir
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_gfortran_versions(platforms)
 
 

--- a/M/MongoC/build_tarballs.jl
+++ b/M/MongoC/build_tarballs.jl
@@ -61,7 +61,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -26,7 +26,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 filter!(!Sys.iswindows, platforms)  # no FLINT_jll available
 
 # The products that we will ensure are always built

--- a/M/mtdev/build_tarballs.jl
+++ b/M/mtdev/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(Sys.islinux, supported_platforms(; experimental=true))
+platforms = filter!(Sys.islinux, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/M/muparser/build_tarballs.jl
+++ b/M/muparser/build_tarballs.jl
@@ -40,7 +40,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/N/NASM/build_tarballs.jl
+++ b/N/NASM/build_tarballs.jl
@@ -22,7 +22,7 @@ install_license LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/N/NLopt/build_tarballs.jl
+++ b/N/NLopt/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true)) # build on all supported platforms
+platforms = expand_cxxstring_abis(supported_platforms()) # build on all supported platforms
 
 # The products that we will ensure are always built
 products = [

--- a/N/NOVAS/build_tarballs.jl
+++ b/N/NOVAS/build_tarballs.jl
@@ -25,7 +25,7 @@ install_license ${WORKSPACE}/srcdir/extras/LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/N/NativeFileDialog/build_tarballs.jl
+++ b/N/NativeFileDialog/build_tarballs.jl
@@ -30,7 +30,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/N/Ncurses/build_tarballs.jl
+++ b/N/Ncurses/build_tarballs.jl
@@ -72,7 +72,7 @@ ln -s ncursesw ${includedir}/ncurses
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = Product[

--- a/N/Netgen/build_tarballs.jl
+++ b/N/Netgen/build_tarballs.jl
@@ -23,7 +23,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> !Sys.iswindows(p), supported_platforms(;experimental=true))
+platforms = filter!(p -> !Sys.iswindows(p), supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/N/Nettle/build_tarballs.jl
+++ b/N/Nettle/build_tarballs.jl
@@ -30,7 +30,7 @@ install_license COPYING*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/N/Ninja/build_tarballs.jl
+++ b/N/Ninja/build_tarballs.jl
@@ -24,7 +24,7 @@ install ninja${exeext} ${bindir}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/N/Notcurses/build_tarballs.jl
+++ b/N/Notcurses/build_tarballs.jl
@@ -45,7 +45,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built.
 products = [

--- a/N/nauty/build_tarballs.jl
+++ b/N/nauty/build_tarballs.jl
@@ -47,7 +47,7 @@ install_license COPYRIGHT
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 filter!(!Sys.iswindows, platforms)
 
 # The products that we will ensure are always built

--- a/N/nghttp2/build_tarballs.jl
+++ b/N/nghttp2/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/N/normaliz/build_tarballs.jl
+++ b/N/normaliz/build_tarballs.jl
@@ -44,7 +44,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 # windows build would require MPIR instead of GMP for 'long long'
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 filter!(!Sys.iswindows, platforms)
 platforms = expand_cxxstring_abis(platforms)
 

--- a/O/ONNX/build_tarballs.jl
+++ b/O/ONNX/build_tarballs.jl
@@ -32,7 +32,7 @@ cmake --build . --config Release --target install -- -j${nproc}
 Sadly, no windows support yet. It looks to me like the upstream treats
 `defined(_WIN32)` as synonymous with `build with MSVC`.
 =#
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true, exclude=Sys.iswindows))
+platforms = expand_cxxstring_abis(supported_platforms(; exclude=Sys.iswindows))
 
 products = [
     FileProduct("lib/libonnx.a", :libonnx),

--- a/O/OSQP/build_tarballs.jl
+++ b/O/OSQP/build_tarballs.jl
@@ -32,7 +32,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/O/Objconv/build_tarballs.jl
+++ b/O/Objconv/build_tarballs.jl
@@ -23,7 +23,7 @@ install_license /usr/share/licenses/GPL3
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/O/OpenJpeg/build_tarballs.jl
+++ b/O/OpenJpeg/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/O/OpenLSTO/build_tarballs.jl
+++ b/O/OpenLSTO/build_tarballs.jl
@@ -37,7 +37,7 @@ install_license ${WORKSPACE}/srcdir/OpenLSTO/LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true); skip=p->false)
+platforms = expand_cxxstring_abis(supported_platforms(); skip=p->false)
 
 # The products that we will ensure are always built
 products = [

--- a/O/OpenLibm/build_tarballs.jl
+++ b/O/OpenLibm/build_tarballs.jl
@@ -35,7 +35,7 @@ install_license ./LICENSE.md
 """
 
 # We enable experimental platforms as this is a core Julia dependency
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 products = [
     LibraryProduct("libopenlibm", :libopenlibm),

--- a/O/OpenMPI/build_tarballs.jl
+++ b/O/OpenMPI/build_tarballs.jl
@@ -69,7 +69,7 @@ install_license $WORKSPACE/srcdir/openmpi*/LICENSE $WORKSPACE/srcdir/MPIconstant
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.
 #platforms = supported_platforms()
-platforms = filter(p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc"), supported_platforms(; experimental=true))
+platforms = filter(p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc"), supported_platforms())
 platforms = expand_gfortran_versions(platforms)
     
 products = [

--- a/O/OpenSSL/build_tarballs.jl
+++ b/O/OpenSSL/build_tarballs.jl
@@ -57,7 +57,7 @@ make install_sw
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built.  What are these naming conventions guys?  Seriously?!
 products = [

--- a/O/OpenSpecFun/build_tarballs.jl
+++ b/O/OpenSpecFun/build_tarballs.jl
@@ -31,7 +31,7 @@ make install OS=${OS} prefix=$prefix
 # platforms are passed in on the command line. Since openspecfun uses
 # Fortran for AMOS, we need the combinatorial explosion of platforms
 # and GCC versions.
-platforms = expand_gfortran_versions(supported_platforms(;experimental=true))
+platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/O/Opus/build_tarballs.jl
+++ b/O/Opus/build_tarballs.jl
@@ -38,7 +38,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -33,7 +33,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # Disable platforms unlikely to work
 filter!(p -> arch(p) ∉ ("armv6l", "armv7l"), platforms)

--- a/O/open62541/build_tarballs.jl
+++ b/O/open62541/build_tarballs.jl
@@ -37,7 +37,7 @@ install_license ../LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/O/openbabel/build_tarballs.jl
+++ b/O/openbabel/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -23,7 +23,7 @@ cp ../target/${rust_target}/release/oxigraph_server${exeext} ${bindir}/
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # Rust toolchain for i686 Windows is unusable
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)

--- a/P/P4est/build_tarballs.jl
+++ b/P/P4est/build_tarballs.jl
@@ -49,7 +49,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/P/PCRE/build_tarballs.jl
+++ b/P/PCRE/build_tarballs.jl
@@ -24,7 +24,7 @@ make install VERBOSE=1
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/P/PCRE2/build_tarballs.jl
+++ b/P/PCRE2/build_tarballs.jl
@@ -45,7 +45,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/P/PPL/build_tarballs.jl
+++ b/P/PPL/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -24,7 +24,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/P/Pangomm/build_tarballs.jl
+++ b/P/Pangomm/build_tarballs.jl
@@ -26,7 +26,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 # We don't have armv6l Pango at the moment
 filter!(p -> arch(p) != "armv6l", platforms)
 

--- a/P/ParseGen/build_tarballs.jl
+++ b/P/ParseGen/build_tarballs.jl
@@ -46,7 +46,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/P/Patchelf/build_tarballs.jl
+++ b/P/Patchelf/build_tarballs.jl
@@ -20,7 +20,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = Product[

--- a/P/Perl/build_tarballs.jl
+++ b/P/Perl/build_tarballs.jl
@@ -130,7 +130,7 @@ sed -i -e "s#--sysroot[ =][^ ']\+##g" \
 # platforms are passed in on the command line
 platforms = filter!(p -> !Sys.iswindows(p) &&
                          arch(p) != "armv6l",
-                    supported_platforms(;experimental=true))
+                    supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/P/PicoSAT/build_tarballs.jl
+++ b/P/PicoSAT/build_tarballs.jl
@@ -25,7 +25,7 @@ install_license LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 filter!(!Sys.iswindows, platforms)
 
 # The products that we will ensure are always built

--- a/P/Pinchot/build_tarballs.jl
+++ b/P/Pinchot/build_tarballs.jl
@@ -23,7 +23,7 @@ install_license ../LICENSE.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/P/Pixman/build_tarballs.jl
+++ b/P/Pixman/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/P/Poppler/build_tarballs.jl
+++ b/P/Poppler/build_tarballs.jl
@@ -39,7 +39,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 filter!(p -> arch(p) != "armv6l", platforms)
 
 # The products that we will ensure are always built

--- a/P/p3a/build_tarballs.jl
+++ b/P/p3a/build_tarballs.jl
@@ -50,7 +50,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+platforms = expand_cxxstring_abis(supported_platforms())
 #Kokkos is only available on 64 bit
 filter!(p -> nbits(p) != 32, platforms)
 

--- a/P/p7zip/build_tarballs.jl
+++ b/P/p7zip/build_tarballs.jl
@@ -68,7 +68,7 @@ fi
 """
 
 # We enable experimental platforms as this is a core Julia dependency
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/P/pciutils/build_tarballs.jl
+++ b/P/pciutils/build_tarballs.jl
@@ -21,7 +21,7 @@ make install PREFIX=${prefix} SHARED=yes SBINDIR=${bindir}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> !Sys.iswindows(p) && !Sys.isapple(p), supported_platforms(;experimental=true))
+platforms = filter!(p -> !Sys.iswindows(p) && !Sys.isapple(p), supported_platforms())
 
 # The products that we will ensure are always built
 products = Product[

--- a/P/poly2tri/build_tarballs.jl
+++ b/P/poly2tri/build_tarballs.jl
@@ -31,7 +31,7 @@ ninja -j${nproc} install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -123,7 +123,7 @@ install_license COPYING
 # platforms are passed in on the command line
 platforms = filter!(p -> !Sys.iswindows(p) &&
                          arch(p) != "armv6l",
-                    supported_platforms(;experimental=true))
+                    supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/P/pprof/build_tarballs.jl
+++ b/P/pprof/build_tarballs.jl
@@ -24,7 +24,7 @@ go build -o ${bindir}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/P/protoc/build_tarballs.jl
+++ b/P/protoc/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/P/psurface/build_tarballs.jl
+++ b/P/psurface/build_tarballs.jl
@@ -47,7 +47,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/P/pugixml/build_tarballs.jl
+++ b/P/pugixml/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/Q/QCDNUM/build_tarballs.jl
+++ b/Q/QCDNUM/build_tarballs.jl
@@ -29,7 +29,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_gfortran_versions(platforms)
 platforms = expand_cxxstring_abis(platforms)
 

--- a/Q/Qhull/build_tarballs.jl
+++ b/Q/Qhull/build_tarballs.jl
@@ -32,7 +32,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/R/RLIBM_32/build_tarballs.jl
+++ b/R/RLIBM_32/build_tarballs.jl
@@ -22,7 +22,7 @@ install_license LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/R/Raylib/build_tarballs.jl
+++ b/R/Raylib/build_tarballs.jl
@@ -29,7 +29,7 @@ make install RAYLIB_LIBTYPE=SHARED DESTDIR="${prefix}" RAYLIB_INSTALL_PATH="${li
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true, exclude=p->arch(p)=="armv6l" || Sys.iswindows(p))
+platforms = supported_platforms(; exclude=p->arch(p)=="armv6l" || Sys.iswindows(p))
 
 
 # The products that we will ensure are always built

--- a/R/Rclone/build_tarballs.jl
+++ b/R/Rclone/build_tarballs.jl
@@ -24,7 +24,7 @@ install -t ${bindir} ${GOPATH}/bin/rclone${exeext}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/R/Readline/build_tarballs.jl
+++ b/R/Readline/build_tarballs.jl
@@ -39,7 +39,7 @@ install_license COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = Product[

--- a/R/Rmath/build_tarballs.jl
+++ b/R/Rmath/build_tarballs.jl
@@ -15,7 +15,7 @@ mkdir -p "${libdir}"
 mv src/libRmath-julia.* "${libdir}"
 """
 
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 products = [
     LibraryProduct("libRmath-julia", :libRmath),

--- a/R/ripgrep/build_tarballs.jl
+++ b/R/ripgrep/build_tarballs.jl
@@ -22,7 +22,7 @@ install_license COPYING LICENSE-MIT UNLICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 # Rust toolchain for i686 Windows is unusable
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
 # All Musl-based ARM platforms fail with this error:

--- a/R/rtmidi/build_tarballs.jl
+++ b/R/rtmidi/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
     
 # Apparently there are no known MIDI backends for FreeBSD :(
 platforms = filter(p -> os(p) != "freebsd", platforms)

--- a/S/SBML/build_tarballs.jl
+++ b/S/SBML/build_tarballs.jl
@@ -45,7 +45,7 @@ make install
 rm ${prefix}/lib/libsbml-static.a
 """
 
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 products = [
     LibraryProduct("libsbml", :libsbml),

--- a/S/SCIP_PaPILO/build_tarballs.jl
+++ b/S/SCIP_PaPILO/build_tarballs.jl
@@ -39,7 +39,7 @@ cp $WORKSPACE/srcdir/scipoptsuite*/gcg/LICENSE ${prefix}/share/licenses/SCIP_PaP
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_gfortran_versions(expand_cxxstring_abis(supported_platforms(; experimental=true)))
+platforms = expand_gfortran_versions(expand_cxxstring_abis(supported_platforms()))
 
 filter!(platforms) do p
     arch(p) ∉ ("armv6l", "armv7l") && !Sys.iswindows(p) && libgfortran_version(p) >= v"4" && libc(p) != "musl"

--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -23,7 +23,7 @@ cp out/libscs*.${dlext} ${libdir}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/S/SISL/build_tarballs.jl
+++ b/S/SISL/build_tarballs.jl
@@ -37,7 +37,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental = true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/S/SLATEC/build_tarballs.jl
+++ b/S/SLATEC/build_tarballs.jl
@@ -67,7 +67,7 @@ install_license ../../LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_gfortran_versions(supported_platforms(; experimental=true))
+platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/S/SOLAR/build_tarballs.jl
+++ b/S/SOLAR/build_tarballs.jl
@@ -19,7 +19,7 @@ make COMPILATOR="c++" LIBS="-lm" EXE="${bindir}/solar${exeext}"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/S/SQLCipher/build_tarballs.jl
+++ b/S/SQLCipher/build_tarballs.jl
@@ -46,7 +46,7 @@ install_license LICENSE*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 filter!(p -> libc(p) != "musl", platforms)
 filter!(p -> !Sys.isfreebsd(p) && !Sys.iswindows(p), platforms)
 

--- a/S/SQLite/build_tarballs.jl
+++ b/S/SQLite/build_tarballs.jl
@@ -44,7 +44,7 @@ install_license "${WORKSPACE}/srcdir/LICENSE"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/S/STYRENE/build_tarballs.jl
+++ b/S/STYRENE/build_tarballs.jl
@@ -21,7 +21,7 @@ make COMPILATOR="c++" LIBS="-lm" EXE="${bindir}/truth${exeext}"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/S/Serd/build_tarballs.jl
+++ b/S/Serd/build_tarballs.jl
@@ -25,7 +25,7 @@ exit
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/S/Shoco/build_tarballs.jl
+++ b/S/Shoco/build_tarballs.jl
@@ -14,7 +14,7 @@ mkdir -p ${libdir}
 ${CC} shoco.c -o "${libdir}/libshoco.${dlext}" -fPIC -std=c99 -shared
 """
 
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 products = [
     LibraryProduct("libshoco", :libshoco),

--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -70,7 +70,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 filter!(!Sys.iswindows, platforms)
 platforms = expand_cxxstring_abis(platforms)
 

--- a/S/SoapyLMS7/build_tarballs.jl
+++ b/S/SoapyLMS7/build_tarballs.jl
@@ -51,7 +51,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> os(p) != "windows", supported_platforms(;experimental=true))
+platforms = filter!(p -> os(p) != "windows", supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/S/SoapyPlutoSDR/build_tarballs.jl
+++ b/S/SoapyPlutoSDR/build_tarballs.jl
@@ -46,7 +46,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms) # requested by auditor
 
 # The products that we will ensure are always built

--- a/S/SoapyRTLSDR/build_tarballs.jl
+++ b/S/SoapyRTLSDR/build_tarballs.jl
@@ -34,7 +34,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(;experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/S/SoapyUHD/build_tarballs.jl
+++ b/S/SoapyUHD/build_tarballs.jl
@@ -35,7 +35,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> !Sys.iswindows(p) && !in(arch(p),("armv7l","armv6l")), supported_platforms(;experimental=true))
+platforms = filter!(p -> !Sys.iswindows(p) && !in(arch(p),("armv7l","armv6l")), supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/S/SuiteSparse/SSGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparse/SSGraphBLAS/build_tarballs.jl
@@ -25,7 +25,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -9,7 +9,7 @@ sources = [
 ]
 
 # We enable experimental platforms as this is a core Julia dependency
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/S/Sundials/Sundials@5/build_tarballs.jl
+++ b/S/Sundials/Sundials@5/build_tarballs.jl
@@ -64,7 +64,7 @@ fi
 """
 
 # We attempt to build for all defined platforms
-platforms = filter!(p -> arch(p) != "powerpc64le", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "powerpc64le", supported_platforms())
 platforms = expand_gfortran_versions(platforms)
 
 products = [

--- a/S/SymEngine/build_tarballs.jl
+++ b/S/SymEngine/build_tarballs.jl
@@ -28,7 +28,7 @@ make -j${nproc}
 make install
 """
 
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/S/samtools/build_tarballs.jl
+++ b/S/samtools/build_tarballs.jl
@@ -27,7 +27,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true, exclude=Sys.iswindows)
+platforms = supported_platforms(; exclude=Sys.iswindows)
 
 # The products that we will ensure are always built
 products = [

--- a/S/seatd/build_tarballs.jl
+++ b/S/seatd/build_tarballs.jl
@@ -26,7 +26,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p ->Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms(; experimental=true))
+platforms = filter!(p ->Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/S/sed/build_tarballs.jl
+++ b/S/sed/build_tarballs.jl
@@ -28,7 +28,7 @@ make install SUBDIRS="po ."
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/S/simdjson/build_tarballs.jl
+++ b/S/simdjson/build_tarballs.jl
@@ -24,7 +24,7 @@ exit
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental = true)
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 
 

--- a/S/snappy/build_tarballs.jl
+++ b/S/snappy/build_tarballs.jl
@@ -37,7 +37,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/S/soapysdr/build_tarballs.jl
+++ b/S/soapysdr/build_tarballs.jl
@@ -21,7 +21,7 @@ install_license LICENSE_1_0.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 
 

--- a/S/spglib/build_tarballs.jl
+++ b/S/spglib/build_tarballs.jl
@@ -28,7 +28,7 @@ make install VERBOSE=1
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/S/startin/build_tarballs.jl
+++ b/S/startin/build_tarballs.jl
@@ -24,7 +24,7 @@ fi
 """
 
 # musl platforms are failing, as is win32
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 # `cdylib` apparently doesn't support musl
 filter!(p -> libc(p) != "musl", platforms)
 # Our Rust toolchain for i686 Windows is unusable

--- a/T/TMatrix/build_tarballs.jl
+++ b/T/TMatrix/build_tarballs.jl
@@ -20,7 +20,7 @@ meson install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_gfortran_versions(supported_platforms(;experimental=true))
+platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/T/TOPCOM/build_tarballs.jl
+++ b/T/TOPCOM/build_tarballs.jl
@@ -35,7 +35,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(;experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 platforms_win = filter(Sys.iswindows, platforms)
 platforms_unix = filter(!Sys.iswindows, platforms)
 

--- a/T/Tar/build_tarballs.jl
+++ b/T/Tar/build_tarballs.jl
@@ -23,7 +23,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.  We are manually disabling
 # many platforms that do not seem to work.
-platforms = filter!(!Sys.iswindows, supported_platforms(; experimental=true))
+platforms = filter!(!Sys.iswindows, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/T/Tesseract/build_tarballs.jl
+++ b/T/Tesseract/build_tarballs.jl
@@ -30,7 +30,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/T/TetGen/build_tarballs.jl
+++ b/T/TetGen/build_tarballs.jl
@@ -56,7 +56,7 @@ ${CXX} $LDFLAGS -shared -fPIC tetgen.o predicates.o  cwrapper.o -o ${libdir}/lib
 install_license LICENSE
 """
 
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 # platforms=[Platform("x86_64", "linux"; libc="glibc")]
 
 products = [

--- a/T/TinyXML/build_tarballs.jl
+++ b/T/TinyXML/build_tarballs.jl
@@ -32,7 +32,7 @@ install_license readme.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/T/Triangle/build_tarballs.jl
+++ b/T/Triangle/build_tarballs.jl
@@ -38,7 +38,7 @@ $CC -Itriangle  -Wno-int-to-pointer-cast  -Wno-pointer-to-int-cast -DREAL=double
 install_license triangle/README
 """
 
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 products = [LibraryProduct("libtriangle", :libtriangle)]
 dependencies = Dependency[]
 

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -26,7 +26,7 @@ cp target/${rust_target}/release/tectonic${exeext} ${bindir}/
 """
 
 # Some platforms disabled for now due issues with rust and musl cross compilation. See #1673.
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 # We dont have all dependencies for armv6l
 filter!(p -> arch(p) != "armv6l", platforms)
 # Rust toolchain for i686 Windows is unusable

--- a/U/URCU/build_tarballs.jl
+++ b/U/URCU/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(!Sys.iswindows, supported_platforms(; experimental=true))
+platforms = filter!(!Sys.iswindows, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/U/USRPHardwareDriver/build_tarballs.jl
+++ b/U/USRPHardwareDriver/build_tarballs.jl
@@ -38,7 +38,7 @@ make install
 # platforms are passed in on the command line
 # TODO: Windows has several issues with boost threads. There is a WIP branch:
 # https://github.com/JuliaTelecom/uhd/tree/juliatelecom/patch-v4.1.0.1
-platforms = expand_cxxstring_abis(filter!(p -> !Sys.iswindows(p) && !in(arch(p),("armv7l","armv6l")), supported_platforms(;experimental=true)))
+platforms = expand_cxxstring_abis(filter!(p -> !Sys.iswindows(p) && !in(arch(p),("armv7l","armv6l")), supported_platforms()))
 
 # The products that we will ensure are always built
 products = Product[

--- a/U/Unishox/build_tarballs.jl
+++ b/U/Unishox/build_tarballs.jl
@@ -15,7 +15,7 @@ cc -o ${libdir}/libunishox.${dlext} unishox2.c -shared -std=gnu11 -fPIC -Werror 
 """
 
 
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 products = [
     LibraryProduct("libunishox", :libunishox),

--- a/U/Usrsctp/build_tarballs.jl
+++ b/U/Usrsctp/build_tarballs.jl
@@ -21,7 +21,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/U/unpaper/build_tarballs.jl
+++ b/U/unpaper/build_tarballs.jl
@@ -27,7 +27,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/U/utf8proc/build_tarballs.jl
+++ b/U/utf8proc/build_tarballs.jl
@@ -28,7 +28,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -90,7 +90,7 @@ install_license COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true, exclude = p -> arch(p) == "powerpc64le")
+platforms = supported_platforms(; exclude = p -> arch(p) == "powerpc64le")
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(Sys.islinux, supported_platforms(; experimental=true))
+platforms = filter!(Sys.islinux, supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/W/WhiteboxTools/build_tarballs.jl
+++ b/W/WhiteboxTools/build_tarballs.jl
@@ -22,7 +22,7 @@ install_license LICENSE.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
 
 # The products that we will ensure are always built

--- a/W/Wigxjpf/build_tarballs.jl
+++ b/W/Wigxjpf/build_tarballs.jl
@@ -32,7 +32,7 @@ cp README $WORKSPACE/destdir/shared/licenses/LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/W/wget/build_tarballs.jl
+++ b/W/wget/build_tarballs.jl
@@ -28,7 +28,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # Disable windows because GnuTLS_jll is not available there
 filter!(!Sys.iswindows, platforms)

--- a/W/wolfSSL/build_tarballs.jl
+++ b/W/wolfSSL/build_tarballs.jl
@@ -31,7 +31,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental = true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/W/wxWidgets/build_tarballs.jl
+++ b/W/wxWidgets/build_tarballs.jl
@@ -93,7 +93,7 @@ install_license docs/preamble.txt docs/licence.txt docs/licendoc.txt docs/gpl.tx
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+platforms = expand_cxxstring_abis(supported_platforms())
 filter!(p -> arch(p) != "armv6l", platforms)
 
 # The products that we will ensure are always built

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -41,7 +41,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/X/XML2/build_tarballs.jl
+++ b/X/XML2/build_tarballs.jl
@@ -28,7 +28,7 @@ rm -rf ${prefix}/share/{doc/libxml2-*,gtk-doc}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/X/XSLT/build_tarballs.jl
+++ b/X/XSLT/build_tarballs.jl
@@ -23,7 +23,7 @@ rm -rf ${prefix}/share/doc/libxslt-*
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/X/XZ/build_tarballs.jl
+++ b/X/XZ/build_tarballs.jl
@@ -21,7 +21,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/X/x264/build_tarballs.jl
+++ b/X/x264/build_tarballs.jl
@@ -30,7 +30,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/X/x265/build_tarballs.jl
+++ b/X/x265/build_tarballs.jl
@@ -42,7 +42,7 @@ rm  ${prefix}/lib/libx265.a
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/X/xsum/build_tarballs.jl
+++ b/X/xsum/build_tarballs.jl
@@ -21,7 +21,7 @@ ${CC} -shared -fPIC -O3 -std=c99 ${xsumfpmath} -fno-inline-functions -o ${libdir
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true) # build on all supported platforms
+platforms = supported_platforms() # build on all supported platforms
 
 # The products that we will ensure are always built
 products = [

--- a/X/xtrx/build_tarballs.jl
+++ b/X/xtrx/build_tarballs.jl
@@ -73,7 +73,7 @@ install_license ${WORKSPACE}/srcdir/libxtrx/LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # Disable everything except glibc Linux for now, and only intel/arm processors
 filter!(p -> Sys.islinux(p) && libc(p) == "glibc" && proc_family(p) ∈ ("intel", "arm"), platforms)

--- a/Y/YASM/build_tarballs.jl
+++ b/Y/YASM/build_tarballs.jl
@@ -23,7 +23,7 @@ install_license COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/Y/Yosys/build_tarballs.jl
+++ b/Y/Yosys/build_tarballs.jl
@@ -45,7 +45,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l" && (Sys.isapple(p) || Sys.islinux(p)), supported_platforms(;experimental=true))
+platforms = filter!(p -> arch(p) != "armv6l" && (Sys.isapple(p) || Sys.islinux(p)), supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 # For some reasons, building for CXX03 string ABI doesn't actually work, skip it
 filter!(x -> cxxstring_abi(x) != "cxx03", platforms)

--- a/Y/yaml_cpp/build_tarballs.jl
+++ b/Y/yaml_cpp/build_tarballs.jl
@@ -28,7 +28,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/Y/yq/build_tarballs.jl
+++ b/Y/yq/build_tarballs.jl
@@ -18,7 +18,7 @@ go build -o ${bindir}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/Z/ZITSOL_1/build_tarballs.jl
+++ b/Z/ZITSOL_1/build_tarballs.jl
@@ -27,7 +27,7 @@ install_license ../{COPYRIGHT,LGPL}
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 # FreeBSD build failed with libgfortran_version=3.0.0
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built

--- a/Z/ZPares/build_tarballs.jl
+++ b/Z/ZPares/build_tarballs.jl
@@ -33,7 +33,7 @@ cp zpares_wrapper.mod "${includedir}"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 platforms = expand_gfortran_versions(platforms)
 
 

--- a/Z/ZeroMQ/build_tarballs.jl
+++ b/Z/ZeroMQ/build_tarballs.jl
@@ -42,7 +42,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/Z/Zlib/build_tarballs.jl
+++ b/Z/Zlib/build_tarballs.jl
@@ -28,7 +28,7 @@ install_license ../README
 """
 
 # We enable experimental platforms as this is a core Julia dependency
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/Z/Zstd/build_tarballs.jl
+++ b/Z/Zstd/build_tarballs.jl
@@ -27,7 +27,7 @@ ninja -j${nproc}
 ninja install
 """
 
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 products = [
     LibraryProduct("libzstd", :libzstd),

--- a/Z/zimg/build_tarballs.jl
+++ b/Z/zimg/build_tarballs.jl
@@ -22,7 +22,7 @@ install_license COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "aarch64", supported_platforms(; experimental=true))
+platforms = filter!(p -> arch(p) != "aarch64", supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built


### PR DESCRIPTION
Now that https://github.com/JuliaPackaging/Yggdrasil/pull/4160 has been merged, `supported_platforms()` and `supported_platforms(;experimental=true)` yield equivalent results, as all previously experimental platforms have been promoted to ‘supported’.

In the past, it was useful to grep through `experimental=true` to monitor Mac M1, etc. support, but with #4160 this is no longer valid. In order to consistently remove this now irrelevant parameter (prevent copy paste errors, etc.), this PR eliminates all cases where `experimental=true` has been used in Yggdrasil.

NOTE: There are a few remaining uses of the experimental keyword, either in functions which wrap `supported_platforms` or in scripts which special case Julia >=1.6. These have been left as-is for the moment.