### PR TITLE
[polymake] fixup: remove openmp flag from config for compiling at runtime on macos

### DIFF
--- a/P/polymake/build_tarballs.jl
+++ b/P/polymake/build_tarballs.jl
@@ -116,6 +116,12 @@ sed -e "s#${prefix}#\${prefix}#g" ${libdir}/polymake/config.ninja > ${libdir}/po
 sed -i -e "s|^#!.*perl|#!/usr/bin/env perl|g" ${bindir}/polymake*
 sed -i -e "s#^PERL = .*#PERL = /usr/bin/env perl#g" ${libdir}/polymake/config*
 
+# the real apple compilers don't support -fopenmp
+# so we need to remove this for compiling wrappers at runtime ...
+if [[ $target == *apple* ]]; then
+  sed -i -e "s#-fopenmp##g" ${libdir}/polymake/config-reloc.ninja
+fi
+
 # cleanup symlink tree
 rm -rf ${prefix}/deps
 


### PR DESCRIPTION
The last update enabling OpenMP for more polymake platforms did unfortunately break some specific Oscar.jl tests because Apple disabled openmp support in their compilers (why?) and the `-fopenmp` flag from the config is not accepted at runtime (polymake does need to compile some C++ template instantiations at runtime).

So we remove this flag from the installed config file at the end.

@giordano a quick merge would be appreciated, thanks!