### PR TITLE
[SCIP, SCIP_PaPILO] use bliss_jll and enable boost

### DIFF
--- a/S/SCIP/build_tarballs.jl
+++ b/S/SCIP/build_tarballs.jl
@@ -3,11 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "SCIP"
-version = v"800.0.300"
+version = v"800.0.301"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://scipopt.org/download/release/scipoptsuite-8.0.3.tgz", "5ad50eb42254c825d96f5747d8f3568dcbff0284dfbd1a727910c5a7c2899091"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
@@ -17,9 +18,15 @@ script = raw"""
 # remove when CMake accounts for this
 if [[ "${target}" == *86*-linux-gnu ]]; then
    export LDFLAGS="-lrt"
+elif [[ "${target}" == *-mingw* ]]; then
+   # this is required to link to bliss on mingw
+   export LDFLAGS=-L${libdir}
 fi
 
 cd scipoptsuite*
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/findbliss.patch
+
 mkdir build
 cd build/
 cmake -DCMAKE_INSTALL_PREFIX=$prefix\
@@ -30,10 +37,14 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix\
   -DGCG=0\
   -DUG=0\
   -DAMPL=0\
-  -DBOOST=off\
+  -DBOOST=ON\
   -DSYM=bliss\
   -DTPI=tny\
-  -DIPOPT_DIR=${prefix} -DIPOPT_LIBRARIES=${libdir} ..
+  -DIPOPT_DIR=${prefix} \
+  -DIPOPT_LIBRARIES=${libdir} \
+  -DBLISS_INCLUDE_DIR=${includedir} \
+  -DBLISS_LIBRARY=bliss \
+  ..
 make -j${nproc}
 make install
 

--- a/S/SCIP/bundled/patches/findbliss.patch
+++ b/S/SCIP/bundled/patches/findbliss.patch
@@ -1,0 +1,41 @@
+diff --git a/scip/CMakeLists.txt b/scip/CMakeLists.txt
+index f7831d9ce8..54915b438f 100644
+--- a/scip/CMakeLists.txt
++++ b/scip/CMakeLists.txt
+@@ -125,24 +125,18 @@ unset(BLISS_TARGET)
+ if(SYM STREQUAL "bliss")
+     message(STATUS "Support SYM: bliss")
+     set(sym symmetry/compute_symmetry_bliss.cpp)
+-
+-    # modify configuration for bliss
+-    set(BUILD_SHARED_LIBS OFF)
+-    set(TMPFLAGS ${CMAKE_C_FLAGS})
+-    set(TMXFLAGS ${CMAKE_CXX_FLAGS})
+-    set(CMAKE_C_FLAGS -w)
+-    set(CMAKE_CXX_FLAGS -w)
+-
+-    add_subdirectory(src/bliss)
+-
+-    # undo modification
+-    set(CMAKE_C_FLAGS ${TMPFLAGS})
+-    set(CMAKE_CXX_FLAGS ${TMXFLAGS})
+-    set(BUILD_SHARED_LIBS ${SHARED})
+-
+-    set(BLISS_TARGET libbliss)
+-    set(SYM_LIBRARIES libbliss)
+-    set(SYM_PIC_LIBRARIES libbliss)
++    find_package(BLISS)
++    if(BLISS_FOUND)
++        message(STATUS "BLISS found")
++        include_directories(${BLISS_INCLUDE_DIRS})
++        set(SYM_LIBRARIES ${BLISS_LIBRARIES})
++        set(SYM_PIC_LIBRARIES ${BLISS_LIBRARIES})
++        if(BLISS_DEFINITIONS STREQUAL "")
++            add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:${BLISS_DEFINITIONS}>")
++        endif()
++    else()
++       message(FATAL_ERROR "BLISS not found, not using vendored BLISS")
++    endif()
+ elseif(SYM STREQUAL "none")
+     message(STATUS "Support SYM: OFF")
+     set(sym symmetry/compute_symmetry_none.cpp)

--- a/S/SCIP_PaPILO/build_tarballs.jl
+++ b/S/SCIP_PaPILO/build_tarballs.jl
@@ -4,15 +4,19 @@ using BinaryBuilder, Pkg
 
 name = "SCIP_PaPILO"
 
-version = v"800.0.300"
+version = v"800.0.301"
 
 sources = [
     ArchiveSource("https://scipopt.org/download/release/scipoptsuite-8.0.3.tgz", "5ad50eb42254c825d96f5747d8f3568dcbff0284dfbd1a727910c5a7c2899091"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd scipoptsuite*
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/findbliss.patch
+
 mkdir build
 cd build/
 cmake -DCMAKE_INSTALL_PREFIX=$prefix\
@@ -22,9 +26,14 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix\
   -DUG=0\
   -DAMPL=0\
   -DGCG=0\
+  -DBOOST=ON\
   -DSYM=bliss\
   -DTPI=tny\
-  -DIPOPT_DIR=${prefix} -DIPOPT_LIBRARIES=${libdir} ..
+  -DIPOPT_DIR=${prefix} \
+  -DIPOPT_LIBRARIES=${libdir} \
+  -DBLISS_INCLUDE_DIR=${includedir} \
+  -DBLISS_LIBRARY=bliss \
+  ..
 make -j${nproc} scip
 make papilo-executable
 

--- a/S/SCIP_PaPILO/bundled/patches/findbliss.patch
+++ b/S/SCIP_PaPILO/bundled/patches/findbliss.patch
@@ -1,0 +1,41 @@
+diff --git a/scip/CMakeLists.txt b/scip/CMakeLists.txt
+index f7831d9ce8..54915b438f 100644
+--- a/scip/CMakeLists.txt
++++ b/scip/CMakeLists.txt
+@@ -125,24 +125,18 @@ unset(BLISS_TARGET)
+ if(SYM STREQUAL "bliss")
+     message(STATUS "Support SYM: bliss")
+     set(sym symmetry/compute_symmetry_bliss.cpp)
+-
+-    # modify configuration for bliss
+-    set(BUILD_SHARED_LIBS OFF)
+-    set(TMPFLAGS ${CMAKE_C_FLAGS})
+-    set(TMXFLAGS ${CMAKE_CXX_FLAGS})
+-    set(CMAKE_C_FLAGS -w)
+-    set(CMAKE_CXX_FLAGS -w)
+-
+-    add_subdirectory(src/bliss)
+-
+-    # undo modification
+-    set(CMAKE_C_FLAGS ${TMPFLAGS})
+-    set(CMAKE_CXX_FLAGS ${TMXFLAGS})
+-    set(BUILD_SHARED_LIBS ${SHARED})
+-
+-    set(BLISS_TARGET libbliss)
+-    set(SYM_LIBRARIES libbliss)
+-    set(SYM_PIC_LIBRARIES libbliss)
++    find_package(BLISS)
++    if(BLISS_FOUND)
++        message(STATUS "BLISS found")
++        include_directories(${BLISS_INCLUDE_DIRS})
++        set(SYM_LIBRARIES ${BLISS_LIBRARIES})
++        set(SYM_PIC_LIBRARIES ${BLISS_LIBRARIES})
++        if(BLISS_DEFINITIONS STREQUAL "")
++            add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:${BLISS_DEFINITIONS}>")
++        endif()
++    else()
++       message(FATAL_ERROR "BLISS not found, not using vendored BLISS")
++    endif()
+ elseif(SYM STREQUAL "none")
+     message(STATUS "Support SYM: OFF")
+     set(sym symmetry/compute_symmetry_none.cpp)


### PR DESCRIPTION
I bumped the patch-level from 300 to 301 to be able to add a compat entry for this version in polymake_jll.
This uses `FindBLISS.cmake` from the scip repo which does not do any version checks but this should not be necessary here.
I ran the testsuite for SCIP.jl on linux with locally built binaries and checked that I can now compile polymake_jll with the scip and soplex interfaces active.

cc: @matbesancon 
fixes: #5651 