### PR TITLE
Fix `c++filt` symbol of executable product in Binutils

### DIFF
--- a/B/Binutils/build_tarballs.jl
+++ b/B/Binutils/build_tarballs.jl
@@ -43,7 +43,7 @@ products = [
     ExecutableProduct("addr2line", :addr2line),
     ExecutableProduct("ar", :ar),
     # ExecutableProduct("as", :as),
-    ExecutableProduct("c++filt", Symbol("c++filt")),
+    ExecutableProduct("c++filt", :cxxfilt),
     # ExecutableProduct("dwp", :dwp),
     ExecutableProduct("elfedit", :elfedit),
     # ExecutableProduct("gprof", :gprof),


### PR DESCRIPTION
Ref JuliaRegistries/General#73995