### PR TITLE
[METIS] Add 64 bit builds

### DIFF
--- a/M/METIS/METIS@5/build_tarballs.jl
+++ b/M/METIS/METIS@5/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "METIS"
-version = v"5.1.1" # <-- This is a lie, we're bumping to 5.1.1 to create a Julia v1.6+ release with experimental platforms
+version = v"5.1.2" # <-- This is a lie, we're bumping to 5.1.1 to create a Julia v1.6+ release with experimental platforms
 
 # Collection of sources required to build METIS
 sources = [

--- a/M/METIS/METIS@5/build_tarballs.jl
+++ b/M/METIS/METIS@5/build_tarballs.jl
@@ -53,7 +53,13 @@ platforms = supported_platforms(;experimental=true)
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libmetis", :libmetis)
+    LibraryProduct("libmetis", :libmetis),
+    LibraryProduct("libmetis_Int32_Real64", :libmetis_Int32_Real64, 
+        ["\$libdir/metis/metis_Int32_Real64/lib", "\$libdir/metis/metis_Int32_Real64/bin"]),
+    LibraryProduct("libmetis_Int64_Real32", :libmetis_Int64_Real32, 
+        ["\$libdir/metis/metis_Int64_Real32/lib", "\$libdir/metis/metis_Int64_Real32/bin"]),
+    LibraryProduct("libmetis_Int64_Real64", :libmetis_Int64_Real64, 
+        ["\$libdir/metis/metis_Int64_Real64/lib", "\$libdir/metis/metis_Int64_Real64/bin"])
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/M/METIS/METIS@5/bundled/patches/005-add-ifndefs.patch
+++ b/M/METIS/METIS@5/bundled/patches/005-add-ifndefs.patch
@@ -1,0 +1,32 @@
+diff --git a/include/metis.h b/include/metis.h
+index e951270..f92026d 100644
+--- a/include/metis.h
++++ b/include/metis.h
+@@ -30,8 +30,9 @@
+  GCC does provides these definitions in stdint.h, but it may require some
+  modifications on other architectures.
+ --------------------------------------------------------------------------*/
+-#define IDXTYPEWIDTH 32
+-
++#ifndef IDXTYPEWIDTH
++  #define IDXTYPEWIDTH 32
++#endif
+ 
+ /*--------------------------------------------------------------------------
+  Specifies the data type that will hold floating-point style information.
+@@ -40,9 +41,9 @@
+    32 : single precission floating point (float)
+    64 : double precission floating point (double)
+ --------------------------------------------------------------------------*/
+-#define REALTYPEWIDTH 32
+-
+-
++#ifndef REALTYPEWIDTH
++  #define REALTYPEWIDTH 32
++#endif
+ 
+ /****************************************************************************
+ * In principle, nothing needs to be changed beyond this point, unless the
+-- 
+2.37.2
+


### PR DESCRIPTION
SuperLU_DIST is currently built incorrectly, we need 64 bit versions of METIS where required.

I left `libmetis` as is, I didn't want to mess with it and break anyone else. Rebuilding the 64 bit versions of PARMETIS and SuperLU is going to be a pain...