### PR TITLE
Build libaec for all platforms

### DIFF
--- a/L/libaec/build_tarballs.jl
+++ b/L/libaec/build_tarballs.jl
@@ -27,7 +27,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude=!Sys.islinux)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
Previously libaec was only built for Linux. Here we expand to all platforms.