### PR TITLE
Add kerberos support to LibCURL on linux

### DIFF
--- a/L/LibCURL/LibCURL/build_tarballs.jl
+++ b/L/LibCURL/LibCURL/build_tarballs.jl
@@ -1,3 +1,5 @@
 include("../common.jl")
 
 build_libcurl(ARGS, "LibCURL")
+
+# Build trigger: 1

--- a/L/LibCURL/common.jl
+++ b/L/LibCURL/common.jl
@@ -60,9 +60,14 @@ function build_libcurl(ARGS, name::String)
         FLAGS+=(--with-mbedtls=${prefix})
     fi
 
-    if [[ ${target} == *linux* ]]; then
-        ## use gssapi on linux
+    if [[ "${target}" == *linux* ]] || [[ "${target}" == *-freebsd* ]]; then
+        # Use gssapi on Linux and FreeBSD
         FLAGS+=(--with-gssapi=${prefix})
+        if [[ "${target}" == *-freebsd* ]]; then
+            # Only for FreeBSD we need to hint that we need to link to libkrb5 and
+            # libcom_err to resolve some undefined symbols.
+            export LIBS="-lkrb5 -lcom_err"
+        fi
     else
         FLAGS+=(--without-gssapi)
     fi
@@ -106,7 +111,7 @@ function build_libcurl(ARGS, name::String)
         # Note that while we unconditionally list MbedTLS as a dependency,
         # we default to schannel/SecureTransport on Windows/MacOS.
         Dependency("MbedTLS_jll"; compat="~2.28.0", platforms=filter(p->Sys.islinux(p) || Sys.isfreebsd(p), platforms)),
-        Dependency("Kerberos_krb5_jll"; platforms=filter(p->Sys.islinux(p), platforms)),
+        Dependency("Kerberos_krb5_jll"; platforms=filter(p->Sys.islinux(p) || Sys.isfreebsd(p), platforms)),
     ]
 
     if this_is_curl_jll

--- a/L/LibCURL/common.jl
+++ b/L/LibCURL/common.jl
@@ -27,7 +27,7 @@ function build_libcurl(ARGS, name::String)
     # Holy crow we really configure the bitlets out of this thing
     FLAGS=(
         # Disable....almost everything
-        --without-ssl --without-gnutls --without-gssapi
+        --without-ssl --without-gnutls
         --without-libidn --without-libidn2 --without-librtmp
         --without-nss --without-polarssl
         --without-spnego --without-libpsl --disable-ares --disable-manual
@@ -58,6 +58,13 @@ function build_libcurl(ARGS, name::String)
     else
         # On all other systems, we use MbedTLS
         FLAGS+=(--with-mbedtls=${prefix})
+    fi
+
+    if [[ ${target} == *linux* ]]; then
+        ## use gssapi on linux
+        FLAGS+=(--with-gssapi=${prefix})
+    else
+        FLAGS+=(--without-gssapi)
     fi
 
     ./configure --prefix=$prefix --host=$target --build=${MACHTYPE} "${FLAGS[@]}"
@@ -99,6 +106,7 @@ function build_libcurl(ARGS, name::String)
         # Note that while we unconditionally list MbedTLS as a dependency,
         # we default to schannel/SecureTransport on Windows/MacOS.
         Dependency("MbedTLS_jll"; compat="~2.28.0", platforms=filter(p->Sys.islinux(p) || Sys.isfreebsd(p), platforms)),
+        Dependency("Kerberos_krb5_jll"; platforms=filter(p->Sys.islinux(p), platforms)),
     ]
 
     if this_is_curl_jll


### PR DESCRIPTION
This adds Kerberos support to LibCURL on Linux.

The Kerberos_krb5 package also support FreeBSD, but compiling LibCURL for FreeBSD with kerberos enabled fails with this error:

```
[17:01:46] checking for sys/socket.h... (cached) yes
[17:01:46] checking for recv... no
[17:01:46] configure: error: Unable to link function recv
[17:01:46]  ---> ./configure --prefix=$prefix --host=$target --build=${MACHTYPE} "${FLAGS[@]}"
[17:01:46]  ---> ./configure --prefix=$prefix --host=$target --build=${MACHTYPE} "${FLAGS[@]}"
[17:01:46] Previous command exited with 1
[17:01:46] Child Process exited, exit code 1
┌ Warning: Build failed, the following log files were generated:
│   - ${WORKSPACE}/srcdir/curl-7.81.0/config.log
│ 
│ Launching debug shell:
└ @ BinaryBuilder ~/.julia/packages/BinaryBuilder/Ftk2f/src/AutoBuild.jl:835
verbose sandbox enabled (running in unprivileged container mode)
```

For reference, here's the thread on slack https://julialang.slack.com/archives/C674ELDNX/p1650049122458139
