### PR TITLE
New Recipe: FlangClassic

### DIFF
--- a/F/FlangClassic/build_tarballs.jl
+++ b/F/FlangClassic/build_tarballs.jl
@@ -2,7 +2,7 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-name = "ClassicFlang"
+name = "FlangClassic"
 version = v"13.0.0"
 
 # Collection of sources required to complete build

--- a/F/FlangClassic/build_tarballs.jl
+++ b/F/FlangClassic/build_tarballs.jl
@@ -27,6 +27,7 @@ atomic_patch -p1 -d ../classic-flang-llvm-project ../patches/0010-add-musl-tripl
 cmake -GNinja -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_CLASSIC_FLANG=ON -DLLVM_ENABLE_PROJECTS="clang;openmp" ../classic-flang-llvm-project/llvm/
 ninja
 ninja install
+install_license ../classic-flang-llvm-project/llvm/LICENSE.TXT
 cd ..
 
 # Begin pgmath build
@@ -44,6 +45,7 @@ cd flang-build
 ## Apply flang patches
 atomic_patch -p1 -d ../flang ../patches/musl-patches.patch
 atomic_patch -p1 -d ../flang ../patches/no-fastmath.patch
+atomic_patch -p1 -d ../flang ../patches/flang2-install-dir.patch
 
 ## Create Compiler wrapper for flang
 cat /opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-clang | sed 's/clang/flang/g' > /opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-flang
@@ -55,6 +57,7 @@ export PATH=${WORKSPACE}/srcdir/flang-build/bin:$PATH
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_Fortran_COMPILER_ARG1="--sysroot=/opt/x86_64-linux-musl/x86_64-linux-musl/sys-root" -DCMAKE_Fortran_COMPILER=x86_64-linux-musl-flang -DCMAKE_Fortran_COMPILER_ID=Flang -DCMAKE_BUILD_TYPE=Release -DWITH_WERROR=OFF ../flang
 make -j$(nproc)
 make install
