### PR TITLE
New Recipe: ColPack v0.1.0

### DIFF
--- a/C/ColPack/build_tarballs.jl
+++ b/C/ColPack/build_tarballs.jl
@@ -1,0 +1,41 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ColPack"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/michel2323/ColPack.git", "c8674588c8204e9f05a2c6adea21a28f7b56f490")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd ColPack/build/automake/
+autoreconf -vif
+mkdir build
+cd build/
+../configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; exclude=p -> Sys.isapple(p) || Sys.iswindows(p))
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libColPack", :libcolpack)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
This is the binary for ColPack forked from https://github.com/CSCsw/ColPack . It should enable advanced coloring algorithms that can be used in SparseDiffTools.jl . A C interface was added and a ColPack.jl package will be published soon.