### PR TITLE
Fix compat bounds of packages depending on NetCDF_jll

### DIFF
--- a/I/IOAPI/build_tarballs.jl
+++ b/I/IOAPI/build_tarballs.jl
@@ -47,7 +47,11 @@ cp *.h ${includedir} # C header files
 cp fixed_src/* ${includedir} # FORTRAN .EXT (include) files
 
 # Convert static library to dynamic library
-gfortran -shared -fPIC -fopenmp -o ${libdir}/libioapi.${dlext} -L${libdir} -Wl,$(flagon --whole-archive) ${BINDIR}/libioapi.a -Wl,$(flagon --no-whole-archive | cut -d' ' -f1) -lnetcdf -Wl,$(flagon --no-whole-archive | cut -d' ' -f1) -lnetcdff
+if [[ "${target}" == *-apple-* ]]; then
+    gfortran -shared -fPIC -fopenmp -o ${libdir}/libioapi.${dlext} -L${libdir} -Wl,$(flagon --whole-archive) ${BINDIR}/libioapi.a -lnetcdf -lnetcdff
+else
+    gfortran -shared -fPIC -fopenmp -o ${libdir}/libioapi.${dlext} -L${libdir} -Wl,$(flagon --whole-archive) ${BINDIR}/libioapi.a -Wl,$(flagon --no-whole-archive) -lnetcdf -Wl,$(flagon --no-whole-archive) -lnetcdff
+fi
 rm ${BINDIR}/libioapi.a
 
 cd ../m3tools/
@@ -136,10 +140,12 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"))
+    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.701.400 - 400.799")
     Dependency(PackageSpec(name="NetCDFF_jll", uuid="78e728a9-57fe-5d11-897c-5014b89e5f84"))
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
-
+    # `MbedTLS_jll` is an indirect dependency through NetCDF, we need to specify
+    # a compatible build version for this to work.
+    BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/MDAL/build_tarballs.jl
+++ b/M/MDAL/build_tarballs.jl
@@ -60,7 +60,7 @@ dependencies = [
     Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"))
     Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
-    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"))
+    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.701.400 - 400.799")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/N/NetCDFF/build_tarballs.jl
+++ b/N/NetCDFF/build_tarballs.jl
@@ -42,8 +42,11 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3")),
+    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.701.400 - 400.799"),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+    # `MbedTLS_jll` is an indirect dependency through NetCDF, we need to specify
+    # a compatible build version for this to work.
+    BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/T/TempestModel/build_tarballs.jl
+++ b/T/TempestModel/build_tarballs.jl
@@ -95,16 +95,11 @@ products = [
 dependencies = [
     Dependency("MKL_jll"),
     Dependency("MPICH_jll"),
-    Dependency("NetCDF_jll"),
+    Dependency("NetCDF_jll"; compat="400.701.400 - 400.799"),
     Dependency("HDF5_jll"),
-    # The following is adapted from NetCDF_jll
-    BuildDependency(PackageSpec(; name="MbedTLS_jll", version="2.24.0")),
-    #Dependency("LibCURL_jll"),
-    # The following libraries are dependencies of LibCURL_jll which is now a
-    # stdlib, but the stdlib doesn't explicitly list its dependencies
-    #Dependency("LibSSH2_jll"),
-    #Dependency("MbedTLS_jll", v"2.24.0"),
-    #Dependency("nghttp2_jll"),
+    # `MbedTLS_jll` is an indirect dependency through NetCDF, we need to specify
+    # a compatible build version for this to work.
+    BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;


### PR DESCRIPTION
NetCDF broke the ABI in the 4.7 -> 4.8 transition (the major soversion changed
from 18 to 19), so we always must specify the compat of packages depending on
it.

PR companion to https://github.com/JuliaRegistries/General/pull/53508.