### PR TITLE
Sundials: Build for msan

### DIFF
--- a/S/Sundials/Sundials@5/build_tarballs.jl
+++ b/S/Sundials/Sundials@5/build_tarballs.jl
@@ -85,6 +85,7 @@ fi
 # We attempt to build for all defined platforms
 platforms = filter!(p -> arch(p) != "powerpc64le", supported_platforms(; experimental=true))
 platforms = expand_gfortran_versions(platforms)
+push!(platforms, Platform("x86_64", "linux"; sanitize="memory"))
 
 products = [
     LibraryProduct("libsundials_arkode", :libsundials_arkode),


### PR DESCRIPTION
There have been some mysterious Sundials memory errors lately,
so there's been a request for running sundials with msan. It'll
also be useful to have a non-Base jll for testing that we can
have the artifacts system properly load the msan variants of
everything, so this will hopefully be useful for that.