### PR TITLE
[SCS_MKL] don't build binaries for i686

### DIFF
--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -1,11 +1,11 @@
 using BinaryBuilder
 
 name = "SCS"
-version = v"3.2.0"
+version = v"3.2.1"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "ac6840a3b3264950e6c300264cbf3937e0bcc6c5")
+    GitSource("https://github.com/cvxgrp/scs.git", "f2da64d314d86a97ebb8e957f215f27f9e2a7b79")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -2,11 +2,11 @@ using Pkg
 using BinaryBuilder
 
 name = "SCS_GPU"
-version = v"3.2.0"
+version = v"3.2.1"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "ac6840a3b3264950e6c300264cbf3937e0bcc6c5")
+    GitSource("https://github.com/cvxgrp/scs.git", "f2da64d314d86a97ebb8e957f215f27f9e2a7b79")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "SCS_MKL"
-version = v"3.2.1"
+version = v"3.2.2"
 
 # Collection of sources required to build SCSBuilder
 sources = [

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -5,7 +5,7 @@ version = v"3.2.1"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "c785d2fad46a30f1d43764d682509d0b56e5c64f")
+    GitSource("https://github.com/cvxgrp/scs.git", "f2da64d314d86a97ebb8e957f215f27f9e2a7b79")
 ]
 
 # Bash recipe for building across all platforms
@@ -37,7 +37,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("MKL_jll"; compat="2022.0.0"),
+    Dependency("MKL_jll"; compat="2022.2.0"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -24,7 +24,7 @@ cp out/libscs*.${dlext} ${libdir}
 # platforms are passed in on the command line
 platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
-    Platform("i686", "linux"; libc="glibc"),
+    # Platform("i686", "linux"; libc="glibc"),
     # Platform("x86_64", "macos"),
     # Platform("i686", "windows"),
     # Platform("x86_64", "windows"),


### PR DESCRIPTION
There are some failures/segfaults on i686 which I can't reproduce/track locally
https://github.com/jump-dev/SCS.jl/pull/255#issuecomment-1107815005

So to move this forward it's best to disable the build until somebody asks for it ;)

Questions:
 1. Is it possible to add compat as `=3.2.1+1` (the version of binary built here?)
 2. does this merit/require changing to `3.2.2`? 

the point is that I want just to remove i686 binaries from the registry ;)