### PR TITLE
[SDL2] Go back to autoconf

### DIFF
--- a/S/SDL2/build_tarballs.jl
+++ b/S/SDL2/build_tarballs.jl
@@ -21,13 +21,17 @@ mkdir build && cd build
 FLAGS=()
 if [[ "${target}" == *-linux-* ]] || [[ "${target}" == *-freebsd* ]]; then
     FLAGS+=(--with-x)
+    if [[ "${target}" == *-freebsd* ]]; then
+        # Needed for libusb_* symbols
+        export LIBUSB_LIBS="-lusb"
+    fi
 fi
 ../configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --enable-shared \
     --disable-static \
     "${FLAGS[@]}"
-make -j${nproc}
-make install
+make -j${nproc} V=1
+make install V=1
 install_license ../LICENSE.txt
 """
 

--- a/S/SDL2/build_tarballs.jl
+++ b/S/SDL2/build_tarballs.jl
@@ -18,10 +18,14 @@ cd $WORKSPACE/srcdir/SDL*/
 # https://github.com/libsdl-org/SDL/issues/6491
 atomic_patch -p1 ../patches/aarch64-darwin-remove-version-check.patch
 mkdir build && cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=$prefix \
-    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DSDL_STATIC=OFF
+FLAGS=()
+if [[ "${target}" == *-linux-* ]] || [[ "${target}" == *-freebsd* ]]; then
+    FLAGS+=(--with-x)
+fi
+../configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
+    --enable-shared \
+    --disable-static \
+    "${FLAGS[@]}"
 make -j${nproc}
 make install
 install_license ../LICENSE.txt


### PR DESCRIPTION
When switching to CMake the soname of macOS binaries went from `@rpath/libSDL2-2.0.0.dylib` to `@rpath/libSDL2-2.0.dylib`, breaking the ABI.

CC: @Gnimuc
