### PR TITLE
Add libaec for szip support for HDF5

### DIFF
--- a/L/libaec/build_tarballs.jl
+++ b/L/libaec/build_tarballs.jl
@@ -1,0 +1,57 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libaec"
+version = v"1.0.6"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://gitlab.dkrz.de/k202009/libaec/-/archive/v$(version)/libaec-v$(version).tar.bz2", "31fb65b31e835e1a0f3b682d64920957b6e4407ee5bbf42ca49549438795a288")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libaec-v1.0.6/
+
+mkdir build && cd build
+cmake \
+    -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("i686", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("powerpc64le", "linux"; libc = "glibc"),
+    Platform("i686", "linux"; libc = "musl"),
+    Platform("x86_64", "linux"; libc = "musl"),
+    Platform("aarch64", "linux"; libc = "musl"),
+    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "musl"),
+    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "musl")
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libsz", :libsz),
+    LibraryProduct("libaec", :libaec),
+    ExecutableProduct("aec", :aec)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
xref:
https://github.com/conda-forge/libaec-feedstock/blob/main/recipe/build.sh
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-libaec/PKGBUILD

It's unclear if we need any of these patches:
https://github.com/conda-forge/libaec-feedstock/blob/main/recipe/disable_static_cmake.patch
https://github.com/conda-forge/libaec-feedstock/blob/main/recipe/windows_restrict_keyword.diff
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-libaec/0005-cmake-fix-cmake-install.patch