### PR TITLE
Kaleido updated to 0.2.1 + macOS aarch64 support

### DIFF
--- a/K/Kaleido/build_tarballs.jl
+++ b/K/Kaleido/build_tarballs.jl
@@ -1,15 +1,16 @@
 using BinaryBuilder
 
 name = "Kaleido"
-version = v"0.1.0"
+version = v"0.2.1"
 
 url_prefix = "https://github.com/plotly/Kaleido/releases/download/v$(version)/kaleido"
 sources = [
-    ArchiveSource("$(url_prefix)_linux_x64.zip", "6214b5e3082f315ead32133d13c3aacd385d1dab0da8eca9c6a6febf1669e9c8"; unpack_target = "x86_64-linux-gnu"),
-    ArchiveSource("$(url_prefix)_linux_arm64.zip", "a66d0ad6da9edb0ea00508c2eaf79b386f6f22cb67b40812537a8aa05ac2e746"; unpack_target = "aarch64-linux-gnu"),
-    ArchiveSource("$(url_prefix)_mac.zip", "4a583ee9363a9feed3ed6b7308ffeb1f11e8da57a978583bb7e9b4591dc55e38"; unpack_target = "x86_64-apple-darwin14"),
-    ArchiveSource("$(url_prefix)_win_x64.zip", "58b57a973e660a4e7395e595a277492aa9008e0a25c3446656a52f7652b5f8a6"; unpack_target = "x86_64-w64-mingw32"),
-    ArchiveSource("$(url_prefix)_win_x86.zip", "aa87ac1957e84f4f66f70de1c2dd9a2355ef7737cdf16b3e4125350836fe0484"; unpack_target = "i686-w64-mingw32"),
+    ArchiveSource("$(url_prefix)_linux_x64.zip", "3eaa3efd41a00db05dd71add7f54ad4e9d4259552e3f7470ac4c1a8594cea214"; unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$(url_prefix)_linux_arm64.zip", "a6040fa4d95692b7047d3880391f539ea7af9353b0c7b0558ea7b8e280013703"; unpack_target = "aarch64-linux-gnu"),
+    ArchiveSource("$(url_prefix)_mac_x64.zip", "57e3e1a1d98f1c25f565a1d37cbc2baf0509c13e37e6b92f7d3cb89c53b28f27"; unpack_target = "x86_64-apple-darwin14"),
+	ArchiveSource("$(url_prefix)_mac_arm64.zip", "e5cc7bceb096db135384928d1f11b115c5697dcd1f66e7064ddb91562a61d55f"; unpack_target = "aarch64-apple-darwin20"),
+    ArchiveSource("$(url_prefix)_win_x64.zip", "22857d6696fe348fea166b2950263e8c2fa41e465a1a354f2e09a6f90dfe6df3"; unpack_target = "x86_64-w64-mingw32"),
+    ArchiveSource("$(url_prefix)_win_x86.zip", "771d0372e003393a313adb38a6a3fed3eaf9a9ad46b1453f92cb5489efcee376"; unpack_target = "i686-w64-mingw32"),
 ]
 
 # Bash recipe for building across all platforms
@@ -34,6 +35,7 @@ platforms = [
     Platform("x86_64", "linux"),
     Platform("aarch64", "linux"),
     Platform("x86_64", "macos"),
+    Platform("aarch64", "macos"),
     Platform("i686", "windows"),
     Platform("x86_64", "windows"),
 ]
@@ -48,4 +50,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/K/Kaleido/build_tarballs.jl
+++ b/K/Kaleido/build_tarballs.jl
@@ -8,7 +8,7 @@ sources = [
     ArchiveSource("$(url_prefix)_linux_x64.zip", "3eaa3efd41a00db05dd71add7f54ad4e9d4259552e3f7470ac4c1a8594cea214"; unpack_target = "x86_64-linux-gnu"),
     ArchiveSource("$(url_prefix)_linux_arm64.zip", "a6040fa4d95692b7047d3880391f539ea7af9353b0c7b0558ea7b8e280013703"; unpack_target = "aarch64-linux-gnu"),
     ArchiveSource("$(url_prefix)_mac_x64.zip", "57e3e1a1d98f1c25f565a1d37cbc2baf0509c13e37e6b92f7d3cb89c53b28f27"; unpack_target = "x86_64-apple-darwin14"),
-	ArchiveSource("$(url_prefix)_mac_arm64.zip", "e5cc7bceb096db135384928d1f11b115c5697dcd1f66e7064ddb91562a61d55f"; unpack_target = "aarch64-apple-darwin20"),
+    ArchiveSource("$(url_prefix)_mac_arm64.zip", "e5cc7bceb096db135384928d1f11b115c5697dcd1f66e7064ddb91562a61d55f"; unpack_target = "aarch64-apple-darwin20"),
     ArchiveSource("$(url_prefix)_win_x64.zip", "22857d6696fe348fea166b2950263e8c2fa41e465a1a354f2e09a6f90dfe6df3"; unpack_target = "x86_64-w64-mingw32"),
     ArchiveSource("$(url_prefix)_win_x86.zip", "771d0372e003393a313adb38a6a3fed3eaf9a9ad46b1453f92cb5489efcee376"; unpack_target = "i686-w64-mingw32"),
 ]


### PR DESCRIPTION
Kaleido updated to 0.2.1 from new [releases](https://github.com/plotly/Kaleido/releases). This added support for macOS aarch64. `julia_compat` is now set to "1.6" for build_tarballs. With these changes, Plotly figures can be saved to image files under aarch64-julia in macOS.