### PR TITLE
[HDF5] add LibCURL_jll compat

### DIFF
--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -76,7 +76,7 @@ products = [
 dependencies = [
     Dependency("Zlib_jll"),
     Dependency("OpenSSL_jll"; compat="1.1.10"),
-    Dependency("LibCURL_jll"),
+    Dependency("LibCURL_jll"; compat="7.73"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Should fix

```
dlopen(/Users/runner/.julia/artifacts/4e3d68673330116b7ef55a34b6d6d405e005fe6d/lib/libhdf5.200.dylib, 1): Library not loaded: @rpath/libcurl.4.dylib
  Referenced from: /Users/runner/.julia/artifacts/4e3d68673330116b7ef55a34b6d6d405e005fe6d/lib/libhdf5.200.dylib
  Reason: Incompatible library version: libhdf5.200.dylib requires version 13.0.0 or later, but libcurl.4.dylib provides version 12.0.0
```

From https://github.com/JuliaIO/HDF5.jl/pull/996

Version 7.73 is the version that julia 1.6 uses:
https://github.com/JuliaLang/julia/blob/v1.6.6/stdlib/LibCURL_jll/Project.toml#L3

Just like #4981