### PR TITLE
[libcxxwrap_julia] Bump version to 0.9.3

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -8,7 +8,7 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "libcxxwrap_julia"
-version = v"0.9.2"
+version = v"0.9.3"
 
 julia_versions = [v"1.6.3", v"1.7", v"1.8", v"1.9", v"1.10"]
 
@@ -18,7 +18,7 @@ unpack_target = is_yggdrasil ? "" : "libcxxwrap-julia"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource(git_repo, "ab9c3f11114d1715ae1780bd4d5e8d3df7f236fb", unpack_target=unpack_target),
+    GitSource(git_repo, "277bec8dae5b84717d2068b4e1f7b8ca8fe64a25", unpack_target=unpack_target),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Adds a bugfix for a crash that appears in QML.jl