### PR TITLE
Avoid pulling in CUDA 12 in Libxc

### DIFF
--- a/L/Libxc/Libxc_GPU/build_tarballs.jl
+++ b/L/Libxc/Libxc_GPU/build_tarballs.jl
@@ -73,7 +73,7 @@ for cuda_version in [v"11.0"], platform in platforms
         BuildDependency(PackageSpec(name="CUDA_full_jll",
                                     version=cuda_full_versions[cuda_version])),
         RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll",
-                                      version="0.2")),  # avoid pulling in CUDA 12 for now.
+                                      version=v"0.2")),  # avoid pulling in CUDA 12 for now.
     ]
 
     build_tarballs(ARGS, name, version, sources, script, [augmented_platform],

--- a/L/Libxc/Libxc_GPU/build_tarballs.jl
+++ b/L/Libxc/Libxc_GPU/build_tarballs.jl
@@ -55,24 +55,25 @@ dependencies = [
 
 # XXX: support only specifying major/minor version (JuliaPackaging/BinaryBuilder.jl#/1212)
 cuda_full_versions = Dict(
-    v"10.2" => v"10.2.89",
-    v"11.0" => v"11.0.3"
+    v"11.0" => v"11.0.3",
+    v"12.0" => v"12.0.0"
 )
 
 # Build Libxc for all supported CUDA toolkits
 #
-# The library doesn't have specific CUDA requirements, so we only build for CUDA 10.2,
-# the oldest version supported by CUDA.jl, and 11.0, which (per semantic versioning)
-# should support every CUDA 11.x version.
+# The library doesn't have specific CUDA requirements, so we only build for CUDA 11.0 and 12.0,
+# which (per semantic versioning) should support every CUDA 11.x and 12.x version.
 #
-for cuda_version in [v"10.2", v"11.0"], platform in platforms
+# TODO Note: 12 not yet fully rolled out.
+for cuda_version in [v"11.0"], platform in platforms
     augmented_platform = Platform(arch(platform), os(platform); cuda=CUDA.platform(cuda_version))
     should_build_platform(triplet(augmented_platform)) || continue
 
     cuda_deps = [
         BuildDependency(PackageSpec(name="CUDA_full_jll",
                                     version=cuda_full_versions[cuda_version])),
-        RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll")),
+        RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll",
+                                      version="0.2")),  # avoid pulling in CUDA 12 for now.
     ]
 
     build_tarballs(ARGS, name, version, sources, script, [augmented_platform],


### PR DESCRIPTION
Not sure I understand this, but it seems #6118 had me pull in CUDA 12 on some machines. I'm now pinning the runtime to 0.2 to avoid this.