### PR TITLE
[MPITrampoline] Do not install MPICH man files

### DIFF
--- a/M/MPItrampoline/build_tarballs.jl
+++ b/M/MPItrampoline/build_tarballs.jl
@@ -139,11 +139,8 @@ if [[ "${target}" == aarch64-apple-* ]]; then
 fi
 
 # Do not install doc and man files which contain files which clashing names on
-
 # case-insensitive file systems:
-
 # * https://github.com/JuliaPackaging/Yggdrasil/pull/315
-
 # * https://github.com/JuliaPackaging/Yggdrasil/issues/6344
 ./configure \
     --build=${MACHTYPE} \

--- a/M/MPItrampoline/build_tarballs.jl
+++ b/M/MPItrampoline/build_tarballs.jl
@@ -138,11 +138,19 @@ if [[ "${target}" == aarch64-apple-* ]]; then
     )
 fi
 
+# Do not install doc and man files which contain files which clashing names on
+
+# case-insensitive file systems:
+
+# * https://github.com/JuliaPackaging/Yggdrasil/pull/315
+
+# * https://github.com/JuliaPackaging/Yggdrasil/issues/6344
 ./configure \
     --build=${MACHTYPE} \
     --host=${target} \
     --disable-dependency-tracking \
     --docdir=/tmp \
+    --mandir=/tmp \
     --enable-shared=no \
     --enable-static=yes \
     --enable-threads=multiple \


### PR DESCRIPTION
They cause clashes on case insensitive file systems. Same as #6345. CC @eschnett 