### PR TITLE
[LLVMOpenMP] update to 15.0.4

### DIFF
--- a/L/LLVMOpenMP/build_tarballs.jl
+++ b/L/LLVMOpenMP/build_tarballs.jl
@@ -3,12 +3,18 @@
 using BinaryBuilder, Pkg
 
 name = "LLVMOpenMP"
-version = v"14.0.4"
+version = v"15.0.4"
 
 sources = [
     ArchiveSource(
         "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/openmp-$(version).src.tar.xz",
-        "d4b627e2668c3c1001b6c772297273dc67b42f2deec934a59650a55731f8d411"
+        "1b6f92013e7555759127d84264c3e98eab116a3a5138570058d8507e1513f76e"
+    ),
+    # we need a bunch of additional cmake files to build the subproject separately
+    # see: https://github.com/llvm/llvm-project/issues/53281#issuecomment-1260187944
+    ArchiveSource(
+        "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/cmake-$(version).src.tar.xz",
+        "9df45bf3a0a46264d5007485592381bbaf50f034b4155290cb0d917539d8facf"
     ),
     DirectorySource("./bundled"),
 ]
@@ -16,6 +22,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/openmp-*/
+mv ../cmake-* ../cmake
 # https://github.com/msys2/MINGW-packages/blob/d440dcb738/mingw-w64-clang/0901-cast-to-make-gcc-happy.patch
 atomic_patch -p1 ../patches/0901-cast-to-make-gcc-happy.patch
 


### PR DESCRIPTION
We [were getting crashes](https://github.com/oscar-system/Oscar.jl/issues/1674) from llvm-openmp on aarch64-apple-darwin:
```
OMP: Error #13: Assertion failure at kmp_dispatch.cpp(1298).
OMP: Hint Please submit a bug report with this message, compile and run commands used, and machine configuration info including native compiler and operating system versions. Faster response will be obtained by including all program sources. For information on submitting this issue, please see https://bugs.llvm.org/.

signal (6): Abort trap: 6
in expression starting at /Users/horn/Projekte/OSCAR/Oscar.jl/test/PolyhedralGeometry/timing.jl:1
__pthread_kill at /usr/lib/system/libsystem_kernel.dylib (unknown line)
Allocations: 137297125 (Pool: 137203552; Big: 93573); GC: 50
```

This seems to be a bug in llvm and according to https://github.com/llvm/llvm-project/issues/54422 this could be fixed with LLVM 15. And indeed I haven't seen these errors since updating to my [test-build of v15.0.4](https://github.com/benlorenz/LLVMOpenMP_jll.jl).
