### PR TITLE
[LibSSH2] Fix import lib name on windows

### DIFF
--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -18,6 +18,9 @@ cd $WORKSPACE/srcdir/libssh2*/
 
 # Apply patch to fix v1.10.0 CVE (https://github.com/libssh2/libssh2/issues/649), drop with v1.11
 atomic_patch -p1 ../patches/0001-userauth-check-for-too-large-userauth_kybd_auth_name.patch
+# Fix import lib name on windows: `liblibssh2.dll.a` ==> `libssh2.dll.a`
+# Drop this when a new release contains: https://github.com/libssh2/libssh2/pull/711
+atomic_patch -p1 ../patches/0002-libssh2-fix-import-lib-name.patch
 
 BUILD_FLAGS=(
     -DCMAKE_BUILD_TYPE=Release

--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -38,11 +38,6 @@ mkdir build && cd build
 cmake .. "${BUILD_FLAGS[@]}"
 make -j${nproc}
 make install
-
-# copy import lib `libssh2.dll.a` => `liblibssh2.dll.a` to maintain backwards compatibility
-if [[ ${target} == *-mingw* ]]; then
-    install -Dvm 0755 "src/libssh2.dll.a" "${prefix}/lib/liblibssh2.dll.a"
-fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -38,6 +38,11 @@ mkdir build && cd build
 cmake .. "${BUILD_FLAGS[@]}"
 make -j${nproc}
 make install
+
+# copy import lib `libssh2.dll.a` => `liblibssh2.dll.a` to maintain backwards compatibility
+if [[ ${target} == *-mingw* ]]; then
+    install -Dvm 0755 "src/libssh2.dll.a" "${prefix}/lib/liblibssh2.dll.a"
+fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/L/LibSSH2/bundled/patches/0002-libssh2-fix-import-lib-name.patch
+++ b/L/LibSSH2/bundled/patches/0002-libssh2-fix-import-lib-name.patch
@@ -1,0 +1,25 @@
+From 3732420725efbf410df5863b91a09ca214ee18ba Mon Sep 17 00:00:00 2001
+From: "Y. Yang" <metab0t@users.noreply.github.com>
+Date: Thu, 16 Jun 2022 19:16:37 +0800
+Subject: [PATCH] Fix DLL import library name
+
+https://aur.archlinux.org/packages/mingw-w64-libssh2
+https://cmake.org/cmake/help/latest/prop_tgt/IMPORT_PREFIX.html
+---
+ src/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index cb8fee1..17ecefd 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -220,6 +220,7 @@ endif()
+ add_library(libssh2 ${SOURCES})
+ # we want it to be called libssh2 on all platforms
+ set_target_properties(libssh2 PROPERTIES PREFIX "")
++set_target_properties(libssh2 PROPERTIES IMPORT_PREFIX "")
+
+ target_compile_definitions(libssh2 PRIVATE ${PRIVATE_COMPILE_DEFINITIONS})
+ target_include_directories(libssh2
+-- 
+2.36.1


### PR DESCRIPTION
`liblibssh2.dll.a` ==> `libssh2.dll.a`
xref: JuliaLang/julia#45914

Do we need to inc version number to v"1.10.3"?