### PR TITLE
[Antic] update to the real v0.2.5

### DIFF
--- a/A/Antic/build_tarballs.jl
+++ b/A/Antic/build_tarballs.jl
@@ -52,7 +52,7 @@ make install LIBDIR=$(basename ${libdir})
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=build_for_julia16_or_newer)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/A/Antic/build_tarballs.jl
+++ b/A/Antic/build_tarballs.jl
@@ -23,15 +23,14 @@ import Pkg.Types: VersionSpec
 
 name = "Antic"
 upstream_version = v"0.2.5"
-build_for_julia16_or_newer = true
-version_offset = build_for_julia16_or_newer ? v"0.0.1" : v"0.0.0"
+version_offset = v"0.1.0"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
                         upstream_version.patch * 100 + version_offset.patch)
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/wbhart/antic.git", "a071e65dd82884b3a048c6436830cea6c6ce59b8"),
+    GitSource("https://github.com/wbhart/antic.git", "cc44b0a5e8fe8d487da725ded5b9d74b897cca03"),
 #    ArchiveSource("https://github.com/wbhart/antic/archive/v$(upstream_version).tar.gz",
 #                  "78a06f67352d7a94905a5399ef0f0add1a34e90fb0c30b8dbdedf8254393e9dd"),
 ]
@@ -61,13 +60,13 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-v = build_for_julia16_or_newer ? v"200.800.101" : v"200.800.100"
+v = v"200.900.000" 
 dependencies = [
     Dependency("FLINT_jll", v; compat = "~$v"),
-    Dependency("GMP_jll", build_for_julia16_or_newer ? v"6.2.0" : v"6.1.2"),
-    Dependency("MPFR_jll", build_for_julia16_or_newer ? v"4.1.1" : v"4.0.2"),
+    Dependency("GMP_jll", v"6.2.0"),
+    Dependency("MPFR_jll", v"4.1.1"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat = build_for_julia16_or_newer ? "1.6" : "1.0-1.5")
+               julia_compat = "1.6")

--- a/A/Antic/build_tarballs.jl
+++ b/A/Antic/build_tarballs.jl
@@ -44,6 +44,7 @@ if [[ ${target} == *musl* ]]; then
 elif [[ ${target} == *mingw* ]]; then
    sed -i -e "s#/lib\>#/$(basename ${libdir})#g" configure
    extraflags=--build=MINGW${nbits};
+   export CFLAGS=-DANTIC_BUILD_DLL
 fi
 ./configure --prefix=$prefix --disable-static --enable-shared --with-gmp=$prefix --with-mpfr=$prefix --with-flint=$prefix ${extraflags}
 make -j${nproc}


### PR DESCRIPTION
The previous version of this file had the upstream erroneously set to 0.2.5 when it was really 0.2.4.
Also, this version of Antic is binary incompatible with the previous, hence I set version_offset = v"0.1.0"