### PR TITLE
[msolve] rebuild with old MPFR

### DIFF
--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -39,6 +39,8 @@ products = [
 dependencies = [
     Dependency("GMP_jll", v"6.2.0"),
     Dependency("FLINT_jll", compat = "~200.900.000"),
+    Dependency("MPFR_jll", v"4.1.1"),
+
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),


### PR DESCRIPTION
... to restore compatibility with Julia 1.6 on macOS. Before this, we got this error on an Intel Mac:

    ERROR: LoadError: LoadError: InitError: could not load library "JULIADEPOT/artifacts/0ee20e199c8939d53a5262356e455ebed54860a1/lib/libmsolve.dylib"
    dlopen(JULIADEPOT/artifacts/0ee20e199c8939d53a5262356e455ebed54860a1/lib/libmsolve.dylib, 1): Library not loaded: @rpath/libmpfr.6.dylib
     Referenced from: JULIADEPOT/artifacts/0ee20e199c8939d53a5262356e455ebed54860a1/lib/libmsolve-0.4.8.dylib
     Reason: Incompatible library version: libmsolve.dylib requires version 9.0.0 or later, but libmpfr.dylib provides version 8.0.0


CC @ederc @wdecker