### PR TITLE
Update P4est to v2.8 and enable MPI support

### DIFF
--- a/P/P4est/build_tarballs.jl
+++ b/P/P4est/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "P4est"
-version = v"2.3.2"
+version = v"2.8"
 
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://p4est.github.io/release/p4est-2.3.2.tar.gz", "076df9e5578e0e7fcfbe12e1a0b080104001f8c986ab1d5a69ec2220050df8e6"),
+    ArchiveSource("https://p4est.github.io/release/p4est-2.8.tar.gz", "6a0586e3abac06c20e31b1018f3a82a564a6a0d9ff6b7f6c772a9e6b0f0cc5e4"),
 ]
 
 # Bash recipe for building across all platforms
@@ -34,15 +34,24 @@ FLAGS=()
 if [[ "${target}" == *-mingw* ]]; then
   # Set linker flags only at build time (see https://docs.binarybuilder.org/v0.3/troubleshooting/#Windows)
   FLAGS+=(LDFLAGS="$LDFLAGS -no-undefined")
-
-  # Add manual definitions to fix missing `htonl` according to `INSTALL_WINDOWS` file
-  # (see https://github.com/cburstedde/p4est/blob/master/INSTALL_WINDOWS)
-  sed -i "1s/^/#define htonl(_val) ( ((uint16_t)(_val) \& 0xff00) >> 8 | ((uint16_t)(_val) \& 0xff) << 8 )\n/" src/p4est_algorithms.c src/p8est_algorithms.c src/p6est.c src/p4est_ghost.c
+  # Configure does not find the correct Fortran compiler
+  export F77="f77"
+  # Link against ws2_32 to use the htonl function from winsock2.h
+  export LIBS="-lmsmpi -lws2_32"
+  # Disable MPI I/O on Windows since it causes p4est to crash
+  mpiopts="--enable-mpi --disable-mpiio"
+  # Linker looks for libmsmpi instead of msmpi, copy existing symlink
+  cp -d ${libdir}/msmpi.dll ${libdir}/libmsmpi.dll
+else
+  # Use MPI including MPI I/O on all other platforms
+  export CC="mpicc"
+  export CXX="mpic++"
+  mpiopts="--enable-mpi"
 fi
 
 # Configure, build, install
 # Note: BLAS is disabled since it is only needed for SC if it is used outside of p4est
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static --without-blas
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static --without-blas ${mpiopts}
 make -j${nproc} "${FLAGS[@]}"
 make install
 """
@@ -50,7 +59,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms(; experimental=true)
-
+# p4est with MPI enabled does not compile for 32 bit Windows
+platforms = filter(p -> !(Sys.iswindows(p) && nbits(p) == 32), platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -60,7 +70,9 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
+    Dependency(PackageSpec(name="MPICH_jll", uuid="7cb0a576-ebde-5e09-9194-50597f1243b4"); platforms=filter(!Sys.iswindows, platforms)),
+    Dependency(PackageSpec(name="MicrosoftMPI_jll", uuid="9237b28f-5490-5468-be7b-bb81f5f5e6cf"); platforms=filter(Sys.iswindows, platforms))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
* Use p4est v2.8 which is the current stable release
* Compile p4est with MPI support (against MicrosoftMPI_jll on Windows and MPICH_jll on all other platforms)
* Compilation with MPI enabled fails for 32 bit Windows, hence that platform is no longer supported

cc @sloede 