### PR TITLE
Change MPItrampoline's ABI name to `MPItrampoline`

### DIFF
--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -22,7 +22,7 @@ const augment = raw"""
         elseif binary == "OpenMPI_jll"
             "OpenMPI"
         elseif binary == "MPItrampoline_jll"
-            "MPIwrapper"
+            "MPItrampoline"
         else
             error("Unknown binary: $binary")
         end
@@ -41,7 +41,7 @@ mpi_abis = (
     ("MPICH", PackageSpec(name="MPICH_jll"), "", !Sys.iswindows) ,
     ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "", !Sys.iswindows),
     ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),
-    ("MPIwrapper", PackageSpec(name="MPItrampoline_jll"), "", !Sys.iswindows)
+    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "", !Sys.iswindows)
 )
 
 function augment_platforms(platforms)


### PR DESCRIPTION
The library that provides the MPI implementation (i.e. the ABI against which the packages link) is provided by MPItrampoline, not MPIwrapper.