### PR TITLE
[HELICS] update to v3.3.2

### DIFF
--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -47,7 +47,7 @@ products = [
 ]
 
 
-platforms = expand_cxxstring_abis(supported_platforms(exclude=Sys.isfreebsd))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 dependencies = [
     Dependency("ZeroMQ_jll"),

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -42,15 +42,9 @@ if [[ "${target}" == *-mingw* ]]; then
 fi
 """
 
-products = if HELICS_VERSION < v"3.0.0"
-    [
-        LibraryProduct("libhelicsSharedLib", :libhelicsSharedLib),
-    ]
-else
-    [
-        LibraryProduct("libhelics", :libhelics),
-    ]
-end
+products = [
+    LibraryProduct("libhelics", :libhelics),
+]
 
 
 platforms = expand_cxxstring_abis(supported_platforms(exclude=Sys.isfreebsd))

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -82,6 +82,6 @@ build_tarballs(
     platforms,
     products,
     dependencies,
-    preferred_gcc_version=v"8",
+    preferred_gcc_version=v"9",
     julia_compat="1.6",
 )

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -24,6 +24,10 @@ sources = [
 ]
 
 script = raw"""
+if [[ "${target}" == x86_64-apple-darwin* ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=10.15
+fi
+
 cd $WORKSPACE/srcdir
 
 cmake -B build \

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -40,7 +40,7 @@ cd $WORKSPACE/srcdir
 
 mkdir build
 cd build
-CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH="${prefix}" -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TARGET_TOOLCHAIN" -DCMAKE_BUILD_TYPE=Release"
+CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH="${prefix}" -DCMAKE_INSTALL_PREFIX="${prefix}" -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TARGET_TOOLCHAIN" -DCMAKE_BUILD_TYPE=Release"
 HELICS_ARGS="-DHELICS_BUILD_TESTS=OFF"
 cmake ${CMAKE_ARGS} ${HELICS_ARGS} ..
 make -j${nproc}
@@ -79,6 +79,6 @@ build_tarballs(
     platforms,
     products,
     dependencies,
-    ; preferred_gcc_version=v"8",
+    preferred_gcc_version=v"8",
     julia_compat="1.6",
 )

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -27,17 +27,13 @@ sources = [
 
 script = raw"""
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
-    export MACOSX_DEPLOYMENT_TARGET=10.15
-    export CXXFLAGS="-mmacosx-version-min=10.15"
-    export CFLAGS="-mmacosx-version-min=10.15"
+    # Install a newer SDK which supports `std::filesystem`
     pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
     rm -rf /opt/${target}/${target}/sys-root/System
     cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
     cp -ra System "/opt/${target}/${target}/sys-root/."
+    export MACOSX_DEPLOYMENT_TARGET=10.15
     popd
-elif [[ "${target}" == aarch64-apple-darwin* ]]; then
-    # While waiting for https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/193 to be merged
-    export CXXFLAGS="-mmacosx-version-min=11.0"
 fi
 
 cd $WORKSPACE/srcdir

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -28,6 +28,9 @@ if [[ "${target}" == x86_64-apple-darwin* ]]; then
     export MACOSX_DEPLOYMENT_TARGET=10.15
 fi
 
+echo "sysroot = ${sysroot}"
+echo "our sysroot = /opt/${target}/${target}/sys-root/"
+
 cd $WORKSPACE/srcdir
 
 cmake -B build \

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -15,8 +15,8 @@
 
 using BinaryBuilder
 
-HELICS_VERSION = v"3.1.2"
-HELICS_SHA = "83ca23e8d313672c738d0251d0b316e5754c6d864dbe427ab6dbb3d270e7c2b0"
+HELICS_VERSION = v"3.3.2"
+HELICS_SHA = "b04013969fc02dc36c697c328e6f50a0ac8dbdaf3d3e69870cd6e6ebeb374286"
 
 sources = [
     ArchiveSource("https://github.com/GMLC-TDC/HELICS/releases/download/v$HELICS_VERSION/Helics-v$HELICS_VERSION-source.tar.gz",

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -21,15 +21,20 @@ HELICS_SHA = "b04013969fc02dc36c697c328e6f50a0ac8dbdaf3d3e69870cd6e6ebeb374286"
 sources = [
     ArchiveSource("https://github.com/GMLC-TDC/HELICS/releases/download/v$HELICS_VERSION/Helics-v$HELICS_VERSION-source.tar.gz",
                   "$HELICS_SHA"),
+    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
+                  "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
 ]
 
 script = raw"""
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
+    # Install a newer SDK which supports `std::filesystem`
+    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
+    rm -rf /opt/${target}/${target}/sys-root/System
+    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
+    cp -ra System "/opt/${target}/${target}/sys-root/."
+    popd
     export MACOSX_DEPLOYMENT_TARGET=10.15
 fi
-
-echo "sysroot = ${sysroot}"
-echo "our sysroot = /opt/${target}/${target}/sys-root/"
 
 cd $WORKSPACE/srcdir
 

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -38,13 +38,16 @@ fi
 
 cd $WORKSPACE/srcdir
 
-mkdir build
-cd build
-CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH="${prefix}" -DCMAKE_INSTALL_PREFIX="${prefix}" -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TARGET_TOOLCHAIN" -DCMAKE_BUILD_TYPE=Release"
-HELICS_ARGS="-DHELICS_BUILD_TESTS=OFF"
-cmake ${CMAKE_ARGS} ${HELICS_ARGS} ..
-make -j${nproc}
-make install
+cmake -B build \
+   -DCMAKE_FIND_ROOT_PATH="${prefix}" \
+   -DCMAKE_INSTALL_PREFIX="${prefix}" \
+   -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TARGET_TOOLCHAIN" \
+   -DCMAKE_BUILD_TYPE=Release \
+   -DHELICS_BUILD_TESTS=OFF \
+   ./
+
+VERBOSE=ON cmake --build build --config Release --target install -- -j${nproc}
+
 if [[ "${target}" == *-mingw* ]]; then
     # Remove a broken link that we don't need anyway
     rm ${prefix}/bin/libzmq.dll.a

--- a/H/HELICS/build_tarballs.jl
+++ b/H/HELICS/build_tarballs.jl
@@ -21,21 +21,9 @@ HELICS_SHA = "b04013969fc02dc36c697c328e6f50a0ac8dbdaf3d3e69870cd6e6ebeb374286"
 sources = [
     ArchiveSource("https://github.com/GMLC-TDC/HELICS/releases/download/v$HELICS_VERSION/Helics-v$HELICS_VERSION-source.tar.gz",
                   "$HELICS_SHA"),
-    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
-                  "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
 ]
 
 script = raw"""
-if [[ "${target}" == x86_64-apple-darwin* ]]; then
-    # Install a newer SDK which supports `std::filesystem`
-    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
-    rm -rf /opt/${target}/${target}/sys-root/System
-    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
-    cp -ra System "/opt/${target}/${target}/sys-root/."
-    export MACOSX_DEPLOYMENT_TARGET=10.15
-    popd
-fi
-
 cd $WORKSPACE/srcdir
 
 cmake -B build \


### PR DESCRIPTION
This PR supercedes #3644, #3645, and #4205.

Changes:
- Get HELICS package working again for the latest HELICS 3.x release (3.3.2)
- Use gcc v9 to address bug with mingw std::filesystem library on older versions of gcc
- Use MacOSX 10.15 SDK on Intel mac builds to address issues with std::filesystem library on older versions of macOS
- Enable FreeBSD builds (CI system for HELICS has tested FreeBSD for some time now)
- Remove build support for HELICS 2.x, which is no longer supported/receiving updates

Squash/merge commit message should include the line (at the end of the commit message):
`Co-authored-by: Dheepak Krishnamurthy <me@kdheepak.com>`