### PR TITLE
[KaHyPar] update build script for M1

### DIFF
--- a/K/KaHyPar/build_tarballs.jl
+++ b/K/KaHyPar/build_tarballs.jl
@@ -13,14 +13,16 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-for f in ${WORKSPACE}/srcdir/patches/*.patch; do
-    atomic_patch -p1 ${f}
-done
-cd kahypar/
+cd $WORKSPACE/srcdir/kahypar/
+# Never build with `-march=native`
+atomic_patch -p1 ../patches/no_native.patch
 git submodule update --init --recursive --depth=1
 mkdir build && cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
+cmake .. \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DKAHYPAR_PYTHON_INTERFACE=OFF
 make install.library
 """
 

--- a/K/KaHyPar/build_tarballs.jl
+++ b/K/KaHyPar/build_tarballs.jl
@@ -44,8 +44,8 @@ products = [
 dependencies = [
     # Boost breaks ABI in every single version because they embed the full version number in
     # the SONAME, so we're compatible with one and only one version at a time.
-    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"); compat="=1.71.0")
+    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"); compat="=1.76.0")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7")

--- a/K/KaHyPar/build_tarballs.jl
+++ b/K/KaHyPar/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "KaHyPar"
-version = v"1.2.1"
+version = v"1.3.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/kahypar/kahypar.git", "971c38a4c7b7ed1ecf001d0263c1099cbc72886e"),
+    GitSource("https://github.com/kahypar/kahypar.git", "3802b7976002663b4126a11c5bff84996a830fb9"),
     DirectorySource("./bundled")
 ]
 
@@ -30,6 +30,7 @@ platforms = [
     Platform("x86_64", "linux"; libc = "glibc"),
     Platform("x86_64", "linux"; libc = "musl"),
     Platform("x86_64", "macos"; ),
+    Platform("aarch64", "macos"; ),
     Platform("x86_64", "freebsd"; )
 ]
 

--- a/K/KaHyPar/build_tarballs.jl
+++ b/K/KaHyPar/build_tarballs.jl
@@ -35,7 +35,7 @@ platforms = [
     Platform("aarch64", "macos"; ),
     Platform("x86_64", "freebsd"; )
 ]
-
+platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/K/KaHyPar/bundled/patches/no_native.patch
+++ b/K/KaHyPar/bundled/patches/no_native.patch
@@ -1,37 +1,21 @@
-diff --git before/kahypar/.git/config after/kahypar/.git/config
-index 2b788ab..9e824f6 100644
---- before/kahypar/.git/config
-+++ after/kahypar/.git/config
-@@ -9,3 +9,12 @@
- [branch "master"]
- 	remote = origin
- 	merge = refs/heads/master
-+[submodule "external_tools/WHFC"]
-+	active = true
-+	url = https://github.com/larsgottesbueren/WHFC.git
-+[submodule "external_tools/googletest"]
-+	active = true
-+	url = https://github.com/google/googletest.git
-+[submodule "python/pybind11"]
-+	active = true
-+	url = https://github.com/pybind/pybind11.git
-diff --git before/kahypar/CMakeLists.txt after/kahypar/CMakeLists.txt
-index 3e5849e..f58a509 100644
---- before/kahypar/CMakeLists.txt
-+++ after/kahypar/CMakeLists.txt
-@@ -253,8 +253,8 @@ if(NOT MSVC)
-   endif()
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9065a70e..c7ad682b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -251,14 +251,8 @@ if(NOT MSVC)
  
    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pthread -g3")
--  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -mtune=native -march=native")
--  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -mtune=native -march=native -g3 ") 
+ 
+-  if(CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
+-    # M1 doesn't seem to support -mtune=native -march=native
+-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3 ")
+-  else()
+-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -mtune=native -march=native")
+-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -mtune=native -march=native -g3 ")
+-  endif()
 +  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
-+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3 ") 
-   
++  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3 ")
+ 
  if(DEFINED ENV{TRAVIS_ENV})  
    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mno-avx")
-@@ -328,4 +328,3 @@ add_subdirectory(kahypar/application)
- add_subdirectory(tools)
- add_subdirectory(lib)
- add_subdirectory(tests)
--add_subdirectory(python)


### PR DESCRIPTION
KaHyPar v1.3.0 supports building for the M1 architecture. This should be a simple update but please review if other changes are needed.