### PR TITLE
Use internal libtiff

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -60,7 +60,7 @@ rm -f ${prefix}/lib/*.la
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-geos=${bindir}/geos-config \
     --with-proj=$prefix \
-    --with-tiff=$prefix \
+    --with-libtiff=internal \
     --with-geotiff=$prefix \
     --with-libz=$prefix \
     --with-expat=$prefix \
@@ -120,7 +120,6 @@ dependencies = [
     Dependency("OpenJpeg_jll"),
     Dependency("Expat_jll"; compat="2.2.10"),
     Dependency("Zstd_jll"),
-    Dependency("Libtiff_jll"; compat="4.3"),
     Dependency("libgeotiff_jll"; compat="1.7"),
     Dependency("LibCURL_jll"),
 ]


### PR DESCRIPTION
So newer compression features work out of the box, such as `LERC` in `COG`. See https://gdal.org/drivers/raster/cog.html and similar PR at https://github.com/OSGeo/homebrew-osgeo4mac/issues/1087.

I'm unsure/unaware about hard differences between the internal and external libtiff library or other drawbacks. I guess it should just work and gives us more features. Looking at https://gdal.org/drivers/raster/gtiff.html#creation-options, newer compression are first introduced in the internal libtiff and only later in the external one (or not yet, such as `JXL`).

Linking to GDAL.jl driver support issue https://github.com/JuliaGeo/GDAL.jl/issues/65