### PR TITLE
[SQLite] Add compiler flags

### DIFF
--- a/S/SQLite/build_tarballs.jl
+++ b/S/SQLite/build_tarballs.jl
@@ -24,11 +24,13 @@ export CPPFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1 \
                  -DSQLITE_ENABLE_UNLOCK_NOTIFY \
                  -DSQLITE_ENABLE_DBSTAT_VTAB=1 \
                  -DSQLITE_ENABLE_FTS3_TOKENIZER=1 \
+                 -DSQLITE_ENABLE_FTS3_PARENTHESIS \
                  -DSQLITE_SECURE_DELETE \
                  -DSQLITE_ENABLE_STMTVTAB \
                  -DSQLITE_MAX_VARIABLE_NUMBER=250000 \
                  -DSQLITE_MAX_EXPR_DEPTH=10000 \
-                 -DSQLITE_ENABLE_MATH_FUNCTIONS"
+                 -DSQLITE_ENABLE_MATH_FUNCTIONS \
+                 -DSQLITE_USE_URI"
 
 ./configure --prefix=${prefix} \
     --build=${MACHTYPE} \


### PR DESCRIPTION
Add SQLITE_ENABLE_FTS3_PARENTHESIS and SQLITE_USE_URI compiler definitions.

The former follows https://github.com/archlinux/svntogit-packages/commit/117e0d7678370c13afaaaf1a4347a3d5055cd3f2

The latter enables https://www.sqlite.org/uri.html in SQLite, so users can use more powerful URI to control the behavior when opening database