### PR TITLE
Bump rr to v5.6 (including Julia-specific patches).

### DIFF
--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "rr"
-version = v"5.5"
+version = v"5.6"
 
 # Collection of sources required to build rr
 sources = [
-    GitSource("https://github.com/Keno/rr.git",
-              "fa6a8da4ecdb20909af13ac8380b7a1d804c71e2")
+    GitSource("https://github.com/JuliaLang/rr.git",
+              "392a88abb35922abdcf73eaf1e21a1980f766762")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bumping to 5.6 to include https://github.com/rr-debugger/rr/pull/3334 for testing InterProcessCommunication.jl on PkgEval. Also moves to JuliaLang/rr, as I didn't have permissions to push to @Keno's personal fork.