### PR TITLE
[libxcrypt] add new recipes

### DIFF
--- a/L/libxcrypt/common.jl
+++ b/L/libxcrypt/common.jl
@@ -1,0 +1,60 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+function build_libxcrypt(ARGS; legacy::Bool)
+   version = v"4.4.28"
+   name = "libxcrypt"
+
+   # Collection of sources required to build libxcrypt
+   sources = [
+       ArchiveSource("https://github.com/besser82/libxcrypt/releases/download/v$(version)/libxcrypt-$(version).tar.xz",
+                     "9e936811f9fad11dbca33ca19bd97c55c52eb3ca15901f27ade046cc79e69e87")
+   ]
+
+   # Bash recipe for building across all platforms
+   script = raw"""
+   cd $WORKSPACE/srcdir/libxcrypt-*/
+   if [[ ${target} == *freebsd* ]]; then
+      extraflags="${extraflags} ax_cv_check_vscript_flag=--version-script"
+   fi
+   ./configure \
+               --prefix=${prefix} \
+               --build=${MACHTYPE} \
+               --host=${target} \
+               --enable-shared \
+               --disable-static \
+               ${extraflags}
+   make -j${nproc}
+   make install
+   install_license COPYING.LIB
+   """
+
+
+   # These are the platforms we will build for by default, unless further
+   # platforms are passed in on the command line
+   platforms = filter(!Sys.iswindows, supported_platforms())
+
+   # legacy variant is to provide a binary-compatible libcrypt.so.1 which can
+   # be used at runtime instead of the removed in recent glibc versions
+   # hence we only build for glibc platforms
+   if legacy
+      name *= "_legacy"
+      filter!(p -> (Sys.islinux(p) && libc(p) == "glibc"), platforms)
+   else
+      # this disables the glibc compatibility api
+      script = "extraflags=--disable-obsolete-api\n" * script
+   end
+
+   # The products that we will ensure are always built
+   products = Product[
+       LibraryProduct("libcrypt", :libcrypt)
+   ]
+
+   # Dependencies that must be installed before this package can be built
+   dependencies = Dependency[
+   ]
+
+   # Build the tarballs, and possibly a `build.jl` as well.
+   build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+end

--- a/L/libxcrypt/libxcrypt/build_tarballs.jl
+++ b/L/libxcrypt/libxcrypt/build_tarballs.jl
@@ -1,0 +1,3 @@
+include("../common.jl")
+
+build_libxcrypt(ARGS; legacy=false)

--- a/L/libxcrypt/libxcrypt_legacy/build_tarballs.jl
+++ b/L/libxcrypt/libxcrypt_legacy/build_tarballs.jl
@@ -1,0 +1,3 @@
+include("../common.jl")
+
+build_libxcrypt(ARGS; legacy=true)


### PR DESCRIPTION
`libxcrypt_legacy_jll` can be used as `RuntimeDependency` for packages that link to `libcrypt.so.1` from the old glibc that is used for building in BinaryBuilder (this is only built for glibc based platforms).
I tested this once by deploying this locally (x86_64-linux-gnu without libcrypt.so.1), loaded the `libxcrypt_legacy_jll` and then successfully loaded the (now obsolete) `Python_jll-3.8.8+2` with the libcrypt problem.

`libxcrypt_jll` which contains `libcrypt.so.2` can be used as a normal dependency for programs that need the crypt api, but this is untested. I am not sure how to make sure that this library will be used instead of the code from the old glibc, but maybe it just works.

This wont compile for mingw platforms, apart from a few minor errors that I was able to work around, the portability notes state:

> libxcrypt should be buildable with any ISO C1999-compliant C compiler, with one critical exception: the symbol versioning macros in crypt-port.h only work with compilers that implement certain GCC and GNU Binutils extensions (__attribute__((alias)), GCC-style asm, and .symver).

And GNU binutils ld supports symbol versions only for ELF platforms.