### PR TITLE
[GnuTLS] Upgrade to 3.7.8

### DIFF
--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -36,7 +36,7 @@ fi
 GMP_CFLAGS="-I${prefix}/include" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-included-libtasn1 \
     --with-included-unistring \
-    --ac_cv_func_malloc_0_nonnull=yes \
+    --gl_cv_func_malloc_posix=no \
     --without-p11-kit 
 
 make -j${nproc}

--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -36,6 +36,7 @@ fi
 GMP_CFLAGS="-I${prefix}/include" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-included-libtasn1 \
     --with-included-unistring \
+    --ac_cv_func_malloc_0_nonnull=yes \
     --without-p11-kit 
 
 make -j${nproc}

--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -36,7 +36,6 @@ fi
 GMP_CFLAGS="-I${prefix}/include" ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-included-libtasn1 \
     --with-included-unistring \
-    --gl_cv_func_malloc_posix=no \
     --without-p11-kit 
 
 make -j${nproc}

--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -22,7 +22,7 @@ cd $WORKSPACE/srcdir/gnutls-*/
 if [[ ${target} == *darwin* ]]; then
     # Fix undefined reference to "_c_isdigit"
     # See https://gitlab.com/gnutls/gnutls/-/issues/1033
-    atomic_patch -p1 ../patches/03-undo-libtasn1-cisdigit.patch
+    # atomic_patch -p1 ../patches/03-undo-libtasn1-cisdigit.patch
 
     # We need to explicitly request a higher `-mmacosx-version-min` here, so that it doesn't
     # complain about: `Symbol not found: ___isOSVersionAtLeast`
@@ -47,7 +47,7 @@ make install
 platforms = supported_platforms(; experimental=true)
 
 # Disable windows because O_NONBLOCK isn't defined
