### PR TITLE
[cmark_gfm] Apply patch to export node types on Windows

### DIFF
--- a/C/cmark_gfm/build_tarballs.jl
+++ b/C/cmark_gfm/build_tarballs.jl
@@ -7,12 +7,14 @@ version = v"0.29.0" # 0.29.0.gfm.3
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/github/cmark-gfm.git", "cf7577d2f74289cb83de0a652afc1a8b08a37036")
+    GitSource("https://github.com/github/cmark-gfm.git", "cf7577d2f74289cb83de0a652afc1a8b08a37036"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/cmark-gfm/
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/extension_type_exports.patch
 mkdir build
 cd build/
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ..

--- a/C/cmark_gfm/bundled/patches/extension_type_exports.patch
+++ b/C/cmark_gfm/bundled/patches/extension_type_exports.patch
@@ -1,0 +1,25 @@
+diff --git a/extensions/strikethrough.h b/extensions/strikethrough.h
+index a52a2b4..cddb1cc 100644
+--- a/extensions/strikethrough.h
++++ b/extensions/strikethrough.h
+@@ -3,6 +3,7 @@
+ 
+ #include "cmark-gfm-core-extensions.h"
+ 
++CMARK_GFM_EXTENSIONS_EXPORT
+ extern cmark_node_type CMARK_NODE_STRIKETHROUGH;
+ cmark_syntax_extension *create_strikethrough_extension(void);
+ 
+diff --git a/extensions/table.h b/extensions/table.h
+index f6a0634..d5d248f 100644
+--- a/extensions/table.h
++++ b/extensions/table.h
+@@ -3,7 +3,7 @@
+ 
+ #include "cmark-gfm-core-extensions.h"
+ 
+-
++CMARK_GFM_EXTENSIONS_EXPORT
+ extern cmark_node_type CMARK_NODE_TABLE, CMARK_NODE_TABLE_ROW,
+     CMARK_NODE_TABLE_CELL;
+ 


### PR DESCRIPTION
There are a few global variables that I need to access, but they're not available on Windows with `dlsym` right now. This patch should fix that by exporting them properly on Windows too.

X-ref: https://github.com/github/cmark-gfm/issues/263