### PR TITLE
[LibGit2] Add patch to fix ownership check on Windows

### DIFF
--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -16,6 +16,7 @@ cd $WORKSPACE/srcdir/libgit2*/
 
 atomic_patch -p1 $WORKSPACE/srcdir/patches/libgit2-agent-nonfatal.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/libgit2-hostkey.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/libgit2-win32-ownership.patch
 
 BUILD_FLAGS=(
     -DCMAKE_BUILD_TYPE=Release

--- a/L/LibGit2/bundled/patches/libgit2-win32-ownership.patch
+++ b/L/LibGit2/bundled/patches/libgit2-win32-ownership.patch
@@ -12,10 +12,10 @@ this behavior.
  tests/libgit2/repo/open.c | 5 +++--
  2 files changed, 4 insertions(+), 3 deletions(-)
 
-diff --git a/src/libgit2/repository.c b/src/libgit2/repository.c
+diff --git a/src/repository.c b/src/repository.c
 index 48a0b70f519..d2484318f10 100644
---- a/src/libgit2/repository.c
-+++ b/src/libgit2/repository.c
+--- a/src/repository.c
++++ b/src/repository.c
 @@ -512,7 +512,7 @@ static int validate_ownership(const char *repo_path)
  	bool is_safe;
  	int error;
@@ -25,20 +25,3 @@ index 48a0b70f519..d2484318f10 100644
  		if (error == GIT_ENOTFOUND)
  			error = 0;
  
-diff --git a/tests/libgit2/repo/open.c b/tests/libgit2/repo/open.c
-index 4b6609a81e1..5c66eca4be9 100644
---- a/tests/libgit2/repo/open.c
-+++ b/tests/libgit2/repo/open.c
-@@ -484,9 +484,10 @@ void test_repo_open__validates_dir_ownership(void)
- 	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
- 	git_repository_free(repo);
- 
--	/* When the system user owns the repo config, fail */
-+	/* When the system user owns the repo config, also acceptable */
- 	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_SYSTEM);
--	cl_git_fail(git_repository_open(&repo, "empty_standard_repo"));
-+	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
-+	git_repository_free(repo);
- 
- 	/* When an unknown user owns the repo config, fail */
- 	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_OTHER);

--- a/L/LibGit2/bundled/patches/libgit2-win32-ownership.patch
+++ b/L/LibGit2/bundled/patches/libgit2-win32-ownership.patch
@@ -1,0 +1,44 @@
+From cdff2f0237f663e0f68155655a8b66d05c1ec716 Mon Sep 17 00:00:00 2001
+From: Edward Thomson <ethomson@edwardthomson.com>
+Date: Mon, 13 Jun 2022 21:34:01 -0400
+Subject: [PATCH] repo: allow administrator to own the configuration
+
+Update our ownership checks that were introduced in libgit2 v1.4.3
+(to combat CVE 2022-24765). These were not compatible with git's; git
+itself allows administrators to own the path. Our checks now match
+this behavior.
+---
+ src/libgit2/repository.c  | 2 +-
+ tests/libgit2/repo/open.c | 5 +++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/libgit2/repository.c b/src/libgit2/repository.c
+index 48a0b70f519..d2484318f10 100644
+--- a/src/libgit2/repository.c
++++ b/src/libgit2/repository.c
+@@ -512,7 +512,7 @@ static int validate_ownership(const char *repo_path)
+ 	bool is_safe;
+ 	int error;
+ 
+-	if ((error = git_fs_path_owner_is_current_user(&is_safe, repo_path)) < 0) {
++	if ((error = git_fs_path_owner_is_system_or_current_user(&is_safe, repo_path)) < 0) {
+ 		if (error == GIT_ENOTFOUND)
+ 			error = 0;
+ 
+diff --git a/tests/libgit2/repo/open.c b/tests/libgit2/repo/open.c
+index 4b6609a81e1..5c66eca4be9 100644
+--- a/tests/libgit2/repo/open.c
++++ b/tests/libgit2/repo/open.c
+@@ -484,9 +484,10 @@ void test_repo_open__validates_dir_ownership(void)
+ 	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
+ 	git_repository_free(repo);
+ 
+-	/* When the system user owns the repo config, fail */
++	/* When the system user owns the repo config, also acceptable */
+ 	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_SYSTEM);
+-	cl_git_fail(git_repository_open(&repo, "empty_standard_repo"));
++	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
++	git_repository_free(repo);
+ 
+ 	/* When an unknown user owns the repo config, fail */
+ 	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_OTHER);


### PR DESCRIPTION
This patch from upstream (https://github.com/libgit2/libgit2/pull/6321) will fix the bug that prevents updating the dependency in julia currently: https://github.com/JuliaLang/julia/pull/45411#issuecomment-1159490130