### PR TITLE
[hyper] Actually compile the C API

### DIFF
--- a/H/hyper/build_tarballs.jl
+++ b/H/hyper/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/hyper*/
-cargo build --release
+RUSTFLAGS="--cfg hyper_unstable_ffi" cargo build --release --features client,http1,http2,ff
 install -Dm 755 target/${rust_target}/release/*hyper.${dlext} "${libdir}/libhyper.${dlext}"
 """
 

--- a/H/hyper/build_tarballs.jl
+++ b/H/hyper/build_tarballs.jl
@@ -3,18 +3,17 @@
 using BinaryBuilder
 
 name = "hyper"
-version = v"0.14.18"
+version = v"0.14.17"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://github.com/hyperium/hyper/archive/refs/tags/v$(version).tar.gz",
-                  "6095636d02ea5af3ff5f06d80b9466f7b58ba76339f39813b33c3f24c663fdef"),
+                  "64420fd550f43af09b0722b3504d4fd919de642d63f01ad54108aa854f5f5470"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/hyper*/
-sed '21 a [lib]\ncrate-type=["cdylib"]\n' -i Cargo.toml
 RUSTFLAGS="--cfg hyper_unstable_ffi" cargo build --release --features client,http1,http2,ffi
 install -Dm 755 target/${rust_target}/release/*hyper.${dlext} "${libdir}/libhyper.${dlext}"
 """

--- a/H/hyper/build_tarballs.jl
+++ b/H/hyper/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "hyper"
-version = v"0.14.17"
+version = v"0.14.18"
 
 # Collection of sources required to complete build
 sources = [

--- a/H/hyper/build_tarballs.jl
+++ b/H/hyper/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/hyper*/
-RUSTFLAGS="--cfg hyper_unstable_ffi" cargo build --release --features client,http1,http2,ff
+RUSTFLAGS="--cfg hyper_unstable_ffi" cargo build --release --features client,http1,http2,ffi
 install -Dm 755 target/${rust_target}/release/*hyper.${dlext} "${libdir}/libhyper.${dlext}"
 """
 

--- a/H/hyper/build_tarballs.jl
+++ b/H/hyper/build_tarballs.jl
@@ -14,6 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/hyper*/
+sed '21 a [lib]\ncrate-type=["cdylib"]\n' -i Cargo.toml
 RUSTFLAGS="--cfg hyper_unstable_ffi" cargo build --release --features client,http1,http2,ffi
 install -Dm 755 target/${rust_target}/release/*hyper.${dlext} "${libdir}/libhyper.${dlext}"
 """

--- a/H/hyper/build_tarballs.jl
+++ b/H/hyper/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"0.14.18"
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://github.com/hyperium/hyper/archive/refs/tags/v$(version).tar.gz",
-                  "64420fd550f43af09b0722b3504d4fd919de642d63f01ad54108aa854f5f5470"),
+                  "6095636d02ea5af3ff5f06d80b9466f7b58ba76339f39813b33c3f24c663fdef"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
According to https://docs.rs/hyper/latest/hyper/ffi/index.html, the C API of hyper is not compiled by default. Extra options and environment variables need to be set to make the C API work.