### PR TITLE
[Glib] Add networking support

### DIFF
--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -86,7 +86,7 @@ dependencies = [
     Dependency("Gettext_jll", v"0.21.0"; compat="=0.21.0"),
     Dependency("PCRE2_jll"; compat="10.35"),
     Dependency("Zlib_jll"),
-    Dependency("GnuTLS_jll"; compat="3.7.8+1"),
+    Dependency("GnuTLS_jll"; compat="3.7.8"),
     Dependency("Libmount_jll"; platforms=filter(Sys.islinux, platforms)),
 ]
 

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"2.74.0"
 sources = [
     ArchiveSource("https://ftp.gnome.org/pub/gnome/sources/glib/$(version.major).$(version.minor)/glib-$(version).tar.xz",
                   "3652c7f072d7b031a6b5edd623f77ebc5dcd2ae698598abcc89ff39ca75add30"),
-    ArchiveSource("https://ftp.gnome.org/pub/gnome/sources/glib/$(version.major).$(version.minor)/glib-networking-$(version).tar.xz",
+    ArchiveSource("https://ftp.gnome.org/pub/gnome/sources/glib-networking/$(version.major).$(version.minor)/glib-networking-$(version).tar.xz",
                   "1f185aaef094123f8e25d8fa55661b3fd71020163a0174adb35a37685cda613b"),
     DirectorySource("./bundled"),
 ]

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -50,19 +50,15 @@ sed -i.bak 's/csrDT/csrD/' build.ninja
 ninja -j${nproc} --verbose
 ninja install
 
+# Now build glib-networking
 cd $WORKSPACE/srcdir/glib-networking*/
 
 mkdir build_glib && cd build_glib
-
 meson --cross-file="${MESON_TARGET_TOOLCHAIN}" \
     --buildtype=release \
     ..
 
-# Meson beautifully forces thin archives, without checking whether the dynamic linker
-# actually supports them: <https://github.com/mesonbuild/meson/issues/10823>.  Let's remove
-# the (deprecated...) `T` option to `ar`
 sed -i.bak 's/csrDT/csrD/' build.ninja
-
 ninja -j${nproc} --verbose
 ninja install
 """


### PR DESCRIPTION
`glib-networking` itself does not produce standalone products.

Related information:

```
The build has produced several libraries and executables.
Please select which of these you want to consider `products`.
These are generally those artifacts you will load or use from julia.

[press: d=done, a=all, n=none]
   [ ] lib/gio/modules/libgioenvironmentproxy.so
 > [ ] lib/gio/modules/libgiognutls.so
```