### PR TITLE
[SHTns] bump v3.5.2, allow omp threads

### DIFF
--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -13,17 +13,19 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/shtns/
-export CC="gcc"
 export CFLAGS="-fPIC -O3" #only -fPIC produces slow code on linux x86 and MacOS x86 (maybe others)
-# I remove openmp fftw checks, because FFTW_jll doesn't provide -lfftw3_omp
-# propaly not the safest way!
-sed -i -e '4908,4957d' configure 
+
+#remove lfftw3_omp library references, as FFTW_jll does not provide it
+sed -i -e 's/lfftw3_omp/lfftw3/' configure
+
 ./configure --prefix=${prefix} --host=${target} --enable-openmp
 make -j${nproc}
 make install
+
 mkdir -p ${libdir}
-gcc -fopenmp -shared -o "${libdir}/libshtns.${dlext}" *.o -lfftw3     
+cc -fopenmp -shared -o "${libdir}/libshtns.${dlext}" *.o -lfftw3     
 rm "${prefix}/lib/libshtns_omp.a"
+
 install_license LICENSE
 """
 
@@ -39,12 +41,14 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a")),
-    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
+    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
+    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
+    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; 
                     julia_compat="1.6", 
-                    # preferred_gcc_version=v"12", 
                     lock_microarchitecture=false,
                     )

--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -3,34 +3,36 @@
 using BinaryBuilder, Pkg
 
 name = "SHTns"
-version = v"3.5.1"
+version = v"3.5.2"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://bitbucket.org/nschaeff/shtns/downloads/shtns-$(version).tar.gz", "77f8a33b94df8786d2ce9b95cbfbe548f00443625b310b8c64012b22c8a7394f")
+    ArchiveSource("https://bitbucket.org/nschaeff/shtns/downloads/shtns-$(version).tar.gz", "dc4ac08c09980e47c71d79d38696c5d1d631f86c2af1ce8aad5d21f7fd2c05b9")
 ]
 
 # Bash recipe for building across all platforms
+#if [[ "${target}" == *-apple-* ]]; then
+    # For some reasons, `configure` insists on setting CC2=gcc, also on macOS
+#    sed -i -e 's/gcc/cc/' -e 's/ -fno-tree-loop-distribute-patterns//' Makefile
+#fi
+#
 script = raw"""
 cd $WORKSPACE/srcdir/shtns/
-export CFLAGS="-fPIC"
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
-if [[ "${target}" == *-apple-* ]]; then
-    # For some reasons, `configure` insists on setting CC2=gcc, also on macOS
-    sed -i -e 's/gcc/cc/' -e 's/ -fno-tree-loop-distribute-patterns//' Makefile
-fi
+export CFLAGS=" -DFFTW_PLAN_SAFE"
+sed -i -e '4908,4957d' configure #removes openmp fftw checks, this is fine as we link to FFTW_jll
+./configure --prefix=${prefix} --host=${target} --enable-openmp
 make -j${nproc}
 make install
 mkdir -p ${libdir}
-cc -shared -o "${libdir}/libshtns.${dlext}" *.o -lfftw3
-rm "${prefix}/lib/libshtns.a"
+cc -shared -o "${libdir}/libshtns.${dlext}" *.o -lfftw3 
+#rm "${prefix}/lib/libshtns_omp.a"
 install_license LICENSE
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-
+platforms = expand_microarchitectures(supported_platforms())
+#platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2", "avx512"]))
 
 # The products that we will ensure are always built
 products = [
@@ -43,4 +45,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6") #, preferred_gcc_version=v"11")
+

--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -66,6 +66,6 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; 
                 julia_compat="1.6", 
-                preferred_gcc_version=v"12",
+                preferred_gcc_version=v"7",
                 augment_platform_block)
 

--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -11,28 +11,25 @@ sources = [
 ]
 
 # Bash recipe for building across all platforms
-#if [[ "${target}" == *-apple-* ]]; then
-    # For some reasons, `configure` insists on setting CC2=gcc, also on macOS
-#    sed -i -e 's/gcc/cc/' -e 's/ -fno-tree-loop-distribute-patterns//' Makefile
-#fi
-#
 script = raw"""
 cd $WORKSPACE/srcdir/shtns/
-export CFLAGS="-fPIC -DFFTW_PLAN_SAFE"
-sed -i -e '4908,4957d' configure #removes openmp fftw checks, this is fine as we link to FFTW_jll
+export CC="gcc"
+export CFLAGS="-fPIC -O3" #only -fPIC produces slow code on linux x86 and MacOS x86 (maybe others)
+# I remove openmp fftw checks, because FFTW_jll doesn't provide -lfftw3_omp
+# propaly not the safest way!
+sed -i -e '4908,4957d' configure 
 ./configure --prefix=${prefix} --host=${target} --enable-openmp
 make -j${nproc}
 make install
 mkdir -p ${libdir}
-cc -shared -o "${libdir}/libshtns.${dlext}" *.o -lfftw3 
-#rm "${prefix}/lib/libshtns_omp.a"
+gcc -fopenmp -shared -o "${libdir}/libshtns.${dlext}" *.o -lfftw3     
+rm "${prefix}/lib/libshtns_omp.a"
 install_license LICENSE
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_microarchitectures(supported_platforms())
-#platforms = expand_cxxstring_abis(expand_microarchitectures(supported_platforms(), ["x86_64", "avx", "avx2", "avx512"]))
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
@@ -41,9 +38,13 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))
+    Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a")),
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6") #, preferred_gcc_version=v"11")
-
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; 
+                    julia_compat="1.6", 
+                    # preferred_gcc_version=v"12", 
+                    lock_microarchitecture=false,
+                    )

--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -18,7 +18,7 @@ sources = [
 #
 script = raw"""
 cd $WORKSPACE/srcdir/shtns/
-export CFLAGS=" -DFFTW_PLAN_SAFE"
+export CFLAGS="-fPIC -DFFTW_PLAN_SAFE"
 sed -i -e '4908,4957d' configure #removes openmp fftw checks, this is fine as we link to FFTW_jll
 ./configure --prefix=${prefix} --host=${target} --enable-openmp
 make -j${nproc}

--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -25,7 +25,7 @@ make -j${nproc}
 make install
 
 mkdir -p ${libdir}
-cc -fopenmp -shared -o "${libdir}/libshtns.${dlext}" *.o -lfftw3     
+cc -fopenmp -shared -o "${libdir}/libshtns.${dlext}" *.o -lfftw3
 rm "${prefix}/lib/libshtns_omp.a"
 
 install_license LICENSE
@@ -64,8 +64,7 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; 
-                julia_compat="1.6", 
-                preferred_gcc_version=v"7",
-                augment_platform_block)
-
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6",
+               preferred_gcc_version=v"10",
+               augment_platform_block)


### PR DESCRIPTION
also hack around fftw_omp requirement of shtns to allow SHTns_jll to use FFTW_jll threads.