### PR TITLE
[libcleri] Do not build with GCC on all platforms

### DIFF
--- a/L/libcleri/build_tarballs.jl
+++ b/L/libcleri/build_tarballs.jl
@@ -7,19 +7,21 @@ version = v"0.12.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/transceptor-technology/libcleri.git", "a8a1adc9dcf4e889a4d44c17acb20d74d0c6cfe5")
+    GitSource("https://github.com/transceptor-technology/libcleri.git",
+              "a8a1adc9dcf4e889a4d44c17acb20d74d0c6cfe5"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
+cd $WORKSPACE/srcdir/libcleri/
+atomic_patch -p1 ../patches/cc-compiler.patch
 export CFLAGS=$(pcre2-config --cflags)
 export LDFLAGS=$(pcre2-config --libs8)
-cd $WORKSPACE/srcdir
-cd libcleri/
 make -C Release FN="libcleri.${dlext}"
 make -C Release FN="libcleri.${dlext}" install INSTALL_PATH=${prefix}
 if [[ "${target}" == *-apple-* ]]; then
-    install_name_tool -id @rpath/libcleri.dylib.0 ${prefix}/lib/libcleri.dylib
+    install_name_tool -id @rpath/libcleri.dylib.0 ${libdir}/libcleri.dylib
 fi
 if [[ "${target}" == *-mingw* ]]; then
     chmod a+x ${prefix}/lib/libcleri.${dlext}
@@ -28,8 +30,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
-
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libcleri/bundled/patches/cc-compiler.patch
+++ b/L/libcleri/bundled/patches/cc-compiler.patch
@@ -1,0 +1,36 @@
+diff --git a/Release/makefile b/Release/makefile
+index 9b2dbc1..c5ce2b5 100644
+--- a/Release/makefile
++++ b/Release/makefile
+@@ -32,8 +32,8 @@ all: libcleri
+ # Tool invocations
+ libcleri: $(OBJS) $(USER_OBJS)
+ 	@echo 'Building target: $@'
+-	@echo 'Invoking: Cross GCC Linker'
+-	gcc -shared -Wl,-$(SO_NAME),$(FN).$(MAJOR) -o $(FN) $(OBJS) $(USER_OBJS) $(LIBS) $(LDFLAGS)
++	@echo 'Invoking: Cross CC Linker'
++	cc -shared -Wl,-$(SO_NAME),$(FN).$(MAJOR) -o $(FN) $(OBJS) $(USER_OBJS) $(LIBS) $(LDFLAGS)
+ 	@chmod -x $(FN)
+ 	@echo 'Finished building target: $@'
+ 	@echo ' '
+@@ -49,4 +49,4 @@ clean:
+ -include ../makefile.targets
+ 
+ test:
+-	@cd ../test && ./test.sh
+\ No newline at end of file
++	@cd ../test && ./test.sh
+diff --git a/Release/src/subdir.mk b/Release/src/subdir.mk
+index a24b4c0..e9a74b3 100644
+--- a/Release/src/subdir.mk
++++ b/Release/src/subdir.mk
+@@ -76,7 +76,7 @@ C_DEPS += \
+ 
+ src/%.o: ../src/%.c
+ 	@echo 'Building file: $<'
+-	@echo 'Invoking: Cross GCC Compiler'
+-	gcc -DNDEBUG -I../inc -O3 -Winline -Wall $(CPPFLAGS) $(CFLAGS) -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
++	@echo 'Invoking: Cross CC Compiler'
++	cc -DNDEBUG -I../inc -O3 -Winline -Wall $(CPPFLAGS) $(CFLAGS) -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
+ 	@echo 'Finished building: $<'
+ 	@echo ' '


### PR DESCRIPTION
Fix #5771, at least for the specific case of libcleri, although other libraries are going to have troubles on Intel macOS Ventura because the dynamic loader change behaviour in a breaking way.