### PR TITLE
Restore the hard fail if the registry download fails

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,13 +49,7 @@ jobs:
       $(JULIA) --compile=min -O0 -e 'using InteractiveUtils, Pkg, Downloads, Dates
           versioninfo()
           if !isnothing(Pkg.pkg_server())
-              resp = try
-                  Downloads.request("$(Pkg.pkg_server())/registries")
-              catch e
-                  # Let us know the download of the registry went wrong, but do not hard fail
-                  @error "Could not download the registry" exception=(e, catch_backtrace())
-                  exit(0)
-              end
+              resp = Downloads.request("$(Pkg.pkg_server())/registries")
               last_mod_idx = findfirst(h -> first(h) == "last-modified", resp.headers)
               msg = "PkgServer: " * resp.url
               delay = if !isnothing(last_mod_idx)


### PR DESCRIPTION
This undoes the changes of https://github.com/JuliaPackaging/Yggdrasil/pull/4304

I think having this hard fail is good. It lets us immediately notice when something is wrong; in this case, it quickly notified us that the CSAIL Pkg server was down. So I'd like to restore the hard fail. When e.g. the CSAIL Pkg server has downtime, I'd prefer that we keep the hard fail and just temporarily use a different Pkg server, as in https://github.com/JuliaPackaging/Yggdrasil/pull/4305