### PR TITLE
Update SuiteSparse GPU build.

### DIFF
--- a/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
@@ -80,6 +80,8 @@ platforms = [
     Platform("x86_64", "linux"),
 ]
 
+push!(dependencies, Dependency("METIS_jll"))
+
 products = [
     products;
     LibraryProduct("libGPUQREngine",            :libGPUQREngine)

--- a/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
@@ -36,9 +36,9 @@ FLAGS+=(BLAS="-l${BLAS_NAME}" LAPACK="-l${BLAS_NAME}")
 # Enable CUDA
 FLAGS+=(CUDA_PATH="$prefix/cuda")
 
-# Disable METIS in CHOLMOD by passing -DNPARTITION and avoiding linking metis
+# To disable METIS in CHOLMOD, pass -DNPARTITION and avoiding linking metis
 FLAGS+=(MY_METIS_LIB="-lmetis" MY_METIS_INC="${prefix}/include")
-FLAGS+=(UMFPACK_CONFIG="$SUN" CHOLMOD_CONFIG+="$SUN -DNPARTITION" SPQR_CONFIG="$SUN")
+FLAGS+=(UMFPACK_CONFIG="$SUN" CHOLMOD_CONFIG+="$SUN" SPQR_CONFIG="$SUN")
 
 make -j${nproc} -C SuiteSparse_config "${FLAGS[@]}" library config
 

--- a/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
@@ -80,8 +80,8 @@ platforms = [
     Platform("x86_64", "linux"),
 ]
 
-dependencies = [ 
-    dependencies, 
+dependencies = [
+    Dependency("libblastrampoline_jll"),
     Dependency("SuiteSparse_jll"),
     Dependency("METIS_jll"),
  ]

--- a/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
@@ -42,7 +42,7 @@ FLAGS+=(UMFPACK_CONFIG="$SUN" CHOLMOD_CONFIG+="$SUN -DNPARTITION" SPQR_CONFIG="$
 
 make -j${nproc} -C SuiteSparse_config "${FLAGS[@]}" library config
 
-for proj in SuiteSparse_config SuiteSparse_GPURuntime GPUQREngine AMD CAMD CCOLAMD COLAMD CHOLMOD SPQR; do
+for proj in SuiteSparse_config SuiteSparse_GPURuntime GPUQREngine CHOLMOD SPQR; do
     make -j${nproc} -C $proj "${FLAGS[@]}" library CFOPENMP="$CFOPENMP"
     make -j${nproc} -C $proj "${FLAGS[@]}" install CFOPENMP="$CFOPENMP"
 done
@@ -80,14 +80,14 @@ platforms = [
     Platform("x86_64", "linux"),
 ]
 
-push!(dependencies, Dependency("METIS_jll"))
+dependencies = [ 
+    dependencies, 
+    Dependency("SuiteSparse_jll"),
+    Dependency("METIS_jll"),
+ ]
 
 products = [
     LibraryProduct("libsuitesparseconfig",      :libsuitesparseconfig),
-    LibraryProduct("libamd",                    :libamd),
-    LibraryProduct("libcamd",                   :libcamd),
-    LibraryProduct("libccolamd",                :libccolamd),
-    LibraryProduct("libcolamd",                 :libcolamd),
     LibraryProduct("libcholmod",                :libcholmod),
     LibraryProduct("libspqr",                   :libspqr),
     LibraryProduct("libGPUQREngine",            :libGPUQREngine),

--- a/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse_GPU/build_tarballs.jl
@@ -83,9 +83,15 @@ platforms = [
 push!(dependencies, Dependency("METIS_jll"))
 
 products = [
-    products;
-    LibraryProduct("libGPUQREngine",            :libGPUQREngine)
-    LibraryProduct("libSuiteSparse_GPURuntime", :libSuiteSparse_GPURuntime)
+    LibraryProduct("libsuitesparseconfig",      :libsuitesparseconfig),
+    LibraryProduct("libamd",                    :libamd),
+    LibraryProduct("libcamd",                   :libcamd),
+    LibraryProduct("libccolamd",                :libccolamd),
+    LibraryProduct("libcolamd",                 :libcolamd),
+    LibraryProduct("libcholmod",                :libcholmod),
+    LibraryProduct("libspqr",                   :libspqr),
+    LibraryProduct("libGPUQREngine",            :libGPUQREngine),
+    LibraryProduct("libSuiteSparse_GPURuntime", :libSuiteSparse_GPURuntime),
 ]
 
 # XXX: support only specifying major/minor version (JuliaPackaging/BinaryBuilder.jl#/1212)


### PR DESCRIPTION
@ViralBShah I removed several components that failed to build (e.g. Slip_LU), making it consistent with the main SuiteSparse build. I'm also not sure why this version included METIS? I couldn't find anything about SuiteSparse+CUDA and any METIS requirements.