### PR TITLE
[AWSCRT] Include all cross-platform libraries in the archive

### DIFF
--- a/A/AWSCRT/build_tarballs.jl
+++ b/A/AWSCRT/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "AWSCRT"
-version = v"0.1.0"
+version = v"0.1.1"
 
 # Collection of sources required to complete build
 sources = [

--- a/A/AWSCRT/bundled/awscrt/CMakeLists.txt
+++ b/A/AWSCRT/bundled/awscrt/CMakeLists.txt
@@ -32,14 +32,17 @@ include(AwsFindPackage)
 add_library(${PROJECT_NAME} empty.c)
 
 set(BUILD_SHARED_LIBS OFF) # Set up static libs for this part because this is required to grab static objects
-# Include the packages that AWS has marked as being part of the CRT bindings
-aws_use_package(aws-c-cal)
-aws_use_package(aws-c-http)
-aws_use_package(aws-c-mqtt)
-aws_use_package(aws-checksums)
-aws_use_package(aws-c-event-stream)
 aws_use_package(aws-c-auth)
+aws_use_package(aws-c-cal)
+aws_use_package(aws-c-common)
+aws_use_package(aws-c-compression)
+aws_use_package(aws-c-event-stream)
+aws_use_package(aws-c-http)
+aws_use_package(aws-c-io)
+aws_use_package(aws-c-mqtt)
 aws_use_package(aws-c-s3)
+aws_use_package(aws-c-sdkutils)
+aws_use_package(aws-checksums)
 set(BUILD_SHARED_LIBS ON)
 
 if(APPLE)


### PR DESCRIPTION
This PR includes all cross-platform CRT libraries in the archive (so all except for aws-lc and s2n-tls). This is done to include some missing symbols I found in my testing.