### PR TITLE
[casacorewrapper] Release v0.1.0

### DIFF
--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -17,7 +17,6 @@ mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ..
 make -j${nproc}
 make install
-exit
 """
 
 # Use the same platforms from casacore

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -28,7 +28,6 @@ make install
 platforms = supported_platforms(exclude=(platform)-> Sys.iswindows(platform) || Sys.isfreebsd(platform))
 platforms = expand_cxxstring_abis(platforms)
 # Expand libgfortran versions because we need to exclude some specific combinations
-platforms = expand_gfortran_versions(platforms)
 filter!(p -> libc(p) != "musl", platforms)
 
 # The products that we will ensure are always built

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -14,7 +14,12 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/casascorewrapper/
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ..
+cmake \
+    -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCASACORE_ROOT_DIR=${prefix} \
+    ..
 make -j${nproc}
 make install
 """
@@ -22,6 +27,8 @@ make install
 # Use the same platforms from casacore
 platforms = supported_platforms(exclude=(platform)-> Sys.iswindows(platform) || Sys.isfreebsd(platform))
 platforms = expand_cxxstring_abis(platforms)
+# Expand libgfortran versions because we need to exclude some specific combinations
+platforms = expand_gfortran_versions(platforms)
 filter!(p -> libc(p) != "musl", platforms)
 filter!(p -> !(arch(p) == "powerpc64le" && libgfortran_version(p) == v"3"), platforms)
 

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -24,7 +24,6 @@ exit
 # Use the same platforms from casacore
 platforms = supported_platforms(exclude=(platform)-> Sys.iswindows(platform) || Sys.isfreebsd(platform))
 platforms = expand_cxxstring_abis(platforms)
-platforms = expand_gfortran_versions(platforms)
 filter!(p -> libc(p) != "musl", platforms)
 filter!(p -> !(arch(p) == "powerpc64le" && libgfortran_version(p) == v"3"), platforms)
 

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -21,9 +21,10 @@ make install
 exit
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = supported_platforms()
+# Use the same platforms from casacore
+platforms = supported_platforms(exclude=(platform)-> Sys.iswindows(platform) || Sys.isfreebsd(platform))
+# Deal with the fact that we have std::string values, which causes issues across the gcc 4/5 boundary
+platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -12,8 +12,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd casascorewrapper/
+cd $WORKSPACE/srcdir/casascorewrapper/
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ..
 make -j${nproc}

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -23,8 +23,10 @@ exit
 
 # Use the same platforms from casacore
 platforms = supported_platforms(exclude=(platform)-> Sys.iswindows(platform) || Sys.isfreebsd(platform))
-# Deal with the fact that we have std::string values, which causes issues across the gcc 4/5 boundary
 platforms = expand_cxxstring_abis(platforms)
+platforms = expand_gfortran_versions(platforms)
+filter!(p -> libc(p) != "musl", platforms)
+filter!(p -> !(arch(p) == "powerpc64le" && libgfortran_version(p) == v"3"), platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -43,4 +43,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"6.1.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7")

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"0.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/kiranshila/casascorewrapper.git", "f7fe573901bb8d651c60fd3f3c23527232de6d57")
+    GitSource("https://github.com/kiranshila/casascorewrapper.git", "d7574e8639c8ac55a360652e4e799a4686bec93c")
 ]
 
 # Bash recipe for building across all platforms

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"0.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/kiranshila/casascorewrapper.git", "3be29194e567baae4ad4f83704d8fa33e11836d3")
+    GitSource("https://github.com/kiranshila/casascorewrapper.git", "f7fe573901bb8d651c60fd3f3c23527232de6d57")
 ]
 
 # Bash recipe for building across all platforms

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -30,7 +30,6 @@ platforms = expand_cxxstring_abis(platforms)
 # Expand libgfortran versions because we need to exclude some specific combinations
 platforms = expand_gfortran_versions(platforms)
 filter!(p -> libc(p) != "musl", platforms)
-filter!(p -> !(arch(p) == "powerpc64le" && libgfortran_version(p) == v"3"), platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/C/casacorewrapper/build_tarballs.jl
+++ b/C/casacorewrapper/build_tarballs.jl
@@ -1,0 +1,39 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "casacorewrapper"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/kiranshila/casascorewrapper.git", "3be29194e567baae4ad4f83704d8fa33e11836d3")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd casascorewrapper/
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ..
+make -j${nproc}
+make install
+exit
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libcasacorewrapper", :libcasacorewrapper)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="casacore_jll", uuid="72fd12c2-f19b-5d3c-931a-6bbe5223e3ce"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"6.1.0")


### PR DESCRIPTION
I'm cleaning up, updating, and packaging Michael Eastwood's wrapper for casacore from [here](https://github.com/mweastwood/CasaCore.jl), this should be good to go. Only sticky bit is that we need at least GCC 6, not sure why.

Here is the repo https://github.com/kiranshila/casascorewrapper/

This is part of the greater effort of updating [CasaCore.jl](https://github.com/mweastwood/CasaCore.jl) to modern julia.