### PR TITLE
[ModularForms] new recipe

### DIFF
--- a/M/ModularForms/build_tarballs.jl
+++ b/M/ModularForms/build_tarballs.jl
@@ -13,7 +13,7 @@ cd $WORKSPACE/srcdir/ModularForms_jll_src
 if [[ ${target} == *musl* ]]; then
    export CFLAGS=-D_GNU_SOURCE
 fi
-./configure --prefix=$prefix --disable-static --enable-shared --with-gmp=$prefix --with-mpfr=$prefix --with-flint=$prefix --with-arb=$prefix ${extraflags}
+./configure --prefix=$prefix --disable-static --enable-shared --with-gmp=$prefix --with-mpfr=$prefix --with-flint=$prefix --with-arb=$prefix
 make -j${nproc}
 make install LIBDIR=$(basename ${libdir})
 """

--- a/M/ModularForms/build_tarballs.jl
+++ b/M/ModularForms/build_tarballs.jl
@@ -13,14 +13,18 @@ cd $WORKSPACE/srcdir/ModularForms_jll_src
 if [[ ${target} == *musl* ]]; then
    export CFLAGS=-D_GNU_SOURCE
 fi
-./configure --prefix=$prefix --disable-static --enable-shared --with-gmp=$prefix --with-mpfr=$prefix --with-flint=$prefix --with-arb=$prefix CC=gcc ${extraflags}
-make -j${nproc} verbose
+./configure --prefix=$prefix --disable-static --enable-shared --with-gmp=$prefix --with-mpfr=$prefix --with-flint=$prefix --with-arb=$prefix ${extraflags}
+make -j${nproc}
 make install LIBDIR=$(basename ${libdir})
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = [p for p in supported_platforms()
+             if contains(triplet(p), "linux")
+             || contains(triplet(p), "apple")
+             || contains(triplet(p), "freebsd")
+            ]
 
 # The products that we will ensure are always built
 products = [
@@ -35,4 +39,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="^1.6", preferred_gcc_version=v"11")
+               julia_compat="^1.6", preferred_gcc_version=v"9")

--- a/M/ModularForms/build_tarballs.jl
+++ b/M/ModularForms/build_tarballs.jl
@@ -20,11 +20,7 @@ make install LIBDIR=$(basename ${libdir})
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [p for p in supported_platforms()
-             if contains(triplet(p), "linux")
-             || contains(triplet(p), "apple")
-             || contains(triplet(p), "freebsd")
-            ]
+platforms = supported_platforms(; exclude=Sys.iswindows)
 
 # The products that we will ensure are always built
 products = [

--- a/M/ModularForms/build_tarballs.jl
+++ b/M/ModularForms/build_tarballs.jl
@@ -1,0 +1,38 @@
+using BinaryBuilder, Pkg
+import Pkg.Types: VersionSpec
+
+name = "ModularForms"
+version = v"0.1.0"
+
+sources = [GitSource("https://gitlab.com/mraum/ModularForms_jll_src.git",
+                     "4d81d41e625fde3e36dc86df5061313a8447cacd")]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/ModularForms_jll_src
+if [[ ${target} == *musl* ]]; then
+   export CFLAGS=-D_GNU_SOURCE
+fi
+./configure --prefix=$prefix --disable-static --enable-shared --with-gmp=$prefix --with-mpfr=$prefix --with-flint=$prefix --with-arb=$prefix CC=gcc ${extraflags}
+make -j${nproc} verbose
+make install LIBDIR=$(basename ${libdir})
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libmodularforms_jll", :libmodularforms_jll)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="Arb_jll"), compat = "~200.2200.0"),
+    Dependency(PackageSpec(name="FLINT_jll"), compat = "^200.800.401")
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="^1.6", preferred_gcc_version=v"11")


### PR DESCRIPTION
Same as #4433, but GitHub closed the merge request after I force pushed the rebased commits.

ModularForms.jl is a new package (at https://gitlab.com/mraum/modularforms.jl) to compute with modular forms based on the Oscar CAS. These are the C dependencies that we use. The build script follows the pattern of, for example, FLINT, but the preferred GCC version was needed to complete local tests successfully.

As for the comment about Windows libs in the review, I only later realized that this would require ModularForms_jll_src to be adjusted, where we do not accept special casing for proprietary platforms. I narrowed down the target platforms accordingly.