### PR TITLE
New Recipe: libsasl2 v2.1.28

### DIFF
--- a/L/libsasl2/build_tarballs.jl
+++ b/L/libsasl2/build_tarballs.jl
@@ -7,15 +7,15 @@ version = v"2.1.28"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/cyrusimap/cyrus-sasl/archive/refs/tags/cyrus-sasl-$(version).tar.gz", "3e38933a30b9ce183a5488b4f6a5937a702549cde0d3287903d80968ad4ec341")
+    ArchiveSource("https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-$(version)/cyrus-sasl-$(version).tar.gz",
+                  "3e38933a30b9ce183a5488b4f6a5937a702549cde0d3287903d80968ad4ec341")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd cyrus-sasl-cyrus-sasl-2.1.28/
-./autogen.sh --prefix=${prefix} --build=${MACHTYPE} --host=${target} ac_cv_gssapi_supports_spnego=yes
-make
+cd $WORKSPACE/srcdir/cyrus-sasl-cyrus-sasl*
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} ac_cv_gssapi_supports_spnego=yes
+make -j{nproc}
 make install
 """
 
@@ -47,7 +47,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"))
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libsasl2/build_tarballs.jl
+++ b/L/libsasl2/build_tarballs.jl
@@ -21,33 +21,18 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("i686", "linux"; libc = "glibc"),
-    Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("aarch64", "linux"; libc = "glibc"),
-    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "glibc"),
-    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc"),
-    Platform("powerpc64le", "linux"; libc = "glibc"),
-    Platform("x86_64", "macos"; ),
-    Platform("aarch64", "macos"; ),
-    Platform("x86_64", "freebsd"; )
-]
+platforms = supported_platforms(; exclude=Sys.iswindows)
 
 
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libsasl2", :libsasl2),
-    LibraryProduct("libcrammd5", :libcrammd5, "lib/sasl2"),
-    LibraryProduct("libanonymous", :libanonymous, "lib/sasl2"),
-    LibraryProduct("libscram", :libscram, "lib/sasl2"),
-    LibraryProduct("libplain", :libplain, "lib/sasl2"),
-    LibraryProduct("libdigestmd5", :libdigestmd5, "lib/sasl2"),
-    LibraryProduct("libotp", :libopt, "lib/sasl2")
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10")
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10"),
+    Dependency(PackageSpec(name="libxcrypt_legacy_jll", uuid="5ef642bb-a58b-5208-ae37-583168b2c491"); platforms=filter(p -> libc(p) == "glibc", platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libsasl2/build_tarballs.jl
+++ b/L/libsasl2/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"2.1.28"
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-$(version)/cyrus-sasl-$(version).tar.gz",
-                  "3e38933a30b9ce183a5488b4f6a5937a702549cde0d3287903d80968ad4ec341")
+                  "7ccfc6abd01ed67c1a0924b353e526f1b766b21f42d4562ee635a8ebfc5bb38c")
 ]
 
 # Bash recipe for building across all platforms

--- a/L/libsasl2/build_tarballs.jl
+++ b/L/libsasl2/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/cyrus-sasl*
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} ac_cv_gssapi_supports_spnego=yes
-make -j{nproc}
+make -j${nproc}
 make install
 """
 

--- a/L/libsasl2/build_tarballs.jl
+++ b/L/libsasl2/build_tarballs.jl
@@ -1,0 +1,54 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libsasl2"
+version = v"2.1.28"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/cyrusimap/cyrus-sasl/archive/refs/tags/cyrus-sasl-$(version).tar.gz", "3e38933a30b9ce183a5488b4f6a5937a702549cde0d3287903d80968ad4ec341")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd cyrus-sasl-cyrus-sasl-2.1.28/
+./autogen.sh --prefix=${prefix} --build=${MACHTYPE} --host=${target} ac_cv_gssapi_supports_spnego=yes
+make
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("i686", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("powerpc64le", "linux"; libc = "glibc"),
+    Platform("x86_64", "macos"; ),
+    Platform("aarch64", "macos"; ),
+    Platform("x86_64", "freebsd"; )
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libsasl2", :libsasl2),
+    LibraryProduct("libcrammd5", :libcrammd5, "lib/sasl2"),
+    LibraryProduct("libanonymous", :libanonymous, "lib/sasl2"),
+    LibraryProduct("libscram", :libscram, "lib/sasl2"),
+    LibraryProduct("libplain", :libplain, "lib/sasl2"),
+    LibraryProduct("libdigestmd5", :libdigestmd5, "lib/sasl2"),
+    LibraryProduct("libotp", :libopt, "lib/sasl2")
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/libsasl2/build_tarballs.jl
+++ b/L/libsasl2/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/cyrus-sasl-cyrus-sasl*
+cd $WORKSPACE/srcdir/cyrus-sasl*
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} ac_cv_gssapi_supports_spnego=yes
 make -j{nproc}
 make install


### PR DESCRIPTION
Hi! This my first time using BinaryBuilder. It seems very slick, but I couldn't get this particular binary to build in some circumstances:

 1. with OpenSSL on musl libc platforms (configure can't find OpenSSL despite it seeming to be there - tried lots of `--with-openssl` and `OPENSSL_DIR` settings to no avail)
 2. on windows (complains about a type ambigutiy for INT8, which seems, at first glance, rather unambiguous, but this SASL lib typedefs it as a signed char (8 bits) and min-gw typedefs it as a long (8 bytes)... who needs namespaces, right?)
 
My actuall goal here is to add SASL-SCRAM support to librdkafka_jll (which currently segfaults when I try and use it... manually linking to my system librdkafka has no such issue). If I can't support the above platforms, I don't know how I'll pull this in as a dependency to librdkafka since it would reduce the platforms that _it_ supports, right?

Anyway, if anyone has any opinions or advice I'm all ears. Thanks!