### PR TITLE
[CUDA] Rename CUDA_compat to CUDA_Driver; add version to JLL.

### DIFF
--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -1,4 +1,4 @@
-# CUDA forward compatibility package as taken from the datacenter driver
+# CUDA forward compatibility driver
 #
 # - https://docs.nvidia.com/deploy/cuda-compatibility/index.html#forward-compatibility-title
 # - https://docs.nvidia.com/datacenter/tesla/index.html
@@ -8,7 +8,7 @@ using BinaryBuilder, Pkg
 
 include("../../../fancy_toys.jl")
 
-name = "CUDA_compat"
+name = "CUDA_Driver"
 version = v"11.8"
 
 cuda_version = "$(version.major)-$(version.minor)"

--- a/C/CUDA/CUDA_compat/build_tarballs.jl
+++ b/C/CUDA/CUDA_compat/build_tarballs.jl
@@ -39,6 +39,10 @@ mkdir -p ${libdir}
 mv usr/local/cuda-*/compat/* ${libdir}
 """
 
+init_block = """
+global version = $(repr(version))
+"""
+
 products = [
     LibraryProduct("libcuda", :libcuda;
                    dont_dlopen=true),
@@ -51,17 +55,17 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 if should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_x86, script,
                    [Platform("x86_64", "linux")], products, dependencies;
-                   lazy_artifacts=true, skip_audit=true)
+                   lazy_artifacts=true, skip_audit=true, init_block)
 end
 
 if should_build_platform("powerpc64le-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_ppc64le, script,
                    [Platform("powerpc64le", "linux")], products, dependencies;
-                   lazy_artifacts=true, skip_audit=true)
+                   lazy_artifacts=true, skip_audit=true, init_block)
 end
 
 if should_build_platform("aarch64-linux-gnu")
     build_tarballs(ARGS, name, version, sources_linux_aarch64, script,
                    [Platform("aarch64", "linux")], products, dependencies;
-                   lazy_artifacts=true, skip_audit=true)
+                   lazy_artifacts=true, skip_audit=true, init_block)
 end


### PR DESCRIPTION
The rename is for consistency with CUDA_Runtime_jll, and the (WIP) CUDA_Driver.jl that will use this JLL.

The other change is embedding the version of the build library in the JLL, as we need it to determine whether we want to use this alternative driver. I was wondering if there isn't a better way to do this though, as putting it in `init_block` results in a non-precompiled global variable.