### PR TITLE
Update to WhiteboxTools 2.1.0

### DIFF
--- a/W/WhiteboxTools/build_tarballs.jl
+++ b/W/WhiteboxTools/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"2.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/jblindsay/whitebox-tools.git", "46229fd27a841e000c51b3b982b93e101a597ebe")
+    GitSource("https://github.com/jblindsay/whitebox-tools.git", "d4f252c84b37a6b70331c59fd930ffa9a574c5e1")
 ]
 
 # Bash recipe for building across all platforms

--- a/W/WhiteboxTools/build_tarballs.jl
+++ b/W/WhiteboxTools/build_tarballs.jl
@@ -3,16 +3,16 @@
 using BinaryBuilder, Pkg, BinaryBuilderBase
 
 name = "WhiteboxTools"
-version = v"2.0.0"
+version = v"2.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/jblindsay/whitebox-tools/archive/refs/tags/v$(version).tar.gz", "18705fc948bdb2f96cd816e5a72d36b9cc460aa8c910383d23fdbd61641aab60")
+    GitSource("https://github.com/jblindsay/whitebox-tools.git", "46229fd27a841e000c51b3b982b93e101a597ebe")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/whitebox-tools-*/
+cd $WORKSPACE/srcdir/whitebox-tools/
 
 cargo build --release
 mkdir -p "${bindir}"


### PR DESCRIPTION
WhiteboxTools stopped doing GitHub releases, but there was a versioning issue in the latest release v2.0.0 that kept everything at v1.5. I want to fix this for my new [package](https://github.com/acgold/Whitebox.jl) that uses WhiteboxTools_jll.jl.

This PR:
- Bumps WhiteboxTools to v2.1.0
- Gets the latest version of the repo with `GitSource()` instead of `ArchiveSource()`
- Changes the working directory within the bash recipe (original code errored when I briefly tested locally)