### PR TITLE
[CUDA_full] Added CUDA 10.2 for aarch64-linux-gnu

### DIFF
--- a/C/CUDA/CUDA_full@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.2/build_tarballs.jl
@@ -19,55 +19,49 @@ sources_windows = [
 ]
 
 version_linux_aarch64 = v"10.2.460"
-sources_linux_aarch64_jetson_apt = [
+sources_linux_aarch64 = [
     # Expected install order for cuda-toolkit-10-2 (provided build-essential was installed prior) - i.e. output from apt-get -s install --no-install-recommends cuda-toolkit-10-2
-    ("cuda-cudart-10-2", "c/cuda-cudart", "10.2.300-1", "e3cd683965f7b2e4a13b27c58754443185dcc545d0f989e52c224840cfde48d1"),
-    ("cuda-driver-dev-10-2", "c/cuda-cudart", "10.2.300-1", "5ea760773de2685acfac3931bcdc2eff3a18eceb28fc86f80061e215e9e81456"),
-    ("cuda-cudart-dev-10-2", "c/cuda-cudart", "10.2.300-1", "d37a94a3fb858db2cf41cde1bcbe1042b9a66d4fd3fd30882805a478523acb18"),
-    ("cuda-nvcc-10-2", "c/cuda-nvcc", "10.2.300-1", "86c138d6903fa35bb512414bbb98dfd519d3e5ee743dc846e9fb1aa42f7e0391"),
-    ("cuda-cupti-10-2", "c/cuda-cupti", "10.2.300-1", "e2024cd43668e3102c6afd0767cfcbc107e49b5198fbb437591758b0c2c4f6f1"),
-    ("cuda-cupti-dev-10-2", "c/cuda-cupti", "10.2.300-1", "731abaaf4c5ce24c4a4ecce6b1921b88662b70e57bffee0b20bbee9b17fc4353"),
-    ("cuda-nvdisasm-10-2", "c/cuda-nvdisasm", "10.2.300-1", "6b9a6f123bc46d525abf351e8720fa6da5573fd9caeebe312590105bef71a146"),
-    ("cuda-cuobjdump-10-2", "c/cuda-cuobjdump", "10.2.300-1", "1a6c02ae2786fadeac0888e8998d47e28282319b36909b6cdc3c0a546afa578a"),
-    ("cuda-gdb-10-2", "c/cuda-gdb", "10.2.300-1", "662c7e43a4cce180f187cf5f2b00d8634d9276a6ecb415eeca638778e27c215f"),
-    ("cuda-memcheck-10-2", "c/cuda-memcheck", "10.2.300-1", "2027d40d3302ecfbfa42790b365f8c097726d5a8b05fb7087971dec7e6bc1f35"),
-    ("cuda-nvprof-10-2", "c/cuda-nvprof", "10.2.300-1", "882c05ec6d681980c1a6cc5afacd4c2a58e6d819cb1aa043ae16bb74f97a70f8"),
-    ("cuda-nvtx-10-2", "c/cuda-nvtx", "10.2.300-1", "fe29d0a639620c161a732cdff520670142e986d795bb3f7afd7c06e41dca340e"),
-    ("cuda-command-line-tools-10-2", "c/cuda-command-line-tools-10-2", "10.2.460-1", "76eb6e1bc49f5a08443ddf8f2b283b057cf16a8d907b033853ce316fa6c89fc5"),
-    ("cuda-nvprune-10-2", "c/cuda-nvprune", "10.2.300-1", "c77f9f554932d7586d58c5cc77b62ae94f2c1a9779aac78fd8b89335b6ad35ba"),
-    ("cuda-compiler-10-2", "c/cuda-compiler-10-2", "10.2.460-1", "9d2ccb1a43782e3b9728c35a81525f229fac1a4e422708da58c00e98e8fdcf1e"),
-    ("cuda-nvrtc-10-2", "c/cuda-nvrtc", "10.2.300-1", "7118079394a22c6cedba1152f0a78ef7bb10ac26c1984ab8c4dcf82fe9f4e20c"),
-    ("cuda-nvrtc-dev-10-2", "c/cuda-nvrtc", "10.2.300-1", "bdce95a7a30daf7d1a52a32385c1ee67a8f742126a2f24d82a7b7dd35d012f3f"),
-    ("libcusolver-10-2", "libc/libcusolver", "10.3.0.300-1", "31a32e7c7e439bc34331d32b93392d08de6c9893d5083865b93703509d6fb7d6"),
-    ("libcusolver-dev-10-2", "libc/libcusolver", "10.3.0.300-1", "c86b549b4501a8ddd451dd7f46ea55b79d548bd987aaa17f3af03813e4b90dba"),
-    ("libcublas10", "libc/libcublas", "10.2.3.300-1", "a4cde28215c01bce78fa7c3d09909afaec487142e1144646bd7ff043a5c6c1df"),
-    ("libcublas-dev", "libc/libcublas", "10.2.3.300-1", "f2575fd6c86c9aa8eed0e782d68122d9ba3d1422ebd6e6c06c71bea096c169db"),
-    ("libcufft-10-2", "libc/libcufft", "10.1.2.300-1", "661a91f35f2d148d938ca907484ebe48727b17f03a8cbb6992e60bb792738caf"),
-    ("libcufft-dev-10-2", "libc/libcufft", "10.1.2.300-1", "43bf089682f745397c7c72bb53ce6d962e2d24246e1e7e686fd8159d3ddf7ba1"),
-    ("libcurand-10-2", "libc/libcurand", "10.1.2.300-1", "45f2bbafdde70b8b8bcdc6f0625a2ab334632b6659f153224654d03e1776057b"),
-    ("libcurand-dev-10-2", "libc/libcurand", "10.1.2.300-1", "7da1321d221290c7c8dcf49bef8970712cb981d8f9a93f405a080364f1bf0b12"),
-    ("libcusparse-10-2", "libc/libcusparse", "10.3.1.300-1", "bd844b7a71adc76694caf5da4818ab03f207e3b7f23340aa2fe86909f799fb92"),
-    ("libcusparse-dev-10-2", "libc/libcusparse", "10.3.1.300-1", "898fab6cae719007fdf0c8ebb27825bc7dd03e48314297b2b60639b604fa6bc4"),
-    ("libnpp-10-2", "libn/libnpp", "10.2.1.300-1", "dc51dc218b7652680138ca236877d01ff0b65546d60a113276ded05f1fea967e"),
-    ("libnpp-dev-10-2", "libn/libnpp", "10.2.1.300-1", "4c64992156eaeb982af504a41920a33df01c701286903d07fe23c1d20c902b38"),
-    ("cuda-samples-10-2", "c/cuda-samples", "10.2.300-1", "bb7726194bac9252863da80ae13e4fdd7e69a657314cb8ff6edf8ba1cd789e2d"),
-    ("cuda-documentation-10-2", "c/cuda-documentation", "10.2.300-1", "d8e8c62156516d5eb2dea0ba49abd1b5cecae010872e0e71650e97a1ccd2e005"),
-    ("cuda-nvgraph-10-2", "c/cuda-nvgraph", "10.2.300-1", "88412a2eecdc5dc2f3db7f6f2dea3d13c234114b8f36ec0356d237190504748e"),
-    ("cuda-libraries-10-2", "c/cuda-libraries-10-2", "10.2.460-1", "a09ecb11e6ccf1d44c4ba941de49e0b9be02f6d70ba7f2f5c8be06a9d50fc9d1"),
-    ("cuda-nvgraph-dev-10-2", "c/cuda-nvgraph", "10.2.300-1", "f280b981d54745d24bd933c48eba76903f4174d13e38aae89454f29433355186"),
-    ("cuda-libraries-dev-10-2", "c/cuda-libraries-dev-10-2", "10.2.460-1", "bb34c354f1b96c170c9d175c360741a098a1c4933abc9864d85df937005c57a8"),
-    ("cuda-nvml-dev-10-2", "c/cuda-nvml-dev", "10.2.300-1", "70620354d37385ff1d34ac2d4f713ca3419d413103f90e385adb0e7112bec501"),
-    ("cuda-visual-tools-10-2", "c/cuda-visual-tools-10-2", "10.2.460-1", "39fb8d2d529a3aee658a51bee429124900f55c8513a6427d4963722d37ef65ff"),
-    ("cuda-tools-10-2", "c/cuda-tools-10-2", "10.2.460-1", "c9c099420ebe15cf385e3b23bcae44c6338bcbc04aba6011560539fa473730c8"),
-    ("cuda-toolkit-10-2", "c/cuda-toolkit-10-2", "10.2.460-1", "4c047e83b805ce9d76cbc5a2de2177548d8a63cd025e03f944705bf653e82828")
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cudart/cuda-cudart-10-2_10.2.300-1_arm64.deb", "e3cd683965f7b2e4a13b27c58754443185dcc545d0f989e52c224840cfde48d1"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cudart/cuda-driver-dev-10-2_10.2.300-1_arm64.deb", "5ea760773de2685acfac3931bcdc2eff3a18eceb28fc86f80061e215e9e81456"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cudart/cuda-cudart-dev-10-2_10.2.300-1_arm64.deb", "d37a94a3fb858db2cf41cde1bcbe1042b9a66d4fd3fd30882805a478523acb18"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvcc/cuda-nvcc-10-2_10.2.300-1_arm64.deb", "86c138d6903fa35bb512414bbb98dfd519d3e5ee743dc846e9fb1aa42f7e0391"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cupti/cuda-cupti-10-2_10.2.300-1_arm64.deb", "e2024cd43668e3102c6afd0767cfcbc107e49b5198fbb437591758b0c2c4f6f1"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cupti/cuda-cupti-dev-10-2_10.2.300-1_arm64.deb", "731abaaf4c5ce24c4a4ecce6b1921b88662b70e57bffee0b20bbee9b17fc4353"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvdisasm/cuda-nvdisasm-10-2_10.2.300-1_arm64.deb", "6b9a6f123bc46d525abf351e8720fa6da5573fd9caeebe312590105bef71a146"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cuobjdump/cuda-cuobjdump-10-2_10.2.300-1_arm64.deb", "1a6c02ae2786fadeac0888e8998d47e28282319b36909b6cdc3c0a546afa578a"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-gdb/cuda-gdb-10-2_10.2.300-1_arm64.deb", "662c7e43a4cce180f187cf5f2b00d8634d9276a6ecb415eeca638778e27c215f"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-memcheck/cuda-memcheck-10-2_10.2.300-1_arm64.deb", "2027d40d3302ecfbfa42790b365f8c097726d5a8b05fb7087971dec7e6bc1f35"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvprof/cuda-nvprof-10-2_10.2.300-1_arm64.deb", "882c05ec6d681980c1a6cc5afacd4c2a58e6d819cb1aa043ae16bb74f97a70f8"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvtx/cuda-nvtx-10-2_10.2.300-1_arm64.deb", "fe29d0a639620c161a732cdff520670142e986d795bb3f7afd7c06e41dca340e"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-command-line-tools-10-2/cuda-command-line-tools-10-2_10.2.460-1_arm64.deb", "76eb6e1bc49f5a08443ddf8f2b283b057cf16a8d907b033853ce316fa6c89fc5"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvprune/cuda-nvprune-10-2_10.2.300-1_arm64.deb", "c77f9f554932d7586d58c5cc77b62ae94f2c1a9779aac78fd8b89335b6ad35ba"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-compiler-10-2/cuda-compiler-10-2_10.2.460-1_arm64.deb", "9d2ccb1a43782e3b9728c35a81525f229fac1a4e422708da58c00e98e8fdcf1e"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvrtc/cuda-nvrtc-10-2_10.2.300-1_arm64.deb", "7118079394a22c6cedba1152f0a78ef7bb10ac26c1984ab8c4dcf82fe9f4e20c"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvrtc/cuda-nvrtc-dev-10-2_10.2.300-1_arm64.deb", "bdce95a7a30daf7d1a52a32385c1ee67a8f742126a2f24d82a7b7dd35d012f3f"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcusolver/libcusolver-10-2_10.3.0.300-1_arm64.deb", "31a32e7c7e439bc34331d32b93392d08de6c9893d5083865b93703509d6fb7d6"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcusolver/libcusolver-dev-10-2_10.3.0.300-1_arm64.deb", "c86b549b4501a8ddd451dd7f46ea55b79d548bd987aaa17f3af03813e4b90dba"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcublas/libcublas10_10.2.3.300-1_arm64.deb", "a4cde28215c01bce78fa7c3d09909afaec487142e1144646bd7ff043a5c6c1df"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcublas/libcublas-dev_10.2.3.300-1_arm64.deb", "f2575fd6c86c9aa8eed0e782d68122d9ba3d1422ebd6e6c06c71bea096c169db"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcufft/libcufft-10-2_10.1.2.300-1_arm64.deb", "661a91f35f2d148d938ca907484ebe48727b17f03a8cbb6992e60bb792738caf"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcufft/libcufft-dev-10-2_10.1.2.300-1_arm64.deb", "43bf089682f745397c7c72bb53ce6d962e2d24246e1e7e686fd8159d3ddf7ba1"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcurand/libcurand-10-2_10.1.2.300-1_arm64.deb", "45f2bbafdde70b8b8bcdc6f0625a2ab334632b6659f153224654d03e1776057b"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcurand/libcurand-dev-10-2_10.1.2.300-1_arm64.deb", "7da1321d221290c7c8dcf49bef8970712cb981d8f9a93f405a080364f1bf0b12"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcusparse/libcusparse-10-2_10.3.1.300-1_arm64.deb", "bd844b7a71adc76694caf5da4818ab03f207e3b7f23340aa2fe86909f799fb92"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcusparse/libcusparse-dev-10-2_10.3.1.300-1_arm64.deb", "898fab6cae719007fdf0c8ebb27825bc7dd03e48314297b2b60639b604fa6bc4"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libn/libnpp/libnpp-10-2_10.2.1.300-1_arm64.deb", "dc51dc218b7652680138ca236877d01ff0b65546d60a113276ded05f1fea967e"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libn/libnpp/libnpp-dev-10-2_10.2.1.300-1_arm64.deb", "4c64992156eaeb982af504a41920a33df01c701286903d07fe23c1d20c902b38"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-samples/cuda-samples-10-2_10.2.300-1_arm64.deb", "bb7726194bac9252863da80ae13e4fdd7e69a657314cb8ff6edf8ba1cd789e2d"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-documentation/cuda-documentation-10-2_10.2.300-1_arm64.deb", "d8e8c62156516d5eb2dea0ba49abd1b5cecae010872e0e71650e97a1ccd2e005"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvgraph/cuda-nvgraph-10-2_10.2.300-1_arm64.deb", "88412a2eecdc5dc2f3db7f6f2dea3d13c234114b8f36ec0356d237190504748e"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-libraries-10-2/cuda-libraries-10-2_10.2.460-1_arm64.deb", "a09ecb11e6ccf1d44c4ba941de49e0b9be02f6d70ba7f2f5c8be06a9d50fc9d1"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvgraph/cuda-nvgraph-dev-10-2_10.2.300-1_arm64.deb", "f280b981d54745d24bd933c48eba76903f4174d13e38aae89454f29433355186"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-libraries-dev-10-2/cuda-libraries-dev-10-2_10.2.460-1_arm64.deb", "bb34c354f1b96c170c9d175c360741a098a1c4933abc9864d85df937005c57a8"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvml-dev/cuda-nvml-dev-10-2_10.2.300-1_arm64.deb", "70620354d37385ff1d34ac2d4f713ca3419d413103f90e385adb0e7112bec501"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-visual-tools-10-2/cuda-visual-tools-10-2_10.2.460-1_arm64.deb", "39fb8d2d529a3aee658a51bee429124900f55c8513a6427d4963722d37ef65ff"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-tools-10-2/cuda-tools-10-2_10.2.460-1_arm64.deb", "c9c099420ebe15cf385e3b23bcae44c6338bcbc04aba6011560539fa473730c8"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-toolkit-10-2/cuda-toolkit-10-2_10.2.460-1_arm64.deb", "4c047e83b805ce9d76cbc5a2de2177548d8a63cd025e03f944705bf653e82828")
 ]
-create_file_name_from_jetson_apt_source(pkg_name::String, version::String; arch = "arm64") = "$(pkg_name)_$(version)_$arch.deb"
-function create_file_source_from_jetson_apt_source(pkg_name::String, section::String, version::String, hash::String; arch = "arm64")
-    url = "https://repo.download.nvidia.com/jetson/common/pool/main/$section/$(create_file_name_from_jetson_apt_source(pkg_name, version))"
-    return FileSource(url, hash)
-end
-sources_linux_aarch64 = [create_file_source_from_jetson_apt_source(args...) for args in sources_linux_aarch64_jetson_apt]
-sources_linux_aarch64_manifest = join([create_file_name_from_jetson_apt_source(pkg_name, version) for (pkg_name, _, version, _) in sources_linux_aarch64_jetson_apt], "\n")
+sources_linux_aarch64_manifest = join([src.filename for src in sources_linux_aarch64], "\n")
 
 script = """
 if [[ \${target} == aarch64-linux-gnu ]]; then

--- a/C/CUDA/CUDA_full@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.2/build_tarballs.jl
@@ -18,7 +18,62 @@ sources_windows = [
                "b538271c4d9ffce1a8520bf992d9bd23854f0f29cee67f48c6139e4cf301e253", "installer.exe")
 ]
 
-script = raw"""
+version_linux_aarch64 = v"10.2.460"
+sources_linux_aarch64_jetson_apt = [
+    # Expected install order for cuda-toolkit-10-2 (provided build-essential was installed prior) - i.e. output from apt-get -s install --no-install-recommends cuda-toolkit-10-2
+    ("cuda-cudart-10-2", "c/cuda-cudart", "10.2.300-1", "e3cd683965f7b2e4a13b27c58754443185dcc545d0f989e52c224840cfde48d1"),
+    ("cuda-driver-dev-10-2", "c/cuda-cudart", "10.2.300-1", "5ea760773de2685acfac3931bcdc2eff3a18eceb28fc86f80061e215e9e81456"),
+    ("cuda-cudart-dev-10-2", "c/cuda-cudart", "10.2.300-1", "d37a94a3fb858db2cf41cde1bcbe1042b9a66d4fd3fd30882805a478523acb18"),
+    ("cuda-nvcc-10-2", "c/cuda-nvcc", "10.2.300-1", "86c138d6903fa35bb512414bbb98dfd519d3e5ee743dc846e9fb1aa42f7e0391"),
+    ("cuda-cupti-10-2", "c/cuda-cupti", "10.2.300-1", "e2024cd43668e3102c6afd0767cfcbc107e49b5198fbb437591758b0c2c4f6f1"),
+    ("cuda-cupti-dev-10-2", "c/cuda-cupti", "10.2.300-1", "731abaaf4c5ce24c4a4ecce6b1921b88662b70e57bffee0b20bbee9b17fc4353"),
+    ("cuda-nvdisasm-10-2", "c/cuda-nvdisasm", "10.2.300-1", "6b9a6f123bc46d525abf351e8720fa6da5573fd9caeebe312590105bef71a146"),
+    ("cuda-cuobjdump-10-2", "c/cuda-cuobjdump", "10.2.300-1", "1a6c02ae2786fadeac0888e8998d47e28282319b36909b6cdc3c0a546afa578a"),
+    ("cuda-gdb-10-2", "c/cuda-gdb", "10.2.300-1", "662c7e43a4cce180f187cf5f2b00d8634d9276a6ecb415eeca638778e27c215f"),
+    ("cuda-memcheck-10-2", "c/cuda-memcheck", "10.2.300-1", "2027d40d3302ecfbfa42790b365f8c097726d5a8b05fb7087971dec7e6bc1f35"),
+    ("cuda-nvprof-10-2", "c/cuda-nvprof", "10.2.300-1", "882c05ec6d681980c1a6cc5afacd4c2a58e6d819cb1aa043ae16bb74f97a70f8"),
+    ("cuda-nvtx-10-2", "c/cuda-nvtx", "10.2.300-1", "fe29d0a639620c161a732cdff520670142e986d795bb3f7afd7c06e41dca340e"),
+    ("cuda-command-line-tools-10-2", "c/cuda-command-line-tools-10-2", "10.2.460-1", "76eb6e1bc49f5a08443ddf8f2b283b057cf16a8d907b033853ce316fa6c89fc5"),
+    ("cuda-nvprune-10-2", "c/cuda-nvprune", "10.2.300-1", "c77f9f554932d7586d58c5cc77b62ae94f2c1a9779aac78fd8b89335b6ad35ba"),
+    ("cuda-compiler-10-2", "c/cuda-compiler-10-2", "10.2.460-1", "9d2ccb1a43782e3b9728c35a81525f229fac1a4e422708da58c00e98e8fdcf1e"),
+    ("cuda-nvrtc-10-2", "c/cuda-nvrtc", "10.2.300-1", "7118079394a22c6cedba1152f0a78ef7bb10ac26c1984ab8c4dcf82fe9f4e20c"),
+    ("cuda-nvrtc-dev-10-2", "c/cuda-nvrtc", "10.2.300-1", "bdce95a7a30daf7d1a52a32385c1ee67a8f742126a2f24d82a7b7dd35d012f3f"),
+    ("libcusolver-10-2", "libc/libcusolver", "10.3.0.300-1", "31a32e7c7e439bc34331d32b93392d08de6c9893d5083865b93703509d6fb7d6"),
+    ("libcusolver-dev-10-2", "libc/libcusolver", "10.3.0.300-1", "c86b549b4501a8ddd451dd7f46ea55b79d548bd987aaa17f3af03813e4b90dba"),
+    ("libcublas10", "libc/libcublas", "10.2.3.300-1", "a4cde28215c01bce78fa7c3d09909afaec487142e1144646bd7ff043a5c6c1df"),
+    ("libcublas-dev", "libc/libcublas", "10.2.3.300-1", "f2575fd6c86c9aa8eed0e782d68122d9ba3d1422ebd6e6c06c71bea096c169db"),
+    ("libcufft-10-2", "libc/libcufft", "10.1.2.300-1", "661a91f35f2d148d938ca907484ebe48727b17f03a8cbb6992e60bb792738caf"),
+    ("libcufft-dev-10-2", "libc/libcufft", "10.1.2.300-1", "43bf089682f745397c7c72bb53ce6d962e2d24246e1e7e686fd8159d3ddf7ba1"),
+    ("libcurand-10-2", "libc/libcurand", "10.1.2.300-1", "45f2bbafdde70b8b8bcdc6f0625a2ab334632b6659f153224654d03e1776057b"),
+    ("libcurand-dev-10-2", "libc/libcurand", "10.1.2.300-1", "7da1321d221290c7c8dcf49bef8970712cb981d8f9a93f405a080364f1bf0b12"),
+    ("libcusparse-10-2", "libc/libcusparse", "10.3.1.300-1", "bd844b7a71adc76694caf5da4818ab03f207e3b7f23340aa2fe86909f799fb92"),
+    ("libcusparse-dev-10-2", "libc/libcusparse", "10.3.1.300-1", "898fab6cae719007fdf0c8ebb27825bc7dd03e48314297b2b60639b604fa6bc4"),
+    ("libnpp-10-2", "libn/libnpp", "10.2.1.300-1", "dc51dc218b7652680138ca236877d01ff0b65546d60a113276ded05f1fea967e"),
+    ("libnpp-dev-10-2", "libn/libnpp", "10.2.1.300-1", "4c64992156eaeb982af504a41920a33df01c701286903d07fe23c1d20c902b38"),
+    ("cuda-samples-10-2", "c/cuda-samples", "10.2.300-1", "bb7726194bac9252863da80ae13e4fdd7e69a657314cb8ff6edf8ba1cd789e2d"),
+    ("cuda-documentation-10-2", "c/cuda-documentation", "10.2.300-1", "d8e8c62156516d5eb2dea0ba49abd1b5cecae010872e0e71650e97a1ccd2e005"),
+    ("cuda-nvgraph-10-2", "c/cuda-nvgraph", "10.2.300-1", "88412a2eecdc5dc2f3db7f6f2dea3d13c234114b8f36ec0356d237190504748e"),
+    ("cuda-libraries-10-2", "c/cuda-libraries-10-2", "10.2.460-1", "a09ecb11e6ccf1d44c4ba941de49e0b9be02f6d70ba7f2f5c8be06a9d50fc9d1"),
+    ("cuda-nvgraph-dev-10-2", "c/cuda-nvgraph", "10.2.300-1", "f280b981d54745d24bd933c48eba76903f4174d13e38aae89454f29433355186"),
+    ("cuda-libraries-dev-10-2", "c/cuda-libraries-dev-10-2", "10.2.460-1", "bb34c354f1b96c170c9d175c360741a098a1c4933abc9864d85df937005c57a8"),
+    ("cuda-nvml-dev-10-2", "c/cuda-nvml-dev", "10.2.300-1", "70620354d37385ff1d34ac2d4f713ca3419d413103f90e385adb0e7112bec501"),
+    ("cuda-visual-tools-10-2", "c/cuda-visual-tools-10-2", "10.2.460-1", "39fb8d2d529a3aee658a51bee429124900f55c8513a6427d4963722d37ef65ff"),
+    ("cuda-tools-10-2", "c/cuda-tools-10-2", "10.2.460-1", "c9c099420ebe15cf385e3b23bcae44c6338bcbc04aba6011560539fa473730c8"),
+    ("cuda-toolkit-10-2", "c/cuda-toolkit-10-2", "10.2.460-1", "4c047e83b805ce9d76cbc5a2de2177548d8a63cd025e03f944705bf653e82828")
+]
+create_file_name_from_jetson_apt_source(pkg_name::String, version::String; arch = "arm64") = "$(pkg_name)_$(version)_$arch.deb"
+function create_file_source_from_jetson_apt_source(pkg_name::String, section::String, version::String, hash::String; arch = "arm64")
+    url = "https://repo.download.nvidia.com/jetson/common/pool/main/$section/$(create_file_name_from_jetson_apt_source(pkg_name, version))"
+    return FileSource(url, hash)
+end
+sources_linux_aarch64 = [create_file_source_from_jetson_apt_source(args...) for args in sources_linux_aarch64_jetson_apt]
+sources_linux_aarch64_manifest = join([create_file_name_from_jetson_apt_source(pkg_name, version) for (pkg_name, _, version, _) in sources_linux_aarch64_jetson_apt], "\n")
+
+script = """
+if [[ \${target} == aarch64-linux-gnu ]]; then
+    echo \"$(sources_linux_aarch64_manifest)\" >> \${WORKSPACE}/srcdir/aarch64-linux-gnu_install.manifest
+fi
+""" * raw"""
 cd ${WORKSPACE}/srcdir
 
 # use a temporary directory to avoid running out of tmpfs in srcdir on Travis
@@ -78,6 +133,16 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # clean-up
     rm ${prefix}/cuda/*.nvi
+elif [[ ${target} == aarch64-linux-gnu ]]; then
+    apk add dpkg
+    cat ${target}_install.manifest | xargs -t -Ideb_file dpkg-deb -x deb_file $temp
+    cd $temp/usr/local/cuda-10.2
+    find .
+
+    # clean-up
+    rm -r doc
+
+    mv * ${prefix}/cuda
 fi
 
 cd ${prefix}/cuda
@@ -107,5 +172,11 @@ end
 if should_build_platform("x86_64-w64-mingw32")
     build_tarballs(ARGS, name, version, sources_windows, script,
                    [Platform("x86_64", "windows")], products, dependencies;
+                   skip_audit=true)
+end
+
+if should_build_platform("aarch64-linux-gnu")
+    build_tarballs(non_reg_ARGS, name, version_linux_aarch64, sources_linux_aarch64, script,
+                   [Platform("aarch64", "linux")], products, dependencies;
                    skip_audit=true)
 end

--- a/C/CUDA/CUDA_full@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.2/build_tarballs.jl
@@ -18,7 +18,6 @@ sources_windows = [
                "b538271c4d9ffce1a8520bf992d9bd23854f0f29cee67f48c6139e4cf301e253", "installer.exe")
 ]
 
-version_linux_aarch64 = v"10.2.460"
 sources_linux_aarch64 = [
     # Expected install order for cuda-toolkit-10-2 (provided build-essential was installed prior) - i.e. output from apt-get -s install --no-install-recommends cuda-toolkit-10-2
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cudart/cuda-cudart-10-2_10.2.300-1_arm64.deb", "e3cd683965f7b2e4a13b27c58754443185dcc545d0f989e52c224840cfde48d1"),
@@ -170,7 +169,7 @@ if should_build_platform("x86_64-w64-mingw32")
 end
 
 if should_build_platform("aarch64-linux-gnu")
-    build_tarballs(non_reg_ARGS, name, version_linux_aarch64, sources_linux_aarch64, script,
+    build_tarballs(non_reg_ARGS, name, version, sources_linux_aarch64, script,
                    [Platform("aarch64", "linux")], products, dependencies;
                    skip_audit=true)
 end

--- a/C/CUDA/CUDA_full@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.2/build_tarballs.jl
@@ -19,46 +19,47 @@ sources_windows = [
 ]
 
 sources_linux_aarch64 = [
-    # Expected install order for cuda-toolkit-10-2 (provided build-essential was installed prior) - i.e. output from apt-get -s install --no-install-recommends cuda-toolkit-10-2
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cudart/cuda-cudart-10-2_10.2.300-1_arm64.deb", "e3cd683965f7b2e4a13b27c58754443185dcc545d0f989e52c224840cfde48d1"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cudart/cuda-driver-dev-10-2_10.2.300-1_arm64.deb", "5ea760773de2685acfac3931bcdc2eff3a18eceb28fc86f80061e215e9e81456"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cudart/cuda-cudart-dev-10-2_10.2.300-1_arm64.deb", "d37a94a3fb858db2cf41cde1bcbe1042b9a66d4fd3fd30882805a478523acb18"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvcc/cuda-nvcc-10-2_10.2.300-1_arm64.deb", "86c138d6903fa35bb512414bbb98dfd519d3e5ee743dc846e9fb1aa42f7e0391"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cupti/cuda-cupti-10-2_10.2.300-1_arm64.deb", "e2024cd43668e3102c6afd0767cfcbc107e49b5198fbb437591758b0c2c4f6f1"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cupti/cuda-cupti-dev-10-2_10.2.300-1_arm64.deb", "731abaaf4c5ce24c4a4ecce6b1921b88662b70e57bffee0b20bbee9b17fc4353"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvdisasm/cuda-nvdisasm-10-2_10.2.300-1_arm64.deb", "6b9a6f123bc46d525abf351e8720fa6da5573fd9caeebe312590105bef71a146"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-cuobjdump/cuda-cuobjdump-10-2_10.2.300-1_arm64.deb", "1a6c02ae2786fadeac0888e8998d47e28282319b36909b6cdc3c0a546afa578a"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-gdb/cuda-gdb-10-2_10.2.300-1_arm64.deb", "662c7e43a4cce180f187cf5f2b00d8634d9276a6ecb415eeca638778e27c215f"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-memcheck/cuda-memcheck-10-2_10.2.300-1_arm64.deb", "2027d40d3302ecfbfa42790b365f8c097726d5a8b05fb7087971dec7e6bc1f35"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvprof/cuda-nvprof-10-2_10.2.300-1_arm64.deb", "882c05ec6d681980c1a6cc5afacd4c2a58e6d819cb1aa043ae16bb74f97a70f8"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvtx/cuda-nvtx-10-2_10.2.300-1_arm64.deb", "fe29d0a639620c161a732cdff520670142e986d795bb3f7afd7c06e41dca340e"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-command-line-tools-10-2/cuda-command-line-tools-10-2_10.2.460-1_arm64.deb", "76eb6e1bc49f5a08443ddf8f2b283b057cf16a8d907b033853ce316fa6c89fc5"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvprune/cuda-nvprune-10-2_10.2.300-1_arm64.deb", "c77f9f554932d7586d58c5cc77b62ae94f2c1a9779aac78fd8b89335b6ad35ba"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-compiler-10-2/cuda-compiler-10-2_10.2.460-1_arm64.deb", "9d2ccb1a43782e3b9728c35a81525f229fac1a4e422708da58c00e98e8fdcf1e"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvrtc/cuda-nvrtc-10-2_10.2.300-1_arm64.deb", "7118079394a22c6cedba1152f0a78ef7bb10ac26c1984ab8c4dcf82fe9f4e20c"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvrtc/cuda-nvrtc-dev-10-2_10.2.300-1_arm64.deb", "bdce95a7a30daf7d1a52a32385c1ee67a8f742126a2f24d82a7b7dd35d012f3f"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcusolver/libcusolver-10-2_10.3.0.300-1_arm64.deb", "31a32e7c7e439bc34331d32b93392d08de6c9893d5083865b93703509d6fb7d6"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcusolver/libcusolver-dev-10-2_10.3.0.300-1_arm64.deb", "c86b549b4501a8ddd451dd7f46ea55b79d548bd987aaa17f3af03813e4b90dba"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcublas/libcublas10_10.2.3.300-1_arm64.deb", "a4cde28215c01bce78fa7c3d09909afaec487142e1144646bd7ff043a5c6c1df"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcublas/libcublas-dev_10.2.3.300-1_arm64.deb", "f2575fd6c86c9aa8eed0e782d68122d9ba3d1422ebd6e6c06c71bea096c169db"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcufft/libcufft-10-2_10.1.2.300-1_arm64.deb", "661a91f35f2d148d938ca907484ebe48727b17f03a8cbb6992e60bb792738caf"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcufft/libcufft-dev-10-2_10.1.2.300-1_arm64.deb", "43bf089682f745397c7c72bb53ce6d962e2d24246e1e7e686fd8159d3ddf7ba1"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcurand/libcurand-10-2_10.1.2.300-1_arm64.deb", "45f2bbafdde70b8b8bcdc6f0625a2ab334632b6659f153224654d03e1776057b"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcurand/libcurand-dev-10-2_10.1.2.300-1_arm64.deb", "7da1321d221290c7c8dcf49bef8970712cb981d8f9a93f405a080364f1bf0b12"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcusparse/libcusparse-10-2_10.3.1.300-1_arm64.deb", "bd844b7a71adc76694caf5da4818ab03f207e3b7f23340aa2fe86909f799fb92"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libc/libcusparse/libcusparse-dev-10-2_10.3.1.300-1_arm64.deb", "898fab6cae719007fdf0c8ebb27825bc7dd03e48314297b2b60639b604fa6bc4"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libn/libnpp/libnpp-10-2_10.2.1.300-1_arm64.deb", "dc51dc218b7652680138ca236877d01ff0b65546d60a113276ded05f1fea967e"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/libn/libnpp/libnpp-dev-10-2_10.2.1.300-1_arm64.deb", "4c64992156eaeb982af504a41920a33df01c701286903d07fe23c1d20c902b38"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-samples/cuda-samples-10-2_10.2.300-1_arm64.deb", "bb7726194bac9252863da80ae13e4fdd7e69a657314cb8ff6edf8ba1cd789e2d"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-documentation/cuda-documentation-10-2_10.2.300-1_arm64.deb", "d8e8c62156516d5eb2dea0ba49abd1b5cecae010872e0e71650e97a1ccd2e005"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvgraph/cuda-nvgraph-10-2_10.2.300-1_arm64.deb", "88412a2eecdc5dc2f3db7f6f2dea3d13c234114b8f36ec0356d237190504748e"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-libraries-10-2/cuda-libraries-10-2_10.2.460-1_arm64.deb", "a09ecb11e6ccf1d44c4ba941de49e0b9be02f6d70ba7f2f5c8be06a9d50fc9d1"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvgraph/cuda-nvgraph-dev-10-2_10.2.300-1_arm64.deb", "f280b981d54745d24bd933c48eba76903f4174d13e38aae89454f29433355186"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-libraries-dev-10-2/cuda-libraries-dev-10-2_10.2.460-1_arm64.deb", "bb34c354f1b96c170c9d175c360741a098a1c4933abc9864d85df937005c57a8"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-nvml-dev/cuda-nvml-dev-10-2_10.2.300-1_arm64.deb", "70620354d37385ff1d34ac2d4f713ca3419d413103f90e385adb0e7112bec501"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-visual-tools-10-2/cuda-visual-tools-10-2_10.2.460-1_arm64.deb", "39fb8d2d529a3aee658a51bee429124900f55c8513a6427d4963722d37ef65ff"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-tools-10-2/cuda-tools-10-2_10.2.460-1_arm64.deb", "c9c099420ebe15cf385e3b23bcae44c6338bcbc04aba6011560539fa473730c8"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-toolkit-10-2/cuda-toolkit-10-2_10.2.460-1_arm64.deb", "4c047e83b805ce9d76cbc5a2de2177548d8a63cd025e03f944705bf653e82828")
+    # Expected install order for cuda-toolkit-10-2, i.e. output from `apt-get -s install --no-install-recommends cuda-toolkit-10-2` (using source: "deb https://repo.download.nvidia.com/jetson/common r32.5 main")
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-license-10-2_10.2.89-1_arm64.deb", "8a862acbff5b33904bfe7ec3e92a553a8312da1db9f651b6cfe14db137a139ce"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvdisasm-10-2_10.2.89-1_arm64.deb", "9523033692cca5a2b29cd69942d69036deedacb8eb3273395662f6024b2c27f9"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cuobjdump-10-2_10.2.89-1_arm64.deb", "719b32f039cd8ed6123e1f9e3fa9badcf4c6ba5ac4a0b24a97d2db88e0764e1e"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-gdb-10-2_10.2.89-1_arm64.deb", "d3fef316b7d5b215cf11ff0190c69d9e8a2652b9dd37f454c7350110954e3496"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvprof-10-2_10.2.89-1_arm64.deb", "54d96b9cdba5a53da92b2cdaada27ec7a886b3a6a29e7d33b5fdf429ad788681"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-memcheck-10-2_10.2.89-1_arm64.deb", "f8f498108e1e4e3fdc40a1cb80cec44bb3da987b2160a3128d3bcf85a8533bbf"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cudart-10-2_10.2.89-1_arm64.deb", "2a718596cf1162bf0076d4ec6db52a5f7c3617b7ab7cd243887376e841a99915"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-driver-dev-10-2_10.2.89-1_arm64.deb", "c1c55ba59d8a28a7d56800504c65683a4d392893f35d08ec7bddf6b45efda468"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cudart-dev-10-2_10.2.89-1_arm64.deb", "5aa2bf1e8e9d467dacbff778b0d2d4a7bd31077a443b7a49711cc798562ea37d"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-misc-headers-10-2_10.2.89-1_arm64.deb", "e92834f576241295c74393b478cb7121d9e20cb3454aed26c464c3523eaeadde"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvcc-10-2_10.2.89-1_arm64.deb", "1a0ea57d4c1b1d9394d7e4f6ab94baa2aa49883f4ba2d59a60b750bb88d0fdeb"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cupti-10-2_10.2.89-1_arm64.deb", "319771f42db1d9a4a273bc5ff753148247ece9cf7544d2008d57d9061e6964f9"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cupti-dev-10-2_10.2.89-1_arm64.deb", "3bd27507b8eef4ae9d5faf8671e8843ef7bd4cede82dc76a8e6519390e22a5dc"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvtx-10-2_10.2.89-1_arm64.deb", "b4f9dedf0c21dbc75daadbabfde6aa17a73b6bdad0d5a18fae3da6e9717bfc99"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-command-line-tools-10-2_10.2.89-1_arm64.deb", "7425afa9751b073b709f969149babb65411e2ab96bbe1744af0d89a517a6f1a2"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvprune-10-2_10.2.89-1_arm64.deb", "1e04820f53fb96b737c6b5d92ae2c1c54414e84a87ae9a55a00fc78c05e4e33f"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-compiler-10-2_10.2.89-1_arm64.deb", "cf15fd18669b88dfd9e49be6e8189e03936ce993be47dfc88b99d1b3d86d3a6d"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cufft-10-2_10.2.89-1_arm64.deb", "7d06a0bdd16b16c2384de79e488cde5bb580b3bc9ee46bd1e23d17ce6d260e01"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cufft-dev-10-2_10.2.89-1_arm64.deb", "239060c552e98511b8a752127c57bd86cd1261af5062b99f85d94a12ef61d876"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-curand-10-2_10.2.89-1_arm64.deb", "1cf024814383a2ec21e562e1e89809050dbae36bceed6ee276affe03185ca266"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-curand-dev-10-2_10.2.89-1_arm64.deb", "f6594cd55b89a4e45ca3a382cef99c6bd3d2efb7ab222a82f261a79cc9e066ce"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cusolver-10-2_10.2.89-1_arm64.deb", "ede4930b8a7d8098590b3691785cf225fdbb08e3cb7853ca8f0ffc7313e89b3f"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cusolver-dev-10-2_10.2.89-1_arm64.deb", "e3d786efc6d92e24c2527a2a76685de4cfc92e609a3b6ab1258cc820a5c867e4"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cusparse-10-2_10.2.89-1_arm64.deb", "459f9e41ac458eef3c94ba0a5d367182af83c070454d9e38b3565252c039a827"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-cusparse-dev-10-2_10.2.89-1_arm64.deb", "3a9ccd17e6916fda5cede14c206a8199fdba27f1118947a1f31cbf33132241df"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvrtc-10-2_10.2.89-1_arm64.deb", "fe9cc7cbdab29035371e5f77d190aecd97bbf31ca66b3f62612bf62580417b16"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvrtc-dev-10-2_10.2.89-1_arm64.deb", "5c3bd9bc84170ec0c3465444409e7912046e2523e6a18d331b53901c0e57d229"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cublas/libcublas10_10.2.2.89-1_arm64.deb", "d0299b139a163136432dfb2c028769944b6c5636ad9238614860c196a1c91aea"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cublas/libcublas-dev_10.2.2.89-1_arm64.deb", "5fa7e3e8fe266fdea7e91778610b7e8d3d85d8950875a4915ce3626c9e564365"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-npp-10-2_10.2.89-1_arm64.deb", "a01a204e6afefb0072424817c7133c5c18a9f3996fbf48f0b31297cb7c07e1ac"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-npp-dev-10-2_10.2.89-1_arm64.deb", "4d572a2472564f5008c3cfe9b24dbef765a1531a73c43436c66a146b4d16cace"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvgraph-10-2_10.2.89-1_arm64.deb", "f800974ac6cb3fb6595a08e613fc0f376d7b91f43eed1b5306b0496f9588e441"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvgraph-dev-10-2_10.2.89-1_arm64.deb", "cc2d9897c54f27a20f90bea5df391875b3f8163ec69745fb7546c1ce57e1d718"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-samples/cuda-samples-10-2_10.2.89-1_arm64.deb", "121e273d8586bde904ceeab72a603a86d781f3bac6d3a21732703ca2ca9ec528"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-documentation-10-2_10.2.89-1_arm64.deb", "746f675b08f29cdf7d9fe39edb325a960ae29106da805369b8dc509e72ec2329"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-libraries-10-2_10.2.89-1_arm64.deb", "71309637bbc86b3d7f014c5ba5da709b88f69dfc0710aa8caa661b3aa40a51b4"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-libraries-dev-10-2_10.2.89-1_arm64.deb", "9d3e1e4cf097f6e04c7f881b4af1a54c52552fb2828f73f7ae8fa5b9efe32d29"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvml-dev-10-2_10.2.89-1_arm64.deb", "c8743e69c84a432c5e6dea6edfcacf1bb6b09b028bee61c8aece7a41d0447265"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-tools-10-2_10.2.89-1_arm64.deb", "eeaae6a103cc5d950bf4e774a277d90286492df0e0815e161f7c12291c9aa5ba"),
+    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-toolkit-10-2_10.2.89-1_arm64.deb", "47a1c8c8bde2c763396a68c38cc901217e1606bb536ec5880d4c072c4eee9073"),
 ]
 sources_linux_aarch64_manifest = join([src.filename for src in sources_linux_aarch64], "\n")
 
@@ -129,13 +130,14 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 elif [[ ${target} == aarch64-linux-gnu ]]; then
     apk add dpkg
     cat ${target}_install.manifest | xargs -t -Ideb_file dpkg-deb -x deb_file $temp
+    find $temp
     cd $temp/usr/local/cuda-10.2
-    find .
 
     # clean-up
     rm -r doc
 
     mv * ${prefix}/cuda
+    mv ${prefix}/cuda/doc/EULA.txt ${prefix}/cuda
 fi
 
 cd ${prefix}/cuda

--- a/C/CUDA/CUDA_full@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.2/build_tarballs.jl
@@ -53,7 +53,7 @@ sources_linux_aarch64 = [
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-npp-dev-10-2_10.2.89-1_arm64.deb", "4d572a2472564f5008c3cfe9b24dbef765a1531a73c43436c66a146b4d16cace"),
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvgraph-10-2_10.2.89-1_arm64.deb", "f800974ac6cb3fb6595a08e613fc0f376d7b91f43eed1b5306b0496f9588e441"),
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvgraph-dev-10-2_10.2.89-1_arm64.deb", "cc2d9897c54f27a20f90bea5df391875b3f8163ec69745fb7546c1ce57e1d718"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-samples/cuda-samples-10-2_10.2.89-1_arm64.deb", "121e273d8586bde904ceeab72a603a86d781f3bac6d3a21732703ca2ca9ec528"),
+    # FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-samples/cuda-samples-10-2_10.2.89-1_arm64.deb", "121e273d8586bde904ceeab72a603a86d781f3bac6d3a21732703ca2ca9ec528"),
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-documentation-10-2_10.2.89-1_arm64.deb", "746f675b08f29cdf7d9fe39edb325a960ae29106da805369b8dc509e72ec2329"),
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-libraries-10-2_10.2.89-1_arm64.deb", "71309637bbc86b3d7f014c5ba5da709b88f69dfc0710aa8caa661b3aa40a51b4"),
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-libraries-dev-10-2_10.2.89-1_arm64.deb", "9d3e1e4cf097f6e04c7f881b4af1a54c52552fb2828f73f7ae8fa5b9efe32d29"),

--- a/C/CUDA/CUDA_full@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.2/build_tarballs.jl
@@ -54,7 +54,7 @@ sources_linux_aarch64 = [
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvgraph-10-2_10.2.89-1_arm64.deb", "f800974ac6cb3fb6595a08e613fc0f376d7b91f43eed1b5306b0496f9588e441"),
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvgraph-dev-10-2_10.2.89-1_arm64.deb", "cc2d9897c54f27a20f90bea5df391875b3f8163ec69745fb7546c1ce57e1d718"),
     # FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda-samples/cuda-samples-10-2_10.2.89-1_arm64.deb", "121e273d8586bde904ceeab72a603a86d781f3bac6d3a21732703ca2ca9ec528"),
-    FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-documentation-10-2_10.2.89-1_arm64.deb", "746f675b08f29cdf7d9fe39edb325a960ae29106da805369b8dc509e72ec2329"),
+    # FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-documentation-10-2_10.2.89-1_arm64.deb", "746f675b08f29cdf7d9fe39edb325a960ae29106da805369b8dc509e72ec2329"),
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-libraries-10-2_10.2.89-1_arm64.deb", "71309637bbc86b3d7f014c5ba5da709b88f69dfc0710aa8caa661b3aa40a51b4"),
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-libraries-dev-10-2_10.2.89-1_arm64.deb", "9d3e1e4cf097f6e04c7f881b4af1a54c52552fb2828f73f7ae8fa5b9efe32d29"),
     FileSource("https://repo.download.nvidia.com/jetson/common/pool/main/c/cuda/cuda-nvml-dev-10-2_10.2.89-1_arm64.deb", "c8743e69c84a432c5e6dea6edfcacf1bb6b09b028bee61c8aece7a41d0447265"),
@@ -131,12 +131,7 @@ elif [[ ${target} == aarch64-linux-gnu ]]; then
     apk add dpkg
     cat ${target}_install.manifest | xargs -t -Ideb_file dpkg-deb -x deb_file $temp
     find $temp
-    cd $temp/usr/local/cuda-10.2
-
-    # clean-up
-    rm -r doc
-
-    mv * ${prefix}/cuda
+    mv $temp/usr/local/cuda-10.2/* ${prefix}/cuda
     mv ${prefix}/cuda/doc/EULA.txt ${prefix}/cuda
 fi
 

--- a/C/CUDA/CUDA_full@10.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@10.2/build_tarballs.jl
@@ -132,6 +132,10 @@ elif [[ ${target} == aarch64-linux-gnu ]]; then
     cat ${target}_install.manifest | xargs -t -Ideb_file dpkg-deb -x deb_file $temp
     find $temp
     mv $temp/usr/local/cuda-10.2/* ${prefix}/cuda
+
+    mv -nv $temp/usr/include/* ${prefix}/cuda/targets/aarch64-linux/include
+    mv -nv $temp/usr/lib/$target/* ${prefix}/cuda/targets/aarch64-linux/lib
+
     mv ${prefix}/cuda/doc/EULA.txt ${prefix}/cuda
 fi
 


### PR DESCRIPTION
Added CUDA 10.2 for aarch64-linux-gnu from the APT archives for Jetson.