### PR TITLE
Add `flashrom`

### DIFF
--- a/F/flashrom/build_tarballs.jl
+++ b/F/flashrom/build_tarballs.jl
@@ -1,0 +1,38 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Base.BinaryPlatforms
+
+name = "flashrom"
+version = v"1.2.900"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/flashrom/flashrom.git",
+              "22e9313d908ce376be6686ebeb3f77828ea70c2e")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/flashrom/
+make PREFIX=${prefix} -j${nproc}
+make PREFIX=${prefix} install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = filter(Sys.islinux, supported_platforms())
+
+# ppc64le kernel headers might be broken, disable for now
+platforms = filter(p -> arch(p) != "powerpc64le", platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("flashrom", :flashrom, "sbin")
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"6")


### PR DESCRIPTION
This is technically not `v1.2`, but instead some random `master` version, because the board I actually need to flash is too new to appear in `v1.2` proper.  So we denote this by calling it `v1.2.900`, in hopes that there will not be a large number of upstream releases on the `v1.2` branch.