### PR TITLE
[NetCDF] drop the c-flag -std=c99 and explicitly disable plugins

### DIFF
--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -30,7 +30,6 @@ script = raw"""
 cd $WORKSPACE/srcdir/netcdf-c-*
 
 export CPPFLAGS="-I${includedir}"
-export CFLAGS="-std=c99"
 export LDFLAGS="-L${libdir}"
 export LDFLAGS_MAKE="${LDFLAGS}"
 CONFIGURE_OPTIONS=""

--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -46,7 +46,7 @@ if [[ ${target} == *-mingw* ]]; then
 
     # additional configure options from
     # https://github.com/Unidata/netcdf-c/blob/5df5539576c5b2aa8f31d4b50c4f8258925589dd/.github/workflows/run_tests_win_mingw.yml#L38
-    CONFIGURE_OPTIONS="--disable-plugins --disable-byterange"
+    CONFIGURE_OPTIONS="--disable-byterange"
 elif [[ "${target}" == *-apple-* ]]; then
     # this file is referenced by hdf.h by not installed
     touch ${includedir}/features.h
@@ -66,6 +66,7 @@ rm /workspace/destdir/lib/*.la
     --enable-shared \
     --disable-static \
     --disable-dap-remote-tests \
+    --disable-plugins \
     $CONFIGURE_OPTIONS
 
 make LDFLAGS="${LDFLAGS_MAKE}" -j${nproc}


### PR DESCRIPTION

* drop the c-flag `-std=c99`: the flag was necessary in the past, but this is longer the case. But more importantly, this flag triggers some memory issue and segmentation fault (https://github.com/Unidata/netcdf-c/issues/2486#issuecomment-1224285775, https://github.com/Alexander-Barth/NCDatasets.jl/issues/187)
* disable plugins: previously plugins are compiled on non-Windows platforms, but not installed. We can re-enable plugins once the upstream issues are solved (see https://github.com/JuliaPackaging/Yggdrasil/pull/5319#issuecomment-1217512599).


I tested my package NCDatasets with this NetCDF_jll, and I don't see any failure on Linux, Mac OS and Windows (all x86_64):
https://github.com/Alexander-Barth/NCDatasets.jl/actions/runs/2902145491
