### PR TITLE
PCRE2: Build static libraries.

### DIFF
--- a/P/PCRE2/build_tarballs.jl
+++ b/P/PCRE2/build_tarballs.jl
@@ -27,7 +27,6 @@ update_configure_scripts
 export CFLAGS="${CFLAGS} -O3"
 
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
-    --disable-static \
     --enable-jit \
     --enable-pcre2-16 \
     --enable-pcre2-32


### PR DESCRIPTION
x86_64-linux-glibc artifact size increases from 1.5 to 2.3MB, which seems acceptable:

```
-rw-r--r-- 1 tim tim 794K Jan  1  1970 libpcre2-16.a
-rw-r--r-- 1 tim tim 768K Jan  1  1970 libpcre2-32.a
-rw-r--r-- 1 tim tim 846K Jan  1  1970 libpcre2-8.a
-rw-r--r-- 1 tim tim 6.9K Jan  1  1970 libpcre2-posix.a
```
