### PR TITLE
Update protoc library products to include `libprotobuf`

### DIFF
--- a/P/protoc/build_tarballs.jl
+++ b/P/protoc/build_tarballs.jl
@@ -26,6 +26,7 @@ platforms = expand_cxxstring_abis(supported_platforms())
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libprotoc", :libprotoc),
+    LibraryProduct("libprotobuf", :libprotobuf),
     ExecutableProduct("protoc", :protoc)
 ]
 


### PR DESCRIPTION
Added another Library product in `protoc/build_tarballs.jl` for `libprotobuf`
Currently, the only product is `libprotoc` but I need a safe way to get the path for the `libprotobuf` library file generated as well. I need this to be able to compile and link my C++ files against the protobuf library.

The hack I currently have and this PR fixes is the following
```
using protoc_jll
protobuf_lib = replace(protoc_jll.get_libprotoc_path(), "libprotoc." => "libprotobuf.")
```