### PR TITLE
[CeresSolver] Bump version to 2.1.0

### DIFF
--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -60,7 +60,7 @@ dependencies = [
     Dependency("glog_jll"),
     Dependency("METIS_jll"),
     Dependency("OpenBLAS_jll"),
-    Dependency("SuiteSparse_jll", build_version=v"5.10.1")
+    Dependency("SuiteSparse_jll", v"5.10.1")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -1,4 +1,4 @@
-using BinaryBuilder, Pkg
+using BinaryBuilder
 
 name = "CeresSolver"
 version = v"2.1.0"
@@ -39,7 +39,7 @@ products = Product[
 dependencies = [
     # CeresSolver is removing OpenMP and dependencies for OpenMP are dropped
     # https://github.com/ceres-solver/ceres-solver/issues/886
-    # Eigen_jll v0.3.4 throws error on powerpc64le with older GCC versions
+    # Eigen_jll v0.3.4 throws errors on powerpc64le with older GCC versions
     BuildDependency("Eigen_jll"),
     Dependency("glog_jll"),
     # Metis replaces SuiteSparse on Windows

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -36,15 +36,11 @@ products = Product[
     LibraryProduct("libceres", :libceres),
 ]
 
-ispowerpc64le(x) = arch(x) == "powerpc64le"
-
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # CeresSolver prefers CXX_THREADS over OpenMP and dependencies for OpenMP are removed
-    BuildDependency("Eigen_jll"; platforms=filter(!ispowerpc64le, platforms)),
-    # Eigen v3.4.0 does not work on powerpc64le
-    BuildDependency(PackageSpec(name="Eigen_jll", version=v"3.3.9");
-        platforms=filter(ispowerpc64le, platforms)),
+    # CeresSolver is removing OpenMP and dependencies for OpenMP are dropped
+    # https://github.com/ceres-solver/ceres-solver/issues/886
+    BuildDependency("Eigen_jll"),
     Dependency("glog_jll"),
     # Metis replaces SuiteSparse on Windows
     Dependency("METIS_jll"),
@@ -54,4 +50,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"5", julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6", julia_compat="1.6")

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -19,7 +19,8 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DBLAS_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DLAPACK_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DMETIS_LIBRARY=${libdir}/libmetis.${dlext}
-              -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.*.${dlext}
+              -DSUITESPARSE=ON
+              -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.*.${dlext}"
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -10,9 +10,6 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-mkdir cmake_build
-cd cmake_build/
-
 if [[ "$target" == *-freebsd* || "$target" == *-apple-* ]]; then
   # Clang doesn't play nicely with OpenMP and
   # compilation fails with glog due to a c++11 error
@@ -42,8 +39,9 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.${dlext}"
               )
 
-cmake ${CMAKE_FLAGS[@]} ..
-
+cd $WORKSPACE/srcdir/ceres-solver/
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ${CMAKE_FLAGS[@]}
 make -j${nproc}
 make install
 

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -23,7 +23,6 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
 
 cd $WORKSPACE/srcdir/ceres-solver/
 mkdir build && cd build
-export OPENBLAS_NUM_THREADS=1
 cmake .. ${CMAKE_FLAGS[@]}
 make -j${nproc}
 make install
@@ -40,6 +39,7 @@ products = Product[
 dependencies = [
     # CeresSolver is removing OpenMP and dependencies for OpenMP are dropped
     # https://github.com/ceres-solver/ceres-solver/issues/886
+    # Eigen_jll v0.3.4 throws error on powerpc64le with older GCC versions
     BuildDependency("Eigen_jll"),
     Dependency("glog_jll"),
     # Metis replaces SuiteSparse on Windows

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -60,7 +60,7 @@ dependencies = [
     Dependency("glog_jll"),
     Dependency("METIS_jll"),
     Dependency("OpenBLAS_jll"),
-    Dependency(PackageSpec(name="SuiteSparse_jll", version="5.10"))
+    Dependency("SuiteSparse_jll", build_version=v"5.10.1")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -40,6 +40,8 @@ cd ..
 """
 
 platforms = expand_cxxstring_abis(supported_platforms())
+# Build for all platforms with cxx03 ABI fails
+filter!(p->cxxstring_abi(p) === :cxx11, platforms)
 
 # The products that we will ensure are always built
 products = Product[

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -59,6 +59,7 @@ dependencies = [
     BuildDependency("Eigen_jll"),
     Dependency("glog_jll"),
     Dependency("METIS_jll"),
+    Dependency("OpenBLAS32_jll"),
     Dependency("OpenBLAS_jll"),
     Dependency("SuiteSparse_jll", v"5.10.1")
 ]

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -20,7 +20,13 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DLAPACK_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DMETIS_LIBRARY=${libdir}/libmetis.${dlext}
               -DSUITESPARSE_INCLUDE_DIR_HINTS=${prefix}/include
-              -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.* ${libdir}/libsuitesparseconfig.*}"
+              -DAMD_LIBRARY="${libdir}/libamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
+              -DCAMD_LIBRARY="${libdir}/libcamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
+              -DCCOLAMD_LIBRARY="${libdir}/libccolamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
+              -DCHOLMOD_LIBRARY="${libdir}/libcholmod.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
+              -DCOLAMD_LIBRARY="${libdir}/libcolamd.${dlext} ${libdir}/libsuitepsarseconfig.${dlext}"
+              -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
+              -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.${dlext}"
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -19,14 +19,6 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DBLAS_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DLAPACK_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DMETIS_LIBRARY=${libdir}/libmetis.${dlext}
-              -DSUITESPARSE_INCLUDE_DIR_HINTS=${prefix}/include
-              -DAMD_LIBRARY="${libdir}/libamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DCAMD_LIBRARY="${libdir}/libcamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DCCOLAMD_LIBRARY="${libdir}/libccolamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DCHOLMOD_LIBRARY="${libdir}/libcholmod.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DCOLAMD_LIBRARY="${libdir}/libcolamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.${dlext}"
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/
@@ -46,21 +38,25 @@ products = Product[
     LibraryProduct("libceres", :libceres),
 ]
 
+ispowerpc64le(x) = arch(x) == "powerpc64le"
+
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    # CeresSolver prefers CXX_THREADS over OpenMP and OpenMP is not used
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
-    Dependency(PackageSpec(name="CompilerSupportLibraries_jll",
-        uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
-        platforms=filter(!Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="LLVMOpenMP_jll",
-        uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
-        platforms=filter(Sys.isbsd, platforms)),
-    BuildDependency("Eigen_jll"),
+    #Dependency(PackageSpec(name="CompilerSupportLibraries_jll",
+    #    uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
+    #    platforms=filter(!Sys.isbsd, platforms)),
+    #Dependency(PackageSpec(name="LLVMOpenMP_jll",
+    #    uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
+    #    platforms=filter(Sys.isbsd, platforms)),
+    BuildDependency("Eigen_jll"; platforms=filter(!ispowerpc64le, platforms)),
+    # Eigen v3.4.0 does not work on powerpc64le
+    BuildDependency("Eigen_jll", v"3.3.9"; platforms=filter(ispowerpc64le, platforms)),
     Dependency("glog_jll"),
     Dependency("METIS_jll"),
     Dependency("OpenBLAS32_jll"),
-    Dependency("OpenBLAS_jll"),
     Dependency("SuiteSparse_jll", v"5.10.1")
 ]
 

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -13,7 +13,6 @@ script = raw"""
 CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
               -DCMAKE_BUILD_TYPE=Release
-              -DCMAKE_CXX_STANDARD=17
               -DBUILD_SHARED_LIBS=ON
               -DBUILD_EXAMPLES=OFF
               -DBUILD_TESTING=OFF
@@ -32,8 +31,6 @@ cd ..
 """
 
 platforms = expand_cxxstring_abis(supported_platforms())
-# Build for all platforms with cxx03 ABI fails
-filter!(p->cxxstring_abi(p) !== "cxx03", platforms)
 
 # The products that we will ensure are always built
 products = Product[

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -53,7 +53,8 @@ dependencies = [
     #    platforms=filter(Sys.isbsd, platforms)),
     BuildDependency("Eigen_jll"; platforms=filter(!ispowerpc64le, platforms)),
     # Eigen v3.4.0 does not work on powerpc64le
-    BuildDependency("Eigen_jll", v"3.3.9"; platforms=filter(ispowerpc64le, platforms)),
+    BuildDependency(PackageSpec(name="Eigen_jll", version=v"3.3.9");
+        platforms=filter(ispowerpc64le, platforms)),
     Dependency("glog_jll"),
     Dependency("METIS_jll"),
     Dependency("OpenBLAS32_jll"),

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -10,18 +10,10 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-if [[ "$target" == *-freebsd* || "$target" == *-apple-* ]]; then
-  # Clang doesn't play nicely with OpenMP and
-  # compilation fails with glog due to a c++11 error
-  CMAKE_FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_gcc.cmake
-               -DMINIGLOG=ON)
-else
-  CMAKE_FLAGS=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
-               -DGLOG_INCLUDE_DIR_HINTS=${prefix}/include)
-fi
-
 CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
-              -DCMAKE_CXX_FLAGS="-std=c++17"
+              -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_CXX_STANDARD=17
               -DBUILD_SHARED_LIBS=ON
               -DBUILD_EXAMPLES=OFF
               -DBUILD_TESTING=OFF
@@ -32,7 +24,7 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
 
 cd $WORKSPACE/srcdir/ceres-solver/
 mkdir build && cd build
-cmake .. ${CMAKE_FLAGS[@]} -DCMAKE_BUILD_TYPE=Release
+cmake .. ${CMAKE_FLAGS[@]}
 make -j${nproc}
 make install
 
@@ -41,7 +33,7 @@ cd ..
 
 platforms = expand_cxxstring_abis(supported_platforms())
 # Build for all platforms with cxx03 ABI fails
-filter!(p->cxxstring_abi(p) === :cxx11, platforms)
+filter!(p->cxxstring_abi(p) !== "cxx03", platforms)
 
 # The products that we will ensure are always built
 products = Product[
@@ -50,7 +42,15 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Eigen_jll"),
+    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
+    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll",
+        uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
+        platforms=filter(!Sys.isbsd, platforms)),
+    Dependency(PackageSpec(name="LLVMOpenMP_jll",
+        uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
+        platforms=filter(Sys.isbsd, platforms)),
+    BuildDependency("Eigen_jll"),
     Dependency("glog_jll"),
     Dependency("METIS_jll"),
     Dependency("OpenBLAS32_jll"),

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -1,17 +1,15 @@
 using BinaryBuilder
 
 name = "CeresSolver"
-version = v"1.14.0"
+version = v"2.1.0"
 
 sources = [
-    ArchiveSource("http://ceres-solver.org/ceres-solver-$(version).tar.gz",
-                  "4744005fc3b902fed886ea418df70690caa8e2ff6b5a90f3dd88a3d291ef8e8e")
+    GitSource("https://github.com/ceres-solver/ceres-solver.git",
+              "f68321e7de8929fbcdb95dd42877531e64f72f66")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/ceres-solver-1.14.0
-
 mkdir cmake_build
 cd cmake_build/
 
@@ -70,4 +68,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -27,8 +27,6 @@ export OPENBLAS_NUM_THREADS=1
 cmake .. ${CMAKE_FLAGS[@]}
 make -j${nproc}
 make install
-
-cd ..
 """
 
 platforms = expand_cxxstring_abis(supported_platforms())
@@ -42,22 +40,16 @@ ispowerpc64le(x) = arch(x) == "powerpc64le"
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # CeresSolver prefers CXX_THREADS over OpenMP and OpenMP is not used
-    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
-    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
-    #Dependency(PackageSpec(name="CompilerSupportLibraries_jll",
-    #    uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
-    #    platforms=filter(!Sys.isbsd, platforms)),
-    #Dependency(PackageSpec(name="LLVMOpenMP_jll",
-    #    uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
-    #    platforms=filter(Sys.isbsd, platforms)),
+    # CeresSolver prefers CXX_THREADS over OpenMP and dependencies for OpenMP are removed
     BuildDependency("Eigen_jll"; platforms=filter(!ispowerpc64le, platforms)),
     # Eigen v3.4.0 does not work on powerpc64le
     BuildDependency(PackageSpec(name="Eigen_jll", version=v"3.3.9");
         platforms=filter(ispowerpc64le, platforms)),
     Dependency("glog_jll"),
+    # Metis replaces SuiteSparse on Windows
     Dependency("METIS_jll"),
     Dependency("OpenBLAS32_jll"),
+    # Hard code the version now as the latest v7.0.1 does not get recognized
     Dependency("SuiteSparse_jll", v"5.10.1")
 ]
 

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -27,6 +27,10 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DCOLAMD_LIBRARY="${libdir}/libcolamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
               -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
               -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.${dlext}"
+              -DSuiteSparse_VERSION=7.0.1
+              -DSuiteSparse_VERSION_MAJOR=7
+              -DSuiteSparse_VERSION_MINOR=0
+              -DSuiteSparse_VERSION_PATCH=1
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -1,4 +1,4 @@
-using BinaryBuilder
+using BinaryBuilder, Pkg
 
 name = "CeresSolver"
 version = v"2.1.0"

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -27,10 +27,6 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DCOLAMD_LIBRARY="${libdir}/libcolamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
               -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
               -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.${dlext}"
-              -DSuiteSparse_VERSION=7.0.1
-              -DSuiteSparse_VERSION_MAJOR=7
-              -DSuiteSparse_VERSION_MINOR=0
-              -DSuiteSparse_VERSION_PATCH=1
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/
@@ -64,7 +60,7 @@ dependencies = [
     Dependency("glog_jll"),
     Dependency("METIS_jll"),
     Dependency("OpenBLAS_jll"),
-    Dependency("SuiteSparse_jll")
+    Dependency(PackageSpec(name="SuiteSparse_jll", version="5.10"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -54,8 +54,7 @@ dependencies = [
     Dependency("glog_jll"),
     Dependency("METIS_jll"),
     Dependency("OpenBLAS32_jll"),
-    Dependency("SuiteSparse_jll"),
-    Dependency("CompilerSupportLibraries_jll"),
+    Dependency("SuiteSparse_jll")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -50,4 +50,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"6", julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -19,8 +19,8 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DBLAS_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DLAPACK_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DMETIS_LIBRARY=${libdir}/libmetis.${dlext}
-              -DSUITESPARSE=ON
-              -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.*.${dlext}"
+              -DSUITESPARSE_INCLUDE_DIR_HINTS=${prefix}/include
+              -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.${dlext} ${libdir}/libsuitesparseconfig.*.${dlext}"
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -41,7 +41,7 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
 
 cd $WORKSPACE/srcdir/ceres-solver/
 mkdir build && cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ${CMAKE_FLAGS[@]}
+cmake .. ${CMAKE_FLAGS[@]} -DCMAKE_BUILD_TYPE=Release
 make -j${nproc}
 make install
 

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -55,4 +55,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"5", julia_compat="1.6")

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -35,6 +35,7 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
 
 cd $WORKSPACE/srcdir/ceres-solver/
 mkdir build && cd build
+export OPENBLAS_NUM_THREADS=1
 cmake .. ${CMAKE_FLAGS[@]}
 make -j${nproc}
 make install

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -20,7 +20,7 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DLAPACK_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DMETIS_LIBRARY=${libdir}/libmetis.${dlext}
               -DSUITESPARSE_INCLUDE_DIR_HINTS=${prefix}/include
-              -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.${dlext} ${libdir}/libsuitesparseconfig.*.${dlext}"
+              -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.* ${libdir}/libsuitesparseconfig.*}"
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -21,13 +21,13 @@ else
 fi
 
 CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
+              -DCMAKE_CXX_FLAGS="-std=c++17"
               -DBUILD_SHARED_LIBS=ON
               -DBUILD_EXAMPLES=OFF
               -DBUILD_TESTING=OFF
               -DBLAS_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DLAPACK_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DMETIS_LIBRARY=${libdir}/libmetis.${dlext}
-              -DSUITESPARSE_INCLUDE_DIR_HINTS=${prefix}/include
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -19,6 +19,7 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DBLAS_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DLAPACK_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DMETIS_LIBRARY=${libdir}/libmetis.${dlext}
+              -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.*.${dlext}
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/
@@ -50,7 +51,7 @@ dependencies = [
     BuildDependency("Eigen_jll"),
     Dependency("glog_jll"),
     Dependency("METIS_jll"),
-    Dependency("OpenBLAS32_jll"),
+    Dependency("OpenBLAS_jll"),
     Dependency("SuiteSparse_jll")
 ]
 

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -24,7 +24,7 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DCAMD_LIBRARY="${libdir}/libcamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
               -DCCOLAMD_LIBRARY="${libdir}/libccolamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
               -DCHOLMOD_LIBRARY="${libdir}/libcholmod.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DCOLAMD_LIBRARY="${libdir}/libcolamd.${dlext} ${libdir}/libsuitepsarseconfig.${dlext}"
+              -DCOLAMD_LIBRARY="${libdir}/libcolamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
               -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
               -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.${dlext}"
               )

--- a/C/CeresSolver/build_tarballs.jl
+++ b/C/CeresSolver/build_tarballs.jl
@@ -24,19 +24,10 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix}
               -DBUILD_SHARED_LIBS=ON
               -DBUILD_EXAMPLES=OFF
               -DBUILD_TESTING=OFF
-              -DOPENMP=ON
-              -DTBB=OFF
               -DBLAS_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DLAPACK_LIBRARIES=${libdir}/libopenblas.${dlext}
               -DMETIS_LIBRARY=${libdir}/libmetis.${dlext}
               -DSUITESPARSE_INCLUDE_DIR_HINTS=${prefix}/include
-              -DAMD_LIBRARY="${libdir}/libamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DCAMD_LIBRARY="${libdir}/libcamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DCCOLAMD_LIBRARY="${libdir}/libccolamd.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DCHOLMOD_LIBRARY="${libdir}/libcholmod.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DCOLAMD_LIBRARY="${libdir}/libcolamd.${dlext} ${libdir}/libsuitepsarseconfig.${dlext}"
-              -DSUITESPARSEQR_LIBRARY="${libdir}/libspqr.${dlext} ${libdir}/libsuitesparseconfig.${dlext}"
-              -DSUITESPARSE_CONFIG_LIBRARY="${libdir}/libsuitesparseconfig.${dlext}"
               )
 
 cd $WORKSPACE/srcdir/ceres-solver/


### PR DESCRIPTION
The purpose of this PR is to generate the latest version of CeresSolver for all platforms, including the Apple Silicon.

Updates:

@giordano Thank you for your comment! There are at least three issues remaining here:

- [x] Setting `preferred_gcc_version=v"5"` fixed the issues with platforms with C++03 ABI. With Eigen_jll.jl v3.4.0, errors are thrown on `powerpc64le`. Setting `preferred_gcc_version=v"8"` fixes this issue.
- [x] SuiteSparse needs to be turned on even though the build will succeed without it. With the latest SuiteSparse_jll.jl v7.0.1, CMake cannot recognoize its version number correctly and SuiteSparse is not used. By manually specifying the older v5.10.1, it works as expected. (SuiteSparse related flags from the old recipe were removed as they are not effective and contains a typo in file path.)
- [x] glog_jll.jl is a dependency that needs to be updated first: https://github.com/JuliaPackaging/Yggdrasil/pull/6412
