### PR TITLE
CGAL with GMP v6.2.1

### DIFF
--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -44,8 +44,8 @@ products = Product[]
 dependencies = [
     # Essential dependencies
     Dependency("boost_jll"; compat="=1.76.0"),
-    Dependency("GMP_jll"; compat="6.2.0"),
-    Dependency("MPFR_jll"; compat="4.1.1"),
+    Dependency("GMP_jll"; compat="6.2.1"),
+    Dependency("MPFR_jll"; compat="4.1.1+3"),
 ]
 
 # Build the tarballs.

--- a/C/CGAL/build_tarballs.jl
+++ b/C/CGAL/build_tarballs.jl
@@ -45,7 +45,7 @@ dependencies = [
     # Essential dependencies
     Dependency("boost_jll"; compat="=1.76.0"),
     Dependency("GMP_jll"; compat="6.2.1"),
-    Dependency("MPFR_jll"; compat="4.1.1+3"),
+    Dependency("MPFR_jll"; compat="4.1.1"),
 ]
 
 # Build the tarballs.


### PR DESCRIPTION
Trying to understand why GMP v6.2.1 wasn't working in https://github.com/JuliaPackaging/Yggdrasil/pull/5496
It should have been working with MPFR v4.1.1+3 thanks to https://github.com/JuliaPackaging/Yggdrasil/pull/5459