### PR TITLE
Bump pprof to latest release b5a4dc8f4f2afdee77047b6aae3834140efc83ed & release v1.0

### DIFF
--- a/P/pprof/build_tarballs.jl
+++ b/P/pprof/build_tarballs.jl
@@ -6,8 +6,8 @@ name = "pprof"
 # identifying a version by a specific commit hash, off of `pprof`'s
 # main branch.
 
-hash = "20978b51388db0648809a2c5cc88b494c7945ec1"
-version = v"0.1.1"
+hash = "b5a4dc8f4f2afdee77047b6aae3834140efc83ed"
+version = v"1.0.0"
 
 # Collection of sources required to build pprof
 sources = [


### PR DESCRIPTION
Bump pprof upstream commit to [`b5a4dc8f4f2afdee77047b6aae3834140efc83ed`](https://github.com/google/pprof/commit/b5a4dc8f4f2afdee77047b6aae3834140efc83ed).

While I'm here, I've gone ahead and upgraded this to be v1.0 instead of v0.2 or v0.1.2, since i think it's been pretty stable. I definitely feel comfortable calling this "v1.0 ready"!

This PR picks up @vilterp's https://github.com/google/pprof/pull/684, which fixes a bug we encounter from julia's PProf, where large flamegraphs don't render (julia hits this more than other languages, since we print full method signatures with arbitrarily large type names): https://github.com/google/pprof/issues/663.

Upstream changes in this release:
https://github.com/google/pprof/compare/20978b51388db0648809a2c5cc88b494c7945ec1...b5a4dc8f4f2afdee77047b6aae3834140efc83ed
