### PR TITLE
Use dont_dlopen=true with GR libraries

### DIFF
--- a/G/GR/build_tarballs.jl
+++ b/G/GR/build_tarballs.jl
@@ -73,10 +73,10 @@ platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libGR", :libGR),
-    LibraryProduct("libGR3", :libGR3),
-    LibraryProduct("libGRM", :libGRM),
-    LibraryProduct("libGKS", :libGKS),
+    LibraryProduct("libGR", :libGR, dont_dlopen=true),
+    LibraryProduct("libGR3", :libGR3, dont_dlopen=true),
+    LibraryProduct("libGRM", :libGRM, dont_dlopen=true),
+    LibraryProduct("libGKS", :libGKS, dont_dlopen=true),
     ExecutableProduct("gksqt", :gksqt),
 ]
 


### PR DESCRIPTION
GR uses a Preferences.jl mechanism to `dlopen` the libraries so the GR_jll does not need to dlopen the binaries directly:
https://github.com/jheinen/GR.jl/blob/f224e831abbade86ad1932a8b4b7fa2c85cec86d/src/funcptrs.jl#L33-L35

On Linux in certain configurations, a LD_PRELOAD is needed to get around this since the GR_jll binaries may be loaded before the system binaries. This pull request resolves this, but having GR_jll not load the binaries.

I'm also looking into using Overrides.toml or local preferences for overrides. Even with JLL overrides, this is still needed in case someone wants to use a Plots.jl backend that is not GR. In that case, using dlopen on GR_jll would just add time to loading. Additionally, GR_jll may interfere with other binaries making it difficult to load another backend like PyPlot.jl.

xref: https://github.com/jheinen/GR.jl/pull/483#issuecomment-1299009903
xref: https://github.com/sciapp/gr/issues/141#issuecomment-1298664206

Do we need a version bump for this?