### PR TITLE
[ImageMagick] rebuild

### DIFF
--- a/I/ImageMagick/ImageMagick@6/build_tarballs.jl
+++ b/I/ImageMagick/ImageMagick@6/build_tarballs.jl
@@ -18,6 +18,9 @@ cd $WORKSPACE/srcdir/ImageMagick6*/
 
 if [[ "${target}" == *-linux-gnu ]]; then
     atomic_patch -p1 ../patches/utilities-link-rt.patch
+elif [[ "${target}" == *-mingw* ]]; then
+    # otherwise autotools looks in ${prefix}/lib
+    export LDFLAGS=-L${libdir}
 fi
 #atomic_patch -p1 ../patches/check-have-clock-realtime.patch
 # included in v6.9.10-39, remove when bumping version

--- a/I/ImageMagick/ImageMagick@6/build_tarballs.jl
+++ b/I/ImageMagick/ImageMagick@6/build_tarballs.jl
@@ -35,6 +35,7 @@ atomic_patch -p1 ../patches/gs-null-init.patch
     --disable-docs \
     --disable-static \
     --with-gslib
+
 make -j${nproc}
 make install
 """


### PR DESCRIPTION
Because libgs was previously broken on mingw builds, ImageMagick wasn't
linking to it on these platforms. (See
https://buildkite.com/julialang/yggdrasil/builds/647#018622f9-1e83-47d2-925f-8c5ea5c0934b/6-1732)
