### PR TITLE
Relax compat bounds with Expat_jll

### DIFF
--- a/D/Dbus/build_tarballs.jl
+++ b/D/Dbus/build_tarballs.jl
@@ -32,7 +32,9 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [p for p in supported_platforms() if Sys.islinux(p) || Sys.isfreebsd(p)]
+platforms = filter!(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
+# TODO: Remove this restriction for the next build
+filter!(p -> arch(p) != "armv6l", platforms)
 
 products = [
     LibraryProduct("libdbus-1", :libdbus),
@@ -41,7 +43,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Expat_jll", v"2.2.7"; compat="~2.2.7"),
+    Dependency("Expat_jll"; compat="2.2.7"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/Fontconfig/build_tarballs.jl
+++ b/F/Fontconfig/build_tarballs.jl
@@ -74,7 +74,7 @@ dependencies = [
     Dependency("Bzip2_jll", v"1.0.7"; compat="1.0.7"),
     Dependency("Zlib_jll"),
     Dependency("Libuuid_jll"),
-    Dependency("Expat_jll", v"2.2.10"; compat="~2.2.7"),
+    Dependency("Expat_jll"; compat="2.2.10"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -118,7 +118,7 @@ dependencies = [
     Dependency("Zlib_jll"),
     Dependency("SQLite_jll"),
     Dependency("OpenJpeg_jll"),
-    Dependency("Expat_jll"; compat="~2.2.10"),
+    Dependency("Expat_jll"; compat="2.2.10"),
     Dependency("Zstd_jll"),
     Dependency("Libtiff_jll"; compat="4.3"),
     Dependency("libgeotiff_jll"; compat="1.7"),

--- a/G/Graphviz/build_tarballs.jl
+++ b/G/Graphviz/build_tarballs.jl
@@ -64,6 +64,8 @@ install_license COPYING
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
+# TODO: remove this restriction in the next build
+filter!(p -> arch(p) != "armv6l" && !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -114,8 +116,8 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="Cairo_jll", uuid="83423d85-b0ee-5818-9007-b63ccbeb887a")),
-    Dependency("Expat_jll", v"2.2.7"; compat="~2.2.7"),
-    Dependency("Pango_jll", v"1.42.4"; compat="1.42.4"),
+    Dependency("Expat_jll"; compat="2.2.7"),
+    Dependency("Pango_jll"; compat="1.42.4"),
     # PCRE is needed only for Windows.  Maybe it's only a build dependency?
     # Dependency(PackageSpec(name="PCRE_jll",  uuid="2f80f16e-611a-54ab-bc61-aa92de5b98fc")),
     # Indirect dependency from pango, but without this, pkg-config doesn't pick up pango

--- a/P/Python/build_tarballs.jl
+++ b/P/Python/build_tarballs.jl
@@ -62,6 +62,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
+# TODO: remove this restriction in the next build
+filter!(p -> arch(p) != "armv6l" && !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
 
 # Disable windows for now, until we can sort through all of these patches
 # and choose the ones that we need:
@@ -76,7 +78,7 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Expat_jll", v"2.2.7"; compat="~2.2.7"),
+    Dependency("Expat_jll", v"2.2.7"; compat="2.2.7"),
     # Future versions of bzip2 should allow a more relaxed compat because the
     # soname of the macOS library shouldn't change at every patch release.
     Dependency("Bzip2_jll", v"1.0.6"; compat="=1.0.6"),

--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -38,7 +38,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Expat_jll"; compat="~2.2.10"),
+    Dependency("Expat_jll"; compat="2.2.10"),
     Dependency("Libffi_jll"; compat="~3.2.2"),
     Dependency("XML2_jll"),
 ]


### PR DESCRIPTION
PR #2996 was too restrictive, there are actually no incompatibilities which
require to restrict compats to ~2.2. I tested some dependent packgages with new
Expat_jll 2.4.4, they work fine.

Companion PR to https://github.com/JuliaRegistries/General/pull/53921