### PR TITLE
[libblastrampoline] Fix julia compat to v1.8

### DIFF
--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -34,7 +34,7 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6",
+               julia_compat="1.8",
                init_block = """
                @static if VERSION < v"1.7.0-DEV.641"
                        ccall((:lbt_forward, libblastrampoline), Int32, (Cstring, Int32, Int32, Ptr{Cvoid}),

--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -35,10 +35,4 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.8",
-               init_block = """
-               @static if VERSION < v"1.7.0-DEV.641"
-                       ccall((:lbt_forward, libblastrampoline), Int32, (Cstring, Int32, Int32, Ptr{Cvoid}),
-                             Libdl.dlpath(Base.libblas_name), 1, 0, C_NULL)
-                   end
-               """
 )


### PR DESCRIPTION
Version 4 of libblastrampoline breaks the ABI compared to v3, and it's used only in julia v1.8: https://github.com/JuliaLang/julia/pull/43877.  We should reflect these constraints in the registry.

CC @staticfloat 