### PR TITLE
Update GAP_jll

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -27,14 +27,14 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "GAP"
 upstream_version = v"4.12.0-dev"
-version = v"400.1191.001"
+version = v"400.1192.001"
 
 julia_versions = [v"1.6", v"1.7", v"1.8", v"1.9"]
 
 # Collection of sources required to complete build
 sources = [
     # snapshot of GAP master branch leading up to GAP 4.12:
-    GitSource("https://github.com/gap-system/gap.git", "401c797476b787e748a3890be4ce95ae4e5d52ae"),
+    GitSource("https://github.com/gap-system/gap.git", "977fb055cf3793aa4c329e3d6ea765774fecc8ac"),
 #    ArchiveSource("https://github.com/gap-system/gap/releases/download/v$(upstream_version)/gap-$(upstream_version)-core.tar.gz",
 #                  "2b6e2ed90fcae4deb347284136427105361123ac96d30d699db7e97d094685ce"),
     DirectorySource("./bundled"),
@@ -48,12 +48,28 @@ for f in ${WORKSPACE}/srcdir/patches/*.patch; do
     atomic_patch -p1 ${f}
 done
 
+# HACK: determine Julia version
+cat > version.c <<EOF
+#include <stdio.h>
+#include "julia/julia_version.h"
+int main(int argc, char**argv)
+{
+    printf("%d.%d", JULIA_VERSION_MAJOR, JULIA_VERSION_MINOR);
+    return 0;
+}
+EOF
+${CC_BUILD} -Wall version.c -o julia_version
+julia_version=$(./julia_version)
+
 # must run autogen.sh if compiling from git snapshot and/or if configure was patched;
 # it doesn't hurt otherwise, too, so just always do it
 ./autogen.sh
 
 # configure GAP
+# the custom ARCHEXT ensures that the different Julia versions use
+# different GAParch values
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
+    ARCHEXT="$julia_version" \
     --with-gmp=${prefix} \
     --with-readline=${prefix} \
     --with-zlib=${prefix} \
@@ -72,8 +88,8 @@ rm ${host_libdir}/*.la  # delete *.la, they hardcode libdir='/workspace/destdir/
     CC=${CC_BUILD} CXX=${CXX_BUILD}
 make -j${nproc}
 cp build/c_*.c ../src/
-#cp ffgen ..
-#cp build/ffdata.* ../build/
+cp ffgen ..
+cp build/ffdata.* ../build/
 cd ..
 
 # remove the native build, it has done its job
@@ -95,7 +111,7 @@ install_license LICENSE
 rm ${prefix}/lib/*.la
 
 # get rid of the wrapper shell script, which is useless for us
-mv ${prefix}/bin/gap.real ${prefix}/bin/gap
+mv ${libdir}/gap/gap ${prefix}/bin/gap
 
 # install gac and sysinfo.gap
 mkdir -p ${prefix}/share/gap/

--- a/G/GAP/bundled/patches/kernel-don-t-waitpid-1.patch
+++ b/G/GAP/bundled/patches/kernel-don-t-waitpid-1.patch
@@ -1,0 +1,33 @@
+From 448a724135c0fff5e559492b7b4e9a244361f205 Mon Sep 17 00:00:00 2001
+From: Max Horn <max@quendi.de>
+Date: Thu, 14 Apr 2022 11:45:17 +0200
+Subject: [PATCH] kernel: don't waitpid(-1)
+
+This causes problems when using GAP as a library. It also
+shouldn't be necessary as we record a list of all known child
+processes.
+---
+ src/iostream.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/src/iostream.c b/src/iostream.c
+index 6289ab6ec..37723ebac 100644
+--- a/src/iostream.c
++++ b/src/iostream.c
+@@ -280,13 +280,6 @@ static void ChildStatusChanged(int whichsig)
+     HashUnlock(PtyIOStreams);
+ 
+ #if !defined(HPCGAP)
+-    /* Collect up any other zombie children */
+-    do {
+-        retcode = waitpid(-1, &status, WNOHANG);
+-        if (retcode == -1 && errno != ECHILD)
+-            Pr("#E Unexpected waitpid error %d\n", errno, 0);
+-    } while (retcode != 0 && retcode != -1);
+-
+     signal(SIGCHLD, ChildStatusChanged);
+ #endif
+ }
+-- 
+2.35.1
+

--- a/G/GAP_lib/build_tarballs.jl
+++ b/G/GAP_lib/build_tarballs.jl
@@ -22,12 +22,12 @@ using BinaryBuilder, Pkg
 
 name = "GAP_lib"
 upstream_version = v"4.11.1"
-version = v"400.1192.000"
+version = v"400.1192.001"
 
 # Collection of sources required to complete build
 sources = [
     # snapshot of GAP master branch leading up to GAP 4.12:
-    GitSource("https://github.com/gap-system/gap.git", "c67fb7d89cafeb9231facd80f85426199e0d62db"),
+    GitSource("https://github.com/gap-system/gap.git", "977fb055cf3793aa4c329e3d6ea765774fecc8ac"),
 #    ArchiveSource("https://github.com/gap-system/gap/releases/download/v$(upstream_version)/gap-$(upstream_version)-core.tar.gz",
 #                  "2b6e2ed90fcae4deb347284136427105361123ac96d30d699db7e97d094685ce"),
     ArchiveSource("https://github.com/gap-system/gap/releases/download/v$(upstream_version)/packages-required-v$(upstream_version).tar.gz",


### PR DESCRIPTION
- remove evil `waitpid(-1)` calls (CC @benlorenz)
- add the Julia version to GAPARCH so that kernel extensions built against different GAP variants (for different Julia versions) can coexist safely (CC @ThomasBreuer)
