### PR TITLE
[CasADi] add initial builder

### DIFF
--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -39,12 +39,12 @@ make install
 
 products = [
     LibraryProduct("libcasadi", :libcasadi),
-    LibraryProduct("libcasadi_nlpsol_ipopt", :libcasadi_nlpsol_ipopts),
+    LibraryProduct("libcasadi_nlpsol_ipopt", :libcasadi_nlpsol_ipopt),
 ]
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = expand_cxxstring_abis(platforms)
 
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -62,7 +62,9 @@ products = [
 # platforms are passed in on the command line
 platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
-filter!(p -> libc(p) != "musl" && arch(p) != "powerpc64le", platforms)
+filter!(platforms) do p
+    return libc(p) != "musl" && arch(p) != "powerpc64le" && arch(p) != "armv7l"
+end
 
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -1,0 +1,65 @@
+using BinaryBuilder, Pkg
+
+name = "CasADi"
+
+version = v"3.5.5"
+
+sources = [
+    GitSource(
+        "https://github.com/casadi/casadi.git",
+        "fadc86444f3c7ab824dc3f2d91d4c0cfe7f9dad5",
+    ),
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir/casadi
+
+mkdir -p build
+cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_IPOPT=ON \
+    -DWITH_PYTHON=OFF \
+    -DWITH_EXAMPLES=OFF \
+    ..
+
+if [[ "${target}" == *-linux-* ]]; then
+        make -j ${nproc}
+else
+    if [[ "${target}" == *-mingw* ]]; then
+        cmake --build . --config Release
+    else
+        cmake --build . --config Release --parallel
+    fi
+fi
+make install
+"""
+
+products = [
+    LibraryProduct("libcasadi", :libcasadi),
+    LibraryProduct("libcasadi_nlpsol_ipopt", :libcasadi_nlpsol_ipopts),
+]
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
+    Dependency("Ipopt_jll"),
+]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    preferred_gcc_version = v"6",
+    julia_compat = "1.6",
+)

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -14,6 +14,7 @@ sources = [
 
 script = raw"""
 cd $WORKSPACE/srcdir/casadi
+install_license LICENSE.txt
 
 mkdir -p build
 cd build
@@ -54,6 +55,7 @@ products = [
 # platforms are passed in on the command line
 platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
+filter!(p -> libc(p) != "musl" && arch(p) != "powerpc64le", platforms)
 
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -9,6 +9,7 @@ sources = [
         "https://github.com/casadi/casadi.git",
         "fadc86444f3c7ab824dc3f2d91d4c0cfe7f9dad5",
     ),
+    DirectorySource("./bundled"),
 ]
 
 script = raw"""
@@ -16,6 +17,9 @@ cd $WORKSPACE/srcdir/casadi
 
 mkdir -p build
 cd build
+
+export CXXFLAGS="${CXXFLAGS} -std=c++11"
+export CFLAGS="${CFLAGS} -fPIC"
 
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
@@ -35,9 +39,13 @@ else
     fi
 fi
 make install
+
+cd $WORKSPACE/srcdir
+${CXX} main.cpp -o ${bindir}/casadi_ipopt -I${includedir} -L${libdir} -lcasadi -std=c++11
 """
 
 products = [
+    ExecutableProduct("casadi_ipopt", :casadi_ipopt),
     LibraryProduct("libcasadi", :libcasadi),
     LibraryProduct("libcasadi_nlpsol_ipopt", :libcasadi_nlpsol_ipopt),
 ]

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -19,7 +19,7 @@ install_license LICENSE.txt
 mkdir -p build
 cd build
 
-export CXXFLAGS="${CXXFLAGS} -std=c++11"
+export CXXFLAGS="-fPIC -std=c++11"
 export CFLAGS="${CFLAGS} -fPIC"
 
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
@@ -32,11 +32,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
 if [[ "${target}" == *-linux-* ]]; then
         make -j ${nproc}
 else
-    if [[ "${target}" == *-mingw* ]]; then
-        cmake --build . --config Release
-    else
-        cmake --build . --config Release --parallel
-    fi
+    cmake --build . --config Release --parallel
 fi
 make install
 
@@ -56,10 +52,10 @@ products = [
 platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 filter!(platforms) do p
-    return libc(p) != "musl" &&
-        arch(p) != "powerpc64le" &&
-        arch(p) != "armv7l" &&
-        os(p) != "windows"
+    return !Sys.iswindows(p)
+        # libc(p) != "musl" &&
+        # arch(p) != "powerpc64le" &&
+        
 end
 
 dependencies = [

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -44,8 +44,11 @@ make install
 # Windows installs to a non-standard location
 if [[ "${target}" == *-mingw* ]]; then
     mkdir -p ${libdir}
-    mv ${prefix}/casadi/* ${prefix}/.
+    cp -r ${prefix}/casadi/* ${prefix}/.
+    rm -r ${prefix}/casadi
     mv ${prefix}/libcasadi* ${libdir}/.
+    mv ${prefix}/cmake ${libdir}/cmake
+    mv ${prefix}/pkgconfig ${libdir}/pkgconfig
 fi
 
 cd $WORKSPACE/srcdir

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -44,6 +44,7 @@ make install
 # Windows installs to a non-standard location
 if [[ "${target}" == *-mingw* ]]; then
     mkdir -p ${libdir}
+    mv ${prefix}/casadi/* ${prefix}/.
     mv ${prefix}/libcasadi* ${libdir}/.
 fi
 

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -44,6 +44,7 @@ products = [
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 
 dependencies = [

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -41,6 +41,12 @@ else
 fi
 make install
 
+# Windows installs to a non-standard location
+if [[ "${target}" == *-mingw* ]]; then
+    mkdir -p ${libdir}
+    mv ${prefix}/libcasadi* ${libdir}/.
+fi
+
 cd $WORKSPACE/srcdir
 ${CXX} main.cpp -o ${bindir}/casadi_ipopt -I${includedir} -L${libdir} -lcasadi -std=c++11
 """

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -26,7 +26,6 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DWITH_IPOPT=ON \
-    -DWITH_PYTHON=OFF \
     -DWITH_EXAMPLES=OFF \
     ..
 
@@ -41,22 +40,13 @@ else
 fi
 make install
 
-# Windows installs to a non-standard location
-if [[ "${target}" == *-mingw* ]]; then
-    mkdir -p ${libdir}
-    cp -r ${prefix}/casadi/* ${prefix}/.
-    rm -r ${prefix}/casadi
-    mv ${prefix}/libcasadi* ${libdir}/.
-    mv ${prefix}/cmake ${libdir}/cmake
-    mv ${prefix}/pkgconfig ${libdir}/pkgconfig
-fi
-
 cd $WORKSPACE/srcdir
-${CXX} main.cpp -o ${bindir}/casadi_ipopt -I${includedir} -L${libdir} -lcasadi -std=c++11
+
+${CXX} main.cpp -o ${bindir}/amplexe -I${includedir} -L${libdir} -lcasadi -std=c++11
 """
 
 products = [
-    ExecutableProduct("casadi_ipopt", :casadi_ipopt),
+    ExecutableProduct("amplexe", :amplexe),
     LibraryProduct("libcasadi", :libcasadi),
     LibraryProduct("libcasadi_nlpsol_ipopt", :libcasadi_nlpsol_ipopt),
 ]
@@ -66,7 +56,10 @@ products = [
 platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 filter!(platforms) do p
-    return libc(p) != "musl" && arch(p) != "powerpc64le" && arch(p) != "armv7l"
+    return libc(p) != "musl" &&
+        arch(p) != "powerpc64le" &&
+        arch(p) != "armv7l" &&
+        os(p) != "windows"
 end
 
 dependencies = [

--- a/C/CasADi/bundled/main.cpp
+++ b/C/CasADi/bundled/main.cpp
@@ -4,9 +4,6 @@
 using namespace casadi;
 
 int main(int argc, char **argv){
-  // No options yet
-  assert(argc == 3);
-  assert(std::string(argv[2]) == "-AMPL");
   std::string nl_filename = argv[1];
   NlpBuilder model;
   model.import_nl(nl_filename);

--- a/C/CasADi/bundled/main.cpp
+++ b/C/CasADi/bundled/main.cpp
@@ -1,0 +1,50 @@
+#include <casadi/casadi.hpp>
+#include <iomanip>
+
+using namespace casadi;
+
+int main(int argc, char **argv){
+  // No options yet
+  assert(argc == 3);
+  assert(std::string(argv[2]) == "-AMPL");
+  std::string nl_filename = argv[1];
+  NlpBuilder model;
+  model.import_nl(nl_filename);
+  Dict options;
+  options["error_on_fail"] = true;
+  options["print_time"] = false;
+  Function solver = nlpsol("casadi", "ipopt", model, options);
+  std::map<std::string, DM> input, solution;
+  input["lbx"] = model.x_lb;
+  input["ubx"] = model.x_ub;
+  input["lbg"] = model.g_lb;
+  input["ubg"] = model.g_ub;
+  input["x0"] = model.x_init;
+  bool is_optimal = false;
+  try {
+    solution = solver(input);
+    is_optimal = true;
+  } catch (std::exception& e) {
+    is_optimal = false;
+  }
+  // Output .sol filename replaces .nl with .sol.
+  std::ofstream solfile;
+  solfile.open(nl_filename.substr(0, nl_filename.find_last_of('.'))+".sol");
+  solfile << "Options" << std::endl;
+  solfile << "0" << std::endl;                // number of options
+  solfile << model.g_lb.size() << std::endl;  // number of constraints
+  solfile << "0" << std::endl;                // number of dual solutions
+  solfile << model.x_lb.size() << std::endl;  // number of variables
+  if (is_optimal) {
+    solfile << model.x_lb.size() << std::endl;  // number of primal solutions
+    for (double xi : std::vector<double>(solution["x"])) {
+      solfile << xi << std::endl;               // primal solutions
+    }
+    solfile << "objno 0 0" << std::endl;
+  } else {
+    solfile << "0" << std::endl;
+    solfile << "objno 0 500" << std::endl;
+  }
+  solfile.close();
+  return 0;
+}


### PR DESCRIPTION
I'm not overly sure how to structure this. The end product I'd like to build is this script: https://github.com/lanl-ansi/rosetta-opf/issues/21#issuecomment-1159837775. But it depends on CasADi. But that binary is non-standard, so I don't know if we should have CasADi_jll and CasADiIpopt_jll, or whether I should sneak the binary into CasADi_jll. 