### PR TITLE
New recipe: gobject-introspection

### DIFF
--- a/G/gobject_introspection/build_tarballs.jl
+++ b/G/gobject_introspection/build_tarballs.jl
@@ -1,0 +1,48 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "gobject_introspection"
+version = v"1.72.0"
+
+sources = [
+    ArchiveSource("https://ftp.gnome.org/pub/gnome/sources/gobject-introspection/$(version.major).$(version.minor)/gobject-introspection-$(version).tar.xz",
+              "02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+# We need to run some commands with a native Python
+apk add python3-dev
+
+# We use the build system's version of gi-scanner to generate XML for glib
+apk add gobject-introspection-dev
+
+cd $WORKSPACE/srcdir/gobject-*/
+
+mkdir build-gi
+
+cd build-gi
+meson .. \
+    --cross-file="${MESON_TARGET_TOOLCHAIN}" \
+    -Dgi_cross_use_prebuilt_gi=true
+ninja -j${nproc}
+ninja install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = filter!(p -> triplet(p) == "x86_64-linux-gnu", supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libgirepository-1.0", :libgirepository),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Glib_jll"; compat="2.68.3")
+    ]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
Builds libgirepository, which reads XML and .typelib files containing info about GObject based libraries. It also includes XML, etc. for Glib and some other libraries that will be useful for testing the corresponding Julia package.

This only builds for x86_64-linux-gnu, which is all I need at the moment. The library builds fine for all platforms, but the XML output (and gi-scanner) don't for anything but x86_64-linux-*. Long term it would be nice to get that working -- I'm sure it's possible.