-# filter!(!Sys.iswindows, platforms)
+filter!(!Sys.iswindows, platforms)
 
 # The products that we will ensure are always built
 products = Product[

--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -47,7 +47,7 @@ make install
 platforms = supported_platforms(; experimental=true)
 
 # Disable windows because O_NONBLOCK isn't defined
-filter!(!Sys.iswindows, platforms)
+# filter!(!Sys.iswindows, platforms)
 
 # The products that we will ensure are always built
 products = Product[

--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder
 
 name = "GnuTLS"
-version = v"3.7.1"
+version = v"3.7.8"
 
 # Collection of sources required to build GnuTLS
 sources = [
     ArchiveSource("https://www.gnupg.org/ftp/gcrypt/gnutls/v$(version.major).$(version.minor)/gnutls-$(version).tar.xz",
-                  "3777d7963eca5e06eb315686163b7b3f5045e2baac5e54e038ace9835e5cac6f"),
+                  "c58ad39af0670efe6a8aee5e3a8b2331a1200418b64b7c51977fb396d4617114"),
     DirectorySource("./bundled"),
 ]
 

--- a/G/GnuTLS/build_tarballs.jl
+++ b/G/GnuTLS/build_tarballs.jl
@@ -22,7 +22,7 @@ cd $WORKSPACE/srcdir/gnutls-*/
 if [[ ${target} == *darwin* ]]; then
     # Fix undefined reference to "_c_isdigit"
     # See https://gitlab.com/gnutls/gnutls/-/issues/1033
-    # atomic_patch -p1 ../patches/03-undo-libtasn1-cisdigit.patch
+    atomic_patch -p1 ../patches/03-undo-libtasn1-cisdigit.patch
 
     # We need to explicitly request a higher `-mmacosx-version-min` here, so that it doesn't
     # complain about: `Symbol not found: ___isOSVersionAtLeast`

--- a/G/GnuTLS/bundled/patches/03-undo-libtasn1-cisdigit.patch
+++ b/G/GnuTLS/bundled/patches/03-undo-libtasn1-cisdigit.patch
@@ -4,11 +4,11 @@
  #include <element.h>
  #include <limits.h>
  #include <intprops.h>
--#include <c-ctype.h>
+-#include "c-ctype.h"
  
  #ifdef DEBUG
  # define warn() fprintf(stderr, "%s: %d\n", __func__, __LINE__)
-@@ -353,7 +352,7 @@
+@@ -353,7 +352,7 @@ _asn1_get_time_der (unsigned type, const unsigned char *der, int der_len, int *r
        p = &der[len_len];
        for (i=0;i<(unsigned)(str_len-1);i++)
           {
@@ -27,7 +27,7 @@
  #include "element.h"
  
  void
-@@ -380,7 +379,7 @@
+@@ -380,7 +379,7 @@ asn1_write_value (asn1_node node_root, const char *name,
      case ASN1_ETYPE_ENUMERATED:
        if (len == 0)
  	{
@@ -36,7 +36,7 @@
  	    {
  	      value_temp = malloc (SIZEOF_UNSIGNED_LONG_INT);
  	      if (value_temp == NULL)
-@@ -453,7 +452,7 @@
+@@ -453,7 +452,7 @@ asn1_write_value (asn1_node node_root, const char *name,
  	  p = node->down;
  	  while (type_field (p->type) != ASN1_ETYPE_DEFAULT)
  	    p = p->right;
@@ -45,7 +45,7 @@
  	    {
  	      default_temp = malloc (SIZEOF_UNSIGNED_LONG_INT);
  	      if (default_temp == NULL)
-@@ -519,7 +518,7 @@
+@@ -519,7 +518,7 @@ asn1_write_value (asn1_node node_root, const char *name,
        break;
      case ASN1_ETYPE_OBJECT_ID:
        for (i = 0; i < _asn1_strlen (value); i++)
@@ -54,7 +54,7 @@
  	  return ASN1_VALUE_NOT_VALID;
        if (node->type & CONST_DEFAULT)
  	{
-@@ -540,7 +539,7 @@
+@@ -540,7 +539,7 @@ asn1_write_value (asn1_node node_root, const char *name,
  	if (len < 11)
  	  return ASN1_VALUE_NOT_VALID;
  	for (k = 0; k < 10; k++)
@@ -63,7 +63,7 @@
  	    return ASN1_VALUE_NOT_VALID;
  	switch (len)
  	  {
-@@ -549,7 +548,7 @@
+@@ -549,7 +548,7 @@ asn1_write_value (asn1_node node_root, const char *name,
  	      return ASN1_VALUE_NOT_VALID;
  	    break;
  	  case 13:
@@ -72,7 +72,7 @@
  		(value[12] != 'Z'))
  	      return ASN1_VALUE_NOT_VALID;
  	    break;
-@@ -557,16 +556,16 @@
+@@ -557,16 +556,16 @@ asn1_write_value (asn1_node node_root, const char *name,
  	    if ((value[10] != '+') && (value[10] != '-'))
  	      return ASN1_VALUE_NOT_VALID;
  	    for (k = 11; k < 15; k++)
@@ -92,7 +92,7 @@
  		return ASN1_VALUE_NOT_VALID;
  	    break;
  	  default:
-@@ -890,7 +889,7 @@
+@@ -890,7 +889,7 @@ asn1_read_value_type (asn1_node_const root, const char *name, void *ivalue,
  	  p = node->down;
  	  while (type_field (p->type) != ASN1_ETYPE_DEFAULT)
  	    p = p->right;
@@ -101,7 +101,6 @@
  	      || (p->value[0] == '+'))
  	    {
  	      result = _asn1_convert_integer
-
 --- a/lib/minitasn1/int.h
 +++ b/lib/minitasn1/int.h
 @@ -29,6 +29,7 @@
@@ -122,7 +121,7 @@
  
  char _asn1_identifierMissing[ASN1_MAX_NAME_SIZE + 1];	/* identifier name not found */
  
-@@ -755,7 +754,7 @@
+@@ -755,7 +754,7 @@ _asn1_expand_object_id (list_type **list, asn1_node node)
  	      p2 = p->down;
  	      if (p2 && (type_field (p2->type) == ASN1_ETYPE_CONSTANT))
  		{
@@ -131,7 +130,7 @@
  		    {
  		      _asn1_str_cpy (name2, sizeof (name2), name_root);
  		      _asn1_str_cat (name2, sizeof (name2), ".");
-@@ -1067,7 +1066,7 @@
+@@ -1067,7 +1066,7 @@ _asn1_check_identifier (asn1_node_const node)
  	  p2 = p->down;
  	  if (p2 && (type_field (p2->type) == ASN1_ETYPE_CONSTANT))
  	    {


### PR DESCRIPTION
This enables the build of the latest `glib-networking`, which is related to #5656