### PR TITLE
Enable builds for MacOS by not explicitly requiring glibc

### DIFF
--- a/C/casacorecxx/build_tarballs.jl
+++ b/C/casacorecxx/build_tarballs.jl
@@ -34,7 +34,7 @@ platforms = expand_cxxstring_abis(platforms)
 
 # Filter this list based on the same filter criteria used in the casacore build script
 filter!(platforms) do p
-    !Sys.iswindows(p) && !Sys.isfreebsd(p) && libc(p) == "glibc"
+    !Sys.iswindows(p) && !Sys.isfreebsd(p) && libc(p) != "musl"
 end
 
 # The products that we will ensure are always built


### PR DESCRIPTION
We want to require only glibc build, as Casacore itself uses glibc specific calls. However, for some reason MacOS platforms have no libc information at all and by requiring `libc(p) == "glibc"` we exclude all MacOS builds.

In this patch, we will require `libc(p) != "musl"` (which is consistent with `casacore_jll`).

