### PR TITLE
[LLVMCompilerRT] Add builder

### DIFF
--- a/L/LLVMCompilerRT/build_tarballs.jl
+++ b/L/LLVMCompilerRT/build_tarballs.jl
@@ -1,0 +1,76 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "LLVMCompilerRT"
+version = v"12.0.0"
+
+sources = [
+    ArchiveSource(
+        "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/compiler-rt-$(version).src.tar.xz",
+        "85a8cd0a62413eaa0457d8d02f8edac38c4dc0c96c00b09dc550260c23268434"
+    ),
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/compiler-rt*/
+
+# We'll codesign during audit
+atomic_patch -p1 ../patches/do-not-codesign.patch
+
+FLAGS=()
+if [[ "${target}" == *-apple-* ]]; then
+    # Fake `PlistBuddy` to make detection of aarch64 support work
+    mkdir -p /usr/libexec
+    cat > /usr/libexec/PlistBuddy << EOF
+#!/bin/bash
+
+if [[ "${target}" == aarch64-* ]]; then
+    echo " arm64"
+else
+    echo " $(uname -m)"
+fi
+EOF
+    chmod +x /usr/libexec/PlistBuddy
+
+    # We use could use `${MACOSX_DEPLOYMENT_TARGET}` to specify the SDK version, but it's
+    # set to 10.10 on x86_64, but compiler-rt requires at least 10.12 and we actually use
+    # 10.12.  On aarch64 it's 11.0, but the CMake script doesn't seem to like values greater
+    # than 10, so let's just use 10.12 everywhere.
+    FLAGS+=(
+            -DDARWIN_macosx_OVERRIDE_SDK_VERSION:STRING=10.12
+            -DDARWIN_macosx_CACHED_SYSROOT=/opt/${target}/${target}/sys-root
+           )
+fi
+
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    "${FLAGS[@]}" \
+    ..
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+# Exclude failing platforms.  This package is a stop-gap solution for being able to link
+# some packages on aarch64-apple-darwin, so there is little need to spend time on getting
+# this to build for _all_ platforms.  The long-term plan is to have these libraries as part
+# of LLVMBootstrap: https://github.com/JuliaPackaging/Yggdrasil/pull/1681
+filter!(p -> arch(p) != "powerpc64le" && !(BinaryBuilder.proc_family(p) == "intel" && libc(p) == "musl"), platforms)
+
+# The products that we will ensure are always built
+products = LibraryProduct[
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8")

--- a/L/LLVMCompilerRT/bundled/patches/do-not-codesign.patch
+++ b/L/LLVMCompilerRT/bundled/patches/do-not-codesign.patch
@@ -1,0 +1,11 @@
+--- a/cmake/Modules/AddCompilerRT.cmake
++++ b/cmake/Modules/AddCompilerRT.cmake
+@@ -354,7 +354,7 @@
+         # Ad-hoc sign the dylibs
+         add_custom_command(TARGET ${libname}
+           POST_BUILD  
+-          COMMAND codesign --sign - $<TARGET_FILE:${libname}>
++          # COMMAND codesign --sign - $<TARGET_FILE:${libname}>
+           WORKING_DIRECTORY ${COMPILER_RT_LIBRARY_OUTPUT_DIR}
+         )
+       endif()


### PR DESCRIPTION
To build some packages for macOS we need libclang_rt.  In the long term
finishing up #1681 is a better option, but compiling a standalone compiler-rt
may be a good stop-gap solution.