### PR TITLE
build Python with sqlite

### DIFF
--- a/P/Python/build_tarballs.jl
+++ b/P/Python/build_tarballs.jl
@@ -21,6 +21,7 @@ apk add autoconf-archive
 rm -f $(which python3)
 
 # We need these for the host python build
+apk update
 apk add zlib-dev libffi-dev
 
 # Create fake `arch` command:
@@ -104,6 +105,7 @@ dependencies = [
     Dependency("Expat_jll"; compat="2.2.10"),
     Dependency("Bzip2_jll"; compat="1.0.8"),
     Dependency("Libffi_jll"; compat="~3.2.2"),
+    Dependency("SQLite_jll"),
     Dependency("LibMPDec_jll"),
     Dependency("Zlib_jll"),
     Dependency("XZ_jll"),


### PR DESCRIPTION
Fixes #6189. The presence of sqlite3 lib causes the Python build to include it, no extra configure flags needed. I also needed the update otherwise was getting package not found errors. 

I personally also need this for Python 3.8 (since I depend on boostpython_jll which is capped at 3.8). Is there a way to also add this as a "backport" to 3.8? (this is my first time doing anything Yggdrasil)