### PR TITLE
[dlfcn-win32] init

### DIFF
--- a/D/dlfcn_win32/build_tarballs.jl
+++ b/D/dlfcn_win32/build_tarballs.jl
@@ -1,0 +1,38 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "dlfcn_win32"
+version = v"1.3.1"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/dlfcn-win32/dlfcn-win32.git", "9d0ef119d9fcb9139f831adc224857b791c81140")
+]
+
+dependencies = [
+
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd dlfcn-win32
+
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = filter!(p -> Sys.iswindows(p), supported_platforms())
+
+# The products that we will ensure are always built
+products = Product[
+    LibraryProduct("libdl", :libdl)
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This adds [dlfcn-win32](https://github.com/dlfcn-win32/dlfcn-win32)

> dlfcn-win32 is an implementation of dlfcn for Windows.

>dlfcn is a set of functions that allows runtime dynamic library loading. It is standardized in the POSIX. Windows also provide similar routines, but not in a POSIX-compatible way. This library attempts to implement a wrapper around the Windows functions to make programs written for POSIX that use dlfcn work in Windows without any modifications.

