### PR TITLE
[CUDNN] Fix Julia compat.

### DIFF
--- a/C/CUDNN/build_tarballs.jl
+++ b/C/CUDNN/build_tarballs.jl
@@ -58,6 +58,7 @@ for cuda_version in cuda_versions
                               "fd324c6923aa4f45a60413665e0b68bb34a7779d0861849e02d2711ff8efb9a4"))
         end
         build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
-                       products, dependencies; lazy_artifacts=true, augment_platform_block)
+                       products, dependencies; lazy_artifacts=true,
+                       julia_compat="1.6", augment_platform_block)
     end
 end


### PR DESCRIPTION
Only spotted by Yggdrasil CI during registration:

```
ERROR: LoadError: Augmentation blocks cannot be used with Julia v1.5-.
Change `julia_compat` to require at least Julia v1.6
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] register_jll(name::String, build_version::VersionNumber, dependencies::Vector{Dependency}, julia_compat::String; deploy_repo::String, code_dir::String, gh_auth::GitHub.OAuth2, gh_username::String, augment_platform_block::String, lazy_artifacts::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ BinaryBuilder /depot/packages/BinaryBuilder/dyIhw/src/AutoBuild.jl:556
 [3] top-level scope
   @ /agent/_work/1/s/.ci/register_package.jl:137
in expression starting at /agent/_work/1/s/.ci/register_package.jl:137
```