### PR TITLE
Add cereal_jll package (dependency of mlpack).

### DIFF
--- a/C/cereal/build_tarballs.jl
+++ b/C/cereal/build_tarballs.jl
@@ -14,7 +14,8 @@ sources = [
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/cereal-*/
-cp -vr include/* ${prefix}/include/
+mkdir "${includedir}"
+cp -vr include/* "${includedir}/."
 """
 
 # These are the platforms we will build for by default, unless further

--- a/C/cereal/build_tarballs.jl
+++ b/C/cereal/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/cereal-*/
-mkdir "${includedir}"
+mkdir -p "${includedir}"
 cp -vr include/* "${includedir}/."
 """
 

--- a/C/cereal/build_tarballs.jl
+++ b/C/cereal/build_tarballs.jl
@@ -1,0 +1,30 @@
+# Build script for cereal: C++ header-only library for serialization.
+# This is basically just a dummy package that installs header files, and makes
+# them available for other packages.
+
+using BinaryBuilder
+
+
+name = "cereal"
+version = v"1.3.2"
+sources = [
+    ArchiveSource("https://github.com/USCILab/cereal/archive/refs/tags/v$(version).tar.gz",
+                  "16a7ad9b31ba5880dac55d62b5d6f243c3ebc8d46a3514149e56b5e7ea81f85f")
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/cereal-*/
+cp -vr include/* ${prefix}/include/
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line.
+platforms = [AnyPlatform()]
+
+# Cereal produces nothing, since it is header-only.
+products = Product[]
+
+# Dependencies that must be installed before this package can be built.
+dependencies = []
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6", julia_compat="1.7")


### PR DESCRIPTION
Just earlier today, mlpack 4.0.0 was released, so I have begun the process of updating the `mlpack_jll` package.  However, mlpack 4 has a new dependency on cereal, a header-only serialization library (this then let mlpack remove its Boost dependency).  So, we just need to add a `cereal_jll` package to make those headers available for mlpack.

I ran and tested this locally---seems to be fine.  We'll see if CI agrees. :)