### PR TITLE
Include Arm SVE in Config arm64

### DIFF
--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -18,8 +18,9 @@ cd blis/
 
 for i in ./config/*/*.mk; do
 
-    # Building in container forbids -march options
-    sed -i "s/-march[^ ]*//g" $i
+    # Building in container forbids -march options <<< Settings overrided.
+    # sed -i "s/-march[^ ]*//g" $i
+
     # Building in container forbids unsafe optimization.
     sed -i "s/-ffast-math//g" $i
     sed -i "s/-funsafe-math-optimizations//g" $i
@@ -80,6 +81,20 @@ if [ ${nbits} = 64 ]; then
     patch frame/include/bli_macro_defs.h < ${WORKSPACE}/srcdir/patches/bli_macro_defs.h.f77suffix64.patch
 fi
 
+# Include SVE support in this metaconfig.
+if [ ${BLI_CONFIG} = arm64 ]; then
+    patch config_registry < ${WORKSPACE}/srcdir/patches/config_registry.metaconfig+armsve.patch
+    # Unscreen Arm SVE code for metaconfig.
+    patch kernels/armsve/bli_kernels_armsve.h \
+        < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
+    patch kernels/armsve/1m/old/bli_dpackm_armsve512_int_12xk.c \
+        < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
+    patch kernels/armsve/1m/bli_dpackm_armsve256_int_8xk.c \
+        < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
+    # Config armsve depends on some family header defines.
+    cp config/armsve/bli_family_armsve.h config/arm64/bli_family_arm64.h
+fi
+
 export BLI_F77BITS=${nbits}
 ./configure -p ${prefix} -t ${BLI_THREAD} -b ${BLI_F77BITS} ${BLI_CONFIG}
 make -j${nproc}
@@ -121,4 +136,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version = v"8.1.0", julia_compat="1.6")
+               preferred_gcc_version = v"10", lock_microarchitecture=false, julia_compat="1.6")

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -83,7 +83,9 @@ fi
 
 # Include SVE support in this metaconfig.
 if [ ${BLI_CONFIG} = arm64 ]; then
+    # Add SVE configs to the registry.
     patch config_registry < ${WORKSPACE}/srcdir/patches/config_registry.metaconfig+armsve.patch
+
     # Unscreen Arm SVE code for metaconfig.
     patch kernels/armsve/bli_kernels_armsve.h \
         < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
@@ -91,8 +93,15 @@ if [ ${BLI_CONFIG} = arm64 ]; then
         < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
     patch kernels/armsve/1m/bli_dpackm_armsve256_int_8xk.c \
         < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
+
     # Config armsve depends on some family header defines.
     cp config/armsve/bli_family_armsve.h config/arm64/bli_family_arm64.h
+
+    # Screen out SVE instructions in config-stage.
+    patch config/a64fx/bli_cntx_init_a64fx.c \
+        < ${WORKSPACE}/srcdir/patches/a64fx_config_screen_sector_cache.patch
+    patch config/armsve/bli_cntx_init_armsve.c \
+        < ${WORKSPACE}/srcdir/patches/armsve_config_screen_non_sve.patch
 fi
 
 export BLI_F77BITS=${nbits}

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -145,4 +145,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version = v"10", lock_microarchitecture=false, julia_compat="1.6")
+               preferred_gcc_version = v"11", lock_microarchitecture=false, julia_compat="1.6")

--- a/B/blis/bundled/patches/a64fx_config_screen_sector_cache.patch
+++ b/B/blis/bundled/patches/a64fx_config_screen_sector_cache.patch
@@ -1,0 +1,5 @@
+145c145
+< #if !defined(CACHE_SECTOR_SIZE_READONLY)
+---
+> #if 0
+

--- a/B/blis/bundled/patches/armsve_config_screen_non_sve.patch
+++ b/B/blis/bundled/patches/armsve_config_screen_non_sve.patch
@@ -1,0 +1,7 @@
+35a36
+> #include <sys/auxv.h>
+38a40,43
+> 	const int HWCAP_SVE = 1 << 22;
+> 	if (!(getauxval( AT_HWCAP ) & HWCAP_SVE))
+> 		return;
+> 

--- a/B/blis/bundled/patches/armsve_kernels_unscreen_arm_sve_h.patch
+++ b/B/blis/bundled/patches/armsve_kernels_unscreen_arm_sve_h.patch
@@ -1,0 +1,4 @@
+48c48
+< #if (defined(BLIS_FAMILY_ARMSVE) && !defined(BLIS_FAMILY_A64FX))
+---
+> #if 1

--- a/B/blis/bundled/patches/config_registry.metaconfig+armsve.patch
+++ b/B/blis/bundled/patches/config_registry.metaconfig+armsve.patch
@@ -1,0 +1,4 @@
+15c15
+< arm64:          firestorm thunderx2 cortexa57 cortexa53 generic
+---
+> arm64:          firestorm armsve a64fx thunderx2 cortexa57 cortexa53 generic


### PR DESCRIPTION
Both SVE configs are added:
- `armsve` the generic one.
- `a64fx` the A64FX one.

Runtime detection supported by upstream.

Select to bypass `-march` limitation since we're building a fat-lib.

Sorry for having opened yet another issue :D