### PR TITLE
[libsharp] add -O3 CFLAGS

### DIFF
--- a/L/libsharp2/build_tarballs.jl
+++ b/L/libsharp2/build_tarballs.jl
@@ -25,6 +25,7 @@ if [[ "${target}" == x86_64-* ]] && [[ "${target}" != *-apple-* ]] && [[ "${targ
     # For Windows, see https://github.com/ziotom78/Libsharp.jl/issues/3
     export CFLAGS="-DMULTIARCH"
 fi
+export CFLAGS="${CFLAGS} -O3"
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install


### PR DESCRIPTION
Testing on a relatively recent Cascade Lake machine suggests that Libsharp is really an anomaly, and O3 has a factor of three (!) performance difference.

@ziotom78 

I think this will close https://github.com/ziotom78/Libsharp.jl/issues/2