### PR TITLE
[Hwloc] Add `lstopo-no-graphics` as an `ExecutableProduct`

### DIFF
--- a/H/Hwloc/build_tarballs.jl
+++ b/H/Hwloc/build_tarballs.jl
@@ -25,7 +25,8 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libhwloc", :libhwloc)
+    LibraryProduct("libhwloc", :libhwloc),
+    ExecutableProduct("lstopo-no-graphics", :lstopo_no_graphics)
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
See https://github.com/JuliaParallel/Hwloc.jl/pull/62#issuecomment-1257248490

In this PR I add `lstopo-no-graphics` as an `ExecutableProduct`. I tested it locally and it looked fine.