### PR TITLE
[TempestRemap] Fix compat of NetCDF

### DIFF
--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -73,7 +73,7 @@ products = [
 
 dependencies = [
     Dependency("OpenBLAS32_jll"),
-    Dependency("NetCDF_jll", compat="400.802.101"),
+    Dependency("NetCDF_jll", compat="400.701.400 - 400.799"),
     Dependency("HDF5_jll"),
     # The following is adapted from NetCDF_jll
     BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),


### PR DESCRIPTION
We want to use NetCDF 4.7, the build of 4.8 has many problems.