### PR TITLE
Fix musl SONAME

### DIFF
--- a/M/Musl/build_tarballs.jl
+++ b/M/Musl/build_tarballs.jl
@@ -29,7 +29,7 @@ musl_arch()
     esac
 }
 
-export LDFLAGS="${LDFLAGS} -Wl,-soname,libc.musl-$(musl_target).so.1"
+export LDFLAGS="${LDFLAGS} -Wl,-soname,libc.musl-$(musl_arch).so.1"
 ${WORKSPACE}/srcdir/musl-*/configure --prefix=/usr \
     --build=${MACHTYPE} \
     --host=${target} \


### PR DESCRIPTION
Without this, our default `musl` in the BB rootfs has the SONAME `libc.musl-.so.1`:

```
# readelf -d /lib/libc.musl-x86_64.so.1 

Dynamic section at offset 0x94928 contains 18 entries:
  Tag        Type                         Name/Value
 0x000000000000000e (SONAME)             Library soname: [libc.musl-.so.1]
```

Note that this doesn't really affect things built with BB, it only affects things built by an `apk`-supplied GCC.