### PR TITLE
[libexif] Upgrade to 0.6.24 and build for new platforms

### DIFF
--- a/L/libexif/build_tarballs.jl
+++ b/L/libexif/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/libexif-*/
+cd $WORKSPACE/srcdir/libexif/
 if [[ "${target}" == powerpc64le-* ]] || [[ "${target}" == *-freebsd* ]]; then
     # Install `autopoint` and other tools needed by `autoreconf`
     apk add gettext-dev

--- a/L/libexif/build_tarballs.jl
+++ b/L/libexif/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "libexif"
-version = v"0.6.21"
+version = v"0.6.24"
 
 # Collection of sources required to complete build
 sources = [
-    "https://jaist.dl.sourceforge.net/project/libexif/libexif/0.6.21/libexif-0.6.21.tar.gz" =>
-    "edb7eb13664cf950a6edd132b75e99afe61c5effe2f16494e6d27bc404b287bf",
+    GitSource("https://github.com/libexif/libexif.git", 
+    "a7121eb4075df87c95004ca0c9d5385f23e6d777"),
 ]
 
 # Bash recipe for building across all platforms
@@ -24,11 +24,12 @@ update_configure_scripts
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
+install_license COPYING
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 
 # The products that we will ensure are always built
@@ -41,4 +42,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/libexif/build_tarballs.jl
+++ b/L/libexif/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/libexif/
+cd $WORKSPACE/srcdir/libexif-*/
 if [[ "${target}" == powerpc64le-* ]] || [[ "${target}" == *-freebsd* ]]; then
     # Install `autopoint` and other tools needed by `autoreconf`
     apk add gettext-dev

--- a/L/libexif/build_tarballs.jl
+++ b/L/libexif/build_tarballs.jl
@@ -7,8 +7,8 @@ version = v"0.6.24"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/libexif/libexif.git", 
-    "a7121eb4075df87c95004ca0c9d5385f23e6d777"),
+    ArchiveSource("https://github.com/libexif/libexif/releases/download/v0.6.24/libexif-0.6.24.tar.bz2", 
+    "d47564c433b733d83b6704c70477e0a4067811d184ec565258ac563d8223f6ae"),
 ]
 
 # Bash recipe for building across all platforms
@@ -29,7 +29,7 @@ install_license COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built


### PR DESCRIPTION
- To add support for libexif in arm based macos