### PR TITLE
New Telescope version

### DIFF
--- a/T/Telescope/build_tarballs.jl
+++ b/T/Telescope/build_tarballs.jl
@@ -40,7 +40,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency("Bullet_jll"),
+    BuildDependency("Bullet_Physics_SDK_jll"),
     BuildDependency("OpenGLMathematics_jll"),
     Dependency("SDL2_jll"),
     Dependency("SDL2_image_jll"),

--- a/T/Telescope/build_tarballs.jl
+++ b/T/Telescope/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "Telescope"
-version = v"0.1.2"
+version = v"0.2.0"
 
 # Collection of sources required to build this package
 sources = [
     ArchiveSource("https://github.com/jhigginbotham64/Telescope/archive/refs/tags/v$(version).tar.gz",
-              "025a24a5dfe4c4d5910ae0cad7664ec2c2fc21cce8ffaae56cc6b42300249de6"),
+              "2d09f72219df5e3d1cdd1fea02ff370cc5f71d9cc37c510cb9d2dd83f4f3e990"),
 ]
 
 # Bash recipe for building across all platforms
@@ -28,7 +28,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude=p->!(Sys.islinux(p) && nbits(p) == 64))
+platforms = supported_platforms()
 
 platforms = expand_cxxstring_abis(platforms)
 

--- a/T/Telescope/build_tarballs.jl
+++ b/T/Telescope/build_tarballs.jl
@@ -30,7 +30,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-
+filter!(p -> arch(p) != "armv6l" & !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/T/Telescope/build_tarballs.jl
+++ b/T/Telescope/build_tarballs.jl
@@ -7,8 +7,8 @@ version = v"0.2.0"
 
 # Collection of sources required to build this package
 sources = [
-    ArchiveSource("https://github.com/jhigginbotham64/Telescope/archive/refs/tags/v$(version).tar.gz",
-              "2d09f72219df5e3d1cdd1fea02ff370cc5f71d9cc37c510cb9d2dd83f4f3e990"),
+    GitSource("https://github.com/jhigginbotham64/Telescope.git",
+              "0b88f367a1fe7905ca87b440b9d58ae1b0a43e8b"),
 ]
 
 # Bash recipe for building across all platforms
@@ -16,6 +16,7 @@ script = raw"""
 export CFLAGS="-I${includedir}"
 export CXXFLAGS="-I${includedir}"
 cd $WORKSPACE/srcdir/Telescope*
+git submodule update --init --recursive
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/T/Telescope/build_tarballs.jl
+++ b/T/Telescope/build_tarballs.jl
@@ -30,7 +30,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-filter!(p -> arch(p) != "armv6l" & !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
+filter!(p -> (arch(p) != "armv6l") && !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/T/Telescope/build_tarballs.jl
+++ b/T/Telescope/build_tarballs.jl
@@ -40,6 +40,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    BuildDependency("Bullet_jll"),
     BuildDependency("OpenGLMathematics_jll"),
     Dependency("SDL2_jll"),
     Dependency("SDL2_image_jll"),


### PR DESCRIPTION
Some platforms fail saying that Bullet needs to be recompiled with -fPIC. Fair enough, I overlooked that in my original PR, it's an easy fix.

Others fail saying that they can't find the header files for SDL Mixer, which...I'm going to need some help figuring out.