### PR TITLE
[CUDA] Update CUDA_Runtime_jll to depend on CUDA_Driver_jll.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -28,8 +28,7 @@ for cuda_version in cuda_versions
 
         should_build_platform(triplet(augmented_platform)) || continue
         push!(builds,
-              (; dependencies=[Dependency("CUDA_Driver"; top_level=true, compat="0.1");
-                               dependencies],
+              (; dependencies=[Dependency("CUDA_Driver_jll"; compat="0.1"); dependencies],
                  script, products, platforms=[augmented_platform],
         ))
     end


### PR DESCRIPTION
Works around:

```
┌ Info: If this is a JLL package, only deps are Pkg, Libdl, and other JLL packages
│   meets_this_guideline = false
└   message = "JLL packages are only allowed to depend on Pkg, Libdl, Artifacts, JLLWrappers, LazyArtifacts, TOML, MPIPreferences and other JLL packages"
```