### PR TITLE
[OpenEXR] version 3.1.4

### DIFF
--- a/O/OpenEXR/build_tarballs.jl
+++ b/O/OpenEXR/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "OpenEXR"
-version = v"3.1.1"
+version = v"3.1.6"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.1.tar.gz", "045254e201c0f87d1d1a4b2b5815c4ae54845af2e6ec0ab88e979b5fdb30a86e")
+    ArchiveSource("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.6.tar.gz", "daa33d93a7b706e27368a162060df0246a7750c39a01a122d33b13f5c45d2029")
 ]
 
 
@@ -49,4 +49,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5.2.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5.2.0", julia_compat = "1.6")

--- a/O/OpenEXR/build_tarballs.jl
+++ b/O/OpenEXR/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"3.1.6"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.6.tar.gz", "daa33d93a7b706e27368a162060df0246a7750c39a01a122d33b13f5c45d2029")
+    GitSource("https://github.com/AcademySoftwareFoundation/openexr.git", "fd9d1ff55f340152ff3764617a2caef796142fc2")
 ]
 
 
@@ -44,7 +44,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Imath_jll"; compat="=3.1.2"),
+    Dependency("Imath_jll"; compat="=3.1.7"),
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 

--- a/O/OpenEXR/build_tarballs.jl
+++ b/O/OpenEXR/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "OpenEXR"
-version = v"3.1.6"
+version = v"3.1.4"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/AcademySoftwareFoundation/openexr.git", "fd9d1ff55f340152ff3764617a2caef796142fc2")
+    GitSource("https://github.com/AcademySoftwareFoundation/openexr.git", "3c3074026309dca667247e2544c4645b6fedeeca")
 ]
 
 
@@ -49,4 +49,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"12", julia_compat = "1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5.2.0", julia_compat = "1.6")

--- a/O/OpenEXR/build_tarballs.jl
+++ b/O/OpenEXR/build_tarballs.jl
@@ -49,4 +49,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5.2.0", julia_compat = "1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"12", julia_compat = "1.6")


### PR DESCRIPTION
Updates OpenEXR to version 3.1.6 and switches to GitSource method: https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.1.6