### PR TITLE
[ducc0] Avoid AVX/AVX2 on Windows

### DIFF
--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -41,7 +41,7 @@ install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]))
 filter!(platforms) do p
     # On Windows, we want to avoid AVX/AVX2
-    Sys.iswindows(p) || ! contains(get(BinaryBuilderBase.march(p), "avx") 
+    Sys.iswindows(p) || ! contains(BinaryBuilderBase.march(p), "avx") 
 end
 
 augment_platform_block = """

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -38,10 +38,10 @@ install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 
 # Expand for microarchitectures on x86_64 (library doesn't have CPU dispatching)
 # Tests on Linux/x86_64 yielded a slow binary with avx512 for some reason, so disable that
-platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]))
+    platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]))
 filter!(platforms) do p
     # On Windows, we want to avoid AVX/AVX2
-    Sys.iswindows(p) || ! contains(something(BinaryBuilderBase.march(p), ""), "avx") 
+    !Sys.iswindows(p) || !contains(something(BinaryBuilderBase.march(p), ""), "avx") 
 end
 
 augment_platform_block = """

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -6,7 +6,7 @@ using BinaryBuilderBase
 include(joinpath(@__DIR__, "..", "..", "platforms", "microarchitectures.jl"))
 
 name = "ducc0"
-version = v"0.29.0"
+version = v"0.29.1"
 
 # Collection of sources required to complete build
 sources = [
@@ -38,8 +38,11 @@ install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 
 # Expand for microarchitectures on x86_64 (library doesn't have CPU dispatching)
 # Tests on Linux/x86_64 yielded a slow binary with avx512 for some reason, so disable that
-platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]); skip=!Sys.iswindows)
-platforms = expand_cxxstring_abis(platforms)
+platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]))
+filter!(platforms) do cur_p
+    # On Windows, we want to avoid AVX/AVX2
+    cur_p.tags["os"] != "windows" || ! contains(get(cur_p.tags, "march", ""), "avx") 
+end
 
 augment_platform_block = """
     $(MicroArchitectures.augment)

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -41,7 +41,7 @@ install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]))
 filter!(platforms) do p
     # On Windows, we want to avoid AVX/AVX2
-    Sys.iswindows(p) || ! contains(BinaryBuilderBase.march(p), "avx") 
+    Sys.iswindows(p) || ! contains(something(BinaryBuilderBase.march(p), ""), "avx") 
 end
 
 augment_platform_block = """

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -6,7 +6,7 @@ using BinaryBuilderBase
 include(joinpath(@__DIR__, "..", "..", "platforms", "microarchitectures.jl"))
 
 name = "ducc0"
-version = v"0.29.1"
+version = v"0.29.0"
 
 # Collection of sources required to complete build
 sources = [

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -38,7 +38,7 @@ install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 
 # Expand for microarchitectures on x86_64 (library doesn't have CPU dispatching)
 # Tests on Linux/x86_64 yielded a slow binary with avx512 for some reason, so disable that
-    platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]))
+platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]))
 filter!(platforms) do p
     # On Windows, we want to avoid AVX/AVX2
     !Sys.iswindows(p) || !contains(something(BinaryBuilderBase.march(p), ""), "avx") 

--- a/D/ducc0/build_tarballs.jl
+++ b/D/ducc0/build_tarballs.jl
@@ -39,9 +39,9 @@ install -Dvm 0755 "libducc_julia.${dlext}" "${libdir}/libducc_julia.${dlext}"
 # Expand for microarchitectures on x86_64 (library doesn't have CPU dispatching)
 # Tests on Linux/x86_64 yielded a slow binary with avx512 for some reason, so disable that
 platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2"]))
-filter!(platforms) do cur_p
+filter!(platforms) do p
     # On Windows, we want to avoid AVX/AVX2
-    cur_p.tags["os"] != "windows" || ! contains(get(cur_p.tags, "march", ""), "avx") 
+    Sys.iswindows(p) || ! contains(get(BinaryBuilderBase.march(p), "avx") 
 end
 
 augment_platform_block = """


### PR DESCRIPTION
Tests done on Windows have shown that the library crashes whenever `alm2leg` is called. Thanks to @mreineck, this was traced back to a wrong alignment (not on 32-bit boundaries). This is caused by AVX/AVX2 flags, which should not be used to compile Ducc0 under Windows.

This PR fixes the problem by filtering Windows+AVX/AVX2 out of the list of binaries to build.