### PR TITLE
[HiGHS] restore build_tarballs.jl

### DIFF
--- a/H/HiGHS/HiGHS/build_tarballs.jl
+++ b/H/HiGHS/HiGHS/build_tarballs.jl
@@ -1,0 +1,27 @@
+include("../highs_common.jl")
+
+script = build_script(shared_libs = "ON")
+
+products = [
+    LibraryProduct("libhighs", :libhighs),
+    ExecutableProduct("highs", :highs),
+]
+
+platforms = expand_cxxstring_abis(platforms)
+
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
+]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    preferred_gcc_version = v"6",
+    julia_compat = "1.6",
+)


### PR DESCRIPTION
This PR restores the build_tarballs.jl script for the dynamic build
of HiGHS. It was removed in #4456 to avoid rebuilding the binary.

[ci skip]