### PR TITLE
Force a rebuild of LibTracyClient.

### DIFF
--- a/L/LibTracyClient/LibTracyClient@0.9.0/build_tarballs.jl
+++ b/L/LibTracyClient/LibTracyClient@0.9.0/build_tarballs.jl
@@ -47,5 +47,3 @@ dependencies = Dependency[]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
-
-# bump


### PR DESCRIPTION
I fixed the registration, but by adding a `skip build` tag we attempted to reuse a previously-registered version, which LibTracyClient (being a new package) doesn't have. So let's force a full rebuild.