### PR TITLE
[gmsh] Update to v4.10.2 and use MMG, FLTK, and OpenCASCADE

### DIFF
--- a/G/gmsh/build_tarballs.jl
+++ b/G/gmsh/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"4.10.2"
 # Collection of sources required to build Gmsh
 sources = [
     ArchiveSource("https://gmsh.info/src/gmsh-$(version)-source.tgz",
-                  "d921109e6c419f68d5507d9612ee815d40b5239a5db175f28285e0cd0dbf2517")
+                  "d921109e6c419f68d5507d9612ee815d40b5239a5db175f28285e0cd0dbf2517"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/gmsh/build_tarballs.jl
+++ b/G/gmsh/build_tarballs.jl
@@ -67,7 +67,7 @@ dependencies = [
     Dependency("FreeType2_jll"),
     Dependency("GLU_jll"; platforms=x11_platforms),
     Dependency("GMP_jll"; compat="6.2"),
-    Dependency("HDF5_jll"; platforms=hdf5_platforms, compat="1.12"),
+    Dependency("HDF5_jll"; platforms=hdf5_platforms, compat="1.12.1"),
     Dependency("JpegTurbo_jll"),
     Dependency("Libglvnd_jll"; platforms=x11_platforms),
     Dependency("libpng_jll"),


### PR DESCRIPTION
Updates Gmsh to v4.10.2 and configures to use OpenCASCADE, FLTK, and MMG dependencies.

Depends on #4888 and #4891.