### PR TITLE
[SoapyPlutoSDR] bump build

### DIFF
--- a/S/SoapyPlutoSDR/build_tarballs.jl
+++ b/S/SoapyPlutoSDR/build_tarballs.jl
@@ -33,7 +33,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> libc(p) != "musl", supported_platforms())
+platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms) # requested by auditor
 
 # The products that we will ensure are always built
@@ -42,4 +42,4 @@ products = Product[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"7")

--- a/S/SoapyPlutoSDR/build_tarballs.jl
+++ b/S/SoapyPlutoSDR/build_tarballs.jl
@@ -33,7 +33,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(;experimental=true)
 platforms = expand_cxxstring_abis(platforms) # requested by auditor
 
 # The products that we will ensure are always built

--- a/S/SoapyPlutoSDR/build_tarballs.jl
+++ b/S/SoapyPlutoSDR/build_tarballs.jl
@@ -7,13 +7,12 @@ version = v"0.2.1" # not yet tagged
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/pothosware/SoapyPlutoSDR.git", "ac9a9da5c14c73e752796618d56e259ca1ac6b11")
+    GitSource("https://github.com/pothosware/SoapyPlutoSDR.git", "a07c37230369653818b3a5c448c00cee1ac9f8e5")
 ]
 
 dependencies = [
-    Dependency("libiio_jll"; compat="~0.23.0"),
-    Dependency("soapysdr_jll"; compat="~0.8.0"),
-    Dependency("libad9361_iio_jll"; compat="~0.2.0")    
+    Dependency("libiio_jll"; compat="~0.24.0"),
+    Dependency("soapysdr_jll"; compat="~0.8.0")
 ]
 
 # Bash recipe for building across all platforms
@@ -21,32 +20,20 @@ script = raw"""
 cd SoapyPlutoSDR
 
 mkdir build && cd build
-if [[ "${target}" != *-apple-* ]]; then
-    cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
-        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-        -DCMAKE_BUILD_TYPE=Release \
-        ..
-    make -j${nproc}
-    make install
-fi
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+make -j${nproc}
+make install
 if [[ "${target}" == *-apple-* ]]; then
-    cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
-        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DLibIIO_INCLUDE_DIR=${libdir}/iio.framework/Versions/0.23/Headers/ \
-        -DLibIIO_LIBRARY=${libdir}/iio.framework/Versions/0.23/iio \
-        -DLibAD9361_INCLUDE_DIR=${libdir}/ad9361.framework/Versions/0.2/Headers/ \
-        -DLibAD9361_LIBRARY=${libdir}/ad9361.framework/Versions/0.2/ad9361 \
-        ..
-    make -j${nproc}
-    make install
     mv ${libdir}/SoapySDR/modules0.8/libPlutoSDRSupport.so  ${libdir}/SoapySDR/modules0.8/libPlutoSDRSupport.dylib
 fi
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = filter!(p -> libc(p) != "musl", supported_platforms())
 platforms = expand_cxxstring_abis(platforms) # requested by auditor
 
 # The products that we will ensure are always built


### PR DESCRIPTION
This is the latest git build, using libiio 0.24. 

This line breaks the Musl builds, but that should be fine for now: https://github.com/pothosware/SoapyPlutoSDR/blob/a07c37230369653818b3a5c448c00cee1ac9f8e5/CMakeLists.txt#L77

We drop libad9361_iio for now, since it is only used for filters and unsupported on latest libiio.