### PR TITLE
Bump pprof to 1.0.1

### DIFF
--- a/P/pprof/build_tarballs.jl
+++ b/P/pprof/build_tarballs.jl
@@ -7,7 +7,7 @@ name = "pprof"
 # main branch.
 
 hash = "b5a4dc8f4f2afdee77047b6aae3834140efc83ed"
-version = v"1.0.0"
+version = v"1.0.1"
 
 # Collection of sources required to build pprof
 sources = [


### PR DESCRIPTION
In the latest 1.0.0+1 release, a large # of JLL dependencies were added. I have a project where JLLs have to be added carefully, and the `+1` build number doesn't allow pinning the version to a pre-lots-of-JLLs version. As recommended in [this slack thread](https://julialang.slack.com/archives/C674ELDNX/p1666244847300719), we can bump the version and then yank the 1.0.0+1 version from the General registry to allow pinning.