### PR TITLE
[LicenseCheck] Rebuild for aarch64

### DIFF
--- a/L/licensecheck/build_tarballs.jl
+++ b/L/licensecheck/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "licensecheck"
-version = v"0.300.101"
+version = v"0.3.101"
 
 sources = [
     GitSource("https://github.com/google/licensecheck",

--- a/L/licensecheck/build_tarballs.jl
+++ b/L/licensecheck/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "licensecheck"
-version = v"0.3.1"
+version = v"0.300.101"
 
 sources = [
     GitSource("https://github.com/google/licensecheck",
@@ -43,4 +43,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers=[:c, :go], preferred_gcc_version=v"6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers=[:c, :go], preferred_gcc_version=v"6", julia_compat="1.6")


### PR DESCRIPTION
There isn't a new version since 0.3.1, so I moved to the "expanded" version scheme. Bumped version and added julia compat per-https://github.com/JuliaPackaging/Yggdrasil/issues/2763.