### PR TITLE
LibPQ: expose headers to client applications

### DIFF
--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -54,6 +54,7 @@ fi
     "${FLAGS[@]}"
 make -C src/interfaces/libpq -j${nproc}
 make -C src/interfaces/libpq install
+make -C src/include install
 
 # Delete static library
 rm ${prefix}/lib/libpq.a


### PR DESCRIPTION
Hi @giordano! This PR exposes the postgres header files to client applications, that can build on top of them. This is for example needed in gdal. Maybe the contents of `$prefix/include/postgresql/server` are unused and can be deleted to save space?