### PR TITLE
[GDAL] add LibCURL_jll compat

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -122,7 +122,7 @@ dependencies = [
     Dependency("Zstd_jll"),
     Dependency("Libtiff_jll"; compat="4.3"),
     Dependency("libgeotiff_jll"; compat="1.7.1"),
-    Dependency("LibCURL_jll"),
+    Dependency("LibCURL_jll"; compat="7.73"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Should fix

```
ERROR: LoadError: InitError: could not load library "/Users/runner/.julia/artifacts/83ad874b4fee57727baf6ef9ca825d716af58f20/lib/libgdal.31.dylib"
dlopen(/Users/runner/.julia/artifacts/83ad874b4fee57727baf6ef9ca825d716af58f20/lib/libgdal.31.dylib, 1): Library not loaded: @rpath/libcurl.4.dylib
  Referenced from: /Users/runner/.julia/artifacts/83ad874b4fee57727baf6ef9ca825d716af58f20/lib/libgdal.31.dylib
  Reason: Incompatible library version: libgdal.31.dylib requires version 13.0.0 or later, but libcurl.4.dylib provides version 12.0.0
```

from https://github.com/JuliaGeo/GDAL.jl/pull/136

Version 7.73 is the version that julia 1.6 uses:
https://github.com/JuliaLang/julia/blob/v1.6.6/stdlib/LibCURL_jll/Project.toml#L3