### PR TITLE
Recompile MUMPS with -fno-stack-check flag for OSX

### DIFF
--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -24,13 +24,17 @@ if [[ "${target}" == aarch64-apple-darwin* ]]; then
     FFLAGS=("-fallow-argument-mismatch")
 fi
 
+if [[ "${target}" == *-apple* ]]; then
+  CFLAGS=("-fno-stack-check")
+fi
+
 make_args+=(OPTF=-O \
             CDEFS=-DAdd_ \
             LMETISDIR=${prefix} \
             IMETIS="-I${includedir}" \
             LMETIS="-L${libdir} -lparmetis -lmetis" \
             ORDERINGSF="-Dpord -Dparmetis" \
-            CC="mpicc -fPIC" \
+            CC="mpicc -fPIC ${CFLAGS[@]}" \
             FC="mpif90 -fPIC ${FFLAGS[@]}" \
             FL="mpif90 -fPIC" \
             SCALAP="${libdir}/scalapack32.${dlext} ${libdir}/libopenblas.${dlext}" \
@@ -81,9 +85,7 @@ cd ..
 cp include/* ${prefix}/include
 """
 
-# OpenMPI and MPICH are not precompiled for Windows
-# SCALAPACK doesn't build on PowerPC
-platforms = expand_gfortran_versions(filter!(p -> !Sys.iswindows(p) && arch(p) != "powerpc64le", supported_platforms()))
+platforms = expand_gfortran_versions(supported_platforms(; exclude=Sys.iswindows))
 
 # The products that we will ensure are always built
 products = [

--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -85,7 +85,9 @@ cd ..
 cp include/* ${prefix}/include
 """
 
-platforms = expand_gfortran_versions(supported_platforms(; exclude=Sys.iswindows))
+# OpenMPI and MPICH are not precompiled for Windows
+# MUMPS doesn't build on PowerPC
+platforms = expand_gfortran_versions(filter!(p -> !Sys.iswindows(p) && arch(p) != "powerpc64le", supported_platforms()))
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
We can compile MUMPS for PowerPC now, SCALAPACK 2.2.0 works for this platform.

Update: We also have the issue with PowerPC platform here in MUMPS....
I will keep the PR to add the flag `-fno-stack-check` for `Apple` platforms.