### PR TITLE
[NEVERMERGE] Test CompilerSupportLibraries_jll on mingw

### DIFF
--- a/H/HelloWorldC/build_tarballs.jl
+++ b/H/HelloWorldC/build_tarballs.jl
@@ -1,7 +1,11 @@
 using BinaryBuilder
 
 name = "HelloWorldC"
-version = v"1.2.1"
+version = v"1.2.4"
+
+# 1.2.2: gcc 6
+# 1.2.3: gcc 7
+# 1.2.4: gcc 8
 
 # No sources, we're just building the testsuite
 sources = [
@@ -11,12 +15,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 mkdir -p ${bindir}
-cc -o ${prefix}/bin/hello_world${exeext} -g -O2 /usr/share/testsuite/c/hello_world/hello_world.c
-
-# Also build with cmake
-mkdir build && cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
-make -j${nproc}
+cc -L${prefix}/lib -o ${prefix}/bin/hello_world${exeext} -g -O2 /usr/share/testsuite/c/hello_world/hello_world.c
 
 install_license /usr/share/licenses/MIT
 """
@@ -32,7 +31,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
+    Dependency("CompilerSupportLibraries_jll"),
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8")


### PR DESCRIPTION
This is not a PR, but a test for the problem with CompilerSupportLibraries_jll that was observed in PR #2339. When binaries depend on CompilerSupportLibraries_jll and are built with GCC version 8, the resulting MinGW binary does not run, with Windows claiming the application is not compatible with the OS. Test binaries for each version are available at: https://github.com/barche/HelloWorldC_jll.jl/releases/tag/HelloWorldC-v1.2.4%2B0

Versions are:

```
1.2.2: gcc 6
1.2.3: gcc 7
1.2.4: gcc 8
```

1.2.4 fails to run. I don't know the exact reason for this, maybe CompilerSupportLibraries_jll needs to distinguish between GCC versions. The problem comes from linking to any of `libgcc.a libgcc_s.a libmsvcrt.a`.