### PR TITLE
Patch PETSc build instead of moving files

### DIFF
--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -99,6 +99,12 @@ build_petsc double real Int64
 build_petsc single real Int64
 build_petsc double complex Int64
 build_petsc single complex Int64
+
+# On windows move back since we can't change the install name
+if [[ "${target}" == *-mingw32* ]]; then
+   mv ${libdir}/petsc/double_real_Int32/lib/libpetsc_double_real_Int32.${dlext} "${libdir}/petsc/double_real_Int32/lib/libpetsc.${dlext}.3.6.5" # TODO fix version suffix
+fi
+   
 """
 
 # We attempt to build for all defined platforms
@@ -106,8 +112,8 @@ platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686
 
 products = [
     # Current default build, equivalent to Float64_Real_Int32
-    LibraryProduct("libpetsc_double_real_Int32", :libpetsc, "\$libdir/petsc/double_real_Int32/lib")
-    LibraryProduct("libpetsc_double_real_Int32", :libpetsc_Float64_Real_Int32, "\$libdir/petsc/double_real_Int32/lib")
+    LibraryProduct(["libpetsc_double_real_Int32", "libpetsc.dll.3.6.5"], :libpetsc, "\$libdir/petsc/double_real_Int32/lib")
+    LibraryProduct(["libpetsc_double_real_Int32", "libpetsc.dll.3.6.5"], :libpetsc_Float64_Real_Int32, "\$libdir/petsc/double_real_Int32/lib")
     LibraryProduct("libpetsc_double_real_Int64", :libpetsc_Float64_Real_Int64, "\$libdir/petsc/double_real_Int64/lib")
     LibraryProduct("libpetsc_single_real_Int64", :libpetsc_Float32_Real_Int64, "\$libdir/petsc/single_real_Int64/lib")
     LibraryProduct("libpetsc_double_complex_Int64", :libpetsc_Float64_Complex_Int64, "\$libdir/petsc/double_complex_Int64/lib")

--- a/P/PETSc/bundled/patches/mingw-version.patch
+++ b/P/PETSc/bundled/patches/mingw-version.patch
@@ -1,0 +1,33 @@
+From 8bc89024f9012ed5dfb1862c305866cfef6f8f6f Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Sun, 10 Apr 2022 04:58:42 -0400
+Subject: [PATCH] When cross-compiling with MingW32 we shouldn't set the
+ dllversion as a suffix
+
+---
+ config/PETSc/options/sharedLibraries.py | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/config/PETSc/options/sharedLibraries.py b/config/PETSc/options/sharedLibraries.py
+index a84083ee67..e9d814633d 100755
+--- a/config/PETSc/options/sharedLibraries.py
++++ b/config/PETSc/options/sharedLibraries.py
+@@ -76,10 +76,13 @@ class Configure(config.base.Configure):
+         # TODO: check that -Wl,-soname,${LIBNAME}.${SL_LINKER_SUFFIX} can be passed (might fail on Intel)
+         # TODO: check whether we need to specify dependent libraries on the link line (long test)
+         self.addMakeRule('shared_arch','shared_linux')
+-        self.addMakeMacro('SONAME_FUNCTION', '$(1).$(SL_LINKER_SUFFIX).$(2)')
+-        self.addMakeMacro('SL_LINKER_FUNCTION', self.framework.getSharedLinkerFlags() + ' -Wl,-soname,$(call SONAME_FUNCTION,$(notdir $(1)),$(2))')
+         if config.setCompilers.Configure.isMINGW(self.framework.getCompiler(),self.log):
+           self.addMakeMacro('PETSC_DLL_EXPORTS', '1')
++          self.addMakeMacro('SONAME_FUNCTION', '$(1)-$(2).$(SL_LINKER_SUFFIX)')
++        else:
++          self.addMakeMacro('SONAME_FUNCTION', '$(1).$(SL_LINKER_SUFFIX).$(2)')
++
++        self.addMakeMacro('SL_LINKER_FUNCTION', self.framework.getSharedLinkerFlags() + ' -Wl,-soname,$(call SONAME_FUNCTION,$(notdir $(1)),$(2))')
+       self.addMakeMacro('BUILDSHAREDLIB','yes')
+     else:
+       self.addMakeRule('shared_arch','')
+-- 
+2.35.1
+

--- a/P/PETSc/bundled/patches/sosuffix.patch
+++ b/P/PETSc/bundled/patches/sosuffix.patch
@@ -23,7 +23,7 @@ index e9d814633d..d3323f93d6 100755
      import sys
 
      self.useShared = self.framework.argDB['with-shared-libraries'] and not self.setCompilers.staticLibraries
-+    if self.framework.argDB['SOSUFFIX'] is None
++    if self.framework.argDB['SOSUFFIX'] is None:
 +        self.SOSUFFIX = ''
 +    else:
 +        self.SOSUFFIX = '_{0}'.format(self.framework.argDB['SOSUFFIX'])

--- a/P/PETSc/bundled/patches/sosuffix.patch
+++ b/P/PETSc/bundled/patches/sosuffix.patch
@@ -1,0 +1,59 @@
+From 22321abcfd93bdd2bc0cd896f6c3c8380892b8c8 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Sun, 10 Apr 2022 05:21:56 -0400
+Subject: [PATCH] Allow users to set a SOSUFFIX
+
+---
+ config/PETSc/options/sharedLibraries.py | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/config/PETSc/options/sharedLibraries.py b/config/PETSc/options/sharedLibraries.py
+index e9d814633d..d3323f93d6 100755
+--- a/config/PETSc/options/sharedLibraries.py
++++ b/config/PETSc/options/sharedLibraries.py
+@@ -19,6 +19,7 @@ class Configure(config.base.Configure):
+     import nargs
+     help.addArgument('PETSc', '-with-shared-libraries=<bool>', nargs.ArgBool(None, 1, 'Make PETSc libraries shared -- libpetsc.so (Unix/Linux) or libpetsc.dylib (Mac)'))
+     help.addArgument('PETSc', '-with-serialize-functions=<bool>', nargs.ArgBool(None, 0, 'Allows function pointers to be serialized to binary files with string representations'))
++    help.addArgument('PETSc', '-SOSUFFIX=<string>', nargs.Arg(None, 0, 'Add a suffix to shared libraries'))
+     return
+
+   def setupDependencies(self, framework):
+@@ -54,6 +55,10 @@ class Configure(config.base.Configure):
+     import sys
+
+     self.useShared = self.framework.argDB['with-shared-libraries'] and not self.setCompilers.staticLibraries
++    if self.framework.argDB['SOSUFFIX'] is None
++        self.SOSUFFIX = ''
++    else:
++        self.SOSUFFIX = '_{0}'.format(self.framework.argDB['SOSUFFIX'])
+
+     if self.useShared:
+       #if config.setCompilers.Configure.isSolaris(self.log) and config.setCompilers.Configure.isGNU(self.framework.getCompiler(),self.log):
+@@ -66,10 +71,10 @@ class Configure(config.base.Configure):
+       # Linux is the default
+       if self.setCompilers.isDarwin(self.log):
+         self.addMakeRule('shared_arch','shared_darwin')
+-        self.addMakeMacro('SONAME_FUNCTION', '$(1).$(2).dylib')
++        self.addMakeMacro('SONAME_FUNCTION', '$(1){0}.$(2).dylib'.format(self.SOSUFFIX))
+         self.addMakeMacro('SL_LINKER_FUNCTION', '-dynamiclib -install_name $(call SONAME_FUNCTION,$(1),$(2)) -compatibility_version $(2) -current_version $(3) -single_module -multiply_defined suppress -undefined dynamic_lookup')
+       elif self.setCompilers.CC.find('win32fe') >=0:
+-        self.addMakeMacro('SONAME_FUNCTION', '$(1).dll')
++        self.addMakeMacro('SONAME_FUNCTION', '$(1){0}.dll'.format(self.SOSUFFIX))
+         self.addMakeMacro('SL_LINKER_FUNCTION', '-LD')
+         self.addMakeMacro('PETSC_DLL_EXPORTS', '1')
+       else:
+@@ -78,9 +83,9 @@ class Configure(config.base.Configure):
+         self.addMakeRule('shared_arch','shared_linux')
+         if config.setCompilers.Configure.isMINGW(self.framework.getCompiler(),self.log):
+           self.addMakeMacro('PETSC_DLL_EXPORTS', '1')
+-          self.addMakeMacro('SONAME_FUNCTION', '$(1)-$(2).$(SL_LINKER_SUFFIX)')
++          self.addMakeMacro('SONAME_FUNCTION', '$(1){0}-$(2).$(SL_LINKER_SUFFIX)'.format(self.SOSUFFIX))
+         else:
+-          self.addMakeMacro('SONAME_FUNCTION', '$(1).$(SL_LINKER_SUFFIX).$(2)')
++          self.addMakeMacro('SONAME_FUNCTION', '$(1){0}.$(SL_LINKER_SUFFIX).$(2)'.format(self.SOSUFFIX))
+
+         self.addMakeMacro('SL_LINKER_FUNCTION', self.framework.getSharedLinkerFlags() + ' -Wl,-soname,$(call SONAME_FUNCTION,$(notdir $(1)),$(2))')
+       self.addMakeMacro('BUILDSHAREDLIB','yes')
+--
+2.35.1


### PR DESCRIPTION
@giordano is it possible to relax the requirement that the file must end in `dll`? If not I will need to fix the petsc build system to not produce files like that.

cc: @boriskaus 