### PR TITLE
Recompile Ipopt with OpenBLAS32 for windows platforms

### DIFF
--- a/C/Coin-OR/Ipopt/build_tarballs.jl
+++ b/C/Coin-OR/Ipopt/build_tarballs.jl
@@ -24,6 +24,12 @@ if [[ ${target} == *mingw* ]]; then
     export LDFLAGS="-L${libdir}"
 fi
 
+if [[ "${target}" == *mingw* ]]; then
+  BLAS_LAPACK="-L${libdir} -lopenblas"
+else
+  BLAS_LAPACK="-L${libdir} -lblastrampoline"
+fi
+
 ./configure \
     --prefix=${prefix} \
     --build=${MACHTYPE} \
@@ -33,9 +39,9 @@ fi
     --with-pic \
     --disable-dependency-tracking \
     lt_cv_deplibs_check_method=pass_all \
-    --with-lapack-lflags=-lblastrampoline \
+    --with-lapack-lflags="${BLAS_LAPACK}" \
     --with-mumps-cflags="-I${includedir}" \
-    --with-mumps-lflags="-ldmumps -lzmumps -lcmumps -lsmumps -lmumps_common -lmpiseq -lpord -lmetis -lblastrampoline -lgfortran -lpthread" \
+    --with-mumps-lflags="-ldmumps -lzmumps -lcmumps -lsmumps -lmumps_common -lmpiseq -lpord -lmetis {BLAS_LAPACK} -lgfortran -lpthread" \
     --with-asl-lflags="${LIBASL}"
 
 # parallel build fails
@@ -58,7 +64,8 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), ASL_version),
     Dependency(PackageSpec(name="MUMPS_seq_jll", uuid="d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"), compat="=$(MUMPS_seq_version)"),
-    Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93")),
+Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2"), platforms=filter(Sys.iswindows, platforms)),
+    Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), platforms=filter(!Sys.iswindows, platforms)),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 

--- a/C/Coin-OR/Ipopt/build_tarballs.jl
+++ b/C/Coin-OR/Ipopt/build_tarballs.jl
@@ -64,7 +64,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), ASL_version),
     Dependency(PackageSpec(name="MUMPS_seq_jll", uuid="d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"), compat="=$(MUMPS_seq_version)"),
-Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2"), platforms=filter(Sys.iswindows, platforms)),
+    Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2"), platforms=filter(Sys.iswindows, platforms)),
     Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), platforms=filter(!Sys.iswindows, platforms)),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -58,7 +58,7 @@ CoinUtils_version =
 
 Ipopt_upstream_version = v"3.14.4"
 Ipopt_gitsha = "d872b3a3d17863c6a2a27475cc9af9e933cb7e92"
-Ipopt_verson_offset = v"0.0.2"
+Ipopt_verson_offset = v"0.0.3"
 Ipopt_version = offset_version(Ipopt_upstream_version, Ipopt_verson_offset)
 
 ALPS_upstream_version = v"1.5.7"
@@ -89,7 +89,7 @@ SHOT_version = offset_version(v"1.1.0", v"0.0.0")
 # Third-party packages needed by COIN-OR libraries.
 ASL_version = v"0.1.3"
 METIS_version = v"5.1.1"
-MUMPS_seq_version = v"500.400.100"
+MUMPS_seq_version = v"500.500.101"
 OpenBLAS32_version = v"0.3.10"
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
@odow 
I recompiled `MUMPS_seq` with `OpenBLAS32` for windows platforms.
It should fix the issue within https://github.com/jump-dev/Ipopt.jl/pull/327.