### PR TITLE
[Xyce] Expand gfortran versions again

### DIFF
--- a/X/Xyce/build_tarballs.jl
+++ b/X/Xyce/build_tarballs.jl
@@ -39,6 +39,11 @@ platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 platforms = expand_gfortran_versions(platforms)
 
+# Exclude some platforms that trigger internal compiler errors
+platforms = filter(platforms) do p
+    return !(arch(p) == "aarch64" && os(p) == "linux" && p["libgfortran_version"] ∈ ("3.0.0", "4.0.0"))
+end
+
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libxyce", :libxyce),

--- a/X/Xyce/build_tarballs.jl
+++ b/X/Xyce/build_tarballs.jl
@@ -37,6 +37,7 @@ make install
 platforms = supported_platforms()
 
 platforms = expand_cxxstring_abis(platforms)
+platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
This was removed, but `libxyce` still links against `libgfortran.so.5`, so we still need this.