### PR TITLE
Add Python support to GDB_jll.

### DIFF
--- a/G/GDB/build_tarballs.jl
+++ b/G/GDB/build_tarballs.jl
@@ -15,7 +15,13 @@ sources = [
 script = raw"""
 apk add texinfo
 cd $WORKSPACE/srcdir/gdb-10.1/
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-expat --with-python=${WORKSPACE}/srcdir/python-cross-configure.sh
+CONFIGURE_FLAGS=(--prefix=${prefix} --build=${MACHTYPE} --host=${target})
+CONFIGURE_FLAGS+=(--with-expat)
+if [[ ${target} != *mingw* ]]; then
+    # Python_jll is not yet available for Windows
+    CONFIGURE_FLAGS+=(--with-python=${WORKSPACE}/srcdir/python-cross-configure.sh)
+fi
+./configure ${CONFIGURE_FLAGS[@]}
 make -j${nproc} all
 make install
 """

--- a/G/GDB/build_tarballs.jl
+++ b/G/GDB/build_tarballs.jl
@@ -3,19 +3,19 @@
 using BinaryBuilder, Pkg
 
 name = "GDB"
-version = v"10.1.0"
+version = v"12.1"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://ftp.gnu.org/gnu/gdb/gdb-10.1.tar.xz",
-                  "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"),
+    ArchiveSource("https://ftp.gnu.org/gnu/gdb/gdb-$(version.major).$(version.minor).tar.xz",
+                  "0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed"),
     DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 apk add texinfo
-cd $WORKSPACE/srcdir/gdb-10.1/
+cd $WORKSPACE/srcdir/gdb-*/
 CONFIGURE_FLAGS=(--prefix=${prefix} --build=${MACHTYPE} --host=${target})
 CONFIGURE_FLAGS+=(--with-expat)
 if [[ ${target} != *mingw* ]]; then

--- a/G/GDB/build_tarballs.jl
+++ b/G/GDB/build_tarballs.jl
@@ -7,14 +7,15 @@ version = v"10.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://ftp.gnu.org/gnu/gdb/gdb-10.1.tar.xz", "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0")
+    ArchiveSource("https://ftp.gnu.org/gnu/gdb/gdb-10.1.tar.xz", "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 apk add texinfo
 cd $WORKSPACE/srcdir/gdb-10.1/
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-expat
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --with-expat --with-python=${WORKSPACE}/srcdir/python-cross-configure.sh
 make -j${nproc} all
 make install
 """
@@ -42,6 +43,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d")),
     Dependency("Expat_jll"),
+    Dependency("Python_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GDB/build_tarballs.jl
+++ b/G/GDB/build_tarballs.jl
@@ -7,7 +7,8 @@ version = v"10.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://ftp.gnu.org/gnu/gdb/gdb-10.1.tar.xz", "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"),
+    ArchiveSource("https://ftp.gnu.org/gnu/gdb/gdb-10.1.tar.xz",
+                  "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"),
     DirectorySource("./bundled")
 ]
 
@@ -49,8 +50,9 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d")),
     Dependency("Expat_jll"),
-    Dependency("Python_jll"),
+    Dependency("Python_jll"; compat="~3.8.8"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8.1.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version = v"8.1.0")

--- a/G/GDB/bundled/python-cross-configure.sh
+++ b/G/GDB/bundled/python-cross-configure.sh
@@ -1,0 +1,26 @@
+#!/bin/sh -ue
+#
+# script that spoofs the python configuration parameters that GDB would normally get from
+# running `python gdb/python/python-config.py`. The values are taken from actually running
+# this script in a container where host == target:
+# $ PYTHONHOME=$prefix $prefix/bin/python3 gdb/python/python-config.py
+
+python=$1
+flag=$2
+
+if [[ $flag == "--prefix" ]]; then
+    echo "$prefix"
+elif [[ $flag == "--exec-prefix" ]]; then
+    echo "$prefix"
+elif [[ $flag == "--includes" ]]; then
+    echo "-I$prefix/include/python3.8"
+elif [[ $flag == "--libs" ]]; then
+    echo "-lpython3.8 -lcrypt -lpthread -ldl -lpthread -lutil -lrt -lm -lm"
+elif [[ $flag == "--cflags" ]]; then
+    echo "-I$prefix/include/python3.8 -I$prefix/include/python3.8 -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall"
+elif [[ $flag == "--ldflags" ]]; then
+    echo "-lpython3.8 -lcrypt -lpthread -ldl -lpthread -lutil -lrt -lm -lm -Xlinker -export-dynamic"
+else
+    echo "Unknown flag: $flag"
+    exit 1
+fi


### PR DESCRIPTION
Our current GDB build doesn't ship python scripting support:

```
julia> using GDB_jll

julia> run(GDB_jll.gdb())
GNU gdb (GDB) 10.1

(gdb) python
>Scripting in the "Python" language is not supported in this copy of GDB.
```

Since I'm working on making BugReporting.jl use GDB_jll for its use of rr, which depends on [quite a bit](https://github.com/rr-debugger/rr/blob/329cbf86a763497fd085f38d59309bddcf031230/src/GdbCommandHandler.cc#L34-L177=) Python functionality to augment GDB, I'd like to add Python support and a Python_jll dep to our GDB_jll build.

Depends on https://github.com/JuliaPackaging/Yggdrasil/pull/5187.