### PR TITLE
GAP: rebuild with -Werror to catch problems sooner

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -77,11 +77,18 @@ julia_version=$(./julia_version)
     --with-julia
 mkdir -p build
 
+# WORKAROUND: avoid error: /usr/local/include: No such file or directory
+export CPPFLAGS="$CPPFLAGS -Wno-missing-include-dirs"
+# WORKAROUND: avoid error: redundant redeclaration of ‘jl_gc_safepoint’ for Julia 1.8 & 1.9
+# (see https://github.com/JuliaLang/julia/pull/45120 for a proper fix)
+export CPPFLAGS="$CPPFLAGS -Wredundant-decls"
+
 # configure & compile a native version of GAP to generate ffdata.{c,h}, c_oper1.c and c_type1.c
 mkdir native-build
 cd native-build
 rm ${host_libdir}/*.la  # delete *.la, they hardcode libdir='/workspace/destdir/lib'
 ../configure --build=${MACHTYPE} --host=${MACHTYPE} \
+    --enable-Werror \
     --with-gmp=${host_prefix} \
     --without-readline \
     --with-zlib=${host_prefix} \

--- a/G/GAP/bundled/patches/kernel-fix-FreeBSD-compiler-warning.patch
+++ b/G/GAP/bundled/patches/kernel-fix-FreeBSD-compiler-warning.patch
@@ -1,0 +1,25 @@
+From b3340c4d8913afac0cc33a7c53c2beb5aa14af5c Mon Sep 17 00:00:00 2001
+From: Max Horn <max@quendi.de>
+Date: Fri, 29 Apr 2022 13:21:58 +0200
+Subject: [PATCH] kernel: fix FreeBSD compiler warning
+
+---
+ src/libgap-api.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libgap-api.c b/src/libgap-api.c
+index 9ccf59bfe..e14f9682f 100644
+--- a/src/libgap-api.c
++++ b/src/libgap-api.c
+@@ -611,7 +611,7 @@ void GAP_LeaveStack_(void)
+ 
+ void GAP_EnterDebugMessage_(char * message, char * file, int line)
+ {
+-    fprintf(stderr, "%s: %d; %s:%d\n", message, EnterStackCount, file, line);
++    fprintf(stderr, "%s: %d; %s:%d\n", message, (int)EnterStackCount, file, line);
+ }
+ 
+ int GAP_Error_Prejmp_(const char * file, int line)
+-- 
+2.36.0
+


### PR DESCRIPTION
A build problem was previously hidden as a compiler warning, so turn those into errors.
