### PR TITLE
iso_codes v4.10.0

### DIFF
--- a/I/iso_codes/build_tarballs.jl
+++ b/I/iso_codes/build_tarballs.jl
@@ -3,17 +3,29 @@
 using BinaryBuilder
 
 name = "iso_codes"
-version = v"4.3"
+version = v"4.10.0"
+
+# the git tag used for versioning has changed format
+if version < v"4.8"
+    if version < v"4.5" && version.patch == 0
+        tag = "iso-codes-$(version.major).$(version.minor)"
+    else
+        tag = "iso-codes-$version"
+    end
+else
+    tag = "v$version"
+end
 
 # Collection of sources required to build iso-codes
 sources = [
-    ArchiveSource("https://salsa.debian.org/iso-codes-team/iso-codes/-/archive/iso-codes-$(version.major).$(version.minor)/iso-codes-iso-codes-$(version.major).$(version.minor).tar.bz2",
-                  "6b539f915d02c957c45fce8133670811f1c36a1f1535d5af3dd95dc519d3c386"),
+    ArchiveSource("https://salsa.debian.org/iso-codes-team/iso-codes/-/archive/$tag/iso-codes-$tag.tar.bz2",
+                  "a33140be9915330d8826783bcda8d4120f02c301c16af6df9a15a8bc657cfb3d"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/iso-codes-*/
+apk update
 apk add gettext
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}


### PR DESCRIPTION
Updating the build for `iso_codes` version 4.10. This required:
- Accounting for the change in format of the git tag used on released versions.
- Adding `apk update` because it could not find `libxml2` otherwise.

Here is the full output if you miss out `apk update`:
```
[ Info: Building for any
[ Info: Downloading https://salsa.debian.org/iso-codes-team/iso-codes/-/archive/iso-codes-4.3/iso-codes-iso-codes-4.3.tar.bz2 to /home/cjdoris/.julia/packages/BinaryBuilderBase/TwlYI/deps/downloads/6b539f915d02c957c45fce8133670811f1c36a1f1535d5af3dd95dc519d3c386-iso-codes-iso-codes-4.3.tar.bz2...
  Downloaded artifact: Rootfs.v2022.4.15.x86_64-linux-musl.unpacked
 Downloading artifact: Rootfs.v2022.4.15.x86_64-linux-musl.unpacked
[ Info: No hash cache found
[ Info: Calculated hash 2f6e972cf3b15c2f7c84fb1fb5799f0b44190f38976d70b77a347e1015432b9c for file /tmp/jl_vVAJk8-download.gz
  Downloaded artifact: Rootfs.v2022.4.15.x86_64-linux-musl.unpacked
┌ Warning: Unable to run unprivileged containers on this system! This may be because your kernel does not support mounting overlay filesystems within user namespaces. To work around this, we will switch to using privileged containers. This requires the use of sudo. To choose this automatically, set the BINARYBUILDER_RUNNER environment variable to "privileged" before starting Julia.
└ @ BinaryBuilderBase ~/.julia/packages/BinaryBuilderBase/TwlYI/src/UserNSRunner.jl:97
[ Info: Running privileged container via `sudo`, may ask for your password:
 Downloading artifact: GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.unpacked
  Downloaded artifact: GCCBootstrap-x86_64-linux-musl.v5.2.0.x86_64-linux-musl.unpacked
 Downloading artifact: LLVMBootstrap.v13.0.1.x86_64-linux-musl.unpacked
  Downloaded artifact: LLVMBootstrap.v13.0.1.x86_64-linux-musl.unpacked
[sudo] password for cjdoris:
(1/4) Installing libgomp (10.3.1_git20211027-r0)
(2/4) Installing gettext-libs (0.21-r0)
(3/4) Installing libxml2 (2.9.13-r0)
ERROR: libxml2-2.9.13-r0: package mentioned in index not found (try 'apk update')
(4/4) Installing gettext (0.21-r0)
Executing busybox-1.34.1-r3.trigger
1 error; 288 MiB in 120 packages
Previous command exited with 1
ERROR: LoadError: Build for iso_codes on any did not complete successfully

Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] autobuild(dir::AbstractString, src_name::AbstractString, src_version::VersionNumber, sources::Vector{<:BinaryBuilderBase.AbstractSource}, script::AbstractString, platforms::Vector, products::Vector{<:Product}, dependencies::Vector{<:BinaryBuilderBase.AbstractDependency}; verbose::Bool, debug::Bool, skip_audit::Bool, ignore_audit_errors::Bool, autofix::Bool, code_dir::Union{Nothing, String}, require_license::Bool, kwargs::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}})
   @ BinaryBuilder ~/.julia/packages/BinaryBuilder/wohhx/src/AutoBuild.jl:872
 [3] build_tarballs(ARGS::Any, src_name::Any, src_version::Any, sources::Any, script::Any, platforms::Any, products::Any, dependencies::Any; julia_compat::String, kwargs::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}})
   @ BinaryBuilder ~/.julia/packages/BinaryBuilder/wohhx/src/AutoBuild.jl:344
 [4] build_tarballs(ARGS::Any, src_name::Any, src_version::Any, sources::Any, script::Any, platforms::Any, products::Any, dependencies::Any)
   @ BinaryBuilder ~/.julia/packages/BinaryBuilder/wohhx/src/AutoBuild.jl:175
 [5] top-level scope
   @ /mnt/c/Users/chris/dev/Yggdrasil/I/iso_codes/build_tarballs.jl:37
in expression starting at /mnt/c/Users/chris/dev/Yggdrasil/I/iso_codes/build_tarballs.jl:37
```