### PR TITLE
Add a CUDA JLL for actually loading the runtime libraries.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_10.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_10.0.jl
@@ -1,0 +1,154 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"10.0.130"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == x86_64-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-apple-darwin* ]]; then
+    # CUDA Runtime
+    mv lib/libcudart.*dylib lib/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib/libcufft.*dylib lib/libcufftw.*dylib ${libdir}
+
+    # CUDA BLAS Library
+    mv lib/libcublas.*dylib ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib/libcusparse.*dylib ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib/libcusolver.*dylib ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib/libcurand.*dylib ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib/libnvvm.*dylib ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib/libcupti.*dylib ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib/libnvToolsExt.*dylib ${libdir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/libx64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+products = [
+    LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_100"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_100"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_100"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_100"], :libcusolver),
+    LibraryProduct(["libcurand", "curand64_100"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_100"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+]
+
+platforms = [Platform("x86_64", "linux"; cuda="10.0"),
+             Platform("x86_64", "macos"; cuda="10.0"),
+             Platform("x86_64", "windows"; cuda="10.0")]

--- a/C/CUDA/CUDA_Runtime/build_10.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_10.2.jl
@@ -1,0 +1,128 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"10.2.89"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == x86_64-linux-gnu || ${target} == aarch64-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    if [[ $target != aarch64-linux-gnu ]]; then
+        mv lib64/libcusolverMg.so* ${libdir}
+    fi
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Nulti GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+products = [
+    LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_10"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_10"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_102"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+]
+
+platforms = [
+    Platform("aarch64", "linux"; cuda="10.2"),
+    Platform("x86_64", "linux"; cuda="10.2"),
+    Platform("x86_64", "windows"; cuda="10.2")
+]

--- a/C/CUDA/CUDA_Runtime/build_11.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.0.jl
@@ -1,0 +1,134 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.0.3"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r Sanitizer/{docs,include}
+    mv Sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r Sanitizer/{docs,include}
+    mv Sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+products = [
+    LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_10"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2020.1.1"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+]
+
+platforms = [Platform("x86_64", "linux"; cuda="11.0"),
+             Platform("powerpc64le", "linux"; cuda="11.0"),
+             Platform("x86_64", "windows"; cuda="11.0")]

--- a/C/CUDA/CUDA_Runtime/build_11.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.1.jl
@@ -1,0 +1,134 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.1.1"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+products = [
+    LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2020.2.1"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+]
+
+platforms = [Platform("x86_64", "linux"; cuda="11.1"),
+             Platform("powerpc64le", "linux"; cuda="11.1"),
+             Platform("x86_64", "windows"; cuda="11.1")]

--- a/C/CUDA/CUDA_Runtime/build_11.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.2.jl
@@ -1,0 +1,134 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.2.2"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+products = [
+    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2020.3.1"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+]
+
+platforms = [Platform("x86_64", "linux"; cuda="11.2"),
+             Platform("powerpc64le", "linux"; cuda="11.2"),
+             Platform("x86_64", "windows"; cuda="11.2")]

--- a/C/CUDA/CUDA_Runtime/build_11.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.3.jl
@@ -1,0 +1,134 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.3.1"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+products = [
+    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2021.1.1"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+]
+
+platforms = [Platform("x86_64", "linux"; cuda="11.3"),
+             Platform("powerpc64le", "linux"; cuda="11.3"),
+             Platform("x86_64", "windows"; cuda="11.3")]

--- a/C/CUDA/CUDA_Runtime/build_11.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.4.jl
@@ -1,0 +1,135 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.4.2"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+products = [
+    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2021.2.2"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+]
+
+platforms = [Platform("x86_64", "linux"; cuda="11.4"),
+             Platform("powerpc64le", "linux"; cuda="11.4"),
+             Platform("aarch64", "linux"; cuda="11.4"),
+             Platform("x86_64", "windows"; cuda="11.4")]

--- a/C/CUDA/CUDA_Runtime/build_11.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.5.jl
@@ -1,0 +1,135 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.5.1"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+products = [
+    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2021.3.1"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+]
+
+platforms = [Platform("x86_64", "linux"; cuda="11.5"),
+             Platform("powerpc64le", "linux"; cuda="11.5"),
+             Platform("aarch64", "linux"; cuda="11.5"),
+             Platform("x86_64", "windows"; cuda="11.5")]

--- a/C/CUDA/CUDA_Runtime/build_11.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.6.jl
@@ -1,0 +1,135 @@
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.6.0"))]
+
+script = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# headers
+mkdir -p ${prefix}/include
+mv include/* ${prefix}/include
+rm -rf ${prefix}/include/thrust
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    # CUDA Runtime
+    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+
+    # CUDA FFT Library
+    mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
+
+    # CUDA BLAS Library
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
+
+    # CUDA Sparse Matrix Library
+    mv lib64/libcusparse.so* ${libdir}
+
+    # CUDA Linear Solver Library
+    mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
+
+    # CUDA Random Number Generation Library
+    mv lib64/libcurand.so* ${libdir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/lib64/libnvvm.so* ${libdir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+
+    # NVIDIA Tools Extension Library
+    mv lib64/libnvToolsExt.so* ${libdir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas ${bindir}
+    mv bin/nvdisasm ${bindir}
+    mv bin/nvlink ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    # CUDA Runtime
+    mv bin/cudart64_*.dll ${bindir}
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    # CUDA FFT Library
+    mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
+
+    # CUDA BLAS Library
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
+
+    # CUDA Sparse Matrix Library
+    mv bin/cusparse64_*.dll ${bindir}
+
+    # CUDA Linear Solver Library
+    mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
+
+    # CUDA Random Number Generation Library
+    mv bin/curand64_*.dll ${bindir}
+
+    # NVIDIA Optimizing Compiler Library
+    mv nvvm/bin/nvvm64_*.dll ${bindir}
+
+    # NVIDIA Common Device Math Functions Library
+    mkdir ${prefix}/share/libdevice
+    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    # CUDA Profiling Tools Interface (CUPTI) Library
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+
+    # NVIDIA Tools Extension Library
+    mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
+
+    # Additional binaries
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+products = [
+    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2022.1.0"], :libcupti),
+    LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+]
+
+platforms = [Platform("x86_64", "linux"; cuda="11.6"),
+             Platform("powerpc64le", "linux"; cuda="11.6"),
+             Platform("aarch64", "linux"; cuda="11.6"),
+             Platform("x86_64", "windows"; cuda="11.6")]

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -1,0 +1,55 @@
+using BinaryBuilder, Pkg
+
+const YGGDRASIL_DIR = "../../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
+
+name = "CUDA_Runtime"
+version = v"0.1"
+
+cuda_versions = [v"10.0", v"10.2",
+                 v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6"]
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+
+    $(CUDA.augment)
+
+    augment_cuda_toolkit!(platform) = augment_cuda_toolkit!(platform, $cuda_versions)
+
+    function augment_platform!(platform::Platform)
+        augment_cuda_toolkit!(platform)
+    end"""
+
+# determine exactly which tarballs we should build
+builds = []
+for cuda_version in cuda_versions
+    cuda_tag = "$(cuda_version.major).$(cuda_version.minor)"
+    include("build_$(cuda_tag).jl")
+
+    for platform in platforms
+        augmented_platform = deepcopy(platform)
+        augmented_platform[CUDA.platform_name] = CUDA.platform(cuda_version)
+
+        should_build_platform(triplet(augmented_platform)) || continue
+        push!(builds, (;
+            dependencies, script, products,
+            platforms=[augmented_platform],
+        ))
+    end
+end
+
+# don't allow `build_tarballs` to override platform selection based on ARGS.
+# we handle that ourselves by calling `should_build_platform`
+non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
+
+# `--register` should only be passed to the latest `build_tarballs` invocation
+non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
+
+for (i,build) in enumerate(builds)
+    build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
+                   name, version, [], build.script,
+                   build.platforms, build.products, build.dependencies;
+                   julia_compat="1.6", lazy_artifacts=true,
+                   augment_platform_block)
+end

--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -1,0 +1,138 @@
+module CUDA
+
+const platform_name = "cuda"
+const augment = """
+    using Libdl
+    using Base: thisminor
+
+
+    #
+    # Augmentation for selecting the CUDA toolkit
+    #
+
+    # NOTE: we set the 'cuda' platform tag to the actual CUDA Toolkit version we'll be using
+    #       and not to the version that this driver supports (letting Pkg select an artifact
+    #       via a comparison strategy). This to simplify dependent packages; otherwise they
+    #       would need to know which toolkits are available to additionaly bound selection.
+
+    # provided by caller: `augment_cuda_toolkit!(platform)` method calling the version below
+    #                     with the available toolkit versions passed along
+
+    function driver_version()
+        libcuda_path = if Sys.iswindows()
+            Libdl.find_library("nvcuda")
+        else
+            Libdl.find_library(["libcuda.so.1", "libcuda.so"])
+        end
+        if libcuda_path == ""
+            return nothing
+        end
+
+        libcuda = Libdl.dlopen(libcuda_path)
+        try
+            function_handle = Libdl.dlsym(libcuda, "cuDriverGetVersion")
+            version_ref = Ref{Cint}()
+            status = ccall(function_handle, UInt32, (Ptr{Cint},), version_ref)
+            if status != 0
+                # TODO: warn here about the error?
+                return nothing
+            end
+            major, ver = divrem(version_ref[], 1000)
+            minor, patch = divrem(ver, 10)
+            return VersionNumber(major, minor, patch)
+        finally
+            Libdl.dlclose(libcuda)
+        end
+    end
+
+    function toolkit_version(cuda_toolkits)
+        cuda_driver = driver_version()
+        if cuda_driver === nothing
+            return nothing
+        end
+
+        cuda_version_override = get(ENV, "JULIA_CUDA_VERSION", nothing)
+        # TODO: support for Preferences.jl-based override?
+
+        # "[...] applications built against any of the older CUDA Toolkits always continued
+        #  to function on newer drivers due to binary backward compatibility"
+        filter!(cuda_toolkits) do toolkit
+            if cuda_version_override !== nothing
+                toolkit == cuda_version_override
+            elseif cuda_driver >= v"11.1"
+                # enhanced compatibility
+                #
+                # "From CUDA 11 onwards, applications compiled with a CUDA Toolkit release
+                #  from within a CUDA major release family can run, with limited feature-set,
+                #  on systems having at least the minimum required driver version"
+                # TODO: check this minimum required driver version?
+                toolkit.major <= cuda_driver.major
+            else
+                thisminor(toolkit) <= thisminor(cuda_driver)
+            end
+        end
+        if isempty(cuda_toolkits)
+            return nothing
+        end
+
+        last(cuda_toolkits)
+    end
+
+    function augment_cuda_toolkit!(platform::Platform, cuda_toolkits::Vector{VersionNumber})
+        haskey(platform, "cuda") && return platform
+
+        cuda_toolkit = toolkit_version(cuda_toolkits)
+        platform["cuda"] = if cuda_toolkit !== nothing
+            "\$(cuda_toolkit.major).\$(cuda_toolkit.minor)"
+        else
+            # don't use an empty string here, because Pkg will then load *any* artifact
+            "none"
+        end
+
+        return platform
+    end
+
+
+    #
+    # Augmentation for selecting artifacts that depend on the CUDA toolkit
+    #
+
+    # imported by caller: CUDA_Runtime_jll
+
+    function cuda_comparison_strategy(a::String, b::String, a_requested::Bool, b_requested::Bool)
+        a = VersionNumber(a)
+        b = VersionNumber(b)
+
+        # If both b and a requested, then we fall back to equality:
+        if a_requested && b_requested
+            return a == b
+        end
+
+        # Otherwise, do the comparison between the the single version cap and the single version:
+        function is_compatible(artifact::VersionNumber, host::VersionNumber)
+            if host >= v"11.0"
+                # enhanced compatibility, semver-style
+                artifact.major == host.major
+            else
+                artifact.major == host.major &&
+                artifact.minor == host.minor
+            end
+        end
+        if a_requested
+            is_compatible(b, a)
+        else
+            is_compatible(a, b)
+        end
+    end
+
+    function augment_cuda_dependent!(platform::Platform)
+        set_compare_strategy!(platform, "cuda", cuda_comparison_strategy)
+        haskey(platform, "cuda") && return platform
+        CUDA_Runtime_jll.augment_cuda_toolkit!(platform)
+    end"""
+
+function platform(cuda::VersionNumber)
+    return "$(cuda.major).$(cuda.minor)"
+end
+
+end


### PR DESCRIPTION
This is an experimental JLL, working my way towards actually using JLLs to load the CUDA runtime libraries instead of doing everything ourselves in CUDA.jl. It uses the `cuda` platform tag to determine which CUDA toolkit to load (based on driver compatibility and toolkit availability). That tag can then used by dependent JLLs, like CUDNN, to determine which library to load.

Note that I didn't use a comparison strategy for determining which toolkit artifact to load. Instead, I'm using plain equality, but providing the list of available toolkits to `augment_platform!` instead (essentially embedding that in the generated JLL). This results in the platform tag containing the actual toolkit loaded, instead of the host's compatibility, which should make it easier for dependent JLLs to determine which artifact they can load.

I'm not sure about the comparison strategy for dependent packages, so @giordano if you could review that (given how you've been looking into this recently).

The other big change that this JLL will result in, is that `using CUDA_Runtime_JLL` will eagerly download and load the CUDA runtime libraries (because we lack the flexibility of lazy-downloading or lazy-loading with JLLs right now, even with lazy artifacts). So packages depending on the CUDA stack will need to use Preferences to avoid loading CUDA if it isn't to be used. That's a departure from how things work right now.