### PR TITLE
[CUDA] Introduce cuda=local platform tag for local discovery.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -5,16 +5,13 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.2.2"
+version = v"0.2.3"
 
 cuda_versions = [v"10.2", v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6", v"11.7", v"11.8"]
 
 augment_platform_block = """
     $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))
-
-    function augment_platform!(platform::Platform)
-        augment_platform!(platform, $cuda_versions)
-    end"""
+    const cuda_toolkits = $cuda_versions"""
 
 # determine exactly which tarballs we should build
 builds = []
@@ -48,5 +45,3 @@ for (i,build) in enumerate(builds)
                    julia_compat="1.6", lazy_artifacts=true,
                    augment_platform_block)
 end
-
-# bump

--- a/C/CUDA/CUDA_Runtime/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Runtime/platform_augmentation.jl
@@ -13,10 +13,20 @@ end
 const CUDA_Runtime_jll_uuid = Base.UUID("76a88914-d11a-5bdc-97e0-2f5a05c973a2")
 const preferences = Base.get_preferences(CUDA_Runtime_jll_uuid)
 
-function toolkit_version(cuda_toolkits)
+# returns the value for the "cuda" tag we should use in the platform.
+# possible values:
+#  - "$MAJOR.$MINOR": a VersionNumber-like string
+#  - "local": the user has requested to use the local CUDA installation
+#  - "none": no compatible CUDA toolkit was found.
+#    note that we don't just leave off the platform tag or Pkg would select *any* artifact.
+function cuda_toolkit_tag()
     # check if the user requested a specific version
     if haskey(preferences, "version")
-        cuda_version_override = VersionNumber(preferences["version"])
+        version = tryparse(VersionNumber, preferences["version"])
+        if version === nothing
+            return preferences["version"]
+        end
+        cuda_version_override = version
     end
     Base.record_compiletime_preference(CUDA_Runtime_jll_uuid, "version")
 
@@ -26,7 +36,7 @@ function toolkit_version(cuda_toolkits)
     if !@isdefined(cuda_version_override)
         if !@isdefined(CUDA_Driver_jll) ||          # see above
            !isdefined(CUDA_Driver_jll, :libcuda)    # no driver found
-            return nothing
+            return "none"
         end
 
         cuda_driver = CUDA_Driver_jll.libcuda_version
@@ -49,23 +59,15 @@ function toolkit_version(cuda_toolkits)
         end
     end
     if isempty(cuda_toolkits)
-        return nothing
+        return "none"
     end
 
-    last(cuda_toolkits)
+    cuda_toolkit = last(cuda_toolkits)
+    "$(cuda_toolkit.major).$(cuda_toolkit.minor)"
 end
 
-# versions will be provided by build_tarballs.jl
-function augment_platform!(platform::Platform, cuda_toolkits::Vector{VersionNumber})
+function augment_platform!(platform::Platform)
     haskey(platform, "cuda") && return platform
-
-    cuda_toolkit = toolkit_version(cuda_toolkits)
-    platform["cuda"] = if cuda_toolkit !== nothing
-        "$(cuda_toolkit.major).$(cuda_toolkit.minor)"
-    else
-        # don't use an empty string here, because Pkg will then load *any* artifact
-        "none"
-    end
-
+    platform["cuda"] = cuda_toolkit_tag()
     return platform
 end

--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -18,6 +18,9 @@ const augment = """
         if a == "none" || b == "none"
             return false
         end
+        if a == "local" || b == "local"
+            return a == b
+        end
         a = VersionNumber(a)
         b = VersionNumber(b)
 


### PR DESCRIPTION
By encoding this as a platform tag incompatible with other CUDA platform tags, this makes it possible to opt-out of the JLL system and not download any artifacts at all.