### PR TITLE
rr: add 32-bit build

### DIFF
--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -19,10 +19,23 @@ cd ${WORKSPACE}/srcdir/rr/
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-      -Ddisable32bit=ON -DBUILD_TESTS=OFF -DWILL_RUN_TESTS=OFF -Dstaticlibs=ON ..
+      -DBUILD_TESTS=OFF -DWILL_RUN_TESTS=OFF -Dstaticlibs=ON ..
 make -j${nproc}
 make install
 """
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+
+    function augment_platform!(platform::Platform)
+        if Sys.islinux()
+            real_arch = chomp(read(`uname -m`, String))
+            remaining_tags = copy(tags(platform))
+            delete!(remaining_tags, "arch")
+            delete!(remaining_tags, "os")
+            Platform(String(real_arch), os(platform), remaining_tags)
+        end
+    end"""
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
@@ -50,5 +63,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies,
-               preferred_gcc_version=v"10")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               augment_platform_block, julia_compat="1.6", preferred_gcc_version=v"10")


### PR DESCRIPTION
This should make it possible to use our x64 rr build with x32 binaries while on a x64 system. This can actually be useful: to be able to execute `julia32 --bug-report=rr` on a x64 system. The platform augmentation hooks make this possible, overloading the platform depending on the system, but currently the build fails because when building for x64 we don't have an x32 compiler.

cc @Keno 