### PR TITLE
New recipe: FlexExtract v7.1.2

### DIFF
--- a/F/FlexExtract/build_tarballs.jl
+++ b/F/FlexExtract/build_tarballs.jl
@@ -30,6 +30,7 @@ platforms = supported_platforms()
 # Remove the unsupported platforms
 filter!(!Sys.iswindows, platforms)
 filter!(!Sys.isapple, platforms)
+filter!(!Sys.isfreebsd, platforms)
 filter!(p -> libc(p) != "musl", platforms)
 platforms = expand_gfortran_versions(platforms)
 

--- a/F/FlexExtract/build_tarballs.jl
+++ b/F/FlexExtract/build_tarballs.jl
@@ -1,0 +1,50 @@
+
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "FlexExtract"
+version = v"7.1.2"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://www.flexpart.eu/gitmob/flex_extract", "e0005c99ac81d12faa45a8ff799debbd592b0dc0"),
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd flex_extract
+atomic_patch -p1 /workspace/srcdir/patches/flexextract-makefile.patch
+cd Source/Fortran/
+make -f makefile_local_gfortran
+cp calc_etadot_fast.out $bindir/calc_etadot
+install_license ../../LICENSE.md
+"""
+
+# platforms = [
+#     Platform("x86_64", "linux"; libc = "glibc")
+# ]
+
+platforms = supported_platforms()
+# Remove the unsupported platforms
+filter!(!Sys.iswindows, platforms)
+filter!(!Sys.isapple, platforms)
+filter!(p -> libc(p) != "musl", platforms)
+platforms = expand_gfortran_versions(platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("calc_etadot", :calc_etadot),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
+    Dependency("eccodes_jll"),
+    BuildDependency("Emoslib_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+julia_compat = "1.6")

--- a/F/FlexExtract/bundled/patches/flexextract-makefile.patch
+++ b/F/FlexExtract/bundled/patches/flexextract-makefile.patch
@@ -1,0 +1,14 @@
+diff --git a/Source/Fortran/makefile_fast b/Source/Fortran/makefile_fast
+index 7b0a215..7e17b21 100644
+--- a/Source/Fortran/makefile_fast
++++ b/Source/Fortran/makefile_fast
+@@ -18,7 +18,7 @@ ECCODES_LIB =  -Bstatic -leccodes_f90 -leccodes -Bdynamic -lm
+ EMOSLIB=-lemosR64
+ LIB =  $(ECCODES_LIB) $(EMOSLIB)
+ 
+-ECCODES_INCLUDE_DIR=/usr/lib/x86_64-linux-gnu/fortran/gfortran-mod-15
++ECCODES_INCLUDE_DIR=${includedir}
+ #/usr/local/include/ #oldstable
+ 
+ INC = -I. -I$(ECCODES_INCLUDE_DIR)
+ 


### PR DESCRIPTION
This comes from the split of #4627 into two separated packages.

[flex_extract](https://www.flexpart.eu/flex_extract/index.html) is a software to retrieve meteorological fields from ECMWF and prepare them to be input of [FLEXPART](https://www.flexpart.eu/). This recipe provides the `calc_etadot` binary needed to post-process the meteorological fields.