### PR TITLE
add tempest model build for x86 unix platforms

### DIFF
--- a/T/TempestModel/build_tarballs.jl
+++ b/T/TempestModel/build_tarballs.jl
@@ -98,12 +98,13 @@ dependencies = Dependency[
     Dependency("NetCDF_jll"),
     Dependency("HDF5_jll"),
     # The following is adapted from NetCDF_jll
-    Dependency("LibCURL_jll"),
+    BuildDependency(PackageSpec(; name="MbedTLS_jll", version="2.24.0")),
+    #Dependency("LibCURL_jll"),
     # The following libraries are dependencies of LibCURL_jll which is now a
     # stdlib, but the stdlib doesn't explicitly list its dependencies
-    Dependency("LibSSH2_jll"),
-    Dependency("MbedTLS_jll", v"2.24.0"),
-    Dependency("nghttp2_jll"),
+    #Dependency("LibSSH2_jll"),
+    #Dependency("MbedTLS_jll", v"2.24.0"),
+    #Dependency("nghttp2_jll"),
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;

--- a/T/TempestModel/build_tarballs.jl
+++ b/T/TempestModel/build_tarballs.jl
@@ -92,7 +92,7 @@ products = [
     ExecutableProduct("RossbyHaurwitzWaveTest", :RossbyHaurwitzWaveTest_exe),
 ]
 
-dependencies = Dependency[
+dependencies = [
     Dependency("MKL_jll"),
     Dependency("MPICH_jll"),
     Dependency("NetCDF_jll"),

--- a/T/TempestModel/build_tarballs.jl
+++ b/T/TempestModel/build_tarballs.jl
@@ -1,0 +1,111 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "TempestModel"
+version = v"0.1"
+sources = [
+    GitSource("https://github.com/paullric/tempestmodel",
+	      "4ecf5146f3100fb24d36156a2f99433f049f0f66"),
+    DirectorySource("./bundled")
+]
+
+script = raw"""
+mkdir -vp $bindir
+mkdir -vp $libdir
+
+cd ${WORKSPACE}/srcdir/tempestmodel*
+
+atomic_patch -p1 ../patches/mk_defs.patch  
+atomic_patch -p1 ../patches/mk_system_macosx.patch
+# linux system fallback
+atomic_patch -p1 ../patches/mk_system_agri.patch
+atomic_patch -p1 ../patches/netcdf_cpp.patch
+
+export CXXFLAGS="-I${includedir}"
+export LDFLAGS="-L${libdir}"
+
+make NETCDF_ROOT=$prefix -j${nproc} all
+
+cp -v test/nonhydro_sphere/ScharMountainSphereTest ${bindir}
+cp -v test/nonhydro_sphere/BaroclinicWaveJWTest ${bindir}
+cp -v test/nonhydro_sphere/StationaryMountainFlowTest ${bindir}
+cp -v test/nonhydro_sphere/MountainWaveSphereTest ${bindir}
+cp -v test/nonhydro_sphere/HeldSuarezTest ${bindir}
+cp -v test/nonhydro_sphere/InertiaGravityWaveTest ${bindir}
+cp -v test/nonhydro_sphere/BaroclinicWaveUMJSTest ${bindir}
+cp -v test/nonhydro_sphere/MountainRossby3DTest ${bindir}
+cp -v test/nonhydro_sphere/BaldaufGravityWaveTest ${bindir}
+
+cp -v test/nonhydro_xz/RobertBubbleCartesianTest ${bindir}
+cp -v test/nonhydro_xz/ShearJetMtnWave2DCartesianTest ${bindir}
+cp -v test/nonhydro_xz/ThermalBubbleCartesian3DTest ${bindir}
+cp -v test/nonhydro_xz/Baroclinic3DCartesianTest ${bindir}
+cp -v test/nonhydro_xz/DensityCurrentCartesianTest ${bindir}
+cp -v test/nonhydro_xz/NonHydroMountainCartesianTest ${bindir}
+cp -v test/nonhydro_xz/HydrostaticMountainCartesianTest ${bindir}
+cp -v test/nonhydro_xz/ThermalBubbleCartesianTest ${bindir}
+cp -v test/nonhydro_xz/Baroclinic3DCartesianRidgeTest ${bindir}
+cp -v test/nonhydro_xz/ScharMountainCartesianTest ${bindir}
+cp -v test/nonhydro_xz/InertialGravityCartesianXZTest ${bindir}
+
+cp -v test/shallowwater_sphere/BarotropicInstabilityTest ${bindir}
+cp -v test/shallowwater_sphere/MountainRossbyTest ${bindir}
+cp -v test/shallowwater_sphere/RossbyHaurwitzWaveTest ${bindir}
+"""
+
+# Note: We are restricted to the platforms that NetCDF supports, the library is Unix only
+platforms = [
+    Platform("x86_64", "linux"),
+    Platform("x86_64", "macos"),
+] 
+platforms = expand_cxxstring_abis(platforms)
+  
+products = [
+    # non-hydro sphere test cases
+    ExecutableProduct("ScharMountainSphereTest", :ScharMountainSphereTest_exe),
+    ExecutableProduct("BaroclinicWaveJWTest", :BaroclinicWaveJWTest_exe),
+    ExecutableProduct("StationaryMountainFlowTest", :StationaryMountainFlowTest_exe),
+    ExecutableProduct("MountainWaveSphereTest", :MountainWaveSphereTest_exe),
+    ExecutableProduct("HeldSuarezTest", :HeldSuarezTest_exe),
+    ExecutableProduct("InertiaGravityWaveTest", :InertiaGravityWaveTest_exe),
+    ExecutableProduct("BaroclinicWaveUMJSTest", :BaroclinicWaveUMJSTest_exe),
+    ExecutableProduct("MountainRossby3DTest", :MountainRossby3DTest_exe),
+    ExecutableProduct("BaldaufGravityWaveTest", :BaldaufGravityWaveTest_exe),
+
+    # non-hydro xz test cases
+    ExecutableProduct("RobertBubbleCartesianTest", :RobertBubbleCartesianTest_exe),
+    ExecutableProduct("ShearJetMtnWave2DCartesianTest", :ShearJetMtnWave2DCartesianTest_exe),
+    ExecutableProduct("ThermalBubbleCartesian3DTest", :ThermalBubbleCartesian3DTest_exe),
+    ExecutableProduct("Baroclinic3DCartesianTest", :Baroclinic3DCartesianTest_exe),
+    ExecutableProduct("DensityCurrentCartesianTest", :DensityCurrentCartesianTest_exe),
+    ExecutableProduct("NonHydroMountainCartesianTest", :NonHydroMountainCartesianTest_exe),
+    ExecutableProduct("HydrostaticMountainCartesianTest", :HydrostaticMountainCartesianTest_exe),
+    ExecutableProduct("ThermalBubbleCartesianTest", :ThermalBubbleCartesianTest_exe),
+    ExecutableProduct("Baroclinic3DCartesianRidgeTest", :Baroclinic3DCartesianRidgeTest_exe),
+    ExecutableProduct("ScharMountainCartesianTest", :ScharMountainCartesianTest_exe),
+    ExecutableProduct("InertialGravityCartesianXZTest", :InertialGravityCartesianXZTest_exe),
+
+    # shallow water test cases
+    ExecutableProduct("BarotropicInstabilityTest", :BarotropicInstabilityTest_exe), 
+    ExecutableProduct("MountainRossbyTest", :MountainRossbyTest_exe),
+    ExecutableProduct("RossbyHaurwitzWaveTest", :RossbyHaurwitzWaveTest_exe),
+]
+
+dependencies = Dependency[
+    Dependency("MKL_jll"),
+    Dependency("MPICH_jll"),
+    Dependency("NetCDF_jll"),
+    Dependency("HDF5_jll"),
+    # The following is adapted from NetCDF_jll
+    Dependency("LibCURL_jll"),
+    # The following libraries are dependencies of LibCURL_jll which is now a
+    # stdlib, but the stdlib doesn't explicitly list its dependencies
+    Dependency("LibSSH2_jll"),
+    Dependency("MbedTLS_jll", v"2.24.0"),
+    Dependency("nghttp2_jll"),
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    julia_compat="1.6",
+)

--- a/T/TempestModel/bundled/patches/mk_defs.patch
+++ b/T/TempestModel/bundled/patches/mk_defs.patch
@@ -1,0 +1,13 @@
+diff --git a/mk/defs.make b/mk/defs.make
+index 8eaad7c..dedcbfc 100644
+--- a/mk/defs.make
++++ b/mk/defs.make
+@@ -23,7 +23,7 @@ TEMPESTLIBS= $(TEMPESTBASEDIR)/lib/libtempestbase.a \
+              $(TEMPESTBASEDIR)/lib/libhardcoreatm.a
+ 
+ # Libraries needed for compilation
+-LIBRARIES+= -lhardcoreatm -ltempestbase
++LIBRARIES+= -lm -lhardcoreatm -ltempestbase
+ LDFLAGS+= -L$(TEMPESTBASEDIR)/lib
+  
+ ###############################################################################

--- a/T/TempestModel/bundled/patches/mk_system_agri.patch
+++ b/T/TempestModel/bundled/patches/mk_system_agri.patch
@@ -1,0 +1,33 @@
+diff --git a/mk/system/agri.make b/mk/system/agri.make
+index 0d3cf21..dc810b9 100644
+--- a/mk/system/agri.make
++++ b/mk/system/agri.make
+@@ -8,7 +8,7 @@
+ 
+ CXX=               g++
+ F90=               gfortran
+-MPICXX=            mpiCC
++MPICXX=            mpic++
+ MPIF90=            mpif90
+ 
+ CXXFLAGS+=         -fPIC -Wno-literal-suffix
+@@ -19,7 +19,7 @@ F90_RUNTIME=       -lgfortran
+ # NetCDF
+ NETCDF_ROOT=       /opt/local
+ NETCDF_CXXFLAGS=   -I$(NETCDF_ROOT)/include
+-NETCDF_LIBRARIES=  -lnetcdf -lnetcdf_c++
++NETCDF_LIBRARIES=  -lnetcdf
+ NETCDF_LDFLAGS=    -L$(NETCDF_ROOT)/lib
+ 
+ # PetSc
+@@ -32,7 +32,7 @@ PETSC_LDFLAGS=     -L$(PETSC_ROOT)/lib -L$(X11_ROOT)/lib
+ # LAPACK (Mac OS X Accelerate Framework)
+ LAPACK_INTERFACE=  FORTRAN
+ LAPACK_CXXFLAGS=
+-LAPACK_LIBRARIES=  -llapack -lblas
+-LAPACK_LDFLAGS=    
++LAPACK_LIBRARIES= -lmkl_intel_lp64 -lmkl_core -lmkl_intel_thread
++LAPACK_LDFLAGS= -lmkl_intel_lp64 -lmkl_core -lmkl_intel_thread -liomp5 -lpthread -lm -ldl
+ 
+ # DO NOT DELETE
+

--- a/T/TempestModel/bundled/patches/mk_system_macosx.patch
+++ b/T/TempestModel/bundled/patches/mk_system_macosx.patch
@@ -1,0 +1,29 @@
+diff --git a/mk/system/macosx.make b/mk/system/macosx.make
+index a36cc9e..8d4ca1f 100644
+--- a/mk/system/macosx.make
++++ b/mk/system/macosx.make
+@@ -8,7 +8,7 @@
+ 
+ CXX=               clang
+ F90=               gfortran
+-MPICXX=            mpicxx
++MPICXX=            mpic++
+ MPIF90=            mpif90
+ 
+ F90_RUNTIME=       -L/usr/local/lib -lgfortran
+@@ -27,10 +27,11 @@ PETSC_CXXFLAGS=    -I$(PETSC_ROOT)/include
+ PETSC_LIBRARIES=   -lpetsc -lX11
+ PETSC_LDFLAGS=     -L$(PETSC_ROOT)/lib -L$(X11_ROOT)/lib
+ 
+-# LAPACK (Mac OS X Accelerate Framework)
+-LAPACK_INTERFACE=  FORTRAN
++# LAPACK (Mac OS X use MKL as well)
++LAPACK_INTERFACE= FORTRAN
+ LAPACK_CXXFLAGS=
+-LAPACK_LIBRARIES=  
+-LAPACK_LDFLAGS=    -framework accelerate
++LAPACK_LIBRARIES= -lmkl_intel_lp64 -lmkl_core -lmkl_intel_thread
++LAPACK_LDFLAGS= -lmkl_intel_lp64 -lmkl_core -lmkl_intel_thread -liomp5 -lpthread -lm -ldl
++
+ 
+ # DO NOT DELETE

--- a/T/TempestModel/bundled/patches/netcdf_cpp.patch
+++ b/T/TempestModel/bundled/patches/netcdf_cpp.patch
@@ -1,0 +1,12 @@
+diff --git a/src/base/netcdf.cpp b/src/base/netcdf.cpp
+index 3467d27..a4b7518 100644
+--- a/src/base/netcdf.cpp
++++ b/src/base/netcdf.cpp
+@@ -7,7 +7,6 @@
+  *   $Header: /upc/share/CVS/netcdf-3/cxx/netcdf.cpp,v 1.18 2009/03/10 15:20:54 russ Exp $
+  *********************************************************************/
+
+-#include "config.h"
+ #include <string.h>
+ #include <stdlib.h>
+ #include <iostream>


### PR DESCRIPTION
tempestmodel is an atomospheric dycore implementation.  this build will help in making it easier for the CliMA team to run comparative simulations on well defined test cases.