### PR TITLE
Do not build tests in OpenCL_Headers recipe

### DIFF
--- a/O/OpenCL_Headers/build_tarballs.jl
+++ b/O/OpenCL_Headers/build_tarballs.jl
@@ -16,7 +16,7 @@ cd $WORKSPACE/srcdir
 
 install_license ./OpenCL-Headers/LICENSE
 
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -S ./OpenCL-Headers -B ./OpenCL-Headers/build
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -S ./OpenCL-Headers -B ./OpenCL-Headers/build
 cmake --build ./OpenCL-Headers/build --target install -j${nproc}
 """
 


### PR DESCRIPTION
Removes unnecessary build instructions.