### PR TITLE
[MKL] Update to 2022.1.0

### DIFF
--- a/M/MKL/build_tarballs.jl
+++ b/M/MKL/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder, Pkg
 
 name = "MKL"
-version = v"2022.0.0"
+version = v"2022.1.0"
 
 # Bash recipes for building across all platforms
 script = read(joinpath(@__DIR__, "script.sh"), String)
@@ -13,8 +13,8 @@ platform_sources = [
     (
         platform = Platform("x86_64", "linux"; libc="glibc"),
         source = ArchiveSource(
-            "https://anaconda.org/intel/mkl/2022.0.1/download/linux-64/mkl-2022.0.1-intel_117.tar.bz2",
-            "62a3567efd4fa413181753dfc36c15bdfc8ec500eae4e5dcb104ed0d24136cfa";
+            "https://anaconda.org/intel/mkl/2022.1.0/download/linux-64/mkl-2022.1.0-intel_223.tar.bz2",
+            "31c225ce08d3dc129f0881e5d36a1ef0ba8dc9fdc0e168397c2ac144d5f0bf54";
             unpack_target = "mkl-x86_64-linux-gnu"
         ),
         # We need to run autofix on Linux, because here libmkl_rt doesn't
@@ -36,8 +36,8 @@ platform_sources = [
     (
         platform = Platform("x86_64", "macos"),
         source = ArchiveSource(
-            "https://anaconda.org/intel/mkl/2022.0.0/download/osx-64/mkl-2022.0.0-intel_105.tar.bz2",
-            "fc026812458fd2053a6327bb5a42f47f97258147c39111bd6376dfabe51d05f5";
+            "https://anaconda.org/intel/mkl/2022.1.0/download/osx-64/mkl-2022.1.0-intel_208.tar.bz2",
+            "98ceaefa60718bbcda84211f56396ed2e7e88484223708643d6ef6aa6b58f7d5";
             unpack_target = "mkl-x86_64-apple-darwin14"
         ),
         # Need to disable autofix: updating linkage of libmkl_intel_thread.dylib on
@@ -59,8 +59,8 @@ platform_sources = [
     (
         platform = Platform("x86_64", "windows"),
         source = ArchiveSource(
-            "https://anaconda.org/intel/mkl/2022.0.0/download/win-64/mkl-2022.0.0-intel_115.tar.bz2",
-            "ba5a1f936b4e9fec0e3b5ae3ce44b56d06a6645a7c9456aa298c7d7373fd34c2";
+            "https://anaconda.org/intel/mkl/2022.1.0/download/win-64/mkl-2022.1.0-intel_192.tar.bz2",
+            "090e0a6121ecc09c3036b96a487cc975386b9c934fe1e3ece5457db7f39baae8";
             unpack_target = "mkl-x86_64-w64-mingw32"
         ),
         autofix = false,


### PR DESCRIPTION
Only the 64-bit binaries have 2022.1.0 updates at https://anaconda.org/intel/mkl/