### PR TITLE
Backport Python 3.11 patch to avoid linking against libcrypt.

### DIFF
--- a/P/Python/bundled/patches/libcrypt.patch
+++ b/P/Python/bundled/patches/libcrypt.patch
@@ -1,0 +1,57 @@
+From be21706f3760bec8bd11f85ce02ed6792b07f51f Mon Sep 17 00:00:00 2001
+From: Mike Gilbert <floppymaster@gmail.com>
+Date: Mon, 11 Oct 2021 19:24:03 -0400
+Subject: [PATCH] bpo-45433: Do not link libpython against libcrypt (GH-28881)
+
+Save/restore LIBS when calling AC_SEARCH_LIBS(..., crypt). This avoid
+linking libpython with libcrypt.
+---
+ Doc/whatsnew/3.11.rst                                          | 2 ++
+ .../NEWS.d/next/Build/2021-10-11-16-08-37.bpo-45433.pVDkMV.rst | 1 +
+ configure                                                      | 3 +++
+ configure.ac                                                   | 3 +++
+ 4 files changed, 9 insertions(+)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-08-37.bpo-45433.pVDkMV.rst
+
+diff --git a/configure b/configure
+index 15c7c54b0953..70f28b0c7064 100755
+--- a/configure
++++ b/configure
+@@ -13227,6 +13227,8 @@ done
+
+ # We search for both crypt and crypt_r as one or the other may be defined
+ # This gets us our -lcrypt in LIBS when required on the target platform.
++# Save/restore LIBS to avoid linking libpython with libcrypt.
++LIBS_SAVE=$LIBS
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing crypt" >&5
+ $as_echo_n "checking for library containing crypt... " >&6; }
+ if ${ac_cv_search_crypt+:} false; then :
+@@ -13368,6 +13370,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+ fi
+
++LIBS=$LIBS_SAVE
+
+ for ac_func in clock_gettime
+ do :
+diff --git a/configure.ac b/configure.ac
+index 6c65b2914bf6..afdc68363cea 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4085,6 +4085,8 @@ AC_CHECK_FUNCS(setpgrp,
+
+ # We search for both crypt and crypt_r as one or the other may be defined
+ # This gets us our -lcrypt in LIBS when required on the target platform.
++# Save/restore LIBS to avoid linking libpython with libcrypt.
++LIBS_SAVE=$LIBS
+ AC_SEARCH_LIBS(crypt, crypt)
+ AC_SEARCH_LIBS(crypt_r, crypt)
+
+@@ -4099,6 +4101,7 @@ char *r = crypt_r("", "", &d);
+     [AC_DEFINE(HAVE_CRYPT_R, 1, [Define if you have the crypt_r() function.])],
+     [])
+ )
++LIBS=$LIBS_SAVE
+
+ AC_CHECK_FUNCS(clock_gettime, [], [
+     AC_CHECK_LIB(rt, clock_gettime, [


### PR DESCRIPTION
Alternative to https://github.com/JuliaPackaging/Yggdrasil/pull/5277 that actually works. Backports https://github.com/python/cpython/pull/28881 to our build of Python 3.8.