### PR TITLE
CUDARuntime_jll add perfworks libs

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_11.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.0.jl
@@ -92,8 +92,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r Sanitizer/{docs,include}
@@ -121,7 +121,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_10"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2020.1.1"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.0.jl
@@ -49,6 +49,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r Sanitizer/{docs,include}
@@ -90,6 +92,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r Sanitizer/{docs,include}
@@ -117,6 +121,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_10"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2020.1.1"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.1.jl
@@ -49,6 +49,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -95,6 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -129,6 +133,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2020.2.1"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.1.jl
@@ -97,8 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -133,7 +133,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2020.2.1"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.2.jl
@@ -49,6 +49,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -95,6 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -129,6 +133,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2020.3.1"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.2.jl
@@ -97,8 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -133,7 +133,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2020.3.1"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.3.jl
@@ -97,8 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -133,7 +133,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2021.1.1"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.3.jl
@@ -49,6 +49,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -95,6 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -129,6 +133,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2021.1.1"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.4.jl
@@ -97,8 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -133,7 +133,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2021.2.2"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.4.jl
@@ -49,6 +49,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -95,6 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -129,6 +133,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2021.2.2"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.5.jl
@@ -97,8 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -133,7 +133,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2021.3.1"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.5.jl
@@ -49,6 +49,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -95,6 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -129,6 +133,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2021.3.1"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.6.jl
@@ -49,6 +49,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -95,6 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -129,6 +133,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2022.1.1"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.6.jl
@@ -97,8 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -133,7 +133,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2022.1.1"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.7.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.7.jl
@@ -49,6 +49,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -95,6 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -129,6 +133,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2022.2.1"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.7.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.7.jl
@@ -97,8 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -133,7 +133,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2022.2.1"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.8.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.8.jl
@@ -97,8 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -133,7 +133,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2022.3.0"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.8.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.8.jl
@@ -49,6 +49,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -95,6 +97,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -129,6 +133,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2022.3.0"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_12.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.0.jl
@@ -99,8 +99,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -136,7 +136,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2022.4.1"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_12.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.0.jl
@@ -50,6 +50,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -97,6 +99,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -132,6 +136,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2022.4.1"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_12.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.1.jl
@@ -50,6 +50,8 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -97,6 +99,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
+    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -132,6 +136,7 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2023.1.0"], :libcupti),
+        LibraryProduct(["libnvperf_host"], :libnvperf_host),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_12.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.1.jl
@@ -99,8 +99,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
-    mv extras/CUPTI/lib64/libnvperf_host.dll* ${libdir}
-    mv extras/CUPTI/lib64/libnvperf_target.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
 
     # Compute Sanitizer
     rm -r compute-sanitizer/{docs,include}
@@ -136,7 +136,8 @@ function get_products(platform)
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_2023.1.0"], :libcupti),
-        LibraryProduct(["libnvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),


### PR DESCRIPTION
Only adding the host lib to the products, unsure if target is actually needed.

In the headers there is a ccall to set the search paths... so I assume that the libs do some dlopen'ing
at least according to `ldd` they don't have a dependency on each.

