### PR TITLE
[GDAL] build version 3.5.0

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -126,4 +126,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version=v"7")

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "GDAL"
-upstream_version = v"3.4.1"
+upstream_version = v"3.5.0"
 version_offset = v"0.0.0"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
@@ -12,7 +12,7 @@ version = VersionNumber(upstream_version.major * 100 + version_offset.major,
 # Collection of sources required to build GDAL
 sources = [
     ArchiveSource("https://github.com/OSGeo/gdal/releases/download/v$upstream_version/gdal-$upstream_version.tar.gz",
-        "e360387bc25ec24940f46afbeada48002d72c74aaf9eccf2a40e8d74e711a2e4"),
+        "3affc513b8aa5a76b996eca55f45cb3e32acacf4a262ce4f686d4c8bba7ced40"),
     DirectorySource("./bundled"),
 ]
 
@@ -25,7 +25,7 @@ if [[ ${target} == *mingw* ]]; then
     # Apply patch to customise PROJ library
     atomic_patch -p1 "$WORKSPACE/srcdir/patches/configure_ac_proj_libs.patch"
     autoreconf -vi
-    export PROJ_LIBS="proj_8_2"
+    export PROJ_LIBS="proj_9_0"
 elif [[ "${target}" == *-linux-* ]]; then
     # Hint to find libstdc++, required to link against C++ libs when using C compiler
     if [[ "${nbits}" == 32 ]]; then
@@ -114,7 +114,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GEOS_jll"; compat="~3.10"),
-    Dependency("PROJ_jll"; compat="~800.200"),
+    Dependency("PROJ_jll"; compat="~900.0"),
     Dependency("Zlib_jll"),
     Dependency("SQLite_jll"),
     Dependency("OpenJpeg_jll"),

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -121,7 +121,7 @@ dependencies = [
     Dependency("Expat_jll"; compat="2.2.10"),
     Dependency("Zstd_jll"),
     Dependency("Libtiff_jll"; compat="4.3"),
-    Dependency("libgeotiff_jll"; compat="1.7"),
+    Dependency("libgeotiff_jll"; compat="1.7.1"),
     Dependency("LibCURL_jll"),
 ]
 


### PR DESCRIPTION
Soon we will have to transition the build script to CMake, see the first point of the [changelog](https://github.com/OSGeo/gdal/blob/v3.5.0/NEWS.md):

> [RFC 84](https://gdal.org/development/rfc/rfc84_cmake.html):
  Addition of a CMake build system, which deprecates the existing
  autoconf/automake and nmake build systems, that will be removed
  in GDAL 3.6.0. Users are encouraged to adopt the new CMake build system.
  Documentation of the CMake build system is at
  https://gdal.org/build_hints.html.

But let's first just get a GDAL 3.5 build using what works now.
