### PR TITLE
[CUDA] Inline CUDA_Driver.jl into CUDA_Driver_jll._

### DIFF
--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -9,43 +9,180 @@ using BinaryBuilder, Pkg
 include("../../../fancy_toys.jl")
 
 name = "CUDA_Driver"
-version = v"11.8"
+version = v"0.1"
 
-cuda_version = "$(version.major)-$(version.minor)"
-driver_version = "520.61.05"
+cuda_version = v"11.8"
+cuda_version_str = "$(cuda_version.major)-$(cuda_version.minor)"
+driver_version_str = "520.61.05"
 build = 1
 
 sources_linux_x86 = [
-    FileSource("https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-compat-$(cuda_version)-$(driver_version)-$(build).x86_64.rpm",
+    FileSource("https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-compat-$(cuda_version_str)-$(driver_version_str)-$(build).x86_64.rpm",
                "0dad75290f8aa33f6d1ae1e1fa9fcc501bc51a74746b5e9e12082866e322eabf", "compat.rpm")
 ]
 sources_linux_ppc64le = [
-    FileSource("https://developer.download.nvidia.com/compute/cuda/repos/rhel8/ppc64le/cuda-compat-$(cuda_version)-$(driver_version)-$(build).ppc64le.rpm",
+    FileSource("https://developer.download.nvidia.com/compute/cuda/repos/rhel8/ppc64le/cuda-compat-$(cuda_version_str)-$(driver_version_str)-$(build).ppc64le.rpm",
                "85dad0fddf28bf3cfcfe63c5dc77ce84acce2100f99afad43ae78143c0277484", "compat.rpm")
 ]
 sources_linux_aarch64 = [
-    FileSource("https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/cuda-compat-$(cuda_version)-$(driver_version)-$(build).aarch64.rpm",
+    FileSource("https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/cuda-compat-$(cuda_version_str)-$(driver_version_str)-$(build).aarch64.rpm",
                "b01278c5cc50cd12b6a828c78417868c30dede086280d519141ff2f1728dd250", "compat.rpm")
 ]
 
 dependencies = []
 
 script = raw"""
-apk add rpm2cpio
-rpm2cpio compat.rpm | cpio -idmv
+    apk add rpm2cpio
+    rpm2cpio compat.rpm | cpio -idmv
 
-mkdir -p ${libdir}
+    mkdir -p ${libdir}
 
-mv usr/local/cuda-*/compat/* ${libdir}
+    mv usr/local/cuda-*/compat/* ${libdir}
 """
 
+# CUDA_Driver_jll provides libcuda_compat, but we can't always use that driver: It requires
+# specific hardware, and a compatible operating system. So we don't just dlopen the library,
+# but instead check during __init__ if we can, and dlopen either the system driver or the
+# compatible one from this JLL.
+#
+# Ordinarily, we'd put this logic in a package that depends on CUDA_Driver_jll (e.g.
+# CUDA_Driver.jl), but that complicates depending on it from other JLLs (like
+# CUDA_Runtime_jll). This will also simplify moving the logic into CUDA_Runtime_jll, which
+# we will have to at some point (because its pkg hooks shouldn't depend on CUDA_Driver_jll).
 init_block = """
-global version = $(repr(version))
+    global compat_version = $(repr(cuda_version))
+""" * raw"""
+    # minimal API call wrappers we need
+    function driver_version(library_handle)
+        function_handle = Libdl.dlsym(library_handle, "cuDriverGetVersion")
+        version_ref = Ref{Cint}()
+        status = ccall(function_handle, Cint, (Ptr{Cint},), version_ref)
+        if status != 0
+            return nothing
+        end
+        major, ver = divrem(version_ref[], 1000)
+        minor, patch = divrem(ver, 10)
+        return VersionNumber(major, minor, patch)
+    end
+    function init_driver(library_handle)
+        function_handle = Libdl.dlsym(library_handle, "cuInit")
+        status = ccall(function_handle, Cint, (UInt32,), 0)
+        Libdl.dlclose(library_handle)
+        return status
+    end
+
+    # find the system driver
+    system_driver = if Sys.iswindows()
+        Libdl.find_library("nvcuda")
+    else
+        Libdl.find_library(["libcuda.so.1", "libcuda.so"])
+    end
+    if system_driver == ""
+        @debug "No system CUDA driver found"
+        return
+    end
+    global libcuda = system_driver
+
+    # check if the system driver is already loaded. in that case, we have to use it because
+    # the code that loaded it in the first place might have made assumptions based on it.
+    system_driver_loaded = Libdl.dlopen(system_driver, Libdl.RTLD_NOLOAD;
+                                        throw_error=false) !== nothing
+    if system_driver_loaded
+        @debug "System CUDA driver already loaded, continuing using it"
+        return
+    end
+    driver_handle = Libdl.dlopen(system_driver; throw_error=true)
+
+    # query the system driver version
+    # XXX: apparently cuDriverGetVersion can be used before cuInit,
+    #      despite the docs stating "any function [...] will return
+    #      CUDA_ERROR_NOT_INITIALIZED"; is this a recent change?
+    system_version = driver_version(driver_handle)
+    if system_version === nothing
+        @debug "Failed to query system CUDA driver version"
+        # note that libcuda is already set here, so we'll continue using the system driver
+        # and CUDA.jl will likely report the reason cuDriverGetVersion didn't work.
+        return
+    end
+    @debug "System CUDA driver found at $system_driver, detected as version $system_version"
+
+    # check the user preference
+    if !parse(Bool, get(ENV, "JULIA_CUDA_USE_COMPAT", "true"))
+        @debug "User disallows using forward-compatible driver."
+        return
+    end
+
+    # check the version
+    if system_version >= compat_version
+        @debug "System CUDA driver is recent enough; not using forward-compatible driver"
+        return
+    end
+
+    # check if we can unload the system driver.
+    # if we didn't, we can't consider a forward compatible library because that would
+    # risk having multiple copies of libcuda.so loaded (also see NVIDIA bug #3418723)
+    Libdl.dlclose(driver_handle)
+    system_driver_loaded = Libdl.dlopen(system_driver, Libdl.RTLD_NOLOAD;
+                                        throw_error=false) !== nothing
+    if system_driver_loaded
+        @debug "Could not unload the system CUDA library;" *
+               " this prevents use of the forward-compatible driver"
+        return
+    end
+
+    # check if this process is hooked by CUDA's injection libraries, which prevents
+    # unloading libcuda after dlopening. this is problematic, because we might want to
+    # after loading a forwards-compatible libcuda and realizing we can't use it. without
+    # being able to unload the library, we'd run into issues (see NVIDIA bug #3418723)
+    hooked = haskey(ENV, "CUDA_INJECTION64_PATH")
+    if hooked
+        @debug "Running under CUDA injection tools;" *
+               " this prevents use of the forward-compatible driver"
+        return
+    end
+
+    # check if we even have an artifact
+    if !@isdefined(libcuda_compat)
+        @debug "No forward-compatible CUDA library available for your platform."
+        return
+    end
+    compat_driver = libcuda_compat
+    @debug "Forward-compatible CUDA driver found at $compat_driver;" *
+           " reported as version $(compat_version)"
+
+    # finally, load the compatibility driver to see if it supports this platform
+    driver_handle = Libdl.dlopen(compat_driver; throw_error=true)
+    # TODO: do we need to dlopen the JIT compiler library for it to be discoverable?
+    #       doesn't that clash with a system one if compat cuInit fails? or should
+    #       we load it _after_ the compat driver initialization succeeds?
+    #compiler_handle = libnvidia_ptxjitcompiler
+    #Libdl.dlopen(compiler_handle)
+
+    init_status = init_driver(driver_handle)
+    if init_status != 0
+        @debug "Could not use forward compatibility package (error $init_status)"
+
+        # see comment above about unloading the system driver
+        Libdl.dlclose(driver_handle)
+        compat_driver_loaded = Libdl.dlopen(compat_driver, Libdl.RTLD_NOLOAD;
+                                            throw_error=false) !== nothing
+        if compat_driver_loaded
+            error("Could not unload the forward compatible CUDA driver library." *
+                "This is probably caused by running Julia under a tool that hooks CUDA API calls." *
+                "In that case, prevent Julia from loading multiple drivers" *
+                " by setting JULIA_CUDA_USE_COMPAT=false in your environment.")
+        end
+
+        return
+    end
+
+    @debug "Successfully loaded forwards-compatible CUDA driver"
+    global system_version = system_version
+    global libcuda = compat_driver
 """
 
 products = [
-    LibraryProduct("libcuda", :libcuda;
-                   dont_dlopen=true),
+    LibraryProduct("libcuda", :libcuda_compat; dont_dlopen=true),
     LibraryProduct("libnvidia-ptxjitcompiler", :libnvidia_ptxjitcompiler;
                    dont_dlopen=true),
 ]


### PR DESCRIPTION
Turns out we have a policy that JLLs cannot depend on non-JLL packages, so having CUDA_Runtime_jll depend on CUDA_Driver doesn't work. Instead, this PR moves the functionality from that package into the JLL by (ab)using the init mechanism. This functionality is required to determine whether the driver provided by CUDA_Driver_jll can be used, or whether we should use the system driver instead.

This change will also make it easier to further inline all of CUDA_Driver(_jll) into CUDA_Runtime_jll, which we sadly have to do because CUDA_Runtime_jll's package hooks cannot depend on _any_ non-stdlib package.