### PR TITLE
[LibGit2] Explicitly request SSH support

### DIFF
--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -19,8 +19,9 @@ atomic_patch -p1 $WORKSPACE/srcdir/patches/libgit2-hostkey.patch
 
 BUILD_FLAGS=(
     -DCMAKE_BUILD_TYPE=Release
-    -DTHREADSAFE=ON
+    -DUSE_THREADS=ON
     -DUSE_BUNDLED_ZLIB=ON
+    -DUSE_SSH=ON
     "-DCMAKE_INSTALL_PREFIX=${prefix}"
     "-DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}""
 )
@@ -36,7 +37,7 @@ if [[ ${target} == *-mingw* ]]; then
     BUILD_FLAGS+=(-Dssh2_RESOLVED=${bindir}/libssh2.dll)
 elif [[ ${target} == *linux* ]] || [[ ${target} == *freebsd* ]]; then
     # If we're on Linux or FreeBSD, explicitly ask for mbedTLS instead of OpenSSL
-    BUILD_FLAGS+=(-DUSE_HTTPS=mbedTLS -DSHA1_BACKEND=CollisionDetection -DCMAKE_INSTALL_RPATH="\$ORIGIN")
+    BUILD_FLAGS+=(-DUSE_HTTPS=mbedTLS -DUSE_SHA1=CollisionDetection -DCMAKE_INSTALL_RPATH="\$ORIGIN")
 fi
 
 mkdir build && cd build


### PR DESCRIPTION
In the [previous build](https://dev.azure.com/JuliaPackaging/Yggdrasil/_build/results?buildId=19752&view=logs&j=012419e0-1f0d-5c7f-8376-cde93101c5d2&t=67007929-a8f9-5c00-96b4-44d560c75917&l=323) we had
```
[17:31:54] -- LIBSSH2 not found. Set CMAKE_PREFIX_PATH if it is installed outside of the default search path.
```
It looks like simply setting `USE_SSH=ON` ([default is `OFF`](https://github.com/libgit2/libgit2/blob/bdab22384cc61d315005a65456a9f9563bb27c8f/CMakeLists.txt#L30)) is sufficient to convince CMake to find libssh (if the search would fail, CMake configuration should [error out](https://github.com/libgit2/libgit2/blob/23c5c315d5f6a3e93cdb1bf1f51016fbacb86881/cmake/SelectSSH.cmake#L13) when `USE_SSH=ON`).  This should hopefully help with https://github.com/JuliaLang/julia/pull/45411#issuecomment-1133801828.  CC: @fxcoudert.

Also, update a couple of other renamed CMake options.