### PR TITLE
Add rocSPARSE 5.2.3

### DIFF
--- a/R/rocSPARSE/common.jl
+++ b/R/rocSPARSE/common.jl
@@ -4,7 +4,7 @@ const ROCM_GIT = "https://github.com/ROCmSoftwarePlatform/rocSPARSE/"
 const GIT_TAGS = Dict(
     v"4.2.0" => "8a86ed49d278e234c82e406a1430dc28f50d416f8f1065cf5bdf25cc5721129c",
     v"4.5.2" => "e37af2cd097e239a55a278df534183b5591ef4d985fe1a268a229bd11ada6599",
-    v"5.2.3" => "e37af2cd097e239a55a278df534183b5591ef4d985fe1a268a229bd11ada6511",
+    v"5.2.3" => "6da3f3303a8ada94c4dbff4b42ee33a2e2883a908ee21c41cb2aa7180382026a",
 )
 
 const ROCM_PLATFORMS = [

--- a/R/rocSPARSE/rocSPARSE@5.2.3/build_tarballs.jl
+++ b/R/rocSPARSE/rocSPARSE@5.2.3/build_tarballs.jl
@@ -3,5 +3,5 @@ using BinaryBuilder
 
 include("../common.jl")
 build_tarballs(
-    ARGS, configure_build(v"4.5.2")...;
-    preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.8")
+    ARGS, configure_build(v"5.2.3")...;
+    preferred_gcc_version=v"7", preferred_llvm_version=v"9")


### PR DESCRIPTION
In the previous PR #5619 I forgot to replace version in `build_tarballs.jl` to `5.2.3` so it just rebuilt `4.5.2`. This one actually adds rocSPARSE 5.2.3