### PR TITLE
new recipe: extrae

### DIFF
--- a/E/extrae/build_tarballs.jl
+++ b/E/extrae/build_tarballs.jl
@@ -31,10 +31,10 @@ make -j${nproc}
 make install
 """
 
-platforms = expand_cxxstring_abis([
+platforms = [
     Platform("i686", "Linux"),
     Platform("x86_64", "Linux"),
-])
+]
 
 products = [
     LibraryProduct("libseqtrace", :libseqtrace),

--- a/E/extrae/build_tarballs.jl
+++ b/E/extrae/build_tarballs.jl
@@ -7,13 +7,20 @@ sources = [
     ArchiveSource(
         "https://github.com/bsc-performance-tools/extrae/archive/refs/tags/$(version).tar.gz",
         "e6765eb087be3f3c162e08d65f425de5f26912811392527d56ecd75d4fb6b99d"),
+        DirectorySource("./bundled"),
 ]
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/extrae-*
+
+atomic_patch -p1 ../patches/0001-autoconf-replace-pointer-size-check-by-AC_CHECK_SIZE.patch
+atomic_patch -p1 ../patches/0002-autoconf-use-simpler-endianiness-check.patch
+
 autoreconf -fvi
 ./configure \
-    --prefix=$prefix \
+    --prefix=${prefix} \
+    --build=${MACHTYPE} \
+    --host=${target} \
     --without-binutils \
     --without-dyninst \
     --without-mpi \

--- a/E/extrae/build_tarballs.jl
+++ b/E/extrae/build_tarballs.jl
@@ -21,6 +21,7 @@ autoreconf -fvi
     --prefix=${prefix} \
     --build=${MACHTYPE} \
     --host=${target} \
+    --disable-openmp \
     --without-binutils \
     --without-dyninst \
     --without-mpi \
@@ -38,7 +39,6 @@ platforms = [
 
 products = [
     LibraryProduct("libseqtrace", :libseqtrace),
-    LibraryProduct("libomptrace", :libomptrace),
     LibraryProduct("libnanostrace", :libnanostrace),
 ]
 

--- a/E/extrae/build_tarballs.jl
+++ b/E/extrae/build_tarballs.jl
@@ -1,0 +1,42 @@
+#!/usr/bin/env julia
+using BinaryBuilder, Pkg
+
+name = "extrae"
+version = v"4.0.1"
+sources = [
+    ArchiveSource(
+        "https://github.com/bsc-performance-tools/extrae/archive/refs/tags/$(version).tar.gz",
+        "e6765eb087be3f3c162e08d65f425de5f26912811392527d56ecd75d4fb6b99d"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/extrae-*
+autoreconf -fvi
+./configure \
+    --prefix=$prefix \
+    --without-binutils \
+    --without-dyninst \
+    --without-mpi \
+    --without-papi \
+    --without-unwind
+
+make -j${nproc}
+make install
+"""
+
+platforms = expand_cxxstring_abis([
+    Platform("i686", "Linux"),
+    Platform("x86_64", "Linux"),
+])
+
+products = [
+    LibraryProduct("libseqtrace", :libseqtrace),
+    LibraryProduct("libomptrace", :libomptrace),
+    LibraryProduct("libnanostrace", :libnanostrace),
+]
+
+dependencies = [
+    Dependency("XML2_jll"),
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/E/extrae/bundled/patches/0001-autoconf-replace-pointer-size-check-by-AC_CHECK_SIZE.patch
+++ b/E/extrae/bundled/patches/0001-autoconf-replace-pointer-size-check-by-AC_CHECK_SIZE.patch
@@ -1,0 +1,86 @@
+From 484d6db84aefd7ad0f392b7009a888f69ef81038 Mon Sep 17 00:00:00 2001
+From: Mirek Kratochvil <miroslav.kratochvil@uni.lu>
+Date: Fri, 21 Oct 2022 11:54:01 +0200
+Subject: [PATCH 1/2] autoconf: replace pointer size check by AC_CHECK_SIZEOF
+
+---
+ config/macros.m4 | 44 ++++----------------------------------------
+ 1 file changed, 4 insertions(+), 40 deletions(-)
+
+diff --git a/config/macros.m4 b/config/macros.m4
+index 7705fa15..d1d28b2d 100644
+--- a/config/macros.m4
++++ b/config/macros.m4
+@@ -433,47 +433,13 @@ dnl AX_FLAGS_SAVE()
+   dnl AX_FLAGS_RESTORE()
+ ])
+ 
+-
+-# AX_CHECK_POINTER_SIZE
+-# ---------------------
+-AC_DEFUN([AX_CHECK_POINTER_SIZE],
+-[
+-   AC_REQUIRE([AX_IS_BGL_MACHINE])
+-   AC_REQUIRE([AX_IS_BGP_MACHINE])
+-   AC_REQUIRE([AX_IS_BGQ_MACHINE])
+-
+-   if test "${IS_BGQ_MACHINE}" = "yes" ; then
+-      POINTER_SIZE=64
+-   elif test "${IS_BGL_MACHINE}" = "yes" -o "${IS_BGP_MACHINE}" = "yes" ; then
+-      POINTER_SIZE=32
+-   elif test "${IS_MIC_MACHINE}" = "yes" ; then
+-      POINTER_SIZE=64
+-   elif test "${IS_ARM_MACHINE}" = "yes" ; then
+-      POINTER_SIZE=32
+-   elif test "${IS_ARM64_MACHINE}" = "yes" ; then
+-      POINTER_SIZE=64
+-   elif test "${IS_SPARC64_MACHINE}" = "yes" ; then
+-      POINTER_SIZE=64
+-   else
+-      AC_TRY_RUN(
+-         [
+-            int main()
+-            {
+-               return sizeof(void *)*8;
+-            }
+-         ],
+-         [ POINTER_SIZE="0" ],
+-         [ POINTER_SIZE="$?"]
+-      )
+-   fi
+-])
+-
+-
+ # AX_SELECT_BINARY_TYPE
+ # ---------------------
+ # Check the binary type the user wants to build and verify whether it can be successfully built
+ AC_DEFUN([AX_SELECT_BINARY_TYPE],
+ [
++	AC_CHECK_SIZEOF([void *])
++
+ 	AC_ARG_WITH(binary-type,
+ 		AC_HELP_STRING(
+ 			[--with-binary-type@<:@=ARG@:>@],
+@@ -498,8 +464,7 @@ AC_DEFUN([AX_SELECT_BINARY_TYPE],
+ 			[for $_AC_LANG_PREFIX[]_compiler compiler default binary type], 
+ 			[[]_AC_LANG_PREFIX[]_ac_cv_compiler_default_binary_type],
+ 			[
+-				AX_CHECK_POINTER_SIZE
+-				Default_Binary_Type="$POINTER_SIZE"
++				Default_Binary_Type=$(( 8 * ${ac_cv_sizeof_void_p} ))
+ 				[]_AC_LANG_PREFIX[]_ac_cv_compiler_default_binary_type="$Default_Binary_Type""-bit"
+ 			]
+ 		)
+@@ -540,8 +505,7 @@ AC_DEFUN([AX_SELECT_BINARY_TYPE],
+ 				old_[]_AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS"
+ 				[]_AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $flag"
+ 
+-				AX_CHECK_POINTER_SIZE()
+-				if test "$POINTER_SIZE" = "$Selected_Binary_Type" ; then
++				if test $(( 8 * ${ac_cv_sizeof_void_p})) = "${Selected_Binary_Type}" ; then
+ 					AC_MSG_RESULT([$flag])
+ 					break
+ 				else
+-- 
+2.35.1
+

--- a/E/extrae/bundled/patches/0002-autoconf-use-simpler-endianiness-check.patch
+++ b/E/extrae/bundled/patches/0002-autoconf-use-simpler-endianiness-check.patch
@@ -1,0 +1,52 @@
+From 548394965fd42d5671222198715a98482ba5feae Mon Sep 17 00:00:00 2001
+From: Mirek Kratochvil <miroslav.kratochvil@uni.lu>
+Date: Fri, 21 Oct 2022 12:04:36 +0200
+Subject: [PATCH 2/2] autoconf: use simpler endianiness check
+
+---
+ config/macros.m4 | 29 ++++-------------------------
+ 1 file changed, 4 insertions(+), 25 deletions(-)
+
+diff --git a/config/macros.m4 b/config/macros.m4
+index d1d28b2d..934a6d55 100644
+--- a/config/macros.m4
++++ b/config/macros.m4
+@@ -544,31 +544,10 @@ AC_DEFUN([AX_ENSURE_CXX_PRESENT],
+ # Test if the architecture is little or big endian
+ AC_DEFUN([AX_CHECK_ENDIANNESS],
+ [
+-   AC_CACHE_CHECK([for the architecture endianness], [ac_cv_endianness],
+-   [
+-      AC_LANG_SAVE()
+-      AC_LANG([C])
+-      AC_TRY_RUN(
+-      [
+-         int main()
+-         {
+-            short s = 1;
+-            short * ptr = &s;
+-            unsigned char c = *((char *)ptr);
+-            return c;
+-         }
+-      ],
+-      [ac_cv_endianness="big endian" ],
+-      [ac_cv_endianness="little endian" ]
+-      )
+-      AC_LANG_RESTORE()
+-   ])
+-   if test "$ac_cv_endianness" = "big endian" ; then
+-      AC_DEFINE(IS_BIG_ENDIAN, 1, [Define to 1 if architecture is big endian])
+-   fi
+-   if test "$ac_cv_endianness" = "little endian" ; then
+-      AC_DEFINE(IS_LITTLE_ENDIAN, 1, [Define to 1 if architecture is little endian])
+-   fi
++   AC_C_BIGENDIAN(
++      AC_DEFINE(IS_BIG_ENDIAN, 1, [Define to 1 if architecture is big endian]),
++      AC_DEFINE(IS_LITTLE_ENDIAN, 1, [Define to 1 if architecture is little endian]),
++      AC_MSG_FAILURE([Cannot detect endianiness]))
+ ])
+ 
+ 
+-- 
+2.35.1
+


### PR DESCRIPTION
Extrae is a specific profiling/instrumentation library developed for analyzing the performance of highly parallel programs at BSC.es. It works nicely with MPI and other HPC technologies. Our aim is to enable export of (some) extrae events from Julia to enable integration with larger workflows that use the tools from the ecosystem to measure/debug performance.

See https://tools.bsc.es/extrae and https://tools.bsc.es/paraver for illustrations.

~~Regarding this PR, I had a some trouble with the Extrae configure script being (completely un)able to find the BinUtils_jll contents, so I decided to just ignore it for now. Managing that would open some more instrumentation options, but both of them are unlikely to be relevant for Julia stuff.~~ I had to disable most of the platforms/packages because extrae fails for various reasons, most suspiciously by 1) being unable to use unwind 2) configure script failing to produce executable binaries. Opinions on that very welcome, esp. if I can help it with more cross-compiling options.

UPDATE: I patched the extrae autoconf machinery to be able to cross-compile and it seems to work. Opinions still welcome. I didn't succeed on making it work with MPI though.

(Cc @clasqui @ArnauMontagud @laurentheirendt)