### PR TITLE
update pandoc_crossref for pandoc 2.9

### DIFF
--- a/P/pandoc_crossref/build_tarballs.jl
+++ b/P/pandoc_crossref/build_tarballs.jl
@@ -3,15 +3,15 @@ using BinaryBuilder
 # Collection of pre-build pandoc binaries
 name = "pandoc_crossref"
 
-version = v"0.3.12"
-crossref_ver = "0.3.11.0"
+crossref_ver = "0.3.14.0"
+version = VersionNumber(crossref_ver)
 
 url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v$(crossref_ver)/pandoc-crossref"
 sources = [
-    ArchiveSource("$(url_prefix)-Linux.tar.xz", "eca741b75d909a60b8ab52653d4b8797058ec90ae168f10189ea94b6b6cd5f5e"; unpack_target = "x86_64-linux-gnu"),
-    ArchiveSource("$(url_prefix)-macOS.tar.xz", "a1866a1d35e8afc16faf13b7cbbc7e492163e3ab91a9705b284006c4c5eb049b"; unpack_target = "x86_64-apple-darwin14"),
-    ArchiveSource("$(url_prefix)-macOS.tar.xz", "a1866a1d35e8afc16faf13b7cbbc7e492163e3ab91a9705b284006c4c5eb049b"; unpack_target = "aarch64-apple-darwin20"),
-    FileSource("$(url_prefix)-Windows.7z", "7eeea4920876e0432b07813be064ab993c52c3a47387a48274415bce7ab881ab"; filename = "x86_64-w64-mingw32"),
+    ArchiveSource("$(url_prefix)-Linux.tar.xz", "9ad4aff57d58198b9d97fef71319c5b060ebcfc570055d87aa95b4117b40db56"; unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$(url_prefix)-macOS.tar.xz", "b29ebe076ecd462bf567f7d0774f70177aa109999a3c0fa542a6c3564ad50e2f"; unpack_target = "x86_64-apple-darwin14"),
+    ArchiveSource("$(url_prefix)-macOS.tar.xz", "b29ebe076ecd462bf567f7d0774f70177aa109999a3c0fa542a6c3564ad50e2f"; unpack_target = "aarch64-apple-darwin20"),
+    FileSource("$(url_prefix)-Windows.7z", "f07e7e64e7a2260d43e93941387aa320914f3e161697bce305622d4250040cb3"; filename = "x86_64-w64-mingw32"),
     FileSource("https://raw.githubusercontent.com/lierdakil/pandoc-crossref/v$(crossref_ver)/LICENSE", "39db8f9acf036595a2566ea3fe560bc7bd65d8749f088e0f4a4ef2f8a6cb4b34"),
 ]
 

--- a/P/pandoc_crossref/build_tarballs.jl
+++ b/P/pandoc_crossref/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder
 name = "pandoc_crossref"
 
 crossref_ver = "0.3.14.0"
-version = VersionNumber(crossref_ver)
+version = v"0.3.14"
 
 url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v$(crossref_ver)/pandoc-crossref"
 sources = [


### PR DESCRIPTION
After this is done, I'll do a follow-up for pandoc_crossref for pandoc 3.0, but it would be nice to have pandoc_crossref work with the last release of the pandoc 2.x series.