### PR TITLE
Update binutils to new syntax and version 2.39

### DIFF
--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -37,7 +37,7 @@ make -j${nproc}
 make install
 """
 
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms(; exclude=!Sys.islinux)
 
 products = [
     ExecutableProduct("addr2line", :addr2line),

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -14,11 +14,10 @@ ln -sf $(which uname) /usr/bin/uname
 
 cd ${WORKSPACE}/srcdir/binutils-*/
 
-update_configure_scripts
-
 ./configure --prefix=${prefix} \
     --target=${target} \
-    --host=${MACHTYPE} \
+    --build=${MACHTYPE} \
+    --host=${target} \
     --disable-dependency-tracking \
     --enable-deterministic-archives \
     --disable-werror \
@@ -27,9 +26,15 @@ update_configure_scripts
     --disable-gas \
     --disable-gold \
     --disable-ld \
+    --enable-install-libbfd \
+    --enable-install-libctf \
+    --enable-install-libiberty \
     --enable-plugins \
     --enable-targets=${target} \
-    --disable-nls
+    --disable-nls \
+    --enable-64-bit-bfd \
+    --disable-static \
+    --enable-shared
 
 make -j${nproc}
 make install
@@ -66,9 +71,12 @@ products = [
     ExecutableProduct("objdump", :objdump),
     ExecutableProduct("ranlib", :ranlib),
     ExecutableProduct("readelf", :readelf),
-    ExecutableProduct(Dict("binnames" => ["size"], "variable_name" => "size", "dir_path" => nothing)),
+    ExecutableProduct("size", :binutils_size),
     ExecutableProduct("strings", :strings),
-    ExecutableProduct(Dict("binnames" => ["strip"], "variable_name" => "strip", "dir_path" => nothing)),
+    ExecutableProduct("strip", :binutils_strip),
+    LibraryProduct("libbfd", :libbfd),
+    LibraryProduct("libctf", :libctf),
+    LibraryProduct("libopcodes", :libopcodes),
 ]
 
 dependencies = []

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -1,93 +1,71 @@
 using BinaryBuilder
 
-compiler_target = triplet(platform_key(ARGS[end]))
-if compiler_target == "unknown-unknown-unknown"
-    error("This is not a typical build_tarballs.jl!  Must provide exactly one platform as the last argument!")
-end
-deleteat!(ARGS, length(ARGS))
+name = "Binutils"
+version = v"2.39"
 
-# Encode the compiler target into the name
-name = "Binutils-$(compiler_target)"
-version = v"2.24"
-
-# Collection of sources required to build Binutils
 sources = [
-    "https://ftp.gnu.org/gnu/binutils/binutils-2.24.tar.bz2" =>
-	"e5e8c5be9664e7f7f96e0d09919110ab5ad597794f5b1809871177a0f0f14137",
-    "https://github.com/tpoechtrager/apple-libtapi.git" =>
-    "e56673694db395e25b31808b4fbb9a7005e6875f",
-    "https://github.com/tpoechtrager/cctools-port.git" =>
-    "ecb84d757b6f011543504967193375305ffa3b2f",
-    "./bundled",
+    ArchiveSource("https://ftp.gnu.org/gnu/binutils/binutils-2.39.tar.xz", "645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00"),
+    DirectorySource("$(@__DIR__)/bundled"),
 ]
 
-# Bash recipe for building across all platforms
-script = """
+script = raw"""
 # FreeBSD build system for binutils apparently requires that uname sit in /usr/bin/
-ln -sf \$(which uname) /usr/bin/uname
+ln -sf $(which uname) /usr/bin/uname
 
-# On MacOS, we don't actually install Binutils.  We install libtapi and cctools.  Le sigh.
-if [[ $(compiler_target) == *apple* ]]; then
-    mkdir -p \${WORKSPACE}/srcdir/apple-libtapi/build
-    cd \${WORKSPACE}/srcdir/apple-libtapi/build
+cd ${WORKSPACE}/srcdir/binutils-*/
 
-    # Install libtapi
-    cmake ../src/apple-llvm/src \\
-        -DLLVM_INCLUDE_TESTS=OFF \\
-        -DCMAKE_BUILD_TYPE=RELEASE \\
-        -DCMAKE_INSTALL_PREFIX=\${prefix}
-    make -j\${nproc} VERBOSE=1
-    make install
+update_configure_scripts
 
-    # Install cctools.  Someday, try this without disabling the clang assembler!
-    cd \${WORKSPACE}/srcdir/cctools-port/cctools
-    ./configure --prefix=\${prefix} \\
-        --target=$(compiler_target) \\
-        --host=\${MACHTYPE} \\
-        --with-libtapi=\${prefix}
-    make -j\${nproc}
-    make install
-else
-    cd \${WORKSPACE}/srcdir/binutils-*/
+./configure --prefix=${prefix} \
+    --target=${target} \
+    --host=${MACHTYPE} \
+    --disable-dependency-tracking \
+    --enable-deterministic-archives \
+    --disable-werror \
+    --disable-gprof \
+    --disable-gprofng \
+    --disable-gas \
+    --disable-gold \
+    --disable-ld \
+    --enable-plugins \
+    --enable-targets=${target} \
+    --disable-nls
 
-    #atomic_patch -p1 "\${WORKSPACE}/srcdir/patches/binutils_COFF_bfd.patch"
-    update_configure_scripts
-
-    ./configure --prefix=\${prefix} \\
-        --target=$(compiler_target) \\
-        --host=\${MACHTYPE} \\
-        --with-sysroot="\${prefix}/$(compiler_target)/sys-root" \\
-        --enable-multilib \\
-        --disable-werror
-
-    make -j\${nproc}
-    make install
-fi
+make -j${nproc}
+make install
 
 # Finally, create a bunch of symlinks stripping out the target so that
 # things like `nm` "just work", as long as we've got our path set properly.
-for f in \${prefix}/bin/$(compiler_target)-*; do
-    fbase=\$(basename \$f)
-    ln -s \$fbase \${prefix}/bin/\${fbase#$(compiler_target)-}
+for f in ${prefix}/bin/${target}-*; do
+    fbase=$(basename $f)
+    ln -s $fbase ${prefix}/bin/${fbase#${target}-}
 done
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = [Platform("x86_64", "linux")]
+platforms = supported_platforms(; exclude=x -> os(x) != "linux")
 
-# The products that we will ensure are always built
-products = prefix -> [
-    ExecutableProduct(prefix, "$(compiler_target)-as", :as),
-    ExecutableProduct(prefix, "$(compiler_target)-nm", :nm),
-    ExecutableProduct(prefix, "$(compiler_target)-ld", :ld),
-    ExecutableProduct(prefix, "$(compiler_target)-strip", :strip),
+products = [
+    ExecutableProduct("addr2line", :addr2line),
+    ExecutableProduct("ar", :ar),
+    # ExecutableProduct("as", :as),
+    ExecutableProduct("c++filt", Symbol("c++filt")),
+    # ExecutableProduct("dwp", :dwp),
+    ExecutableProduct("elfedit", :elfedit),
+    # ExecutableProduct("gprof", :gprof),
+    # ExecutableProduct("gprofng", :gprofng),
+    # ExecutableProduct("ld", :ld),
+    # ExecutableProduct("ld.bfd", Symbol("ld.bfd")),
+    # ExecutableProduct("ld.gold", Symbol("ld.gold")),
+    ExecutableProduct("nm", :nm),
+    ExecutableProduct("objcopy", :objcopy),
+    ExecutableProduct("objdump", :objdump),
+    ExecutableProduct("ranlib", :ranlib),
+    ExecutableProduct("readelf", :readelf),
+    ExecutableProduct(Dict("binnames" => ["size"], "variable_name" => "size", "dir_path" => nothing)),
+    ExecutableProduct("strings", :strings),
+    ExecutableProduct(Dict("binnames" => ["strip"], "variable_name" => "strip", "dir_path" => nothing)),
 ]
 
-# Dependencies that must be installed before this package can be built
-dependencies = [
-    "https://github.com/staticfloat/KernelHeadersBuilder/releases/download/v4.12.0-0/build_KernelHeaders.v4.12.0.jl",
-]
+dependencies = []
 
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; skip_audit=true)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -52,7 +52,7 @@ if [ ${target} != "x86_64-linux-musl" ]; then
 fi
 """
 
