### PR TITLE
openssl: New version 1.1.1q

### DIFF
--- a/O/OpenSSL/build_tarballs.jl
+++ b/O/OpenSSL/build_tarballs.jl
@@ -2,11 +2,11 @@ using BinaryBuilder
 
 # Collection of sources required to build OpenSSL
 name = "OpenSSL"
-version = v"1.1.16"
+version = v"1.1.17"
 
 sources = [
-    ArchiveSource("https://www.openssl.org/source/openssl-1.1.1p.tar.gz",
-                  "bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f"),
+    ArchiveSource("https://www.openssl.org/source/openssl-1.1.1q.tar.gz",
+                  "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This is a security update. It should be backported to older releases of Julia.