### PR TITLE
add ImageStreamIO

### DIFF
--- a/I/ImageStreamIO/build_tarballs.jl
+++ b/I/ImageStreamIO/build_tarballs.jl
@@ -1,0 +1,38 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ImageStreamIO"
+version = v"1.0.3-beta"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/milk-org/ImageStreamIO.git", "c4b3c531f4653f3b570345f43b2686cd25af0db8")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ImageStreamIO
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [Platform("x86_64", "linux")]
+
+# The products that we will ensure are always built
+products = Product[
+    LibraryProduct("libImageStreamIO", :libimagestreamio)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="CMake_jll", uuid="3f4e10e2-61f2-5801-8945-23b9d642d0e6"))
+    Dependency(PackageSpec(name="CUDA_jll", uuid="e9e359dc-d701-5aa8-82ae-09bbf812ea83"))
+    Dependency(PackageSpec(name="CFITSIO_jll", uuid="b3e40c51-02ae-5482-8a39-3ace5868dcf4"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", allow_unsafe_flags=true)

--- a/I/ImageStreamIO/build_tarballs.jl
+++ b/I/ImageStreamIO/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "ImageStreamIO"
-version = v"1.0.3-beta"
+version = v"1.0.3"
 
 # Collection of sources required to complete build
 sources = [
@@ -29,8 +29,8 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="CMake_jll", uuid="3f4e10e2-61f2-5801-8945-23b9d642d0e6"))
-    Dependency(PackageSpec(name="CUDA_jll", uuid="e9e359dc-d701-5aa8-82ae-09bbf812ea83"))
+    BuildDependency(PackageSpec(name="CMake_jll", uuid="3f4e10e2-61f2-5801-8945-23b9d642d0e6"))
+    BuildDependency(PackageSpec(name="CUDA_full_jll", uuid="4f82f1eb-248c-5f56-a42e-99106d144614"))
     Dependency(PackageSpec(name="CFITSIO_jll", uuid="b3e40c51-02ae-5482-8a39-3ace5868dcf4"))
 ]
 


### PR DESCRIPTION
Note on supported platforms:
I may be underspecifying the platforms. Big constraints are CUDA and using `mman`, so that restricts to Linux, but the underlying software only compiles to x86, so it only seems to work on the one platform.

Please let me know if I'm missing any files, I've never had to open one of these manually before!