### PR TITLE
[Xgboost] fix gpu build target logic

### DIFF
--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -22,7 +22,7 @@ git submodule update --init
 (cd dmlc-core; atomic_patch -p1 "../../patches/dmlc_windows.patch")
 
 mkdir build && cd build
-if  [[ "${target}" == *linux-gnu-cuda* ]]; then
+if  [[ $bb_full_target == x86_64-linux*cuda* ]]; then
     # nvcc writes to /tmp, which is a small tmpfs in our sandbox.
     # make it use the workspace instead
     export TMPDIR=${WORKSPACE}/tmpdir
@@ -33,8 +33,7 @@ if  [[ "${target}" == *linux-gnu-cuda* ]]; then
     cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
             -DUSE_CUDA=ON \
-            -DBUILD_WITH_CUDA_CUB=ON \
-            -DUSE_NCCL=ON
+            -DBUILD_WITH_CUDA_CUB=ON
     make -j${nproc}
 else
     cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" 
@@ -98,7 +97,6 @@ for cuda_version in cuda_versions, platform in cuda_platforms
         BuildDependency(PackageSpec(name="CUDA_full_jll",
                                     version=cuda_full_versions[cuda_version])),
         RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll")),
-        RuntimeDependency(PackageSpec(name="NCCL_jll", version=v"2.15.1")),
     ]
 
     build_tarballs(ARGS, name, version, sources, script, [augmented_platform], products, [dependencies; cuda_deps];

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -86,7 +86,7 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-# build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")
 
 # build cuda tarballs
 for cuda_version in cuda_versions, platform in cuda_platforms

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -57,19 +57,24 @@ fi
 install_license LICENSE
 """
 
+cuda_full_versions = Dict(
+    v"11.0" => v"11.0.3",
+)
+cuda_version = v"11.0"
+augment_platform_block = CUDA.augment
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
 cuda_platforms = expand_cxxstring_abis(Platform("x86_64", "linux"))
+augmented_cuda_platforms = Vector{Platform}()
 
-cuda_versions = [v"11.0"]
-
-cuda_full_versions = Dict(
-    v"11.0" => v"11.0.3",
-)
-
-augment_platform_block = CUDA.augment
+for platform in cuda_platforms
+    augmented_platform = Platform(arch(platform), os(platform);
+                                cxxstring_abi=cxxstring_abi(platform), 
+                                cuda=CUDA.platform(cuda_version))
+    push!(augmented_cuda_platforms, augmented_platform)
+end
 
 # The products that we will ensure are always built
 products = [
@@ -83,24 +88,17 @@ dependencies = [
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
+    BuildDependency(PackageSpec(name="CUDA_full_jll", version=cuda_full_versions[cuda_version]), platforms=augmented_cuda_platforms),
+    RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll"), platforms=augmented_cuda_platforms),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")
 
 # build cuda tarballs
-for cuda_version in cuda_versions, platform in cuda_platforms
-    augmented_platform = Platform(arch(platform), os(platform);
-                                cxxstring_abi=cxxstring_abi(platform), 
-                                cuda=CUDA.platform(cuda_version))
+for augmented_platform in augmented_cuda_platforms
     should_build_platform(triplet(augmented_platform)) || continue
 
-    cuda_deps = [
-        BuildDependency(PackageSpec(name="CUDA_full_jll",
-                                    version=cuda_full_versions[cuda_version])),
-        RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll")),
-    ]
-
-    build_tarballs(ARGS, name, version, sources, script, [augmented_platform], products, [dependencies; cuda_deps];
+    build_tarballs(ARGS, name, version, sources, script, [augmented_platform], products, dependencies;
                    preferred_gcc_version=v"8", lazy_artifacts=true, julia_compat="1.6", augment_platform_block)
 end

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -32,6 +32,7 @@ if  [[ $bb_full_target == x86_64-linux*cuda* ]]; then
     export PATH=$PATH:$CUDA_HOME/bin
     cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
+            -DCUDA_TOOLKIT_ROOT_DIR=${WORKSPACE}/destdir/cuda \
             -DUSE_CUDA=ON \
             -DBUILD_WITH_CUDA_CUB=ON
     make -j${nproc}
@@ -85,12 +86,13 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")
+# build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")
 
 # build cuda tarballs
 for cuda_version in cuda_versions, platform in cuda_platforms
     augmented_platform = Platform(arch(platform), os(platform);
-                                  cuda=CUDA.platform(cuda_version))
+                                cxxstring_abi=cxxstring_abi(platform), 
+                                cuda=CUDA.platform(cuda_version))
     should_build_platform(triplet(augmented_platform)) || continue
 
     cuda_deps = [

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -65,7 +65,8 @@ cuda_version = v"11.0"
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
-cuda_platforms = expand_cxxstring_abis(Platform("x86_64", "linux"; cuda=CUDA.platform(cuda_version)))
+cuda_platforms = expand_cxxstring_abis(Platform("x86_64", "linux"; 
+                                        cuda=CUDA.platform(cuda_version)))
 
 for p in cuda_platforms
     push!(platforms, p)
@@ -84,15 +85,15 @@ dependencies = [
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
+
+    # You can only specify one cuda version in the deps. To build against more than 
+    # one cuda version, you have to include them as Archive Sources. (see Torch_jll)
     BuildDependency(PackageSpec(name="CUDA_full_jll", version=cuda_full_versions[cuda_version]), platforms=cuda_platforms),
     RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll"), platforms=cuda_platforms),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms[end-4:end], products, dependencies; 
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; 
                 preferred_gcc_version=v"8", 
                 julia_compat="1.6",
                 augment_platform_block=CUDA.augment)
-
-
-                


### PR DESCRIPTION
This fixes the GPU build that was merged earlier today (https://github.com/JuliaPackaging/Yggdrasil/pull/5892). The logic for determining the build always built the CPU version of the library. I have updated it to use `$bb_full_target` instead of `$target`, so we can correctly build the CUDA version. 

The only thing this should change is that the x64_linux + CUDA build should now have GPU support. 

I have also removed NCCL (for the time being) because it will require extra work. The no issues that I experienced were due to the incorrect target logic, not the CUDA+NCCL build working.

@ExpandingMan