### PR TITLE
Python_jll: Avoid linking to `libcrypt.so.1` on glibc systems.

### DIFF
--- a/P/Python/build_tarballs.jl
+++ b/P/Python/build_tarballs.jl
@@ -57,13 +57,20 @@ mkdir build_target && cd build_target
 export CPPFLAGS="${CPPFLAGS} -I${prefix}/include"
 export LDFLAGS="${LDFLAGS} -L${prefix}/lib -L${prefix}/lib64"
 export PATH=$(echo ${WORKSPACE}/srcdir/Python-*/build_host):$PATH
-../configure --prefix="${prefix}" --host="${target}" --build="${MACHTYPE}" \
-    --enable-shared \
-    --disable-ipv6 \
-    --with-ensurepip=no \
-    ac_cv_file__dev_ptmx=no \
-    ac_cv_file__dev_ptc=no \
-    ac_cv_have_chflags=no
+conf_args=()
+conf_args+=(--enable-shared)
+conf_args+=(--disable-ipv6)
+conf_args+=(--with-ensurepip=no)
+conf_args+=(ac_cv_file__dev_ptmx=no)
+conf_args+=(ac_cv_file__dev_ptc=no)
+conf_args+=(ac_cv_have_chflags=no)
+if [[ "${target}" == *-linux-gnu* ]]; then
+    # We use very old versions of glibc which used to have `libcrypt.so.1`, but modern
+    # glibcs have `libcrypt.so.2`, so if we link to `libcrypt.so.1` most users would
+    # have troubles running the programs at runtime.
+    conf_args+=(ac_cv_lib_crypt_crypt=no)
+fi
+../configure --prefix="${prefix}" --host="${target}" --build="${MACHTYPE}" "${conf_args[@]}"
 make -j${nproc}
 make install
 """


### PR DESCRIPTION
Equivalent of https://github.com/JuliaPackaging/Yggdrasil/pull/4879.

Fixes:

```
ERROR: LoadError: InitError: could not load library "/home/pkgeval/.julia/artifacts/e1a397270be4e889bccc3bed5512d1e0fbac5979/lib/libpython3.8.so"
libcrypt.so.1: cannot open shared object file: No such file or directory
Stacktrace:
  [1] dlopen(s::String, flags::UInt32; throw_error::Bool)
    @ Base.Libc.Libdl ./libdl.jl:117
  [2] dlopen(s::String, flags::UInt32)
    @ Base.Libc.Libdl ./libdl.jl:116
  [3] macro expansion
    @ ~/.julia/packages/JLLWrappers/QpMQW/src/products/library_generators.jl:54 [inlined]
  [4] __init__()
    @ Python_jll ~/.julia/packages/Python_jll/myk8c/src/wrappers/x86_64-linux-gnu.jl:15
  [5] _include_from_serialized(pkg::Base.PkgId, path::String, depmods::Vector{Any})
    @ Base ./loading.jl:831
  [6] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String, build_id::UInt64)
    @ Base ./loading.jl:1039
  [7] _require(pkg::Base.PkgId)
    @ Base ./loading.jl:1315
  [8] _require_prelocked(uuidkey::Base.PkgId)
    @ Base ./loading.jl:1200
  [9] macro expansion
    @ ./loading.jl:1180 [inlined]
 [10] macro expansion
    @ ./lock.jl:223 [inlined]
 [11] require(into::Module, mod::Symbol)
    @ Base ./loading.jl:1144
 [12] include(mod::Module, _path::String)
    @ Base ./Base.jl:422
 [13] top-level scope
    @ ~/.julia/packages/JLLWrappers/QpMQW/src/toplevel_generators.jl:188
 [14] include
    @ ./Base.jl:422 [inlined]
 [15] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::String)
    @ Base ./loading.jl:1554
 [16] top-level scope
    @ stdin:1
during initialization of module Python_jll
```