### PR TITLE
Build LibYAML also for macOS aarch64

### DIFF
--- a/L/LibYAML/build_tarballs.jl
+++ b/L/LibYAML/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "LibYAML"
-version = v"0.2.5"
+version = v"0.2.6" #​ <-- This version is a lie, we need to bump it to build for experimental platforms
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("http://pyyaml.org/download/libyaml/yaml-$version.tar.gz", "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4")
+    ArchiveSource("http://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz", "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4")
 ]
 
 # Bash recipe for building across all platforms

--- a/L/LibYAML/build_tarballs.jl
+++ b/L/LibYAML/build_tarballs.jl
@@ -33,4 +33,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
Rebuild LibYAML to add support for macOS aarch64. It seems a `julia_compat` entry is required.