### PR TITLE
[GDAL] build 3.6.0 and add Arrow & Parquet

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -3,8 +3,8 @@
 using BinaryBuilder, Pkg
 
 name = "GDAL"
-upstream_version = v"3.5.2"
-version_offset = v"0.0.0"
+upstream_version = v"3.6.0"
+version_offset = v"1.0.0"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
                         upstream_version.patch * 100 + version_offset.patch)
@@ -12,7 +12,7 @@ version = VersionNumber(upstream_version.major * 100 + version_offset.major,
 # Collection of sources required to build GDAL
 sources = [
     ArchiveSource("https://github.com/OSGeo/gdal/releases/download/v$upstream_version/gdal-$upstream_version.tar.gz",
-        "fbd696e1b2a858fbd2eb3718db16b14ed9ba82521d3578770d480c74fe1146d2"),
+        "0d6a79eec0c6afb97c7172e429ec05c9d15d3917987ad686a914b292c83531db"),
 ]
 
 # Bash recipe for building across all platforms
@@ -47,7 +47,9 @@ CMAKE_FLAGS=(-DCMAKE_INSTALL_PREFIX=${prefix}
 -DGDAL_USE_ZSTD=ON
 -DGDAL_USE_POSTGRESQL=ON
 -DPostgreSQL_INCLUDE_DIR=${includedir}
--DPostgreSQL_LIBRARY=${libdir}/libpq.${dlext})
+-DPostgreSQL_LIBRARY=${libdir}/libpq.${dlext}
+-DGDAL_USE_ARROW=ON
+-DGDAL_USE_PARQUET=ON)
 
 # NetCDF is the most restrictive dependency as far as platform availability, so we'll use it where applicable but disable it otherwise
 if ! find ${libdir} -name "libnetcdf*.${dlext}" -exec false '{}' +; then
@@ -123,6 +125,7 @@ dependencies = [
     Dependency("LibCURL_jll"; compat="7.73"),
     Dependency("NetCDF_jll"; compat="400.902.5", platforms=hdf5_platforms),
     Dependency("HDF5_jll"; platforms=hdf5_platforms),
+    Dependency("Arrow_jll"; compat="10"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -13,6 +13,8 @@ version = VersionNumber(upstream_version.major * 100 + version_offset.major,
 sources = [
     ArchiveSource("https://github.com/OSGeo/gdal/releases/download/v$upstream_version/gdal-$upstream_version.tar.gz",
         "0d6a79eec0c6afb97c7172e429ec05c9d15d3917987ad686a914b292c83531db"),
+    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
+        "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
 ]
 
 # Bash recipe for building across all platforms
@@ -26,7 +28,7 @@ if [[ "${target}" == *-freebsd* ]]; then
     # complain if this symbol is used in the built library, even if this won't
     # be a problem at runtime. The flag `-undefined` allows having undefined symbols.
     # The flag `-lexecinfo` fixes "undefined reference to `backtrace'".
-    export LDFLAGS="-undefined -lexecinfo"
+    export LDFLAGS="-lexecinfo -undefined"
 fi
 
 if [[ "${target}" == x86_64-apple-darwin* ]]; then


### PR DESCRIPTION
The [release notes](https://github.com/OSGeo/gdal/releases/tag/v3.6.0) mention a bump of the shared lib major version, so I'm bumping the major version here as well.

Adding these deps was discussed before at https://github.com/JuliaGeo/GDAL.jl/issues/65#issuecomment-1220678410 and was the main motivation to finish the Arrow_jll build in #5425 by @evetion. This PR should enable us to make use of GDAL's [RFC 86: Column-oriented read API for vector layers](https://gdal.org/development/rfc/rfc86_column_oriented_api.html).