### PR TITLE
[ecCodes] Enable fortran and bump version

### DIFF
--- a/E/eccodes/build_tarballs.jl
+++ b/E/eccodes/build_tarballs.jl
@@ -41,7 +41,7 @@ install_license ../LICENSE
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-
+platforms = expand_gfortran_versions(platforms)
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libeccodes", :eccodes),

--- a/E/eccodes/build_tarballs.jl
+++ b/E/eccodes/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "eccodes"
-version = v"2.21.0"
+version = v"2.25.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://confluence.ecmwf.int/download/attachments/45757960/eccodes-$version-Source.tar.gz", "da0a0bf184bb436052e3eae582defafecdb7c08cdaab7216780476e49b509755"),
+    ArchiveSource("https://confluence.ecmwf.int/download/attachments/45757960/eccodes-$version-Source.tar.gz", "8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e"),
     DirectorySource("./bundled"),
 ]
 
@@ -20,6 +20,7 @@ if [[ ${target} = *-mingw* ]] ; then
 else
     atomic_patch -p1 /workspace/srcdir/patches/unix.patch
 fi
+atomic_patch -p1 /workspace/srcdir/patches/kinds.patch
 mkdir build
 cd build
 export CFLAGS="-I${includedir}"
@@ -28,9 +29,9 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_BUILD_TYPE=Release \
     -DENABLE_NETCDF=OFF \
     -DENABLE_PNG=ON \
-    -DENABLE_PYTHON=OFF \
-    -DENABLE_FORTRAN=OFF \
+    -DENABLE_FORTRAN=ON \
     -DENABLE_ECCODES_THREADS=ON \
+    -DENABLE_AEC=OFF \
     ..
 make -j${nproc}
 make install
@@ -43,14 +44,16 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libeccodes", :eccodes)
+    LibraryProduct("libeccodes", :eccodes),
+    LibraryProduct("libeccodes_f90", :libeccodes_f90),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f"))
-    Dependency(PackageSpec(name="OpenJpeg_jll", uuid="643b3616-a352-519d-856d-80112ee9badc"))
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+    Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f")),
+    Dependency(PackageSpec(name="OpenJpeg_jll", uuid="643b3616-a352-519d-856d-80112ee9badc")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/E/eccodes/bundled/patches/kinds.patch
+++ b/E/eccodes/bundled/patches/kinds.patch
@@ -1,0 +1,40 @@
+diff --git a/fortran/CMakeLists.txt b/fortran/CMakeLists.txt
+index 650296c0..5ba26708 100644
+--- a/fortran/CMakeLists.txt
++++ b/fortran/CMakeLists.txt
+@@ -7,14 +7,10 @@ if( HAVE_FORTRAN )
+ 
+     include_directories( ${srcdir} ${bindir} )
+ 
+-    ecbuild_add_executable( TARGET  grib_types
+-                            NOINSTALL
+-                            SOURCES grib_types.f90 grib_fortran_kinds.c )
+-
+-    add_custom_command( OUTPUT  grib_kinds.h
+-                        COMMAND grib_types > grib_kinds.h
+-                        DEPENDS grib_types )
+-
++    check_type_size(long longsize LANGUAGE C)
++    check_type_size(size_t size_t_size LANGUAGE C)
++    configure_file(grib_kinds.h.in grib_kinds.h)
++    
+     if( ${ECCODES_SIZEOF_INT} EQUAL ${ECCODES_SIZEOF_LONG} )
+         set( _long_int_interface    grib_f90_int.f90 )
+         set( _long_int_interface_ec eccodes_f90_int.f90 )
+diff --git a/fortran/grib_kinds.h.in b/fortran/grib_kinds.h.in
+new file mode 100644
+index 00000000..a490f87d
+--- /dev/null
++++ b/fortran/grib_kinds.h.in
+@@ -0,0 +1,11 @@
++ integer,public,parameter :: kindOfInt=           4
++ integer,public,parameter :: kindOfLong=          ${longsize}
++ integer,public,parameter :: kindOfSize_t=        ${size_t_size}
++ integer,public,parameter :: kindOfSize=          ${size_t_size}
++ integer,public,parameter :: kindOfDouble=        8
++ integer,public,parameter :: kindOfFloat=         4
++ integer,public,parameter :: sizeOfInteger=       4
++ integer,public,parameter :: sizeOfInteger2=      2
++ integer,public,parameter :: sizeOfInteger4=      4
++ integer,public,parameter :: sizeOfReal4=         4
++ integer,public,parameter :: sizeOfReal8=         8


### PR DESCRIPTION
This updates the version of ecCodes and adds the fortran module and library, which we need for the subsequent JLL for the FLEXPART particle dispersion code.