### PR TITLE
Update tectonic to 0.11.0

### DIFF
--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -3,13 +3,13 @@
 using BinaryBuilder, Pkg
 
 name = "tectonic"
-version = v"0.10.0"
+version = v"0.11.0"
 
 # Collection of sources required to build tar
 sources = [
     ArchiveSource(
         "https://github.com/tectonic-typesetting/tectonic/archive/tectonic@$(version).tar.gz",
-        "8c3295007b2602ff1a43a42d335589ebfe3731072e749a8087348ad0cfecf662"
+        "7bdd4b4b18af2bd6c127ab03e1abf3088ac2e3b5471467387bd60620331eab4d"
     )
 ]
 

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -3,13 +3,13 @@
 using BinaryBuilder, Pkg
 
 name = "tectonic"
-version = v"0.9.0"
+version = v"0.10.0"
 
 # Collection of sources required to build tar
 sources = [
     ArchiveSource(
         "https://github.com/tectonic-typesetting/tectonic/archive/tectonic@$(version).tar.gz",
-        "a239ca85bff1955792b2842fabfa201ba9576d916ece281278781f42c7547b9f"
+        "8c3295007b2602ff1a43a42d335589ebfe3731072e749a8087348ad0cfecf662"
     )
 ]
 


### PR DESCRIPTION
There's also a 0.11.0 that was released shortly after the 0.10.0. Do we care about having all the intermediate versions available, or should I just switch this PR to updating directly to 0.11.0?