### PR TITLE
LAMMPS: Require MPItrampoline 5

### DIFF
--- a/L/LAMMPS/build_tarballs.jl
+++ b/L/LAMMPS/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "LAMMPS"
-version = v"2.2.2" # Equivalent to 29Sep2021_update2
+version = v"2.2.3" # Equivalent to 29Sep2021_update2
 
 # Version table
 # 1.0.0 -> https://github.com/lammps/lammps/releases/tag/stable_29Oct2020
@@ -50,26 +50,24 @@ fi
 augment_platform_block = """
     using Base.BinaryPlatforms
     $(MPI.augment)
-    function augment_platform!(platform::Platform)
-        augment_mpi!(platform)
-    end
+    augment_platform!(platform::Platform) = augment_mpi!(platform)
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 # platforms = supported_platforms(; experimental=true)
 platforms = supported_platforms()
-platforms = filter(p -> !(Sys.isfreebsd(p) || libc(p) == "musl"), platforms)
-
-# We need this since currently MPItrampoline_jll has a dependency on gfortran
-platforms = expand_gfortran_versions(platforms)
-# libgfortran3 does not support `!GCC$ ATTRIBUTES NO_ARG_CHECK`. (We
-# could in principle build without Fortran support there.)
-platforms = filter(p -> libgfortran_version(p) ≠ v"3", platforms)
-# Compiler failure
-filter!(p -> !(Sys.islinux(p) && arch(p) == "aarch64" && libc(p) =="glibc" && libgfortran_version(p) == v"4") , platforms)
-
 platforms = expand_cxxstring_abis(platforms)
+
+platforms, platform_dependencies = MPI.augment_platforms(platforms)
+# Avoid platforms where the MPI implementation isn't supported
+# OpenMPI
+platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)
+# MPItrampoline
+platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)
+platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
+
+platforms = filter(p -> !(Sys.isfreebsd(p) || libc(p) == "musl"), platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -81,14 +79,8 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll")),
 ]
-
-all_platforms, platform_dependencies = MPI.augment_platforms(platforms)
 append!(dependencies, platform_dependencies)
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, all_platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"8",
-               augment_platform_block)
-
-# bump
-
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               augment_platform_block, julia_compat="1.6", preferred_gcc_version=v"8")


### PR DESCRIPTION
- Don't expand gfortran versions
- Build with libgfortran3 as well
- Avoid platforms where the MPI implementation doesn't exist