### PR TITLE
[FastTransforms] Use LLVM OpenMP on BSD systems

### DIFF
--- a/F/FastTransforms/build_tarballs.jl
+++ b/F/FastTransforms/build_tarballs.jl
@@ -1,4 +1,4 @@
-using BinaryBuilder
+using BinaryBuilder, Pkg
 
 # Collection of sources required to build FastTransforms
 name = "FastTransforms"
@@ -36,8 +36,8 @@ if [[ ${nbits} == 64 ]]; then
 else
     BLAS=openblas
 fi
-make assembly CC=gcc
-make lib CC=gcc FT_PREFIX=${prefix} FT_BLAS=${BLAS} FT_FFTW_WITH_COMBINED_THREADS=1
+make assembly
+make lib FT_PREFIX=${prefix} FT_BLAS=${BLAS} FT_FFTW_WITH_COMBINED_THREADS=1
 mv -f libfasttransforms.${dlext} ${libdir}
 """
 
@@ -50,10 +50,13 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("CompilerSupportLibraries_jll"),
     Dependency("FFTW_jll"),
     Dependency("MPFR_jll", v"4.1.1"),
     Dependency("OpenBLAS_jll", v"0.3.17"),
+    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
+    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
+    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
@MikaelSlevinsky you may be interested in this.  It took us some time since
#2701, but LLVM OpenMP is finally available.  Let me know if you're OK with this
change.