### PR TITLE
Rebuild GAP

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -27,7 +27,7 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "GAP"
 upstream_version = v"4.12.1"
-version = v"400.1200.100"
+version = v"400.1200.101"
 
 julia_versions = [v"1.6", v"1.7", v"1.8", v"1.9"]
 

--- a/G/GAP/bundled/patches/sysinfo.patch
+++ b/G/GAP/bundled/patches/sysinfo.patch
@@ -1,0 +1,29 @@
+From e17bc994f740af163473049d37cb58df42c45365 Mon Sep 17 00:00:00 2001
+From: Max Horn <max@quendi.de>
+Date: Mon, 31 Oct 2022 16:25:12 +0100
+Subject: [PATCH] Patch linker flags for use with libgap
+
+---
+ Makefile.rules | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.rules b/Makefile.rules
+index c7ecd4cda..1920d8353 100644
+--- a/Makefile.rules
++++ b/Makefile.rules
+@@ -303,10 +303,10 @@ else
+     # HACK: we need to point to the real GAP binary, not a shell script
+     # wrapper. We can remove this hack (and once again use SYSINFO_GAP)
+     # once we get rid of the shell script wrapper
+-    GAC_LDFLAGS = -bundle -bundle_loader $(SYSINFO_GAP2)
++    GAC_LDFLAGS = -bundle -lgap
+   else
+     GAC_CFLAGS = -fPIC
+-    GAC_LDFLAGS = -shared
++    GAC_LDFLAGS = -shared -fPIC -lgap
+   endif
+ endif
+ 
+-- 
+2.38.1
+


### PR DESCRIPTION
... to deal with Julia 1.9-DEV ABI changes.

Also patch sysinfo.gap so we can later simplify GAP_pkg_* recipes
