### PR TITLE
Create MParT build tarballs

### DIFF
--- a/M/MParT/build_tarballs.jl
+++ b/M/MParT/build_tarballs.jl
@@ -24,7 +24,7 @@ make -j${nprocs} install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> Sys.isunix(p) && nbits(p) == 64, supported_platforms())
+platforms = filter!(p -> !Sys.iswindows(p) && nbits(p) == 64, supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/M/MParT/build_tarballs.jl
+++ b/M/MParT/build_tarballs.jl
@@ -34,7 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="Kokkos_jll", uuid="c1216c3d-6bb3-5a2b-bbbf-529b35eba709"); compat="^1.6.0")
+    Dependency(PackageSpec(name="Kokkos_jll", uuid="c1216c3d-6bb3-5a2b-bbbf-529b35eba709"); compat="=3.6.0")
     Dependency(PackageSpec(name="Eigen_jll", uuid="bc6bbf8a-a594-5541-9c57-10b0d0312c70"))
 ]
 

--- a/M/MParT/build_tarballs.jl
+++ b/M/MParT/build_tarballs.jl
@@ -14,7 +14,11 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 mkdir MParT/build && cd MParT/build
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DMPART_BUILD_TESTS=OFF -DMPART_PYTHON=OFF ..
+cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DMPART_BUILD_TESTS=OFF \
+  -DMPART_PYTHON=OFF ..
 make -j${nprocs} install
 """
 

--- a/M/MParT/build_tarballs.jl
+++ b/M/MParT/build_tarballs.jl
@@ -14,6 +14,11 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 mkdir MParT/build && cd MParT/build
+
+if [[ "${target}" == *-freebsd* ]]; then
+    export LDFLAGS="-lexecinfo"
+fi
+
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
   -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
   -DCMAKE_BUILD_TYPE=Release \

--- a/M/MParT/build_tarballs.jl
+++ b/M/MParT/build_tarballs.jl
@@ -24,15 +24,7 @@ make -j${nprocs} install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("aarch64", "linux"; libc = "glibc"),
-    Platform("powerpc64le", "linux"; libc = "glibc"),
-    Platform("x86_64", "linux"; libc = "musl"),
-    Platform("aarch64", "linux"; libc = "musl"),
-    Platform("x86_64", "macos"; ),
-    Platform("aarch64", "macos"; )
-]
+platforms = filter!(p -> Sys.isunix(p) && nbits(p) == 64, supported_platforms())
 
 
 # The products that we will ensure are always built
@@ -42,7 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="Kokkos_jll", uuid="c1216c3d-6bb3-5a2b-bbbf-529b35eba709"))
+    Dependency(PackageSpec(name="Kokkos_jll", uuid="c1216c3d-6bb3-5a2b-bbbf-529b35eba709"); compat="^1.6.0")
     Dependency(PackageSpec(name="Eigen_jll", uuid="bc6bbf8a-a594-5541-9c57-10b0d0312c70"))
 ]
 

--- a/M/build_tarballs.jl
+++ b/M/build_tarballs.jl
@@ -1,0 +1,47 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "MParT"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/MeasureTransport/MParT.git", "64e4b8ee7637382ab7f9aa091ace41ed6a5cbcc6")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mkdir MParT/build && cd MParT/build
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DMPART_BUILD_TESTS=OFF -DMPART_PYTHON=OFF ..
+make -j${nprocs} install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("powerpc64le", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "musl"),
+    Platform("aarch64", "linux"; libc = "musl"),
+    Platform("x86_64", "macos"; ),
+    Platform("aarch64", "macos"; )
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libmpart", :libmpart)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="Kokkos_jll", uuid="c1216c3d-6bb3-5a2b-bbbf-529b35eba709"))
+    Dependency(PackageSpec(name="Eigen_jll", uuid="bc6bbf8a-a594-5541-9c57-10b0d0312c70"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"8.1.0")
+


### PR DESCRIPTION
Adds a `build_tarballs.jl` for the [MParT repository](https://github.com/MeasureTransport/MParT).