### PR TITLE
Update IVerilog

### DIFF
--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -15,13 +15,12 @@ dependencies = [
     HostBuildDependency("Bison_jll"),
     Dependency("Readline_jll"; compat="8.1.1"),
     HostBuildDependency("gperf_jll"),
-    Dependency("Zlib_jll"; compat="~1.2.11"),
+    Dependency("Zlib_jll"; compat="1.2.12"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd iverilog
-export CPPFLAGS="-I${includedir}"
 sh ./autoconf.sh
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-zlib=${prefix}
 make -j${nproc}

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -6,34 +6,25 @@ name = "IVerilog"
 version = v"12.0.0"
 
 # Collection of sources required to complete build
-# TODO stable once available, this is "12.0 (devel)"
 sources = [
    GitSource("https://github.com/steveicarus/iverilog.git", "2693dd32b075243cca20400cf3a808cef119477e")
 ]
 
 dependencies = [
     HostBuildDependency("Bison_jll"),
-    Dependency("Readline_jll"; compat="8.1.1"),
     HostBuildDependency("gperf_jll"),
-    Dependency("Zlib_jll"; compat="1.2.12"),
+    Dependency("Readline_jll"; compat="8.1.1"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd iverilog
-export CFLAGS="-O2"
-export CXXFLAGS="-O2"
 sh ./autoconf.sh
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-zlib=${prefix}
+# The generated configure script is replacing a variable incorrectly
+sed -i 's/EXEEXT=$ac_cv_build_exeext/BUILD_EXEEXT=$ac_cv_build_exeext/' configure
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
-
-# build is generating Windows binaries without extension, hack them back
-if [[ "${target}" == *-mingw* ]]; then
-    mv "${bindir}/iverilog" "${bindir}/iverilog${exeext}"
-    mv "${bindir}/iverilog-vpi" "${bindir}/iverilog-vpi${exeext}"
-    mv "${bindir}/vvp" "${bindir}/vvp${exeext}"
-fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -27,7 +27,6 @@ sh ./autoconf.sh
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-zlib=${prefix}
 make -j${nproc}
 make install
-"""
 
 # build is generating Windows binaries without extension, hack them back
 if [[ "${target}" == *-mingw* ]]; then
@@ -35,6 +34,7 @@ if [[ "${target}" == *-mingw* ]]; then
     mv "${bindir}/iverilog-vpi" "${bindir}/iverilog-vpi${exeext}"
     mv "${bindir}/vvp" "${bindir}/vvp${exeext}"
 fi
+"""
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -36,7 +36,7 @@ platforms = expand_cxxstring_abis(platforms)
 # The products that we will ensure are always built
 products = [
     ExecutableProduct("iverilog", :iverilog),
-    ExecutableProduct("iverilog-vpi", :iverilog_vpi)
+    ExecutableProduct("iverilog-vpi", :iverilog_vpi),
     ExecutableProduct(":vvp", :vvp)
 ]
 

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -20,6 +20,8 @@ dependencies = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd iverilog
+export CFLAGS="-O2"
+export CXXFLAGS="-O2"
 sh ./autoconf.sh
 # The generated configure script is replacing a variable incorrectly
 sed -i 's/EXEEXT=$ac_cv_build_exeext/BUILD_EXEEXT=$ac_cv_build_exeext/' configure

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -37,7 +37,7 @@ platforms = expand_cxxstring_abis(platforms)
 products = [
     ExecutableProduct("iverilog", :iverilog),
     ExecutableProduct("iverilog-vpi", :iverilog_vpi)
-    ExecutableProduct("iverilog-vpi", :vvp)
+    ExecutableProduct(":vvp", :vvp)
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -6,11 +6,9 @@ name = "IVerilog"
 version = v"12.0.0"
 
 # Collection of sources required to complete build
-# This is a patched master including https://github.com/steveicarus/iverilog/pull/511/
-# to allow for cross compilation 
-# TODO use upstream + stable once available
+# TODO stable once available, this is "12.0 (devel)"
 sources = [
-   GitSource("https://github.com/sjkelly/iverilog.git", "1f09b041f1060116840b901c21938ad31d79bb98")
+   GitSource("https://github.com/steveicarus/iverilog.git", "2693dd32b075243cca20400cf3a808cef119477e")
 ]
 
 dependencies = [
@@ -39,6 +37,7 @@ platforms = expand_cxxstring_abis(platforms)
 products = [
     ExecutableProduct("iverilog", :iverilog),
     ExecutableProduct("iverilog-vpi", :iverilog_vpi)
+    ExecutableProduct("iverilog-vpi", :vvp)
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -14,6 +14,7 @@ dependencies = [
     HostBuildDependency("Bison_jll"),
     HostBuildDependency("gperf_jll"),
     Dependency("Readline_jll"; compat="8.1.1"),
+    Dependency("Zlib_jll"; compat="1.2.12"),
 ]
 
 # Bash recipe for building across all platforms

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -29,6 +29,13 @@ make -j${nproc}
 make install
 """
 
+# build is generating Windows binaries without extension, hack them back
+if [[ "${target}" == *-mingw* ]]; then
+    mv "${bindir}/iverilog" "${bindir}/iverilog${exeext}"
+    mv "${bindir}/iverilog-vpi" "${bindir}/iverilog-vpi${exeext}"
+    mv "${bindir}/vvp" "${bindir}/vvp${exeext}"
+fi
+
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -21,6 +21,8 @@ dependencies = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd iverilog
+export CFLAGS="-O2"
+export CXXFLAGS="-O2"
 sh ./autoconf.sh
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-zlib=${prefix}
 make -j${nproc}

--- a/I/IVerilog/build_tarballs.jl
+++ b/I/IVerilog/build_tarballs.jl
@@ -37,7 +37,7 @@ platforms = expand_cxxstring_abis(platforms)
 products = [
     ExecutableProduct("iverilog", :iverilog),
     ExecutableProduct("iverilog-vpi", :iverilog_vpi),
-    ExecutableProduct(":vvp", :vvp)
+    ExecutableProduct("vvp", :vvp)
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
* add `vvp` to products
* point to upstream since https://github.com/steveicarus/iverilog/pull/511/ has been merged in Dec 2021


CC: @giordano 
* On Centos 7.6 gcc is 4.8.5, and this is looking for `libstdc++.so.6.0.20`.  Setting `LD_LIBRARY_PATH` is a user workaround.
* On Windows 10, I see
```
ivl.exe - System Error 
The code execution cannot proceed because libgcc_s_seh-1.dll was not 
found. Reinstalling the program may fix this problem. 
```
and
```
ivl.exe - System Error 
The code execution cannot proceed because libstdc++-6.dll was not 
found. Reinstalling the program may fix this problem.
```

