### PR TITLE
Add recipe for CLFFT

### DIFF
--- a/C/CLFFT/build_tarballs.jl
+++ b/C/CLFFT/build_tarballs.jl
@@ -23,7 +23,7 @@ cmake --build ./clFFT/build --target install -j${nproc}
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-
+platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/C/CLFFT/build_tarballs.jl
+++ b/C/CLFFT/build_tarballs.jl
@@ -46,9 +46,9 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     BuildDependency(PackageSpec(; name="OpenCL_Headers_jll", version=v"2022.09.23")),
-    BuildDependency(PackageSpec(; name="OpenCL_jll", version=v"2022.09.23")),
-    BuildDependency(PackageSpec(; name="FFTW_jll", version=v"3.3.10")),
-    BuildDependency(PackageSpec(; name="boost_jll", version=v"1.76.0"))
+    Dependency(PackageSpec(; name="OpenCL_jll", version=v"2022.09.23")),
+    Dependency(PackageSpec(; name="FFTW_jll", version=v"3.3.10")),
+    Dependency(PackageSpec(; name="boost_jll", version=v"1.76.0"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CLFFT/build_tarballs.jl
+++ b/C/CLFFT/build_tarballs.jl
@@ -1,0 +1,42 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "CLFFT"
+version = v"2.12.2"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/clMathLibraries/clFFT.git", "1e4833f060976971c4df4b54b1b9ad1620aaf1fb")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+
+install_license ./clFFT/LICENSE
+
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -S ./clFFT/src -B ./clFFT/build
+cmake --build ./clFFT/build --target install -j${nproc}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libclFFT", :libclfft)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="OpenCL_Headers_jll", uuid="a7aa756b-2b7f-562a-9e9d-e94076c5c8ee"))
+    Dependency(PackageSpec(name="OpenCL_jll", uuid="6cb37087-e8b6-5417-8430-1f242f1e46e4"))
+    Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))
+    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"6.1.0")

--- a/C/CLFFT/build_tarballs.jl
+++ b/C/CLFFT/build_tarballs.jl
@@ -34,8 +34,8 @@ products = [
 dependencies = [
     BuildDependency(PackageSpec(; name="OpenCL_Headers_jll", version=v"2022.09.23")),
     BuildDependency(PackageSpec(; name="OpenCL_jll", version=v"2022.09.23")),
-    BuildDependency(PackageSpec(name="FFTW_jll", version=v"3.3.10")),
-    BuildDependency(PackageSpec(name="boost_jll", version=v"1.76.0"))
+    BuildDependency(PackageSpec(; name="FFTW_jll", version=v"3.3.10")),
+    BuildDependency(PackageSpec(; name="boost_jll", version=v"1.76.0"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CLFFT/build_tarballs.jl
+++ b/C/CLFFT/build_tarballs.jl
@@ -7,7 +7,9 @@ version = v"2.12.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/clMathLibraries/clFFT.git", "1e4833f060976971c4df4b54b1b9ad1620aaf1fb")
+    GitSource("https://github.com/clMathLibraries/clFFT.git", "1e4833f060976971c4df4b54b1b9ad1620aaf1fb"),
+    FileSource("https://patch-diff.githubusercontent.com/raw/clMathLibraries/clFFT/pull/245.patch",
+               "b78e80258bd5dd41572dfad8f4c8fe3b0192d7d4f3bdaa85aae2d59f61184a88")
 ]
 
 # Bash recipe for building across all platforms
@@ -16,13 +18,24 @@ cd $WORKSPACE/srcdir
 
 install_license ./clFFT/LICENSE
 
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -S ./clFFT/src -B ./clFFT/build
+patch ./clFFT/src/CMakeLists.txt 245.patch
+
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=OFF -S ./clFFT/src -B ./clFFT/build
 cmake --build ./clFFT/build --target install -j${nproc}
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = [
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("powerpc64le", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "musl"),
+    Platform("aarch64", "linux"; libc = "musl"),
+    Platform("aarch64", "macos"),
+    Platform("x86_64", "macos")
+]
+
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/C/CLFFT/build_tarballs.jl
+++ b/C/CLFFT/build_tarballs.jl
@@ -46,9 +46,9 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     BuildDependency(PackageSpec(; name="OpenCL_Headers_jll", version=v"2022.09.23")),
-    Dependency(PackageSpec(; name="OpenCL_jll", version=v"2022.09.23")),
-    Dependency(PackageSpec(; name="FFTW_jll", version=v"3.3.10")),
-    Dependency(PackageSpec(; name="boost_jll", version=v"1.76.0"))
+    Dependency("OpenCL_jll", compat="2022.09.23"),
+    Dependency("FFTW_jll", compat="3.3.10"),
+    Dependency("boost_jll", compat="1.76.0")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CLFFT/build_tarballs.jl
+++ b/C/CLFFT/build_tarballs.jl
@@ -48,7 +48,7 @@ dependencies = [
     BuildDependency(PackageSpec(; name="OpenCL_Headers_jll", version=v"2022.09.23")),
     Dependency("OpenCL_jll", compat="2022.09.23"),
     Dependency("FFTW_jll", compat="3.3.10"),
-    Dependency("boost_jll", compat="1.76.0")
+    Dependency("boost_jll", compat="=1.76.0")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CLFFT/build_tarballs.jl
+++ b/C/CLFFT/build_tarballs.jl
@@ -32,10 +32,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenCL_Headers_jll", uuid="a7aa756b-2b7f-562a-9e9d-e94076c5c8ee"))
-    Dependency(PackageSpec(name="OpenCL_jll", uuid="6cb37087-e8b6-5417-8430-1f242f1e46e4"))
-    Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))
-    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"))
+    BuildDependency(PackageSpec(; name="OpenCL_Headers_jll", version=v"2022.09.23")),
+    BuildDependency(PackageSpec(; name="OpenCL_jll", version=v"2022.09.23")),
+    BuildDependency(PackageSpec(name="FFTW_jll", version=v"3.3.10")),
+    BuildDependency(PackageSpec(name="boost_jll", version=v"1.76.0"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This is the last PR in a series of PRs to revive OpenCL + CLFFT binaries for OpenCL.jl and CLFFT.jl respectively.

Appreciate if you can review @giordano. In particular, could you please double check which dependency is a BuildDependency and which is an actual Dependency? That is not 100% clear for me.