### PR TITLE
[AZP] Temporarily force use of `us-east` PkgServer

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ variables:
     JULIA: unbuffer julia --project=$(Build.SourcesDirectory)/.ci --color=yes
     # We limit our parallelism somewhat in order to avoid strange OOM errors while building LLVM
     BINARYBUILDER_NPROC: 16
+    JULIA_PKG_SERVER: us-east.pkg.julialang.org
 
 jobs:
 - job: generator

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,8 @@ jobs:
       $(JULIA) --compile=min -O0 -e 'using InteractiveUtils, Pkg, Downloads, Dates
           versioninfo()
           if !isnothing(Pkg.pkg_server())
-              try
-                  resp = Downloads.request("$(Pkg.pkg_server())/registries")
+              resp = try
+                  Downloads.request("$(Pkg.pkg_server())/registries")
               catch e
                   # Let us know the download of the registry went wrong, but do not hard fail
                   @error "Could not download the registry" exception=(e, catch_backtrace())


### PR DESCRIPTION
There is currently an outage of the PkgServer used by Yggdrasil, redirecting to
a working PkgServer should avoid issues.