### PR TITLE
[Arrow] add libarrow_dataset LibraryProduct

### DIFF
--- a/A/Arrow/build_tarballs.jl
+++ b/A/Arrow/build_tarballs.jl
@@ -69,7 +69,8 @@ platforms = expand_cxxstring_abis(supported_platforms())
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libparquet", :libparquet),
-    LibraryProduct("libarrow", :libarrow)
+    LibraryProduct("libarrow", :libarrow),
+    LibraryProduct("libarrow_dataset", :libarrow_dataset),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
I'm not sure if this makes sense, but I noticed #5848 got [tagged](https://github.com/JuliaBinaryWrappers/GDAL_jll.jl/releases/tag/GDAL-v301.600.0%2B0) but not [registered](https://github.com/JuliaRegistries/General/pull/72100) since `import GDAL_jll` failed.

Trying to dev GDAL_jll locally I get this on `import GDAL_jll`:

```
ERROR: InitError: could not load library "d:\visser_mn\.julia\artifacts\a2b72ddc9b6d6e60c1f41aa1351392f97af055d1\bin\libgdal-32.dll"
The specified module could not be found.
```

Loading it with DependencyWalker I see 3 libraries are not found:

```
  ✗ libarrow_dataset.dll (NOT FOUND)
  ✗ ODBCCP32.dll (NOT FOUND)
  ✗ ODBC32.dll (NOT FOUND)
```

The last two have been like that for a while and don't really cause issues, but since Arrow is a new dependency I suspect the problem may be there. I don't understand why it would though, since the Arrow_jll artifact bin contains:

- libarrow.dll
- libarrow_dataset.dll
- libparquet.dll

And the other two are fine, and all can be dlopened directly. Can it help to add this LibraryProduct? Or at least trigger extra audits.