### PR TITLE
libjulia_jll: turn LibOSXUnwind_jll into a build dep for Julia 1.6

### DIFF
--- a/L/libjulia/build_tarballs.jl
+++ b/L/libjulia/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("common.jl")
-jllversion=v"1.7.0"
+jllversion=v"1.7.1"
 build_julia(ARGS, v"1.6.3"; jllversion)
 build_julia(ARGS, v"1.7.0"; jllversion)
 build_julia(ARGS, v"1.8.0-DEV"; jllversion)

--- a/L/libjulia/bundled/libunwind-julia-1.6.patch
+++ b/L/libjulia/bundled/libunwind-julia-1.6.patch
@@ -1,0 +1,65 @@
+diff --git a/src/julia_internal.h b/src/julia_internal.h
+index 0b76696791..f6bd2f1f3f 100644
+--- a/src/julia_internal.h
++++ b/src/julia_internal.h
+@@ -893,48 +893,7 @@ typedef struct {
+ 
+ // Might be called from unmanaged thread
+ uint64_t jl_getUnwindInfo(uint64_t dwBase);
+-#ifdef _OS_WINDOWS_
+-#include <dbghelp.h>
+-JL_DLLEXPORT EXCEPTION_DISPOSITION __julia_personality(
+-        PEXCEPTION_RECORD ExceptionRecord, void *EstablisherFrame, PCONTEXT ContextRecord, void *DispatcherContext);
+-extern HANDLE hMainThread;
+-typedef CONTEXT bt_context_t;
+-#if defined(_CPU_X86_64_)
+-typedef CONTEXT bt_cursor_t;
+-#else
+-typedef struct {
+-    STACKFRAME64 stackframe;
+-    CONTEXT context;
+-} bt_cursor_t;
+-#endif
+-extern jl_mutex_t jl_in_stackwalk;
+-#elif !defined(JL_DISABLE_LIBUNWIND)
+-// This gives unwind only local unwinding options ==> faster code
+-#  define UNW_LOCAL_ONLY
+-#  include <libunwind.h>
+-typedef unw_context_t bt_context_t;
+-typedef unw_cursor_t bt_cursor_t;
+-#  if (!defined(SYSTEM_LIBUNWIND) || UNW_VERSION_MAJOR > 1 ||   \
+-       (UNW_VERSION_MAJOR == 1 && UNW_VERSION_MINOR != 0 && UNW_VERSION_MINOR != 1))
+-// Enable our memory manager only for libunwind with our patch or
+-// on a newer release
+-#    define JL_UNW_HAS_FORMAT_IP 1
+-#  endif
+-#else
+-// Unwinding is disabled
+-typedef int bt_context_t;
+-typedef int bt_cursor_t;
+-#endif
+-size_t rec_backtrace(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTSAFEPOINT;
+-// Record backtrace from a signal handler. `ctx` is the context of the code
+-// which was asynchronously interrupted.
+-size_t rec_backtrace_ctx(jl_bt_element_t *bt_data, size_t maxsize, bt_context_t *ctx,
+-                         jl_gcframe_t *pgcstack) JL_NOTSAFEPOINT;
+-#ifdef LIBOSXUNWIND
+-size_t rec_backtrace_ctx_dwarf(jl_bt_element_t *bt_data, size_t maxsize, bt_context_t *ctx, jl_gcframe_t *pgcstack) JL_NOTSAFEPOINT;
+-#endif
+ JL_DLLEXPORT jl_value_t *jl_get_backtrace(void);
+-void jl_critical_error(int sig, bt_context_t *context);
+ JL_DLLEXPORT void jl_raise_debugger(void);
+ int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline) JL_NOTSAFEPOINT;
+ JL_DLLEXPORT void jl_gdblookup(void* ip) JL_NOTSAFEPOINT;
+diff --git a/src/julia_threads.h b/src/julia_threads.h
+index f42984130f..8a8411f822 100644
+--- a/src/julia_threads.h
++++ b/src/julia_threads.h
+@@ -67,7 +67,6 @@ typedef struct {
+ #endif
+ #if defined(JL_HAVE_UCONTEXT) || defined(JL_HAVE_UNW_CONTEXT)
+ #define UNW_LOCAL_ONLY
+-#include <libunwind.h>
+ typedef struct {
+     ucontext_t ctx;
+ #if defined(JL_TSAN_ENABLED)

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -318,13 +318,13 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
     end
 
     if version < v"1.6"
-        push!(dependencies, BuildDependency(PackageSpec(name="SuiteSparse_jll", version="5.4.0")))
+        push!(dependencies, BuildDependency(PackageSpec(name="SuiteSparse_jll", version=v"5.4.0")))
     else
         push!(dependencies, BuildDependency("SuiteSparse_jll"))
     end
 
     if version < v"1.7"
-        push!(dependencies, BuildDependency(PackageSpec(name="PCRE2_jll", version="10")))
+        push!(dependencies, BuildDependency(PackageSpec(name="PCRE2_jll", version=v"10")))
     #else
     #    push!(dependencies, BuildDependency("PCRE2_jll", compat="10.36"))
     end
@@ -339,13 +339,13 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         push!(dependencies, Dependency("libLLVM_jll", compat="8.0.1"))
         push!(dependencies, BuildDependency("LibGit2_jll", compat="0.28.2"))
     elseif version.major == 1 && version.minor == 5
-        push!(dependencies, BuildDependency(PackageSpec(name="OpenBLAS_jll", version="0.3.9")))
+        push!(dependencies, BuildDependency(PackageSpec(name="OpenBLAS_jll", version=v"0.3.9")))
         push!(dependencies, Dependency("libLLVM_jll", compat="9.0.1"))
-        push!(dependencies, BuildDependency(PackageSpec(name="LibGit2_jll", version="0.28.2")))
+        push!(dependencies, BuildDependency(PackageSpec(name="LibGit2_jll", version=v"0.28.2")))
     elseif version.major == 1 && version.minor == 6
-        push!(dependencies, BuildDependency(PackageSpec(name="OpenBLAS_jll", version="0.3.10")))
+        push!(dependencies, BuildDependency(PackageSpec(name="OpenBLAS_jll", version=v"0.3.10")))
         push!(dependencies, Dependency("libLLVM_jll", compat="11.0.1"))
-        push!(dependencies, BuildDependency(PackageSpec(name="LibGit2_jll", version="1.2")))
+        push!(dependencies, BuildDependency(PackageSpec(name="LibGit2_jll", version=v"1.2")))
     elseif version.major == 1 && version.minor == 7
         #push!(dependencies, BuildDependency("OpenBLAS_jll", compat="0.3.13"))
         #push!(dependencies, Dependency("libLLVM_jll", compat="12.0.0"))

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -12,21 +12,14 @@ function libjulia_platforms(julia_version)
     #    libunwind.so.8: undefined reference to `setcontext'
     filter!(p -> !(Sys.islinux(p) && libc(p) == "musl" && arch(p) == "i686"), platforms)
 
-    # in Julia <= 1.3 skip PowerPC builds (see https://github.com/JuliaPackaging/Yggdrasil/pull/1795)
-    if julia_version < v"1.4"
-        filter!(p -> !(Sys.islinux(p) && arch(p) == "powerpc64le"), platforms)
-    end
-
     if julia_version < v"1.7"
         # In Julia <= 1.6, skip macOS on ARM and Linux on armv6l
         filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
         filter!(p -> arch(p) != "armv6l", platforms)
     end
 
-    if julia_version >= v"1.6"
-        for p in platforms
-            p["julia_version"] = string(julia_version)
-        end
+    for p in platforms
+        p["julia_version"] = string(julia_version)
     end
 
     # While the "official" Julia kernel ABI itself does not involve any C++
@@ -45,10 +38,6 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
     name = "libjulia"
 
     checksums = Dict(
-        v"1.3.1" => "3d9037d281fb41ad67b443f42d8a8e400b016068d142d6fafce1952253ae93db",
-        v"1.4.2" => "76a94e06e68fb99822e0876a37c2ed3873e9061e895ab826fd8c9fc7e2f52795",
-        v"1.5.3" => "be19630383047783d6f314ebe0bf5e3f95f82b0c203606ec636dced405aab1fe",
-        v"1.5.4" => "852122bf1bdefd39307b1dd2aa546e3885d76ede7c07cb04d90814b9510ea9f9",
         v"1.6.3" => "2593def8cc9ef81663d1c6bfb8addc3f10502dd9a1d5a559728316a11dea2594",
         v"1.7.0" => "8e870dbef71bc72469933317a1a18214fd1b4b12f1080784af7b2c56177efcb4",
     )
@@ -147,13 +136,7 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
     elif [[ "${target}" == *apple* ]]; then
         LLVMLINK="-L${prefix}/lib -lLLVM"
     else
-        if [[ "${version}" == 1.3.* ]]; then
-            LLVMLINK="-L${prefix}/lib -lLLVM-6.0"
-        elif [[ "${version}" == 1.4.* ]]; then
-            LLVMLINK="-L${prefix}/lib -lLLVM-8jl"
-        elif [[ "${version}" == 1.5.* ]]; then
-            LLVMLINK="-L${prefix}/lib -lLLVM-9jl"
-        elif [[ "${version}" == 1.6.* ]]; then
+        if [[ "${version}" == 1.6.* ]]; then
             LLVMLINK="-L${prefix}/lib -lLLVM-11jl"
         elif [[ "${version}" == 1.7.* ]]; then
             LLVMLINK="-L${prefix}/lib -lLLVM-12jl"
@@ -167,12 +150,9 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
 
     # enable extglob for BB_TRIPLET_LIBGFORTRAN_CXXABI
     shopt -s extglob
-    if [[ "${version}" == 1.[0-5].* ]]; then
-        BB_TRIPLET_LIBGFORTRAN_CXXABI=${bb_full_target/-julia_version+([^-])}
-    else
-        # Strip the OS version from Darwin and FreeBSD
-        BB_TRIPLET_LIBGFORTRAN_CXXABI=$(echo ${bb_full_target/-julia_version+([^-])} | sed 's/\(darwin\|freebsd\)[0-9.]*/\1/')
-    fi
+
+    # Strip the OS version from Darwin and FreeBSD
+    BB_TRIPLET_LIBGFORTRAN_CXXABI=$(echo ${bb_full_target/-julia_version+([^-])} | sed 's/\(darwin\|freebsd\)[0-9.]*/\1/')
 
     cat << EOM >Make.user
     USE_SYSTEM_LLVM=1
@@ -233,10 +213,6 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         LIBLAPACKNAME=libopenblas
     EOM
     elif [[ "${version}" == 1.[0-6].* ]]; then
-        if [[ "${version}" == 1.[0-4].* ]]; then
-            # remove broken dylib placeholder to force static linking
-            rm -f ${prefix}/lib/libosxunwind.dylib
-        fi
         cat << EOM >>Make.user
         USECLANG=1
 
@@ -268,9 +244,6 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
     # So we include a private copy of libopenlibm
     mkdir -p usr/lib
     cp ${prefix}/*/libopenlibm.a usr/lib/
-
-    # Mac build complains about checksum
-    rm -rf /workspace/srcdir/julia-1.5.1/deps/checksums/lapack-3.9.0.tgz
 
     # choose make targets which compile libjulia but don't try to build a sysimage
     if [[ "${version}" == 1.[0-5].* ]]; then
@@ -334,55 +307,20 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         BuildDependency("MPFR_jll"),
         BuildDependency("GMP_jll"),
         BuildDependency("Objconv_jll"),
+        BuildDependency("SuiteSparse_jll"),
     ]
-    if version < v"1.5.1"
-        push!(dependencies, Dependency("LibOSXUnwind_jll", compat="0.0.5"))
-    elseif version < v"1.6"
-        push!(dependencies, BuildDependency(PackageSpec(; name="LibOSXUnwind_jll", version=v"0.0.6")))
-    end
 
-    if version < v"1.6"
-        push!(dependencies, BuildDependency(PackageSpec(name="SuiteSparse_jll", version=v"5.4.0")))
-    else
-        push!(dependencies, BuildDependency("SuiteSparse_jll"))
-    end
-
-    #if version < v"1.7"
-    #    push!(dependencies, BuildDependency(PackageSpec(name="PCRE2_jll", version=v"10")))
-    #else
-    #    push!(dependencies, BuildDependency("PCRE2_jll", compat="10.36"))
-    #end
-
-    if version.major == 1 && version.minor == 3
-        push!(dependencies, BuildDependency("OpenBLAS_jll", compat="0.3.5"))
-        # there is no libLLVM_jll 6.0.1, so we use LLVM_jll instead
-        push!(dependencies, Dependency("LLVM_jll", compat="6.0.1"))
-        push!(dependencies, BuildDependency("LibGit2_jll", compat="0.28.2"))
-    elseif version.major == 1 && version.minor == 4
-        push!(dependencies, BuildDependency("OpenBLAS_jll", compat="0.3.5"))
-        push!(dependencies, Dependency("libLLVM_jll", compat="8.0.1"))
-        push!(dependencies, BuildDependency("LibGit2_jll", compat="0.28.2"))
-    elseif version.major == 1 && version.minor == 5
-        push!(dependencies, BuildDependency(PackageSpec(name="OpenBLAS_jll", version=v"0.3.9")))
-        push!(dependencies, Dependency("libLLVM_jll", compat="9.0.1"))
-        push!(dependencies, BuildDependency(PackageSpec(name="LibGit2_jll", version=v"0.28.2")))
-    elseif version.major == 1 && version.minor == 6
-        push!(dependencies, BuildDependency(get_addable_spec("OpenBLAS_jll", v"0.3.10+10")))
+    # HACK: we can't install LLVM 12 JLLs for Julia 1.7 from within Julia 1.6. Similar
+    # for several other standard JLLs.
+    # So we use get_addable_spec below to "fake it" for now.
+    # This means the resulting package has fewer dependencies declared, but at least it
+    # will work and allow people to build JLL binaries ready for Julia 1.7
+    if version.major == 1 && version.minor == 6
         push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"11.0.1+3")))
+        push!(dependencies, BuildDependency(get_addable_spec("OpenBLAS_jll", v"0.3.10+10")))
         push!(dependencies, BuildDependency(get_addable_spec("LibGit2_jll", v"1.2.3+0")))
     elseif version.major == 1 && version.minor == 7
-        #push!(dependencies, BuildDependency("OpenBLAS_jll", compat="0.3.13"))
-        #push!(dependencies, Dependency("libLLVM_jll", compat="12.0.0"))
-        #push!(dependencies, BuildDependency("LibGit2_jll", compat="1.0.1"))
-
-        # HACK: we can't install LLVM 12 JLLs for Julia 1.7 from within Julia 1.6. Similar
-        # for several other standard JLLs.
-        # So we use get_addable_spec below to "fake it" for now.
-        # This means the resulting package has fewer dependencies declared, but at least it
-        # will work and allow people to build JLL binaries ready for Julia 1.7
         push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"12.0.1+3")))
-
-        # starting with Julia 1.7, we need LLVMLibUnwind_jll
         push!(dependencies, BuildDependency(get_addable_spec("LLVMLibUnwind_jll", v"11.0.1+1")))
     elseif version.major == 1 && version.minor == 8
         push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"12.0.1+4")))

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -57,7 +57,7 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
 
     if version == v"1.8.0-DEV"
         sources = [
-            GitSource("https://github.com/JuliaLang/julia", "00646634c6a73998eaae3785eb78fea881c39502"),
+            GitSource("https://github.com/JuliaLang/julia.git", "00646634c6a73998eaae3785eb78fea881c39502"),
             DirectorySource("./bundled"),
         ]
     else


### PR DESCRIPTION
This is experimental. I still need to verify that the result can
be used to build other JLLs using `libjulia_jll`. But I thought
it'd be good to already collect feedback here.


[skip ci] [skip build]﻿