### PR TITLE
Specify PYTHONHOME during loading of Python_jll.

### DIFF
--- a/P/Python/build_tarballs.jl
+++ b/P/Python/build_tarballs.jl
@@ -70,6 +70,10 @@ filter!(p -> arch(p) != "armv6l" && !(Sys.isapple(p) && arch(p) == "aarch64"), p
 # https://github.com/msys2/MINGW-packages/tree/1e753359d9b55a46d9868c3e4a31ad674bf43596/mingw-w64-python3
 filter!(!Sys.iswindows, platforms)
 
+# Disable macOS M1 for now, python 3.8.3 is not compatible with it (and upgrading to 3.8.3
+# involves configure-script changes that seem incompatible with out BB set-up)
+filter!(isequal(Platform("aarch64", "macos")), platforms)
+
 # The products that we will ensure are always built
 products = Product[
     ExecutableProduct(["python", "python3"], :python),

--- a/P/Python/build_tarballs.jl
+++ b/P/Python/build_tarballs.jl
@@ -88,5 +88,10 @@ dependencies = [
     Dependency("OpenSSL_jll"),
 ]
 
+init_block = raw"""
+ENV["PYTHONHOME"] = artifact_dir
+"""
+
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               init_block)


### PR DESCRIPTION
Normally this should already be detected properly:

```
julia> using Python_jll

julia> run(Python_jll.python())
Python 3.8.1 (default, Aug  8 2021, 21:34:14)
[GCC 4.8.5] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.base_exec_prefix
'/home/tim/Julia/depot/artifacts/4dcd8a52e092c1e82cef8e0c0ed138b30c4cd17b'
```

However, when using Python via `libpython`, that doesn't seem to be the case:

```
julia> using GDB_jll # (WIP, with Python integration)

julia> run(GDB_jll.gdb())
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
```

Explicitly setting `PYTHONHOME` (to the same value it should have been autodetected) fixes this.