### PR TITLE
[HIP 5.2.3] Disable legacy folder structure

### DIFF
--- a/H/HIP/HIP@4.5.2/bundled/patches/improve-compilation-disable-tests.patch
+++ b/H/HIP/HIP@4.5.2/bundled/patches/improve-compilation-disable-tests.patch
@@ -2,6 +2,18 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index b1ab39e7..a0f6b3c0 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -35,6 +35,11 @@ project(hip)
+ #  By default, CMake will search for a folder named vdi or ROCclr relative to the current path. Specify -DROCCLR_PATH=$ROCCLR_DIR if rocclr source is in obscure location.
+ #  By default, CMake will search for a folder named opencl or ROCm-OpenCL-Runtime relative to the current path. Specify -DAMD_OPENCL_PATH=$OPENCL_DIR if opencl source is in obscure location.
+ list(APPEND CMAKE_MODULE_PATH ${HIP_COMMON_DIR}/cmake)
++
++set(CMAKE_SKIP_BUILD_RPATH TRUE)
++set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
++set(CMAKE_INSTALL_RPATH "$ORIGIN/../../lib")
++
+ #############################
+ # Options
+ #############################
 @@ -87,7 +87,17 @@ string(REPLACE "-" ";" VERSION_LIST ${HIP_VERSION_PATCH_GITHASH})
  list(GET VERSION_LIST 0 HIP_VERSION_PATCH)
  set(HIP_VERSION_GITDATE 0)

--- a/H/HIP/HIP@4.5.2/bundled/patches/improve-compilation-disable-tests.patch
+++ b/H/HIP/HIP@4.5.2/bundled/patches/improve-compilation-disable-tests.patch
@@ -2,18 +2,6 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index b1ab39e7..a0f6b3c0 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -35,6 +35,11 @@ project(hip)
- #  By default, CMake will search for a folder named vdi or ROCclr relative to the current path. Specify -DROCCLR_PATH=$ROCCLR_DIR if rocclr source is in obscure location.
- #  By default, CMake will search for a folder named opencl or ROCm-OpenCL-Runtime relative to the current path. Specify -DAMD_OPENCL_PATH=$OPENCL_DIR if opencl source is in obscure location.
- list(APPEND CMAKE_MODULE_PATH ${HIP_COMMON_DIR}/cmake)
-+
-+set(CMAKE_SKIP_BUILD_RPATH TRUE)
-+set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
-+set(CMAKE_INSTALL_RPATH "$ORIGIN/../../lib")
-+
- #############################
- # Options
- #############################
 @@ -87,7 +87,17 @@ string(REPLACE "-" ";" VERSION_LIST ${HIP_VERSION_PATCH_GITHASH})
  list(GET VERSION_LIST 0 HIP_VERSION_PATCH)
  set(HIP_VERSION_GITDATE 0)

--- a/H/HIP/HIP@5.2.3/bundled/patches/improve-compilation-disable-tests.patch
+++ b/H/HIP/HIP@5.2.3/bundled/patches/improve-compilation-disable-tests.patch
@@ -13,7 +13,7 @@ index f425504d..c5213688 100755
 +set(CMAKE_SKIP_BUILD_RPATH TRUE)
 +set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
 +set(CMAKE_INSTALL_RPATH "$ORIGIN/../../lib")
- 
+
  #############################
  # Options
 @@ -91,7 +90,18 @@ string(REPLACE "-" ";" VERSION_LIST ${HIP_VERSION_PATCH_GITHASH})
@@ -46,15 +46,6 @@ index f425504d..c5213688 100755
  endif()
  
  ## Debian package specific variables
-@@ -190,7 +197,7 @@ if (DEFINED ENV{ROCM_RPATH})
-     set (CMAKE_INSTALL_RPATH "$ENV{ROCM_RPATH}")
-     set (CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-     set (CMAKE_SKIP_BUILD_RPATH TRUE)
--    set (CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
-+    # set (CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
- endif ()
- 
- # overwrite HIP_VERSION_PATCH for packaging
 @@ -429,36 +436,6 @@ if(CLANGFORMAT_EXE)
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
  endif()

--- a/H/HIP/HIP@5.2.3/bundled/patches/improve-compilation-disable-tests.patch
+++ b/H/HIP/HIP@5.2.3/bundled/patches/improve-compilation-disable-tests.patch
@@ -13,6 +13,7 @@ index f425504d..c5213688 100755
 +set(CMAKE_SKIP_BUILD_RPATH TRUE)
 +set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
 +set(CMAKE_INSTALL_RPATH "$ORIGIN/../../lib")
+ 
  #############################
  # Options
 @@ -91,7 +90,18 @@ string(REPLACE "-" ";" VERSION_LIST ${HIP_VERSION_PATCH_GITHASH})

--- a/H/HIP/HIP@5.2.3/bundled/patches/improve-compilation-disable-tests.patch
+++ b/H/HIP/HIP@5.2.3/bundled/patches/improve-compilation-disable-tests.patch
@@ -13,7 +13,6 @@ index f425504d..c5213688 100755
 +set(CMAKE_SKIP_BUILD_RPATH TRUE)
 +set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
 +set(CMAKE_INSTALL_RPATH "$ORIGIN/../../lib")
-
  #############################
  # Options
 @@ -91,7 +90,18 @@ string(REPLACE "-" ";" VERSION_LIST ${HIP_VERSION_PATCH_GITHASH})

--- a/H/HIP/common.jl
+++ b/H/HIP/common.jl
@@ -74,6 +74,11 @@ function get_hip_cmake(cmake_cxx_prefix::String, version::VersionNumber)
         -DHIP_SRC_PATH=${HIPAMD_DIR} \
         -DAMD_OPENCL_PATH=${OPENCL_SRC} \
         """
+        if version ≥ v"5.2.3"
+            cmake_flags *= raw"""
+            -DFILE_REORG_BACKWARD_COMPATIBILITY=OFF \
+            """
+        end
     end
 
     setup_and_patches *


### PR DESCRIPTION
Disable legacy folder structure using `-DFILE_REORG_BACKWARD_COMPATIBILITY=OFF`.
Otherwise it creates a duplicate library directory which confuses rocBLAS and other libraries.
This is only in 5.2.3.