### PR TITLE
libiconv: Build static libraries.

### DIFF
--- a/L/Libiconv/build_tarballs.jl
+++ b/L/Libiconv/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = "VERSION=$(version.major).$(version.minor)\n" * raw"""
 cd $WORKSPACE/srcdir/libiconv-*/
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static --enable-extra-encodings
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-static --enable-extra-encodings
 make -j${nproc}
 make install
 


### PR DESCRIPTION
Inflates the x86_64-linux-glibc artifact size from 1 to 1.9MB. Not great, not terrible.

Note that we'll eventually want to move these out, e.g. using https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/778, but in the meantime let's just put these in main JLL.