### PR TITLE
[Tectonic] Set `lazy_artifacts=true`

### DIFF
--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -52,4 +52,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers=[:c, :rust], preferred_gcc_version=v"7", lock_microarchitecture=false, julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    compilers=[:c, :rust], preferred_gcc_version=v"7", lazy_artifacts=true, lock_microarchitecture=false, julia_compat="1.6")


### PR DESCRIPTION
- Small improvement to https://github.com/JuliaPackaging/Yggdrasil/pull/4992.

It would be nice for packages which want to allow PDF building as an optional feature. As far as I see there aren't any downsides to setting lazy to true for Tectonic (?)