### PR TITLE
[FLAC] Downgrade to v1.3.4

### DIFF
--- a/F/FLAC/build_tarballs.jl
+++ b/F/FLAC/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "FLAC"
-version = v"1.4.2"
+version = v"1.3.4"
 
 # Collection of sources required to build FLAC
 sources = [
     ArchiveSource("https://ftp.osuosl.org/pub/xiph/releases/flac/flac-$(version).tar.xz",
-                  "e322d58a1f48d23d9dd38f432672865f6f79e73a6f9cc5a5f57fcaa83eb5a8e4"),
+                  "8ff0607e75a322dd7cd6ec48f4f225471404ae2730d0ea945127b1355155e737"),
     DirectorySource("./bundled"),
 ]
 
@@ -16,11 +16,9 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/flac-*/
 
-if [[ "${target}" == *-linux-* ]]; then
-    # Include patch for finding definition of `AT_HWCAP2` for PowerPC within the Linux
-    # kernel headers, rather than the glibc headers, sicne our glibc is too old
-    atomic_patch -p1 "${WORKSPACE}/srcdir/patches/flac_linux_headers.patch"
-fi
+# Include patch for finding definition of `AT_HWCAP2` for PowerPC within the Linux
+# kernel headers, rather than the glibc headers, sicne our glibc is too old
+atomic_patch -p1 "${WORKSPACE}/srcdir/patches/flac_linux_headers.patch"
 
 if [[ "${target}" == *-mingw* ]]; then
     # Fix error

--- a/F/FLAC/bundled/patches/flac_linux_headers.patch
+++ b/F/FLAC/bundled/patches/flac_linux_headers.patch
@@ -1,11 +1,11 @@
 --- a/src/libFLAC/cpu.c
 +++ b/src/libFLAC/cpu.c
-@@ -54,7 +54,7 @@
- #endif
+@@ -55,7 +55,7 @@
  
- #if defined(HAVE_SYS_AUXV_H)
+ #if defined FLAC__CPU_PPC
+ #if defined(__linux__) || (defined(__FreeBSD__) && (__FreeBSD__ >= 12))
 -#include <sys/auxv.h>
 +#include <linux/auxvec.h>
  #endif
+ #endif
  
- #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && FLAC__HAS_X86INTRIN && !defined FLAC__NO_ASM


### PR DESCRIPTION
Rebuild v1.3.4, but now with CompilerSupportLibraries as dependency.