### PR TITLE
New Recipe: CPUInfo v0.0.20200122

### DIFF
--- a/C/CPUInfo/build_tarballs.jl
+++ b/C/CPUInfo/build_tarballs.jl
@@ -44,9 +44,6 @@ filter!(p -> os(p) != "freebsd", platforms) # FreeBSD unsupported
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libcpuinfo", :libcpuinfo),
-    ExecutableProduct("isa-info", :isa_info),
-    ExecutableProduct("cpu-info", :cpu_info),
-    ExecutableProduct("cache-info", :cache_info)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/C/CPUInfo/build_tarballs.jl
+++ b/C/CPUInfo/build_tarballs.jl
@@ -1,7 +1,6 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
-using BinaryBuilderBase: os
 
 name = "CPUInfo"
 version = v"0.0.20200122"
@@ -38,8 +37,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-filter!(p -> arch(p) != "aarch64" || os(p) != "macos", platforms) # aarch64-macos unsupported
-filter!(p -> os(p) != "freebsd", platforms) # FreeBSD unsupported
+filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64"), platforms) # aarch64-macos unsupported
+filter!(p -> !Sys.isfreebsd(p), platforms) # FreeBSD unsupported
 
 # The products that we will ensure are always built
 products = [

--- a/C/CPUInfo/build_tarballs.jl
+++ b/C/CPUInfo/build_tarballs.jl
@@ -1,6 +1,7 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
+using BinaryBuilderBase: os
 
 name = "CPUInfo"
 version = v"0.0.20200122"
@@ -37,6 +38,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
+filter!(p -> arch(p) != "aarch64" || os(p) != "macos", platforms) # aarch64-macos unsupported
+filter!(p -> os(p) != "freebsd", platforms) # FreeBSD unsupported
 
 # The products that we will ensure are always built
 products = [

--- a/C/CPUInfo/build_tarballs.jl
+++ b/C/CPUInfo/build_tarballs.jl
@@ -42,6 +42,7 @@ fi
 platforms = supported_platforms()
 filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64"), platforms) # aarch64-macos unsupported
 filter!(p -> !Sys.isfreebsd(p), platforms) # FreeBSD unsupported
+filter!(p -> !(Sys.iswindows(p) && arch(p) == "i686"), platforms) # Failing to link
 
 # The products that we will ensure are always built
 products = [

--- a/C/CPUInfo/build_tarballs.jl
+++ b/C/CPUInfo/build_tarballs.jl
@@ -32,6 +32,9 @@ cmake \
     ..
 cmake --build . -- -j $nproc
 make install
+if [[ $target == *-w64-mingw32 ]]; then
+    install -Dvm 755 libcpuinfo.dll "${libdir}/libcpuinfo.dll"
+fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/C/CPUInfo/build_tarballs.jl
+++ b/C/CPUInfo/build_tarballs.jl
@@ -39,7 +39,6 @@ products = [
     LibraryProduct("libcpuinfo", :libcpuinfo),
     ExecutableProduct("isa-info", :isa_info),
     ExecutableProduct("cpu-info", :cpu_info),
-    ExecutableProduct("cpuid-dump", :cpuid_dump),
     ExecutableProduct("cache-info", :cache_info)
 ]
 

--- a/C/CPUInfo/build_tarballs.jl
+++ b/C/CPUInfo/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "CPUInfo"
+version = v"0.0.20200122"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/pytorch/cpuinfo.git", "0e6bde92b343c5fbcfe34ecd41abf9515d54b4a7")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd cpuinfo
+mkdir build
+cd build
+cmake \
+    -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_LIBDIR=$libdir \
+    -DCPUINFO_BUILD_UNIT_TESTS=OFF \
+    -DCPUINFO_BUILD_MOCK_TESTS=OFF \
+    -DCPUINFO_BUILD_BENCHMARKS=OFF \
+    -DCPUINFO_LIBRARY_TYPE=shared \
+    ..
+cmake --build . -- -j $nproc
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libcpuinfo", :libcpuinfo),
+    ExecutableProduct("isa-info", :isa_info),
+    ExecutableProduct("cpu-info", :cpu_info),
+    ExecutableProduct("cpuid-dump", :cpuid_dump),
+    ExecutableProduct("cache-info", :cache_info)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/C/CPUInfo/build_tarballs.jl
+++ b/C/CPUInfo/build_tarballs.jl
@@ -7,13 +7,17 @@ version = v"0.0.20200122"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/pytorch/cpuinfo.git", "0e6bde92b343c5fbcfe34ecd41abf9515d54b4a7")
+    GitSource("https://github.com/pytorch/cpuinfo.git", "0e6bde92b343c5fbcfe34ecd41abf9515d54b4a7"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
 cd cpuinfo
+if [[ $target == *-w64-mingw32 ]]; then
+    atomic_patch -p1 ../patches/lowercase-windows-include.patch
+fi
 mkdir build
 cd build
 cmake \

--- a/C/CPUInfo/bundled/patches/lowercase-windows-include.patch
+++ b/C/CPUInfo/bundled/patches/lowercase-windows-include.patch
@@ -1,0 +1,13 @@
+diff --git a/src/x86/windows/init.c b/src/x86/windows/init.c
+index 7a2090e..115f366 100644
+--- a/src/x86/windows/init.c
++++ b/src/x86/windows/init.c
+@@ -8,7 +8,7 @@
+ #include <cpuinfo/internal-api.h>
+ #include <cpuinfo/log.h>
+ 
+-#include <Windows.h>
++#include <windows.h>
+ 
+ static inline uint32_t bit_mask(uint32_t bits) {
+ 	return (UINT32_C(1) << bits) - UINT32_C(1);


### PR DESCRIPTION
Packaging similar to [libcpuinfo0](https://packages.ubuntu.com/impish/libcpuinfo0) in Ubuntu.

Starting with an old version - used by PyTorch v1.5.