### PR TITLE
Exodus_jll updates

### DIFF
--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -32,7 +32,7 @@ cmake \
     -D CMAKE_Fortran_FLAGS="" \
     -D Seacas_ENABLE_STRONG_C_COMPILE_WARNINGS="" \
     -D Seacas_ENABLE_STRONG_CXX_COMPILE_WARNINGS="" \
-    -D CMAKE_INSTALL_RPATH:PATH=${prefix}/lib \
+    -D CMAKE_INSTALL_RPATH:PATH="${libdir}" \
     -D BUILD_SHARED_LIBS:BOOL=YES \
     -D Seacas_ENABLE_SEACASExodus=YES \
     -D Seacas_ENABLE_SEACASExodus_for=NO \

--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -3,26 +3,67 @@
 using BinaryBuilder, Pkg
 
 name = "Exodus"
-version = v"0.1.1"
+version = v"8.19.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/gsjaardema/seacas.git", "a1da779b061fbdc750f18bcae29295dc5064cb74")
-    # GitSource("https://github.com/gsjaardema/seacas.git", "1452c325ab5d507d000397c713a5b0c4dc57bf81")
+    GitSource("https://github.com/gsjaardema/seacas.git", "cfc1edd1e1602fd1edc8da90053b66e92499c8e9"),
+    DirectorySource("bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/seacas
+
+for p in ../patches/*.patch; do
+    atomic_patch -p1 "${p}"
+done
+
 mkdir build
 cd build
-### The SEACAS code will install in ${INSTALL_PATH}/bin, ${INSTALL_PATH}/lib, and ${INSTALL_PATH}/include.
-INSTALL_PATH=${prefix} \
-FORTRAN=NO \
-NETCDF_PATH=${prefix} \
-PNETCDF_PATH=${prefix} \
-HDF5_PATH=${prefix} \
-../cmake-exodus
+
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    \
+    -D CMAKE_CXX_COMPILER:FILEPATH=${CXX} \
+    -D CMAKE_C_COMPILER:FILEPATH=${CC} \
+    -D CMAKE_Fortran_COMPILER:FILEPATH=${FC} \
+    -D CMAKE_CXX_FLAGS="-Wall -Wunused -pedantic" \
+    -D CMAKE_C_FLAGS="-Wall -Wunused -pedantic -std=c11" \
+    -D CMAKE_Fortran_FLAGS="" \
+    -D Seacas_ENABLE_STRONG_C_COMPILE_WARNINGS="" \
+    -D Seacas_ENABLE_STRONG_CXX_COMPILE_WARNINGS="" \
+    -D CMAKE_INSTALL_RPATH:PATH=${prefix}/lib \
+    -D BUILD_SHARED_LIBS:BOOL=YES \
+    -D Seacas_ENABLE_SEACASExodus=YES \
+    -D Seacas_ENABLE_SEACASExodus_for=NO \
+    -D Seacas_ENABLE_SEACASExoIIv2for32=NO \
+    -D Seacas_ENABLE_TESTS=NO \
+    -D SEACASExodus_ENABLE_STATIC:BOOL=NO \
+    -D Seacas_SKIP_FORTRANCINTERFACE_VERIFY_TEST:BOOL=YES \
+    -D Seacas_HIDE_DEPRECATED_CODE:BOOL=NO \
+    -D Seacas_ENABLE_Fortran=NO \
+    \
+    -DSeacas_ENABLE_SEACASNemslice:BOOL=ON \
+    -DSeacas_ENABLE_SEACASNemspread:BOOL=ON \
+    \
+    -DSeacas_ENABLE_SEACASEpu:BOOL=ON \
+    \
+    -DSeacas_ENABLE_SEACASExodiff:BOOL=ON \
+    \
+    -D TPL_ENABLE_Netcdf:BOOL=YES \
+    -D TPL_ENABLE_MPI:BOOL=NO \
+    -D TPL_ENABLE_Pthread:BOOL=NO \
+    -D SEACASExodus_ENABLE_THREADSAFE:BOOL=NO \
+    \
+    -D NetCDF_ROOT:PATH=${prefix} \
+    -D HDF5_ROOT:PATH=${prefix} \
+    -D HDF5_NO_SYSTEM_PATHS=YES \
+    -D PNetCDF_ROOT:PATH=${prefix} \
+    \
+    ..
 
 make -j${nproc}
 make install
@@ -33,20 +74,30 @@ make install
 platforms = [
     Platform("x86_64", "linux"; libc = "glibc"),
     Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("x86_64", "macos"),
+    Platform("aarch64","macos"),
+    Platform("x86_64", "windows"),
+    Platform("i686", "windows"),
 ]
 
+platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libexodus", :libexodus)
+    ExecutableProduct("nem_slice", :nem_slice_exe)
+    ExecutableProduct("nem_spread", :nem_spread_exe)
+    ExecutableProduct("exodiff", :exodiff_exe)
+    ExecutableProduct("epu", :epu_exe)
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
-    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"))
+    Dependency(PackageSpec(name="Fmt_jll", uuid="5dc1e892-f187-50dd-85f3-7dff85c47fc5"))
     Dependency(PackageSpec(name="HDF5_jll", uuid="0234f1f7-429e-5d53-9886-15a909be8d59"))
+    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"))
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")

--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -27,9 +27,6 @@ cmake \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     \
-    -D CMAKE_CXX_COMPILER:FILEPATH=${CXX} \
-    -D CMAKE_C_COMPILER:FILEPATH=${CC} \
-    -D CMAKE_Fortran_COMPILER:FILEPATH=${FC} \
     -D CMAKE_CXX_FLAGS="-Wall -Wunused -pedantic" \
     -D CMAKE_C_FLAGS="-Wall -Wunused -pedantic -std=c11" \
     -D CMAKE_Fortran_FLAGS="" \

--- a/E/Exodus/bundled/patches/0001-Patch-for-changes-to-some-library-names-and-NetCDF-c.patch
+++ b/E/Exodus/bundled/patches/0001-Patch-for-changes-to-some-library-names-and-NetCDF-c.patch
@@ -1,0 +1,73 @@
+From 8047cdbe21a53fa91de8614b4bed4a6c013757b3 Mon Sep 17 00:00:00 2001
+From: cmhamel <cmhamel32@gmail.com>
+Date: Sun, 19 Feb 2023 11:15:34 -0500
+Subject: [PATCH] Patch for changes to some library names and NetCDF cmake
+ build to accomodate for Windows builds with the BinaryBuilder.jl toolset.
+ Four files were changed minimally
+
+---
+ cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake | 6 +++---
+ packages/seacas/applications/epu/EP_Internals.C         | 2 +-
+ packages/seacas/applications/epu/EP_ParallelDisks.C     | 2 +-
+ packages/seacas/libraries/suplib_cpp/sys_info.C         | 2 +-
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake b/cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake
+index b3e70fe3cd..2f424bd3f8 100644
+--- a/cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake
++++ b/cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake
+@@ -270,9 +270,9 @@ if ( NetCDF_ROOT OR NetCDF_BIN_DIR )
+         set(NetCDF_NEEDS_PNetCDF "${netCDF_HAS_PNETCDF}")
+     else()
+         # Otherwise, try calling the nc-config shell script
+-        if (WIN32)
+-            message(FATAL_ERROR "nc-config can't be used on Windows, please use CMake to install NetCDF")
+-        endif()
++        #if (WIN32)
++        #    message(FATAL_ERROR "nc-config can't be used on Windows, please use CMake to install NetCDF")
++        #endif()
+         find_program(netcdf_config nc-config
+                        PATHS ${NetCDF_ROOT}/bin ${NetCDF_BIN_DIR}
+ 		           NO_DEFAULT_PATH
+diff --git a/packages/seacas/applications/epu/EP_Internals.C b/packages/seacas/applications/epu/EP_Internals.C
+index 39700e0dcd..0e86f3d7f2 100644
+--- a/packages/seacas/applications/epu/EP_Internals.C
++++ b/packages/seacas/applications/epu/EP_Internals.C
+@@ -23,7 +23,7 @@
+ 
+ #if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) ||                \
+     defined(__MINGW32__) || defined(_WIN64) || defined(__MINGW64__)
+-#include <Shlwapi.h>
++#include <shlwapi.h>
+ #endif
+ 
+ extern "C" {
+diff --git a/packages/seacas/applications/epu/EP_ParallelDisks.C b/packages/seacas/applications/epu/EP_ParallelDisks.C
+index f5496b983e..e11ca5c47a 100644
+--- a/packages/seacas/applications/epu/EP_ParallelDisks.C
++++ b/packages/seacas/applications/epu/EP_ParallelDisks.C
+@@ -15,7 +15,7 @@
+ 
+ #if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) ||                \
+     defined(__MINGW32__) || defined(_WIN64) || defined(__MINGW64__)
+-#include <Shlwapi.h>
++#include <shlwapi.h>
+ #endif
+ 
+ /*****************************************************************************/
+diff --git a/packages/seacas/libraries/suplib_cpp/sys_info.C b/packages/seacas/libraries/suplib_cpp/sys_info.C
+index cc034e1815..5f36b1f8b1 100644
+--- a/packages/seacas/libraries/suplib_cpp/sys_info.C
++++ b/packages/seacas/libraries/suplib_cpp/sys_info.C
+@@ -12,7 +12,7 @@
+ #ifndef NOMINMAX
+ #define NOMINMAX
+ #endif
+-#include <Windows.h>
++#include <windows.h>
+ #undef IN
+ #undef OUT
+ #include <fmt/ostream.h>
+-- 
+2.37.2
+


### PR DESCRIPTION
Adding a patch to the seacas git repository that fixes 4 minors issues on Windows builds. Three of them are the name of header files are capitalized vs. not and the fourth is related to the seacas cmake build automatically killing windows builds, that was simply commented out in the git patch.

Differences to the build_tarballs.jl include
1. Changed version number to actually match the exodusII library version number in seacas.
2. Added atomic_patch of git patch described above.
3. Added exodiff as executable product. This is used to test diffs between exodusII databases.
4. nem_slice and nem_spread libraries as products. These are used to perform mesh decomposition for parallel calculations.
5. epu as executable product. This is used to 'stitch' decomposed meshes back together after parallel computations.
6. Added windows platforms
7. Added preferred gcc version as 5 since one of the new products requires this to compile.