### PR TITLE
Bump OpenEXR from 3.1.1 to 3.1.5

### DIFF
--- a/O/OpenEXR/build_tarballs.jl
+++ b/O/OpenEXR/build_tarballs.jl
@@ -50,4 +50,15 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5.2.0")
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    preferred_gcc_version = v"5.2.0",
+    julia_compat = "1.6"
+)

--- a/O/OpenEXR/build_tarballs.jl
+++ b/O/OpenEXR/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "OpenEXR"
-version = v"3.1.1"
+version = v"3.1.5"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.1.tar.gz", "045254e201c0f87d1d1a4b2b5815c4ae54845af2e6ec0ab88e979b5fdb30a86e")
+    ArchiveSource("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.5.tar.gz", "93925805c1fc4f8162b35f0ae109c4a75344e6decae5a240afdfce25f8a433ec")
 ]
 
 

--- a/O/OpenEXR/build_tarballs.jl
+++ b/O/OpenEXR/build_tarballs.jl
@@ -7,7 +7,8 @@ version = v"3.1.5"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.5.tar.gz", "93925805c1fc4f8162b35f0ae109c4a75344e6decae5a240afdfce25f8a433ec")
+    ArchiveSource("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v$(version).tar.gz",
+                  "93925805c1fc4f8162b35f0ae109c4a75344e6decae5a240afdfce25f8a433ec")
 ]
 
 


### PR DESCRIPTION
Upstream release notes: https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.1.5. Not tested locally.