### PR TITLE
Add ducc0 package

### DIFF
--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -11,8 +11,8 @@ version = v"0.27.0"
 # Collection of sources required to complete build
 sources = [
 GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a6d51ab375d3fb9d"),
-#ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
-#                  "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
+ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
+                  "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
 ]
 
 # Bash recipe for building across all platforms
@@ -20,12 +20,12 @@ script = raw"""
 
 #XFLAGS=
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
-#    # Install a newer SDK to work around compilation failures
-#    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
-#    rm -rf /opt/${target}/${target}/sys-root/System
-#    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
-#    cp -ra System "/opt/${target}/${target}/sys-root/."
-#    popd
+    # Install a newer SDK to work around compilation failures
+    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
+    rm -rf /opt/${target}/${target}/sys-root/System
+    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
+    cp -ra System "/opt/${target}/${target}/sys-root/."
+    popd
     MACFLAGS=-mmacosx-version-min=10.14
 fi
 

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -16,8 +16,8 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/ducc-*/julia
-${CXX} ${CFLAGS} -O3 -ffast-math -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -c
-${CXX} ${CFLAGS} -O3 -march=native -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
+${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -c
+${CXX} ${CFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
 install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 """
 

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -10,7 +10,7 @@ version = v"0.27.0"
 
 # Collection of sources required to complete build
 sources = [
-GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "0fde4979684d28966157356211ad278ec3278cf9")
+GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a6d51ab375d3fb9d")
 ]
 
 # Bash recipe for building across all platforms

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -10,7 +10,7 @@ version = v"0.27.0"
 
 # Collection of sources required to complete build
 sources = [
-GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "886556fb9d22c5c70d91e2eccdbbcf1697906e1d")
+GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "0fde4979684d28966157356211ad278ec3278cf9")
 ]
 
 # Bash recipe for building across all platforms

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -15,6 +15,9 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
+echo ${CXX}
+echo ${CFLAGS}
+
 cd $WORKSPACE/srcdir/ducc-*/julia
 ${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -c
 ${CXX} ${CFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -1,0 +1,50 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+using BinaryBuilderBase
+
+include(joinpath(@__DIR__, "..", "..", "platforms", "microarchitectures.jl"))
+
+name = "ducc0"
+version = v"0.27.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://gitlab.mpcdf.mpg.de/mtr/ducc/-/archive/juliatest.tar.gz", "d8e3ce4cbc4212a69cf0ad9ddfbb46f056c5bc7c87d73ceb9c3f15d4a2da426c")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/ducc-*/julia
+${CXX} ${CFLAGS} -O3 -ffast-math -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -c
+${CXX} ${CFLAGS} -O3 -march=native -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
+install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
+"""
+
+# Expand for microarchitectures on x86_64 (library doesn't have CPU dispatching)
+# Tests on Linux/x86_64 yielded a slow binary with avx512 for some reason, so disable that
+platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]); skip=!Sys.iswindows)
+
+augment_platform_block = """
+    $(MicroArchitectures.augment)
+    function augment_platform!(platform::Platform)
+        # We augment only x86_64
+        @static if Sys.ARCH === :x86_64
+            augment_microarchitecture!(platform)
+        else
+            platform
+        end
+    end
+    """
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libducc_julia", :libducc_julia)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = []
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"8", julia_compat="1.6", augment_platform_block)

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -10,17 +10,13 @@ version = v"0.27.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://gitlab.mpcdf.mpg.de/mtr/ducc/-/archive/juliatest.tar.gz", "d8e3ce4cbc4212a69cf0ad9ddfbb46f056c5bc7c87d73ceb9c3f15d4a2da426c")
+GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "886556fb9d22c5c70d91e2eccdbbcf1697906e1d")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-echo ${CXX}
-${CXX} -v
-echo ${CFLAGS}
-echo ${CXXFLAGS}
 
-cd $WORKSPACE/srcdir/ducc-*/julia
+cd $WORKSPACE/srcdir/ducc*/julia
 ${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -c
 ${CXX} ${CFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
 install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -17,7 +17,8 @@ GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a
 script = raw"""
 
 cd $WORKSPACE/srcdir/ducc*/julia
-${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -fcx-limited-range -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
+${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
+# -fcx-limited-range is not supported by clang
 ${CXX} ${CFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
 install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 """

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -11,8 +11,8 @@ version = v"0.27.0"
 # Collection of sources required to complete build
 sources = [
 GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a6d51ab375d3fb9d"),
-ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.14.sdk.tar.xz",
-              "123dcd2e02051bed8e189581f6eea1b04eddd55a80f98960214421404aa64b72"),
+ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
+                  "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
 ]
 
 # Bash recipe for building across all platforms

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -25,6 +25,7 @@ if [[ "${target}" == x86_64-apple-darwin* ]]; then
     cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
     cp -ra System "/opt/${target}/${target}/sys-root/."
     popd
+    CFLAGS=$CFLAGS -mmacosx-version-min=10.14
 fi
 
 cd $WORKSPACE/srcdir/ducc*/julia

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -10,8 +10,8 @@ version = v"0.27.0"
 
 # Collection of sources required to complete build
 sources = [
-GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a6d51ab375d3fb9d"),
-ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
+    GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a6d51ab375d3fb9d"),
+    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
                   "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
 ]
 
@@ -25,20 +25,21 @@ if [[ "${target}" == x86_64-apple-darwin* ]]; then
     cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
     cp -ra System "/opt/${target}/${target}/sys-root/."
     popd
-    MACFLAGS=-mmacosx-version-min=10.14
+    CXXFLAGS="-mmacosx-version-min=10.14"
 fi
 
 cd $WORKSPACE/srcdir/ducc*/julia
 install_license ../LICENSE
-${CXX} ${CFLAGS} ${MACFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
+${CXX} ${CXXFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
 # -fcx-limited-range is not supported by clang
-${CXX} ${CFLAGS} ${MACFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
+${CXX} ${CXXFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
 install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 """
 
 # Expand for microarchitectures on x86_64 (library doesn't have CPU dispatching)
 # Tests on Linux/x86_64 yielded a slow binary with avx512 for some reason, so disable that
 platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]); skip=!Sys.iswindows)
+platforms = expand_cxxstring_abis(platforms)
 
 augment_platform_block = """
     $(MicroArchitectures.augment)
@@ -58,7 +59,9 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = []
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll"; platforms=filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), platforms))
+]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -29,7 +29,7 @@ if [[ "${target}" == x86_64-apple-darwin* ]]; then
 fi
 
 cd $WORKSPACE/srcdir/ducc*/julia
-install_license LICENSE
+install_license ../LICENSE
 ${CXX} ${CFLAGS} ${MACFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
 # -fcx-limited-range is not supported by clang
 ${CXX} ${CFLAGS} ${MACFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -16,7 +16,9 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 echo ${CXX}
+${CXX} -v
 echo ${CFLAGS}
+echo ${CXXFLAGS}
 
 cd $WORKSPACE/srcdir/ducc-*/julia
 ${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -c

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -10,11 +10,22 @@ version = v"0.27.0"
 
 # Collection of sources required to complete build
 sources = [
-GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a6d51ab375d3fb9d")
+GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a6d51ab375d3fb9d"),
+ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.14.sdk.tar.xz",
+              "123dcd2e02051bed8e189581f6eea1b04eddd55a80f98960214421404aa64b72"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
+
+if [[ "${target}" == x86_64-apple-darwin* ]]; then
+    # Install a newer SDK to work around compilation failures
+    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
+    rm -rf /opt/${target}/${target}/sys-root/System
+    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
+    cp -ra System "/opt/${target}/${target}/sys-root/."
+    popd
+fi
 
 cd $WORKSPACE/srcdir/ducc*/julia
 ${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -17,7 +17,7 @@ GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a
 script = raw"""
 
 cd $WORKSPACE/srcdir/ducc*/julia
-${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -c
+${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -fcx-limited-range -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
 ${CXX} ${CFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
 install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 """

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -18,7 +18,6 @@ ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/M
 # Bash recipe for building across all platforms
 script = raw"""
 
-#XFLAGS=
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
     # Install a newer SDK to work around compilation failures
     pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
@@ -30,6 +29,7 @@ if [[ "${target}" == x86_64-apple-darwin* ]]; then
 fi
 
 cd $WORKSPACE/srcdir/ducc*/julia
+install_license LICENSE
 ${CXX} ${CFLAGS} ${MACFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
 # -fcx-limited-range is not supported by clang
 ${CXX} ${CFLAGS} ${MACFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -11,26 +11,28 @@ version = v"0.27.0"
 # Collection of sources required to complete build
 sources = [
 GitSource("https://gitlab.mpcdf.mpg.de/mtr/ducc.git", "84967dd5d3e3062874a03c99a6d51ab375d3fb9d"),
-ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
-                  "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
+#ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
+#                  "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 
+#XFLAGS=
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
-    # Install a newer SDK to work around compilation failures
-    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
-    rm -rf /opt/${target}/${target}/sys-root/System
-    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
-    cp -ra System "/opt/${target}/${target}/sys-root/."
-    popd
+#    # Install a newer SDK to work around compilation failures
+#    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
+#    rm -rf /opt/${target}/${target}/sys-root/System
+#    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
+#    cp -ra System "/opt/${target}/${target}/sys-root/."
+#    popd
+    MACFLAGS=-mmacosx-version-min=10.14
 fi
 
 cd $WORKSPACE/srcdir/ducc*/julia
-${CXX} ${CFLAGS} -mmacosx-version-min=10.14 -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
+${CXX} ${CFLAGS} ${MACFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
 # -fcx-limited-range is not supported by clang
-${CXX} ${CFLAGS} -mmacosx-version-min=10.14 -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
+${CXX} ${CFLAGS} ${MACFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
 install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 """
 

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -25,13 +25,12 @@ if [[ "${target}" == x86_64-apple-darwin* ]]; then
     cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
     cp -ra System "/opt/${target}/${target}/sys-root/."
     popd
-    CFLAGS=$CFLAGS -mmacosx-version-min=10.14
 fi
 
 cd $WORKSPACE/srcdir/ducc*/julia
-${CXX} ${CFLAGS} -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
+${CXX} ${CFLAGS} -mmacosx-version-min=10.14 -O3 -I ../src/ ducc_julia.cc -Wfatal-errors -pthread -std=c++17 -fPIC -fno-math-errno -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math -ffp-contract=fast -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -c
 # -fcx-limited-range is not supported by clang
-${CXX} ${CFLAGS} -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
+${CXX} ${CFLAGS} -mmacosx-version-min=10.14 -O3 -o libducc_julia.${dlext} ducc_julia.o -Wfatal-errors -pthread -std=c++17 -shared -fPIC
 install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 """
 


### PR DESCRIPTION
This adds a rudimentary JLL interface for the ducc0 package (https://gitlab.mpcdf.mpg.de/mtr/ducc). This is most likely not generally useful yet, but I don't know how to test the binary building without opening a PR and letting the CI build and test the package.