### PR TITLE
Lower compatibility limit for bitshuffle.

### DIFF
--- a/B/bitshuffle/build_tarballs.jl
+++ b/B/bitshuffle/build_tarballs.jl
@@ -33,4 +33,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.3")


### PR DESCRIPTION
The lower limit for Julia compatibility for bitshuffle was set to 1.6, however HDF5.jl (the main user of this library) supports 1.3.