### PR TITLE
[GAP_pkg] avoid issue with irregular upstream_version

### DIFF
--- a/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "Browse"
-upstream_version = v"1.8.19" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.8.19" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "cvec"
-upstream_version = v"2.7.6" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "2.7.6" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "datastructures"
-upstream_version = v"0.3.0" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "0.3.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "digraphs"
-upstream_version = v"1.6.1" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.6.1" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_edim/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_edim/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "EDIM"
-upstream_version = v"1.3.6" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.3.6" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_ferret/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_ferret/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "ferret"
-upstream_version = v"1.0.9" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.0.9" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_float/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_float/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "float"
-upstream_version = v"1.0.3" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.0.3" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_io/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_io/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "io"
-upstream_version = v"4.8.0" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "4.8.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_json/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_json/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "json"
-upstream_version = v"2.1.1" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "2.1.1" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -12,7 +12,7 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "JuliaInterface"
-upstream_version = v"0.8.2" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "0.8.2" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "NormalizInterface"
-upstream_version = v"1.3.5" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.3.5" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_nq/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_nq/build_tarballs.jl
@@ -3,7 +3,7 @@
 include("../common.jl")
 
 name = "nq"
-upstream_version = v"2.5.9" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "2.5.9" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/GAP_pkg_orb/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_orb/build_tarballs.jl
@@ -5,7 +5,7 @@ include("../common.jl")
 gap_version = v"400.1200.200"
 gap_lib_version = v"400.1201.200"
 name = "orb"
-upstream_version = v"4.9.0" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "4.9.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 

--- a/G/GAP_pkg/common.jl
+++ b/G/GAP_pkg/common.jl
@@ -11,7 +11,8 @@ version and changes to the JLL which retain the same upstream version.
 When the `upstream` version is changed, `offset` version numbers should be reset
 to `v"0.0.0"` and incremented following semantic versioning.
 """
-function offset_version(upstream, offset)
+function offset_version(upstream_str, offset)
+    upstream = VersionNumber(replace(upstream_str, "-" => "."))
     return VersionNumber(
         upstream.major * 100 + offset.major,
         upstream.minor * 100 + offset.minor,

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -57,8 +57,8 @@ function update_gap_pkg_recipe(dir)
         gap_lib_version
     end
 
-    old_upstream_version = match(r"upstream_version = v\"([^\"]+)\"", recipe).captures[1]
-    old_offset = VersionNumber(match(r"offset = v\"([^\"]+)\"", recipe).captures[1])
+    old_upstream_version = match(r"upstream_version = v?\"([^\"]+)\"", recipe).captures[1]
+    offset = VersionNumber(match(r"offset = v\"([^\"]+)\"", recipe).captures[1])
 
     # new metadata from the GAP package registry
     if pkgname == "juliainterface"
@@ -90,12 +90,10 @@ function update_gap_pkg_recipe(dir)
         end
         @info "skipping $pkgname"
         return
-    end
-
-    if old_upstream_version != upstream_version
+    elseif old_upstream_version != upstream_version
         offset = v"0.0.0"
     else
-        offset = VersionNumber(old_offset.major, old_offset.minor, old_offset.patch + 1)
+        offset = VersionNumber(offset.major, offset.minor, offset.patch + 1)
     end
 
     # update the metadata
@@ -103,7 +101,7 @@ function update_gap_pkg_recipe(dir)
     recipe = replace(recipe, r"gap_lib_version = v\"[^\"]+\"" => "gap_lib_version = v\"$gap_lib_version\"")
 
     # update version
-    recipe = replace(recipe, r"upstream_version = v\"[^\"]+\"" => "upstream_version = v\"$upstream_version\"")
+    recipe = replace(recipe, r"upstream_version = v?\"[^\"]+\"" => "upstream_version = \"$upstream_version\"")
     recipe = replace(recipe, r"offset = v\"[^\"]+\"" => "offset = v\"$offset\"")
 
     if pkgname != "juliainterface"


### PR DESCRIPTION
Deal with upstream_version not being of the form X.Y.Z, but rather say X.Y and
X.Y-Z. For both it is important to keep upstream_version as a plain string, so
that the download URL derived from it stays valid. For the latter, we want to
replace the - by . (these GAP package versions do *not* follow semvar)

[skip build]
[skip ci]
