### PR TITLE
[GTK4] add call to glib-compile-schemas

### DIFF
--- a/G/GTK4/build_tarballs.jl
+++ b/G/GTK4/build_tarballs.jl
@@ -72,6 +72,9 @@ meson .. \
 ninja -j${nproc}
 ninja install
 
+# post-install script is disabled when cross-compiling
+glib-compile-schemas ${prefix}/share/glib-2.0/schemas
+
 # Remove temporary links
 rm ${bindir}/gdk-pixbuf-pixdata ${bindir}/glib-compile-{resources,schemas}
 """


### PR DESCRIPTION
The absence of `gschemas.compiled` in `${prefix}/share/glib-2.0/schemas` breaks some dialogs (https://github.com/JuliaGtk/Gtk4.jl/issues/2). This PR just adds a call to `glib-compile-schemas` after installation to create that file. A post-install script that does this in the build of GTK3 is not run for GTK4 when cross compiling.

The post-install script does other stuff:
• calling `gtk_update_icon_cache` is not necessary, I think, since we're not compiling `gtk4-demo`
• updating module cache for print backends -- I tried adding this but the output file `giomodule.cache` didn't end up in the tarball -- printing isn't a high priority IMHO anyway
• updating module cache for media backends isn't relevant since none are built

Since these other items don't seem necessary/important, I opted to just call glib-compile-schemas rather than run the full script.

Note that this "don't run post-install script when cross compiling" policy was recently added to GTK3 (see https://gitlab.gnome.org/GNOME/gtk/-/commit/b5d0c44a87443bc4aadcb35009ecb5e2674432df) so if GTK3_jll is updated this same issue will probably pop up.