### PR TITLE
[FFMPEG] Add explicit dependency on `PCRE2_jll`

### DIFF
--- a/F/FFMPEG/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/FFMPEG/build_tarballs.jl
@@ -39,7 +39,7 @@ dependencies = [
     Dependency("Zlib_jll"),
     Dependency("OpenSSL_jll"),
     Dependency("Opus_jll"),
-    Dependency("PCRE_jll"),
+    Dependency("PCRE2_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FFMPEG/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/FFMPEG/build_tarballs.jl
@@ -39,6 +39,7 @@ dependencies = [
     Dependency("Zlib_jll"),
     Dependency("OpenSSL_jll"),
     Dependency("Opus_jll"),
+    Dependency("PCRE_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
It appears FFMPEG explicitly requires PCRE, dependency that we were previously
getting indirectly from Glib, but now Glib 2.74 dropped PCRE for PCRE2, so now
the dependency is gone and we have to restore it directly.

***Edit***: actually, FFMPEG seems to prefer PCRE2 over PCRE, use that one instead.