### PR TITLE
CUDNN: Explicitly list (and thus dlopen) sublibraries to work around discoverability issues.

### DIFF
--- a/C/CUDNN/build_tarballs.jl
+++ b/C/CUDNN/build_tarballs.jl
@@ -39,6 +39,14 @@ fi
 augment_platform_block = CUDA.augment
 
 products = [
+    LibraryProduct(["libcudnn_ops_infer", "cudnn_ops_infer64_$(version.major)"], :libcudnn_ops_infer64),
+    LibraryProduct(["libcudnn_ops_train", "cudnn_ops_train64_$(version.major)"], :libcudnn_ops_train64),
+    LibraryProduct(["libcudnn_cnn_infer", "cudnn_cnn_infer64_$(version.major)"], :libcudnn_cnn_infer64),
+    LibraryProduct(["libcudnn_cnn_train", "cudnn_cnn_train64_$(version.major)"], :libcudnn_cnn_train64),
+    LibraryProduct(["libcudnn_adv_infer", "cudnn_adv_infer64_$(version.major)"], :libcudnn_adv_infer64),
+    LibraryProduct(["libcudnn_adv_train", "cudnn_adv_train64_$(version.major)"], :libcudnn_adv_train64),
+
+    # shim layer
     LibraryProduct(["libcudnn", "cudnn64_$(version.major)"], :libcudnn),
 ]
 
@@ -60,6 +68,7 @@ for build in builds
         end
         build_tarballs(ARGS, name, version, sources, script, [augmented_platform],
                        products, dependencies; lazy_artifacts=true,
-                       julia_compat="1.6", augment_platform_block)
+                       julia_compat="1.6", augment_platform_block,
+                       dont_dlopen=true)
     end
 end


### PR DESCRIPTION
x-ref https://github.com/JuliaGPU/CUDA.jl/issues/1777