### PR TITLE
SLICOT 5.8.0, Julia 1.8 compat

### DIFF
--- a/S/SLICOT/build_tarballs.jl
+++ b/S/SLICOT/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder, Pkg
 using BinaryBuilderBase: get_addable_spec
 
 name = "SLICOT"
-version = v"5.8.1"
+version = v"5.8.0"
 
 # Collection of sources required to complete build
 # Note to maintainers: extracts from LAPACK are deprecated routines, so probably don't want

--- a/S/SLICOT/build_tarballs.jl
+++ b/S/SLICOT/build_tarballs.jl
@@ -100,7 +100,9 @@ platforms = expand_gfortran_versions(supported_platforms())
 # https://github.com/JuliaPackaging/Yggdrasil/pull/4770
 # Since we need to link to libblastrampoline which has seen multiple
 # ABI-incompatible versions, we need to expand the julia versions we target
-julia_versions = [v"1.7.0", v"1.8.0", v"1.9.0"]
+#julia_versions = [v"1.7.0", v"1.8.0", v"1.9.0"]
+# Focus on Julia v"1.8.0" during debug
+julia_versions = [v"1.8.0"]
 function set_julia_version(platforms::Vector{Platform}, julia_version::VersionNumber)
     _platforms = deepcopy(platforms)
     for p in _platforms
@@ -119,8 +121,9 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(get_addable_spec("libblastrampoline_jll", v"3.0.4+0"); platforms=filter(p -> VersionNumber(p["julia_version"]) == v"1.7.0", platforms)),
-    Dependency(get_addable_spec("libblastrampoline_jll", v"5.1.0+0"); platforms=filter(p -> VersionNumber(p["julia_version"]) >= v"1.8.0", platforms)),
+    # Focus on 1.8 during debug
+    #Dependency(get_addable_spec("libblastrampoline_jll", v"3.0.4+0"); platforms=filter(p -> VersionNumber(p["julia_version"]) == v"1.7.0", platforms)),
+    Dependency(get_addable_spec("libblastrampoline_jll", v"5.1.1+1"); platforms=filter(p -> VersionNumber(p["julia_version"]) >= v"1.8.0", platforms)),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 

--- a/S/SLICOT/build_tarballs.jl
+++ b/S/SLICOT/build_tarballs.jl
@@ -1,9 +1,10 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
+using BinaryBuilderBase: get_addable_spec
 
 name = "SLICOT"
-version = v"5.8.0"
+version = v"5.8.1"
 
 # Collection of sources required to complete build
 # Note to maintainers: extracts from LAPACK are deprecated routines, so probably don't want
@@ -95,6 +96,21 @@ install_license ../LICENSE
 # platforms are passed in on the command line
 platforms = expand_gfortran_versions(supported_platforms())
 
+# The following was derived from #4770 (Pfapack)
+# https://github.com/JuliaPackaging/Yggdrasil/pull/4770
+# Since we need to link to libblastrampoline which has seen multiple
+# ABI-incompatible versions, we need to expand the julia versions we target
+julia_versions = [v"1.7.0", v"1.8.0", v"1.9.0"]
+function set_julia_version(platforms::Vector{Platform}, julia_version::VersionNumber)
+    _platforms = deepcopy(platforms)
+    for p in _platforms
+        p["julia_version"] = string(julia_version)
+    end
+    return _platforms
+end
+expand_julia_versions(platforms::Vector{Platform}, julia_versions::Vector{VersionNumber}) =
+    vcat(set_julia_version.(Ref(platforms), julia_versions)...)
+platforms = expand_julia_versions(platforms, julia_versions)
 
 # The products that we will ensure are always built
 products = [
@@ -103,7 +119,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"); compat="3.0.4"),
+    Dependency(get_addable_spec("libblastrampoline_jll", v"3.0.4+0"); platforms=filter(p -> VersionNumber(p["julia_version"]) == v"1.7.0", platforms)),
+    Dependency(get_addable_spec("libblastrampoline_jll", v"5.1.0+0"); platforms=filter(p -> VersionNumber(p["julia_version"]) >= v"1.8.0", platforms)),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 

--- a/S/SLICOT/build_tarballs.jl
+++ b/S/SLICOT/build_tarballs.jl
@@ -100,9 +100,7 @@ platforms = expand_gfortran_versions(supported_platforms())
 # https://github.com/JuliaPackaging/Yggdrasil/pull/4770
 # Since we need to link to libblastrampoline which has seen multiple
 # ABI-incompatible versions, we need to expand the julia versions we target
-#julia_versions = [v"1.7.0", v"1.8.0", v"1.9.0"]
-# Focus on Julia v"1.8.0" during debug
-julia_versions = [v"1.8.0"]
+julia_versions = [v"1.7.0", v"1.8.0", v"1.9.0"]
 function set_julia_version(platforms::Vector{Platform}, julia_version::VersionNumber)
     _platforms = deepcopy(platforms)
     for p in _platforms
@@ -121,8 +119,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # Focus on 1.8 during debug
-    #Dependency(get_addable_spec("libblastrampoline_jll", v"3.0.4+0"); platforms=filter(p -> VersionNumber(p["julia_version"]) == v"1.7.0", platforms)),
+    Dependency(get_addable_spec("libblastrampoline_jll", v"3.0.4+0"); platforms=filter(p -> VersionNumber(p["julia_version"]) == v"1.7.0", platforms)),
     Dependency(get_addable_spec("libblastrampoline_jll", v"5.1.1+1"); platforms=filter(p -> VersionNumber(p["julia_version"]) >= v"1.8.0", platforms)),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]


### PR DESCRIPTION
> Someone should do something like #4770 (for lack of better options at the moment)

_Originally posted by @giordano in https://github.com/JuliaPackaging/Yggdrasil/issues/4969#issuecomment-1146836975_

I'm "someone".

https://discourse.julialang.org/t/too-many-julia-versions/84538/15?u=mkitti

1. Do we need a version bump to SLICOT 5.8.1 to do this?
2. @andreasvarga can we coordinate a SLICOT 5.8.1 release?

cc: @RalphAS