### PR TITLE
[CompilerSupportLibraries] Fix dependency of `libgcc_s.1.dylib`

### DIFF
--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.0/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.0/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"1.0.0"; preferred_gcc_version=v"12", windows_staticlibs=true, julia_compat="1.9")
+build_csl(ARGS, v"1.0.1"; preferred_gcc_version=v"12", windows_staticlibs=true, julia_compat="1.9")
 
 # Build trigger: 1


### PR DESCRIPTION
We have to manually fix a dependency of `libgcc.1.dylib` in order to
make the library properly loadable.