### PR TITLE
[Tar] Add MinGW patches for Windows

### DIFF
--- a/T/Tar/build_tarballs.jl
+++ b/T/Tar/build_tarballs.jl
@@ -19,8 +19,8 @@ cd $WORKSPACE/srcdir/tar-*/
 if [[ "${target}" == *-mingw* ]]; then
     # Apply patches for MinGW:
     # https://github.com/msys2/MSYS2-packages/tree/master/tar
-    atomic_patch -p1 ../patches/gnulib-weak-symbols.patch
-    atomic_patch -p1 ../patches/tar-1.33-msys2.patch
+    # atomic_patch -p1 ../patches/gnulib-weak-symbols.patch
+    # atomic_patch -p1 ../patches/tar-1.33-msys2.patch
     atomic_patch -p1 ../patches/tar-1.33-textmount.patch
     autoreconf -fv
 fi

--- a/T/Tar/build_tarballs.jl
+++ b/T/Tar/build_tarballs.jl
@@ -9,11 +9,22 @@ version = v"1.34"
 sources = [
     ArchiveSource("https://ftp.gnu.org/gnu/tar/tar-$(version.major).$(version.minor).tar.xz",
                   "63bebd26879c5e1eea4352f0d03c991f966aeb3ddeb3c7445c902568d5411d28"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/tar-*/
+
+if [[ "${target}" == *-mingw* ]]; then
+    # Apply patches for MinGW:
+    # https://github.com/msys2/MSYS2-packages/tree/master/tar
+    atomic_patch -p1 ../patches/gnulib-weak-symbols.patch
+    atomic_patch -p1 ../patches/tar-1.33-msys2.patch
+    atomic_patch -p1 ../patches/tar-1.33-textmount.patch
+    autoreconf -fv
+fi
+
 export FORCE_UNSAFE_CONFIGURE=1
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
@@ -21,9 +32,8 @@ make install
 """
 
 # These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line.  We are manually disabling
-# many platforms that do not seem to work.
-platforms = filter!(!Sys.iswindows, supported_platforms(; experimental=true))
+# platforms are passed in on the command line.
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
@@ -32,7 +42,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Attr_jll"),
+    Dependency("Attr_jll"; platforms=filter(Sys.islinux, platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/T/Tar/bundled/patches/gnulib-weak-symbols.patch
+++ b/T/Tar/bundled/patches/gnulib-weak-symbols.patch
@@ -1,0 +1,12 @@
+--- tar-1.34/m4/threadlib.m4.orig	2021-12-30 06:20:11.337213800 +0100
++++ tar-1.34/m4/threadlib.m4	2021-12-30 06:20:16.092888400 +0100
+@@ -101,6 +101,9 @@
+ #pragma weak fputs
+ int main ()
+ {
++#ifdef __CYGWIN__
++  return 1;
++#endif
+   return (fputs == NULL);
+ }]])],
+          [gl_cv_have_weak=yes],

--- a/T/Tar/bundled/patches/tar-1.33-msys2.patch
+++ b/T/Tar/bundled/patches/tar-1.33-msys2.patch
@@ -1,0 +1,262 @@
+diff -Naur tar-1.33-orig/build-aux/compile tar-1.33/build-aux/compile
+--- tar-1.33-orig/build-aux/compile	2021-01-07 17:25:19.000000000 +0300
++++ tar-1.33/build-aux/compile	2021-01-12 09:07:31.903196000 +0300
+@@ -53,7 +53,7 @@
+ 	  MINGW*)
+ 	    file_conv=mingw
+ 	    ;;
+-	  CYGWIN*)
++	  CYGWIN* | MSYS*)
+ 	    file_conv=cygwin
+ 	    ;;
+ 	  *)
+@@ -67,7 +67,7 @@
+ 	mingw/*)
+ 	  file=`cmd //C echo "$file " | sed -e 's/"\(.*\) " *$/\1/'`
+ 	  ;;
+-	cygwin/*)
++	cygwin/* | msys/*)
+ 	  file=`cygpath -m "$file" || echo "$file"`
+ 	  ;;
+ 	wine/*)
+diff -Naur tar-1.33-orig/build-aux/config.guess tar-1.33/build-aux/config.guess
+--- tar-1.33-orig/build-aux/config.guess	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/build-aux/config.guess	2021-01-12 09:07:31.906821100 +0300
+@@ -915,6 +915,9 @@
+     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
+ 	echo x86_64-pc-cygwin
+ 	exit ;;
++    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
++	echo x86_64-unknown-msys
++	exit ;;
+     prep*:SunOS:5.*:*)
+ 	echo powerpcle-unknown-solaris2"$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*//')"
+ 	exit ;;
+diff -Naur tar-1.33-orig/build-aux/config.rpath tar-1.33/build-aux/config.rpath
+--- tar-1.33-orig/build-aux/config.rpath	2021-01-07 17:29:12.000000000 +0300
++++ tar-1.33/build-aux/config.rpath	2021-01-12 09:07:31.910547300 +0300
+@@ -57,7 +57,7 @@
+     aix*)
+       wl='-Wl,'
+       ;;
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       ;;
+     hpux9* | hpux10* | hpux11*)
+       wl='-Wl,'
+@@ -149,7 +149,7 @@
+ hardcode_minus_L=no
+ 
+ case "$host_os" in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -198,7 +198,7 @@
+         ld_shlibs=no
+       fi
+       ;;
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+       # no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -348,7 +348,7 @@
+       ;;
+     bsdi[45]*)
+       ;;
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -533,7 +533,7 @@
+   bsdi[45]*)
+     library_names_spec='$libname$shrext'
+     ;;
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     shrext=.dll
+     library_names_spec='$libname.dll.a $libname.lib'
+     ;;
+diff -Naur tar-1.33-orig/m4/btowc.m4 tar-1.33/m4/btowc.m4
+--- tar-1.33-orig/m4/btowc.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/btowc.m4	2021-01-12 09:07:31.912322700 +0300
+@@ -41,7 +41,7 @@
+ changequote(,)dnl
+            case "$host_os" in
+                       # Guess no on Cygwin.
+-             cygwin*) gl_cv_func_btowc_nul="guessing no" ;;
++             cygwin* | msys*) gl_cv_func_btowc_nul="guessing no" ;;
+                       # Guess yes on native Windows.
+              mingw*)  gl_cv_func_btowc_nul="guessing yes" ;;
+                       # Guess yes otherwise.
+diff -Naur tar-1.33-orig/m4/double-slash-root.m4 tar-1.33/m4/double-slash-root.m4
+--- tar-1.33-orig/m4/double-slash-root.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/double-slash-root.m4	2021-01-12 09:07:31.916347700 +0300
+@@ -16,7 +16,7 @@
+         # special semantics and is distinct from /, please report it to
+         # <bug-gnulib@gnu.org>.
+         case $host in
+-          *-cygwin | i370-ibm-openedition)
++          *-cygwin | *-msys | i370-ibm-openedition)
+             gl_cv_double_slash_root=yes ;;
+           *)
+             # Be optimistic and assume that / and // are the same when we
+diff -Naur tar-1.33-orig/m4/dup2.m4 tar-1.33/m4/dup2.m4
+--- tar-1.33-orig/m4/dup2.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/dup2.m4	2021-01-12 09:20:50.807069000 +0300
+@@ -71,6 +71,8 @@
+            gl_cv_func_dup2_works="guessing no" ;;
+          cygwin*) # on cygwin 1.5.x, dup2(1,1) returns 0
+            gl_cv_func_dup2_works="guessing no" ;;
++         msys*) # on msys 1.5.x, dup2(1,1) returns 0
++           gl_cv_func_dup2_works="guessing no" ;;
+          aix* | freebsd*)
+                  # on AIX 7.1 and FreeBSD 6.1, dup2 (1,toobig) gives EMFILE,
+                  # not EBADF.
+diff -Naur tar-1.33-orig/m4/fchmodat.m4 tar-1.33/m4/fchmodat.m4
+--- tar-1.33-orig/m4/fchmodat.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/fchmodat.m4	2021-01-12 09:21:31.409253900 +0300
+@@ -58,7 +58,7 @@
+          [gl_cv_func_fchmodat_works=no],
+          [case "$host_os" in
+             dnl Guess no on Linux with glibc and Cygwin, yes otherwise.
+-            linux-gnu* | cygwin*) gl_cv_func_fchmodat_works="guessing no" ;;
++            linux-gnu* | cygwin* | msys*) gl_cv_func_fchmodat_works="guessing no" ;;
+             *)                    gl_cv_func_fchmodat_works="$gl_cross_guess_normal" ;;
+           esac
+          ])
+diff -Naur tar-1.33-orig/m4/fcntl.m4 tar-1.33/m4/fcntl.m4
+--- tar-1.33-orig/m4/fcntl.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/fcntl.m4	2021-01-12 09:07:31.923235200 +0300
+@@ -70,7 +70,7 @@
+          [gl_cv_func_fcntl_f_dupfd_works=yes],
+          [gl_cv_func_fcntl_f_dupfd_works=no],
+          [case $host_os in
+-            aix* | cygwin* | haiku*)
++            aix* | cygwin* | msys* | haiku*)
+                gl_cv_func_fcntl_f_dupfd_works="guessing no" ;;
+             *) gl_cv_func_fcntl_f_dupfd_works="guessing yes" ;;
+           esac])])
+diff -Naur tar-1.33-orig/m4/getcwd.m4 tar-1.33/m4/getcwd.m4
+--- tar-1.33-orig/m4/getcwd.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/getcwd.m4	2021-01-12 09:22:34.149099000 +0300
+@@ -55,6 +55,8 @@
+             *-musl*)       gl_cv_func_getcwd_null="guessing yes";;
+                            # Guess yes on Cygwin.
+             cygwin*)       gl_cv_func_getcwd_null="guessing yes";;
++                           # Guess yes on MSYS.
++            msys*)         gl_cv_func_getcwd_null="guessing yes";;
+                            # If we don't know, obey --enable-cross-guesses.
+             *)             gl_cv_func_getcwd_null="$gl_cross_guess_normal";;
+           esac
+diff -Naur tar-1.33-orig/m4/getdtablesize.m4 tar-1.33/m4/getdtablesize.m4
+--- tar-1.33-orig/m4/getdtablesize.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/getdtablesize.m4	2021-01-12 09:07:31.931994800 +0300
+@@ -42,7 +42,7 @@
+              [gl_cv_func_getdtablesize_works=yes],
+              [gl_cv_func_getdtablesize_works=no],
+              [case "$host_os" in
+-                cygwin*) # on cygwin 1.5.25, getdtablesize() automatically grows
++                cygwin* | msys* ) # on cygwin 1.5.25, getdtablesize() automatically grows
+                   gl_cv_func_getdtablesize_works="guessing no" ;;
+                 *) gl_cv_func_getdtablesize_works="guessing yes" ;;
+               esac
+diff -Naur tar-1.33-orig/m4/malloc.m4 tar-1.33/m4/malloc.m4
+--- tar-1.33-orig/m4/malloc.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/malloc.m4	2021-01-12 09:23:28.730950400 +0300
+@@ -25,7 +25,7 @@
+        [case "$host_os" in
+           # Guess yes on platforms where we know the result.
+           *-gnu* | gnu* | *-musl* | freebsd* | netbsd* | openbsd* \
+-          | hpux* | solaris* | cygwin* | mingw*)
++          | hpux* | solaris* | cygwin* | msys* | mingw*)
+             ac_cv_func_malloc_0_nonnull="guessing yes" ;;
+           # If we don't know, obey --enable-cross-guesses.
+           *) ac_cv_func_malloc_0_nonnull="$gl_cross_guess_normal" ;;
+diff -Naur tar-1.33-orig/m4/printf.m4 tar-1.33/m4/printf.m4
+--- tar-1.33-orig/m4/printf.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/printf.m4	2021-01-12 09:24:25.722450100 +0300
+@@ -813,6 +813,7 @@
+            irix*)           gl_cv_func_printf_directive_ls="guessing no";;
+            solaris*)        gl_cv_func_printf_directive_ls="guessing no";;
+            cygwin*)         gl_cv_func_printf_directive_ls="guessing no";;
++           msys*)           gl_cv_func_printf_directive_ls="guessing no";;
+            beos* | haiku*)  gl_cv_func_printf_directive_ls="guessing no";;
+                             # Guess no on Android.
+            linux*-android*) gl_cv_func_printf_directive_ls="guessing no";;
+@@ -897,6 +898,7 @@
+ changequote(,)dnl
+          case "$host_os" in
+            cygwin*)         gl_cv_func_printf_flag_grouping="guessing no";;
++           msys*)           gl_cv_func_printf_flag_grouping="guessing no";;
+            netbsd*)         gl_cv_func_printf_flag_grouping="guessing no";;
+                             # Guess no on Android.
+            linux*-android*) gl_cv_func_printf_flag_grouping="guessing no";;
+@@ -1605,7 +1607,7 @@
+            darwin[1-6].*)        gl_cv_func_vsnprintf_zerosize_c99="guessing no";;
+            darwin*)              gl_cv_func_vsnprintf_zerosize_c99="guessing yes";;
+                                  # Guess yes on Cygwin.
+-           cygwin*)              gl_cv_func_vsnprintf_zerosize_c99="guessing yes";;
++           cygwin* | msys*)              gl_cv_func_vsnprintf_zerosize_c99="guessing yes";;
+                                  # Guess yes on Solaris >= 2.6.
+            solaris2.[0-5] | solaris2.[0-5].*)
+                                  gl_cv_func_vsnprintf_zerosize_c99="guessing no";;
+diff -Naur tar-1.33-orig/m4/realloc.m4 tar-1.33/m4/realloc.m4
+--- tar-1.33-orig/m4/realloc.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/realloc.m4	2021-01-12 09:24:50.342352500 +0300
+@@ -25,7 +25,7 @@
+        [case "$host_os" in
+           # Guess yes on platforms where we know the result.
+           *-gnu* | gnu* | *-musl* | freebsd* | netbsd* | openbsd* \
+-          | hpux* | solaris* | cygwin* | mingw*)
++          | hpux* | solaris* | cygwin* | msys* | mingw*)
+             ac_cv_func_realloc_0_nonnull="guessing yes" ;;
+           # If we don't know, obey --enable-cross-guesses.
+           *) ac_cv_func_realloc_0_nonnull="$gl_cross_guess_normal" ;;
+diff -Naur tar-1.33-orig/m4/setlocale_null.m4 tar-1.33/m4/setlocale_null.m4
+--- tar-1.33-orig/m4/setlocale_null.m4	2021-01-07 17:29:12.000000000 +0300
++++ tar-1.33/m4/setlocale_null.m4	2021-01-12 09:25:23.879954100 +0300
+@@ -14,7 +14,7 @@
+     [gl_cv_func_setlocale_null_all_mtsafe],
+     [case "$host_os" in
+        # Guess no on musl libc, macOS, FreeBSD, NetBSD, OpenBSD, AIX, Haiku, Cygwin.
+-       *-musl* | darwin* | freebsd* | netbsd* | openbsd* | aix* | haiku* | cygwin*)
++       *-musl* | darwin* | freebsd* | netbsd* | openbsd* | aix* | haiku* | cygwin* | msys*)
+          gl_cv_func_setlocale_null_all_mtsafe=no ;;
+        # Guess yes on glibc, HP-UX, IRIX, Solaris, native Windows.
+        *-gnu* | gnu* | hpux* | irix* | solaris* | mingw*)
+@@ -48,7 +48,7 @@
+        openbsd* | aix*)
+          gl_cv_func_setlocale_null_one_mtsafe=no ;;
+        # Guess yes on glibc, musl libc, macOS, FreeBSD, NetBSD, HP-UX, IRIX, Solaris, Haiku, Cygwin, native Windows.
+-       *-gnu* | gnu* | *-musl* | darwin* | freebsd* | netbsd* | hpux* | irix* | solaris* | haiku* | cygwin* | mingw*)
++       *-gnu* | gnu* | *-musl* | darwin* | freebsd* | netbsd* | hpux* | irix* | solaris* | haiku* | cygwin* | msys* | mingw*)
+          gl_cv_func_setlocale_null_one_mtsafe=yes ;;
+        # If we don't know, obey --enable-cross-guesses.
+        *)
+diff -Naur tar-1.33-orig/m4/threadlib.m4 tar-1.33/m4/threadlib.m4
+--- tar-1.33-orig/m4/threadlib.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/threadlib.m4	2021-01-12 09:25:47.309442100 +0300
+@@ -413,7 +413,7 @@
+          dnl Disable multithreading by default on Cygwin 1.5.x, because it has
+          dnl bugs that lead to endless loops or crashes. See
+          dnl <https://cygwin.com/ml/cygwin/2009-08/msg00283.html>.
+-         cygwin*)
++         cygwin* | msys*)
+                case `uname -r` in
+                  1.[0-5].*) gl_use_threads=no ;;
+                  *)         gl_use_threads=yes ;;
+diff -Naur tar-1.33-orig/m4/unlinkdir.m4 tar-1.33/m4/unlinkdir.m4
+--- tar-1.33-orig/m4/unlinkdir.m4	2021-01-07 17:27:55.000000000 +0300
++++ tar-1.33/m4/unlinkdir.m4	2021-01-12 09:07:31.950057500 +0300
+@@ -25,6 +25,7 @@
+   linux-* | linux | \
+   freebsd2.2* | freebsd[[3-9]]* | freebsd[[1-9]][[0-9]]* | \
+   cygwin | \
++  msys | \
+   mingw*)
+     AC_DEFINE([UNLINK_CANNOT_UNLINK_DIR], [1],
+       [Define to 1 if unlink (dir) cannot possibly succeed.]);;

--- a/T/Tar/bundled/patches/tar-1.33-textmount.patch
+++ b/T/Tar/bundled/patches/tar-1.33-textmount.patch
@@ -1,0 +1,106 @@
+--- tar-1.33-orig/lib/rmt.h
++++ tar-1.33/lib/rmt.h
+@@ -62,7 +62,7 @@ extern bool force_local_option;
+ #define rmtcreat(dev_name, mode, command) \
+    (_remdev (dev_name) \
+     ? rmt_open__ (dev_name, O_CREAT | O_WRONLY, __REM_BIAS, command) \
+-    : creat (dev_name, mode))
++    : open (dev_name, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, mode))
+ 
+ #define rmtlstat(dev_name, muffer) \
+   (_remdev (dev_name) ? (errno = EOPNOTSUPP), -1 : lstat (dev_name, buffer))
+--- tar-1.33-orig/rmt/rmt.c
++++ tar-1.33/rmt/rmt.c
+@@ -338,7 +338,7 @@ open_device (char *str)
+       if (device_fd >= 0)
+ 	close (device_fd);
+ 
+-      device_fd = open (device, flag, MODE_RW);
++      device_fd = open (device, flag | O_BINARY, MODE_RW);
+       if (device_fd < 0)
+ 	rmt_error (errno);
+       else
+--- tar-1.33-orig/src/buffer.c
++++ tar-1.33/src/buffer.c
+@@ -766,6 +766,7 @@ _open_archive (enum access_mode wanted_a
+             enum compress_type type;
+ 
+             archive = STDIN_FILENO;
++            freopen (NULL, "rb", stdin);
+             type = check_compressed_archive (&shortfile);
+             if (type != ct_tar && type != ct_none)
+               FATAL_ERROR ((0, 0,
+@@ -778,12 +779,19 @@ _open_archive (enum access_mode wanted_a
+ 
+         case ACCESS_WRITE:
+           archive = STDOUT_FILENO;
++          freopen (NULL,
++                   fcntl (STDOUT_FILENO, F_GETFL) & O_APPEND ? "ab" : "wb",
++                   stdout);
+           if (!index_file_name)
+             stdlis = stderr;
+           break;
+ 
+         case ACCESS_UPDATE:
+           archive = STDIN_FILENO;
++          freopen (NULL, "rb", stdin);
++          freopen (NULL,
++                   fcntl (STDOUT_FILENO, F_GETFL) & O_APPEND ? "ab" : "wb",
++                   stdout);
+           write_archive_to_stdout = true;
+           record_end = record_start; /* set up for 1st record = # 0 */
+           if (!index_file_name)
+@@ -1182,7 +1190,7 @@ init_volume_number (void)
+ void
+ closeout_volume_number (void)
+ {
+-  FILE *file = fopen (volno_file_option, "w");
++  FILE *file = fopen (volno_file_option, "wb");
+ 
+   if (file)
+     {
+--- tar-1.33-orig/src/incremen.c
++++ tar-1.33/src/incremen.c
+@@ -1333,7 +1333,7 @@ read_directory_file (void)
+   int fd;
+   char *buf = NULL;
+   size_t bufsize = 0;
+-  int flags = O_RDWR | O_CREAT;
++  int flags = O_RDWR | O_CREAT | O_BINARY;
+ 
+   if (incremental_level == 0)
+     flags |= O_TRUNC;
+@@ -1347,7 +1347,7 @@ read_directory_file (void)
+       return;
+     }
+ 
+-  listed_incremental_stream = fdopen (fd, "r+");
++  listed_incremental_stream = fdopen (fd, "rb+");
+   if (! listed_incremental_stream)
+     {
+       open_error (listed_incremental_option);
+--- tar-1.33-orig/src/system.c
++++ tar-1.33/src/system.c
+@@ -366,7 +366,8 @@ sys_child_open_for_compress (void)
+ 	 compressor.  */
+       if (strcmp (archive_name_array[0], "-"))
+ 	{
+-	  archive = creat (archive_name_array[0], MODE_RW);
++	  archive = open (archive_name_array[0],
++			  O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, MODE_RW);
+ 	  if (archive < 0)
+ 	    {
+ 	      int saved_errno = errno;
+@@ -407,7 +408,11 @@ sys_child_open_for_compress (void)
+   xclose (child_pipe[PWRITE]);
+ 
+   if (strcmp (archive_name_array[0], "-") == 0)
+-    archive = STDOUT_FILENO;
++    {
++      archive = STDOUT_FILENO;
++      freopen (NULL, fcntl (STDOUT_FILENO, F_GETFL) & O_APPEND ? "ab" : "wb",
++	       stdout);
++    }
+   else
+     {
+       archive = rmtcreat (archive_name_array[0], MODE_RW, rsh_command_option);


### PR DESCRIPTION
I found the MinGW patches for Tar, but it still doesn't quite work:

```
[00:43:13] system.h:491:21: error: dereferencing pointer to incomplete type
[00:43:13]    if (initgroups (pw->pw_name, getgid ()))
[00:43:13]                      ^
[...]
[00:43:13] rtapelib.c: In function ‘rmt_write__’:
[00:43:13] rtapelib.c:607:26: error: ‘SIGPIPE’ undeclared (first use in this function)
[00:43:13]    pipe_handler = signal (SIGPIPE, SIG_IGN);
[00:43:13]                           ^
[00:43:13] make[3]: *** [Makefile:1502: rtapelib.o] Error 1
```