### PR TITLE
[CUDA_full] Support aarch64 arch in v11.0, v11.1, v11.2

### DIFF
--- a/C/CUDA/CUDA_full@11.0/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@11.0/build_tarballs.jl
@@ -13,6 +13,10 @@ sources_linux_ppc64le = [
     FileSource("https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux_ppc64le.run",
                "4775b21df004b1433bafff9b48a324075c008509f4c0fe28cd060d042d2e0794", "installer.run")
 ]
+sources_linux_aarch64 = [
+    FileSource("https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux_sbsa.run",
+               "1e24f61f79c1043aa3d1d126ff6158daa03a62a51b5195a2ed5fbe75c3b718f3", "installer.run")
+]
 sources_win10 = [
     FileSource("http://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_451.82_win10.exe",
                "a639e0c097717c5f544f7a81b7162b4cb49243a30fd892f3267bc5532c8e2584", "installer.exe")
@@ -107,6 +111,12 @@ end
 if should_build_platform("powerpc64le-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_ppc64le, script,
                    [Platform("powerpc64le", "linux")], products, dependencies;
+                   skip_audit=true)
+end
+
+if should_build_platform("aarch64-linux-gnu")
+    build_tarballs(non_reg_ARGS, name, version, sources_linux_aarch64, script,
+                   [Platform("aarch64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 

--- a/C/CUDA/CUDA_full@11.1/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@11.1/build_tarballs.jl
@@ -13,6 +13,10 @@ sources_linux_ppc64le = [
     FileSource("https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux_ppc64le.run",
                "023e571fe26ee829c98138dfc305a92279854aac7d184d255fd58c06c6af3c17", "installer.run")
 ]
+sources_linux_aarch64 = [
+    FileSource("https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux_sbsa.run",
+               "9ab1dbafba205c06bea8c88e38cdadb3038af19cb56e7b3ba734d3d7a84b8f02", "installer.run")
+]
 sources_win10 = [
     FileSource("https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_456.81_win10.exe",
                "c05b81319a272a8edd7a5e26bddcb4719071837c438be76e586da289b50ef853", "installer.exe")
@@ -109,6 +113,12 @@ end
 if should_build_platform("powerpc64le-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_ppc64le, script,
                    [Platform("powerpc64le", "linux")], products, dependencies;
+                   skip_audit=true)
+end
+
+if should_build_platform("aarch64-linux-gnu")
+    build_tarballs(non_reg_ARGS, name, version, sources_linux_aarch64, script,
+                   [Platform("aarch64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 

--- a/C/CUDA/CUDA_full@11.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_full@11.2/build_tarballs.jl
@@ -13,6 +13,10 @@ sources_linux_ppc64le = [
     FileSource("https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux_ppc64le.run",
                "2304ec235fe5d1f8bf75f00dc2c2d11473759dc23428dbbd5fb5040bc8c757e3", "installer.run")
 ]
+sources_linux_aarch64 = [
+    FileSource("https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux_sbsa.run",
+               "2f915ad631331eebdafaabd971723a60290ae8bb090d771075b9e6a0b28cbae6", "installer.run")
+]
 sources_win10 = [
     FileSource("https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_461.33_win10.exe",
                "e572654ac90ea720b73cf72f14af6b175dddf4ff282af822e32c19d63f0284c4", "installer.exe")
@@ -109,6 +113,12 @@ end
 if should_build_platform("powerpc64le-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_ppc64le, script,
                    [Platform("powerpc64le", "linux")], products, dependencies;
+                   skip_audit=true)
+end
+
+if should_build_platform("aarch64-linux-gnu")
+    build_tarballs(non_reg_ARGS, name, version, sources_linux_aarch64, script,
+                   [Platform("aarch64", "linux")], products, dependencies;
                    skip_audit=true)
 end
 


### PR DESCRIPTION
Installers for the aarch64 architecture are present in CUDA_full >= v11.3 but the installers for CUDA v11.0, v11.1, v11.2 were missing. This PR adds the respective installers to the recipes.