### PR TITLE
[Minuit2_Julia_Wrapper] remove CxxWrap version restriction

### DIFF
--- a/M/Minuit2_Julia_Wrapper/build_tarballs.jl
+++ b/M/Minuit2_Julia_Wrapper/build_tarballs.jl
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-        Dependency(PackageSpec(name="libcxxwrap_julia_jll",version=v"0.8.5")),
+        Dependency(PackageSpec(name="libcxxwrap_julia_jll")),
         Dependency(PackageSpec(name="Minuit2_jll")),
         BuildDependency(PackageSpec(name="libjulia_jll", version=julia_version))
 ]


### PR DESCRIPTION
I'm trying to remove the version spec from the libcxxwrap dependency and hope that fixes the failing tests at https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2022-11/24/Minuit2.primary.log