### PR TITLE
Add DebianGlibc@2.33 for aarch64-linux-gnu

### DIFF
--- a/G/Glibc/DebianGlibc@2.33/build_tarballs.jl
+++ b/G/Glibc/DebianGlibc@2.33/build_tarballs.jl
@@ -15,7 +15,7 @@ push!(sources,
     "c4dd741a08918861796cf62a8d3209a56d41d807344a7db481b73a4d17f726bc"),)
 script = glibc_script()
 platforms =  filter(p -> libc(p) == "glibc" && arch(p) == "aarch64",
-    supported_platforms(;experimental=true))
+    supported_platforms())
 products = Product[] # glibc_products()
 dependencies = glibc_dependencies()
 

--- a/G/Glibc/DebianGlibc@2.33/build_tarballs.jl
+++ b/G/Glibc/DebianGlibc@2.33/build_tarballs.jl
@@ -1,0 +1,23 @@
+using BinaryBuilder
+
+# This package builds debian glibc 2.33 for use as a replacement glibc in
+# debian bookworm in order to address the lse initialization order issue.
+# It is hopefully temporary until the upstream bug is fixed.
+
+include("../common.jl")
+
+name = "DebianGlibc"
+version = v"2.33"
+
+sources = glibc_sources(version)
+push!(sources,
+    ArchiveSource("http://deb.debian.org/debian/pool/main/g/glibc/glibc_2.33-7.debian.tar.xz",
+    "c4dd741a08918861796cf62a8d3209a56d41d807344a7db481b73a4d17f726bc"),)
+script = glibc_script()
+platforms =  filter(p -> libc(p) == "glibc" && arch(p) == "aarch64",
+    supported_platforms(;experimental=true))
+products = Product[] # glibc_products()
+dependencies = glibc_dependencies()
+
+# Build the tarballs
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"11", lock_microarchitecture=false)

--- a/G/Glibc/DebianGlibc@2.33/bundled/patches/glibc-003-sunrpc_on_musl.patch
+++ b/G/Glibc/DebianGlibc@2.33/bundled/patches/glibc-003-sunrpc_on_musl.patch
@@ -1,0 +1,1 @@
+../../../Glibc@2.12.2/bundled/patches/glibc-003-sunrpc_on_musl.patch

--- a/G/Glibc/common.jl
+++ b/G/Glibc/common.jl
@@ -12,6 +12,10 @@ function glibc_sources(version)
             ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.19.tar.xz",
                           "2d3997f588401ea095a0b27227b1d50cdfdd416236f6567b564549d3b46ea2a2"),
         ],
+        v"2.33" => [
+            ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.33.tar.xz",
+                          "2e2556000e105dbd57f0b6b2a32ff2cf173bde4f0d85dffccfd8b7e51a0677ff"),
+        ],
         v"2.34" => [
             ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.34.tar.xz",
                           "44d26a1fe20b8853a48f470ead01e4279e869ac149b195dda4e44a195d981ab2"),
@@ -41,12 +45,29 @@ function glibc_script()
     # Various configure overrides
     GLIBC_CONFIGURE_OVERRIDES=( libc_cv_forced_unwind=yes libc_cv_c_cleanup=yes )
 
+    mkdir -p $WORKSPACE/srcdir/glibc_build
+
+    if [[ -d ../debian ]]; then
+        echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories
+        apk update
+        apk add quilt
+        QUILT_PATCHES=$PWD/../debian/patches quilt push
+        echo "libdir = /usr/lib/${target}" >> $WORKSPACE/srcdir/glibc_build/configparms
+        echo "slibdir = /lib/${target}" >> $WORKSPACE/srcdir/glibc_build/configparms
+        echo "rtlddir = /lib" >> $WORKSPACE/srcdir/glibc_build/configparms
+        if [[ ${COMPILER_TARGET} == aarc64-linux-gnu ]]; then
+            # At the moment -moutline-atomics (as used in the official debian binaries)
+            # intermittently causes binaries that are incompatible with rr. Forcing ARM
+            # 8.3 will result in inlined LSE atomics, working around the issue.
+            GLIBC_CONFIGURE_OVERRIDES += CFLAGS="-march=armv8.3-a -mno-outline-atomics -O2"
+        fi
+    fi
+
     # We have problems with libssp on ppc64le
     if [[ ${COMPILER_TARGET} == powerpc64le-* ]]; then
         GLIBC_CONFIGURE_OVERRIDES+=( libc_cv_ssp=no libc_cv_ssp_strong=no )
     fi
-    
-    mkdir -p $WORKSPACE/srcdir/glibc_build
+
     cd $WORKSPACE/srcdir/glibc_build
     $WORKSPACE/srcdir/glibc-*/configure \
         --prefix=/usr \
@@ -55,9 +76,9 @@ function glibc_script()
         --disable-multilib \
         --disable-werror \
         ${GLIBC_CONFIGURE_OVERRIDES[@]}
-    
+
     make -j${nproc}
-    
+
     # Install to the main prefix and also to the sysroot.
     make install install_root=${prefix}
     """


### PR DESCRIPTION
This builds a replacement glibc for use in debian testing images
that need to be compatible with rr (such as our JuliaCI images).
Due an interaction between libgcc and glibc, current versions of
these dependencies currently, intermittently, result in
rr-incompatible binaries due to an accidental use of legacy atomics
instructions. Building with `-march=armv8.3-a -mno-outline-atomics`
works around this issue at the cost of losing compatibility with pre-8.3
ARMv8. The product of this builder can be applied with `tar -C / xf`
over an existing debian rootfs to work around this issue while we
work with upstream to correct it.

cc @DilumAluthge 