### PR TITLE
New recipe: Vulkan_Volk v1.3.204

### DIFF
--- a/V/Vulkan_Volk/build_tarballs.jl
+++ b/V/Vulkan_Volk/build_tarballs.jl
@@ -41,4 +41,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
I have been unable to create a [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader) JLL package due to [this issue](https://github.com/KhronosGroup/Vulkan-Loader/issues/249), so here's an alternative way to build projects that load Vulkan functions.