### PR TITLE
[Cares] Update to version 1.19.0

### DIFF
--- a/C/Cares/build_tarballs.jl
+++ b/C/Cares/build_tarballs.jl
@@ -3,15 +3,16 @@
 using BinaryBuilder, Pkg
 
 name = "Cares"
-version = v"1.18.1"
+version = v"1.19.0"
 
-# Collection of sources required to complete build
+# url = "https://c-ares.org/"
+# description = "C library for asynchronous DNS requests (including name resolves)"
+
 sources = [
     ArchiveSource("https://c-ares.org/download/c-ares-$(version).tar.gz",
-                  "1a7d52a8a84a9fbffb1be9133c0f6e17217d91ea5a6fa61f6b4729cda78ebbcf"),
+                  "bfceba37e23fd531293829002cac0401ef49a6dc55923f7f92236585b7ad1dd3"),
 ]
 
-# Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/c-ares-*/
 
@@ -27,11 +28,8 @@ make install
 install_license ../LICENSE.md
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
-# The products that we will ensure are always built
 products = [
     ExecutableProduct("acountry", :acountry),
     ExecutableProduct("adig", :adig),
@@ -39,10 +37,8 @@ products = [
     LibraryProduct("libcares", :libcares)
 ]
 
-# Dependencies that must be installed before this package can be built
 dependencies = Dependency[
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.6")


### PR DESCRIPTION
From the changelog:

```
Security:

    Low. Stack overflow in ares_set_sortlist() which is used during
    c-ares initialization and typically provided by an administrator and
    not an end user.
```

See https://c-ares.org/changelog.html