### PR TITLE
[libgeotiff] allow PROJ 9.1 compat

### DIFF
--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -1,11 +1,15 @@
 using BinaryBuilder, Pkg
 
 name = "libgeotiff"
-version = v"1.7.1"
+upstream_version = v"1.7.1"
+version_offset = v"0.0.0"
+version = VersionNumber(upstream_version.major * 100 + version_offset.major,
+                        upstream_version.minor * 100 + version_offset.minor,
+                        upstream_version.patch * 100 + version_offset.patch)
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/OSGeo/libgeotiff/releases/download/$version/libgeotiff-$version.tar.gz",
+    ArchiveSource("https://github.com/OSGeo/libgeotiff/releases/download/$upstream_version/libgeotiff-$upstream_version.tar.gz",
                   "05ab1347aaa471fc97347d8d4269ff0c00f30fa666d956baba37948ec87e55d6"),
 ]
 
@@ -41,7 +45,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("PROJ_jll"; compat="~900.0"),
+    Dependency("PROJ_jll"; compat="900"),
     Dependency("Libtiff_jll"; compat="4.3"),
     Dependency("LibCURL_jll"),
 ]

--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -45,7 +45,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("PROJ_jll"; compat="900"),
+    Dependency("PROJ_jll"; compat="~900.100"),
     Dependency("Libtiff_jll"; compat="4.3"),
     Dependency("LibCURL_jll"),
 ]


### PR DESCRIPTION
The current `Dependency("PROJ_jll"; compat="~900.0")`, which is also used in GDAL_jll, blocks PROJ_jll 900.100 that was just released.

The SOVERSION of PROJ 9.0 and 9.1 are the same, so I went for `Dependency("PROJ_jll"; compat="900")` to allow both. Or is it better to just allow compat of 9.1 and not higher?

Version and instructions around PROJ_SOVERSION:
https://github.com/OSGeo/PROJ/blob/9.1.0/CMakeLists.txt#L119
https://github.com/OSGeo/PROJ/blob/9.1.0/HOWTO-RELEASE#L36-L39
