### PR TITLE
MAGEMin v1.2.0

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "MAGEMin"
-version = v"1.1.1"
+version = v"1.2.0"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "72198b66c94a7026497824b460096d7e034cecca")
+                    "209cb14f95c8be986fe66523a31e04b22bdbecf4")
         ]
 
 # Bash recipe for building across all platforms

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"1.2.0"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "209cb14f95c8be986fe66523a31e04b22bdbecf4")
+                    "d68cd2f80761cca10546b691f0ebc63a2a50be7c")
         ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
We are happy to announce version 1.2.0. This brings a number of changes & improvements:
1. Updated the PGE solver to further improve stability and convergence
2. Added a Linear-Programming "legacy solver" to deal with failing PGE points and provide a slower back-up solution (mainly for water undersaturated cases) when cases do not converge.
3. Extended pseudocompound checks during PGE iterations to further improve convergence to global minimum
4. Added an option to provide bulk-rock composition in "wt fraction"
5. Added outputting of the system composition in "wt fraction" 
6. Corrected a minor biotite memory allocation mistake
7. Updated the documentation which now fully describes the content of the output structure. Added a "Tips and Issues" section to the documentation to report known issues and useful tips