### PR TITLE
[jlqml] Version 0.4 (Qt 6)

### DIFF
--- a/J/jlqml/build_tarballs.jl
+++ b/J/jlqml/build_tarballs.jl
@@ -10,19 +10,15 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 julia_versions = [v"1.6.3", v"1.7.0", v"1.8.0", v"1.9.0"]
 
 name = "jlqml"
-version = v"0.3"
+version = v"0.4"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/barche/jlqml.git", "4d21e2fcf0bcae29c45e76c8ac9d1d45893a77e6"),
+    GitSource("https://github.com/barche/jlqml.git", "2f463a86e305fb49e072bc5c2c2cc8e6026ae8dd"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-if test -f "$prefix/lib/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake"; then
-    sed -i 's/_qt5gui_find_extra_libs.*AGL.framework.*//' $prefix/lib/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake
-fi
-
 # Override compiler ID to silence the horrible "No features found" cmake error
 if [[ $target == *"apple-darwin"* ]]; then
   macos_extra_flags="-DCMAKE_CXX_COMPILER_ID=AppleClang -DCMAKE_CXX_COMPILER_VERSION=10.0.0 -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT=11"
@@ -36,10 +32,6 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DJulia_PREFIX=${prefix} \
-    -DQt5Core_DIR=$prefix/lib/cmake/Qt5Core \
-    -DQt5Quick_DIR=$prefix/lib/cmake/Qt5Quick \
-    -DQt5Svg_DIR=$prefix/lib/cmake/Qt5Svg \
-    -DQt5Widgets_DIR=$prefix/lib/cmake/Qt5Widgets \
     $macos_extra_flags \
     ../jlqml/
 VERBOSE=ON cmake --build . --config Release --target install -- -j${nproc}
@@ -51,9 +43,7 @@ install_license $WORKSPACE/srcdir/jlqml*/LICENSE.md
 include("../../L/libjulia/common.jl")
 platforms = vcat(libjulia_platforms.(julia_versions)...)
 platforms = expand_cxxstring_abis(platforms)
-
-filter!(p -> libc(p) != "musl", platforms) # Qt_jll is currently not available for muslc
-# Qt5Declarative_jll is not available for these architectures:
+# Qt6Declarative_jll is not available for these architectures:
 filter!(p -> arch(p) != "armv6l", platforms)
 
 # The products that we will ensure are always built
@@ -64,8 +54,9 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("libcxxwrap_julia_jll"),
-    Dependency("Qt5Declarative_jll"),
-    Dependency("Qt5Svg_jll"),
+    Dependency("Qt6Declarative_jll"),
+    HostBuildDependency("Qt6Declarative_jll"),
+    Dependency("Qt6Svg_jll"),
     BuildDependency("Libglvnd_jll"),
     BuildDependency("libjulia_jll"),
 ]


### PR DESCRIPTION
New version that depends on Qt6. The Qt5 support remains in 0.3, but no further updates there are planned.