### PR TITLE
[Qt6Base] Build tools (host build)

### DIFF
--- a/Q/Qt6Base/build_tarballs.jl
+++ b/Q/Qt6Base/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"6.4.2"
 # Set this to true first when updating the version. It will build only for the host (linux musl).
 # After that JLL is in the registyry, set this to false to build for the other platforms, using
 # this same package as host build dependency.
-const host_build = false
+const host_build = true
 
 # Collection of sources required to build qt6
 sources = [
@@ -42,9 +42,9 @@ export OPENSSL_LIBS="-L${libdir} -lssl -lcrypto"
 
 sed -i 's/"-march=haswell"/"-mavx2" "-mf16c" "-mfma" "-mbmi2" "-mlzcnt"/' $qtsrcdir/cmake/QtCompilerOptimization.cmake
 
-case "$target" in
+case "$bb_full_target" in
 
-    x86_64-linux-musl-cxx11)
+    x86_64-linux-musl-libgfortran5-cxx11)
         ../qtbase-everywhere-src-*/configure -prefix $prefix $commonoptions -fontconfig -- -DCMAKE_PREFIX_PATH=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_HOST_TOOLCHAIN}
     ;;
 


### PR DESCRIPTION
The wrong case logic here caused the host tools to be removed from the build, causing errors in the other Qt packages. Sorry build agents, and 🤞 that all this gets done before 6.4.3 is released ;)