### PR TITLE
Add MPI platform tag and have LAMMPS use it

### DIFF
--- a/L/LAMMPS/build_tarballs.jl
+++ b/L/LAMMPS/build_tarballs.jl
@@ -86,4 +86,6 @@ all_platforms, platform_dependencies = MPI.augment_platforms(platforms)
 append!(dependencies, platform_dependencies)
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, all_platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8", augment_platform_block)
+build_tarballs(ARGS, name, version, sources, script, all_platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version=v"8",
+               augment_platform_block, lazy_artifacts=true) # Change lazy_artifacts after https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/1179

--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -1,0 +1,59 @@
+module MPI
+
+const tag_name = "mpi"
+
+const augment = """
+    # Can't use Preferences since we might be running this very early with a non-existing Manifest
+    MPIPreferences_UUID = Base.UUID("3da0fdf6-3ccc-4f1b-acd9-58baa6c99267")
+    const preferences = Base.get_preferences(MPIPreferences_UUID)
+
+    # Keep logic in sync with MPIPreferences.jl
+    const binary = get(preferences, "binary", Sys.iswindows() ? "MicrosoftMPI_jll" : "MPICH_jll")
+
+    const abi = if binary == "system"
+        get(preferences, "abi")
+    elseif binary == "MicrosoftMPI_jll"
+        "MicrosoftMPI"
+    elseif binary == "MPICH_jll"
+        "MPICH"
+    elseif binary == "OpenMPI_jll"
+        "OpenMPI"
+    elseif binary == "MPItrampoline_jll"
+        "MPIwrapper"
+    else
+        error("Unknown binary: $binary")
+    end
+
+    function augment_mpi!(platform)
+        if !haskey(platform, "mpi")
+            platform["mpi"] = abi
+        end
+        return platform
+    end
+"""
+
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
+
+mpi_abis = (
+    ("MPICH", PackageSpec(name="MPICH_jll"), "", !Sys.iswindows) ,
+    ("OpenMPI", PackageSpec(name="OpenMPI"), "", !Sys.iswindows),
+    ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),
+    ("MPIwrapper", PackageSpec(name="MPItrampoline_jll"), "2", !Sys.iswindows)
+)
+
+function augment_platforms(platforms)
+    all_platforms = AbstractPlatform[]
+    dependencies = []
+    for (abi, pkg, compat, f) in mpi_abis
+        pkg_platforms = deepcopy(filter(f, platforms))
+        foreach(pkg_platforms) do p
+            p[tag_name] = abi
+        end
+        append!(all_platforms, pkg_platforms)
+        push!(dependencies, Dependency(pkg; compat, platforms=pkg_platforms))
+    end
+    return all_platforms, dependencies
+end
+
+end

--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -2,7 +2,7 @@ module MPI
 
 const tag_name = "mpi"
 
-const augment = """
+const augment = raw"""
     # Can't use Preferences since we might be running this very early with a non-existing Manifest
     MPIPreferences_UUID = Base.UUID("3da0fdf6-3ccc-4f1b-acd9-58baa6c99267")
     const preferences = Base.get_preferences(MPIPreferences_UUID)

--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -39,7 +39,7 @@ mpi_abis = (
     ("MPICH", PackageSpec(name="MPICH_jll"), "", !Sys.iswindows) ,
     ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "", !Sys.iswindows),
     ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),
-    ("MPIwrapper", PackageSpec(name="MPItrampoline_jll"), "3", !Sys.iswindows)
+    ("MPIwrapper", PackageSpec(name="MPItrampoline_jll"), "", !Sys.iswindows)
 )
 
 function augment_platforms(platforms)

--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -37,9 +37,9 @@ using Base.BinaryPlatforms
 
 mpi_abis = (
     ("MPICH", PackageSpec(name="MPICH_jll"), "", !Sys.iswindows) ,
-    ("OpenMPI", PackageSpec(name="OpenMPI"), "", !Sys.iswindows),
+    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "", !Sys.iswindows),
     ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),
-    ("MPIwrapper", PackageSpec(name="MPItrampoline_jll"), "2", !Sys.iswindows)
+    ("MPIwrapper", PackageSpec(name="MPItrampoline_jll"), "3", !Sys.iswindows)
 )
 
 function augment_platforms(platforms)


### PR DESCRIPTION
Based off https://github.com/JuliaParallel/MPI.jl/pull/541 (but also independent enough that we can use it before that lands)

Replaces https://github.com/JuliaPackaging/Yggdrasil/pull/4073
