### PR TITLE
[XGBoost] Add GPU support 

### DIFF
--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -4,7 +4,6 @@ name = "XGBoost"
 version = v"1.7.1"
 
 const YGGDRASIL_DIR = "../.."
-include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 # Collection of sources required to build XGBoost
@@ -22,7 +21,7 @@ git submodule update --init
 (cd dmlc-core; atomic_patch -p1 "../../patches/dmlc_windows.patch")
 
 mkdir build && cd build
-if [[ ${target} == x86_64-linux* ]]; then
+if [[ ${target} == x86_64-linux-gnu* ]]; then
     export CUDA_HOME=${WORKSPACE}/destdir/cuda
     export PATH=$PATH:$CUDA_HOME/bin
     cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" -DUSE_CUDA=ON -DBUILD_WITH_CUDA_CUB=ON
@@ -50,7 +49,7 @@ install_license LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms())[3:4]
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [
@@ -64,7 +63,7 @@ dependencies = [
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
-    BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.0.3"); platforms = platforms), #[3:4]),
+    BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.0.3"); platforms = platforms[3:4]),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -3,6 +3,10 @@ using BinaryBuilder, Pkg
 name = "XGBoost"
 version = v"1.7.1"
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
+
 # Collection of sources required to build XGBoost
 sources = [
     GitSource("https://github.com/dmlc/xgboost.git","534c940a7ea50ab3b8a827546ac9908f859379f2"), 
@@ -18,8 +22,15 @@ git submodule update --init
 (cd dmlc-core; atomic_patch -p1 "../../patches/dmlc_windows.patch")
 
 mkdir build && cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}"
-make -j${nproc}
+if [[ ${target} == x86_64-linux* ]]; then
+    export CUDA_HOME=${WORKSPACE}/destdir/cuda
+    export PATH=$PATH:$CUDA_HOME/bin
+    cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" -DUSE_CUDA=ON -DBUILD_WITH_CUDA_CUB=ON
+    make -j${nproc}
+else
+    cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" 
+    make -j${nproc}
+fi
 
 # Manual installation, to avoid installing dmlc
 cd ..
@@ -39,7 +50,7 @@ install_license LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms())
+platforms = expand_cxxstring_abis(supported_platforms())[3:4]
 
 # The products that we will ensure are always built
 products = [
@@ -53,6 +64,7 @@ dependencies = [
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
+    BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.0.3"); platforms = platforms), #[3:4]),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -4,6 +4,7 @@ name = "XGBoost"
 version = v"1.7.1"
 
 const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 # Collection of sources required to build XGBoost
@@ -21,7 +22,7 @@ git submodule update --init
 (cd dmlc-core; atomic_patch -p1 "../../patches/dmlc_windows.patch")
 
 mkdir build && cd build
-if  [[ "${target}" == x86_64-linux-gnu* ]]; then
+if  [[ "${target}" == *linux-gnu-cuda* ]]; then
     # nvcc writes to /tmp, which is a small tmpfs in our sandbox.
     # make it use the workspace instead
     export TMPDIR=${WORKSPACE}/tmpdir
@@ -33,14 +34,6 @@ if  [[ "${target}" == x86_64-linux-gnu* ]]; then
             -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
             -DUSE_CUDA=ON \
             -DBUILD_WITH_CUDA_CUB=ON
-    make -j${nproc}
-elif [[ ${target} == x86_64-w64-mingw* ]]; then
-    export CUDA_HOME=${WORKSPACE}/destdir/cuda
-    export PATH=$PATH:$CUDA_HOME/bin
-    export CUDACXX=${WORKSPACE}/destdir/cuda/bin/nvcc.exe
-    cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
-        -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
-        -DUSE_CUDA=ON 
     make -j${nproc}
 else
     cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" 
@@ -63,10 +56,25 @@ fi
 install_license LICENSE
 """
 
+
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
-cuda_platforms = expand_cxxstring_abis(supported_platforms()[[2,16]])
+cuda_platforms = [Platform("x86_64", "linux"),
+                  # Platform("powerpc64le", "linux"),
+                  # Platform("aarch64", "linux"),
+                  # Platform("x86_64", "windows")
+                 ] |> expand_cxxstring_abis
+
+cuda_versions = [v"11.0", v"11.8"]
+
+cuda_full_versions = Dict(
+    v"11.0" => v"11.0.3",
+    v"11.4" => v"11.4.2",
+    v"11.8" => v"11.8"
+)
+
+augment_platform_block = CUDA.augment
 
 # The products that we will ensure are always built
 products = [
@@ -80,8 +88,28 @@ dependencies = [
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
-    BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.0.3"); platforms = cuda_platforms),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")
+
+
+# build cuda tarballs
+for cuda_version in cuda_versions, platform in cuda_platforms
+    # not all platforms have all versions of CUDA_full_jll
+    if cuda_version == v"11.0" && platform == Platform("aarch64", "linux")
+        cuda_version = v"11.4"
+    end
+
+    augmented_platform = Platform(arch(platform), os(platform);
+                                  cuda=CUDA.platform(cuda_version))
+    should_build_platform(triplet(augmented_platform)) || continue
+
+    cuda_deps = [
+        BuildDependency(PackageSpec(name="CUDA_full_jll",
+                                    version=cuda_full_versions[cuda_version])),
+    ]
+
+    build_tarballs(ARGS, name, version, sources, script, [augmented_platform], products, [dependencies; cuda_deps];
+                   preferred_gcc_version=v"8", lazy_artifacts=true, julia_compat="1.6", augment_platform_block)
+end

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -34,7 +34,7 @@ if  [[ "${target}" == x86_64-linux-gnu* ]]; then
             -DUSE_CUDA=ON \
             -DBUILD_WITH_CUDA_CUB=ON
     make -j${nproc}
-elif [[ ${target} == *w64-mingw* ]]; then
+elif [[ ${target} == x86_64-w64-mingw* ]]; then
     export CUDA_HOME=${WORKSPACE}/destdir/cuda
     export PATH=$PATH:$CUDA_HOME/bin
     export CUDACXX=${WORKSPACE}/destdir/cuda/bin/nvcc.exe

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -33,7 +33,8 @@ if  [[ "${target}" == *linux-gnu-cuda* ]]; then
     cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
             -DUSE_CUDA=ON \
-            -DBUILD_WITH_CUDA_CUB=ON
+            -DBUILD_WITH_CUDA_CUB=ON \
+            -DUSE_NCCL=ON
     make -j${nproc}
 else
     cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" 
@@ -89,7 +90,6 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")
 
-
 # build cuda tarballs
 for cuda_version in cuda_versions, platform in cuda_platforms
     augmented_platform = Platform(arch(platform), os(platform);
@@ -99,6 +99,7 @@ for cuda_version in cuda_versions, platform in cuda_platforms
     cuda_deps = [
         BuildDependency(PackageSpec(name="CUDA_full_jll",
                                     version=cuda_full_versions[cuda_version])),
+        RuntimeDependency(PackageSpec(name="NCCL_jll", version=v"2.15.1")),
     ]
 
     build_tarballs(ARGS, name, version, sources, script, [augmented_platform], products, [dependencies; cuda_deps];

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -35,7 +35,12 @@ if  [[ "${target}" == x86_64-linux-gnu* ]]; then
             -DBUILD_WITH_CUDA_CUB=ON
     make -j${nproc}
 elif [[ ${target} == *w64-mingw* ]]; then
-    cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" 
+    export CUDA_HOME=${WORKSPACE}/destdir/cuda
+    export PATH=$PATH:$CUDA_HOME/bin
+    export CUDACXX=${WORKSPACE}/destdir/cuda/bin/nvcc.exe
+    cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
+        -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
+        -DUSE_CUDA=ON 
     make -j${nproc}
 else
     cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" 

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -63,12 +63,10 @@ install_license LICENSE
 platforms = expand_cxxstring_abis(supported_platforms())
 cuda_platforms = expand_cxxstring_abis(Platform("x86_64", "linux"))
 
-cuda_versions = [v"11.0", v"11.8"]
+cuda_versions = [v"11.0"]
 
 cuda_full_versions = Dict(
     v"11.0" => v"11.0.3",
-    v"11.4" => v"11.4.2",
-    v"11.8" => v"11.8"
 )
 
 augment_platform_block = CUDA.augment
@@ -99,6 +97,7 @@ for cuda_version in cuda_versions, platform in cuda_platforms
     cuda_deps = [
         BuildDependency(PackageSpec(name="CUDA_full_jll",
                                     version=cuda_full_versions[cuda_version])),
+        RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll")),
         RuntimeDependency(PackageSpec(name="NCCL_jll", version=v"2.15.1")),
     ]
 

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -21,7 +21,6 @@ git submodule update --init
 (cd dmlc-core; atomic_patch -p1 "../../patches/dmlc_windows.patch")
 
 mkdir build && cd build
-# if  [[ "${target}" == powerpc64le-linux* || "${target}" == x86_64-linux-gnu* ]]; then
 if  [[ "${target}" == x86_64-linux-gnu* ]]; then
     # nvcc writes to /tmp, which is a small tmpfs in our sandbox.
     # make it use the workspace instead

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -60,11 +60,7 @@ install_license LICENSE
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
-cuda_platforms = [Platform("x86_64", "linux"),
-                  # Platform("powerpc64le", "linux"),
-                  # Platform("aarch64", "linux"),
-                  # Platform("x86_64", "windows")
-                 ] |> expand_cxxstring_abis
+cuda_platforms = expand_cxxstring_abis(Platform("x86_64", "linux"))
 
 cuda_versions = [v"11.0", v"11.8"]
 
@@ -96,11 +92,6 @@ build_tarballs(ARGS, name, version, sources, script, platforms, products, depend
 
 # build cuda tarballs
 for cuda_version in cuda_versions, platform in cuda_platforms
-    # not all platforms have all versions of CUDA_full_jll
-    if cuda_version == v"11.0" && platform == Platform("aarch64", "linux")
-        cuda_version = v"11.4"
-    end
-
     augmented_platform = Platform(arch(platform), os(platform);
                                   cuda=CUDA.platform(cuda_version))
     should_build_platform(triplet(augmented_platform)) || continue


### PR DESCRIPTION
This PR is a WIP. I am trying to build XGBoost with GPU support (https://github.com/dmlc/XGBoost.jl/issues/134). 

Currently, the `x86_64-linux-gnu` cuda build is working. I am struggling to get it to also build with NCCL, but that is not a necessity. 

The `x86_64-w64-mingw` cuda build is not working. Cmake throws the following error:

```
CMake Error at /usr/share/cmake/Modules/CMakeTestCUDACompiler.cmake:56 (message):
[19:10:08]   The CUDA compiler
[19:10:08] 
[19:10:08]     "/workspace/destdir/cuda/bin/nvcc.exe"
[19:10:08] 
[19:10:08]   is not able to compile a simple test program.
[19:10:08] 
[19:10:08]   It fails with the following output:
[19:10:08] 
[19:10:08]     Change Dir: /workspace/srcdir/xgboost/build/CMakeFiles/CMakeTmp
[19:10:08]     
[19:10:08]     Run Build Command(s):/usr/bin/make -f Makefile cmTC_e97c7/fast && /usr/bin/make  -f CMakeFiles/cmTC_e97c7.dir/build.make CMakeFiles/cmTC_e97c7.dir/build
[19:10:08]     make[1]: Entering directory '/workspace/srcdir/xgboost/build/CMakeFiles/CMakeTmp'
[19:10:08]     Building CUDA object CMakeFiles/cmTC_e97c7.dir/main.cu.obj
[19:10:08]     /workspace/destdir/cuda/bin/nvcc.exe      -c /workspace/srcdir/xgboost/build/CMakeFiles/CMakeTmp/main.cu -o CMakeFiles/cmTC_e97c7.dir/main.cu.obj
[19:10:08]     /workspace/destdir/cuda/bin/nvcc.exe: line 1: MZÿÿ¸@º´: not found
[19:10:08]     /workspace/destdir/cuda/bin/nvcc.exe: line 1: syntax error: unexpected end of file (expecting ")")
[19:10:08]     make[1]: *** [CMakeFiles/cmTC_e97c7.dir/build.make:78: CMakeFiles/cmTC_e97c7.dir/main.cu.obj] Error 2
[19:10:08]     make[1]: Leaving directory '/workspace/srcdir/xgboost/build/CMakeFiles/CMakeTmp'
[19:10:08]     make: *** [Makefile:127: cmTC_e97c7/fast] Error 2

```