### PR TITLE
[GDAL] Use NetCDF and HDF5 when available.

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -95,6 +95,16 @@ products = [
     ExecutableProduct("ogrtindex", :ogrtindex_path),
 ]
 
+hdf5_platforms = [
+    Platform("x86_64", "linux"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    Platform("x86_64", "windows"),
+    Platform("i686", "windows"),
+    Platform("aarch64", "macos"),
+]
+hdf5_platforms = expand_cxxstring_abis(hdf5_platforms)
+
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GEOS_jll"; compat="~3.11"),
@@ -107,8 +117,8 @@ dependencies = [
     Dependency("Libtiff_jll"; compat="4.3"),
     Dependency("libgeotiff_jll"; compat="100.700.100"),
     Dependency("LibCURL_jll"; compat="7.73"),
-    Dependency("NetCDF_jll"; compat="400.902.5"),
-    Dependency("HDF5_jll"),
+    Dependency("NetCDF_jll"; compat="400.902.5", platforms=hdf5_platforms),
+    Dependency("HDF5_jll"; platforms=hdf5_platforms),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -6,8 +6,8 @@ name = "GDAL"
 upstream_version = v"3.5.1"
 version_offset = v"0.0.1"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
-    upstream_version.minor * 100 + version_offset.minor,
-    upstream_version.patch * 100 + version_offset.patch)
+                        upstream_version.minor * 100 + version_offset.minor,
+                        upstream_version.patch * 100 + version_offset.patch)
 
 # Collection of sources required to build GDAL
 sources = [
@@ -108,9 +108,9 @@ dependencies = [
     Dependency("libgeotiff_jll"; compat="100.700.100"),
     Dependency("LibCURL_jll"; compat="7.73"),
     Dependency("NetCDF_jll"; compat="400.902.5"),
-    Dependency("HDF5_jll")
+    Dependency("HDF5_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6", preferred_gcc_version=v"8")
+               julia_compat="1.6", preferred_gcc_version=v"8")

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder, Pkg
 
 name = "GDAL"
 upstream_version = v"3.5.1"
-version_offset = v"0.0.1"
+version_offset = v"0.0.2"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
                         upstream_version.patch * 100 + version_offset.patch)


### PR DESCRIPTION
@visr 

Fixes #4950 (at least partially).

Uses the same approach as #5383, by only using NetCDF and HDF5 on the platforms where they are available. While this introduces a disparity between platforms, it helps the most common platforms (Windows, macOS, Linux gnu).

Platforms without HDF5 and NetCDF
- FreeBSD
- Linux
	- musl
	- i686
	- arm
	- powerpc

