### PR TITLE
Bump glibc for x86(_64) to 2.17.

### DIFF
--- a/0_RootFS/gcc_sources.jl
+++ b/0_RootFS/gcc_sources.jl
@@ -213,20 +213,15 @@ function gcc_sources(gcc_version::VersionNumber, compiler_target::Platform; kwar
 
     if Sys.islinux(compiler_target) && libc(compiler_target) == "glibc"
         # Depending on our architecture, we choose different versions of glibc
-        if arch(compiler_target) in ["x86_64", "i686"]
+        if arch(compiler_target) in ["x86_64", "i686", "powerpc64le"]
             libc_sources = [
-                ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.12.2.tar.xz",
-                              "0eb4fdf7301a59d3822194f20a2782858955291dd93be264b8b8d4d56f87203f"),
+                ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.17.tar.xz",
+                              "6914e337401e0e0ade23694e1b2c52a5f09e4eda3270c67e7c3ba93a89b5b23e"),
             ]
         elseif arch(compiler_target) in ["armv7l", "aarch64"]
             libc_sources = [
                 ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.19.tar.xz",
                               "2d3997f588401ea095a0b27227b1d50cdfdd416236f6567b564549d3b46ea2a2"),
-            ]
-        elseif arch(compiler_target) in ["powerpc64le"]
-            libc_sources = [
-                ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.17.tar.xz",
-                              "6914e337401e0e0ade23694e1b2c52a5f09e4eda3270c67e7c3ba93a89b5b23e"),
             ]
         else
             error("Unknown arch for glibc for compiler target $(compiler_target)")


### PR DESCRIPTION
This is probably very naive, but as I read in https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/863#issuecomment-708651389 that it would be OK to bump glibc to 2.17 now that CentOS 6 has been EOL'd, I figured why not. This should unblock a couple of recipes that rely on a somewhat more recent glibc than than the 2.12 we're currently using.

I'm not sure if I need to bump each of the `build_tarballs.jl`s individually as well, and if building/uploading RootFSs is just as automatic as regular recipes, so cc @staticfloat @giordano.

EDIT: nothing happened, so I figure this needs some manual action.