### PR TITLE
DuckDB:Support for Parquet extension

### DIFF
--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "DuckDB"
-version = v"0.3.1"
+version = v"0.3.1.1"
 
 # Collection of sources required to complete build
 sources = [
@@ -18,6 +18,7 @@ mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DBUILD_PARQUET_EXTENSION=TRUE \
       -DCMAKE_BUILD_TYPE=Release -DDISABLE_UNITY=TRUE \
       -DENABLE_SANITIZER=FALSE -DBUILD_UNITTESTS=FALSE ..
 make -j${nproc}


### PR DESCRIPTION
DuckDB's source package includes extensions. And the default setting in `Makefile` is nowadays  
`-DBUILD_PARQUET_EXTENSION=TRUE`. 