### PR TITLE
Add a shared library for METIS4

### DIFF
--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -15,7 +15,7 @@ using BinaryBuilder, Pkg
 
 name = "METIS4"
 upstream_version = v"4.0.3"
-version_offset = v"0.0.0" # reset to 0.0.0 once the upstream version changes
+version_offset = v"0.0.1" # reset to 0.0.0 once the upstream version changes
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
                         upstream_version.patch * 100 + version_offset.patch)
@@ -48,6 +48,8 @@ mkdir -p ${prefix}/lib
 mv libmetis.a ${prefix}/lib
 mkdir -p ${prefix}/include
 cp Lib/metis.h ${prefix}/include
+cd ${prefix}/lib
+$CC -shared $(flagon -Wl,--whole-archive) libmetis.a $(flagon -Wl,--no-whole-archive) -o libmetis4.${dlext}
 """
 
 # These are the platforms we will build for by default, unless further
@@ -56,6 +58,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
+    LibraryProduct("libmetis4", :libmetis4),
     FileProduct("lib/libmetis.a", :libmetis_a)
 ]
 

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -48,7 +48,7 @@ mkdir -p ${prefix}/lib
 mkdir -p ${prefix}/include
 cp Lib/metis.h ${prefix}/include
 cd ${prefix}/lib
-$CC -shared $(flagon -Wl,--whole-archive) libmetis.a $(flagon -Wl,--no-whole-archive) $(flagon -Wl,-soname,libmetis4.${dlext}) -o libmetis4.${dlext}
+$CC -shared $(flagon -Wl,--whole-archive) Lib/libmetis.a $(flagon -Wl,--no-whole-archive) $(flagon -Wl,-soname,libmetis4.${dlext}) -o libmetis4.${dlext}
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -42,12 +42,16 @@ cd Lib
 make -j${nproc} COPTIONS="${COPTIONS} -fPIC"
 cd ..
 
-# We copy the .a files into ${prefix}/lib since the main purpose is to link them in other builds.
-# Specifically this is in a separate location than the typical location for libraries on Windows.
-mkdir -p ${prefix}/lib
-mkdir -p ${prefix}/include
-cp Lib/metis.h ${prefix}/include
-$CC -shared $(flagon -Wl,--whole-archive) libmetis.a $(flagon -Wl,--no-whole-archive) $(flagon -Wl,-soname,libmetis4.${dlext}) -o ${prefix}/lib/libmetis4.${dlext}
+if [[ "${target}" == *apple* ]]; then
+    SONAME="-install_name"
+else
+    SONAME="-soname"
+fi
+
+mkdir -p $libdir
+mkdir -p $includedir
+cp Lib/metis.h $includedir
+$CC -shared -Wl,$SONAME,libmetis4.${dlext} $(flagon -Wl,--whole-archive) libmetis.a $(flagon -Wl,--no-whole-archive) -o ${libdir}/libmetis4.${dlext}
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -45,11 +45,10 @@ cd ..
 # We copy the .a files into ${prefix}/lib since the main purpose is to link them in other builds.
 # Specifically this is in a separate location than the typical location for libraries on Windows.
 mkdir -p ${prefix}/lib
-mv libmetis.a ${prefix}/lib
 mkdir -p ${prefix}/include
 cp Lib/metis.h ${prefix}/include
 cd ${prefix}/lib
-$CC -shared $(flagon -Wl,--whole-archive) libmetis.a $(flagon -Wl,--no-whole-archive) -o libmetis4.${dlext}
+$CC -shared $(flagon -Wl,--whole-archive) libmetis.a $(flagon -Wl,--no-whole-archive) $(flagon -Wl,-soname,libmetis4.${dlext}) -o libmetis4.${dlext}
 """
 
 # These are the platforms we will build for by default, unless further
@@ -59,7 +58,6 @@ platforms = supported_platforms()
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libmetis4", :libmetis4),
-    FileProduct("lib/libmetis.a", :libmetis_a)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/M/METIS/METIS@4/build_tarballs.jl
+++ b/M/METIS/METIS@4/build_tarballs.jl
@@ -47,8 +47,7 @@ cd ..
 mkdir -p ${prefix}/lib
 mkdir -p ${prefix}/include
 cp Lib/metis.h ${prefix}/include
-cd ${prefix}/lib
-$CC -shared $(flagon -Wl,--whole-archive) Lib/libmetis.a $(flagon -Wl,--no-whole-archive) $(flagon -Wl,-soname,libmetis4.${dlext}) -o libmetis4.${dlext}
+$CC -shared $(flagon -Wl,--whole-archive) libmetis.a $(flagon -Wl,--no-whole-archive) $(flagon -Wl,-soname,libmetis4.${dlext}) -o ${prefix}/lib/libmetis4.${dlext}
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Mosè, do we need to modify the soname with `patchelf` when we generate a shared library from a static library with a different name?
I don't want to create conflicts with `metis.$dlext` from METIS_jll.
I'm also not sure that we can have two shared libraries that coexist with the same symbols even if they have different name and soname.