### PR TITLE
[BLIS] Upgrade to v0.9

### DIFF
--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -111,14 +111,14 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    # Platform("x86_64", "linux"; libc="musl"),
-    # Platform("armv7l", "linux"; libc="glibc"),
-    # Platform("x86_64", "windows"),
-    # Platform("x86_64", "macos"),
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="glibc"),
+    Platform("x86_64", "windows"),
+    Platform("x86_64", "macos"),
     Platform("x86_64", "linux"; libc="glibc"),
-    Platform("aarch64", "linux"; libc="glibc") # ,
-    # Platform("aarch64", "macos"),
-    # Platform("x86_64", "freebsd")
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("aarch64", "macos"),
+    Platform("x86_64", "freebsd")
 ]
 
 

--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "blis"
-version = v"0.8.1"
+version = v"0.9.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/flame/blis.git", "c9700f369aa84fc00f36c4b817ffb7dab72b865d"),
+    GitSource("https://github.com/flame/blis.git", "14c86f66b20901b60ee276da355c1b62642c18d2"),
     DirectorySource("./bundled")
 ]
 
@@ -18,7 +18,7 @@ cd blis/
 
 for i in ./config/*/*.mk; do
 
-    # Building in container forbids -march options <<< Settings overrided.
+    # Building in container forbids -march options <<< Settings overriden.
     # sed -i "s/-march[^ ]*//g" $i
 
     # Building in container forbids unsafe optimization.
@@ -75,10 +75,10 @@ if [ ${nbits} = 64 ]; then
     patch frame/include/bli_macro_defs.h < ${WORKSPACE}/srcdir/patches/bli_macro_defs.h.f77suffix64.patch
 fi
 
-# Include SVE support in this metaconfig.
+# Include A64FX in Arm64 metaconfig.
 if [ ${BLI_CONFIG} = arm64 ]; then
-    # Add SVE configs to the registry.
-    patch config_registry < ${WORKSPACE}/srcdir/patches/config_registry.metaconfig+armsve.patch
+    # Add A64FX to the registry.
+    patch config_registry < ${WORKSPACE}/srcdir/patches/config_registry.metaconfig+a64fx.patch
 
     # Unscreen Arm SVE code for metaconfig.
     patch kernels/armsve/bli_kernels_armsve.h \
@@ -88,14 +88,9 @@ if [ ${BLI_CONFIG} = arm64 ]; then
     patch kernels/armsve/1m/bli_dpackm_armsve256_int_8xk.c \
         < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
 
-    # Config armsve depends on some family header defines.
-    cp config/armsve/bli_family_armsve.h config/arm64/bli_family_arm64.h
-
-    # Screen out SVE instructions in config-stage.
+    # Screen out A64FX sector cache.
     patch config/a64fx/bli_cntx_init_a64fx.c \
         < ${WORKSPACE}/srcdir/patches/a64fx_config_screen_sector_cache.patch
-    patch config/armsve/bli_cntx_init_armsve.c \
-        < ${WORKSPACE}/srcdir/patches/armsve_config_screen_non_sve.patch
 fi
 
 export BLI_F77BITS=${nbits}
@@ -116,14 +111,14 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Platform("x86_64", "linux"; libc="musl"),
-    Platform("armv7l", "linux"; libc="glibc"),
-    Platform("x86_64", "windows"),
-    Platform("x86_64", "macos"),
+    # Platform("x86_64", "linux"; libc="musl"),
+    # Platform("armv7l", "linux"; libc="glibc"),
+    # Platform("x86_64", "windows"),
+    # Platform("x86_64", "macos"),
     Platform("x86_64", "linux"; libc="glibc"),
-    Platform("aarch64", "linux"; libc="glibc"),
-    Platform("aarch64", "macos"),
-    Platform("x86_64", "freebsd")
+    Platform("aarch64", "linux"; libc="glibc") # ,
+    # Platform("aarch64", "macos"),
+    # Platform("x86_64", "freebsd")
 ]
 
 
@@ -142,4 +137,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version = v"11", lock_microarchitecture=false, julia_compat="1.6")
+               preferred_gcc_version=v"11", lock_microarchitecture=false, julia_compat="1.6")

--- a/B/blis/bundled/patches/armsve_config_screen_non_sve.patch
+++ b/B/blis/bundled/patches/armsve_config_screen_non_sve.patch
@@ -1,7 +1,0 @@
-35a36
-> #include <sys/auxv.h>
-38a40,43
-> 	const int HWCAP_SVE = 1 << 22;
-> 	if (!(getauxval( AT_HWCAP ) & HWCAP_SVE))
-> 		return;
-> 

--- a/B/blis/bundled/patches/armsve_kernels_unscreen_arm_sve_h.patch
+++ b/B/blis/bundled/patches/armsve_kernels_unscreen_arm_sve_h.patch
@@ -1,4 +1,4 @@
 48c48
-< #if (defined(BLIS_FAMILY_ARMSVE) && !defined(BLIS_FAMILY_A64FX))
+< #if !defined(BLIS_FAMILY_A64FX)
 ---
 > #if 1

--- a/B/blis/bundled/patches/config_registry.metaconfig+a64fx.patch
+++ b/B/blis/bundled/patches/config_registry.metaconfig+a64fx.patch
@@ -1,0 +1,4 @@
+15c15
+< arm64:          armsve firestorm thunderx2 cortexa57 cortexa53 generic
+---
+> arm64:          a64fx armsve firestorm thunderx2 cortexa57 cortexa53 generic

--- a/B/blis/bundled/patches/config_registry.metaconfig+armsve.patch
+++ b/B/blis/bundled/patches/config_registry.metaconfig+armsve.patch
@@ -1,4 +1,0 @@
-15c15
-< arm64:          firestorm thunderx2 cortexa57 cortexa53 generic
----
-> arm64:          firestorm armsve a64fx thunderx2 cortexa57 cortexa53 generic


### PR DESCRIPTION
Not that big update.
The build script for v0.8.1 was already building pre-0.9 instead of tag 0.8.1