### PR TITLE
[Extrae] Update to version 4.0.3

### DIFF
--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -28,7 +28,7 @@ if [[ $bb_target = powerpc64le* ]]; then
     export ENABLE_POWERPC64LE=1
 fi
 
-if [[ $bb_full_target = *cuda* ]]; then
+if [[ $bb_full_target = *cuda\+[0-9]* ]]; then
     export ENABLE_CUDA=1
 fi
 

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -83,7 +83,7 @@ cuda_products = [
 dependencies = BinaryBuilder.AbstractDependency[
     Dependency("Binutils_jll"),
     Dependency("LibUnwind_jll"),
-    Dependency("PAPI_jll"; compat="6.0"),
+    Dependency("PAPI_jll"),
     Dependency("XML2_jll"),
     RuntimeDependency("CUDA_Runtime_jll"),
 ]

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -61,12 +61,12 @@ platforms = [
     Platform("aarch64", "linux"; libc="glibc"),
 ]
 
-cuda_versions_to_build = Any[v"10.2", v"11.0", v"12.1", nothing]
+cuda_versions_to_build = Any[v"10.2", v"11.0", nothing] #= v"12.1", =#
 
 cuda_versions = Dict(
     v"10.2" => v"10.2.89",
     v"11.0" => v"11.0.3",
-    v"12.1" => v"12.1.0"
+    # v"12.1" => v"12.1.0"
 )
 
 products = [

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -94,6 +94,11 @@ for cuda_version in cuda_versions_to_build, platform in platforms
         continue
     end
 
+    # TODO PAPI_jll 7.0.0+2 does not support CUDA on aarch64 (only x86_64, powerpc64le with glibc)
+    if arch(platform) == "aarch64" && !isnothing(cuda_version)
+        continue
+    end
+
     platform_tags = [Symbol(k) => v for (k, v) in tags(platform) if k ∉ ("arch", "os")]
     augmented_platform = Platform(arch(platform), os(platform);
         platform_tags...,

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -94,7 +94,7 @@ for cuda_version in cuda_versions_to_build, platform in platforms
         continue
     end
 
-    platform_tags = filter(((k, v),) -> k ∉ ("arch", "os"), tags(platform))
+    platform_tags = [Symbol(k) => v for (k, v) in tags(platform) if k ∉ ("arch", "os")]
     augmented_platform = Platform(arch(platform), os(platform);
         platform_tags...,
         cuda=isnothing(cuda_version) ? "none" : CUDA.platform(cuda_version)

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -83,7 +83,7 @@ cuda_products = [
 dependencies = BinaryBuilder.AbstractDependency[
     Dependency("Binutils_jll"),
     Dependency("LibUnwind_jll"),
-    Dependency("PAPI_jll"),
+    Dependency("PAPI_jll"; compat="6.0"),
     Dependency("XML2_jll"),
     RuntimeDependency("CUDA_Runtime_jll"),
 ]

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -94,9 +94,9 @@ for cuda_version in cuda_versions_to_build, platform in platforms
         continue
     end
 
-    tags = filter(((k, v),) -> k ∉ ("arch", "os"), tags(platform))
+    platform_tags = filter(((k, v),) -> k ∉ ("arch", "os"), tags(platform))
     augmented_platform = Platform(arch(platform), os(platform);
-        tags...,
+        platform_tags...,
         cuda=isnothing(cuda_version) ? "none" : CUDA.platform(cuda_version)
     )
     should_build_platform(triplet(augmented_platform)) || continue

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -60,11 +60,11 @@ platforms = expand_cxxstring_abis([
     Platform("aarch64", "linux"; libc="glibc"),
 ])
 
-cuda_versions_to_build = Any[v"10.2", v"11.8", v"12.1", nothing]
+cuda_versions_to_build = Any[v"10.2", v"11.0", v"12.1", nothing]
 
 cuda_versions = Dict(
     v"10.2" => v"10.2.89",
-    v"11.8" => v"11.8.0",
+    v"11.0" => v"11.0.3",
     v"12.1" => v"12.1.0"
 )
 

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -55,7 +55,7 @@ make install
 """
 
 platforms = expand_cxxstring_abis([
-    Platform("x86_64", "Linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
     Platform("powerpc64le", "linux"; libc="glibc"),
     Platform("aarch64", "linux"; libc="glibc"),
 ])

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -7,9 +7,9 @@ include(joinpath(dirname(dirname(@__DIR__)), "platforms", "cuda.jl"))
 
 
 name = "Extrae"
-version = v"4.0.3"
+version = v"4.0.2"
 sources = [
-    ArchiveSource("https://ftp.tools.bsc.es/extrae/extrae-$version-src.tar.bz2", "b5139a07dbb1f4aa9758c1d62d54e42c01125bcfa9aa0cb9ee4f863afae93db1"),
+    ArchiveSource("https://ftp.tools.bsc.es/extrae/extrae-$version-src.tar.bz2", "6f81f4e0335ece97a936ef6cbd30387d67a1a4484f3e42b3e74c42ef06e865d9"),
     DirectorySource(joinpath(@__DIR__, "bundled")),
 ]
 

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -7,9 +7,9 @@ include(joinpath(dirname(dirname(@__DIR__)), "platforms", "cuda.jl"))
 
 
 name = "Extrae"
-version = v"4.0.2"
+version = v"4.0.3"
 sources = [
-    ArchiveSource("https://ftp.tools.bsc.es/extrae/extrae-$version-src.tar.bz2", "6f81f4e0335ece97a936ef6cbd30387d67a1a4484f3e42b3e74c42ef06e865d9"),
+    ArchiveSource("https://ftp.tools.bsc.es/extrae/extrae-$version-src.tar.bz2", "b5139a07dbb1f4aa9758c1d62d54e42c01125bcfa9aa0cb9ee4f863afae93db1"),
     DirectorySource(joinpath(@__DIR__, "bundled")),
 ]
 

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -54,11 +54,11 @@ make -j${nproc}
 make install
 """
 
-platforms = expand_cxxstring_abis([
+platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
     Platform("powerpc64le", "linux"; libc="glibc"),
     Platform("aarch64", "linux"; libc="glibc"),
-])
+]
 
 cuda_versions_to_build = Any[v"10.2", v"11.0", v"12.1", nothing]
 

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -90,7 +90,7 @@ dependencies = BinaryBuilder.AbstractDependency[
 
 for cuda_version in cuda_versions_to_build, platform in platforms
     # powerpc64le not supported until CUDA 11.0
-    if arch(platform) == "powerpc64le" && cuda_version < v"11.0"
+    if arch(platform) == "powerpc64le" && !isnothing(cuda_version) && cuda_version < v"11.0"
         continue
     end
 

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -91,7 +91,7 @@ dependencies = BinaryBuilder.AbstractDependency[
 
 for cuda_version in cuda_versions_to_build, platform in platforms
     # powerpc64le not supported until CUDA 11.0
-    if arch(platform) == "powerpc64le" && !isnothing(cuda_version) && cuda_version < v"11.0"
+    if arch(platform) == "powerpc64le" && !isnothing(cuda_version) && cuda_version <= v"11.0"
         continue
     end
 

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -16,9 +16,6 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/extrae-*
 
-# atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0001-autoconf-replace-pointer-size-check-by-AC_CHECK_SIZE.patch
-# atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0002-autoconf-use-simpler-endianiness-check.patch
-# atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0003-autoconf-support-powerpc64le-cross-compilation.patch
 atomic_patch -p0 ${WORKSPACE}/srcdir/patches/0004-cuda-cupti-undefined-structs-since-v12.patch
 
 if [[ $bb_target = aarch64* ]]; then

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -19,6 +19,7 @@ cd ${WORKSPACE}/srcdir/extrae-*
 # atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0001-autoconf-replace-pointer-size-check-by-AC_CHECK_SIZE.patch
 # atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0002-autoconf-use-simpler-endianiness-check.patch
 # atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0003-autoconf-support-powerpc64le-cross-compilation.patch
+atomic_patch -p0 ${WORKSPACE}/srcdir/patches/0004-cuda-cupti-undefined-structs-since-v12.patch
 
 if [[ $bb_target = aarch64* ]]; then
     export ENABLE_ARM64=1

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -7,18 +7,18 @@ include(joinpath(dirname(dirname(@__DIR__)), "platforms", "cuda.jl"))
 
 
 name = "Extrae"
-version = v"4.0.2" # NOTE this is version 4.0.2rc1. its release candidate, but we needed a patch for Binutils 2.39
+version = v"4.0.3"
 sources = [
-    GitSource("https://github.com/bsc-performance-tools/extrae", "5eb2a8ad56aca035b1e13b021a944143e59e6b4a"),
+    ArchiveSource("https://ftp.tools.bsc.es/extrae/extrae-$version-src.tar.bz2", "b5139a07dbb1f4aa9758c1d62d54e42c01125bcfa9aa0cb9ee4f863afae93db1"),
     DirectorySource(joinpath(@__DIR__, "bundled")),
 ]
 
 script = raw"""
-cd ${WORKSPACE}/srcdir/extrae
+cd ${WORKSPACE}/srcdir/extrae-*
 
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0001-autoconf-replace-pointer-size-check-by-AC_CHECK_SIZE.patch
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0002-autoconf-use-simpler-endianiness-check.patch
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0003-autoconf-support-powerpc64le-cross-compilation.patch
+# atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0001-autoconf-replace-pointer-size-check-by-AC_CHECK_SIZE.patch
+# atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0002-autoconf-use-simpler-endianiness-check.patch
+# atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0003-autoconf-support-powerpc64le-cross-compilation.patch
 
 if [[ $bb_target = aarch64* ]]; then
     export ENABLE_ARM64=1

--- a/E/Extrae/bundled/patches/0004-cuda-cupti-undefined-structs-since-v12.patch
+++ b/E/Extrae/bundled/patches/0004-cuda-cupti-undefined-structs-since-v12.patch
@@ -1,0 +1,27 @@
+diff --git src/tracer/wrappers/CUDA/cuda_wrapper_cupti.c src/tracer/wrappers/CUDA/cuda_wrapper_cupti.c
+index c07e14f7..f19dfabe 100644
+--- src/tracer/wrappers/CUDA/cuda_wrapper_cupti.c
++++ src/tracer/wrappers/CUDA/cuda_wrapper_cupti.c
+@@ -43,6 +43,7 @@
+ #include <cupti.h>
+ #include "cuda_common.h"
+ #include "cuda_probe.h"
++#include "cuda_wrapper_cupti.h"
+ 
+ #define LOG_UNTRACKED_CALLBACKS 0
+ #define LOG_OTHER_DOMAIN_UNTRACKED_CALLBACKS 0
+diff --git src/tracer/wrappers/CUDA/cuda_wrapper_cupti.h src/tracer/wrappers/CUDA/cuda_wrapper_cupti.h
+index 164531e8..23718f7f 100644
+--- src/tracer/wrappers/CUDA/cuda_wrapper_cupti.h
++++ src/tracer/wrappers/CUDA/cuda_wrapper_cupti.h
+@@ -36,6 +36,10 @@ typedef struct cudaConfigureCall_v3020_params_st {
+ typedef struct cudaStreamDestroy_v3020_params_st {
+     cudaStream_t stream;
+ } cudaStreamDestroy_v3020_params;
++
++typedef struct cudaLaunch_v3020_params_st {
++    const char *func;
++} cudaLaunch_v3020_params;
+ #endif /* CUPTI_API_VERSION > 12 */
+ 
+ void Extrae_CUDA_init (int rank);

--- a/E/Extrae/bundled/patches/0004-cuda-cupti-undefined-structs-since-v12.patch
+++ b/E/Extrae/bundled/patches/0004-cuda-cupti-undefined-structs-since-v12.patch
@@ -11,17 +11,28 @@ index c07e14f7..f19dfabe 100644
  #define LOG_UNTRACKED_CALLBACKS 0
  #define LOG_OTHER_DOMAIN_UNTRACKED_CALLBACKS 0
 diff --git src/tracer/wrappers/CUDA/cuda_wrapper_cupti.h src/tracer/wrappers/CUDA/cuda_wrapper_cupti.h
-index 164531e8..23718f7f 100644
+index 164531e8..6eaf196f 100644
 --- src/tracer/wrappers/CUDA/cuda_wrapper_cupti.h
 +++ src/tracer/wrappers/CUDA/cuda_wrapper_cupti.h
-@@ -36,6 +36,10 @@ typedef struct cudaConfigureCall_v3020_params_st {
+@@ -25,7 +25,7 @@
+ #ifndef CUDA_WRAPPER_CUPTI_H_
+ #define CUDA_WRAPPER_CUPTI_H_
+ 
+-#if CUPTI_API_VERSION > 12
++#if CUPTI_API_VERSION > 11
+ typedef struct cudaConfigureCall_v3020_params_st {
+ 	dim3 gridDim;
+ 	dim3 blockDim;
+@@ -36,7 +36,11 @@ typedef struct cudaConfigureCall_v3020_params_st {
  typedef struct cudaStreamDestroy_v3020_params_st {
      cudaStream_t stream;
  } cudaStreamDestroy_v3020_params;
+-#endif /* CUPTI_API_VERSION > 12 */
 +
 +typedef struct cudaLaunch_v3020_params_st {
 +    const char *func;
 +} cudaLaunch_v3020_params;
- #endif /* CUPTI_API_VERSION > 12 */
++#endif /* CUPTI_API_VERSION > 11 */
  
  void Extrae_CUDA_init (int rank);
+ 


### PR DESCRIPTION
Extrae v4.0.3 was released last week and contains some of the patches we needed in order to build it for Yggdrasil. This PR updates the version and disables the patches.

It also refactors the recipe so it is more maintainable ~~and adds support for CUDA 12.1~~.