### PR TITLE
[oneAPI] Do dlopen the support library during init.

### DIFF
--- a/O/oneAPI_Support/build_tarballs.jl
+++ b/O/oneAPI_Support/build_tarballs.jl
@@ -105,7 +105,7 @@ rm -rf ${includedir}
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["liboneapi_support"], :liboneapi_support, dont_dlopen=true),
+    LibraryProduct(["liboneapi_support"], :liboneapi_support),
 ]
 
 # Dependencies that must be installed before this package can be built
@@ -127,5 +127,6 @@ for (idx, (platform, sources)) in enumerate(platform_sources)
         args = ARGS
     end
     build_tarballs(args, name, version, [generic_sources; sources], script, [platform],
-                   products, dependencies; skip_audit=true, preferred_gcc_version=v"8")
+                   products, dependencies; skip_audit=true, dont_dlopen=true,
+                   preferred_gcc_version=v"8")
 end


### PR DESCRIPTION
I _think_ this is why I'm running into:

```
ERROR: could not load library "/home/tim/Julia/depot/artifacts/89bcb2617e71169efe39a4770f3a92ac6b37c210/lib/liboneapi_support.so"
libmkl_sycl.so.2: cannot open shared object file: No such file or directory
```

... as `libmkl_sycl.so.2` is just provided in the same directory as `liboneapi_support.so`, and there's no proper dependency on a JLL loading that library.

