### PR TITLE
[libblastrampoline] Add init for julia 1.6

### DIFF
--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -36,8 +36,8 @@ dependencies = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.8",
                init_block = """
-  using OpenBLAS_jll
   if VERSION < v"1.7"
+     using OpenBLAS_jll
      ccall((:lbt_forward, libblastrampoline), Int32, (Cstring, Int32, Int32, Cstring), OpenBLAS_jll.libopenblas_path, 1, 0, C_NULL)
   end
 """)

--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -35,4 +35,9 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.8",
-)
+               init_block = """
+  using OpenBLAS_jll
+  if VERSION < v"1.7"
+     ccall((:lbt_forward, libblastrampoline), Int32, (Cstring, Int32, Int32, Cstring), OpenBLAS_jll.libopenblas_path, 1, 0, C_NULL)
+  end
+""")


### PR DESCRIPTION
In Julia 1.7 onwards, we do the initialization in `LinearAlgebra`. On Julia 1.6, we just need this init to happen when libblastrampoline_jll is installed when a package declares a dependency on it, and the BLAS/LAPACK symbols get forwarded to OpenBLAS.

We only need this `init` function for Julia 1.6.