### PR TITLE
[Antlr4CppRuntime] Update gcc version.

### DIFF
--- a/A/Antlr4CppRuntime/build_tarballs.jl
+++ b/A/Antlr4CppRuntime/build_tarballs.jl
@@ -41,4 +41,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7")


### PR DESCRIPTION
g++-6 on linux was causing issues downstream when linking with ANTLR driver code compiled with later versions. Verified locally that the issue goes away with g++-7.