### PR TITLE
Add Zlib and Ncurses dep to Metal LLVM tools

### DIFF
--- a/M/Metal_LLVM_Tools/build_tarballs.jl
+++ b/M/Metal_LLVM_Tools/build_tarballs.jl
@@ -99,7 +99,8 @@ for llvm_version in llvm_versions, llvm_assertions in (false, true)
     llvm_name = llvm_assertions ? "LLVM_full_assert_jll" : "LLVM_full_jll"
     dependencies = [
         BuildDependency(PackageSpec(name=llvm_name, version=llvm_version)),
-        Dependency("Zlib_jll")
+        Dependency("Zlib_jll"),
+        Dependency("Ncurses_jll")
     ]
 
     for platform in platforms

--- a/M/Metal_LLVM_Tools/build_tarballs.jl
+++ b/M/Metal_LLVM_Tools/build_tarballs.jl
@@ -71,6 +71,17 @@ CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
 # Only build the Metal back-end
 CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD=Metal)
 
+# Turn on ZLIB
+CMAKE_FLAGS+=(-DLLVM_ENABLE_ZLIB=ON)
+# Turn off XML2
+CMAKE_FLAGS+=(-DLLVM_ENABLE_LIBXML2=OFF)
+
+# Disable useless things like docs, terminfo, etc....
+CMAKE_FLAGS+=(-DLLVM_INCLUDE_DOCS=Off)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_TERMINFO=Off)
+CMAKE_FLAGS+=(-DHAVE_HISTEDIT_H=Off)
+CMAKE_FLAGS+=(-DHAVE_LIBEDIT=Off)
+
 cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]}
 ninja -j${nproc} \
     tools/metallib-as/install \
@@ -99,8 +110,7 @@ for llvm_version in llvm_versions, llvm_assertions in (false, true)
     llvm_name = llvm_assertions ? "LLVM_full_assert_jll" : "LLVM_full_jll"
     dependencies = [
         BuildDependency(PackageSpec(name=llvm_name, version=llvm_version)),
-        Dependency("Zlib_jll"),
-        Dependency("Ncurses_jll")
+        Dependency("Zlib_jll")
     ]
 
     for platform in platforms

--- a/M/Metal_LLVM_Tools/build_tarballs.jl
+++ b/M/Metal_LLVM_Tools/build_tarballs.jl
@@ -98,7 +98,8 @@ for llvm_version in llvm_versions, llvm_assertions in (false, true)
     # Dependencies that must be installed before this package can be built
     llvm_name = llvm_assertions ? "LLVM_full_assert_jll" : "LLVM_full_jll"
     dependencies = [
-        BuildDependency(PackageSpec(name=llvm_name, version=llvm_version))
+        BuildDependency(PackageSpec(name=llvm_name, version=llvm_version)),
+        Dependency("Zlib_jll")
     ]
 
     for platform in platforms


### PR DESCRIPTION
```
❯ otool -L /Users/tim/Julia/depot/artifacts/0ec307395e9dd683100b6ecbb14963c6ddd232e6/bin/metallib-as
/Users/tim/Julia/depot/artifacts/0ec307395e9dd683100b6ecbb14963c6ddd232e6/bin/metallib-as:
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
	/usr/lib/libncurses.5.4.dylib (compatibility version 5.4.0, current version 5.4.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 904.4.0)
```

I'm not sure where the ncurses use comes from... It doesn't happen with `llvm-as` (or any other tool) from LLVM_full_jll:

```
$ otool -L llvm-as
llvm-as:
	@rpath/libLLVM.dylib (compatibility version 1.0.0, current version 14.0.6)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 904.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
```

EDIT: ah, probably `DLLVM_ENABLE_TERMINFO`