### PR TITLE
Add ROCmLLVM 5.2.3

### DIFF
--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/build_tarballs.jl
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/build_tarballs.jl
@@ -1,0 +1,7 @@
+using Pkg
+using BinaryBuilder
+
+include("../common.jl")
+build_tarballs(
+    ARGS, configure_build(v"5.2.3")...;
+    preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.9")

--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/crt_patches/define-fp-magic.patch
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/crt_patches/define-fp-magic.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 82048f0eae2e..9b1922a7e8da 100644
+--- a/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -218,6 +218,10 @@ namespace __sanitizer {
+ 
+   unsigned ucontext_t_sz(void *ctx) {
+ #    if SANITIZER_LINUX && SANITIZER_X64
++    // Added in Linux kernel 3.4.0, merged to glibc in 2.16
++#      ifndef FP_XSTATE_MAGIC1
++#        define FP_XSTATE_MAGIC1 0x46505853U
++#      endif
+     // See kernel arch/x86/kernel/fpu/signal.c for details.
+     const auto *fpregs = static_cast<ucontext_t *>(ctx)->uc_mcontext.fpregs;
+     // The member names differ across header versions, but the actual layout

--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/libcxx_patches/7005_libcxx_musl.patch
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/libcxx_patches/7005_libcxx_musl.patch
@@ -1,0 +1,22 @@
+diff --git a/include/locale b/include/locale
+index 2043892fa2d..4af51464208 100644
+--- a/include/locale
++++ b/include/locale
+@@ -737,7 +737,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        long long __ll = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        long long __ll = strtoll(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;
+@@ -777,7 +777,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        unsigned long long __ll = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        unsigned long long __ll = strtoull(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;

--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0050-unique_function_clang-sa.patch
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0050-unique_function_clang-sa.patch
@@ -1,0 +1,28 @@
+From 1fa6efaa946243004c45be92e66b324dc980df7d Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Thu, 17 Sep 2020 23:22:45 +0200
+Subject: [PATCH] clang-sa can't determine that !RHS implies !LHS
+
+---
+ llvm/include/llvm/ADT/FunctionExtras.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/llvm/include/llvm/ADT/FunctionExtras.h b/llvm/include/llvm/ADT/FunctionExtras.h
+index 121aa527a5d..b9b6d829b14 100644
+--- a/llvm/include/llvm/ADT/FunctionExtras.h
++++ b/llvm/include/llvm/ADT/FunctionExtras.h
+@@ -193,9 +193,11 @@ public:
+     // Copy the callback and inline flag.
+     CallbackAndInlineFlag = RHS.CallbackAndInlineFlag;
+ 
++#ifndef __clang_analyzer__
+     // If the RHS is empty, just copying the above is sufficient.
+     if (!RHS)
+       return;
++#endif
+ 
+     if (!isInlineStorage()) {
+       // The out-of-line case is easiest to move.
+-- 
+2.28.0
+

--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0100-llvm-12-musl-bb.patch
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0100-llvm-12-musl-bb.patch
@@ -1,0 +1,37 @@
+From f1901de14ff1f1abcc729c4adccfbd5017e30357 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 7 May 2021 13:54:41 -0400
+Subject: [PATCH] [Compiler-RT] Fix compilation on musl
+
+---
+ compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp                    | 1 +
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.cpp     | 1 -
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+index b87798603fda..452a08aafe0e 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+@@ -26,6 +26,7 @@
+ 
+ #include <cassert>
+ #include <cstdint>
++#include <stddef.h>
+ #include <dlfcn.h> // for dlsym()
+ 
+ static void *getFuncAddr(const char *name, uintptr_t wrapper_addr) {
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 12dd39e674ac..bb0f7a2daa8c 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -69,7 +69,6 @@
+ #include <malloc.h>
+ #include <mntent.h>
+ #include <netinet/ether.h>
+-#include <sys/sysinfo.h>
+ #include <sys/vt.h>
+ #include <linux/cdrom.h>
+ #include <linux/fd.h>
+-- 
+2.31.1
+

--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0100-revert-sdk-requirement-tsan.patch
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0100-revert-sdk-requirement-tsan.patch
@@ -1,0 +1,33 @@
+From beb762862751560f5499aaf2a4487277f08003e4 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Sat, 30 Apr 2022 14:55:36 -0400
+Subject: [PATCH] [PATCH] Revert "[TSan] Add CMake check for minimal SDK
+ requirements on Darwin"
+
+This reverts commit 3bf3996cd4ef2d4898b32d4cef52d6549bbe6820.
+---
+ compiler-rt/lib/tsan/rtl/CMakeLists.txt | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/compiler-rt/lib/tsan/rtl/CMakeLists.txt b/compiler-rt/lib/tsan/rtl/CMakeLists.txt
+index 0da2b89fd807..1bf6f8b187c4 100644
+--- a/compiler-rt/lib/tsan/rtl/CMakeLists.txt
++++ b/compiler-rt/lib/tsan/rtl/CMakeLists.txt
+@@ -111,14 +111,6 @@ if("${CMAKE_C_FLAGS}" MATCHES "-Wno-(error=)?unused-command-line-argument")
+ endif()
+ 
+ if(APPLE)
+-  # Ideally we would check the SDK version for the actual platform we are
+-  # building for here.  To make our lifes easier we assume the host SDK setup is
+-  # sane and use the macOS SDK version as a proxy for aligned SDKs.
+-  find_darwin_sdk_version(macosx_sdk_version "macosx")
+-  if ("${macosx_sdk_version}" VERSION_LESS 10.12)
+-    message(FATAL_ERROR "Building the TSan runtime requires at least macOS SDK 10.12 (or aligned SDK on other platforms)")
+-  endif()
+-
+   add_asm_sources(TSAN_ASM_SOURCES
+     tsan_rtl_amd64.S
+     tsan_rtl_aarch64.S
+-- 
+2.35.1
+

--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0101-fix-darwin-tsan-on-old-sdks.patch
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0101-fix-darwin-tsan-on-old-sdks.patch
@@ -1,0 +1,66 @@
+From 36d2fc022bb0437333276db8c75fb43b338da343 Mon Sep 17 00:00:00 2001
+From: Julian Lettner <julian.lettner@apple.com>
+Date: Wed, 5 Feb 2020 08:17:06 -0800
+Subject: [PATCH 2/2] [TSan] Ensure we can compile the runtime with older SDKs
+
+One of my changes [1] included in this release silently bumped the
+minimal macOS SDK required for building the TSan runtime to SDK 10.12.
+Let's ensure release 10 does not unexpectedly break builders with old
+SDKs and add proper minimal SDK checking in CMake for subsequent
+releases.
+
+This fix `#ifdef`s out interceptors for newer APIs.  Note that the
+resulting TSan runtime is less complete: when these newer APIs are used
+TSan will report false positives.
+
+Fixes llvm 10 release blocker: #44682
+https://bugs.llvm.org/show_bug.cgi?id=44682
+
+[1] 894abb46f891cba2e0ef581650f27f512a7824b4
+
+Reviewed By: dmajor
+
+Differential Revision: https://reviews.llvm.org/D74059
+---
+ compiler-rt/lib/tsan/rtl/tsan_interceptors_mac.cpp | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/tsan/rtl/tsan_interceptors_mac.cpp b/compiler-rt/lib/tsan/rtl/tsan_interceptors_mac.cpp
+index aa29536d861..91584914d86 100644
+--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_mac.cpp
++++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_mac.cpp
+@@ -23,9 +23,12 @@
+ #include <errno.h>
+ #include <libkern/OSAtomic.h>
+ #include <objc/objc-sync.h>
+-#include <os/lock.h>
+ #include <sys/ucontext.h>
+ 
++#if defined(__has_include) && __has_include(<os/lock.h>)
++#include <os/lock.h>
++#endif
++
+ #if defined(__has_include) && __has_include(<xpc/xpc.h>)
+ #include <xpc/xpc.h>
+ #endif  // #if defined(__has_include) && __has_include(<xpc/xpc.h>)
+@@ -247,6 +250,8 @@ TSAN_INTERCEPTOR(void, os_lock_unlock, void *lock) {
+   REAL(os_lock_unlock)(lock);
+ }
+ 
++#if defined(__has_include) && __has_include(<os/lock.h>)
++
+ TSAN_INTERCEPTOR(void, os_unfair_lock_lock, os_unfair_lock_t lock) {
+   if (!cur_thread()->is_inited || cur_thread()->is_dead) {
+     return REAL(os_unfair_lock_lock)(lock);
+@@ -286,6 +291,8 @@ TSAN_INTERCEPTOR(void, os_unfair_lock_unlock, os_unfair_lock_t lock) {
+   REAL(os_unfair_lock_unlock)(lock);
+ }
+ 
++#endif  // #if defined(__has_include) && __has_include(<os/lock.h>)
++
+ #if defined(__has_include) && __has_include(<xpc/xpc.h>)
+ 
+ TSAN_INTERCEPTOR(void, xpc_connection_set_event_handler,
+-- 
+2.28.0
+

--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0101-llvm-12-musl-bb-32.patch
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0101-llvm-12-musl-bb-32.patch
@@ -1,0 +1,28 @@
+From a9083bb6f5450e0a705c8735ed9b460b3185266b Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Mon, 2 May 2022 12:24:20 -0400
+Subject: [PATCH] [Sanitizers] Fix compilation on musl 32bit
+
+Without this compiling the santizers on i686-musl fail
+
+Differential Revision: https://reviews.llvm.org/D124779
+---
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.h      | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+index 4472b6efa963..e9213d2a905f 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -478,7 +478,7 @@ struct __sanitizer_dirent {
+   unsigned short d_reclen;
+   // more fields that we don't care about
+ };
+-#  elif SANITIZER_ANDROID || defined(__x86_64__) || defined(__hexagon__)
++#  elif SANITIZER_ANDROID || defined(__x86_64__) || defined(__hexagon__) || !defined(__GLIBC__)
+ struct __sanitizer_dirent {
+   unsigned long long d_ino;
+   unsigned long long d_off;
+-- 
+2.35.1
+

--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0702-apple-codesign.patch
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0702-apple-codesign.patch
@@ -1,0 +1,13 @@
+diff --git a/compiler-rt/cmake/Modules/AddCompilerRT.cmake b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -321,7 +321,7 @@
+         set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")
+         set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
+       endif()
+-      if(APPLE)
++      if(IOS)
+         # Ad-hoc sign the dylibs
+         add_custom_command(TARGET ${libname}
+           POST_BUILD  
+

--- a/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0703-apple-10..12.patch
+++ b/R/ROCmLLVM/ROCmLLVM@5.2.3/bundled/patches/0703-apple-10..12.patch
@@ -1,0 +1,25 @@
+From b7dc5e42d82238845581d06ad33ad19326f9e096 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Sun, 1 May 2022 22:10:14 -0400
+Subject: [PATCH] [PATCH] disable OSX 10.12 optimization
+
+---
+ llvm/lib/Support/Unix/Path.inc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/llvm/lib/Support/Unix/Path.inc b/llvm/lib/Support/Unix/Path.inc
+index 788460d657fe..80b334b78b20 100644
+--- a/llvm/lib/Support/Unix/Path.inc
++++ b/llvm/lib/Support/Unix/Path.inc
+@@ -1462,7 +1462,7 @@ namespace fs {
+ std::error_code copy_file(const Twine &From, const Twine &To) {
+   std::string FromS = From.str();
+   std::string ToS = To.str();
+-#if __has_builtin(__builtin_available)
++#if __has_builtin(__builtin_available) && 0
+   if (__builtin_available(macos 10.12, *)) {
+     // Optimistically try to use clonefile() and handle errors, rather than
+     // calling stat() to see if it'll work.
+-- 
+2.35.1
+

--- a/R/ROCmLLVM/common.jl
+++ b/R/ROCmLLVM/common.jl
@@ -2,10 +2,12 @@ const ROCM_GIT = "https://github.com/RadeonOpenCompute/llvm-project"
 const ROCM_TAGS = Dict(
     v"4.2.0" => "b204d7f0cae65b6cd4446eec50fc1fb675d582af",
     v"4.5.2" => "9bbd96fd1936641cd47defd8022edafd063019d5",
+    v"5.2.3" => "575c504b18f2f7e06fa77a3d2f63c83ed930053a",
 )
 const LLVM_VERSIONS = Dict(
     v"4.2.0" => v"12.0.0",
     v"4.5.2" => v"13.0.0",
+    v"5.2.3" => v"14.0.0",
 )
 const ROCM_PLATFORMS = [
     Platform("x86_64", "linux"; libc="glibc", cxxstring_abi="cxx11"),

--- a/R/ROCmLLVM/common.jl
+++ b/R/ROCmLLVM/common.jl
@@ -30,7 +30,6 @@ function configure_build(rocm_version; assert::Bool = false)
     lbin = "llvm/bin"
     products = [
         FileProduct(joinpath(llib, "libLLVMCore.a"), :libllvmcore),
-        FileProduct(joinpath(llib, "liblldCore.a"), :liblldcore),
         FileProduct(joinpath(llib, "libclangBasic.a"), :libclangbasic),
         LibraryProduct("libclang", :libclang, llib; dont_dlopen=true),
         LibraryProduct("libclang-cpp", :libclang_cpp, llib; dont_dlopen=true),


### PR DESCRIPTION
Patches are taken from respective LLVM_full recipe.
Added `define-fp-magic.patch` which is already fixed on master, but not in 5.2.3.