### PR TITLE
Import libblastrampoline-Style Num. Threads Setter / Getter

### DIFF
--- a/B/blis/build_tarballs.jl
+++ b/B/blis/build_tarballs.jl
@@ -93,6 +93,9 @@ if [ ${BLI_CONFIG} = arm64 ]; then
         < ${WORKSPACE}/srcdir/patches/a64fx_config_screen_sector_cache.patch
 fi
 
+# Import libblastrampoline-style nthreads setter.
+cp ${WORKSPACE}/srcdir/nthreads64_.c frame/compat/nthreads64_.c
+
 export BLI_F77BITS=${nbits}
 ./configure -p ${prefix} -t ${BLI_THREAD} -b ${BLI_F77BITS} ${BLI_CONFIG}
 make -j${nproc}

--- a/B/blis/bundled/nthreads64_.c
+++ b/B/blis/bundled/nthreads64_.c
@@ -1,0 +1,31 @@
+#include "blis.h"
+
+void bli_thread_set_num_threads64_
+     (
+       const int nt
+     )
+{
+        // Initialize BLIS.
+        bli_init_auto();
+
+        // Call the BLIS function.
+        bli_thread_set_num_threads( nt );
+
+        // Finalize BLIS.
+        bli_finalize_auto();
+}
+
+int bli_thread_get_num_threads64_ ()
+{
+        // Initialize BLIS.
+        bli_init_auto();
+
+        // Call the BLIS function.
+        dim_t nt = bli_thread_get_num_threads( );
+
+        // Finalize BLIS.
+        bli_finalize_auto();
+
+        return nt;
+}
+


### PR DESCRIPTION
Cf. JuliaLinearAlgebra/BLIS.jl#3

- 32-bit machines can call `bli_thread_set_num_threads` with 32-bit integers. `dim_t` in this case is also 32-bit.
- 64-bit machines can call `bli_thread_set_num_threads64_` with 32-bit integers (as is done in `libblastrampoline`). The additional `nthreads64_.c` converts it to 64-bit `dim_t` types.

F77-style `bli_thread_set_num_threads_` and `bli_thread_set_num_threads_64_` are left alone.