-platforms = supported_platforms(; exclude=x -> os(x) != "linux")
+platforms = supported_platforms(; exclude=!Sys.islinux)
 
 products = [
     ExecutableProduct("addr2line", :addr2line),

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -79,6 +79,6 @@ products = [
     LibraryProduct("libopcodes", :libopcodes),
 ]
 
-dependencies = []
+dependencies = Dependency[]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -9,9 +9,6 @@ sources = [
 ]
 
 script = raw"""
-# FreeBSD build system for binutils apparently requires that uname sit in /usr/bin/
-ln -sf $(which uname) /usr/bin/uname
-
 cd ${WORKSPACE}/srcdir/binutils-*/
 
 ./configure --prefix=${prefix} \

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -35,18 +35,6 @@ cd ${WORKSPACE}/srcdir/binutils-*/
 
 make -j${nproc}
 make install
-
-# Finally, create a bunch of symlinks stripping out the target so that
-# things like `nm` "just work", as long as we've got our path set properly.
-# NOTE: In 'x86_64-linux-musl' binaries are already stripped
-if [ ${target} != "x86_64-linux-musl" ]; then
-    for f in ${prefix}/bin/${target}-*; do
-        fbase=$(basename $f)
-        if [ ! -f ${prefix}/bin/${fbase#${target}-} ]; then
-            ln -s $fbase ${prefix}/bin/${fbase#${target}-}
-        fi
-    done
-fi
 """
 
 platforms = supported_platforms(; exclude=!Sys.islinux)

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -4,7 +4,7 @@ name = "Binutils"
 version = v"2.39"
 
 sources = [
-    ArchiveSource("https://ftp.gnu.org/gnu/binutils/binutils-2.39.tar.xz", "645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00"),
+    ArchiveSource("https://ftp.gnu.org/gnu/binutils/binutils-$(version.major).$(version.minor).tar.xz", "645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00"),
     DirectorySource("$(@__DIR__)/bundled"),
 ]
 

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -36,10 +36,15 @@ make install
 
 # Finally, create a bunch of symlinks stripping out the target so that
 # things like `nm` "just work", as long as we've got our path set properly.
-for f in ${prefix}/bin/${target}-*; do
-    fbase=$(basename $f)
-    ln -s $fbase ${prefix}/bin/${fbase#${target}-}
-done
+# NOTE: In 'x86_64-linux-musl' binaries are already stripped
+if [ ${target} != "x86_64-linux-musl" ]; then
+    for f in ${prefix}/bin/${target}-*; do
+        fbase=$(basename $f)
+        if [ ! -f ${prefix}/bin/${fbase#${target}-} ]; then
+            ln -s $fbase ${prefix}/bin/${fbase#${target}-}
+        fi
+    done
+fi
 """
 
 platforms = supported_platforms(; exclude=x -> os(x) != "linux")

--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -37,7 +37,7 @@ make -j${nproc}
 make install
 """
 
-platforms = supported_platforms(; exclude=!Sys.islinux)
+platforms = supported_platforms(; experimental=true)
 
 products = [
     ExecutableProduct("addr2line", :addr2line),


### PR DESCRIPTION
Current Binutils recipe not only does not longer work but also generated artifacts are wrong (it provides *.exe binaries in Linux...).

This PR updates to the syntax, exports `libbfd`, `libctf`, `libopcodes` shared libraries and refactors the recipe.