### PR TITLE
DuckDB version 0.3.2

### DIFF
--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "DuckDB"
-version = v"0.3.1"
+version = v"0.3.2"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
[0.3.2 Preview Release "Gibberifrons"](https://github.com/duckdb/duckdb/releases)
