### PR TITLE
Add CyrusSASL dependency to librdkafka

### DIFF
--- a/L/librdkafka/build_tarballs.jl
+++ b/L/librdkafka/build_tarballs.jl
@@ -9,7 +9,7 @@ version = v"2.0.2"
 sources = [
     # git rev-list -n 1 v2.0.2
     GitSource("https://github.com/confluentinc/librdkafka.git",
-              "292d2a66b9921b783f08147807992e603c7af059",
+        "292d2a66b9921b783f08147807992e603c7af059",
     ),
 ]
 
@@ -45,12 +45,13 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="Lz4_jll", uuid="5ced341a-0733-55b8-9ab6-a4889d929147"))
-    Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4"))
-    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"))
+    Dependency(PackageSpec(name="Lz4_jll", uuid="5ced341a-0733-55b8-9ab6-a4889d929147")),
+    Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4")),
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95")),
+    Dependency(PackageSpec(name="CyrusSASL_jll", uuid="6422fedd-75a7-50c2-a7c3-a11dad25a896")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6")
+    julia_compat="1.6")

--- a/L/librdkafka/build_tarballs.jl
+++ b/L/librdkafka/build_tarballs.jl
@@ -48,7 +48,7 @@ dependencies = [
     Dependency(PackageSpec(name="Lz4_jll", uuid="5ced341a-0733-55b8-9ab6-a4889d929147")),
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4")),
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95")),
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10"),
     Dependency(PackageSpec(name="CyrusSASL_jll", uuid="6422fedd-75a7-50c2-a7c3-a11dad25a896")),
 ]
 

--- a/L/librdkafka/build_tarballs.jl
+++ b/L/librdkafka/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "librdkafka"
-version = v"2.0.2"
+version = v"2.0.3" # note: bumped from 2.0.2 for SASL integration
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
This change enables SASL-based authentication when connecting to Kafka. Currently RDKafka.jl can segfaul with certain connection configurations, and this should provide the necessary functionality to support e.g. SASL-SCRAM authentication.

I have verified locally that the configure script finds libsasl2 and that it is linked.