### PR TITLE
Wizard recipe: BladeRFHardwareDriver-v2.4.1

### DIFF
--- a/B/BladeRFHardwareDriver/build_tarballs.jl
+++ b/B/BladeRFHardwareDriver/build_tarballs.jl
@@ -1,0 +1,62 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "BladeRFHardwareDriver"
+version = v"2.4.1"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/Nuand/bladeRF.git", "0ffb795c450fe814060f95cd37455847c9c536d2")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd bladeRF/host/
+mkdir build
+cd build
+if [[ "${target}" == *86*-linux-gnu ]]; then
+    export LDFLAGS="-lrt";
+fi
+cmake -DCMAKE_INSTALL_PREFIX=$prefix\
+  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}\
+  -DCMAKE_BUILD_TYPE=Release\
+  -DENABLE_BACKEND_LIBUSB=TRUE ..
+make
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("i686", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("powerpc64le", "linux"; libc = "glibc"),
+    Platform("i686", "linux"; libc = "musl"),
+    Platform("x86_64", "linux"; libc = "musl"),
+    Platform("aarch64", "linux"; libc = "musl"),
+    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "musl"),
+    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "musl"),
+    Platform("x86_64", "macos"; ),
+    Platform("aarch64", "macos"; )
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libbladeRF", :libbladerf),
+    ExecutableProduct("bladeRF-fsk", :bladerf_fsk),
+    ExecutableProduct("bladeRF-cli", :bladerf_cli)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="libusb_jll", uuid="a877fdc9-fe69-5ed6-b93d-11ecd0dc2d49"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/B/BladeRFHardwareDriver/build_tarballs.jl
+++ b/B/BladeRFHardwareDriver/build_tarballs.jl
@@ -7,15 +7,17 @@ version = v"2.4.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/Nuand/bladeRF.git", "0ffb795c450fe814060f95cd37455847c9c536d2")
+    GitSource("https://github.com/Nuand/bladeRF.git",
+              "0ffb795c450fe814060f95cd37455847c9c536d2"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd bladeRF/host/
-mkdir build
-cd build
+cd $WORKSPACE/srcdir/bladeRF/host/
+# Hotfix for FreeBSD: https://github.com/Nuand/bladeRF/issues/891
+atomic_patch -p2 ../../patches/readline-freebsd.patch
+mkdir build && cd build
 if [[ "${target}" == *86*-linux-gnu ]]; then
     export LDFLAGS="-lrt";
 fi
@@ -29,7 +31,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude=p -> Sys.isfreebsd(p) || Sys.iswindows(p))
+platforms = supported_platforms(; exclude=Sys.iswindows)
 
 # The products that we will ensure are always built
 products = [

--- a/B/BladeRFHardwareDriver/build_tarballs.jl
+++ b/B/BladeRFHardwareDriver/build_tarballs.jl
@@ -23,7 +23,7 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix\
   -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}\
   -DCMAKE_BUILD_TYPE=Release\
   -DENABLE_BACKEND_LIBUSB=TRUE ..
-make
+make -j${nproc}
 make install
 """
 

--- a/B/BladeRFHardwareDriver/build_tarballs.jl
+++ b/B/BladeRFHardwareDriver/build_tarballs.jl
@@ -29,22 +29,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("i686", "linux"; libc = "glibc"),
-    Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("aarch64", "linux"; libc = "glibc"),
-    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "glibc"),
-    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc"),
-    Platform("powerpc64le", "linux"; libc = "glibc"),
-    Platform("i686", "linux"; libc = "musl"),
-    Platform("x86_64", "linux"; libc = "musl"),
-    Platform("aarch64", "linux"; libc = "musl"),
-    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "musl"),
-    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "musl"),
-    Platform("x86_64", "macos"; ),
-    Platform("aarch64", "macos"; )
-]
-
+platforms = supported_platforms(; exclude=p -> Sys.isfreebsd(p) || Sys.iswindows(p))
 
 # The products that we will ensure are always built
 products = [

--- a/B/BladeRFHardwareDriver/bundled/patches/readline-freebsd.patch
+++ b/B/BladeRFHardwareDriver/bundled/patches/readline-freebsd.patch
@@ -1,0 +1,16 @@
+diff --git a/host/utilities/bladeRF-cli/src/input/editline.c b/host/utilities/bladeRF-cli/src/input/editline.c
+index a832c45b..893bd83d 100644
+--- a/host/utilities/bladeRF-cli/src/input/editline.c
++++ b/host/utilities/bladeRF-cli/src/input/editline.c
+@@ -20,7 +20,11 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <histedit.h>
++#ifdef __FreeBSD__
++#include <edit/readline/readline.h>
++#else
+ #include <editline/readline.h>
++#endif
+ #include <string.h>
+ #include <errno.h>
+ #include "input_impl.h"


### PR DESCRIPTION
This pull request contains a new build recipe I built using the BinaryBuilder.jl wizard:

* Package name: BladeRFHardwareDriver
* Version: v2.4.1

@staticfloat please review and merge.

It does not cross compile for freebsd and windows:
https://github.com/Nuand/bladeRF/issues/890
https://github.com/Nuand/bladeRF/issues/891
https://github.com/Nuand/bladeRF/issues/892
