### PR TITLE
After building rr, run the rr test suite

### DIFF
--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -19,8 +19,13 @@ cd ${WORKSPACE}/srcdir/rr/
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-      -Ddisable32bit=ON -DBUILD_TESTS=OFF -DWILL_RUN_TESTS=OFF -Dstaticlibs=ON ..
+      -Ddisable32bit=ON -DBUILD_TESTS=ON -DWILL_RUN_TESTS=ON -Dstaticlibs=ON ..
 make -j${nproc}
+
+# WIP
+# Run the rr test suite
+ctest --output-on-failure -j${nproc}
+
 make install
 """
 


### PR DESCRIPTION
I think that we should run the rr test suite as part of the Ygg build.

The motivation here is that recently, Base Julia CI broke because of an update to the Ygg rr. By running the tests here, we can catch those breakages early, instead of waiting until it hits Base CI.