### PR TITLE
[cmark-gfm] Declare second .so as a LibraryProduct

### DIFF
--- a/C/cmark_gfm/build_tarballs.jl
+++ b/C/cmark_gfm/build_tarballs.jl
@@ -27,6 +27,7 @@ platforms = supported_platforms()
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libcmark-gfm", :libcmark_gfm),
+    LibraryProduct("libcmark-gfm-extensions", :libcmark_gfm_extensions),
     ExecutableProduct("cmark-gfm", :cmark_gfm)
 ]
 


### PR DESCRIPTION
Following up on #4917: I had forgotten that the GFM library provides two separate shared libraries.