### PR TITLE
BLIS Append 64_ Suffix to All F77 Exported

### DIFF
--- a/B/blis/bundled/patches/bli_macro_defs.h.f77suffix64.patch
+++ b/B/blis/bundled/patches/bli_macro_defs.h.f77suffix64.patch
@@ -1,4 +1,10 @@
-160c160
+88,91c88,91
+< #define PASTEF770(name)                                      name ## _
 < #define PASTEF77(ch1,name)                     ch1        ## name ## _
+< #define PASTEF772(ch1,ch2,name)                ch1 ## ch2 ## name ## _
+< #define PASTEF773(ch1,ch2,ch3,name)     ch1 ## ch2 ## ch3 ## name ## _
 ---
+> #define PASTEF770(name)                                      name ## _64_
 > #define PASTEF77(ch1,name)                     ch1        ## name ## _64_
+> #define PASTEF772(ch1,ch2,name)                ch1 ## ch2 ## name ## _64_
+> #define PASTEF773(ch1,ch2,ch3,name)     ch1 ## ch2 ## ch3 ## name ## _64_


### PR DESCRIPTION
Resolves JuliaLinearAlgebra/libblastrampoline#36

Currently only level-1/2/3 S/D/C/Z routines are exported w/ `64_` suffix, while libblastrampoline identifies BLAS suffix against `isamax`. This causes the issue above. The patch here should resolve the issue and kickoff lbt+libblis.