### PR TITLE
[Coin-OR] OpenBLAS version bump

### DIFF
--- a/C/Coin-OR/Clp/build_tarballs.jl
+++ b/C/Coin-OR/Clp/build_tarballs.jl
@@ -87,5 +87,5 @@ build_tarballs(
     products,
     dependencies;
     preferred_gcc_version = gcc_version,
-    julia_compat = "1.6",
+    julia_compat = Julia_compat_version,
 )

--- a/C/Coin-OR/Ipopt/build_tarballs.jl
+++ b/C/Coin-OR/Ipopt/build_tarballs.jl
@@ -63,7 +63,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), ASL_version),
-    Dependency(PackageSpec(name="MUMPS_seq_jll", uuid="d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"), compat="=$(MUMPS_seq_version)"),
+    Dependency(PackageSpec(name="MUMPS_seq_jll", uuid="d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"), compat="=$(MUMPS_seq_version_LBT)"),
     Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2"), platforms=filter(Sys.iswindows, platforms)),
     Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), platforms=filter(!Sys.iswindows, platforms)),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -76,7 +76,7 @@ SHOT_version = offset_version(v"1.1.0", v"0.0.0")
 Julia_compat_version = "1.6"
 ASL_version = v"0.1.3"
 METIS_version = v"5.1.2"
-MUMPS_seq_version = v"500.500.101"
+MUMPS_seq_version = v"5.4.1"
 OpenBLAS32_version = v"0.3.21"
 
 # These are the platforms we will build for by default, unless further

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -18,7 +18,7 @@ function offset_version(upstream, offset)
 end
 
 # GCC version for building the whole system
-gcc_version = v"12"
+gcc_version = v"8"
 
 # Versions of various COIN-OR libraries
 
@@ -77,6 +77,7 @@ Julia_compat_version = "1.6"
 ASL_version = v"0.1.3"
 METIS_version = v"5.1.2"
 MUMPS_seq_version = v"5.4.1"
+MUMPS_seq_version_LBT = v"500.500.101"
 OpenBLAS32_version = v"0.3.21"
 
 # These are the platforms we will build for by default, unless further

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -74,9 +74,9 @@ SHOT_version = offset_version(v"1.1.0", v"0.0.0")
 
 # Third-party packages needed by COIN-OR libraries.
 ASL_version = v"0.1.3"
-METIS_version = v"5.1.1"
+METIS_version = v"5.1.2"
 MUMPS_seq_version = v"500.500.101"
-OpenBLAS32_version = v"0.3.10"
+OpenBLAS32_version = v"0.3.21"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -73,6 +73,7 @@ SHOT_gitsha = "11fda1ecb84af9718f1e0c0ebf7ae5ae8c45041a"
 SHOT_version = offset_version(v"1.1.0", v"0.0.0")
 
 # Third-party packages needed by COIN-OR libraries.
+Julia_compat_version = "1.6"
 ASL_version = v"0.1.3"
 METIS_version = v"5.1.2"
 MUMPS_seq_version = v"500.500.101"

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -18,7 +18,7 @@ function offset_version(upstream, offset)
 end
 
 # GCC version for building the whole system
-gcc_version = v"6"
+gcc_version = v"12"
 
 # Versions of various COIN-OR libraries
 


### PR DESCRIPTION
@giordano We use gcc v6. Is that good for M1? Or should we be on something newer?

`MUMPS_seq` has a `julia_compat` of 1.8. I wonder if that will create a problem.