### PR TITLE
Update SPIRV_Headers to version 1.6.0

### DIFF
--- a/S/SPIRV_Headers/build_tarballs.jl
+++ b/S/SPIRV_Headers/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "SPIRV_Headers"
-version = v"1.5.4"
+version = v"1.6.0"
 
 # Collection of sources required to build this package
 sources = [
     GitSource("https://github.com/KhronosGroup/SPIRV-Headers.git",
-              "f027d53ded7e230e008d37c8b47ede7cd308e19d"),
+              "aa331ab0ffcb3a67021caa1a0c1c9017712f2f31"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
The patch version is not indicated officially, so it can be used to indicate subsequent releases of the same minor version.