### PR TITLE
Add patch to SymEngine so that it frees GMP strings correctly

### DIFF
--- a/S/SymEngine/build_tarballs.jl
+++ b/S/SymEngine/build_tarballs.jl
@@ -16,10 +16,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/symengine-*
 
-for f in $WORKSPACE/srcdir/patches/*.patch; do
-    echo "Applying patch ${f}"
-    atomic_patch -p1 ${f}
-done
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/gmp-fix.patch
 
 mkdir build
 cd build

--- a/S/SymEngine/build_tarballs.jl
+++ b/S/SymEngine/build_tarballs.jl
@@ -15,6 +15,12 @@ sources = [
 
 script = raw"""
 cd $WORKSPACE/srcdir/symengine-*
+
+for f in $WORKSPACE/srcdir/patches/*.patch; do
+    echo "Applying patch ${f}"
+    atomic_patch -p1 ${f}
+done
+
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/S/SymEngine/build_tarballs.jl
+++ b/S/SymEngine/build_tarballs.jl
@@ -9,6 +9,7 @@ version = v"0.9.0"
 sources = [
     ArchiveSource("https://github.com/symengine/symengine/releases/download/v$(version)/symengine-$(version).tar.gz",
                   "dcf174ac708ed2acea46691f6e78b9eb946d8a2ba62f75e87cf3bf4f0d651724"),
+                  DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SymEngine/bundled/patches/gmp-fix.patch
+++ b/S/SymEngine/bundled/patches/gmp-fix.patch
@@ -4,71 +4,19 @@ Date: Thu, 17 Nov 2022 12:28:32 -0300
 Subject: [PATCH] Use the correct freefunc
 
 ---
- symengine/mp_class.h     | 14 +++++++++++---
  symengine/mp_wrapper.cpp | 17 +++++++++++++----
- 2 files changed, 24 insertions(+), 7 deletions(-)
+ 1 file changed, 13 insertions(+), 4 deletions(-)
 
-diff --git a/symengine/mp_class.h b/symengine/mp_class.h
-index 84e932b292..088f667fb8 100644
---- a/symengine/mp_class.h
-+++ b/symengine/mp_class.h
-@@ -3,6 +3,7 @@
- 
- #include <symengine/symengine_config.h>
- #include <symengine/symengine_casts.h>
-+#include <cstring>
- #if SYMENGINE_INTEGER_CLASS != SYMENGINE_BOOSTMP
- #include <symengine/mp_wrapper.h>
- #endif
-@@ -123,9 +124,11 @@ inline void mp_set_str(integer_class &i, const std::string &a)
- 
- inline std::string mp_get_hex_str(const integer_class &i)
- {
-+    void (*freefunc)(void *, size_t);
-+    mp_get_memory_functions(NULL, NULL, &freefunc);
-     char *c = mpz_get_str(NULL, 16, i.get_mpz_t());
-     std::string r = std::string(c);
--    free(c);
-+    freefunc(c, strlen(c) + 1);
-     return r;
- }
- 
-@@ -476,9 +479,12 @@ inline void mp_set_str(integer_class &i, const std::string &a)
- 
- inline std::string mp_get_hex_str(const integer_class &i)
- {
-+
-+    void (*freefunc)(void *, size_t);
-+    mp_get_memory_functions(NULL, NULL, &freefunc);
-     char *c = mpz_get_str(NULL, 16, i.get_mpz_view());
-     std::string r = std::string(c);
--    free(c);
-+    freefunc(c, strlen(c) + 1);
-     return r;
- }
- 
-@@ -612,9 +618,11 @@ inline void mp_set_str(fmpz_wrapper &i, const std::string &a)
- 
- inline std::string mp_get_hex_str(const fmpz_wrapper &i)
- {
-+    void (*freefunc)(void *, size_t);
-+    mp_get_memory_functions(NULL, NULL, &freefunc);
-     char *c = fmpz_get_str(NULL, 16, i.get_fmpz_t());
-     std::string r = std::string(c);
--    free(c);
-+    freefunc(c, strlen(c) + 1);
-     return r;
- }
- 
+
 diff --git a/symengine/mp_wrapper.cpp b/symengine/mp_wrapper.cpp
-index 6b8e523f02..4a841c3f53 100644
+index 6b8e523f02..4a84di1c3f53 100644
 --- a/symengine/mp_wrapper.cpp
 +++ b/symengine/mp_wrapper.cpp
 @@ -1,39 +1,48 @@
  #include <symengine/mp_wrapper.h>
  #include <stdlib.h>
 +#include <cstring>
- 
+
  namespace SymEngine
  {
  #if SYMENGINE_INTEGER_CLASS == SYMENGINE_FLINT
@@ -82,7 +30,7 @@ index 6b8e523f02..4a841c3f53 100644
 +    freefunc(c, strlen(c) + 1);
      return os;
  }
- 
+
  std::ostream &operator<<(std::ostream &os, const fmpq_wrapper &f)
  {
 +    void (*freefunc)(void *, size_t);
@@ -94,7 +42,7 @@ index 6b8e523f02..4a841c3f53 100644
      return os;
  }
  #elif SYMENGINE_INTEGER_CLASS == SYMENGINE_GMP
- 
+
  std::ostream &operator<<(std::ostream &os, const mpz_wrapper &f)
  {
 +    void (*freefunc)(void *, size_t);
@@ -105,7 +53,7 @@ index 6b8e523f02..4a841c3f53 100644
 +    freefunc(c, strlen(c) + 1);
      return os;
  }
- 
+
  std::ostream &operator<<(std::ostream &os, const mpq_wrapper &f)
  {
 +    void (*freefunc)(void *, size_t);

--- a/S/SymEngine/bundled/patches/gmp-fix.patch
+++ b/S/SymEngine/bundled/patches/gmp-fix.patch
@@ -1,0 +1,119 @@
+From 1595e600076415cafc002085731a219a497371e6 Mon Sep 17 00:00:00 2001
+From: Gabriel Baraldi <baraldigabriel@gmail.com>
+Date: Thu, 17 Nov 2022 12:28:32 -0300
+Subject: [PATCH] Use the correct freefunc
+
+---
+ symengine/mp_class.h     | 14 +++++++++++---
+ symengine/mp_wrapper.cpp | 17 +++++++++++++----
+ 2 files changed, 24 insertions(+), 7 deletions(-)
+
+diff --git a/symengine/mp_class.h b/symengine/mp_class.h
+index 84e932b292..088f667fb8 100644
+--- a/symengine/mp_class.h
++++ b/symengine/mp_class.h
+@@ -3,6 +3,7 @@
+ 
+ #include <symengine/symengine_config.h>
+ #include <symengine/symengine_casts.h>
++#include <cstring>
+ #if SYMENGINE_INTEGER_CLASS != SYMENGINE_BOOSTMP
+ #include <symengine/mp_wrapper.h>
+ #endif
+@@ -123,9 +124,11 @@ inline void mp_set_str(integer_class &i, const std::string &a)
+ 
+ inline std::string mp_get_hex_str(const integer_class &i)
+ {
++    void (*freefunc)(void *, size_t);
++    mp_get_memory_functions(NULL, NULL, &freefunc);
+     char *c = mpz_get_str(NULL, 16, i.get_mpz_t());
+     std::string r = std::string(c);
+-    free(c);
++    freefunc(c, strlen(c) + 1);
+     return r;
+ }
+ 
+@@ -476,9 +479,12 @@ inline void mp_set_str(integer_class &i, const std::string &a)
+ 
+ inline std::string mp_get_hex_str(const integer_class &i)
+ {
++
++    void (*freefunc)(void *, size_t);
++    mp_get_memory_functions(NULL, NULL, &freefunc);
+     char *c = mpz_get_str(NULL, 16, i.get_mpz_view());
+     std::string r = std::string(c);
+-    free(c);
++    freefunc(c, strlen(c) + 1);
+     return r;
+ }
+ 
+@@ -612,9 +618,11 @@ inline void mp_set_str(fmpz_wrapper &i, const std::string &a)
+ 
+ inline std::string mp_get_hex_str(const fmpz_wrapper &i)
+ {
++    void (*freefunc)(void *, size_t);
++    mp_get_memory_functions(NULL, NULL, &freefunc);
+     char *c = fmpz_get_str(NULL, 16, i.get_fmpz_t());
+     std::string r = std::string(c);
+-    free(c);
++    freefunc(c, strlen(c) + 1);
+     return r;
+ }
+ 
+diff --git a/symengine/mp_wrapper.cpp b/symengine/mp_wrapper.cpp
+index 6b8e523f02..4a841c3f53 100644
+--- a/symengine/mp_wrapper.cpp
++++ b/symengine/mp_wrapper.cpp
+@@ -1,39 +1,48 @@
+ #include <symengine/mp_wrapper.h>
+ #include <stdlib.h>
++#include <cstring>
+ 
+ namespace SymEngine
+ {
+ #if SYMENGINE_INTEGER_CLASS == SYMENGINE_FLINT
+ std::ostream &operator<<(std::ostream &os, const fmpz_wrapper &f)
+ {
++    void (*freefunc)(void *, size_t);
++    mp_get_memory_functions(NULL, NULL, &freefunc);
+     char *c = fmpz_get_str(NULL, 10, f.get_fmpz_t());
+     os << std::string(c);
+-    free(c);
++    freefunc(c, strlen(c) + 1);
+     return os;
+ }
+ 
+ std::ostream &operator<<(std::ostream &os, const fmpq_wrapper &f)
+ {
++    void (*freefunc)(void *, size_t);
++    mp_get_memory_functions(NULL, NULL, &freefunc);
+     char *c = fmpq_get_str(NULL, 10, f.get_fmpq_t());
+     os << std::string(c);
+-    free(c);
++    freefunc(c, strlen(c) + 1);
+     return os;
+ }
+ #elif SYMENGINE_INTEGER_CLASS == SYMENGINE_GMP
+ 
+ std::ostream &operator<<(std::ostream &os, const mpz_wrapper &f)
+ {
++    void (*freefunc)(void *, size_t);
++    mp_get_memory_functions(NULL, NULL, &freefunc);
+     char *c = mpz_get_str(NULL, 10, f.get_mpz_t());
+     os << std::string(c);
+-    free(c);
++    freefunc(c, strlen(c) + 1);
+     return os;
+ }
+ 
+ std::ostream &operator<<(std::ostream &os, const mpq_wrapper &f)
+ {
++    void (*freefunc)(void *, size_t);
++    mp_get_memory_functions(NULL, NULL, &freefunc);
+     char *c = mpq_get_str(NULL, 10, f.get_mpq_t());
+     os << std::string(c);
+-    free(c);
++    freefunc(c, strlen(c) + 1);
+     return os;
+ }
+ #endif


### PR DESCRIPTION
Found by experimenting with mimalloc, upstream PR is https://github.com/symengine/symengine/pull/1940