### PR TITLE
libjulia: add 1.10, update 1.9, add debug shared libs

### DIFF
--- a/L/libjulia/build_tarballs.jl
+++ b/L/libjulia/build_tarballs.jl
@@ -1,7 +1,7 @@
 include("common.jl")
-jllversion=v"1.8.0"
+jllversion=v"1.10.0"
 build_julia(ARGS, v"1.6.3"; jllversion)
 build_julia(ARGS, v"1.7.0"; jllversion)
 build_julia(ARGS, v"1.8.2"; jllversion)
 build_julia(ARGS, v"1.9.0-DEV"; jllversion)
-
+build_julia(ARGS, v"1.10.0-DEV"; jllversion)

--- a/L/libjulia/bundled/patches/1.10.0-DEV/cycleclock.patch
+++ b/L/libjulia/bundled/patches/1.10.0-DEV/cycleclock.patch
@@ -1,0 +1,54 @@
+From cc7f4029d82343f1c109d925fa4beb1c87a62387 Mon Sep 17 00:00:00 2001
+From: Max Horn <max@quendi.de>
+Date: Thu, 27 Oct 2022 17:06:17 +0200
+Subject: [PATCH] Provider cycleclock() for 32bit ARM targets
+
+Taken from https://github.com/google/benchmark/blob/main/src/cycleclock.h
+---
+ src/julia_internal.h | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/src/julia_internal.h b/src/julia_internal.h
+index 7eb34239e7..9eec7f5b69 100644
+--- a/src/julia_internal.h
++++ b/src/julia_internal.h
+@@ -20,6 +20,9 @@
+ #else
+ #define sleep(x) Sleep(1000*x)
+ #endif
++#if defined(_CPU_ARM_)
++#include <sys/time.h>
++#endif
+ 
+ #ifdef __cplusplus
+ extern "C" {
+@@ -216,6 +219,26 @@ static inline uint64_t cycleclock(void) JL_NOTSAFEPOINT
+     int64_t virtual_timer_value;
+     __asm__ volatile("mrs %0, cntvct_el0" : "=r"(virtual_timer_value));
+     return virtual_timer_value;
++#elif defined(_CPU_ARM_)
++  // V6 is the earliest arch that has a standard cyclecount
++#if (__ARM_ARCH >= 6)
++  uint32_t pmccntr;
++  uint32_t pmuseren;
++  uint32_t pmcntenset;
++  // Read the user mode perf monitor counter access permissions.
++  asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
++  if (pmuseren & 1) {  // Allows reading perfmon counters for user mode code.
++    asm volatile("mrc p15, 0, %0, c9, c12, 1" : "=r"(pmcntenset));
++    if (pmcntenset & 0x80000000ul) {  // Is it counting?
++      asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(pmccntr));
++      // The counter is set up to count every 64th cycle
++      return (int64_t)(pmccntr) * 64;  // Should optimize to << 6
++    }
++  }
++#endif
++  struct timeval tv;
++  gettimeofday(&tv, NULL);
++  return (int64_t)(tv.tv_sec) * 1000000 + tv.tv_usec;
+ #elif defined(_CPU_PPC64_)
+     // This returns a time-base, which is not always precisely a cycle-count.
+     // https://reviews.llvm.org/D78084
+-- 
+2.38.1
+

--- a/L/libjulia/bundled/patches/1.10.0-DEV/msys_build.patch
+++ b/L/libjulia/bundled/patches/1.10.0-DEV/msys_build.patch
@@ -1,0 +1,13 @@
+diff --git a/Make.inc b/Make.inc
+index dfc2594c40..72fb4b4b01 100644
+--- a/Make.inc
++++ b/Make.inc
+@@ -774,7 +774,7 @@ else ifeq (cygwin, $(shell $(CC) -dumpmachine | cut -d\- -f3))
+ $(error "cannot build julia with cygwin-target compilers. set XC_HOST to i686-w64-mingw32 or x86_64-w64-mingw32 for mingw cross-compile")
+ else ifeq (msys, $(shell $(CC) -dumpmachine | cut -d\- -f3))
+ $(error "cannot build julia with msys-target compilers. please see the README.windows document for instructions on setting up mingw-w64 compilers")
+-else ifneq (,$(findstring MSYS,$(shell uname)))
++else ifneq (,$(findstring MSYS,$(BUILD_OS)))
+ $(error "cannot build julia from a msys shell. please launch a mingw shell instead by setting MSYSTEM=MINGW64")
+ endif
+ 

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -28,13 +28,17 @@ function libjulia_platforms(julia_version)
         p["julia_version"] = string(julia_version)
     end
 
-    # While the "official" Julia kernel ABI itself does not involve any C++
-    # symbols on the linker level, `libjulia` still exports "unofficial" symbols
+    # While the "official" Julia kernel ABI does not involve any C++ linker
+    # symbols before Julia 1.6, `libjulia` exported "unofficial" symbols
     # dependent on the C++ strings ABI (coming from LLVM related code). This
     # doesn't matter if the client code is pure C, but as soon as there are
     # other (actual) C++ dependencies, we must make sure to use the matching C++
     # strings ABI. Hence we must use `expand_cxxstring_abis` below.
