### PR TITLE
[ViennaRNA] Fix wrong ExecutableProduct statement

### DIFF
--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -100,7 +100,7 @@ products = [
     ExecutableProduct("b2ct", :b2ct),
     ExecutableProduct("ct2db", :ct2db),
     ExecutableProduct("Kinfold", :Kinfold),
-    ExecutableProduct("kinwalker", :Kinfold),
+    ExecutableProduct("kinwalker", :kinwalker),
     ExecutableProduct("popt", :popt),
     ExecutableProduct("RNA2Dfold", :RNA2Dfold),
     ExecutableProduct("RNAaliduplex", :RNAaliduplex),


### PR DESCRIPTION
This caused warnings on loading the ViennaRNA_jll package.