### PR TITLE
[oneTBB] bump version and try adding mingw platforms back in

### DIFF
--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -7,8 +7,7 @@ version = v"2021.5.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/oneapi-src/oneTBB.git",
-              "ec39c5463d5fbfe01150bcd8cbfe60b5e064d693"),
+    ArchiveSource("https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.5.0.tar.gz", "e5b57537c741400cf6134b428fc1689a649d7d38d9bb9c1b6d64f092ea28178a"),
     DirectorySource("./bundled"),
 ]
 
@@ -17,9 +16,13 @@ script = raw"""
 cd $WORKSPACE/srcdir/oneTBB/
 
 if [[ ${target} == *-linux-musl* ]]; then
-# Adapt patch from
-# https://github.com/oneapi-src/oneTBB/pull/203
-atomic_patch -p1 ../patches/musl.patch
+    # Adapt patch from https://github.com/oneapi-src/oneTBB/pull/203
+    atomic_patch -p1 ../patches/musl.patch
+
+elif [[ ${target} == *-mingw* ]]; then
+    #derived from https://github.com/oneapi-src/oneTBB/commit/ce476173772f289c66ba98089618c1ff767ecea4, can hopefully be removed next release
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/lowercase-windows-include.patch
+    atomic_patch -p1 ${WORKSPACE}/srcdir/patches/NOMINMAX-defines.patch
 fi
 
 mkdir build && cd build/

--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "oneTBB"
-version = v"2021.4.1"
+version = v"2021.5.0"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/oneapi-src/oneTBB.git",
-              "b7a062e2d965cbdee01542a09d90cff49ac02e08"),
+              "ec39c5463d5fbfe01150bcd8cbfe60b5e064d693"),
     DirectorySource("./bundled"),
 ]
 
@@ -38,10 +38,6 @@ platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
 # Disable platforms unlikely to work
 filter!(p -> arch(p) ∉ ("armv6l", "armv7l"), platforms)
 
-# Windows with MinGW at the moment doesn't work, but it may change in the near
-# future, watch out <https://github.com/oneapi-src/oneTBB/pull/351>. See also
-# <https://stackoverflow.com/q/67572880/2442087>.
-filter!(!Sys.iswindows, platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -16,9 +16,11 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/oneTBB/
 
+if [[ ${target} == *-linux-musl* ]]; then
 # Adapt patch from
 # https://github.com/oneapi-src/oneTBB/pull/203
 atomic_patch -p1 ../patches/musl.patch
+fi
 
 mkdir build && cd build/
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/oneTBB/
+cd $WORKSPACE/srcdir/oneTBB*
 
 if [[ ${target} == *-linux-musl* ]]; then
     # Adapt patch from https://github.com/oneapi-src/oneTBB/pull/203

--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -50,7 +50,7 @@ filter!(p -> arch(p) ∉ ("armv6l", "armv7l"), platforms)
 products = [
     LibraryProduct("libtbbmalloc", :libtbbmalloc),
     LibraryProduct("libtbbmalloc_proxy", :libtbbmalloc_proxy),
-    LibraryProduct("libtbb", :libtbb),
+    LibraryProduct(["libtbb", "libtbb12"], :libtbb),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -49,6 +49,9 @@ platforms = expand_cxxstring_abis(supported_platforms())
 # Disable platforms unlikely to work
 filter!(p -> arch(p) ∉ ("armv6l", "armv7l"), platforms)
 
+#i686 mingw fails with errors about _control87
+filter!(p -> !Sys.iswindows(p) && arch(p) != "i686", platforms)
+
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libtbbmalloc", :libtbbmalloc),

--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -23,6 +23,9 @@ elif [[ ${target} == *-mingw* ]]; then
     #derived from https://github.com/oneapi-src/oneTBB/commit/ce476173772f289c66ba98089618c1ff767ecea4, can hopefully be removed next release
     atomic_patch -p1 ${WORKSPACE}/srcdir/patches/lowercase-windows-include.patch
     atomic_patch -p1 ${WORKSPACE}/srcdir/patches/NOMINMAX-defines.patch
+    # `CreateSemaphoreEx` requires at least Windows Vista/Server 2008:
+    # https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsemaphoreexa
+    export CXXFLAGS="-D_WIN32_WINNT=0x0600"
 fi
 
 mkdir build && cd build/
@@ -38,11 +41,10 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # Disable platforms unlikely to work
 filter!(p -> arch(p) ∉ ("armv6l", "armv7l"), platforms)
-
 
 # The products that we will ensure are always built
 products = [

--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -58,4 +58,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")

--- a/O/oneTBB/build_tarballs.jl
+++ b/O/oneTBB/build_tarballs.jl
@@ -15,6 +15,9 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/oneTBB*
 
+# We can't do Link-Time-Optimization with Clang, disable it.
+atomic_patch -p1 ../patches/clang-no-lto.patch
+
 if [[ ${target} == *-linux-musl* ]]; then
     # Adapt patch from https://github.com/oneapi-src/oneTBB/pull/203
     atomic_patch -p1 ../patches/musl.patch

--- a/O/oneTBB/bundled/patches/NOMINMAX-defines.patch
+++ b/O/oneTBB/bundled/patches/NOMINMAX-defines.patch
@@ -1,0 +1,14 @@
+diff --git a/include/oneapi/tbb/detail/_machine.h b/include/oneapi/tbb/detail/_machine.h
+index 8d67289..510c539 100644
+--- a/include/oneapi/tbb/detail/_machine.h
++++ b/include/oneapi/tbb/detail/_machine.h
+@@ -26,7 +26,9 @@
+ #include <intrin.h>
+ #ifdef __TBBMALLOC_BUILD
+ #define WIN32_LEAN_AND_MEAN
++#ifndef NOMINMAX
+ #define NOMINMAX
++#endif
+ #include <windows.h> // SwitchToThread()
+ #endif
+ #ifdef _MSC_VER

--- a/O/oneTBB/bundled/patches/clang-no-lto.patch
+++ b/O/oneTBB/bundled/patches/clang-no-lto.patch
@@ -1,0 +1,15 @@
+--- a/cmake/compilers/Clang.cmake
++++ b/cmake/compilers/Clang.cmake
+@@ -58,12 +58,6 @@
+     list(APPEND TBB_COMMON_COMPILE_FLAGS -U__STRICT_ANSI__)
+ endif()
+ 
+-# Enabling LTO on Android causes the NDK bug.
+-# NDK throws the warning: "argument unused during compilation: '-Wa,--noexecstack'"
+-if (NOT ANDROID_PLATFORM AND BUILD_SHARED_LIBS)
+-    set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
+-    set(TBB_IPO_LINK_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
+-endif()
+ 
+ # TBB malloc settings
+ set(TBBMALLOC_LIB_COMPILE_FLAGS -fno-rtti -fno-exceptions)

--- a/O/oneTBB/bundled/patches/lowercase-windows-include.patch
+++ b/O/oneTBB/bundled/patches/lowercase-windows-include.patch
@@ -1,0 +1,27 @@
+diff --git a/src/tbb/allocator.cpp b/src/tbb/allocator.cpp
+index bb7dc99..e610ade 100644
+--- a/src/tbb/allocator.cpp
++++ b/src/tbb/allocator.cpp
+@@ -25,7 +25,7 @@
+ #include <cstdlib>
+ 
+ #if _WIN32 || _WIN64
+-#include <Windows.h>
++#include <windows.h>
+ #else
+ #include <dlfcn.h>
+ #endif /* _WIN32||_WIN64 */
+
+diff --git a/src/tbb/dynamic_link.h b/src/tbb/dynamic_link.h
+index a41493e..f2499da 100644
+--- a/src/tbb/dynamic_link.h
++++ b/src/tbb/dynamic_link.h
+@@ -27,7 +27,7 @@
+ 
+ #include <cstddef>
+ #if _WIN32
+-#include <Windows.h>
++#include <windows.h>
+ #endif /* _WIN32 */
+ 
+ namespace tbb {


### PR DESCRIPTION
This PR bumps the commit hash to current master and bumps the version number up to the most recent release for `oneTBB`.
I am also removing the windows platform filter. The commit referenced about the export attributes has been merged. In addition, I am using the most current master instead of the release archive to include a [commit with mingw specific fixes](https://github.com/oneapi-src/oneTBB/commit/ce476173772f289c66ba98089618c1ff767ecea4) that didn't make it in to the release.