+install_license ../flang/LICENSE.txt
 """
 
 # These are the platforms we will build for by default, unless further
@@ -67,7 +70,7 @@ platforms = [
 products = Product[
     ExecutableProduct("flang", :flang),
     ExecutableProduct("flang1", :flang1),
-    ExecutableProduct("flang2", :flang1)
+    ExecutableProduct("flang2", :flang2)
     # TODO: Runtime libraries?
 ]
 

--- a/F/FlangClassic/build_tarballs.jl
+++ b/F/FlangClassic/build_tarballs.jl
@@ -1,0 +1,80 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ClassicFlang"
+version = v"13.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/flang-compiler/flang.git", "a459f3ca34b244c6c1e59d6495e8ec90952c2448"),
+    GitSource("https://github.com/flang-compiler/classic-flang-llvm-project.git", "528906c87cd4cae63a52c3170365cb382daf94cb"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+
+# Begin (LLVM + flang driver) build
+mkdir llvm-build
+cd llvm-build/
+
+## Apply LLVM patches
+atomic_patch -p1 -d ../classic-flang-llvm-project ../patches/0010-add-musl-triples.patch
+
+## Configure & Build
+cmake -GNinja -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_CLASSIC_FLANG=ON -DLLVM_ENABLE_PROJECTS="clang;openmp" ../classic-flang-llvm-project/llvm/
+ninja
+ninja install
+cd ..
+
+# Begin pgmath build
+mkdir pgmath-build
+cd pgmath-build
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../flang/runtime/libpgmath/
+ninja
+ninja install
+cd ..
+
+# Begin Flang (Compiler/Runtime) build
+mkdir flang-build
+cd flang-build
+
+## Apply flang patches
+atomic_patch -p1 -d ../flang ../patches/musl-patches.patch
+atomic_patch -p1 -d ../flang ../patches/no-fastmath.patch
+
+## Create Compiler wrapper for flang
+cat /opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-clang | sed 's/clang/flang/g' > /opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-flang
+chmod +x /opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-flang
+ln -s ${WORKSPACE}/destdir/bin/flang /opt/x86_64-linux-musl/bin/flang
+
+## Configure & Build
+export PATH=${WORKSPACE}/srcdir/flang-build/bin:$PATH
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_Fortran_COMPILER_ARG1="--sysroot=/opt/x86_64-linux-musl/x86_64-linux-musl/sys-root" -DCMAKE_Fortran_COMPILER=x86_64-linux-musl-flang -DCMAKE_Fortran_COMPILER_ID=Flang -DCMAKE_BUILD_TYPE=Release -DWITH_WERROR=OFF ../flang
+make -j$(nproc)
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc = "musl"),
+]
+
+# The products that we will ensure are always built
+products = Product[
+    ExecutableProduct("flang", :flang),
+    ExecutableProduct("flang1", :flang1),
+    ExecutableProduct("flang2", :flang1)
+    # TODO: Runtime libraries?
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    julia_compat="1.6", preferred_gcc_version=v"10", lock_microarchitecture=false)

--- a/F/FlangClassic/build_tarballs.jl
+++ b/F/FlangClassic/build_tarballs.jl
@@ -22,6 +22,7 @@ cd llvm-build/
 
 ## Apply LLVM patches
 atomic_patch -p1 -d ../classic-flang-llvm-project ../patches/0010-add-musl-triples.patch
+atomic_patch -p1 -d ../classic-flang-llvm-project ../patches/nosincos.patch
 
 ## Configure & Build
 cmake -GNinja -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_CLASSIC_FLANG=ON -DLLVM_ENABLE_PROJECTS="clang;openmp" ../classic-flang-llvm-project/llvm/

--- a/F/FlangClassic/bundled/patches/0010-add-musl-triples.patch
+++ b/F/FlangClassic/bundled/patches/0010-add-musl-triples.patch
@@ -1,0 +1,26 @@
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2077,6 +2077,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
+   static const char *const AArch64Triples[] = {
+       "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
++      "aarch64-linux-musl",
+       "aarch64-suse-linux", "aarch64-linux-android"};
+   static const char *const AArch64beLibDirs[] = {"/lib"};
+   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
+@@ -2105,6 +2106,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "x86_64-redhat-linux",    "x86_64-suse-linux",
+       "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
+       "x86_64-slackware-linux", "x86_64-unknown-linux",
++      "x86_64-linux-musl",
+       "x86_64-amazon-linux",    "x86_64-linux-android"};
+   static const char *const X32Triples[] = {"x86_64-linux-gnux32",
+                                            "x86_64-pc-linux-gnux32"};
+@@ -2115,6 +2117,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "i686-pc-linux-gnu",  "i386-redhat-linux6E",
+       "i686-redhat-linux",  "i386-redhat-linux",
+       "i586-suse-linux",    "i686-montavista-linux",
++      "i686-linux-musl",
+       "i686-linux-android", "i686-gnu",
+   };
+ 

--- a/F/FlangClassic/bundled/patches/flang2-install-dir.patch
+++ b/F/FlangClassic/bundled/patches/flang2-install-dir.patch
@@ -1,0 +1,20 @@
+commit 2d70a9559ec55f97d0b9c153a1c00ef8ac803ae9 (HEAD -> master)
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Sun Aug 14 17:54:01 2022 -0400
+
+    Correct flang2 install dir
+
+diff --git a/tools/flang2/flang2exe/CMakeLists.txt b/tools/flang2/flang2exe/CMakeLists.txt
+index a9649e99..5aeeb048 100644
+--- a/tools/flang2/flang2exe/CMakeLists.txt
++++ b/tools/flang2/flang2exe/CMakeLists.txt
+@@ -160,7 +160,7 @@ target_include_directories(flang2
+ 
+ # Install flang2 executable
+ install(TARGETS flang2
+-        RUNTIME DESTINATION ${LLVM_TOOLS_BINARY_DIR})
++        RUNTIME DESTINATION bin)
+ 
+ # Local Variables:
+ # mode: cmake
+

--- a/F/FlangClassic/bundled/patches/musl-patches.patch
+++ b/F/FlangClassic/bundled/patches/musl-patches.patch
@@ -1,0 +1,84 @@
+commit 4a7a5fc01f95f5548b28d284566298aff77fdb53 (HEAD -> master)
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Sun Aug 14 12:21:28 2022 -0400
+
+    Fix build on musl
+    
+    Guard a few glibc-extensions by appropriate __GLIBC__ checks
+    and move some headers around since musl doesn't implicitly
+    include the same headers as glibc.
+
+diff --git a/runtime/flangrti/ktrap.c b/runtime/flangrti/ktrap.c
+index 573152d6..efbfddd3 100644
+--- a/runtime/flangrti/ktrap.c
++++ b/runtime/flangrti/ktrap.c
+@@ -52,8 +52,11 @@ __ktrap(void)
+         excepts |= FE_INEXACT;
+ #ifdef TARGET_OSX
+       __fenv_feenableexcept(excepts);
+-#else
++#elif defined(__GLIBC__)
+       feenableexcept(excepts);  /* glibc 2.2 extension to fenv.h */
++#else
++#warning "feenableexcept not available; -Ktrap will not work"
++      (void)excepts;
+ #endif
+     }
+   }
+diff --git a/runtime/flangrti/trace_lin.c b/runtime/flangrti/trace_lin.c
+index 57a57245..0182445c 100644
+--- a/runtime/flangrti/trace_lin.c
++++ b/runtime/flangrti/trace_lin.c
+@@ -11,7 +11,6 @@
+ #ifdef _WIN64
+ #include <windows.h>
+ #else
+-#include <execinfo.h>
+ #include <unistd.h>
+ #include <limits.h>
+ #include <sys/types.h>
+@@ -182,6 +181,7 @@ __abort_trace(int skip)
+     dumpregs(regs);
+   }
+ 
++#if defined(__GLIBC__)
+   size = backtrace(array, MAXTRACE);
+   if (skip + 1 >= size) {
+     fprintf(__io_stderr(), "  --- traceback not available\n");
+@@ -199,6 +199,9 @@ __abort_trace(int skip)
+       print_back_trace_line(strings[i], array[i]);
+   }
+   free(strings);
++#else
++  fprintf(__io_stderr(), "  --- traceback not available\n");
++#endif
+ }
+ 
+ /*
+diff --git a/runtime/include/komp.h b/runtime/include/komp.h
+index 33c0cd7e..40f56d4b 100644
+--- a/runtime/include/komp.h
++++ b/runtime/include/komp.h
+@@ -9,6 +9,9 @@
+ #define _PGOMP_H
+ 
+ #include <stdint.h>
++#if !defined(WIN32) && !defined(WIN64) && !defined(__WORDSIZE)
++#include <sys/reg.h>
++#endif
+ 
+ /* simple lock */
+ 
+diff --git a/tools/flang2/flang2exe/gbldefs.h b/tools/flang2/flang2exe/gbldefs.h
+index 366b3913..a3e594c7 100644
+--- a/tools/flang2/flang2exe/gbldefs.h
++++ b/tools/flang2/flang2exe/gbldefs.h
+@@ -19,6 +19,7 @@
+ #include "platform.h"
+ #include "pgifeat.h"
+ #include <scutil.h>
++#include <alloca.h>
+ 
+ #define NEW_ARG_PARSER
+ 
+

--- a/F/FlangClassic/bundled/patches/no-fastmath.patch
+++ b/F/FlangClassic/bundled/patches/no-fastmath.patch
@@ -1,0 +1,26 @@
+commit 992ba1030064ec38b85dbe0163fbe9683c61a571 (HEAD -> master)
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Sun Aug 14 12:20:57 2022 -0400
+
+    Drop fastmath
+
+diff --git a/runtime/flang/CMakeLists.txt b/runtime/flang/CMakeLists.txt
+index aefc4a4a..340ab9b0 100644
+--- a/runtime/flang/CMakeLists.txt
++++ b/runtime/flang/CMakeLists.txt
+@@ -606,14 +606,14 @@ if (NOT MSVC  OR "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "GNU")
+     ${I8_FILES_DIR}/red_norm2_stride1.c
+     red_norm2_stride1.c
+     PROPERTIES
+-    COMPILE_FLAGS "-ffast-math"
++    COMPILE_FLAGS ""
+     )
+ else()
+   set_source_files_properties(
+     ${I8_FILES_DIR}/red_norm2_stride1.c
+     red_norm2_stride1.c
+     PROPERTIES
+-    COMPILE_FLAGS "/fp:fast"
++    COMPILE_FLAGS ""
+     )
+ endif()

--- a/F/FlangClassic/bundled/patches/nosincos.patch
+++ b/F/FlangClassic/bundled/patches/nosincos.patch
@@ -1,0 +1,62 @@
+commit b7f530fb1d5c4dbf7dcebb69746e1656a69e12d3
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Sun Aug 14 23:38:03 2022 +0000
+
+    Delete pgmath veclib definitions for sincos
+    
+    As noted in https://github.com/flang-compiler/classic-flang-llvm-project/issues/11,
+    flang currently crashes when encountering a sincos reference into pgmath.
+    The issue is is that __fd_sincos_1 is defined as returning a `<{ double, double }>`
+    struct and there is no LLVM support for automatically vectorizing target
+    functions of this form. In particular, it is somewhat ambiguous how
+    to vectorize such function, i.e. how they pack their return values into
+    the vector registers. `libpgmath` itself also has a somewhat questionable
+    implementation of the vector forms of `sincos`, relying on this beatuty:
+    https://github.com/flang-compiler/flang/blob/master/runtime/libpgmath/lib/common/mth_vreturns.c#L8-L47
+    
+    This may sometimes work in practice, but it is not particularly robust.
+    For example, this will definitely break in any sort of LTO or
+    instrumentation setting.
+    
+    I think until libpgmath is updated and LLVM upstream has a consensus on how
+    to vectorize these function, we just need to drop trying to vectorize these
+    functions. As noted, since LLVM was crashing anyway, no performance and
+    functionality is lost here over current master.
+    
+    Fixes https://github.com/flang-compiler/classic-flang-llvm-project/issues/11
+
+diff --git a/llvm/lib/Analysis/TargetLibraryInfo.cpp b/llvm/lib/Analysis/TargetLibraryInfo.cpp
+index 41a37a38b023..e48af584735e 100644
+--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
++++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
+@@ -1735,30 +1735,6 @@ void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
+         {"__rs_cos_1", "__rs_cos_8", FIXED(8)},
+         {"__rs_cos_1", "__rs_cos_16", FIXED(16)},
+ 
+-        {"__fd_sincos_1", "__fd_sincos_2", FIXED(2)},
+-        {"__fd_sincos_1", "__fd_sincos_4", FIXED(4)},
+-        {"__fd_sincos_1", "__fd_sincos_8", FIXED(8)},
+-
+-        {"__fs_sincos_1", "__fs_sincos_4", FIXED(4)},
+-        {"__fs_sincos_1", "__fs_sincos_8", FIXED(8)},
+-        {"__fs_sincos_1", "__fs_sincos_16", FIXED(16)},
+-
+-        {"__pd_sincos_1", "__pd_sincos_2", FIXED(2)},
+-        {"__pd_sincos_1", "__pd_sincos_4", FIXED(4)},
+-        {"__pd_sincos_1", "__pd_sincos_8", FIXED(8)},
+-
+-        {"__ps_sincos_1", "__ps_sincos_4", FIXED(4)},
+-        {"__ps_sincos_1", "__ps_sincos_8", FIXED(8)},
+-        {"__ps_sincos_1", "__ps_sincos_16", FIXED(16)},
+-
+-        {"__rd_sincos_1", "__rd_sincos_2", FIXED(2)},
+-        {"__rd_sincos_1", "__rd_sincos_4", FIXED(4)},
+-        {"__rd_sincos_1", "__rd_sincos_8", FIXED(8)},
+-
+-        {"__rs_sincos_1", "__rs_sincos_4", FIXED(4)},
+-        {"__rs_sincos_1", "__rs_sincos_8", FIXED(8)},
+-        {"__rs_sincos_1", "__rs_sincos_16", FIXED(16)},
+-
+         {"__fd_tan_1", "__fd_tan_2", FIXED(2)},
+         {"__fd_tan_1", "__fd_tan_4", FIXED(4)},
+         {"__fd_tan_1", "__fd_tan_8", FIXED(8)},


### PR DESCRIPTION
This adds a new recipe for "flang classic" (not to be confused
with LLVM's new flang which cannot yet generate code) from
https://github.com/flang-compiler/flang. Currently only
x86_64-linux-musl is supported because the build does complicated
bootstrap things to build its runtime library. The intent here
is to try to this in sanitizer builds of fortran-containing jlls,
so the musl version is sufficient (though we'll need to figure out
how to build the rtlib for each target).