### PR TITLE
[HDF5] redistribute 1.12.2

### DIFF
--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -10,7 +10,7 @@ sources = [
     ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-libaec-1.0.6-2-any.pkg.tar.zst", "c6cff1a6f8a9f75e986589d8debc35e8076a7af38aa32cbda78bb6c2fbbbe58c"; unpack_target="i686-w64-mingw32"),
     ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-zlib-1.2.12-1-any.pkg.tar.zst", "74ace327d8e28cdb0c777fffc6003f5097836c247be40cf3b483bd9fd1c23183"; unpack_target="i686-w64-mingw32"),
     # We need some special compiler support libraries from mingw for i686 (libgcc_s_dw2)
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-libs-12.1.0-3-any.pkg.tar.zst", "dbf02e2b0569677879597f404ed2c15bb1d2998c2d19412b1ac33afd104d9dbf"; unpack_target="i686-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-libs-11.2.0-6-any.pkg.tar.zst", "bdc359047f61c8e96401ba25b17c80f5f8039c25a063c622e3680123bb0de9d1"; unpack_target="i686-w64-mingw32"),
 
     # 64-bit Windows from https://packages.msys2.org/package/mingw-w64-x86_64-hdf5
     ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-hdf5-1.12.2-1-any.pkg.tar.zst", "3ba6521d45368aabb334131e10282b25fab9891a20fb9129d897c65c8b6cdbda"; unpack_target="x86_64-w64-mingw32"),
@@ -18,7 +18,7 @@ sources = [
     ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-zlib-1.2.12-1-any.pkg.tar.zst", "e728df08b4db7b291a52d8fd60b96f19016f059ab15170fc98120e5d580c86ac"; unpack_target="x86_64-w64-mingw32"),
 
     # x86_64 and aarch64 for Linux and macOS from https://anaconda.org/conda-forge/hdf5/files
-    # NOTE: make sure to select those compatible with OpenSSL 1.1.1 (click 🛈)
+    # NOTE: make sure to select those compatible with OpenSSL 1.1.1 (click info icon)
     ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.2/download/linux-64/hdf5-1.12.2-nompi_h2386368_100.tar.bz2", "6f0a1e7fe9c76fee4f490b33a91465a3a4690a5ccf1df21c7bde141ab320ea96"; unpack_target="x86_64-linux-gnu"),
     ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.2/download/linux-aarch64/hdf5-1.12.2-nompi_h7bde11e_100.tar.bz2", "934324fea28f82ceb0f57c881bf49687154c17af8cc7a1a57753133e5224db2c"; unpack_target="aarch64-linux-gnu"),
     ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.2/download/osx-64/hdf5-1.12.2-nompi_hc782337_100.tar.bz2", "066c8feca3d77184e7cb38cd58d9918409f7395a66b16e7d330339225f9c0bea"; unpack_target="x86_64-apple-darwin14"),

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -2,27 +2,27 @@ using BinaryBuilder
 
 # Collection of sources required to build HDF5
 name = "HDF5"
-version = v"1.12.1"
+version = v"1.12.2"
 
 sources = [
     # 32-bit Windows from https://packages.msys2.org/package/mingw-w64-i686-hdf5
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-hdf5-1.12.1-2-any.pkg.tar.zst", "ab7e4568c99e2a7a9b96ad06867ef9e829d286539e0735a93b9295ad8778a818"; unpack_target="i686-w64-mingw32"),
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-libaec-1.0.6-1-any.pkg.tar.zst", "43ef1aee2be7cc192d14c6641627ed0a1eca50c21234eba3405fce77302517a8"; unpack_target="i686-w64-mingw32"),
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-zlib-1.2.11-9-any.pkg.tar.zst", "8d594fc14497d41a66415bfdd200d7d1d56a6ecd3fe81b9190bec0c4841a5eff"; unpack_target="i686-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-hdf5-1.12.2-1-any.pkg.tar.zst", "f37511b6208245b081a5b72a1f2021a73b67da07835ede1e092f7d7f20569319"; unpack_target="i686-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-libaec-1.0.6-2-any.pkg.tar.zst", "c6cff1a6f8a9f75e986589d8debc35e8076a7af38aa32cbda78bb6c2fbbbe58c"; unpack_target="i686-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-zlib-1.2.12-1-any.pkg.tar.zst", "74ace327d8e28cdb0c777fffc6003f5097836c247be40cf3b483bd9fd1c23183"; unpack_target="i686-w64-mingw32"),
     # We need some special compiler support libraries from mingw for i686 (libgcc_s_dw2)
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-libs-11.2.0-6-any.pkg.tar.zst", "bdc359047f61c8e96401ba25b17c80f5f8039c25a063c622e3680123bb0de9d1"; unpack_target="i686-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-libs-12.1.0-3-any.pkg.tar.zst", "dbf02e2b0569677879597f404ed2c15bb1d2998c2d19412b1ac33afd104d9dbf"; unpack_target="i686-w64-mingw32"),
 
     # 64-bit Windows from https://packages.msys2.org/package/mingw-w64-x86_64-hdf5
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-hdf5-1.12.1-2-any.pkg.tar.zst", "540d8b9fd71d0d848e28723f531948dea497c7cb8f95c53e1a3b06f750f12c40"; unpack_target="x86_64-w64-mingw32"),
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-libaec-1.0.6-1-any.pkg.tar.zst", "839b271b1313f013227c13944876651429b8e0edb40760d64f817a36c8b9435c"; unpack_target="x86_64-w64-mingw32"),
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-zlib-1.2.11-9-any.pkg.tar.zst", "9da9ebafaef832dba2f442ad44d9ae8759784b86478dcbe326500195f8ea6339"; unpack_target="x86_64-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-hdf5-1.12.2-1-any.pkg.tar.zst", "3ba6521d45368aabb334131e10282b25fab9891a20fb9129d897c65c8b6cdbda"; unpack_target="x86_64-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-libaec-1.0.6-2-any.pkg.tar.zst", "d970bd71e55fc5bd4a55e95ef22355d8c479631973860f2a9c37b49c931c5f35"; unpack_target="x86_64-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-zlib-1.2.12-1-any.pkg.tar.zst", "e728df08b4db7b291a52d8fd60b96f19016f059ab15170fc98120e5d580c86ac"; unpack_target="x86_64-w64-mingw32"),
 
     # x86_64 and aarch64 for Linux and macOS from https://anaconda.org/conda-forge/hdf5/files
-    # NOTE: make sure to select those compatible with OpenSSL 1.1.1
-    ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.1/download/linux-64/hdf5-1.12.1-nompi_h2750804_103.tar.bz2", "bd7bb0657d63acf52c9d30d1b89276356c6da4ff8a90dd5fcbd0cfde6578f317"; unpack_target="x86_64-linux-gnu"),
-    ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.1/download/linux-aarch64/hdf5-1.12.1-nompi_h774d4d8_103.tar.bz2", "8688cfc983962bf7a59a97becb0d67ee64eb4a7dd5793b915cf50dccd90bfa2d"; unpack_target="aarch64-linux-gnu"),
-    ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.1/download/osx-64/hdf5-1.12.1-nompi_h2f0ef1a_102.tar.bz2", "4a4640e44adea33833e7efb6ac3070dd4c80a8a156c2fd3aa7cfcac8865f5a26"; unpack_target="x86_64-apple-darwin14"),
-    ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.1/download/osx-arm64/hdf5-1.12.1-nompi_had0e5e0_103.tar.bz2", "ef48b684b22c6b0077bc9836e0cc6d15abb88868d7a6c842226666ebb8bbd449"; unpack_target="aarch64-apple-darwin20"),
+    # NOTE: make sure to select those compatible with OpenSSL 1.1.1 (click 🛈)
+    ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.2/download/linux-64/hdf5-1.12.2-nompi_h2386368_100.tar.bz2", "6f0a1e7fe9c76fee4f490b33a91465a3a4690a5ccf1df21c7bde141ab320ea96"; unpack_target="x86_64-linux-gnu"),
+    ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.2/download/linux-aarch64/hdf5-1.12.2-nompi_h7bde11e_100.tar.bz2", "934324fea28f82ceb0f57c881bf49687154c17af8cc7a1a57753133e5224db2c"; unpack_target="aarch64-linux-gnu"),
+    ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.2/download/osx-64/hdf5-1.12.2-nompi_hc782337_100.tar.bz2", "066c8feca3d77184e7cb38cd58d9918409f7395a66b16e7d330339225f9c0bea"; unpack_target="x86_64-apple-darwin14"),
+    ArchiveSource("https://anaconda.org/conda-forge/hdf5/1.12.2/download/osx-arm64/hdf5-1.12.2-nompi_h8968d4b_100.tar.bz2", "3efe747b24b173c6c3be71009c1831049032d81d0414d07d920b0650b8022a58"; unpack_target="aarch64-apple-darwin20"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
NetCDF_jll is broken when building against the current HDF5_jll 1.12.1. This should resolve that issue, see @Alexander-Barth's comment in https://github.com/JuliaPackaging/Yggdrasil/issues/4511#issuecomment-1155003075.

This also bumps the MinGW dependencies, assuming it's fine to bundle `gcc-libs-12` instead of `gcc-libs-11` for 32 bit Windows, though I'd be happy to keep that as is as well.