### PR TITLE
make libunwind substantially faster

### DIFF
--- a/L/LibUnwind/LibUnwind@1.5.0/build_tarballs.jl
+++ b/L/LibUnwind/LibUnwind@1.5.0/build_tarballs.jl
@@ -38,6 +38,7 @@ export CFLAGS="-DPI -fPIC"
     --enable-minidebuginfo \
     --enable-zlibdebuginfo \
     --disable-tests
+    --disable-conservative-checks
 make -j${nproc}
 make install
 

--- a/L/LibUnwind/LibUnwind@1.5.0/build_tarballs.jl
+++ b/L/LibUnwind/LibUnwind@1.5.0/build_tarballs.jl
@@ -37,7 +37,7 @@ export CFLAGS="-DPI -fPIC"
     --libdir=${libdir} \
     --enable-minidebuginfo \
     --enable-zlibdebuginfo \
-    --disable-tests
+    --disable-tests \
     --disable-conservative-checks
 make -j${nproc}
 make install


### PR DESCRIPTION
Unfortunately, while this code has been often getting copied to other platforms lately, the option here (CONSERVATIVE_CHECKS) is typically lost when the libunwind authors do the code copying. Unfortunately also, the help continues implies that disabled should be the default value, although this was changed many years ago to be enabled. This should a give very substantial performance improvement on x86_64, by disabling unnecessary checks. It is not supposed to be enabled, since it is known to hurt performance very badly:
https://github.com/libunwind/libunwind/commit/649f1fb3449a65dd0626a709432d8b02a7c56bbc but then later got enabled because some people were using buggy compilers: https://github.com/libunwind/libunwind/commit/045c55b2a296988c16a4c1b90f3d8b7e8b78752b

Note: in v1.6, it looks like Aarch64 libunwind performance may get very badly impacted, as these conservative checks appear to have been copied there during that window, but the authors failed to copy over this flag.