### PR TITLE
[tblis] Make `CompilerSupportLibraries_jll` available on all platforms

### DIFF
--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -101,8 +101,10 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="Hwloc_jll", uuid="e33a78d0-f292-5ffc-b300-72abe9b543c8"))
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
-    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
-    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms))
+    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.  However we
+    # need to make `CompilerSupportLibraries_jll` available on all platforms because libtci
+    # needs libatomic.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms))
 ]
 


### PR DESCRIPTION
libtci needs libatomic also on macOS.  Ref https://github.com/JuliaPackaging/Yggdrasil/pull/4653#issuecomment-1358816331.  CC: @xrq-phys.