### PR TITLE
[CUDA] Fix comparison strategy in case of missing CUDA.

### DIFF
--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -15,6 +15,9 @@ const augment = """
     end
 
     function cuda_comparison_strategy(a::String, b::String, a_requested::Bool, b_requested::Bool)
+        if a == "none" || b == "none"
+            return false
+        end
         a = VersionNumber(a)
         b = VersionNumber(b)
 


### PR DESCRIPTION
We're currently using 'none' as a special case to indicate no CUDA toolkit, so need to handle this appropriately.