### PR TITLE
libsndfile_jll: Add LAME and mpg123 as dependencies

### DIFF
--- a/L/libsndfile/build_tarballs.jl
+++ b/L/libsndfile/build_tarballs.jl
@@ -48,6 +48,8 @@ products = [
 dependencies = [
     Dependency("alsa_jll"; platforms=filter(Sys.islinux, platforms)),
     Dependency("FLAC_jll"),
+    Dependency("LAME_jll"),
+    Dependency("mpg123_jll"),
     Dependency("libvorbis_jll"),
     Dependency("Ogg_jll"),
     Dependency("Opus_jll"),


### PR DESCRIPTION
Libsndfile 1.1.0 added support for mp3 with LAME for encoding and mpg123 for decoding. I added them as dependencies here in the interest of maybe adding such support to libsndfile.jl (especially now given that mp3.jl is unmaintained and apparently unregistered)