### PR TITLE
Add zlib-ng

### DIFF
--- a/Z/ZlibNG/build_tarballs.jl
+++ b/Z/ZlibNG/build_tarballs.jl
@@ -1,0 +1,62 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ZlibNG"
+version = v"1.2.12"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/zlib-ng/zlib-ng.git", "0c118a14dd56d0484a8ca432cf801b9a6e6d024a")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/zlib-ng
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS="-O3" \
+    -WITH_NATIVE_INSTRUCTIONS=true \
+    -DZLIB_COMPAT=true \
+    ..
+make -j${nproc}
+make install
+
+if [[ "${target}" == *-mingw* ]]; then
+    cp "${WORKSPACE}/srcdir/zlib-ng/build/zlib1.dll" "${libdir}/libz.dll"
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("i686", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("powerpc64le", "linux"; libc = "glibc"),
+    Platform("i686", "linux"; libc = "musl"),
+    Platform("x86_64", "linux"; libc = "musl"),
+    Platform("aarch64", "linux"; libc = "musl"),
+    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "musl"),
+    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "musl"),
+    Platform("x86_64", "macos"; ),
+    Platform("aarch64", "macos"; ),
+    Platform("i686", "windows"; ),
+    Platform("x86_64", "windows"; )
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libz", :libz)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/Z/ZlibNG/build_tarballs.jl
+++ b/Z/ZlibNG/build_tarballs.jl
@@ -22,10 +22,6 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     ..
 make -j${nproc}
 make install
-
-if [[ "${target}" == *-mingw* ]]; then
-    cp "${WORKSPACE}/srcdir/zlib-ng/build/libzlib1.dll" "${libdir}/libz.dll"
-fi
 """
 
 # These are the platforms we will build for by default, unless further
@@ -51,7 +47,7 @@ platforms = [
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libz", :libz)
+    LibraryProduct(["libz", "libzlib1"], :libzng)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/Z/ZlibNG/build_tarballs.jl
+++ b/Z/ZlibNG/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "ZlibNG"
-version = v"1.2.12"
+version = v"2.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/zlib-ng/zlib-ng.git", "0c118a14dd56d0484a8ca432cf801b9a6e6d024a")
+    GitSource("https://github.com/zlib-ng/zlib-ng.git", "b3dcf11b4204a16fde71fa8224d7b7054e225b93")
 ]
 
 # Bash recipe for building across all platforms
@@ -18,7 +18,6 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_FLAGS="-O3" \
-    -DZLIB_COMPAT=ON \
     ..
 make -j${nproc}
 make install
@@ -26,28 +25,12 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("i686", "linux"; libc = "glibc"),
-    Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("aarch64", "linux"; libc = "glibc"),
-    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "glibc"),
-    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc"),
-    Platform("powerpc64le", "linux"; libc = "glibc"),
-    Platform("i686", "linux"; libc = "musl"),
-    Platform("x86_64", "linux"; libc = "musl"),
-    Platform("aarch64", "linux"; libc = "musl"),
-    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "musl"),
-    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "musl"),
-    Platform("x86_64", "macos"; ),
-    Platform("aarch64", "macos"; ),
-    Platform("i686", "windows"; ),
-    Platform("x86_64", "windows"; )
-]
+platforms = supported_platforms(exclude=[Platform("x86_64", "freebsd")])
 
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["libz", "libzlib1"], :libzng)
+    LibraryProduct(["libz-ng", "libzlib-ng2"], :libzng)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/Z/ZlibNG/build_tarballs.jl
+++ b/Z/ZlibNG/build_tarballs.jl
@@ -17,6 +17,7 @@ mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DZLIB_ENABLE_TESTS=OFF \
     ..
 make -j${nproc}
 make install
@@ -24,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(exclude=[Platform("x86_64", "freebsd")])
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built

--- a/Z/ZlibNG/build_tarballs.jl
+++ b/Z/ZlibNG/build_tarballs.jl
@@ -18,14 +18,13 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_FLAGS="-O3" \
-    -WITH_NATIVE_INSTRUCTIONS=true \
-    -DZLIB_COMPAT=true \
+    -DZLIB_COMPAT=ON \
     ..
 make -j${nproc}
 make install
 
 if [[ "${target}" == *-mingw* ]]; then
-    cp "${WORKSPACE}/srcdir/zlib-ng/build/zlib1.dll" "${libdir}/libz.dll"
+    cp "${WORKSPACE}/srcdir/zlib-ng/build/libzlib1.dll" "${libdir}/libz.dll"
 fi
 """
 

--- a/Z/ZlibNG/build_tarballs.jl
+++ b/Z/ZlibNG/build_tarballs.jl
@@ -17,6 +17,7 @@ mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
     -DZLIB_ENABLE_TESTS=OFF \
     ..
 make -j${nproc}

--- a/Z/ZlibNG/build_tarballs.jl
+++ b/Z/ZlibNG/build_tarballs.jl
@@ -17,7 +17,6 @@ mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_C_FLAGS="-O3" \
     ..
 make -j${nproc}
 make install


### PR DESCRIPTION
I don't have much experience building C libraries and this is my first direct interaction with BinaryBuilder.jl.
I'm trying to build one of the more performant zlib forks, the `ZLIB_COMPAT` flag builds a version with an API compatible with the original zlib. Since the only purpose of this recipe is to unlock more performance, I tried setting some of the optimizations on but I am not sure if it is safe to do so. Any guidance would be greatly appreciated!

On my two laptops (M1 mac and intel linux), when trying to compress and decompress 1MB of lorem ipsum text, I see ~2x performance increase when I plug the resulting binary into CodecZlib.jl.

cc: @quinnj 

EDIT: No longer using the `ZLIB_COMPAT` due to soname clash with zlib.