### PR TITLE
[snappy] Add upstream patch to fix compilation of asm statements

### DIFF
--- a/S/snappy/build_tarballs.jl
+++ b/S/snappy/build_tarballs.jl
@@ -9,18 +9,14 @@ version = v"1.1.9"
 sources = [
     GitSource("https://github.com/google/snappy.git",
               "2b63814b15a2aaae54b7943f0cd935892fae628f"),
-    #ArchiveSource("https://github.com/google/snappy/archive/$(version).tar.gz",
-    #              "75c1fbb3d618dd3a0483bff0e26d0a92b495bbe5059c8b4f1c962b478b6e06e7"),
     DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd snappy*
-git submodule update --init
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/snappy.patch
-export CXXFLAGS="-I${includedir}"
+cd $WORKSPACE/srcdir/snappy*
+atomic_patch -p1 ../patches/snappy.patch
+atomic_patch -p1 ../patches/0001-Fix-compilation-for-older-GCC-and-Clang-versions.patch
 mkdir cmake-build
 cd cmake-build
 cmake \
@@ -29,7 +25,9 @@ cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
     -DSNAPPY_BUILD_BENCHMARKS=OFF \
+    -DSNAPPY_USE_BUNDLED_BENCHMARK_LIB=OFF \
     -DSNAPPY_BUILD_TESTS=OFF \
+    -DSNAPPY_USE_BUNDLED_GTEST=OFF \
     ..
 make -j${nproc}
 make install
@@ -37,7 +35,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [

--- a/S/snappy/bundled/patches/0001-Fix-compilation-for-older-GCC-and-Clang-versions.patch
+++ b/S/snappy/bundled/patches/0001-Fix-compilation-for-older-GCC-and-Clang-versions.patch
@@ -1,0 +1,31 @@
+From 8dd58a519f79f0742d4c68fbccb2aed2ddb651e8 Mon Sep 17 00:00:00 2001
+From: Snappy Team <no-reply@google.com>
+Date: Mon, 24 Jan 2022 09:05:38 +0000
+Subject: [PATCH 1/1] Fix compilation for older GCC and Clang versions.
+
+Not everything defining __GNUC__ supports flag outputs
+from asm statements; in particular, some Clang versions
+on macOS does not. The correct test per the GCC documentation
+is __GCC_ASM_FLAG_OUTPUTS__, so use that instead.
+
+PiperOrigin-RevId: 423749308
+---
+ snappy.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/snappy.cc b/snappy.cc
+index ee9a2c4..30505ad 100644
+--- a/snappy.cc
++++ b/snappy.cc
+@@ -1041,7 +1041,7 @@ size_t AdvanceToNextTagX86Optimized(const uint8_t** ip_p, size_t* tag) {
+   size_t literal_len = *tag >> 2;
+   size_t tag_type = *tag;
+   bool is_literal;
+-#if defined(__GNUC__) && defined(__x86_64__)
++#if defined(__GCC_ASM_FLAG_OUTPUTS__) && defined(__x86_64__)
+   // TODO clang misses the fact that the (c & 3) already correctly
+   // sets the zero flag.
+   asm("and $3, %k[tag_type]\n\t"
+-- 
+2.36.1
+


### PR DESCRIPTION
We need to apply https://github.com/google/snappy/commit/8dd58a519f79f0742d4c68fbccb2aed2ddb651e8 to properly compile the library with GCC.  Ref: https://github.com/JuliaIO/Snappy.jl/issues/32 and https://github.com/JuliaIO/Snappy.jl/pull/35.