### PR TITLE
Try building a `GCCBootstrap_jll` using `crosstool-ng`

### DIFF
--- a/0_RootFS/Rootfs/bundled/libs/libc/download_libcs.sh
+++ b/0_RootFS/Rootfs/bundled/libs/libc/download_libcs.sh
@@ -12,5 +12,5 @@ done
 for arch in i686 x86_64; do
     rm -rf musl-${arch}
     mkdir -p musl-${arch}
-    curl -L "https://github.com/JuliaBinaryWrappers/Musl_jll.jl/releases/download/Musl-v1.2.2%2B1/Musl.v1.2.2.${arch}-linux-musl.tar.gz" | tar --wildcards --strip-components=1 -zxv -C musl-${arch} "lib*/"
+    curl -L "https://github.com/JuliaBinaryWrappers/Musl_jll.jl/releases/download/Musl-v1.2.2%2B2/Musl.v1.2.2.${arch}-linux-musl.tar.gz" | tar --wildcards --strip-components=1 -zxv -C musl-${arch} "lib*/"
 done

--- a/G/GCCBootstrap/build_tarballs.jl
+++ b/G/GCCBootstrap/build_tarballs.jl
@@ -1,0 +1,130 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "GCCBootstrap"
+version = v"9.4.0"
+
+# Collection of sources required to complete build
+sources = [
+    # crosstool-ng will provide the build script
+    ArchiveSource("http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.25.0_rc1.tar.bz2",
+                  "8a839df71bea7b2c411447b41b917f2142482df171733ddb92d615cec2f0f43a"),
+
+    # We provide some configs for crostool-ng
+    DirectorySource("./bundled"),
+
+    # crosstool-ng can download the files, but we'd rather download them ourselves
+    FileSource("http://mirrors.kernel.org/gnu/gcc/gcc-9.4.0/gcc-9.4.0.tar.xz",
+               "c95da32f440378d7751dd95533186f7fc05ceb4fb65eb5b85234e6299eb9838e"),
+    FileSource("https://mirrors.kernel.org/gnu/mpfr/mpfr-4.1.0.tar.xz",
+               "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"),
+    FileSource("https://mirrors.kernel.org/gnu/mpc/mpc-1.2.1.tar.gz",
+               "17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459"),
+    FileSource("https://gcc.gnu.org/pub/gcc/infrastructure/isl-0.24.tar.bz2",
+               "fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0"),
+    FileSource("https://mirrors.kernel.org/gnu/gmp/gmp-6.2.1.tar.xz",
+               "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2"),
+    FileSource("http://mirrors.kernel.org/pub/linux/kernel/v4.x/linux-4.1.49.tar.xz",
+               "ff2e0ea5c536650aef64447c3aaa49c1a25e8f1db4ec4f7da700d3176f512ba8"),
+    FileSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.19.tar.xz",
+               "2d3997f588401ea095a0b27227b1d50cdfdd416236f6567b564549d3b46ea2a2"),
+    FileSource("https://musl.libc.org/releases/musl-1.2.2.tar.gz",
+               "9b969322012d796dc23dda27a35866034fa67d8fb67e0e2c45c913c3d43219dd"),
+    FileSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v9.0.0.tar.bz2",
+               "1929b94b402f5ff4d7d37a9fe88daa9cc55515a6134805c104d1794ae22a4181"),
+    FileSource("https://github.com/madler/zlib/archive/refs/tags/v1.2.11.tar.gz",
+               "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
+               filename="zlib-1.2.11.tar.gz"),
+    FileSource("http://mirrors.kernel.org/gnu/ncurses/ncurses-6.2.tar.gz",
+               "30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d"),
+    FileSource("http://mirrors.kernel.org/gnu/libiconv/libiconv-1.16.tar.gz",
+               "e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04"),
+    FileSource("http://mirrors.kernel.org/gnu/gettext/gettext-0.21.tar.xz",
+               "d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192"),
+    FileSource("http://mirrors.kernel.org/gnu/binutils/binutils-2.29.1.tar.xz",
+               "e7010a46969f9d3e53b650a518663f98a5dde3c3ae21b7d71e5e6803bc36b577"),
+    FileSource("http://mirrors.kernel.org/gnu/binutils/binutils-2.38.tar.xz",
+               "e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/crosstool-ng*/
+
+# These tools will help us to bootstrap
+apk add build-base texinfo help2man ncurses-dev
+
+# Copy in our extra patches for all packages
+for package in ${WORKSPACE}/srcdir/patches/*; do
+    package="$(basename "${package}")"
+    for version in ${WORKSPACE}/srcdir/patches/${package}/*; do
+        version="$(basename "${version}")"
+        if [ ! -d packages/${package}/${version} ]; then
+            continue
+        fi
+        cp -v ${WORKSPACE}/srcdir/patches/${package}/${version}/* packages/${package}/${version}/
+    done
+done
+
+# Disable some checks that ct-ng performs
+export CT_ALLOW_BUILD_AS_ROOT_SURE=1
+
+# Unset some things that BB automatically inserts into the environment,
+# but which crosstool-ng rightfully complains about.
+unset LD_LIBRARY_PATH
+for TOOL in CC CXX LD AS AR FC OBJCOPY OBJDUMP RANLIB STRIP LIPO MESON NM READELF; do
+    unset "${TOOL}" "BUILD_${TOOL}" "${TOOL}_BUILD" "${TOOL}_FOR_BUILD" "HOST${TOOL}"
+done
+PATH="$(printf "%s" "$(echo -n "${PATH}" | tr ':' '\n' | grep -v "/opt")" | tr '\n' ':')"
+
+
+# Build crosstool-ng for the current host
+./configure --enable-local
+make -j${nproc}
+
+# Generate the appropriate crosstool-ng config file for our current target
+${WORKSPACE}/srcdir/gen_config.sh > .config
+cat .config
+
+# This takes our stripped-down config and fills out all the other options
+./ct-ng upgradeconfig
+
+# Do the actual build!
+./ct-ng build
+
+# Fix case-insensitivity problems in netfilter headers
+if [[ "${target}" == *linux* ]]; then
+    NF="${prefix}/${target}/sysroot/usr/include/linux/netfilter"
+    for NAME in CONNMARK DSCP MARK RATEEST TCPMSS; do
+        mv "${NF}/xt_${NAME}.h" "${NF}/xt_${NAME}_.h"
+    done
+    for NAME in ECN TTL; do
+        mv "${NF}_ipv4/ipt_${NAME}.h" "${NF}_ipv4/ipt_${NAME}_.h"
+    done
+    mv "${NF}_ipv6/ip6t_HL.h" "${NF}_ipv6/ip6t_HL_.h"
+fi
+
+# Move licenses to the right spot
+mkdir -p /tmp/GCCBootstrap
+mv ${prefix}/share/licenses/* /tmp/GCCBootstrap
+mv /tmp/GCCBootstrap ${prefix}/share/licenses/
+
+[[ -f "${bindir}/${target}-gcc" ]]
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = filter(p -> Sys.islinux(p) || Sys.iswindows(p), supported_platforms())
+
+# The products that we will ensure are always built
+products = Product[
+    #ExecutableProduct("gcc", :gcc)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/G/GCCBootstrap/bundled/gen_config.sh
+++ b/G/GCCBootstrap/bundled/gen_config.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Start wtih things that are always true
+cat <<-EOF
+CT_CONFIG_VERSION=4
+
+# Always build GCC v9.X
+CT_GCC_V_9=y
+
+# Disable progress bar, it fills up our logs:
+CT_LOG_PROGRESS_BAR=n
+
+# We use some experimental features, just enable them for all
+CT_EXPERIMENTAL=y
+
+# Explicitly claim the '--build' triplet, so there's no confusion
+CT_BUILD="${MACHTYPE}"
+
+# Tell ct-ng to not remove our prefix... this really confused me, as the
+# build would finish, but the resultant artifact was empty, because it
+# would have cleared out the symlink to the target-specific prefix. Orz.
+CT_PREFIX_DIR="${prefix}"
+CT_PREFIX_DIR_RO=n
+CT_RM_RF_PREFIX_DIR=n
+
+# Don't download any tarballs; we should have taken care of that already
+CT_FORBID_DOWNLOAD=y
+CT_LOCAL_TARBALLS_DIR="${WORKSPACE}/srcdir"
+
+# We always want to build g++
+CT_CC_LANG_CXX=y
+EOF
+
+# Handle OS stuff
+case "${target}" in
+    *linux*)
+        cat <<-EOF
+# We're building against linux, and always use an older kernel
+# version so that we are maximally compatible.
+CT_KERNEL_LINUX=y
+CT_LINUX_V_4_1=y
+
+# We don't like the 'unknown' for Linux
+CT_OMIT_TARGET_VENDOR=y
+CT_TARGET_VENDOR=
+EOF
+        ;;
+    *mingw*)
+        cat <<-EOF
+CT_TARGET_VENDOR="w64"
+CT_KERNEL_WINDOWS=y
+EOF
+        ;;
+    *)
+        echo "Unhandled OS '${target}'" >&2
+        exit 1
+        ;;
+esac
+
+# Handle arch stuff
+case "${target}" in
+    arm*)
+        echo "CT_ARCH_ARM=y"
+        echo "CT_ARCH_FLOAT_HW=y"
+        if [[ "${bb_full_target}" == armv6l* ]]; then
+            echo "CT_ARCH_ARCH=\"armv6+fp\""
+        elif [[ "${bb_full_target}" == armv7l* ]]; then
+            echo "CT_ARCH_ARCH=\"armv7-a+fp\""
+        else
+            echo "ERROR: Unknown arm microarchitecture in ${bb_full_target}!" >&2
+            exit 1
+        fi
+        ;;
+    aarch64*)
+        echo "CT_ARCH_ARM=y"
+        echo "CT_ARCH_64=y"
+        ;;
+    i686*)
+        echo "CT_ARCH_X86=y"
+        echo "CT_ARCH_ARCH=\"pentium4\""
+        ;;
+    x86_64*)
+        echo "CT_ARCH_X86=y"
+        echo "CT_ARCH_64=y"
+        echo "CT_ARCH_ARCH=\"x86-64\""
+        ;;
+    powerpc64le*)
+        echo "CT_ARCH_POWERPC=y"
+        echo "CT_ARCH_LE=y"
+        echo "CT_ARCH_64=y"
+        ;;
+    *)
+        echo "ERROR: Unhandled arch '${target}'" >&2
+        exit 1
+esac
+
+# Handle libc stuff
+case "${target}" in
+    *gnu*)
+        echo "CT_GLIBC_V_2_19=y"
+        ;;
+    *musl*)
+        echo "CT_LIBC_MUSL=y"
+        echo "CT_MUSL_v_1_2_2=y"
+        ;;
+    *mingw*)
+        echo "CT_LIBC_MINGW_W64=y"
+        echo "CT_THREADS_POSIX=y"
+        echo "CT_MINGW_W64_V_V9_0=y"
+        ;;
+    *)
+        echo "ERROR: Unhandled libc '${target}'" >&2
+        exit 1
+        ;;
+esac

--- a/G/GCCBootstrap/bundled/patches/glibc/2.19/0100-sunrpc_on_musl.patch
+++ b/G/GCCBootstrap/bundled/patches/glibc/2.19/0100-sunrpc_on_musl.patch
@@ -1,0 +1,22 @@
+diff --git a/sunrpc/rpc/types.h b/sunrpc/rpc/types.h
+index cf50141400..4adc625243 100644
+--- a/sunrpc/rpc/types.h
++++ b/sunrpc/rpc/types.h
+@@ -68,7 +68,7 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
+-#ifndef __u_char_defined
++#if 0
+ typedef __u_char u_char;
+ typedef __u_short u_short;
+ typedef __u_int u_int;
+@@ -78,7 +78,7 @@ typedef __u_quad_t u_quad_t;
+ typedef __fsid_t fsid_t;
+ # define __u_char_defined
+ #endif
+-#ifndef __daddr_t_defined
++#if 0
+ typedef __daddr_t daddr_t;
+ # if ! defined(caddr_t) && ! defined(__caddr_t_defined)
+ typedef __caddr_t caddr_t;

--- a/G/GCCBootstrap/bundled/patches/glibc/2.19/0101-ppc64le_mtfsf.patch
+++ b/G/GCCBootstrap/bundled/patches/glibc/2.19/0101-ppc64le_mtfsf.patch
@@ -1,0 +1,156 @@
+diff --git a/sysdeps/unix/sysv/linux/powerpc/powerpc64/setcontext.S b/sysdeps/unix/sysv/linux/powerpc/powerpc64/setcontext.S
+index e47a57a0d6..8a08dc4a8b 100644
+--- a/sysdeps/unix/sysv/linux/powerpc/powerpc64/setcontext.S
++++ b/sysdeps/unix/sysv/linux/powerpc/powerpc64/setcontext.S
+@@ -81,22 +81,31 @@ ENTRY(__novec_setcontext)
+ 
+ # ifdef _ARCH_PWR6
+   /* Use the extended four-operand version of the mtfsf insn.  */
+-  mtfsf  0xff,fp0,1,0
+-# else
+   .machine push
+   .machine "power6"
++
++  mtfsf  0xff,fp0,1,0
++
++  .machine pop
++# else
+   /* Availability of DFP indicates a 64-bit FPSCR.  */
+   andi.  r6,r5,PPC_FEATURE_HAS_DFP
+   beq    5f
+   /* Use the extended four-operand version of the mtfsf insn.  */
++  .machine push
++  .machine "power6"
++
+   mtfsf  0xff,fp0,1,0
++
++  .machine pop
++
+   b      6f
+   /* Continue to operate on the FPSCR as if it were 32-bits.  */
+ 5:
+   mtfsf  0xff,fp0
+ 6:
+-  .machine pop
+ # endif /* _ARCH_PWR6 */
++
+   lfd  fp29,(SIGCONTEXT_FP_REGS+(PT_R29*8))(r31)
+   lfd  fp28,(SIGCONTEXT_FP_REGS+(PT_R28*8))(r31)
+   lfd  fp27,(SIGCONTEXT_FP_REGS+(PT_R27*8))(r31)
+@@ -364,22 +373,31 @@ L(has_no_vec):
+ 
+ # ifdef _ARCH_PWR6
+   /* Use the extended four-operand version of the mtfsf insn.  */
+-  mtfsf  0xff,fp0,1,0
+-# else
+   .machine push
+   .machine "power6"
++
++  mtfsf  0xff,fp0,1,0
++
++  .machine pop
++# else
+   /* Availability of DFP indicates a 64-bit FPSCR.  */
+   andi.  r6,r5,PPC_FEATURE_HAS_DFP
+   beq    7f
+   /* Use the extended four-operand version of the mtfsf insn.  */
++  .machine push
++  .machine "power6"
++
+   mtfsf  0xff,fp0,1,0
++
++  .machine pop
++
+   b      8f
+   /* Continue to operate on the FPSCR as if it were 32-bits.  */
+ 7:
+   mtfsf  0xff,fp0
+ 8:
+-  .machine pop
+ # endif /* _ARCH_PWR6 */
++
+   lfd  fp29,(SIGCONTEXT_FP_REGS+(PT_R29*8))(r31)
+   lfd  fp28,(SIGCONTEXT_FP_REGS+(PT_R28*8))(r31)
+   lfd  fp27,(SIGCONTEXT_FP_REGS+(PT_R27*8))(r31)
+diff --git a/sysdeps/unix/sysv/linux/powerpc/powerpc64/swapcontext.S b/sysdeps/unix/sysv/linux/powerpc/powerpc64/swapcontext.S
+index bc02a21739..2421ca400b 100644
+--- a/sysdeps/unix/sysv/linux/powerpc/powerpc64/swapcontext.S
++++ b/sysdeps/unix/sysv/linux/powerpc/powerpc64/swapcontext.S
+@@ -173,24 +173,34 @@ ENTRY(__novec_swapcontext)
+   lfd  fp0,(SIGCONTEXT_FP_REGS+(32*8))(r31)
+   lfd  fp31,(SIGCONTEXT_FP_REGS+(PT_R31*8))(r31)
+   lfd  fp30,(SIGCONTEXT_FP_REGS+(PT_R30*8))(r31)
++
+ # ifdef _ARCH_PWR6
+   /* Use the extended four-operand version of the mtfsf insn.  */
+-  mtfsf  0xff,fp0,1,0
+-# else
+   .machine push
+   .machine "power6"
++
++  mtfsf  0xff,fp0,1,0
++
++  .machine pop
++# else
+   /* Availability of DFP indicates a 64-bit FPSCR.  */
+   andi.  r6,r8,PPC_FEATURE_HAS_DFP
+   beq    5f
+-  /* Use the extended four-operand version of the mtfsf insn.  */
++
++  .machine push
++  .machine "power6"
++
+   mtfsf  0xff,fp0,1,0
++
++  .machine pop
++
+   b      6f
+   /* Continue to operate on the FPSCR as if it were 32-bits.  */
+ 5:
+   mtfsf  0xff,fp0
+ 6:
+-  .machine pop
+ #endif /* _ARCH_PWR6 */
++
+   lfd  fp29,(SIGCONTEXT_FP_REGS+(PT_R29*8))(r31)
+   lfd  fp28,(SIGCONTEXT_FP_REGS+(PT_R28*8))(r31)
+   lfd  fp27,(SIGCONTEXT_FP_REGS+(PT_R27*8))(r31)
+@@ -652,24 +662,34 @@ L(has_no_vec2):
+   lfd  fp0,(SIGCONTEXT_FP_REGS+(32*8))(r31)
+   lfd  fp31,(SIGCONTEXT_FP_REGS+(PT_R31*8))(r31)
+   lfd  fp30,(SIGCONTEXT_FP_REGS+(PT_R30*8))(r31)
++
+ # ifdef _ARCH_PWR6
+   /* Use the extended four-operand version of the mtfsf insn.  */
+-  mtfsf  0xff,fp0,1,0
+-# else
+   .machine push
+   .machine "power6"
++
++  mtfsf  0xff,fp0,1,0
++
++  .machine pop
++# else
+   /* Availability of DFP indicates a 64-bit FPSCR.  */
+   andi.  r6,r8,PPC_FEATURE_HAS_DFP
+   beq    7f
+-  /* Use the extended four-operand version of the mtfsf insn.  */
++
++  .machine push
++  .machine "power6"
++
+   mtfsf  0xff,fp0,1,0
++
++  .machine pop
++
+   b      8f
+   /* Continue to operate on the FPSCR as if it were 32-bits.  */
+ 7:
+   mtfsf  0xff,fp0
+ 8:
+-  .machine pop
+ #endif /* _ARCH_PWR6 */
++
+   lfd  fp29,(SIGCONTEXT_FP_REGS+(PT_R29*8))(r31)
+   lfd  fp28,(SIGCONTEXT_FP_REGS+(PT_R28*8))(r31)
+   lfd  fp27,(SIGCONTEXT_FP_REGS+(PT_R27*8))(r31)


### PR DESCRIPTION
TODO before merging:

- [X] Cleanup `glibc` patches!  Note that we're building against glibc 2.19
  on all platforms right now; this is fine, because this glibc is not
  what will be used in production, and it mostly affects what version of
  glibc must be available on the _host_ system when compiling, not on the
  _target_ system when running things built with this compiler.  So by
  using 2.19 here, we simply make it impossible to use BinaryBuilder on
  ancient CentOS systems, which I'm okay with.

- [X] Build for `musl`

- [X] Build for windows; supposedly we can build against mingw32.

- [x] Fix case-insensitivity issues

- [x] Fix ARM default arch level

- [x] Fix weird `musl` linkage problem:
```
/tmp/bin # ./x86_64-linux-gnu-readelf -d ./x86_64-linux-gnu-gcc

Dynamic section at offset 0x1f7a18 contains 21 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libc.musl-.so.1]
```

UPDATE: This will be fixed by a new RootFS containing: https://github.com/JuliaPackaging/Yggdrasil/pull/4762, which is currently in a PR at https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/237