### PR TITLE
Git: Don't use `readlink` in script wrappers.

### DIFF
--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -69,7 +69,7 @@ if [[ "${target}" == *-apple-* ]]; then
     cat > "${bindir}/git" << 'EOF'
 #!/bin/bash
 
-SCRIPT_DIR=$( cd -- "$( dirname -- $(readlink -f "${BASH_SOURCE[0]}") )" &> /dev/null && pwd )
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export DYLD_FALLBACK_LIBRARY_PATH="${JLL_DYLD_FALLBACK_LIBRARY_PATH}"
 exec -a "${BASH_SOURCE[0]}" "${SCRIPT_DIR}/_git" "$@"
 EOF


### PR DESCRIPTION
`readlink -f` isn't available on macOS.
We don't expect these to be symlinks anyway.

Fixes https://github.com/JuliaVersionControl/Git.jl/issues/48.