### PR TITLE
Add likwid 5.2.1

### DIFF
--- a/L/likwid/build_tarballs.jl
+++ b/L/likwid/build_tarballs.jl
@@ -1,0 +1,44 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "likwid"
+version = v"5.2.1"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("http://ftp.fau.de/pub/likwid/likwid-$(version).tar.gz", "1b8e668da117f24302a344596336eca2c69d2bc2f49fa228ca41ea0688f6cbc2")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd likwid-5.2.1/
+sed -i 's/PREFIX ?= .*/PREFIX ?= \/workspace\/destdir/' config.mk
+sed -i 's/ACCESSMODE = .*/ACCESSMODE = perf_event/' config.mk
+sed -i 's/BUILDFREQ = .*/BUILDFREQ = false/' config.mk
+make
+make install
+exit
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc = "glibc")
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("liblikwid", :liblikwid),
+    ExecutableProduct("likwid-lua", :likwid_lua),
+    ExecutableProduct("likwid-bench", :likwid_bench)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
This is my attempt to provide a basic configuration of [LIKWID](https://github.com/RRZE-HPC/likwid), in particular the library `liblikwid`, via BinaryBuilder (https://github.com/JuliaPerf/LIKWID.jl/issues/24). The plan is to later use this as a fallback in [LIKWID.jl](https://github.com/JuliaPerf/LIKWID.jl) (if there is no system-wide likwid available).

To modify the `config.mk`, I've opted for three `sed` commands. (Should I use a patch instead? What would be the advantage / disadvantage?)

**Potential future TODOs:**
* provide the executable lua scripts (e.g. `likwid-topology`, `likwid-perfctr`, etc.) as `FileProducts`
* support for musl (if possible)

**Question / Remark:**
I get the following `make` log:
```
sandbox:${WORKSPACE}/srcdir/likwid-5.2.1 # make
ldd: --version: No such file or directory
sh: 4: unknown operand
Info: Compiling for perf_event interface. Measurements of thermal information is disabled
===>  GENERATE HEADER GCC/perfmon_a15_events.h
===>  GENERATE HEADER GCC/perfmon_a57_events.h
===>  GENERATE HEADER GCC/perfmon_a64fx_events.h
[ ... many more GENERATE HEADERs ... ]
===>  GENERATE HEADER GCC/perfmon_zen2_events.h
===>  GENERATE HEADER GCC/perfmon_zen3_events.h
===>  GENERATE HEADER GCC/perfmon_zen_events.h
===>  COMPILE  GCC/access.o
===>  COMPILE  GCC/access_client.o
===>  COMPILE  GCC/access_x86.o
[ ... many more COMPILEs ...]
===>  COMPILE  GCC/tree.o
===>  COMPILE  GCC/voltage.o
===>  COMPILE  GCC/loadData.o
===>  ENTER  /workspace/srcdir/likwid-5.2.1/ext/hwloc
ldd: --version: No such file or directory
sh: 4: unknown operand
Info: Compiling for perf_event interface. Measurements of thermal information is disabled
===>  ENTER  /workspace/srcdir/likwid-5.2.1/ext/lua
ldd: --version: No such file or directory
sh: 4: unknown operand
Info: Compiling for perf_event interface. Measurements of thermal information is disabled
===>  CREATE SHARED LIB  liblikwid.so
===>  CREATE LIB  liblikwidpin.so
make[1]: Entering directory '/workspace/srcdir/likwid-5.2.1/src/pthread-overload'
ldd: --version: No such file or directory
sh: 4: unknown operand
Info: Compiling for perf_event interface. Measurements of thermal information is disabled
make[1]: Leaving directory '/workspace/srcdir/likwid-5.2.1/src/pthread-overload'
===>  ADJUSTING  likwid-perfctr
===>  ADJUSTING  likwid-pin
===>  ADJUSTING  likwid-powermeter
===>  ADJUSTING  likwid-topology
===>  ADJUSTING  likwid-memsweeper
===>  ADJUSTING  likwid-mpirun
===>  ADJUSTING  likwid-features
===>  ADJUSTING  likwid-perfscope
===>  ADJUSTING  likwid-genTopoCfg
===>  ADJUSTING  likwid.lua
===>  ENTER  bench
ldd: --version: No such file or directory
sh: 4: unknown operand
Info: Compiling for perf_event interface. Measurements of thermal information is disabled
===>  COMPILE C GCC/allocator.o
===>  COMPILE C GCC/barrier.o
===>  COMPILE C GCC/bench.o
===>  COMPILE C GCC/bstrlib.o
===>  COMPILE C GCC/bstrlib_helper.o
===>  COMPILE C GCC/ptt2asm.o
===>  COMPILE C GCC/strUtil.o
===>  COMPILE C GCC/threads.o
===>  GENERATE BENCHMARKS
===>  ASSEMBLE  GCC/clcopy.o
===>  ASSEMBLE  GCC/clload.o
[ ... many more ASSEMBLEs ...]
===>  ASSEMBLE  GCC/update_sp_sse.o
===>  ASSEMBLE  GCC/update_sse.o
===>  LINKING  likwid-bench
```

Note the
```
ldd: --version: No such file or directory
sh: 4: unknown operand
Info: Compiling for perf_event interface. Measurements of thermal information is disabled
```
bits. Should I care about those given that the build process seems to proceed just fine?

(@TomTheBear, @Suavesito-Olimpiada FYI)