### PR TITLE
[Singular] update to 403.1.100

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -28,14 +28,14 @@ import Pkg.Types: VersionSpec
 #
 name = "Singular"
 upstream_version = v"4.3.0-1" # 4.3.0 plus some changes
-version_offset = v"0.0.0"
+version_offset = v"0.1.0"
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,
                         upstream_version.patch * 100 + version_offset.minor,
                         Int(upstream_version.prerelease[1]) * 100 + version_offset.patch)
 
 # Collection of sources required to build normaliz
 sources = [
-    GitSource("https://github.com/Singular/Singular.git", "bbc293564bf76fcdfdc37354d406b7ca77bc780f"),
+    GitSource("https://github.com/Singular/Singular.git", "c1d1d924a0316c8dd9d96b185d6269552e5dcac3"),
     #ArchiveSource("https://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/$(upstream_version.major)-$(upstream_version.minor)-$(upstream_version.patch)/singular-$(upstream_version).tar.gz",
     #              "5b0f6c036b4a6f58bf620204b004ec6ca3a5007acc8352fec55eade2fc9d63f6"),
     #DirectorySource("./bundled")


### PR DESCRIPTION
I hope I got the version right. The upstream is still on version 4.3.0 (+1 for bug fixes) but has had new functionality added that we would like to use.