### PR TITLE
Bump Python_jll's Bzip2 dependency.

### DIFF
--- a/P/Python/build_tarballs.jl
+++ b/P/Python/build_tarballs.jl
@@ -85,9 +85,9 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Expat_jll", v"2.2.7"; compat="2.2.7"),
-    Dependency("Bzip2_jll", v"1.0.8"; compat="1.0.8"),
-    Dependency("Libffi_jll", v"3.2.1"; compat="~3.2.1"),
+    Dependency("Expat_jll"; compat="2.2.10"),
+    Dependency("Bzip2_jll"; compat="1.0.8"),
+    Dependency("Libffi_jll"; compat="~3.2.2"),
     Dependency("Zlib_jll"),
     Dependency("XZ_jll"),
     Dependency("OpenSSL_jll"),

--- a/P/Python/build_tarballs.jl
+++ b/P/Python/build_tarballs.jl
@@ -86,9 +86,7 @@ products = Product[
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Expat_jll", v"2.2.7"; compat="2.2.7"),
-    # Future versions of bzip2 should allow a more relaxed compat because the
-    # soname of the macOS library shouldn't change at every patch release.
-    Dependency("Bzip2_jll", v"1.0.6"; compat="=1.0.6"),
+    Dependency("Bzip2_jll", v"1.0.8"; compat="1.0.8"),
     Dependency("Libffi_jll", v"3.2.1"; compat="~3.2.1"),
     Dependency("Zlib_jll"),
     Dependency("XZ_jll"),


### PR DESCRIPTION
Starting with Bzip2_jll 1.0.8, macOS has a stable SONAME.
Ref https://github.com/JuliaPackaging/Yggdrasil/pull/2981