### PR TITLE
Specify compat for FLAC dependants

### DIFF
--- a/L/libsndfile/build_tarballs.jl
+++ b/L/libsndfile/build_tarballs.jl
@@ -47,7 +47,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("alsa_jll"; platforms=filter(Sys.islinux, platforms)),
-    Dependency("FLAC_jll"),
+    Dependency("FLAC_jll"; compat="1.3.4"),
     Dependency("libvorbis_jll"),
     Dependency("Ogg_jll"),
     Dependency("Opus_jll"),

--- a/L/libsndfile/build_tarballs.jl
+++ b/L/libsndfile/build_tarballs.jl
@@ -47,7 +47,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("alsa_jll"; platforms=filter(Sys.islinux, platforms)),
-    Dependency("FLAC_jll"; compat="1.3.4"),
+    Dependency("FLAC_jll"; compat="~1.3.4"),
     Dependency("libvorbis_jll"),
     Dependency("Ogg_jll"),
     Dependency("Opus_jll"),

--- a/S/SFML/build_tarballs.jl
+++ b/S/SFML/build_tarballs.jl
@@ -68,7 +68,7 @@ products = [
 dependencies = [
     Dependency("Libglvnd_jll"),
     Dependency("Ogg_jll"),
-    Dependency("FLAC_jll"),
+    Dependency("FLAC_jll"; compat="1.3.3"),
     Dependency("FreeType2_jll"),
     Dependency("libvorbis_jll"),
     Dependency("Xorg_libXrandr_jll"),

--- a/S/SFML/build_tarballs.jl
+++ b/S/SFML/build_tarballs.jl
@@ -68,7 +68,7 @@ products = [
 dependencies = [
     Dependency("Libglvnd_jll"),
     Dependency("Ogg_jll"),
-    Dependency("FLAC_jll"; compat="1.3.3"),
+    Dependency("FLAC_jll"; compat="~1.3.3"),
     Dependency("FreeType2_jll"),
     Dependency("libvorbis_jll"),
     Dependency("Xorg_libXrandr_jll"),


### PR DESCRIPTION
FLAC broke the ABI in the 1.3 -> 1.4 update, so we must specify the compat