### PR TITLE
[Tar] Build without `acl_jll`

### DIFF
--- a/T/Tar/build_tarballs.jl
+++ b/T/Tar/build_tarballs.jl
@@ -32,7 +32,6 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("acl_jll"),
     Dependency("Attr_jll"),
 ]
 


### PR DESCRIPTION
The use of `acl_jll` caused a lot of troubles in https://github.com/staticfloat/Sandbox.jl/pull/51, revert it.