### PR TITLE
mpi.jl: Require version 5 of MPItrampoline

### DIFF
--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -47,7 +47,7 @@ mpi_abis = (
     ("MPICH", PackageSpec(name="MPICH_jll"), "", !Sys.iswindows) ,
     ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "", !Sys.iswindows),
     ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),
-    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "", !Sys.iswindows)
+    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5", !Sys.iswindows)
 )
 
 function augment_platforms(platforms)


### PR DESCRIPTION
This avoids the wrong SOVERSIONs in earlier versions of MPItrampoline.