### PR TITLE
Rebuild using a GMT source that can find ghostscript

### DIFF
--- a/L/LLVMExtra/build_tarballs.jl
+++ b/L/LLVMExtra/build_tarballs.jl
@@ -7,14 +7,14 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
 
 name = "LLVMExtra"
 repo = "https://github.com/maleadt/LLVM.jl.git"
-version = v"0.0.19"
+version = v"0.0.20"
 
-llvm_versions = [v"11.0.1", v"12.0.1", v"13.0.1", v"14.0.2", v"15.0.7"]
+llvm_versions = [v"11.0.1", v"12.0.1", v"13.0.1", v"14.0.6", v"15.0.7"]
 
 
 # Collection of sources required to build LLVMExtra
 sources = [
-    GitSource(repo, "00e61c8ed984ca1cb6222a447e5b63d465dc5b78"),
+    GitSource(repo, "53cf34b17fb72acfd1e5a0a6781fd3c899572002"),
     ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz",
     "0f03869f72df8705b832910517b47dd5b79eb4e160512602f593ed243b28715f"),
 ]


### PR DESCRIPTION
There are some difficulties with finding ghostscript when it is called directly from the GMT binary, which expects to find it via path. A new change in the C lib adds a code path, that is active only for GMT_jll, to seek the full gs path saved in a file stored in ~/.gmt