### PR TITLE
add spectra

### DIFF
--- a/S/spectra/build_tarballs.jl
+++ b/S/spectra/build_tarballs.jl
@@ -1,0 +1,41 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "spectra"
+version = v"1.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/yixuan/spectra/archive/refs/tags/v$(version).tar.gz", "45228b7d77b916b5384245eb13aa24bc994f3b0375013a8ba6b85adfd2dafd67")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/spectra-*
+mkdir build && cd build/
+
+cmake .. \
+-DCMAKE_INSTALL_PREFIX=$prefix \
+-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+-DCMAKE_BUILD_TYPE=Release
+
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [AnyPlatform()]
+
+# The products that we will ensure are always built
+#header only, so no products
+products = Product[]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    BuildDependency(PackageSpec(name="Eigen_jll", uuid="bc6bbf8a-a594-5541-9c57-10b0d0312c70"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
This PR adds a `build_tarballs.jl` for the [spectra](https://github.com/yixuan/spectra) library. This is another header only library. I believe I remembered to use the correct dependency type this time around.