### PR TITLE
Revert "[CUDA_Driver] Initialize globals to nothing"

### DIFF
--- a/C/CUDA/CUDA_Driver/init.jl
+++ b/C/CUDA/CUDA_Driver/init.jl
@@ -1,7 +1,7 @@
 # global variables we will set
-global libcuda = nothing
-global libcuda_version = nothing
-global libcuda_original_version = nothing
+global libcuda
+global libcuda_version
+global libcuda_original_version
 # compat_version is set in build_tarballs.jl
 
 # minimal API call wrappers we need


### PR DESCRIPTION
Reverts JuliaPackaging/Yggdrasil#6398

I'm not sure how, but this code _did_ apparently got into user environments:

```
Failed to precompile package  
ERROR: LoadError: MethodError: no method matching dlopen(::Nothing; throw_error=false)                                                         
Closest candidates are:                                                                                                                        
  dlopen(::AbstractString) at /opt/julia-1.7.3/share/julia/base/libdl.jl:116 got unsupported keyword argument "throw_error"                    
  dlopen(::AbstractString, ::Integer; throw_error) at /opt/julia-1.7.3/share/julia/base/libdl.jl:116                                           
  dlopen(::Function, ::Any...; kwargs...) at /opt/julia-1.7.3/share/julia/base/libdl.jl:141                                                    
  ...
Stacktrace:
 [1] cuda_toolkit_tag()
   @ CUDA_Runtime_jll ~/data/.julia/packages/CUDA_Runtime_jll/cq9MZ/.pkg/platform_augmentation.jl:94
 [2] augment_platform!(platform::Base.BinaryPlatforms.Platform)
   @ CUDA_Runtime_jll ~/data/.julia/packages/CUDA_Runtime_jll/cq9MZ/.pkg/platform_augmentation.jl:137
 [3] top-level scope
   @ ~/data/.julia/packages/JLLWrappers/QpMQW/src/toplevel_generators.jl:124
```

cc @simonbyrne 