### PR TITLE
[CUDA] Add compat entry for CUDA_Driver.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -28,7 +28,8 @@ for cuda_version in cuda_versions
 
         should_build_platform(triplet(augmented_platform)) || continue
         push!(builds,
-              (; dependencies=[Dependency("CUDA_Driver"; top_level=true); dependencies],
+              (; dependencies=[Dependency("CUDA_Driver"; top_level=true, compat="0.1");
+                               dependencies],
                  script, products, platforms=[augmented_platform],
         ))
     end


### PR DESCRIPTION
Otherwise registration fails with:

```
┌ Error: Dependency "CUDA_Driver" does not have a compat entry that has an upper bound
└ @ RegistryCI.AutoMerge ~/.julia/packages/RegistryCI/78Rh8/src/AutoMerge/guidelines.jl:134
```