### PR TITLE
WIP: [Torch] Renamed Torch to TorchCUDA, and added a CPU-only Torch

### DIFF
--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -10,7 +10,7 @@ sources = [
     GitSource("https://github.com/dhairyagandhi96/Torch.jl.git", "85bd08d39e7fba29ec4a643f60dd006ed8be8ede"),
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.10.2%2Bcpu.zip", "fa3fad287c677526277f64d12836266527d403f21f41cc2e7fb9d904969d4c4a"; unpack_target = "x86_64-linux-gnu-cxx03"),
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcpu.zip", "83e43d63d0e7dc9d57ccbdac8a8d7edac6c9e18129bf3043be475486b769a9c2"; unpack_target = "x86_64-linux-gnu-cxx11"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.10.2.zip", "d1711e844dc69c2338adfc8ce634806a9ae36e54328afbe501bafd2d70f550e2"; unpack_target = "x86_64-apple-darwin"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.10.2.zip", "d1711e844dc69c2338adfc8ce634806a9ae36e54328afbe501bafd2d70f550e2"; unpack_target = "x86_64-apple-darwin14"),
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-1.10.2%2Bcpu.zip", "0ce2ccd959704cd85c44ad1f3f335c56734c7ff09418bd563e07d5bb7142510c"; unpack_target = "x86_64-w64-mingw32"),
 ]
 

--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -25,7 +25,6 @@ if [[ $target == *linux* ]]; then
 else
     cd $target
 fi
