### PR TITLE
qemu: add recipe for statically-built user-mode emulation binaries.

### DIFF
--- a/Q/Qemu_static/build_tarballs.jl
+++ b/Q/Qemu_static/build_tarballs.jl
@@ -1,0 +1,93 @@
+# statically-compiled QEMU binaries, suitable for e.g. use within a container.
+
+using BinaryBuilder, BinaryBuilderBase, Pkg
+
+name = "Qemu_static"
+version = v"7.1.0"
+
+# Collection of sources required to build libffi
+sources = [
+    ArchiveSource("https://download.qemu.org/qemu-$(version).tar.xz",
+                  "a0634e536bded57cf38ec8a751adb124b89c776fe0846f21ab6c6728f1cbbbe6"),
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/qemu-*
+install_license COPYING
+
+# check if we need to use a more recent glibc
+if [[ -f "$prefix/usr/include/sched.h" ]]; then
+    GLIBC_ARTIFACT_DIR=$(dirname $(dirname $(dirname $(realpath $prefix/usr/include/sched.h))))
+    rsync --archive ${GLIBC_ARTIFACT_DIR}/ /opt/${target}/${target}/sys-root/
+fi
+
+# include `falloc` header in `strace.c` (requires glibc 2.25)
+atomic_patch -p1 "${WORKSPACE}/srcdir/patches/qemu_falloc.patch"
+
+if [[ "${target}" == *-*-musl ]]; then
+    # fix messy header situation on musl
+    atomic_patch -p1 "${WORKSPACE}/srcdir/patches/qemu_syscall.patch"
+
+    # include kernel headers for a definition of speculation control prctls (musl 1.1.20)
+    sed -i 's/#include <sys\/prctl.h>/#include <linux\/prctl.h>/g' linux-user/syscall.c
+fi
+
+# disable tests
+atomic_patch -p1 "${WORKSPACE}/srcdir/patches/qemu_disable_tests.patch"
+
+# properly link to rt
+#atomic_patch -p1 "${WORKSPACE}/srcdir/patches/qemu_link_rt.patch"
+
+# recurse on execve
+atomic_patch -p1 "${WORKSPACE}/srcdir/patches/qemu_execve.patch"
+
+./configure --prefix=$prefix --host-cc="${HOSTCC}" \
+    --extra-cflags="-I${prefix}/include -Wno-unused-result" \
+    --target-list="aarch64-linux-user ppc64le-linux-user i386-linux-user x86_64-linux-user arm-linux-user" \
+    --static
+
+make -j${nproc}
+
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="musl"),
+]
+platforms = expand_cxxstring_abis(platforms)
+
+# some platforms need a newer glibc, because the default one is too old
+glibc_platforms = filter(platforms) do p
+    libc(p) == "glibc" && proc_family(p) in ["intel", "power"]
+end
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("qemu-aarch64"            , :qemu_aarch64            ),
+    ExecutableProduct("qemu-arm"                , :qemu_arm                ),
+    ExecutableProduct("qemu-i386"               , :qemu_i386               ),
+    ExecutableProduct("qemu-ppc64le"            , :qemu_ppc64le            ),
+    ExecutableProduct("qemu-x86_64"             , :qemu_x86_64             ),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    BuildDependency("Glib_jll"),
+    BuildDependency("PCRE2_jll"),
+    BuildDependency("Libiconv_jll"),
+
+    # qemu needs glibc >=2.14 for CLOCK_BOOTTIME
+    BuildDependency(PackageSpec(name = "Glibc_jll", version = v"2.17");
+                    platforms=glibc_platforms),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"8", julia_compat="1.6",
+               lock_microarchitecture=false)

