### PR TITLE
Add recipe for crun.

### DIFF
--- a/C/crun/build_tarballs.jl
+++ b/C/crun/build_tarballs.jl
@@ -1,0 +1,64 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, BinaryBuilderBase, Pkg
+
+name = "crun"
+version = v"1.7.1"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/containers/crun",
+              "0356bf4aff9a133d655dc13b1d9ac9424706cac4")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+# check if we need to use a more recent glibc
+if [[ -f "$prefix/usr/include/sched.h" ]]; then
+    GLIBC_ARTIFACT_DIR=$(dirname $(dirname $(dirname $(realpath $prefix/usr/include/sched.h))))
+    rsync --archive ${GLIBC_ARTIFACT_DIR}/ /opt/${target}/${target}/sys-root/
+fi
+
+cd crun
+install_license COPYING
+
+./autogen.sh
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
+            --enable-shared --enable-dynamic \
+            --disable-criu # missing JLL
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+filter!(Sys.islinux, platforms)
+filter!(p -> libc(p) == "glibc", platforms)
+
+# some platforms need a newer glibc, because the default one is too old
+glibc_platforms = filter(platforms) do p
+    libc(p) == "glibc" && proc_family(p) in ["intel", "power"]
+end
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("crun", :crun),
+    LibraryProduct("libcrun", :libcrun)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("YAJL_jll"),
+    Dependency("libcap_jll"),
+    Dependency("systemd_jll"),
+    Dependency("libseccomp_jll"),
+
+    # crun needs glibc >2.14
+    BuildDependency(PackageSpec(name = "Glibc_jll", version = v"2.17");
+                    platforms=glibc_platforms),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version=v"7", dont_dlopen=true)


### PR DESCRIPTION
> crun:  A fast and lightweight fully featured OCI runtime and C library for running containers 

I'm running into some weird compiler errors though:

```
[17:48:59] cc -DHAVE_CONFIG_H -I.    -I /workspace/srcdir/crun-1.7.1/libocispec/src -I /workspace/srcdir/crun-1.7.1/libocispec/src -D CRUN_LIBDIR="\"/workspace/destdir/lib/crun\"" -g -O2 -fPIC -MT src/crun-kill.o -MD -MP -MF src/.deps/crun-kill.Tpo -c -o src/crun-kill.o `test -f 'src/kill.c' || echo './'`src/kill.c
[17:48:59] src/libcrun/cloned_binary.c: In function ‘is_self_cloned’:
[17:48:59] src/libcrun/cloned_binary.c:147:36: error: ‘struct statfs’ has no member named ‘f_flags’
[17:48:59]   147 |                 is_cloned |= (fsbuf.f_flags & MS_RDONLY);
[17:48:59]       |                                    ^

[17:48:59] src/libcrun/cloned_binary.c: In function ‘seal_execfd’:
[17:48:59] src/libcrun/cloned_binary.c:353:38: error: ‘O_PATH’ undeclared (first use in this function)
[17:48:59]   353 |                 newfd = open(fdpath, O_PATH | O_CLOEXEC);
[17:48:59]       |                                      ^~~~~~
```

Both these are pretty basic, `f_flags` isn't hidden behind `_GNU_SOURCE` or anything, and `O_PATH` should be available on any sufficiently recent glibc, so I'm not sure what's going on here. Hopefully somebody does!