-find .
 mv libtorch/share/* $prefix/share/
 mv libtorch/lib/* $libdir
 rm -r libtorch/lib libtorch/share libtorch/bin libtorch/include

--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -25,10 +25,10 @@ if [[ $target == *linux* ]]; then
 else
     cd $target
 fi
+find .
 mv libtorch/share/* $prefix/share/
 mv libtorch/lib/* $libdir
-rm -r libtorch/lib
-rm -r libtorch/share
+rm -r libtorch/lib libtorch/share libtorch/bin libtorch/include
 mv libtorch/* $prefix
 rm -r libtorch
 

--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -25,11 +25,9 @@ if [[ $target == *linux* ]]; then
 else
     cd $target
 fi
+mv libtorch/include/* $includedir
 mv libtorch/share/* $prefix/share/
 mv libtorch/lib/* $libdir
-rm -r libtorch/lib libtorch/share libtorch/bin libtorch/include
-mv libtorch/* $prefix
-rm -r libtorch
 
 cd $WORKSPACE/srcdir/Torch.jl/build
 mkdir build && cd build

--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -1,0 +1,64 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Torch"
+version = v"1.10.2"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/dhairyagandhi96/Torch.jl.git", "85bd08d39e7fba29ec4a643f60dd006ed8be8ede"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.10.2%2Bcpu.zip", "fa3fad287c677526277f64d12836266527d403f21f41cc2e7fb9d904969d4c4a"; unpack_target = "x86_64-linux-gnu-cxx03"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcpu.zip", "83e43d63d0e7dc9d57ccbdac8a8d7edac6c9e18129bf3043be475486b769a9c2"; unpack_target = "x86_64-linux-gnu-cxx11"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.10.2.zip", "d1711e844dc69c2338adfc8ce634806a9ae36e54328afbe501bafd2d70f550e2"; unpack_target = "x86_64-apple-darwin"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-1.10.2%2Bcpu.zip", "0ce2ccd959704cd85c44ad1f3f335c56734c7ff09418bd563e07d5bb7142510c"; unpack_target = "x86_64-w64-mingw32"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+
+if [[ $target == *linux* ]]; then
+    echo "target: $target"; echo "bb_target: $bb_target"; echo "bb_full_target: $bb_full_target"
+    cd $bb_full_target
+else
+    cd $target
+fi
+mv libtorch/share/* $prefix/share/
+mv libtorch/lib/* $prefix/lib/
+rm -r libtorch/lib
+rm -r libtorch/share
+mv libtorch/* $prefix
+rm -r libtorch
+
+cd $WORKSPACE/srcdir/Torch.jl/build
+mkdir build && cd build
+cmake -DCMAKE_PREFIX_PATH=$prefix -DTorch_DIR=$prefix/share/cmake/Torch ..
+cmake --build .
+
+mkdir -p "${libdir}"
+cp -r $WORKSPACE/srcdir/Torch.jl/build/build/*.${dlext} "${libdir}"
+install_license ${WORKSPACE}/srcdir/Torch.jl/LICENSE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
+]
+platforms = expand_cxxstring_abis(platforms; skip = !Sys.islinux)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libdoeye_caml", :libdoeye_caml, dont_dlopen = true),
+    LibraryProduct("libtorch", :libtorch, dont_dlopen = true),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7.1.0")

--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"1.10.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/dhairyagandhi96/Torch.jl.git", "85bd08d39e7fba29ec4a643f60dd006ed8be8ede"),
+    GitSource("https://github.com/FluxML/Torch.jl.git", "4167e3c21421555ad90868ca5483cd5c2ad0c449"), # v0.1.2
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.10.2%2Bcpu.zip", "fa3fad287c677526277f64d12836266527d403f21f41cc2e7fb9d904969d4c4a"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx03"),
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcpu.zip", "83e43d63d0e7dc9d57ccbdac8a8d7edac6c9e18129bf3043be475486b769a9c2"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx11"),
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.10.2.zip", "d1711e844dc69c2338adfc8ce634806a9ae36e54328afbe501bafd2d70f550e2"; unpack_target = "x86_64-apple-darwin14"),

--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -8,8 +8,8 @@ version = v"1.10.2"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/FluxML/Torch.jl.git", "4167e3c21421555ad90868ca5483cd5c2ad0c449"), # v0.1.2
-    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.10.2%2Bcpu.zip", "fa3fad287c677526277f64d12836266527d403f21f41cc2e7fb9d904969d4c4a"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx03"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcpu.zip", "83e43d63d0e7dc9d57ccbdac8a8d7edac6c9e18129bf3043be475486b769a9c2"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx11"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.10.2%2Bcpu.zip", "fa3fad287c677526277f64d12836266527d403f21f41cc2e7fb9d904969d4c4a"; unpack_target = "x86_64-linux-gnu-cxx03"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcpu.zip", "83e43d63d0e7dc9d57ccbdac8a8d7edac6c9e18129bf3043be475486b769a9c2"; unpack_target = "x86_64-linux-gnu-cxx11"),
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.10.2.zip", "d1711e844dc69c2338adfc8ce634806a9ae36e54328afbe501bafd2d70f550e2"; unpack_target = "x86_64-apple-darwin14"),
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-1.10.2%2Bcpu.zip", "0ce2ccd959704cd85c44ad1f3f335c56734c7ff09418bd563e07d5bb7142510c"; unpack_target = "x86_64-w64-mingw32"),
 ]
@@ -21,7 +21,7 @@ mkdir -p $includedir $libdir $prefix/share
 cd $WORKSPACE/srcdir
 
 if [[ $target == *linux* ]]; then
-    cd $bb_full_target
+    cd $target-`echo $bb_full_target | sed -E -e 's/.*(cxx..).*/\1/'`
 else
     cd $target
 fi

--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -16,6 +16,8 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
+mkdir -p $includedir $libdir $prefix/share
+
 cd $WORKSPACE/srcdir
 
 if [[ $target == *linux* ]]; then
