### PR TITLE
Update for OptimPack version 3.2.0

### DIFF
--- a/O/OptimPack/build_tarballs.jl
+++ b/O/OptimPack/build_tarballs.jl
@@ -7,8 +7,8 @@ version = v"3.2.0"
 
 # Collection of sources required to build OptimPAck
 sources = [
-    "https://github.com/emmt/OptimPack/releases/download/v$(version)/optimpack-$(version).tar.gz" =>
-    "3df032cde5ba6a3ffa04f0b0fd95d0694b75af82c8d2ddff0666c61e86c3ef5a",
+    ArchiveSource("https://github.com/emmt/OptimPack/releases/download/v$(version)/optimpack-$(version).tar.gz",
+                  "3df032cde5ba6a3ffa04f0b0fd95d0694b75af82c8d2ddff0666c61e86c3ef5a"),
 ]
 
 # Bash recipe for building across all platforms
@@ -37,8 +37,8 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/O/OptimPack/build_tarballs.jl
+++ b/O/OptimPack/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "OptimPack"
-version = v"3.1.0"
+version = v"3.2.0"
 
 # Collection of sources required to build OptimPAck
 sources = [
     "https://github.com/emmt/OptimPack/releases/download/v$(version)/optimpack-$(version).tar.gz" =>
-    "fa1efdbebf6efa42a1d6b4f6223c7ca0b871fad5c0b53f7dc9be296e4c766190",
+    "3df032cde5ba6a3ffa04f0b0fd95d0694b75af82c8d2ddff0666c61e86c3ef5a",
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
- Status returned by `BOBYQA`, `COBYLA`, and `NEWUOA` algorithms are now enumerations.

- Names of functions, types, and macros no longer start with an underscore (reserved to future development of the C language).  Names of types, structures, and enumerations no longer have a `_t` suffix.  Names of opaque structures have a trailing underscore.  File [`tools/update_3p1_to_3p2`](tools/update_3p1_to_3p2) provides a simple Perl script to make the necessary changes in your code.