### PR TITLE
PTSCOTCH: Require MPItrampoline 5, and build with OpenMPI as well

### DIFF
--- a/P/PTSCOTCH/build_tarballs.jl
+++ b/P/PTSCOTCH/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "PTSCOTCH"
-version = v"6.1.4"
+version = v"6.1.5"
 ptscotch_version = v"6.1.3"
 scotch_jll_version = v"6.1.3"
 

--- a/P/PTSCOTCH/build_tarballs.jl
+++ b/P/PTSCOTCH/build_tarballs.jl
@@ -49,9 +49,6 @@ platforms = supported_platforms(; exclude=Sys.iswindows)
 
 platforms, platform_dependencies = MPI.augment_platforms(platforms)
 
-# There is a build error with OpenMPI (this could probably be circumvented)
-platforms = filter(p -> p["mpi"] ≠ "openmpi", platforms)
-
 # Avoid platforms where the MPI implementation isn't supported
 # OpenMPI
 platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)


### PR DESCRIPTION
It's easy if cmake auto-detects OpenMPI.