### PR TITLE
[libjulia] move Pkg.jl hack

### DIFF
--- a/L/libjulia/build_tarballs.jl
+++ b/L/libjulia/build_tarballs.jl
@@ -1,4 +1,36 @@
 include("common.jl")
+
+# HACK HACK HACK: modify Pkg.jl in Julia 1.7 to allow us to install stdlib JLLs
+# different from what was bundled with the Julia running this script.
+# If/when we upgrade Yggdrasil to a newer version of Julia, this hack must be
+# adjusted (ideally, with a new Pkg.jl it could be removed)
+@assert v"1.7" <= VERSION < v"1.8"
+function Pkg.Types.is_stdlib(uuid::Base.UUID, julia_version::VersionNumber)
+
+    # Only use the cache if we are asking for stdlibs in a custom Julia version
+    if julia_version == VERSION
+        return Pkg.Types.is_stdlib(uuid)
+    end
+
+    # If this UUID is known to be unregistered, always return `true`
+    if haskey(Pkg.Types.UNREGISTERED_STDLIBS, uuid)
+        return true
+    end
+
+    last_stdlibs = Pkg.Types.get_last_stdlibs(julia_version)
+
+    # BEGIN HACK
+    if haskey(last_stdlibs, uuid)
+        name, _ = last_stdlibs[uuid]
+        return !endswith(name, "_jll")
+    end
+    # END HACK
+
+    # Note that if the user asks for something like `julia_version = 0.7.0`, we'll
+    # fall through with an empty `last_stdlibs`, which will always return `false`.
+    return false
+end
+
 jllversion=v"1.10.0"
 build_julia(ARGS, v"1.6.3"; jllversion)
 build_julia(ARGS, v"1.7.0"; jllversion)

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -4,37 +4,6 @@ using BinaryBuilder, Pkg
 
 include("../../fancy_toys.jl") # for get_addable_spec
 
-# HACK HACK HACK: modify Pkg.jl in Julia 1.7 to allow us to install stdlib JLLs
-# different from what was bundled with the Julia running this script.
-# If/when we upgrade Yggdrasil to a newer version of Julia, this hack must be
-# adjusted (ideally, with a new Pkg.jl it could be removed)
-@assert v"1.7" <= VERSION < v"1.8"
-function Pkg.Types.is_stdlib(uuid::Base.UUID, julia_version::VersionNumber)
-
-    # Only use the cache if we are asking for stdlibs in a custom Julia version
-    if julia_version == VERSION
-        return Pkg.Types.is_stdlib(uuid)
-    end
-
-    # If this UUID is known to be unregistered, always return `true`
-    if haskey(Pkg.Types.UNREGISTERED_STDLIBS, uuid)
-        return true
-    end
-
-    last_stdlibs = Pkg.Types.get_last_stdlibs(julia_version)
-
-    # BEGIN HACK
-    if haskey(last_stdlibs, uuid)
-        name, _ = last_stdlibs[uuid]
-        return !endswith(name, "_jll")
-    end
-    # END HACK
-
-    # Note that if the user asks for something like `julia_version = 0.7.0`, we'll
-    # fall through with an empty `last_stdlibs`, which will always return `false`.
-    return false
-end
-
 # return the platforms supported by libjulia
 function libjulia_platforms(julia_version)
     platforms = supported_platforms()


### PR DESCRIPTION
Since several packages include L/libjulia/common.jl, move the
monkey patch for Pkg.jl into build_tarballs.jl, so that it does
not accidentally affect other packages.

[skip build]
[skip ci]
