### PR TITLE
[SBML] FbcModelPlugin missing functions patch

### DIFF
--- a/S/SBML/build_tarballs.jl
+++ b/S/SBML/build_tarballs.jl
@@ -7,10 +7,14 @@ sources = [
     ArchiveSource(
         "https://github.com/sbmlteam/libsbml/archive/v$(version).tar.gz",
         "77990b0f7b7419269061fbe671540c10f87f52bf8a8568953675ee615584efa6"),
+    DirectorySource("./bundled"),
 ]
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/libsbml-*
+
+# https://github.com/sbmlteam/libsbml/pull/252
+atomic_patch -p1 ../patches/0001-FbcModelPlugin-C-API-for-createObjective-and-createG.patch
 
 mkdir build
 cd build

--- a/S/SBML/bundled/patches/0001-FbcModelPlugin-C-API-for-createObjective-and-createG.patch
+++ b/S/SBML/bundled/patches/0001-FbcModelPlugin-C-API-for-createObjective-and-createG.patch
@@ -1,0 +1,102 @@
+From 8dd8654d6661c376251008c76694f5f34ca9b6e4 Mon Sep 17 00:00:00 2001
+From: Mirek Kratochvil <miroslav.kratochvil@uni.lu>
+Date: Mon, 18 Jul 2022 14:32:37 +0200
+Subject: [PATCH] FbcModelPlugin C API for createObjective and
+ createGeneProduct
+
+---
+ .../packages/fbc/extension/FbcModelPlugin.cpp | 16 +++++++++
+ .../packages/fbc/extension/FbcModelPlugin.h   | 36 +++++++++++++++++++
+ 2 files changed, 52 insertions(+)
+
+diff --git a/src/sbml/packages/fbc/extension/FbcModelPlugin.cpp b/src/sbml/packages/fbc/extension/FbcModelPlugin.cpp
+index ce957abee..1f660e1d4 100644
+--- a/src/sbml/packages/fbc/extension/FbcModelPlugin.cpp
++++ b/src/sbml/packages/fbc/extension/FbcModelPlugin.cpp
+@@ -2546,6 +2546,14 @@ FbcModelPlugin_getNumFluxBounds(SBasePlugin_t * fbc)
+ }
+ 
+ 
++LIBSBML_EXTERN
++Objective_t*
++FbcModelPlugin_createObjective(SBasePlugin_t * fbc)
++{
++  return static_cast<FbcModelPlugin*>(fbc)->createObjective();
++}
++
++
+ LIBSBML_EXTERN
+ int
+ FbcModelPlugin_addObjective(SBasePlugin_t * fbc, Objective_t * obj)
+@@ -2596,6 +2604,14 @@ FbcModelPlugin_setActiveObjectiveId(SBasePlugin_t * fbc, const char * activeId)
+ }
+ 
+ 
++LIBSBML_EXTERN
++GeneProduct_t*
++FbcModelPlugin_createGeneProduct(SBasePlugin_t * fbc)
++{
++  return static_cast<FbcModelPlugin*>(fbc)->createGeneProduct();
++}
++
++
+ LIBSBML_EXTERN
+ int
+ FbcModelPlugin_addGeneProduct(SBasePlugin_t * fbc, GeneProduct_t * fb)
+diff --git a/src/sbml/packages/fbc/extension/FbcModelPlugin.h b/src/sbml/packages/fbc/extension/FbcModelPlugin.h
+index 13e24aef6..3536e782f 100644
+--- a/src/sbml/packages/fbc/extension/FbcModelPlugin.h
++++ b/src/sbml/packages/fbc/extension/FbcModelPlugin.h
+@@ -1843,6 +1843,24 @@ unsigned int
+ FbcModelPlugin_getNumFluxBounds(SBasePlugin_t * fmp);
+ 
+ 
++/**
++ * Creates a new Objective_t object, adds it to this FbcModelPlugin_t object
++ * and returns the created object.
++ *
++ * @param fmp the FbcModelPlugin_t structure to which the
++ * Objective_t should be added.
++ *
++ * @return a new Objective_t object instance.
++ *
++ * @copydetails doc_returned_unowned_pointer
++ *
++ * @memberof FbcModelPlugin_t
++ */
++LIBSBML_EXTERN
++Objective_t*
++FbcModelPlugin_createObjective(SBasePlugin_t * fmp);
++
++
+ /**
+  * Appends a copy of the given Objective_t structure to the given FbcModelPlugin_t
+  * structure.
+@@ -1932,6 +1950,24 @@ int
+ FbcModelPlugin_setActiveObjectiveId(SBasePlugin_t * fmp, const char * activeObjective);
+ 
+ 
++/**
++ * Creates a new GeneProduct_t object, adds it to this FbcModelPlugin_t object
++ * and returns the created object.
++ *
++ * @param fmp the FbcModelPlugin_t structure to which the
++ * GeneProduct_t should be added.
++ *
++ * @return a new GeneProduct_t object instance.
++ *
++ * @copydetails doc_returned_unowned_pointer
++ *
++ * @memberof FbcModelPlugin_t
++ */
++LIBSBML_EXTERN
++GeneProduct_t*
++FbcModelPlugin_createGeneProduct(SBasePlugin_t * fmp);
++
++
+ /**
+  * Appends a copy of the given GeneProduct_t structure to the given FbcModelPlugin_t
+  * structure.
+-- 
+2.35.1
+


### PR DESCRIPTION
This adds code from https://github.com/sbmlteam/libsbml/pull/252 to allow
development and deployment before upstream merges and releases the patched
version.