### PR TITLE
[Arpack] Build v3.5 also for experimental platforms

### DIFF
--- a/A/Arpack/build_tarballs.jl
+++ b/A/Arpack/build_tarballs.jl
@@ -6,7 +6,7 @@ version = v"3.5.1" # <-- This is actually v3.5.0, but we need to build for new p
 
 sources = [
     GitSource("https://github.com/opencollab/arpack-ng.git",
-              "7b7ce1a46e3f8e6393226c2db85cc457ddcdb16d"),
+              "9233f7f86f063ca6ca3793cb54dec590eb146e10"),
 ]
 
 # Bash recipe for building across all platforms

--- a/A/Arpack/build_tarballs.jl
+++ b/A/Arpack/build_tarballs.jl
@@ -64,6 +64,16 @@ if [[ ${nbits} == 64 ]]; then
     FFLAGS="${FFLAGS} -fdefault-integer-8 ${SYMBOL_DEFS[@]}"
 fi
 
+# Work around error
+#
+#     Error: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
+#
+# Properly fixed upstream in v3.8.0 with https://github.com/opencollab/arpack-ng/pull/245.
+# TODO: Remove this line when we upgrade to that version.
+if [[ "${target}" == aarch64-apple-* ]]; then
+    FFLAGS="${FFLAGS} -fallow-argument-mismatch"
+fi
+
 mkdir build
 cd build
 export LDFLAGS="${EXE_LINK_FLAGS[@]} -L$prefix/lib -lpthread"


### PR DESCRIPTION
The previous build of v3.5.0 of Arpack was actually still using the git revision
of v3.8.0, which is known to be problematic.