### PR TITLE
Update RadeonProRender version, build on macos aarch64

### DIFF
--- a/R/RadeonProRender/build_tarballs.jl
+++ b/R/RadeonProRender/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "RadeonProRender"
-version = v"2.2.9"
+version = v"2.02.12"
 
 # Collection of sources required to complete build
 sources = [
@@ -69,4 +69,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.6")

--- a/R/RadeonProRender/build_tarballs.jl
+++ b/R/RadeonProRender/build_tarballs.jl
@@ -16,9 +16,9 @@ echo ${target}
 cd $WORKSPACE/srcdir/RadeonProRenderSDK/RadeonProRender
 if [[ ${target} == x86_64-linux-gnu ]]; then
     cp binUbuntu18/* ${libdir}/
-elif [[ ${target} == x86_64-apple-darwin* ]]; then
+elif [[ ${target} == *-apple-darwin* ]]; then
     cp binMacOS/* ${libdir}/
-elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+elif [[ ${target} == *-mingw* ]]; then
     cp binWin64/* ${libdir}/
 fi
 """

--- a/R/RadeonProRender/build_tarballs.jl
+++ b/R/RadeonProRender/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"2.2.9"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderSDK.git", "5916c58f9cc037899e0aa85e5f5a67c6e1ee7b29")
+    GitSource("https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderSDK.git", "e284dfac04ee3a142603ba955a2bf8d11a78d945")
 ]
 
 # TODO, also ship headers for Clang.jl generation!?
@@ -27,6 +27,7 @@ fi
 platforms = [
     Platform("x86_64", "linux"),
     Platform("x86_64", "macos"),
+    Platform("aarch64", "macos"),
     Platform("x86_64", "windows")
 ]
 


### PR DESCRIPTION
This updates the version of RadeonProRender to [v2.02.12](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderSDK/commit/e284dfac04ee3a142603ba955a2bf8d11a78d945), released in March 2022.  Additionally, it adds Mac M1 as a build target, given that the website claims it can run on M1 chips as well.