### PR TITLE
[MariaDB_Connector_ODBC] Make `MariaDB_Connector_C` a runtime dependency

### DIFF
--- a/M/MariaDB_Connector_ODBC/build_tarballs.jl
+++ b/M/MariaDB_Connector_ODBC/build_tarballs.jl
@@ -100,7 +100,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency("MariaDB_Connector_C_jll"),
+    Dependency("MariaDB_Connector_C_jll"),
     Dependency("iODBC_jll"),
     Dependency("Libiconv_jll"),
     Dependency("unixODBC_jll"),


### PR DESCRIPTION
The PR in the General registry https://github.com/JuliaRegistries/General/pull/67306 initially failed to load the package with
```
ERROR: InitError: could not load library "/tmp/jl_37WPXe/artifacts/5da83d1208b15cd03019a90afe1b30e61a28bbf3/lib/mariadb/libmaodbc.so"
libmariadb.so.3: cannot open shared object file: No such file or directory
```
This is explained by the fact
```
julia> using MariaDB_Connector_ODBC_jll

julia> run(addenv(`libtree -p $(libmaodbc)`, "LD_LIBRARY_PATH"=>MariaDB_Connector_ODBC_jll.LIBPATH[]));
/home/mose/.julia/artifacts/5da83d1208b15cd03019a90afe1b30e61a28bbf3/lib/mariadb/libmaodbc.so 
├── /home/mose/.julia/artifacts/84637f9dbc8f313838011977325eec613e7ca1bc/lib/libodbcinst.so.2 [LD_LIBRARY_PATH]
│   └── /lib/libpthread.so.0 [default path]
├── /home/mose/.julia/artifacts/25fa81dbac6496585a91dbdc258273d39442466f/lib/libssl.so.1.1 [LD_LIBRARY_PATH]
│   ├── /home/mose/.julia/artifacts/25fa81dbac6496585a91dbdc258273d39442466f/lib/libcrypto.so.1.1 [LD_LIBRARY_PATH]
│   │   └── /lib/libpthread.so.0 [default path]
│   └── /lib/libpthread.so.0 [default path]
├── /home/mose/.julia/artifacts/25fa81dbac6496585a91dbdc258273d39442466f/lib/libcrypto.so.1.1 [LD_LIBRARY_PATH]
├── /home/mose/.julia/juliaup/julia-1.8.0+0.x64/bin/../lib/julia/libz.so.1 [LD_LIBRARY_PATH]
└── /lib/libmariadb.so.3 [default path]
    ├── /home/mose/.julia/artifacts/25fa81dbac6496585a91dbdc258273d39442466f/lib/libssl.so.1.1 [LD_LIBRARY_PATH]
    ├── /home/mose/.julia/artifacts/25fa81dbac6496585a91dbdc258273d39442466f/lib/libcrypto.so.1.1 [LD_LIBRARY_PATH]
    └── /home/mose/.julia/juliaup/julia-1.8.0+0.x64/bin/../lib/julia/libz.so.1 [LD_LIBRARY_PATH]
```
Note that this is working for me because `libmariadb.so.3` is found in the system under `/lib`, but it isn't in any of the runtime dependencies of `MariaDB_Connector_ODBC_jll`.  `libmariadb.so` _is_ provided by `MariaDB_Connector_C`, which _is_ a dependency of `MariaDB_Connector_ODBC`, but only a build-time one: https://github.com/JuliaPackaging/Yggdrasil/blob/b15a965d9e44920b50f661f1a9d40a7afefa9df3/M/MariaDB_Connector_ODBC/build_tarballs.jl#L103 This PR solves the issue by making `MariaDB_Connector_C` a normal build- and run-time dependency.

I'm not really sure why in #1055 I made this choice of making the dependency a build-time only, but I suspect something changed in the build system of `MariaDB_Connector_ODBC` which now forces us to properly have a libmariadb at runtime.