### PR TITLE
[libjlnode] Update to v18.0.0. Add support for Windows/macOS

### DIFF
--- a/L/libjlnode/build_tarballs.jl
+++ b/L/libjlnode/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "libjlnode"
-version = v"16.1.0"
+version = v"18.0.0"
 
 # Collection of sources required to complete build
 sources = [

--- a/L/libjlnode/build_tarballs.jl
+++ b/L/libjlnode/build_tarballs.jl
@@ -7,14 +7,37 @@ version = v"16.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/sunoru/jlnode/archive/refs/tags/v$version.tar.gz", "18ae255bf47c21187ba882d80ac19909ab0fcb23fa587b5f4f1043d43208521c"),
-    ArchiveSource("https://github.com/nodejs/node-addon-api/archive/refs/tags/v5.0.0.tar.gz", "2bdf9c540f67c43036d58b3146e61b437148939efc8d4cde2d1314fdaeb39e9b")
+    ArchiveSource("https://github.com/sunoru/jlnode/archive/refs/tags/v$version.tar.gz", "82991ee31522e89179dd0f9c1b43a0d9f5c5f28932440f32e8580f2d28ce5fda"),
+    ArchiveSource("https://github.com/nodejs/node-addon-api/archive/refs/tags/v5.0.0.tar.gz", "2bdf9c540f67c43036d58b3146e61b437148939efc8d4cde2d1314fdaeb39e9b"),
+    ArchiveSource(
+        "https://github.com/sunoru/jlnode/releases/download/v$(version)/Windows-dist.zip",
+        "072ee1ea8df849e24581a2a016a425fedd1b33d7e4d6336ff566629c2798ae8e",
+        unpack_target = "x86_64-w64-mingw32"
+    ),
+    ArchiveSource(
+        "https://github.com/sunoru/jlnode/releases/download/v$(version)/macOS-dist.zip",
+        "fb2c809aef9941bf2a113a5a897589257d6f90514a17d304aad922c03672614d",
+        unpack_target = "x86_64-apple-darwin14"
+    ),
 ]
 
-# Bash recipe for building across all platforms
-script = raw"""
-cd $WORKSPACE/srcdir
+w64_script = raw"""
+cd ${target}
+mkdir -p ${bindir}
+mv lib/*.dll ${bindir}/
+mv lib ${prefix}/
+cd ../jlnode-*
+install_license /LICENSE.md
+"""
 
+mac_script = raw"""
+cd ${target}
+mv * ${prefix}/
+cd ../jlnode-*
+install_license ./LICENSE.md
+"""
+
+linux_script = raw"""
 cd node-addon-api-*
 export NAPI_INC=`pwd`
 
@@ -33,6 +56,20 @@ cmake --install .
 install_license ../LICENSE.md
 """
 
+script = """
+cd \$WORKSPACE/srcdir
+if [[ \$target == *w64* ]]
+then
+    $w64_script
+elif [[ \$target == *apple* ]]
+then
+    $mac_script
+elif [[ \$target == *linux* ]]
+then
+    $linux_script
+fi
+"""
+
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
@@ -42,10 +79,10 @@ platforms = [
     Platform("x86_64", "linux"; libc="musl"),
     Platform("aarch64", "linux"; libc="musl"),
 
-    # Platform("x86_64", "macos"),
+    Platform("x86_64", "macos"),
     # Platform("aarch64", "macos"),
 
-    # Platform("x86_64", "windows"),
+    Platform("x86_64", "windows"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 
@@ -57,7 +94,7 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
-    Dependency("libnode_jll", v"16.14.0", compat="16")
+    Dependency("libnode_jll", v"18.12.1", compat="18")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libjlnode/build_tarballs.jl
+++ b/L/libjlnode/build_tarballs.jl
@@ -26,14 +26,14 @@ cd ${target}/*-dist
 mkdir -p ${bindir}
 mv lib/*.dll ${bindir}/
 mv lib ${prefix}/
-cd ../jlnode-*
+cd ../../jlnode-*
 install_license /LICENSE.md
 """
 
 mac_script = raw"""
 cd ${target}/*-dist
 mv * ${prefix}/
-cd ../jlnode-*
+cd ../../jlnode-*
 install_license ./LICENSE.md
 """
 

--- a/L/libjlnode/build_tarballs.jl
+++ b/L/libjlnode/build_tarballs.jl
@@ -22,7 +22,7 @@ sources = [
 ]
 
 w64_script = raw"""
-cd ${target}
+cd ${target}/*-dist
 mkdir -p ${bindir}
 mv lib/*.dll ${bindir}/
 mv lib ${prefix}/
@@ -31,7 +31,7 @@ install_license /LICENSE.md
 """
 
 mac_script = raw"""
-cd ${target}
+cd ${target}/*-dist
 mv * ${prefix}/
 cd ../jlnode-*
 install_license ./LICENSE.md

--- a/L/libjlnode/build_tarballs.jl
+++ b/L/libjlnode/build_tarballs.jl
@@ -27,12 +27,12 @@ mkdir -p ${bindir}
 mv lib/*.dll ${bindir}/
 mv lib ${prefix}/
 cd ../../jlnode-*
-install_license /LICENSE.md
+install_license ./LICENSE.md
 """
 
 mac_script = raw"""
 cd ${target}/*-dist
-mv * ${prefix}/
+mv lib/* ${prefix}/lib/
 cd ../../jlnode-*
 install_license ./LICENSE.md
 """


### PR DESCRIPTION
An approach similar to #5859 is used here since they can't be cross-compiled