### PR TITLE
[SCIP_PaPILO] Use OpenBLAS32 instead of OpenBLAS

### DIFF
--- a/S/SCIP_PaPILO/build_tarballs.jl
+++ b/S/SCIP_PaPILO/build_tarballs.jl
@@ -59,7 +59,7 @@ dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"), v"6.2.0"),
     Dependency(PackageSpec(name="Ipopt_jll", uuid="9cc047cb-c261-5740-88fc-0cf96f7bdcc7"), v"300.1400.400"),
-    Dependency(PackageSpec(name="OpenBLAS_jll", uuid="4536629a-c528-5b80-bd46-f80d51c5b363"); compat="0.3.21"),
+    Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2"); compat="0.3.10"),
     Dependency(PackageSpec(name="oneTBB_jll", uuid="1317d2d5-d96f-522e-a858-c73665f53c3e"); compat="2021.4.1"),
     Dependency(PackageSpec(name="Readline_jll", uuid="05236dd9-4125-5232-aa7c-9ec0c9b2c25a")),
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),


### PR DESCRIPTION
As far as I understand, this is what was used before through IPOPT.  At least,
this library was linking to `libopenblas.so`, not `libopenblas64_.so`.  Also,
relax compat bound to be actually compatible with Julia v1.6.