### PR TITLE
[libpolymake-julia] update to 0.8.1 for polymake 4.7

### DIFF
--- a/L/libpolymake_julia/build_tarballs.jl
+++ b/L/libpolymake_julia/build_tarballs.jl
@@ -10,7 +10,7 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "libpolymake_julia"
-version = v"0.8.0"
+version = v"0.8.1"
 
 # reminder: change the above version if restricting the supported julia versions
 julia_versions = [v"1.6.3", v"1.7.0", v"1.8.0", v"1.9.0"]
@@ -19,7 +19,7 @@ julia_compat = join("~" .* string.(getfield.(julia_versions, :major)) .* "." .* 
 # Collection of sources required to build libpolymake_julia
 sources = [
     ArchiveSource("https://github.com/oscar-system/libpolymake-julia/archive/v$(version).tar.gz",
-                  "da459c1fc819a446cfa683cc8e6e890a54194b7a943ac8d62c4c71061512dbee"),
+                  "cd905d195a0e371408274462fef7e8c7e3351850155ae2976dd3e335e40baf5c"),
 ]
 
 # Bash recipe for building across all platforms
@@ -48,7 +48,7 @@ $host_bindir/perl $host_bindir/polymake --iscript libpolymake-j*/src/polymake/ap
 include("../../L/libjulia/common.jl")
 
 platforms = vcat(libjulia_platforms.(julia_versions)...)
-filter!(p -> !Sys.iswindows(p) && arch(p) != "armv6l", platforms)
+filter!(p -> !Sys.iswindows(p) && nbits(p) > 32, platforms)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
@@ -64,14 +64,14 @@ dependencies = [
     BuildDependency("GMP_jll"),
     BuildDependency("MPFR_jll"),
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("FLINT_jll", compat = "~200.800.401"),
+    Dependency("FLINT_jll", compat = "~200.900.000"),
     Dependency("TOPCOM_jll"),
     Dependency("lib4ti2_jll"),
     Dependency("libcxxwrap_julia_jll"),
-    Dependency("polymake_jll"; compat = "~400.600.0"),
+    Dependency("polymake_jll"; compat = "~400.700.0"),
 
     HostBuildDependency(PackageSpec(name="Perl_jll", version=v"5.34.0")),
-    HostBuildDependency(PackageSpec(name="polymake_jll", version=v"400.600.0")),
+    HostBuildDependency(PackageSpec(name="polymake_jll", version=v"400.700.0")),
     HostBuildDependency("lib4ti2_jll"),
     HostBuildDependency("TOPCOM_jll"),
 ]


### PR DESCRIPTION
update flint to 2.9
drop support for 32bit platforms