### PR TITLE
[LLVMOpenMP] Upgrade to v13.0.1

### DIFF
--- a/L/LLVMOpenMP/build_tarballs.jl
+++ b/L/LLVMOpenMP/build_tarballs.jl
@@ -40,7 +40,6 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
     -DLIBOMP_INSTALL_ALIASES=OFF \
     -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
-    -DCLANG_TOOL="$(which clang)" \
     "${platform_config[@]}" \
     ..
 make -j${nproc}

--- a/L/LLVMOpenMP/build_tarballs.jl
+++ b/L/LLVMOpenMP/build_tarballs.jl
@@ -39,6 +39,7 @@ mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
     -DLIBOMP_INSTALL_ALIASES=OFF \
+    -DCLANG_TOOL="$(which clang)" \
     "${platform_config[@]}" \
     ..
 make -j${nproc}
@@ -61,6 +62,8 @@ dependencies = [
     # We need libclang_rt.osx.a for linking libomp, because this library provides the
     # implementation of `__divdc3`.
     BuildDependency(PackageSpec(name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=v"12.0.0"); platforms=[Platform("aarch64", "macos")]),
+    # libomptarget.so links to Zlib on Linux
+    Dependency("Zlib_jll"; platforms=filter(Sys.islinux, platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/LLVMOpenMP/build_tarballs.jl
+++ b/L/LLVMOpenMP/build_tarballs.jl
@@ -39,6 +39,7 @@ mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
     -DLIBOMP_INSTALL_ALIASES=OFF \
+    -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
     -DCLANG_TOOL="$(which clang)" \
     "${platform_config[@]}" \
     ..
@@ -62,8 +63,6 @@ dependencies = [
     # We need libclang_rt.osx.a for linking libomp, because this library provides the
     # implementation of `__divdc3`.
     BuildDependency(PackageSpec(name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=v"12.0.0"); platforms=[Platform("aarch64", "macos")]),
-    # libomptarget.so links to Zlib on Linux
-    Dependency("Zlib_jll"; platforms=filter(Sys.islinux, platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/LLVMOpenMP/build_tarballs.jl
+++ b/L/LLVMOpenMP/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "LLVMOpenMP"
-version = v"12.0.1"
+version = v"13.0.1"
 
 sources = [
     ArchiveSource(
         "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/openmp-$(version).src.tar.xz",
-        "60fe79440eaa9ebf583a6ea7f81501310388c02754dbe7dc210776014d06b091"
+        "6b79261371616c31fea18cd3ee1797c79ee38bcaf8417676d4fa366a24c96b4f"
     ),
     DirectorySource("./bundled"),
 ]


### PR DESCRIPTION
New attempt at building OpenMP from LLVM 13.0.1, after #3271.  Main issue on
Linux was that we had to point to the right target `clang`, which is used to
build some files.  This currently fails on FreeBSD.