### PR TITLE
[CJieba] Add new recipe 

### DIFF
--- a/C/CJieba/build_tarballs.jl
+++ b/C/CJieba/build_tarballs.jl
@@ -1,0 +1,41 @@
+using BinaryBuilder, Pkg
+
+name = "CJieba"
+version = v"0.3.0"
+
+sources = [
+    ArchiveSource(
+        "https://github.com/yanyiwu/cjieba/archive/refs/tags/v$(version).tar.gz",
+        "1f5ca82c5d19c38485c8fd50db8711602d339b1e85f15fb864fc116c7f770f12"
+    )
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir
+mkdir $libdir $prefix/share
+curl https://raw.githubusercontent.com/yanyiwu/cppjieba/master/LICENSE > LICENSE
+install_license LICENSE 
+cd cjieba-0.3.0/
+g++ lib/jieba.cpp -shared -fPIC -I./deps/ -std=c++11 -o libcjieba.so
+cp libcjieba.so $libdir
+cp -a dict $prefix/share/
+"""
+
+platforms = supported_platforms()
+
+products = [
+    LibraryProduct("libcjieba", :libcjieba),
+    FileProduct("share/dict/hmm_model.utf8", :hmm_model),
+    FileProduct("share/dict/idf.utf8", :idf),
+    FileProduct("share/dict/jieba.dict.utf8", :jiebadict),
+    FileProduct("share/dict/stop_words.utf8", :stopwords),
+    FileProduct("share/dict/user.dict.utf8", :userdict)
+]
+
+dependencies = Dependency[
+]
+
+build_tarballs(
+    ARGS, name, version, sources, script, platforms, products, dependencies;
+    julia_compat="1.6"
+)


### PR DESCRIPTION
Hello,

This is a recipe for [cjieba](https://github.com/yanyiwu/cjieba/).

Some background:
- [jieba](https://github.com/fxsjy/jieba) is a popular Chinese word tokenizor/POS tagger etc.
- Originally implemented in Python.
- The C library this recipe wrapped is the low-level C api for the C++ implementation [cppjieba](https://github.com/yanyiwu/cppjieba), which I found quite adequate for simple tasks.

_I couldn't get all the way through in wizard, keep failing at download/install amd64 apple darwin20 toolchain. But it looks pretty OK._

Cheers,
Alex