### PR TITLE
[GAP] Avoid access to members of Julia kernel structs

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -27,7 +27,7 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "GAP"
 upstream_version = v"4.12.0-dev"
-version = v"400.1192.001"
+version = v"400.1192.002"
 
 julia_versions = [v"1.6", v"1.7", v"1.8", v"1.9"]
 

--- a/G/GAP/bundled/patches/kernel-tweak-Julia-integration.patch
+++ b/G/GAP/bundled/patches/kernel-tweak-Julia-integration.patch
@@ -1,0 +1,68 @@
+From ca3f30838d02c350e45049f8bb50e504a9c4e9eb Mon Sep 17 00:00:00 2001
+From: Max Horn <max@quendi.de>
+Date: Wed, 27 Apr 2022 14:15:18 +0200
+Subject: [PATCH] kernel: tweak Julia integration
+
+Avoid all access to struct members defined by Julia, as these structs tend to
+change across releases, requiring recompilation of `julia_gc.c`; this makes it
+annoying to develop against ever-changing Julia nightly builds.
+---
+ src/julia_gc.c | 20 ++++++++------------
+ 1 file changed, 8 insertions(+), 12 deletions(-)
+
+diff --git a/src/julia_gc.c b/src/julia_gc.c
+index a10fafd28..01e85713d 100644
+--- a/src/julia_gc.c
++++ b/src/julia_gc.c
+@@ -40,6 +40,7 @@
+ #include <unistd.h>
+ 
+ #include <julia.h>
++#include <julia_threads.h>  // for jl_get_ptls_states
+ #include <julia_gcext.h>
+ 
+ /****************************************************************************
+@@ -209,11 +210,12 @@ static UInt            startTime, totalTime;
+ 
+ void SetJuliaTLS(void)
+ {
+-#if (JULIA_VERSION_MAJOR * 100 + JULIA_VERSION_MINOR) <= 106
++    // In Julia >= 1.7 we are supposed to use `jl_get_current_task()->ptls`
++    // instead of calling `jl_get_ptls_states`. But then we depend on the
++    // offset of the member `ptls` of struct `jl_task_t` not changing, so
++    // calling jl_get_ptls_states() is safer.
+     JuliaTLS = jl_get_ptls_states();
+-#else
+-    JuliaTLS = jl_get_current_task()->ptls;
+-#endif
++//    JuliaTLS = jl_get_current_task()->ptls;
+ }
+ 
+ #if !defined(SCAN_STACK_FOR_MPTRS_ONLY)
+@@ -785,7 +787,7 @@ static uintptr_t BagMarkFunc(jl_ptls_t ptls, jl_value_t * obj)
+ // create Julia types for use in our allocations. The types will be stored
+ // in the given 'module', and the MPtr type will be a subtype of 'parent'.
+ //
+-// If 'module' is NULL then a new module 'ForeignGAP' is created & exported.
++// If 'module' is NULL then 'jl_main_module' is used.
+ // If 'parent' is NULL then 'jl_any_type' is used.
+ void GAP_InitJuliaMemoryInterface(jl_module_t *   module,
+                                   jl_datatype_t * parent)
+@@ -819,13 +821,7 @@ void GAP_InitJuliaMemoryInterface(jl_module_t *   module,
+     // jl_gc_enable(0); /// DEBUGGING
+ 
+     if (module == 0) {
+-        jl_sym_t * sym = jl_symbol("ForeignGAP");
+-        module = jl_new_module(sym);
+-        module->parent = jl_main_module;
+-        // make the module available in the Main module (this also ensures
+-        // that it won't be GC'ed prematurely, and hence also our datatypes
+-        // won't be GCed)
+-        jl_set_const(jl_main_module, sym, (jl_value_t *)module);
++        module = jl_main_module;
+     }
+ 
+     if (parent == 0) {
+-- 
+2.36.0
+


### PR DESCRIPTION
This way we don't have to recompile against new libjulia builds as often