--- a/Q/Qemu_static/bundled/patches/qemu_disable_tests.patch
+++ b/Q/Qemu_static/bundled/patches/qemu_disable_tests.patch
@@ -1,0 +1,22 @@
+--- a/meson.build
++++ b/meson.build
+@@ -2620,8 +2620,8 @@
+ specific_ss.add_all(when: 'CONFIG_LINUX_USER', if_true: linux_user_ss)
+ 
+ # needed for fuzzing binaries
+-subdir('tests/qtest/libqos')
+-subdir('tests/qtest/fuzz')
++#subdir('tests/qtest/libqos')
++#subdir('tests/qtest/fuzz')
+ 
+ # accel modules
+ tcg_real_module_ss = ss.source_set()
+@@ -3107,7 +3107,7 @@
+ subdir('tools')
+ subdir('pc-bios')
+ subdir('docs')
+-subdir('tests')
++#subdir('tests')
+ if gtk.found()
+   subdir('po')
+ endif

--- a/Q/Qemu_static/bundled/patches/qemu_execve.patch
+++ b/Q/Qemu_static/bundled/patches/qemu_execve.patch
@@ -1,0 +1,359 @@
+From 5c38ea8c40cb8da1703051a482a4db755180df9e Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Sun, 11 Dec 2022 12:54:36 +0100
+Subject: [PATCH] linux-user: add option to intercept execve() syscalls
+
+In order for one to use QEMU user mode emulation under a chroot, it is
+required to use binfmt_misc. This can be avoided by QEMU never doing a
+raw execve() to the host system.
+
+Introduce a new option, -execve, that uses the current QEMU interpreter
+to intercept execve().
+
+qemu_execve() will prepend the interpreter path , similar to what
+binfmt_misc would do, and then pass the modified execve() to the host.
+
+It is necessary to parse hashbang scripts in that function otherwise
+the kernel will try to run the interpreter of a script without QEMU and
+get an invalid exec format error.
+
+Authored-by: Petros Angelatos <petrosagg@resin.io>
+---
+ linux-user/main.c           |  35 ++++++++
+ linux-user/syscall.c        | 164 +++++++++++++++++++++++++++++++-----
+ linux-user/user-internals.h |   1 +
+ 3 files changed, 177 insertions(+), 23 deletions(-)
+
+diff --git a/linux-user/main.c b/linux-user/main.c
+index e44bdb17b8..5bb6a9d183 100644
+--- a/linux-user/main.c
++++ b/linux-user/main.c
+@@ -123,6 +123,7 @@ static void usage(int exitcode);
+ 
+ static const char *interp_prefix = CONFIG_QEMU_INTERP_PREFIX;
+ const char *qemu_uname_release;
++const char *qemu_execve_path;
+ 
+ /* XXX: on x86 MAP_GROWSDOWN only works if ESP <= address + 32, so
+    we allocate a bigger stack. Need a better solution, for example
+@@ -356,6 +357,38 @@ static void handle_arg_guest_base(const char *arg)
+     have_guest_base = true;
+ }
+ 
++static void handle_arg_execve(const char *arg)
++{
++    const char *execfn;
++    char buf[PATH_MAX];
++    char *ret;
++    int len;
++
++    /* try getauxval() */
++    execfn = (const char *) qemu_getauxval(AT_EXECFN);
++
++    if (execfn != 0) {
++        ret = realpath(execfn, buf);
++
++        if (ret != NULL) {
++            qemu_execve_path = strdup(buf);
++            return;
++        }
++    }
++
++    /* try /proc/self/exe */
++    len = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
++
++    if (len != -1) {
++        buf[len] = '\0';
++        qemu_execve_path = strdup(buf);
++        return;
++    }
++
++    fprintf(stderr, "qemu_execve: unable to determine intepreter's path\n");
++    exit(EXIT_FAILURE);
++}
++
+ static void handle_arg_reserved_va(const char *arg)
+ {
+     char *p;
+@@ -458,6 +491,8 @@ static const struct qemu_argument arg_table[] = {
+      "uname",      "set qemu uname release string to 'uname'"},
+     {"B",          "QEMU_GUEST_BASE",  true,  handle_arg_guest_base,
+      "address",    "set guest_base address to 'address'"},
++    {"execve",     "QEMU_EXECVE",      false, handle_arg_execve,
++     "",           "use this interpreter when a process calls execve()"},
+     {"R",          "QEMU_RESERVED_VA", true,  handle_arg_reserved_va,
+      "size",       "reserve 'size' bytes for guest virtual address space"},
+     {"d",          "QEMU_LOG",         true,  handle_arg_log,
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index f409121202..7d57d6edde 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -62,6 +62,7 @@
+ #include <linux/in6.h>
+ #include <linux/errqueue.h>
+ #include <linux/random.h>
++#include <linux/binfmts.h>
+ #ifdef CONFIG_TIMERFD
+ #include <sys/timerfd.h>
+ #endif
+@@ -1010,7 +1011,7 @@ static inline rlim_t target_to_host_rlim(abi_ulong target_rlim)
+ {
+     abi_ulong target_rlim_swap;
+     rlim_t result;
+-    
++
+     target_rlim_swap = tswapal(target_rlim);
+     if (target_rlim_swap == TARGET_RLIM_INFINITY)
+         return RLIM_INFINITY;
+@@ -1018,7 +1019,7 @@ static inline rlim_t target_to_host_rlim(abi_ulong target_rlim)
+     result = target_rlim_swap;
+     if (target_rlim_swap != (rlim_t)result)
+         return RLIM_INFINITY;
+-    
++
+     return result;
+ }
+ #endif
+@@ -1028,13 +1029,13 @@ static inline abi_ulong host_to_target_rlim(rlim_t rlim)
+ {
+     abi_ulong target_rlim_swap;
+     abi_ulong result;
+-    
++
+     if (rlim == RLIM_INFINITY || rlim != (abi_long)rlim)
+         target_rlim_swap = TARGET_RLIM_INFINITY;
+     else
+         target_rlim_swap = rlim;
+     result = tswapal(target_rlim_swap);
+-    
++
+     return result;
+ }
+ #endif
+@@ -1761,9 +1762,9 @@ static inline abi_long target_to_host_cmsg(struct msghdr *msgh,
+     abi_ulong target_cmsg_addr;
+     struct target_cmsghdr *target_cmsg, *target_cmsg_start;
+     socklen_t space = 0;
+-    
++
+     msg_controllen = tswapal(target_msgh->msg_controllen);
+-    if (msg_controllen < sizeof (struct target_cmsghdr)) 
++    if (msg_controllen < sizeof (struct target_cmsghdr))
+         goto the_end;
+     target_cmsg_addr = tswapal(target_msgh->msg_control);
+     target_cmsg = lock_user(VERIFY_READ, target_cmsg_addr, msg_controllen, 1);
+@@ -1849,7 +1850,7 @@ static inline abi_long host_to_target_cmsg(struct target_msghdr *target_msgh,
+     socklen_t space = 0;
+ 
+     msg_controllen = tswapal(target_msgh->msg_controllen);
+-    if (msg_controllen < sizeof (struct target_cmsghdr)) 
++    if (msg_controllen < sizeof (struct target_cmsghdr))
+         goto the_end;
+     target_cmsg_addr = tswapal(target_msgh->msg_control);
+     target_cmsg = lock_user(VERIFY_WRITE, target_cmsg_addr, msg_controllen, 0);
+@@ -6160,7 +6161,7 @@ abi_long do_set_thread_area(CPUX86State *env, abi_ulong ptr)
+     }
+     unlock_user_struct(target_ldt_info, ptr, 1);
+ 
+-    if (ldt_info.entry_number < TARGET_GDT_ENTRY_TLS_MIN || 
++    if (ldt_info.entry_number < TARGET_GDT_ENTRY_TLS_MIN ||
+         ldt_info.entry_number > TARGET_GDT_ENTRY_TLS_MAX)
+            return -TARGET_EINVAL;
+     seg_32bit = ldt_info.flags & 1;
+@@ -6238,7 +6239,7 @@ static abi_long do_get_thread_area(CPUX86State *env, abi_ulong ptr)
+     lp = (uint32_t *)(gdt_table + idx);
+     entry_1 = tswap32(lp[0]);
+     entry_2 = tswap32(lp[1]);
+-    
++
+     read_exec_only = ((entry_2 >> 9) & 1) ^ 1;
+     contents = (entry_2 >> 10) & 3;
+     seg_not_present = ((entry_2 >> 15) & 1) ^ 1;
+@@ -6254,8 +6255,8 @@ static abi_long do_get_thread_area(CPUX86State *env, abi_ulong ptr)
+         (read_exec_only << 3) | (limit_in_pages << 4) |
+         (seg_not_present << 5) | (useable << 6) | (lm << 7);
+     limit = (entry_1 & 0xffff) | (entry_2  & 0xf0000);
+-    base_addr = (entry_1 >> 16) | 
+-        (entry_2 & 0xff000000) | 
++    base_addr = (entry_1 >> 16) |
++        (entry_2 & 0xff000000) |
+         ((entry_2 & 0xff) << 16);
+     target_ldt_info->base_addr = tswapal(base_addr);
+     target_ldt_info->limit = tswap32(limit);
+@@ -8397,6 +8398,133 @@ static int host_to_target_cpu_mask(const unsigned long *host_mask,
+     return 0;
+ }
+ 
++/* qemu_execve() Must return target values and target errnos. */
++static abi_long qemu_execve(char *filename, char *argv[],
++                  char *envp[])
++{
++    char *i_arg = NULL, *i_name = NULL;
++    char **new_argp;
++    const char *new_filename;
++    int argc, fd, ret, i, qemu_args = 5, exec_args = 1;
++    char *cp;
++    char buf[BINPRM_BUF_SIZE];
++
++    /* normal execve case */
++    if (qemu_execve_path == NULL || *qemu_execve_path == 0) {
++        new_filename = filename;
++        new_argp = argv;
++    } else {
++        new_filename = qemu_execve_path;
++
++        for (argc = 0; argv[argc] != NULL; argc++) {
++            /* nothing */ ;
++        }
++
++        fd = open(filename, O_RDONLY);
++        if (fd == -1) {
++            return get_errno(fd);
++        }
++
++        ret = read(fd, buf, BINPRM_BUF_SIZE);
++        if (ret == -1) {
++            close(fd);
++            return get_errno(ret);
++        }
++
++        /* if we have less than 2 bytes, we can guess it is not executable */
++        if (ret < 2) {
++            close(fd);
++            return -host_to_target_errno(ENOEXEC);
++        }
++
++        close(fd);
++
++        /* shebang detection
++         * adapted from the kernel
++         * https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/fs/binfmt_script.c
++         */
++        if ((buf[0] == '#') && (buf[1] == '!')) {
++            buf[BINPRM_BUF_SIZE - 1] = '\0';
++            cp = strchr(buf, '\n');
++            if (cp == NULL) {
++                cp = buf + BINPRM_BUF_SIZE - 1;
++            }
++            *cp = '\0';
++            while (cp > buf) {
++                cp--;
++                if ((*cp == ' ') || (*cp == '\t')) {
++                    *cp = '\0';
++                } else {
++                    break;
++                }
++            }
++            for (cp = buf + 2; (*cp == ' ') || (*cp == '\t'); cp++) {
++                /* nothing */ ;
++            }
++            if (*cp == '\0') {
++                return -ENOEXEC; /* No interpreter name found */
++            }
++            i_name = cp;
++            i_arg = NULL;
++            for ( ; *cp && (*cp != ' ') && (*cp != '\t'); cp++) {
++                /* nothing */ ;
++            }
++            while ((*cp == ' ') || (*cp == '\t')) {
++                *cp++ = '\0';
++            }
++            if (*cp) {
++                i_arg = cp;
++            }
++
++            if (i_arg) {
++                exec_args = 3;
++            } else {
++                exec_args = 2;
++            }
++        }
++
++        new_argp = alloca((qemu_args + exec_args + argc + 1) * sizeof(void *));
++
++        /* set qemu args */
++        new_argp[0] = strdup(qemu_execve_path);
++        new_argp[1] = strdup("-execve");
++        new_argp[2] = strdup("-L");
++        new_argp[3] = strdup(path("/"));
++        new_argp[4] = strdup("-0");
++
++        /* set execution args */
++        if (i_name) {
++            new_argp[qemu_args] = i_name;
++            new_argp[qemu_args + 1] = i_name;
++
++            if (i_arg) {
++                new_argp[qemu_args + 2] = i_arg;
++            }
++        } else {
++            new_argp[qemu_args] = argv[0];
++        }
++        new_argp[qemu_args+exec_args] = filename;
++
++        /* set application args */
++        for (i = 1; i < argc; i++) {
++            new_argp[qemu_args + exec_args + i] = argv[i];
++        }
++        new_argp[qemu_args + exec_args + argc] = NULL;
++    }
++
++    /* Although execve() is not an interruptible syscall it is
++     * a special case where we must use the safe_syscall wrapper:
++     * if we allow a signal to happen before we make the host
++     * syscall then we will 'lose' it, because at the point of
++     * execve the process leaves QEMU's control. So we use the
++     * safe syscall wrapper to ensure that we either take the
++     * signal as a guest signal, or else it does not happen
++     * before the execve completes and makes it the other
++     * program's problem.
++     */
++    return get_errno(safe_execve(new_filename, new_argp, envp));
++}
++
+ #ifdef TARGET_NR_getdents
+ static int do_getdents(abi_long dirfd, abi_long arg2, abi_long count)
+ {
+@@ -8833,17 +8961,7 @@ static abi_long do_syscall1(CPUArchState *cpu_env, int num, abi_long arg1,
+ 
+             if (!(p = lock_user_string(arg1)))
+                 goto execve_efault;
+-            /* Although execve() is not an interruptible syscall it is
+-             * a special case where we must use the safe_syscall wrapper:
+-             * if we allow a signal to happen before we make the host
+-             * syscall then we will 'lose' it, because at the point of
+-             * execve the process leaves QEMU's control. So we use the
+-             * safe syscall wrapper to ensure that we either take the
+-             * signal as a guest signal, or else it does not happen
+-             * before the execve completes and makes it the other
+-             * program's problem.
+-             */
+-            ret = get_errno(safe_execve(p, argp, envp));
++            ret = qemu_execve(p, argp, envp);
+             unlock_user(p, arg1, 0);
+ 
+             goto execve_end;
+@@ -11360,7 +11478,7 @@ static abi_long do_syscall1(CPUArchState *cpu_env, int num, abi_long arg1,
+         return get_errno(fchown(arg1, low2highuid(arg2), low2highgid(arg3)));
+ #if defined(TARGET_NR_fchownat)
+     case TARGET_NR_fchownat:
+-        if (!(p = lock_user_string(arg2))) 
++        if (!(p = lock_user_string(arg2)))
+             return -TARGET_EFAULT;
+         ret = get_errno(fchownat(arg1, p, low2highuid(arg3),
+                                  low2highgid(arg4), arg5));
+diff --git a/linux-user/user-internals.h b/linux-user/user-internals.h
+index 0280e76add..7586971298 100644
+--- a/linux-user/user-internals.h
++++ b/linux-user/user-internals.h
+@@ -27,6 +27,7 @@ void init_task_state(TaskState *ts);
+ void task_settid(TaskState *);
+ void stop_all_tasks(void);
+ extern const char *qemu_uname_release;
++extern const char *qemu_execve_path;
+ extern unsigned long mmap_min_addr;
+ 
+ typedef struct IOCTLEntry IOCTLEntry;
+-- 
+2.38.1
+

--- a/Q/Qemu_static/bundled/patches/qemu_falloc.patch
+++ b/Q/Qemu_static/bundled/patches/qemu_falloc.patch
@@ -1,0 +1,13 @@
+--- a/linux-user/strace.c
++++ b/linux-user/strace.c
+@@ -18,6 +18,10 @@
+ #include "user-internals.h"
+ #include "strace.h"
+ 
++#if defined(CONFIG_FALLOCATE_PUNCH_HOLE) || defined(CONFIG_FALLOCATE_ZERO_RANGE)
++#include <linux/falloc.h>
++#endif
++
+ struct syscallname {
+     int nr;
+     const char *name;

--- a/Q/Qemu_static/bundled/patches/qemu_syscall.patch
+++ b/Q/Qemu_static/bundled/patches/qemu_syscall.patch
@@ -1,0 +1,61 @@
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index f1cfcc810..52cfe29d6 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -49,6 +49,7 @@
+ #include <sys/statfs.h>
+ #include <utime.h>
+ #include <sys/sysinfo.h>
++#define _LINUX_SYSINFO_H
+ #include <sys/signalfd.h>
+ //#include <sys/user.h>
+ #include <netinet/in.h>
+@@ -7281,12 +7282,47 @@ static inline abi_long host_to_target_timex64(abi_long target_addr,
+ #endif
+ 
+ #ifndef HAVE_SIGEV_NOTIFY_THREAD_ID
++typedef union _sigval {
++	int sival_int;
++	void *sival_ptr;
++} sigval_t;
++
++/*
++ * This works because the alignment is ok on all current architectures
++ * but we leave open this being overridden in the future
++ */
++#ifndef __ARCH_SIGEV_PREAMBLE_SIZE
++#define __ARCH_SIGEV_PREAMBLE_SIZE	(sizeof(int) * 2 + sizeof(sigval_t))
++#endif
++
++#define SIGEV_MAX_SIZE	64
++#define SIGEV_PAD_SIZE	((SIGEV_MAX_SIZE - __ARCH_SIGEV_PREAMBLE_SIZE) \
++		/ sizeof(int))
++
++typedef struct _sigevent {
++	sigval_t sigev_value;
++	int sigev_signo;
++	int sigev_notify;
++	union {
++		int _pad[SIGEV_PAD_SIZE];
++		 int _tid;
++
++		struct {
++			void (*_function)(sigval_t);
++			void *_attribute;	/* really pthread_attr_t */
++		} _sigev_thread;
++	} _sigev_un;
++} sigevent_t;
++
+ #define sigev_notify_thread_id _sigev_un._tid
++#else
++#define _sigevent sigevent
+ #endif
+ 
+-static inline abi_long target_to_host_sigevent(struct sigevent *host_sevp,
++static inline abi_long target_to_host_sigevent(struct sigevent *_host_sevp,
+                                                abi_ulong target_addr)
+ {
++    struct _sigevent *host_sevp = (struct _sigevent*)_host_sevp;
+     struct target_sigevent *target_sevp;
+ 
+     if (!lock_user_struct(VERIFY_READ, target_sevp, target_addr, 1)) {


### PR DESCRIPTION
These binaries are convenient for use _within_ a container, where the dynamic libraries that Qemu_jll depends on aren't available.

I intend to (try to) use this in PkgEval, for testing e.g. aarch64 binaries on x86. That's why I've only included targets that Julia supports, or otherwise the artifact size balloons to over 500MB.

I've also included an additional patch to inject qemu on execve so that you can launch other foreign processes. Normally you'd do this by installing qemu on the host and registering it with the kernel using binfmt, but I'd like to avoid any required set-up.