### PR TITLE
[SoapyRTLSDR] Bump to 3.3

### DIFF
--- a/S/SoapyRTLSDR/build_tarballs.jl
+++ b/S/SoapyRTLSDR/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "SoapyRTLSDR"
-version = v"0.3.2"
+version = v"0.3.3"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/pothosware/SoapyRTLSDR.git", "e4b963926012399904aceb57690df3a4f293ce67")
+    GitSource("https://github.com/pothosware/SoapyRTLSDR.git", "80c93fbe189def3ab68d47a6ad3f813f96d3cb99")
 ]
 
 dependencies = [


### PR DESCRIPTION
```
Release 0.3.3 (2022-06-04)
==========================

- Add setting for test mode (#60)
- Add getSampleRateRange (closes #54)

```
via: https://github.com/pothosware/SoapyRTLSDR/blob/80c93fbe189def3ab68d47a6ad3f813f96d3cb99/Changelog.txt#L1-L5