### PR TITLE
CUDA: Create and include compiler library, export cublasLt.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_11.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.0.jl
@@ -105,23 +105,26 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
-products = [
-    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-    LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
-    LibraryProduct(["libcusolverMg", "cusolverMg64_10"], :libcusolverMg),
-    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_2020.1.1"], :libcupti),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    ExecutableProduct("ptxas", :ptxas),
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    ExecutableProduct("nvlink", :nvlink),
-    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
-]
+function get_products(platform)
+    products = [
+        LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
+        LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
+        LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+        LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
+        LibraryProduct(["libcusolverMg", "cusolverMg64_10"], :libcusolverMg),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_2020.1.1"], :libcupti),
+        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+        ExecutableProduct("ptxas", :ptxas),
+        ExecutableProduct("nvdisasm", :nvdisasm),
+        ExecutableProduct("nvlink", :nvlink),
+        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    ]
+    return products
+end
 
 platforms = [Platform("x86_64", "linux"; cuda="11.0"),
              Platform("powerpc64le", "linux"; cuda="11.0"),

--- a/C/CUDA/CUDA_Runtime/build_11.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.1.jl
@@ -58,6 +58,11 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv bin/ptxas ${bindir}
     mv bin/nvdisasm ${bindir}
     mv bin/nvlink ${bindir}
+
+    # Convert the static compiler library to a dynamic one
+    ${CC} -std=c99 -fPIC -shared -lm \
+          -Llib64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+          -o ${libdir}/libnvPTXCompiler.so
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Runtime
     mv bin/cudart64_*.dll ${bindir}
@@ -100,28 +105,41 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv bin/nvdisasm.exe ${bindir}
     mv bin/nvlink.exe ${bindir}
 
+    # Convert the static compiler library to a dynamic one
+    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
+    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
+    #${CC} -std=c99 -shared -lm \
+    #      -Llib/x64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+    #      -o ${libdir}/nvPTXCompiler.dll
+
     # Fix permissions
     chmod +x ${bindir}/*.{exe,dll}
 fi
 """
 
-products = [
-    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-    LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
-    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
-    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_2020.2.1"], :libcupti),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    ExecutableProduct("ptxas", :ptxas),
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    ExecutableProduct("nvlink", :nvlink),
-    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
-]
+function get_products(platform)
+    products = [
+        LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
+        LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
+        LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+        LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+        LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_2020.2.1"], :libcupti),
+        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+        ExecutableProduct("ptxas", :ptxas),
+        ExecutableProduct("nvdisasm", :nvdisasm),
+        ExecutableProduct("nvlink", :nvlink),
+        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    ]
+    if !Sys.iswindows(platform)
+        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
+    end
+    return products
+end
 
 platforms = [Platform("x86_64", "linux"; cuda="11.1"),
              Platform("powerpc64le", "linux"; cuda="11.1"),

--- a/C/CUDA/CUDA_Runtime/build_11.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.2.jl
@@ -58,6 +58,11 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv bin/ptxas ${bindir}
     mv bin/nvdisasm ${bindir}
     mv bin/nvlink ${bindir}
+
+    # Convert the static compiler library to a dynamic one
+    ${CC} -std=c99 -fPIC -shared -lm \
+          -Llib64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+          -o ${libdir}/libnvPTXCompiler.so
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Runtime
     mv bin/cudart64_*.dll ${bindir}
@@ -100,28 +105,41 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv bin/nvdisasm.exe ${bindir}
     mv bin/nvlink.exe ${bindir}
 
+    # Convert the static compiler library to a dynamic one
+    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
+    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
+    #${CC} -std=c99 -shared -lm \
+    #      -Llib/x64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+    #      -o ${libdir}/nvPTXCompiler.dll
+
     # Fix permissions
     chmod +x ${bindir}/*.{exe,dll}
 fi
 """
 
-products = [
-    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
-    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
-    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_2020.3.1"], :libcupti),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    ExecutableProduct("ptxas", :ptxas),
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    ExecutableProduct("nvlink", :nvlink),
-    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
-]
+function get_products(platform)
+    products = [
+        LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
+        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+        LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+        LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+        LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_2020.3.1"], :libcupti),
+        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+        ExecutableProduct("ptxas", :ptxas),
+        ExecutableProduct("nvdisasm", :nvdisasm),
+        ExecutableProduct("nvlink", :nvlink),
+        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    ]
+    if !Sys.iswindows(platform)
+        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
+    end
+    return products
+end
 
 platforms = [Platform("x86_64", "linux"; cuda="11.2"),
              Platform("powerpc64le", "linux"; cuda="11.2"),

--- a/C/CUDA/CUDA_Runtime/build_11.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.3.jl
@@ -58,6 +58,11 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv bin/ptxas ${bindir}
     mv bin/nvdisasm ${bindir}
     mv bin/nvlink ${bindir}
+
+    # Convert the static compiler library to a dynamic one
+    ${CC} -std=c99 -fPIC -shared -lm \
+          -Llib64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+          -o ${libdir}/libnvPTXCompiler.so
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Runtime
     mv bin/cudart64_*.dll ${bindir}
@@ -100,28 +105,41 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv bin/nvdisasm.exe ${bindir}
     mv bin/nvlink.exe ${bindir}
 
+    # Convert the static compiler library to a dynamic one
+    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
+    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
+    #${CC} -std=c99 -shared -lm \
+    #      -Llib/x64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+    #      -o ${libdir}/nvPTXCompiler.dll
+
     # Fix permissions
     chmod +x ${bindir}/*.{exe,dll}
 fi
 """
 
-products = [
-    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
-    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
-    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_2021.1.1"], :libcupti),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    ExecutableProduct("ptxas", :ptxas),
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    ExecutableProduct("nvlink", :nvlink),
-    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
-]
+function get_products(platform)
+    products = [
+        LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
+        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+        LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+        LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+        LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_2021.1.1"], :libcupti),
+        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+        ExecutableProduct("ptxas", :ptxas),
+        ExecutableProduct("nvdisasm", :nvdisasm),
+        ExecutableProduct("nvlink", :nvlink),
+        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    ]
+    if !Sys.iswindows(platform)
+        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
+    end
+    return products
+end
 
 platforms = [Platform("x86_64", "linux"; cuda="11.3"),
              Platform("powerpc64le", "linux"; cuda="11.3"),

--- a/C/CUDA/CUDA_Runtime/build_11.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.4.jl
@@ -1,4 +1,4 @@
-dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.4.2"))]
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.4.4"))]
 
 script = raw"""
 # First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
@@ -58,6 +58,11 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv bin/ptxas ${bindir}
     mv bin/nvdisasm ${bindir}
     mv bin/nvlink ${bindir}
+
+    # Convert the static compiler library to a dynamic one
+    ${CC} -std=c99 -fPIC -shared -lm \
+          -Llib64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+          -o ${libdir}/libnvPTXCompiler.so
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Runtime
     mv bin/cudart64_*.dll ${bindir}
@@ -100,28 +105,41 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv bin/nvdisasm.exe ${bindir}
     mv bin/nvlink.exe ${bindir}
 
+    # Convert the static compiler library to a dynamic one
+    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
+    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
+    #${CC} -std=c99 -shared -lm \
+    #      -Llib/x64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+    #      -o ${libdir}/nvPTXCompiler.dll
+
     # Fix permissions
     chmod +x ${bindir}/*.{exe,dll}
 fi
 """
 
-products = [
-    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
-    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
-    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_2021.2.2"], :libcupti),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    ExecutableProduct("ptxas", :ptxas),
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    ExecutableProduct("nvlink", :nvlink),
-    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
-]
+function get_products(platform)
+    products = [
+        LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
+        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+        LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+        LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+        LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_2021.2.2"], :libcupti),
+        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+        ExecutableProduct("ptxas", :ptxas),
+        ExecutableProduct("nvdisasm", :nvdisasm),
+        ExecutableProduct("nvlink", :nvlink),
+        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    ]
+    if !Sys.iswindows(platform)
+        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
+    end
+    return products
+end
 
 platforms = [Platform("x86_64", "linux"; cuda="11.4"),
              Platform("powerpc64le", "linux"; cuda="11.4"),

--- a/C/CUDA/CUDA_Runtime/build_11.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.5.jl
@@ -1,4 +1,4 @@
-dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.5.1"))]
+dependencies = [BuildDependency(PackageSpec(name="CUDA_full_jll", version=v"11.5.2"))]
 
 script = raw"""
 # First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
@@ -58,6 +58,11 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv bin/ptxas ${bindir}
     mv bin/nvdisasm ${bindir}
     mv bin/nvlink ${bindir}
+
+    # Convert the static compiler library to a dynamic one
+    ${CC} -std=c99 -fPIC -shared -lm \
+          -Llib64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+          -o ${libdir}/libnvPTXCompiler.so
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Runtime
     mv bin/cudart64_*.dll ${bindir}
@@ -100,28 +105,41 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv bin/nvdisasm.exe ${bindir}
     mv bin/nvlink.exe ${bindir}
 
+    # Convert the static compiler library to a dynamic one
+    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
+    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
+    #${CC} -std=c99 -shared -lm \
+    #      -Llib/x64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+    #      -o ${libdir}/nvPTXCompiler.dll
+
     # Fix permissions
     chmod +x ${bindir}/*.{exe,dll}
 fi
 """
 
-products = [
-    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
-    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
-    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_2021.3.1"], :libcupti),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    ExecutableProduct("ptxas", :ptxas),
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    ExecutableProduct("nvlink", :nvlink),
-    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
-]
+function get_products(platform)
+    products = [
+        LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
+        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+        LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+        LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+        LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_2021.3.1"], :libcupti),
+        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+        ExecutableProduct("ptxas", :ptxas),
+        ExecutableProduct("nvdisasm", :nvdisasm),
+        ExecutableProduct("nvlink", :nvlink),
+        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    ]
+    if !Sys.iswindows(platform)
+        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
+    end
+    return products
+end
 
 platforms = [Platform("x86_64", "linux"; cuda="11.5"),
              Platform("powerpc64le", "linux"; cuda="11.5"),

--- a/C/CUDA/CUDA_Runtime/build_11.7.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.7.jl
@@ -58,6 +58,11 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv bin/ptxas ${bindir}
     mv bin/nvdisasm ${bindir}
     mv bin/nvlink ${bindir}
+
+    # Convert the static compiler library to a dynamic one
+    ${CC} -std=c99 -fPIC -shared -lm \
+          -Llib64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+          -o ${libdir}/libnvPTXCompiler.so
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Runtime
     mv bin/cudart64_*.dll ${bindir}
@@ -100,28 +105,41 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv bin/nvdisasm.exe ${bindir}
     mv bin/nvlink.exe ${bindir}
 
+    # Convert the static compiler library to a dynamic one
+    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
+    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
+    #${CC} -std=c99 -shared -lm \
+    #      -Llib/x64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+    #      -o ${libdir}/nvPTXCompiler.dll
+
     # Fix permissions
     chmod +x ${bindir}/*.{exe,dll}
 fi
 """
 
-products = [
-    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
-    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
-    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_2022.2.1"], :libcupti),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    ExecutableProduct("ptxas", :ptxas),
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    ExecutableProduct("nvlink", :nvlink),
-    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
-]
+function get_products(platform)
+    products = [
+        LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
+        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+        LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+        LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+        LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_2022.2.1"], :libcupti),
+        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+        ExecutableProduct("ptxas", :ptxas),
+        ExecutableProduct("nvdisasm", :nvdisasm),
+        ExecutableProduct("nvlink", :nvlink),
+        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    ]
+    if !Sys.iswindows(platform)
+        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
+    end
+    return products
+end
 
 platforms = [Platform("x86_64", "linux"; cuda="11.7"),
              Platform("powerpc64le", "linux"; cuda="11.7"),

--- a/C/CUDA/CUDA_Runtime/build_11.8.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.8.jl
@@ -58,6 +58,11 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv bin/ptxas ${bindir}
     mv bin/nvdisasm ${bindir}
     mv bin/nvlink ${bindir}
+
+    # Convert the static compiler library to a dynamic one
+    ${CC} -std=c99 -fPIC -shared -lm \
+          -Llib64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+          -o ${libdir}/libnvPTXCompiler.so
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Runtime
     mv bin/cudart64_*.dll ${bindir}
@@ -100,28 +105,41 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv bin/nvdisasm.exe ${bindir}
     mv bin/nvlink.exe ${bindir}
 
+    # Convert the static compiler library to a dynamic one
+    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
+    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
+    #${CC} -std=c99 -shared -lm \
+    #      -Llib/x64 -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+    #      -o ${libdir}/nvPTXCompiler.dll
+
     # Fix permissions
     chmod +x ${bindir}/*.{exe,dll}
 fi
 """
 
-products = [
-    LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-    LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
-    LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
-    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_2022.3.0"], :libcupti),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    ExecutableProduct("ptxas", :ptxas),
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    ExecutableProduct("nvlink", :nvlink),
-    ExecutableProduct("compute-sanitizer", :compute_sanitizer),
-]
+function get_products(platform)
+    products = [
+        LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
+        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
+        LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
+        LibraryProduct(["libcusparse", "cusparse64_11"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
+        LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_2022.3.0"], :libcupti),
+        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+        ExecutableProduct("ptxas", :ptxas),
+        ExecutableProduct("nvdisasm", :nvdisasm),
+        ExecutableProduct("nvlink", :nvlink),
+        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
+    ]
+    if !Sys.iswindows(platform)
+        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
+    end
+    return products
+end
 
 platforms = [Platform("x86_64", "linux"; cuda="11.8"),
              Platform("powerpc64le", "linux"; cuda="11.8"),

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -5,7 +5,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.3.0"
+version = v"0.3.1"
 
 cuda_versions = [v"11.0", v"11.1", v"11.2", v"11.3", v"11.4", v"11.5", v"11.6", v"11.7", v"11.8",
                  v"12.0"]
@@ -27,7 +27,7 @@ for cuda_version in cuda_versions
         should_build_platform(triplet(augmented_platform)) || continue
         push!(builds,
               (; dependencies=[Dependency("CUDA_Driver_jll"; compat="0.2,0.3"); dependencies],
-                 script, products, platforms=[augmented_platform],
+                 script, products=get_products(platform), platforms=[augmented_platform],
         ))
     end
 end
@@ -43,8 +43,6 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, [], build.script,
                    build.platforms, build.products, build.dependencies;
-                   julia_compat="1.6", lazy_artifacts=true,
-                   augment_platform_block)
+                   julia_compat="1.6", preferred_gcc_version = v"6.1.0",
+                   lazy_artifacts=true, augment_platform_block)
 end
-
-# bump


### PR DESCRIPTION
Sadly compiling the dynamic library doesn't work on Windows, as the static library we're linking here has been generated by MSVC, and there's no guarantee static libraries work across toolchains...