### PR TITLE
LLD_jll: Add compat builds for 12 and 13

### DIFF
--- a/L/LLVM/LLD@12.0.1/build_tarballs.jl
+++ b/L/LLVM/LLD@12.0.1/build_tarballs.jl
@@ -1,0 +1,39 @@
+name = "LLD"
+llvm_full_version = v"12.0.1+4"
+libllvm_version = v"12.0.1+4"
+
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
+
+const YGGDRASIL_DIR = "../../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
+# Include common tools.
+include("../common.jl")
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+    $(LLVM.augment)
+    function augment_platform!(platform::Platform)
+        augment_llvm!(platform)
+    end"""
+
+# determine exactly which tarballs we should build
+builds = []
+for llvm_assertions in (false, true)
+    push!(builds, configure_extraction(ARGS, llvm_full_version, name, libllvm_version; assert=llvm_assertions, augmentation=true))
+end
+
+# don't allow `build_tarballs` to override platform selection based on ARGS.
+# we handle that ourselves by calling `should_build_platform`
+non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
+
+# `--register` should only be passed to the latest `build_tarballs` invocation
+non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
+
+for (i, build) in enumerate(builds)
+    build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
+                   build...;
+                   skip_audit=true, julia_compat="1.7",
+                   augment_platform_block)
+end

--- a/L/LLVM/LLD@13.0.1/build_tarballs.jl
+++ b/L/LLVM/LLD@13.0.1/build_tarballs.jl
@@ -1,0 +1,39 @@
+name = "LLD"
+llvm_full_version = v"13.0.1+3"
+libllvm_version = v"13.0.1+3"
+
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
+
+const YGGDRASIL_DIR = "../../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
+# Include common tools.
+include("../common.jl")
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+    $(LLVM.augment)
+    function augment_platform!(platform::Platform)
+        augment_llvm!(platform)
+    end"""
+
+# determine exactly which tarballs we should build
+builds = []
+for llvm_assertions in (false, true)
+    push!(builds, configure_extraction(ARGS, llvm_full_version, name, libllvm_version; assert=llvm_assertions, augmentation=true))
+end
+
+# don't allow `build_tarballs` to override platform selection based on ARGS.
+# we handle that ourselves by calling `should_build_platform`
+non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
+
+# `--register` should only be passed to the latest `build_tarballs` invocation
+non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
+
+for (i, build) in enumerate(builds)
+    build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
+                   build...;
+                   skip_audit=true, julia_compat="1.8",
+                   augment_platform_block)
+end

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -379,6 +379,9 @@ else
     mv -v ${LLVM_ARTIFACT_DIR}/tools/*lld* ${prefix}/tools/
     mv -v ${LLVM_ARTIFACT_DIR}/tools/wasm-ld* ${prefix}/tools/
 fi
+if [ -f ${LLVM_ARTIFACT_DIR}/bin/lld* ]; then
+    mv -v ${LLVM_ARTIFACT_DIR}/bin/lld* ${prefix}/tools/
+fi
 # mv -v ${LLVM_ARTIFACT_DIR}/$(basename ${libdir})/liblld*.${dlext}* ${libdir}/
 mv -v ${LLVM_ARTIFACT_DIR}/lib/liblld*.a ${prefix}/lib
 install_license ${LLVM_ARTIFACT_DIR}/share/licenses/LLVM_full*/*


### PR DESCRIPTION
Since LLD_jll only supports LLVM 14 and Julia 1.9, it's not possible to depend on it and also support Julia 1.7/1.8. The intent of these builders (which don't currently work) is to re-export `lld` and friends from LLVM_jll.