### PR TITLE
Bump NEO to v22.25.23529.

### DIFF
--- a/N/NEO/build_tarballs.jl
+++ b/N/NEO/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "NEO"
-version = v"22.17.23034"
+version = v"22.25.23529"
 
 # Collection of sources required to build this package
 sources = [
     GitSource("https://github.com/intel/compute-runtime.git",
-              "e4437fcf54dac9e9c38c7e6ecc4ef4676a634ca2"),
+              "9c18c0247e51b5f2b37ab24bee9ccb3c8eada86a"),
 ]
 
 # Bash recipe for building across all platforms
@@ -74,8 +74,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("gmmlib_jll"; compat="=22.1.2"),
-    Dependency("libigc_jll"; compat="=1.0.11061"),
+    Dependency("gmmlib_jll"; compat="=22.1.3"),
+    Dependency("libigc_jll"; compat="=22.25.23529"),
     Dependency("oneAPI_Level_Zero_Headers_jll", v"1.3.7"; compat="~1.3"),  # XXX: don't specify patch version
 ]
 


### PR DESCRIPTION
Intel's documentation was wrong, mentioning 1.3.7 on the NEO release page while the spec mentions 1.4.0.