### PR TITLE
[ImageMagick] tag 6.9.10 as 6.9.11 instead

### DIFF
--- a/I/ImageMagick/build_tarballs.jl
+++ b/I/ImageMagick/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 name = "ImageMagick"
 upstream_version = v"6.9.10-12"
-version = VersionNumber(upstream_version.major, upstream_version.minor, upstream_version.patch)
+version = v"6.9.11" # needed because we bumped Julia compat
 
 # Collection of sources required to build imagemagick
 sources = [


### PR DESCRIPTION
We bumped Julia compat, so this needs to be a new patch release.

ref https://github.com/JuliaRegistries/General/pull/76930#issuecomment-1416084767
