### PR TITLE
[ROCmCompilerSupport] Add Julia 1.9 compat for 5.2.3

### DIFF
--- a/R/ROCmCompilerSupport/ROCmCompilerSupport@5.2.3/build_tarballs.jl
+++ b/R/ROCmCompilerSupport/ROCmCompilerSupport@5.2.3/build_tarballs.jl
@@ -4,4 +4,4 @@ using BinaryBuilder
 include("../common.jl")
 build_tarballs(
     ARGS, configure_build(v"5.2.3")...;
-    preferred_gcc_version=v"7", preferred_llvm_version=v"9")
+    preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.9")

--- a/R/ROCmCompilerSupport/common.jl
+++ b/R/ROCmCompilerSupport/common.jl
@@ -43,8 +43,8 @@ function configure_build(version)
     dependencies = [
         BuildDependency(PackageSpec(; name="ROCmLLVM_jll", version)),
         BuildDependency(PackageSpec(; name="rocm_cmake_jll", version)),
-        Dependency("ROCmDeviceLibs_jll", version),
-        Dependency("hsa_rocr_jll", version),
+        Dependency("ROCmDeviceLibs_jll"; compat=string(version)),
+        Dependency("hsa_rocr_jll"; compat=string(version)),
     ]
     NAME, version, sources, BUILDSCRIPT, ROCM_PLATFORMS, PRODUCTS, dependencies
 end


### PR DESCRIPTION
- Add `julia_compat=1.9` to 5.2.3
- Specify `compat` version instead of regular version.

Leaving out `julia_compat=1.9` introduces more problems than it solves:
https://github.com/JuliaGPU/AMDGPU.jl/issues/313#issuecomment-1289107341

If we had `julia_compat=1.9` for all ROCm 5.2.3 packages we could've safely deleted `Manifest.toml` from AMDGPU.jl and let it automatically resolve correct versions of artifacts.

Also I don't think we need to account for the fact that you can rebuild Julia with different LLVM, as LLVM itself [specifies](https://github.com/JuliaPackaging/Yggdrasil/blob/d2cbdb2501f0e25c29e34575b302a8c4b1498737/L/LLVM/LLVM%4014/build_tarballs.jl#L37) `julia_compat` bounds.

And ROCm 5.2.3 requires LLVM 14, which is what Julia 1.9 uses, so it makes sense to have `julia_compat` set.