-    platforms = expand_cxxstring_abis(platforms)
+    #
+    # In Julia >= 1.6, these C++ symbols all moved into `libjulia-internal`.
+    if julia_version < v"1.6"
+        platforms = expand_cxxstring_abis(platforms)
+    end
 
     return platforms
 end

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -18,7 +18,7 @@ function libjulia_platforms(julia_version)
         filter!(p -> arch(p) != "armv6l", platforms)
     end
 
-    if julia_version == v"1.9.0"
+    if julia_version == v"1.9.0" || julia_version == v"1.10.0"
         # 32bit ARM seems broken, see https://github.com/JuliaLang/julia/issues/47345
         filter!(p -> arch(p) != "armv6l", platforms)
         filter!(p -> arch(p) != "armv7l", platforms)
@@ -51,7 +51,12 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
 
     if version == v"1.9.0-DEV"
         sources = [
-            GitSource("https://github.com/JuliaLang/julia.git", "37e0579af04919e1e6264bbfc33ed8f4c537005a"),
+            GitSource("https://github.com/JuliaLang/julia.git", "9b20acac2069c8a374c89c89acd15f20d0f2a7ae"),
+            DirectorySource("./bundled"),
+        ]
+    elseif version == v"1.10.0-DEV"
+        sources = [
+            GitSource("https://github.com/JuliaLang/julia.git", "7fe6b16f4056906c99cee1ca8bbed08e2c154c1a"),
             DirectorySource("./bundled"),
         ]
     else
@@ -141,6 +146,8 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
             LLVMLINK="-L${prefix}/bin -lLLVM-13jl"
         elif [[ "${version}" == 1.9.* ]]; then
             LLVMLINK="-L${prefix}/bin -lLLVM-14jl"
+        elif [[ "${version}" == 1.10.* ]]; then
+            LLVMLINK="-L${prefix}/bin -lLLVM-14jl"
         else
             LLVMLINK="-L${prefix}/bin -lLLVM"
         fi
@@ -156,6 +163,8 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         elif [[ "${version}" == 1.8.* ]]; then
             LLVMLINK="-L${prefix}/lib -lLLVM-13jl"
         elif [[ "${version}" == 1.9.* ]]; then
+            LLVMLINK="-L${prefix}/lib -lLLVM-14jl"
+        elif [[ "${version}" == 1.10.* ]]; then
             LLVMLINK="-L${prefix}/lib -lLLVM-14jl"
         else
             echo "Error, LLVM version not specified"
@@ -263,9 +272,9 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
 
     # choose make targets which compile libjulia but don't try to build a sysimage
     if [[ "${version}" == 1.[0-5].* ]]; then
-        MAKE_TARGET=julia-ui-release
+        MAKE_TARGET="julia-ui-release julia-ui-debug"
     else
-        MAKE_TARGET="julia-src-release julia-cli-release"
+        MAKE_TARGET="julia-src-release julia-cli-release julia-src-debug julia-cli-debug"
     fi
 
     # Start the actual build. We pass DSYMUTIL='true -ignore' to skip the
@@ -305,6 +314,7 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
     # The products that we will ensure are always built
     products = [
         LibraryProduct("libjulia", :libjulia; dont_dlopen=true),
+        LibraryProduct("libjulia-debug", :libjulia_debug; dont_dlopen=true),
     ]
 
     # Dependencies that must be installed before this package can be built/used
@@ -346,6 +356,11 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         push!(dependencies, Dependency(get_addable_spec("LLVMLibUnwind_jll", v"12.0.1+0"); platforms=filter(Sys.isapple, platforms)))
         push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"13.0.1+3")))
     elseif version.major == 1 && version.minor == 9
+        push!(dependencies, Dependency(get_addable_spec("LibUV_jll", v"2.0.1+11")))
+        push!(dependencies, Dependency(get_addable_spec("LibUnwind_jll", v"1.5.0+4"); platforms=filter(!Sys.isapple, platforms)))
+        push!(dependencies, Dependency(get_addable_spec("LLVMLibUnwind_jll", v"12.0.1+0"); platforms=filter(Sys.isapple, platforms)))
+        push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"14.0.6+0")))
+    elseif version.major == 1 && version.minor == 10
         push!(dependencies, Dependency(get_addable_spec("LibUV_jll", v"2.0.1+11")))
         push!(dependencies, Dependency(get_addable_spec("LibUnwind_jll", v"1.5.0+4"); platforms=filter(!Sys.isapple, platforms)))
         push!(dependencies, Dependency(get_addable_spec("LLVMLibUnwind_jll", v"12.0.1+0"); platforms=filter(Sys.isapple, platforms)))


### PR DESCRIPTION
Also update Julia 1.9-DEV to latest git version, just in case.

First step towards #5787. It does *not* add `debug` to the platform as Julia happily allows `libjulia` and `libjulia-debug` to co-exist...

... though perhaps we *should* augment the platform like that, and only build either `libjulia` or `libjulia-debug`? One argument for doing that is that it should make it impossible to accidentally link against `libjulia` when one should be linking against `libjulia-debug`, and vice-versa.

As an additional data point, I looked into adding a `platforms/julia-debug.jl`, and realized that all packages that would include it already including `L/libjulia/common.jl`. So now I am wondering if either the `augment_platform` helpers should just go in there -- or dually, that it should all go into a `platforms/julia.jl` file (which then would also be included by `L/libjulia/common.jl`).

Thoughts, opinions, preferences?