@@ -25,7 +27,7 @@ else
     cd $target
 fi
 mv libtorch/share/* $prefix/share/
-mv libtorch/lib/* $prefix/lib/
+mv libtorch/lib/* $libdir
 rm -r libtorch/lib
 rm -r libtorch/share
 mv libtorch/* $prefix
@@ -36,7 +38,6 @@ mkdir build && cd build
 cmake -DCMAKE_PREFIX_PATH=$prefix -DTorch_DIR=$prefix/share/cmake/Torch ..
 cmake --build .
 
-mkdir -p "${libdir}"
 cp -r $WORKSPACE/srcdir/Torch.jl/build/build/*.${dlext} "${libdir}"
 install_license ${WORKSPACE}/srcdir/Torch.jl/LICENSE
 """

--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -57,7 +57,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/T/Torch/Torch/build_tarballs.jl
+++ b/T/Torch/Torch/build_tarballs.jl
@@ -8,8 +8,8 @@ version = v"1.10.2"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/dhairyagandhi96/Torch.jl.git", "85bd08d39e7fba29ec4a643f60dd006ed8be8ede"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.10.2%2Bcpu.zip", "fa3fad287c677526277f64d12836266527d403f21f41cc2e7fb9d904969d4c4a"; unpack_target = "x86_64-linux-gnu-cxx03"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcpu.zip", "83e43d63d0e7dc9d57ccbdac8a8d7edac6c9e18129bf3043be475486b769a9c2"; unpack_target = "x86_64-linux-gnu-cxx11"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.10.2%2Bcpu.zip", "fa3fad287c677526277f64d12836266527d403f21f41cc2e7fb9d904969d4c4a"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx03"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcpu.zip", "83e43d63d0e7dc9d57ccbdac8a8d7edac6c9e18129bf3043be475486b769a9c2"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx11"),
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.10.2.zip", "d1711e844dc69c2338adfc8ce634806a9ae36e54328afbe501bafd2d70f550e2"; unpack_target = "x86_64-apple-darwin14"),
     ArchiveSource("https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-1.10.2%2Bcpu.zip", "0ce2ccd959704cd85c44ad1f3f335c56734c7ff09418bd563e07d5bb7142510c"; unpack_target = "x86_64-w64-mingw32"),
 ]
@@ -21,7 +21,6 @@ mkdir -p $includedir $libdir $prefix/share
 cd $WORKSPACE/srcdir
 
 if [[ $target == *linux* ]]; then
-    echo "target: $target"; echo "bb_target: $bb_target"; echo "bb_full_target: $bb_full_target"
     cd $bb_full_target
 else
     cd $target

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -57,7 +57,6 @@ products = [
 ]
 
 dependencies = [
-    Dependency("CUDA_loader_jll")
 ]
 
 cuda_versions = [v"10.2", v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6"]
@@ -72,7 +71,7 @@ for cuda_version in cuda_versions
     for platform in platforms
         augmented_platform = Platform(arch(platform), os(platform); cuda=cuda_tag)
         should_build_platform(triplet(augmented_platform)) || continue
-        platform_dependencies = vcat(dependencies, [BuildDependency(PackageSpec(; name = "CUDA_jll", version = cuda_version, level = UPLEVEL_PATCH))])
+        platform_dependencies = vcat(dependencies, [BuildDependency("CUDA_full_jll")])
         build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
                        products, platform_dependencies; lazy_artifacts=true,
                        preferred_gcc_version = v"7.1.0")

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -57,11 +57,22 @@ products = [
 ]
 
 dependencies = [
-    BuildDependency("CUDA_full_jll"),
     Dependency("CUDNN_jll")
 ]
 
 cuda_versions = [v"10.2", v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6"]
+
+cuda_full_version = Dict{VersionNumber,VersionNumber}(
+    v"10.2" => v"10.2.89",
+    v"11.0" => v"11.0.3",
+    v"11.1" => v"11.1.1",
+    v"11.2" => v"11.2.2",
+    v"11.3" => v"11.3.1",
+    v"11.4" => v"11.4.2",
+    v"11.5" => v"11.5.1",
+    v"11.6" => v"11.6.0"
+)
+
 for cuda_version in cuda_versions
     cuda_tag = "$(cuda_version.major).$(cuda_version.minor)"
     if cuda_version.major == 10
@@ -73,8 +84,11 @@ for cuda_version in cuda_versions
     for platform in platforms
         augmented_platform = Platform(arch(platform), os(platform); cuda=cuda_tag)
         should_build_platform(triplet(augmented_platform)) || continue
+        platform_dependencies = vcat(dependencies, [
+            BuildDependency(PackageSpec("CUDA_full_jll", Base.UUID("4f82f1eb-248c-5f56-a42e-99106d144614"), cuda_full_version[cuda_version]))
+        ])
         build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
-                       products, dependencies; lazy_artifacts=true,
+                       products, platform_dependencies; lazy_artifacts=true,
                        preferred_gcc_version = v"7.1.0")
     end
 end

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -72,7 +72,7 @@ for cuda_version in cuda_versions
     for platform in platforms
         augmented_platform = Platform(arch(platform), os(platform); cuda=cuda_tag)
         should_build_platform(triplet(augmented_platform)) || continue
-        platform_dependencies = vcat(dependencies, [BuildDependency(PackageSpec("CUDA_jll", Base.UUID("e9e359dc-d701-5aa8-82ae-09bbf812ea83"), cuda_version))])
+        platform_dependencies = vcat(dependencies, [BuildDependency(PackageSpec(; name = "CUDA_jll", version = cuda_version, level = UPLEVEL_PATCH))])
         build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
                        products, platform_dependencies; lazy_artifacts=true,
                        preferred_gcc_version = v"7.1.0")

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -57,22 +57,11 @@ products = [
 ]
 
 dependencies = [
+    BuildDependency("CUDA_full_jll"),
     Dependency("CUDNN_jll")
 ]
 
 cuda_versions = [v"10.2", v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6"]
-
-cuda_full_version = Dict{VersionNumber,VersionNumber}(
-    v"10.2" => v"10.2.89",
-    v"11.0" => v"11.0.3",
-    v"11.1" => v"11.1.1",
-    v"11.2" => v"11.2.2",
-    v"11.3" => v"11.3.1",
-    v"11.4" => v"11.4.2",
-    v"11.5" => v"11.5.1",
-    v"11.6" => v"11.6.0"
-)
-
 for cuda_version in cuda_versions
     cuda_tag = "$(cuda_version.major).$(cuda_version.minor)"
     if cuda_version.major == 10
@@ -84,11 +73,8 @@ for cuda_version in cuda_versions
     for platform in platforms
         augmented_platform = Platform(arch(platform), os(platform); cuda=cuda_tag)
         should_build_platform(triplet(augmented_platform)) || continue
-        platform_dependencies = vcat(dependencies, [
-            BuildDependency(PackageSpec("CUDA_full_jll", Base.UUID("4f82f1eb-248c-5f56-a42e-99106d144614"), cuda_full_version[cuda_version]))
-        ])
         build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
-                       products, platform_dependencies; lazy_artifacts=true,
+                       products, dependencies; lazy_artifacts=true,
                        preferred_gcc_version = v"7.1.0")
     end
 end

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -57,6 +57,8 @@ products = [
 ]
 
 dependencies = [
+    BuildDependency("CUDA_full_jll"),
+    Dependency("CUDNN_jll")
 ]
 
 cuda_versions = [v"10.2", v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6"]
@@ -71,9 +73,8 @@ for cuda_version in cuda_versions
     for platform in platforms
         augmented_platform = Platform(arch(platform), os(platform); cuda=cuda_tag)
         should_build_platform(triplet(augmented_platform)) || continue
-        platform_dependencies = vcat(dependencies, [BuildDependency("CUDA_full_jll")])
         build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
-                       products, platform_dependencies; lazy_artifacts=true,
+                       products, dependencies; lazy_artifacts=true,
                        preferred_gcc_version = v"7.1.0")
     end
 end

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -32,11 +32,9 @@ if [[ $target == *linux* ]]; then
 else
     cd $target
 fi
+mv libtorch/include/* $includedir
 mv libtorch/share/* $prefix/share/
 mv libtorch/lib/* $libdir
-rm -r libtorch/lib libtorch/share libtorch/bin libtorch/include
-mv libtorch/* $prefix
-rm -r libtorch
 
 cd $WORKSPACE/srcdir/Torch.jl/build
 mkdir build && cd build

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -28,7 +28,6 @@ mkdir -p $includedir $libdir $prefix/share
 
 cd $WORKSPACE/srcdir
 
-mv cudnn $prefix
 if [[ $target == *linux* ]]; then
     cd $bb_full_target
 else
@@ -41,18 +40,12 @@ rm -r libtorch/share
 mv libtorch/* $prefix
 rm -r libtorch
 
-mkdir -p /usr/local/cuda/lib64
-cd /usr/local/cuda/lib64
-ln -s ${prefix}/cuda/lib64/libcudart.so libcudart.so
-ln -s ${prefix}/cuda/lib64/libnvToolsExt.so libnvToolsExt.so
-
 cd $WORKSPACE/srcdir/Torch.jl/build
 mkdir build && cd build
 cmake -DCMAKE_PREFIX_PATH=$prefix -DTorch_DIR=$prefix/share/cmake/Torch -DCUDA_TOOLKIT_ROOT_DIR=$prefix/cuda ..
 cmake --build .
 
 cp -r $WORKSPACE/srcdir/Torch.jl/build/build/*.${dlext} "${libdir}"
-rm -rf $prefix/cuda
 install_license ${WORKSPACE}/srcdir/Torch.jl/LICENSE
 """
 

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -12,15 +12,15 @@ common_sources = [
 ]
 
 cuda_10_sources = [
-    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-shared-with-deps-1.10.2%2Bcu102.zip", "fa3fad287c677526277f64d12836266527d403f21f41cc2e7fb9d904969d4c4a"; unpack_target = "x86_64-linux-gnu-cxx03"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcu102.zip", "83e43d63d0e7dc9d57ccbdac8a8d7edac6c9e18129bf3043be475486b769a9c2"; unpack_target = "x86_64-linux-gnu-cxx11"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-win-shared-with-deps-1.10.2%2Bcu102.zip", "0ce2ccd959704cd85c44ad1f3f335c56734c7ff09418bd563e07d5bb7142510c"; unpack_target = "x86_64-w64-mingw32"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-shared-with-deps-1.10.2%2Bcu102.zip", "206ab3f44d482a1d9837713cafbde9dd9d7907efac2dc94f1dc86e9a1101296f"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx03"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcu102.zip", "c1f994b4a019f2f75e3a58b8ddb132aaf8bb99673abc35f0f6d21c3b8f622cc4"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx11"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-win-shared-with-deps-1.10.2%2Bcu102.zip", "558971c390853aac7f1be002fcb1a4d0d94e480edcc23435e1d9c720312d812b"; unpack_target = "x86_64-w64-mingw32"),
 ]
 
 cuda_11_sources = [
-    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-shared-with-deps-1.10.2%2Bcu113.zip", "fa3fad287c677526277f64d12836266527d403f21f41cc2e7fb9d904969d4c4a"; unpack_target = "x86_64-linux-gnu-cxx03"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcu113.zip", "83e43d63d0e7dc9d57ccbdac8a8d7edac6c9e18129bf3043be475486b769a9c2"; unpack_target = "x86_64-linux-gnu-cxx11"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-win-shared-with-deps-1.10.2%2Bcu113.zip", "0ce2ccd959704cd85c44ad1f3f335c56734c7ff09418bd563e07d5bb7142510c"; unpack_target = "x86_64-w64-mingw32"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-shared-with-deps-1.10.2%2Bcu113.zip", "39f799e272924be118e99582eec10342dc7643c248ee404944defc6753bd88b7"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx03"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcu113.zip", "2557943af80ec93f8249f6c5c829db6c6688842afa25a7d848f5c471473eb898"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx11"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-win-shared-with-deps-1.10.2%2Bcu113.zip", "abe442bb99e166a68c05e9132e2d4a076e9d31af9fd09610e93be9bde62d3bdc"; unpack_target = "x86_64-w64-mingw32"),
 ]
 
 script = raw"""

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -3,7 +3,6 @@ using Base.BinaryPlatforms: arch, os
 
 include("../../../fancy_toys.jl")
 
-
 name = "TorchCUDA"
 version = v"1.10.2"
 
@@ -33,7 +32,6 @@ if [[ $target == *linux* ]]; then
 else
     cd $target
 fi
-find .
 mv libtorch/share/* $prefix/share/
 mv libtorch/lib/* $libdir
 rm -r libtorch/lib libtorch/share libtorch/bin libtorch/include

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -58,7 +58,9 @@ products = [
     LibraryProduct("libtorch", :libtorch, dont_dlopen = true),
 ]
 
-dependencies = [Dependency(PackageSpec(name="CUDA_loader_jll"))]
+dependencies = [
+    Dependency("CUDA_loader_jll")
+]
 
 cuda_versions = [v"10.2", v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6"]
 for cuda_version in cuda_versions
@@ -72,8 +74,9 @@ for cuda_version in cuda_versions
     for platform in platforms
         augmented_platform = Platform(arch(platform), os(platform); cuda=cuda_tag)
         should_build_platform(triplet(augmented_platform)) || continue
+        platform_dependencies = vcat(dependencies, [BuildDependency(PackageSpec("CUDA_jll", Base.UUID("e9e359dc-d701-5aa8-82ae-09bbf812ea83"), cuda_version))])
         build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
-                       products, dependencies; lazy_artifacts=true,
+                       products, platform_dependencies; lazy_artifacts=true,
                        preferred_gcc_version = v"7.1.0")
     end
 end

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -12,14 +12,14 @@ common_sources = [
 ]
 
 cuda_10_sources = [
-    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-shared-with-deps-1.10.2%2Bcu102.zip", "206ab3f44d482a1d9837713cafbde9dd9d7907efac2dc94f1dc86e9a1101296f"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx03"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcu102.zip", "c1f994b4a019f2f75e3a58b8ddb132aaf8bb99673abc35f0f6d21c3b8f622cc4"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx11"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-shared-with-deps-1.10.2%2Bcu102.zip", "206ab3f44d482a1d9837713cafbde9dd9d7907efac2dc94f1dc86e9a1101296f"; unpack_target = "x86_64-linux-gnu-cxx03"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcu102.zip", "c1f994b4a019f2f75e3a58b8ddb132aaf8bb99673abc35f0f6d21c3b8f622cc4"; unpack_target = "x86_64-linux-gnu-cxx11"),
     ArchiveSource("https://download.pytorch.org/libtorch/cu102/libtorch-win-shared-with-deps-1.10.2%2Bcu102.zip", "558971c390853aac7f1be002fcb1a4d0d94e480edcc23435e1d9c720312d812b"; unpack_target = "x86_64-w64-mingw32"),
 ]
 
 cuda_11_sources = [
-    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-shared-with-deps-1.10.2%2Bcu113.zip", "39f799e272924be118e99582eec10342dc7643c248ee404944defc6753bd88b7"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx03"),
-    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcu113.zip", "2557943af80ec93f8249f6c5c829db6c6688842afa25a7d848f5c471473eb898"; unpack_target = "x86_64-linux-gnu-libgfortran4-cxx11"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-shared-with-deps-1.10.2%2Bcu113.zip", "39f799e272924be118e99582eec10342dc7643c248ee404944defc6753bd88b7"; unpack_target = "x86_64-linux-gnu-cxx03"),
+    ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.10.2%2Bcu113.zip", "2557943af80ec93f8249f6c5c829db6c6688842afa25a7d848f5c471473eb898"; unpack_target = "x86_64-linux-gnu-cxx11"),
     ArchiveSource("https://download.pytorch.org/libtorch/cu113/libtorch-win-shared-with-deps-1.10.2%2Bcu113.zip", "abe442bb99e166a68c05e9132e2d4a076e9d31af9fd09610e93be9bde62d3bdc"; unpack_target = "x86_64-w64-mingw32"),
 ]
 
@@ -29,8 +29,7 @@ mkdir -p $includedir $libdir $prefix/share
 cd $WORKSPACE/srcdir
 
 if [[ $target == *linux* ]]; then
-    ls -la
-    cd $bb_full_target
+    cd $target-`echo $bb_full_target | sed -E -e 's/.*(cxx..).*/\1/'`
 else
     cd $target
 fi

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -2,7 +2,7 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-name = "Torch"
+name = "TorchCUDA"
 version = v"1.4.0"
 
 # Collection of sources required to complete build

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -8,7 +8,7 @@ name = "TorchCUDA"
 version = v"1.10.2"
 
 common_sources = [
-    GitSource("https://github.com/dhairyagandhi96/Torch.jl.git", "85bd08d39e7fba29ec4a643f60dd006ed8be8ede"),
+    GitSource("https://github.com/FluxML/Torch.jl.git", "4167e3c21421555ad90868ca5483cd5c2ad0c449"), # v0.1.2
 ]
 
 cuda_10_sources = [

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -24,6 +24,8 @@ cuda_11_sources = [
 ]
 
 script = raw"""
+mkdir -p $includedir $libdir $prefix/share
+
 cd $WORKSPACE/srcdir
 
 mv cudnn $prefix
@@ -33,7 +35,7 @@ else
     cd $target
 fi
 mv libtorch/share/* $prefix/share/
-mv libtorch/lib/* $prefix/lib/
+mv libtorch/lib/* $libdir
 rm -r libtorch/lib
 rm -r libtorch/share
 mv libtorch/* $prefix
@@ -49,7 +51,6 @@ mkdir build && cd build
 cmake -DCMAKE_PREFIX_PATH=$prefix -DTorch_DIR=$prefix/share/cmake/Torch -DCUDA_TOOLKIT_ROOT_DIR=$prefix/cuda ..
 cmake --build .
 
-mkdir -p "${libdir}"
 cp -r $WORKSPACE/srcdir/Torch.jl/build/build/*.${dlext} "${libdir}"
 rm -rf $prefix/cuda
 install_license ${WORKSPACE}/srcdir/Torch.jl/LICENSE

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms: arch, os
 
-include("../../fancy_toys.jl")
+include("../../../fancy_toys.jl")
 
 
 name = "TorchCUDA"

--- a/T/Torch/TorchCUDA/build_tarballs.jl
+++ b/T/Torch/TorchCUDA/build_tarballs.jl
@@ -29,14 +29,15 @@ mkdir -p $includedir $libdir $prefix/share
 cd $WORKSPACE/srcdir
 
 if [[ $target == *linux* ]]; then
+    ls -la
     cd $bb_full_target
 else
     cd $target
 fi
+find .
 mv libtorch/share/* $prefix/share/
 mv libtorch/lib/* $libdir
-rm -r libtorch/lib
-rm -r libtorch/share
+rm -r libtorch/lib libtorch/share libtorch/bin libtorch/include
 mv libtorch/* $prefix
 rm -r libtorch
 


### PR DESCRIPTION
Currently a WIP. Aims at resolving https://github.com/FluxML/Torch.jl/issues/20.

Similar approach as for ONNXRuntime - separate binaries for CPU-only and CUDA etc. (CPU: #4369, CUDA: #4386).

Relates to: #1529 