### PR TITLE
glib: also generate static libraries.

### DIFF
--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -35,6 +35,7 @@ atomic_patch -p1 ../patches/utimensat-macos.patch
 mkdir build_glib && cd build_glib
 
 meson --cross-file="${MESON_TARGET_TOOLCHAIN}" \
+    --default-library both \
     --buildtype=release \
     -Dman=false \
     "${MESON_FLAGS[@]}" \

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -15,6 +15,9 @@ script = raw"""
 cd $WORKSPACE/srcdir/glib-*/
 install_license COPYING
 
+# meson shouldn't be so opinionated (mesonbuild/meson#4542 is incomplete)
+sed -i '/Werror=unused-command-line-argument/d' /usr/lib/python3.9/site-packages/mesonbuild/compilers/mixins/clang.py
+
 if [[ "${target}" == *-freebsd* ]]; then
     # Our FreeBSD libc has `environ` as undefined symbol, so the linker will
     # complain if this symbol is used in the built library, even if this won't


### PR DESCRIPTION
I need the `.a`'s to compile qemu statically. It's not ideal to ship these to users, but lacking separate dev JLLs this is the only solution for now, and it's only a couple of MBs.