### PR TITLE
[glmnet] New version 2.0.13

### DIFF
--- a/G/glmnet/build_tarballs.jl
+++ b/G/glmnet/build_tarballs.jl
@@ -3,24 +3,16 @@
 using BinaryBuilder, Pkg
 
 name = "glmnet"
-version = v"4.0.2"
+version = v"2.0.13"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/cran/glmnet.git", "b1a4b50de01e0cd24343959d7cf86452bac17b26")
+    GitSource("https://github.com/cran/glmnet.git", "6de9dbc14c515d08999a7af77ff01e44218a4f4e")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/glmnet/src
-
-# Add stub for `setpb`, which normally comes from `pb.c` to connect the 
-# progress meter to R, but we don't need that
-echo "
-      subroutine setpb(val)
-      return
-      end
-" > pb.f
 
 flags="-fdefault-real-8 -ffixed-form -shared -O3"
 if [[ ${target} != *mingw* ]]; then
@@ -30,10 +22,9 @@ if [[ ${target} != aarch64* ]] && [[ ${target} != arm* ]]; then
     flags="${flags} -m${nbits}";
 fi
 mkdir -p ${libdir}
-${FC} ${LDFLAGS} ${flags} glmnet5dpclean.f wls.f pb.f -o ${libdir}/libglmnet.${dlext}
+${FC} ${LDFLAGS} ${flags} glmnet5.f90 -o ${libdir}/libglmnet.${dlext}
 install_license ../DESCRIPTION
 """
-
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_gfortran_versions(supported_platforms())
@@ -49,4 +40,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
This is the most recent version of the glmnet library (tagged as [`2.0-13`](https://github.com/cran/glmnet/tree/2.0-13/src)) that works with the current (0.7) release of the GLMNet.jl package.

Trying to use the following [`2.0-16`](https://github.com/cran/glmnet/tree/2.0-16/src) release or any later version with the current GLMNet.jl results in a segfault. I am trying to figure this out, but have not yet been successful (see [here](https://discourse.julialang.org/t/help-with-updating-fortran-wrapper/86221) for more info). This problem occurs with v4.0.2 build that was added in #2028, this version has never been used by the GLMNet.jl package.

This version of the source is more recent than the JLL that is currently used by GLMNet.jl (which was added in #540 as v5.0.0, because confusingly glmnet changed their versioning scheme at some point, see [prior discussion](https://github.com/JuliaPackaging/Yggdrasil/pull/2028#issuecomment-720110906))

The main reason for this update is to rebuild a working version of the JLL to get support for the new platforms, specifically macaarch64, so that the GLMNet.jl package can work here now that Julia 1.8 is released and supported. Currently there is no artifact available here, and I would like to fix that ASAP while continuing to figure out the problems with later glmnet versions