### PR TITLE
Add initial recipe for Metal LLVM tools.

### DIFF
--- a/M/Metal_LLVM_Tools/build_tarballs.jl
+++ b/M/Metal_LLVM_Tools/build_tarballs.jl
@@ -1,0 +1,129 @@
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
+
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
+
+name = "Metal_LLVM_Tools"
+repo = "https://github.com/JuliaGPU/llvm-metal"
+version = v"0.1"
+
+llvm_versions = [v"13.0.1"]
+
+# Collection of sources required to build SPIRV_LLVM_Translator
+sources = Dict(
+    v"13.0.1" => [GitSource(repo, "c7e15c7e199a2019b39633906b3acaf964916bd2")],
+)
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "macos"; ),
+    Platform("aarch64", "macos"; )
+]
+platforms = expand_cxxstring_abis(platforms)
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd llvm-metal/llvm
+LLVM_SRCDIR=$(pwd)
+
+install_license LICENSE.TXT
+
+# The very first thing we need to do is to build llvm-tblgen for x86_64-linux-muslc
+# This is because LLVM's cross-compile setup is kind of borked, so we just
+# build the tools natively ourselves, directly.  :/
+
+# Build llvm-tblgen and llvm-config
+mkdir ${WORKSPACE}/bootstrap
+pushd ${WORKSPACE}/bootstrap
+CMAKE_FLAGS=()
+CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD:STRING=host)
+CMAKE_FLAGS+=(-DLLVM_HOST_TRIPLE=${MACHTYPE})
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='llvm')
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING=False)
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_HOST_TOOLCHAIN})
+cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]}
+ninja -j${nproc} llvm-tblgen llvm-config
+popd
+
+# Let's do the actual build within the `build` subdirectory
+mkdir ${WORKSPACE}/build && cd ${WORKSPACE}/build
+CMAKE_FLAGS=()
+
+# Tell LLVM where our pre-built tblgen tools are
+CMAKE_FLAGS+=(-DLLVM_TABLEGEN=${WORKSPACE}/bootstrap/bin/llvm-tblgen)
+CMAKE_FLAGS+=(-DLLVM_CONFIG_PATH=${WORKSPACE}/bootstrap/bin/llvm-config)
+
+# Install things into $prefix
+CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+
+# Explicitly use our cmake toolchain file and tell CMake we're cross-compiling
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
+
+# Release build for best performance
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+
+# Only build the Metal back-end
+CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD=Metal)
+
+cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]}
+ninja -j${nproc} \
+    tools/metallib-as/install \
+    tools/metallib-dis/install
+"""
+
+# The products that we will ensure are always built
+products = Product[
+    ExecutableProduct("metallib-as", :metallib_as),
+    ExecutableProduct("metallib-dis", :metallib_dis),
+]
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+
+    $(LLVM.augment)
+
+    function augment_platform!(platform::Platform)
+        augment_llvm!(platform)
+    end"""
+
+# determine exactly which tarballs we should build
+builds = []
+for llvm_version in llvm_versions, llvm_assertions in (false, true)
+    # Dependencies that must be installed before this package can be built
+    llvm_name = llvm_assertions ? "LLVM_full_assert_jll" : "LLVM_full_jll"
+    dependencies = [
+        BuildDependency(PackageSpec(name=llvm_name, version=llvm_version))
+    ]
+
+    for platform in platforms
+        augmented_platform = deepcopy(platform)
+        augmented_platform[LLVM.platform_name] = LLVM.platform(llvm_version, llvm_assertions)
+
+        should_build_platform(triplet(augmented_platform)) || continue
+        push!(builds, (;
+            dependencies,
+            sources=sources[llvm_version],
+            platforms=[augmented_platform],
+        ))
+    end
+end
+
+# don't allow `build_tarballs` to override platform selection based on ARGS.
+# we handle that ourselves by calling `should_build_platform`
+non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
+
+# `--register` should only be passed to the latest `build_tarballs` invocation
+non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
+
+for (i,build) in enumerate(builds)
+    build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
+                   name, version, build.sources, script,
+                   build.platforms, products, build.dependencies;
+                   preferred_gcc_version=v"7", julia_compat="1.6",
+                   augment_platform_block, lazy_artifacts=true)
+end


### PR DESCRIPTION
For the upcoming Metal.jl package, we have a custom LLVM back-end capable of writing MetalLib archives (essentially LLVM bitcode, but packaged up differently). Instead of adding this back-end to the LLVM build of Julia (which we want to avoid, since it locks us to the Julia release cycle, while also adding questionable code to the Julia distribution everybody uses) I'm exploring a different approach here, instead building essentially a specialized `llc` that is only capable of generating MetalLib output: https://github.com/JuliaGPU/llvm-metal/tree/main/llvm/tools/metallib-as. We then generate and optimize LLVM IR using Julia's LLVM library as usual, but hand it of to `metallib-as` to generate machine code.

Apart from the many obvious advantages, this approach also has a couple of disadvantages: Since the LLVM library used during codegen doesn't support our actual hardware back-end, we're unable to instantiate a target machine, which might change or inhibit optimizations that inspect the triple (the datalayout is still fine). Certain passes might also not be run at all, i.e. the ones scheduled by the target's pass manager builder hooks (but we aren't running those properly anyway: https://github.com/JuliaGPU/GPUCompiler.jl/issues/263). For Metal, this doesn't matter that much, because we just repackage LLVM IR, but it might prohibit using this approach for other back-ends.

The resulting binaries are not just all of LLVM (64MB here). From https://github.com/maleadt/Metal_LLVM_Tools_jll.jl:

```
$ ls -lah /Users/tim/Julia/depot/artifacts/c29ab3820bd73fd75845dc33133281afea48ae79/bin
total 29904
drwxr-xr-x  4 tim  staff   128B Mar 18 08:32 .
drwxr-xr-x  5 tim  staff   160B Mar 18 08:32 ..
-r-xr-xr-x  1 tim  staff    12M Mar 18 08:32 metallib-as
-r-xr-xr-x  1 tim  staff   2.4M Mar 18 08:32 metallib-dis
```

Although we could probably still prune the list of components that's needed.

cc @vchuravy @jpsamaroo @max-Hawkins