### PR TITLE
Don't build the crun library.

### DIFF
--- a/C/crun/build_tarballs.jl
+++ b/C/crun/build_tarballs.jl
@@ -24,7 +24,6 @@ install_license COPYING
 
 ./autogen.sh
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
-            --enable-shared --enable-dynamic \
             --disable-criu # missing JLL
 make -j${nproc}
 make install
@@ -43,8 +42,7 @@ end
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("crun", :crun),
-    LibraryProduct("libcrun", :libcrun)
+    ExecutableProduct("crun", :crun)
 ]
 
 # Dependencies that must be installed before this package can be built
@@ -61,4 +59,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"7", dont_dlopen=true)
+               julia_compat="1.6", preferred_gcc_version=v"7")


### PR DESCRIPTION
`libcrun` is an interesting library, in that it completely breaks Julia when `dlopen`ed:

```
julia> using Libdl

julia> Libdl.dlopen("/home/tim/Julia/depot/artifacts/682a441bd76a9926b58816127b0085eed6e26604/lib/libcrun.so")
/home/tim/Julia/depot/juliaup/julia-1.8.3+0.x64.linux.gnu/bin/julia: error while loading shared libraries: libjulia.so.1: cannot open shared object file: No such file or directory
❯
```

For some reason, loading the library triggers a search for `libjulia` in system directories:

```
   2985658:	calling init: /home/tim/Julia/depot/artifacts/682a441bd76a9926b58816127b0085eed6e26604/lib/libcrun.so
   2985658:
   2985658:	find library=libdl.so.2 [0]; searching
   2985658:	 search path=/memfd:crun_cloned:/proc/self/../lib/glibc-hwcaps/x86-64-v3:/memfd:crun_cloned:/proc/self/../lib/glibc-hwcaps/x86-64-v2:/memfd:crun_cloned:/proc/self/../lib/tls/x86_64/x86_64:/memfd:crun_cloned:/proc/self/../lib/tls/x86_64:/memfd:crun_cloned:/proc/self/../lib/tls/x86_64:/memfd:crun_cloned:/proc/self/../lib/tls:/memfd:crun_cloned:/proc/self/../lib/x86_64/x86_64:/memfd:crun_cloned:/proc/self/../lib/x86_64:/memfd:crun_cloned:/proc/self/../lib/x86_64:/memfd:crun_cloned:/proc/self/../lib:/memfd:crun_cloned:/proc/self/../lib/julia/glibc-hwcaps/x86-64-v3:/memfd:crun_cloned:/proc/self/../lib/julia/glibc-hwcaps/x86-64-v2:/memfd:crun_cloned:/proc/self/../lib/julia/tls/x86_64/x86_64:/memfd:crun_cloned:/proc/self/../lib/julia/tls/x86_64:/memfd:crun_cloned:/proc/self/../lib/julia/tls/x86_64:/memfd:crun_cloned:/proc/self/../lib/julia/tls:/memfd:crun_cloned:/proc/self/../lib/julia/x86_64/x86_64:/memfd:crun_cloned:/proc/self/../lib/julia/x86_64:/memfd:crun_cloned:/proc/self/../lib/julia/x86_64:/memfd:crun_cloned:/proc/self/../lib/julia		(RPATH from file /home/tim/Julia/depot/juliaup/julia-1.8.3+0.x64.linux.gnu/bin/julia)
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/glibc-hwcaps/x86-64-v3/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/glibc-hwcaps/x86-64-v2/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/tls/x86_64/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/tls/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/tls/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/tls/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/x86_64/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/glibc-hwcaps/x86-64-v3/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/glibc-hwcaps/x86-64-v2/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/tls/x86_64/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/tls/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/tls/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/tls/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/x86_64/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/x86_64/libdl.so.2
   2985658:	  trying file=/memfd:crun_cloned:/proc/self/../lib/julia/libdl.so.2
   2985658:	 search cache=/etc/ld.so.cache
   2985658:	  trying file=/usr/lib/libdl.so.2
   2985658:
   2985658:	find library=libpthread.so.0 [0]; searching
   2985658:	 search cache=/etc/ld.so.cache
   2985658:	  trying file=/usr/lib/libpthread.so.0
   2985658:
   2985658:	find library=libc.so.6 [0]; searching
   2985658:	 search cache=/etc/ld.so.cache
   2985658:	  trying file=/usr/lib/libc.so.6
   2985658:
   2985658:	find library=libjulia.so.1 [0]; searching
   2985658:	 search cache=/etc/ld.so.cache
   2985658:	 search path=/usr/lib/glibc-hwcaps/x86-64-v3:/usr/lib/glibc-hwcaps/x86-64-v2:/usr/lib/tls/x86_64/x86_64:/usr/lib/tls/x86_64:/usr/lib/tls/x86_64:/usr/lib/tls:/usr/lib/x86_64/x86_64:/usr/lib/x86_64:/usr/lib/x86_64:/usr/lib		(system search path)
   2985658:	  trying file=/usr/lib/glibc-hwcaps/x86-64-v3/libjulia.so.1
   2985658:	  trying file=/usr/lib/glibc-hwcaps/x86-64-v2/libjulia.so.1
   2985658:	  trying file=/usr/lib/tls/x86_64/x86_64/libjulia.so.1
   2985658:	  trying file=/usr/lib/tls/x86_64/libjulia.so.1
   2985658:	  trying file=/usr/lib/tls/x86_64/libjulia.so.1
   2985658:	  trying file=/usr/lib/tls/libjulia.so.1
   2985658:	  trying file=/usr/lib/x86_64/x86_64/libjulia.so.1
   2985658:	  trying file=/usr/lib/x86_64/libjulia.so.1
   2985658:	  trying file=/usr/lib/x86_64/libjulia.so.1
   2985658:	  trying file=/usr/lib/libjulia.so.1
   2985658:
/home/tim/Julia/depot/juliaup/julia-1.8.3+0.x64.linux.gnu/bin/julia: error while loading shared libraries: libjulia.so.1: cannot open shared object file: No such file or directory
```

Since I don't currently have plans to ccall libcrun directly, let's just drop the library. FWIW, this also happens with the `libcrun` packaged by Arch, so doesn't seem related to our glibc/systemd handling.