### PR TITLE
MAGEMin v1.3.0

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,11 +6,11 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.2.8"
+version = v"1.3.0"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "029260c1577befb69dede77d9f2a65408b797bab")
+                    "eb15fb6a6b633e0a4ff5c50ad963d90a552b3a33")
         ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
- Added metapelite database with MnO (White et al., 2014), use the flag --db=ig or --db=mp to change database from igneous to metapelite
- Improved GUI (PlotPseudosection.mlapp): added option to change database; added panel to plot isocontour (mode and end-member fractions); added option to save pseudosection with isocontour in vector format (eps)
- Updated python scripts to translate database from TC to MAGEMin (check ./python/SS_Analytical_multi_DB.ipynb)
- Documentation udpate
