### PR TITLE
[CUDA] Rework CUDA_Runtime_jll.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_11.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.0.jl
@@ -112,6 +112,7 @@ fi
 """
 
 products = [
+    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
     LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
     LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
     LibraryProduct(["libcublas", "cublas64_11"], :libcublas),

--- a/C/CUDA/CUDA_Runtime/build_11.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.1.jl
@@ -112,6 +112,7 @@ fi
 """
 
 products = [
+    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
     LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
     LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
     LibraryProduct(["libcublas", "cublas64_11"], :libcublas),

--- a/C/CUDA/CUDA_Runtime/build_11.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.2.jl
@@ -112,6 +112,7 @@ fi
 """
 
 products = [
+    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
     LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
     LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
     LibraryProduct(["libcublas", "cublas64_11"], :libcublas),

--- a/C/CUDA/CUDA_Runtime/build_11.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.3.jl
@@ -112,6 +112,7 @@ fi
 """
 
 products = [
+    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
     LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
     LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
     LibraryProduct(["libcublas", "cublas64_11"], :libcublas),

--- a/C/CUDA/CUDA_Runtime/build_11.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.4.jl
@@ -112,6 +112,7 @@ fi
 """
 
 products = [
+    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
     LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
     LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
     LibraryProduct(["libcublas", "cublas64_11"], :libcublas),

--- a/C/CUDA/CUDA_Runtime/build_11.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.5.jl
@@ -112,6 +112,7 @@ fi
 """
 
 products = [
+    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
     LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
     LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
     LibraryProduct(["libcublas", "cublas64_11"], :libcublas),

--- a/C/CUDA/CUDA_Runtime/build_11.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.6.jl
@@ -112,6 +112,7 @@ fi
 """
 
 products = [
+    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
     LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
     LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
     LibraryProduct(["libcublas", "cublas64_11"], :libcublas),

--- a/C/CUDA/CUDA_Runtime/build_11.8.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.8.jl
@@ -1,4 +1,4 @@
-dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"10.0.130"))]
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.8.0"))]
 
 script = raw"""
 # First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
@@ -18,7 +18,7 @@ rm -rf ${prefix}/include/thrust
 
 # binaries
 mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
-if [[ ${target} == x86_64-linux-gnu ]]; then
+if [[ ${target} == *-linux-gnu ]]; then
     # CUDA Runtime
     mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
 
@@ -26,13 +26,16 @@ if [[ ${target} == x86_64-linux-gnu ]]; then
     mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
 
     # CUDA BLAS Library
-    mv lib64/libcublas.so* ${libdir}
+    mv lib64/libcublas.so* lib64/libcublasLt.so* ${libdir}
 
     # CUDA Sparse Matrix Library
     mv lib64/libcusparse.so* ${libdir}
 
     # CUDA Linear Solver Library
     mv lib64/libcusolver.so* ${libdir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv lib64/libcusolverMg.so* ${libdir}
 
     # CUDA Random Number Generation Library
     mv lib64/libcurand.so* ${libdir}
@@ -50,41 +53,9 @@ if [[ ${target} == x86_64-linux-gnu ]]; then
     # NVIDIA Tools Extension Library
     mv lib64/libnvToolsExt.so* ${libdir}
 
-    # Additional binaries
-    mv bin/ptxas ${bindir}
-    mv bin/nvdisasm ${bindir}
-    mv bin/nvlink ${bindir}
-elif [[ ${target} == x86_64-apple-darwin* ]]; then
-    # CUDA Runtime
-    mv lib/libcudart.*dylib lib/libcudadevrt.a ${libdir}
-
-    # CUDA FFT Library
-    mv lib/libcufft.*dylib lib/libcufftw.*dylib ${libdir}
-
-    # CUDA BLAS Library
-    mv lib/libcublas.*dylib ${libdir}
-
-    # CUDA Sparse Matrix Library
-    mv lib/libcusparse.*dylib ${libdir}
-
-    # CUDA Linear Solver Library
-    mv lib/libcusolver.*dylib ${libdir}
-
-    # CUDA Random Number Generation Library
-    mv lib/libcurand.*dylib ${libdir}
-
-    # NVIDIA Optimizing Compiler Library
-    mv nvvm/lib/libnvvm.*dylib ${libdir}
-
-    # NVIDIA Common Device Math Functions Library
-    mkdir ${prefix}/share/libdevice
-    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
-
-    # CUDA Profiling Tools Interface (CUPTI) Library
-    mv extras/CUPTI/lib/libcupti.*dylib ${libdir}
-
-    # NVIDIA Tools Extension Library
-    mv lib/libnvToolsExt.*dylib ${libdir}
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
 
     # Additional binaries
     mv bin/ptxas ${bindir}
@@ -99,13 +70,16 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
 
     # CUDA BLAS Library
-    mv bin/cublas64_*.dll ${bindir}
+    mv bin/cublas64_*.dll bin/cublasLt64_*.dll ${bindir}
 
     # CUDA Sparse Matrix Library
     mv bin/cusparse64_*.dll ${bindir}
 
     # CUDA Linear Solver Library
     mv bin/cusolver64_*.dll ${bindir}
+
+    # CUDA Linear Solver Multi GPU Library
+    mv bin/cusolverMg64_*.dll ${bindir}
 
     # CUDA Random Number Generation Library
     mv bin/curand64_*.dll ${bindir}
@@ -118,10 +92,14 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
 
     # CUDA Profiling Tools Interface (CUPTI) Library
-    mv extras/CUPTI/libx64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
 
     # NVIDIA Tools Extension Library
     mv bin/nvToolsExt64_1.dll ${bindir}
+
+    # Compute Sanitizer
+    rm -r compute-sanitizer/{docs,include}
+    mv compute-sanitizer/* ${bindir}
 
     # Additional binaries
     mv bin/ptxas.exe ${bindir}
@@ -134,21 +112,25 @@ fi
 """
 
 products = [
-    LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_100"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_100"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_100"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_100"], :libcusolver),
-    LibraryProduct(["libcurand", "curand64_100"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_100"], :libcupti),
+    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
+    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+    LibraryProduct(["libcupti", "cupti64_2022.3.0"], :libcupti),
     LibraryProduct(["libnvToolsExt", "nvToolsExt64_1"], :libnvtoolsext),
     FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
     FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
     ExecutableProduct("ptxas", :ptxas),
     ExecutableProduct("nvdisasm", :nvdisasm),
     ExecutableProduct("nvlink", :nvlink),
+    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
 ]
 
-platforms = [Platform("x86_64", "linux"; cuda="10.0"),
-             Platform("x86_64", "macos"; cuda="10.0"),
-             Platform("x86_64", "windows"; cuda="10.0")]
+platforms = [Platform("x86_64", "linux"; cuda="11.8"),
+             Platform("powerpc64le", "linux"; cuda="11.8"),
+             Platform("aarch64", "linux"; cuda="11.8"),
+             Platform("x86_64", "windows"; cuda="11.8")]

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -5,20 +5,15 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.1"
+version = v"0.2"
 
-cuda_versions = [v"10.0", v"10.2",
-                 v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6"]
+cuda_versions = [v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6", v"11.7", v"11.8"]
 
 augment_platform_block = """
-    using Base.BinaryPlatforms
-
-    $(CUDA.augment)
-
-    augment_cuda_toolkit!(platform) = augment_cuda_toolkit!(platform, $cuda_versions)
+    $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))
 
     function augment_platform!(platform::Platform)
-        augment_cuda_toolkit!(platform)
+        augment_platform!(platform, $cuda_versions)
     end"""
 
 # determine exactly which tarballs we should build
@@ -32,9 +27,8 @@ for cuda_version in cuda_versions
         augmented_platform[CUDA.platform_name] = CUDA.platform(cuda_version)
 
         should_build_platform(triplet(augmented_platform)) || continue
-        push!(builds, (;
-            dependencies, script, products,
-            platforms=[augmented_platform],
+        push!(builds, (; dependencies=[Dependency("CUDA_Driver"); dependencies],
+                         script, products, platforms=[augmented_platform],
         ))
     end
 end

--- a/C/CUDA/CUDA_Runtime/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Runtime/platform_augmentation.jl
@@ -1,0 +1,78 @@
+using Libdl
+
+using CUDA_Driver
+
+using Base.BinaryPlatforms
+
+function driver_version()
+    if libcuda() === nothing
+        return nothing
+    end
+
+    libcuda_handle = Libdl.dlopen(libcuda())
+    try
+        function_handle = Libdl.dlsym(libcuda_handle, "cuDriverGetVersion")
+        version_ref = Ref{Cint}()
+        status = ccall(function_handle, UInt32, (Ptr{Cint},), version_ref)
+        if status != 0
+            # TODO: warn here about the error?
+            return nothing
+        end
+        major, ver = divrem(version_ref[], 1000)
+        minor, patch = divrem(ver, 10)
+        return VersionNumber(major, minor, patch)
+    finally
+        Libdl.dlclose(libcuda_handle)
+    end
+end
+
+function toolkit_version(cuda_toolkits)
+    cuda_driver = driver_version()
+    if cuda_driver === nothing
+        return nothing
+    elseif cuda_driver < v"11"
+        @error "CUDA driver 11+ is required (found $cuda_driver)."
+        return nothing
+    end
+
+    cuda_version_override = get(ENV, "JULIA_CUDA_VERSION", nothing)
+    if cuda_version_override === ""
+        return nothing
+    elseif cuda_version_override !== nothing
+        cuda_version_override = VersionNumber(cuda_version_override)
+    end
+    # TODO: support for Preferences.jl-based override?
+
+    # "[...] applications built against any of the older CUDA Toolkits always continued
+    #  to function on newer drivers due to binary backward compatibility"
+    filter!(cuda_toolkits) do toolkit
+        if cuda_version_override !== nothing
+            toolkit == cuda_version_override
+        else
+            # "From CUDA 11 onwards, applications compiled with a CUDA Toolkit release
+            #  from within a CUDA major release family can run, with limited feature-set,
+            #  on systems having at least the minimum required driver version"
+            toolkit.major <= cuda_driver.major
+        end
+    end
+    if isempty(cuda_toolkits)
+        return nothing
+    end
+
+    last(cuda_toolkits)
+end
+
+# versions will be provided by build_tarballs.jl
+function augment_platform!(platform::Platform, cuda_toolkits::Vector{VersionNumber})
+    haskey(platform, "cuda") && return platform
+
+    cuda_toolkit = toolkit_version(cuda_toolkits)
+    platform["cuda"] = if cuda_toolkit !== nothing
+        "$(cuda_toolkit.major).$(cuda_toolkit.minor)"
+    else
+        # don't use an empty string here, because Pkg will then load *any* artifact
+        "none"
+    end
+
+    return platform
+end

--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -1,103 +1,11 @@
 module CUDA
 
+# the "cuda" platform tag contains the major and minor version of the CUDA runtime loaded
+# by CUDA_Runtime_jll, and is used to select artifacts that depend on the CUDA runtime.
+
 const platform_name = "cuda"
 const augment = """
-    using Libdl
-    using Base: thisminor
-
-
-    #
-    # Augmentation for selecting the CUDA toolkit
-    #
-
-    # NOTE: we set the 'cuda' platform tag to the actual CUDA Toolkit version we'll be using
-    #       and not to the version that this driver supports (letting Pkg select an artifact
-    #       via a comparison strategy). This to simplify dependent packages; otherwise they
-    #       would need to know which toolkits are available to additionaly bound selection.
-
-    # provided by caller: `augment_cuda_toolkit!(platform)` method calling the version below
-    #                     with the available toolkit versions passed along
-
-    function driver_version()
-        libcuda_path = if Sys.iswindows()
-            Libdl.find_library("nvcuda")
-        else
-            Libdl.find_library(["libcuda.so.1", "libcuda.so"])
-        end
-        if libcuda_path == ""
-            return nothing
-        end
-
-        libcuda = Libdl.dlopen(libcuda_path)
-        try
-            function_handle = Libdl.dlsym(libcuda, "cuDriverGetVersion")
-            version_ref = Ref{Cint}()
-            status = ccall(function_handle, UInt32, (Ptr{Cint},), version_ref)
-            if status != 0
-                # TODO: warn here about the error?
-                return nothing
-            end
-            major, ver = divrem(version_ref[], 1000)
-            minor, patch = divrem(ver, 10)
-            return VersionNumber(major, minor, patch)
-        finally
-            Libdl.dlclose(libcuda)
-        end
-    end
-
-    function toolkit_version(cuda_toolkits)
-        cuda_driver = driver_version()
-        if cuda_driver === nothing
-            return nothing
-        end
-
-        cuda_version_override = get(ENV, "JULIA_CUDA_VERSION", nothing)
-        # TODO: support for Preferences.jl-based override?
-
-        # "[...] applications built against any of the older CUDA Toolkits always continued
-        #  to function on newer drivers due to binary backward compatibility"
-        filter!(cuda_toolkits) do toolkit
-            if cuda_version_override !== nothing
-                toolkit == cuda_version_override
-            elseif cuda_driver >= v"11.1"
-                # enhanced compatibility
-                #
-                # "From CUDA 11 onwards, applications compiled with a CUDA Toolkit release
-                #  from within a CUDA major release family can run, with limited feature-set,
-                #  on systems having at least the minimum required driver version"
-                # TODO: check this minimum required driver version?
-                toolkit.major <= cuda_driver.major
-            else
-                thisminor(toolkit) <= thisminor(cuda_driver)
-            end
-        end
-        if isempty(cuda_toolkits)
-            return nothing
-        end
-
-        last(cuda_toolkits)
-    end
-
-    function augment_cuda_toolkit!(platform::Platform, cuda_toolkits::Vector{VersionNumber})
-        haskey(platform, "cuda") && return platform
-
-        cuda_toolkit = toolkit_version(cuda_toolkits)
-        platform["cuda"] = if cuda_toolkit !== nothing
-            "\$(cuda_toolkit.major).\$(cuda_toolkit.minor)"
-        else
-            # don't use an empty string here, because Pkg will then load *any* artifact
-            "none"
-        end
-
-        return platform
-    end
-
-
-    #
-    # Augmentation for selecting artifacts that depend on the CUDA toolkit
-    #
-
-    # imported by caller: CUDA_Runtime_jll
+    using CUDA_Runtime_jll
 
     function cuda_comparison_strategy(a::String, b::String, a_requested::Bool, b_requested::Bool)
         a = VersionNumber(a)
@@ -125,10 +33,10 @@ const augment = """
         end
     end
 
-    function augment_cuda_dependent!(platform::Platform)
+    function augment_platform!(platform::Platform)
         set_compare_strategy!(platform, "cuda", cuda_comparison_strategy)
         haskey(platform, "cuda") && return platform
-        CUDA_Runtime_jll.augment_cuda_toolkit!(platform)
+        CUDA_Runtime_jll.augment_platform!(platform)
     end"""
 
 function platform(cuda::VersionNumber)


### PR DESCRIPTION
- remove support for 10.x
- add 11.7 and 11.8
- add libcudart and libcusolverMg
- put the non-reusable platform augmentation parts in the directory of this jll
- depend on CUDA_Driver for driver discovery