### PR TITLE
[FINUFFT] Microarchitecture expansion

### DIFF
--- a/F/finufft/build_tarballs.jl
+++ b/F/finufft/build_tarballs.jl
@@ -1,6 +1,7 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
+using BinaryBuilderBase
 
 name = "finufft"
 version = v"2.0.3"
@@ -23,6 +24,11 @@ mv lib/libfinufft.so "${libdir}/libfinufft.${dlext}"
 # platforms are passed in on the command line
 platforms = supported_platforms()
 
+# Expand for microarchitectures (library doesn't have CPU dispatching)
+platforms = expand_microarchitectures(platforms)
+
+# Tests on Linux/x86_64 yielded a slower binary with avx512 for some reason, so disable
+platforms = filter(p -> p.tags["march"] != "avx512", platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/F/finufft/build_tarballs.jl
+++ b/F/finufft/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder, Pkg
 using BinaryBuilderBase
 
 name = "finufft"
-version = v"2.0.3"
+version = v"2.0.4"
 julia_compat = "1.6"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/flatironinstitute/finufft/archive/v$(version).zip", "bf5b762a1899b57982b4db851fe472784700da389eabd5de6c7bc17240340f1f")
+    ArchiveSource("https://github.com/flatironinstitute/finufft/archive/v$(version).zip", "2434f694b4fbdbeb65c77f65d784a1712852130b9c61e15999555a2e2cf1a9fa")
 ]
 
 # Bash recipe for building across all platforms

--- a/F/finufft/build_tarballs.jl
+++ b/F/finufft/build_tarballs.jl
@@ -5,6 +5,7 @@ using BinaryBuilderBase
 
 name = "finufft"
 version = v"2.0.3"
+julia_compat = "1.6"
 
 # Collection of sources required to complete build
 sources = [
@@ -42,4 +43,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8", julia_compat=julia_compat)


### PR DESCRIPTION
The FINUFFT library doesn't have CPU instruction set dispatch, but benefits a lot from optimization with SIMD instructions, so compiling it for different microarchitectures seems like a good idea.