### PR TITLE
Bump oneAPI headers API version.

### DIFF
--- a/O/oneAPI_Level_Zero/common.jl
+++ b/O/oneAPI_Level_Zero/common.jl
@@ -1,5 +1,5 @@
 version = v"1.8.1"
-api_version = v"1.3.7"
+api_version = v"1.4.0"
 
 # Collection of sources required to build this package
 #

--- a/O/oneAPI_Level_Zero/oneAPI_Level_Zero_Headers/build_tarballs.jl
+++ b/O/oneAPI_Level_Zero/oneAPI_Level_Zero_Headers/build_tarballs.jl
@@ -27,3 +27,5 @@ products = [
 dependencies = Dependency[]
 
 build_tarballs(ARGS, name, api_version, sources, script, platforms, products, dependencies)
+
+# bump


### PR DESCRIPTION
Intel's documentation was wrong, mentioning 1.3.7 on the NEO release page while the spec mentions 1.4.0.