### PR TITLE
[llama_cpp] Bump version 

### DIFF
--- a/L/llama_cpp/build_tarballs.jl
+++ b/L/llama_cpp/build_tarballs.jl
@@ -19,11 +19,11 @@ version = v"0.0.6"  # fake version number
 # 0.0.3           22.03.2023       master-d5850c5    https://github.com/ggerganov/llama.cpp/releases/tag/master-d5850c5
 # 0.0.4           25.03.2023       master-1972616    https://github.com/ggerganov/llama.cpp/releases/tag/master-1972616
 # 0.0.5           30.03.2023       master-3bcc129    https://github.com/ggerganov/llama.cpp/releases/tag/master-3bcc129
-# 0.0.6           31.03.2023       master-02c5b27    https://github.com/ggerganov/llama.cpp/releases/tag/master-02c5b27
+# 0.0.6           31.03.2023       master-3525899    https://github.com/ggerganov/llama.cpp/releases/tag/master-3525899
 
 sources = [
     GitSource("https://github.com/ggerganov/llama.cpp.git",
-              "02c5b27e91a6d18cf1043d3a2d8dbc59610ac257"),
+              "3525899277d2e2bdc8ec3f0e6e40c47251608700"),
     DirectorySource("./bundled"),
 ]
 

--- a/L/llama_cpp/build_tarballs.jl
+++ b/L/llama_cpp/build_tarballs.jl
@@ -32,8 +32,6 @@ cd $WORKSPACE/srcdir/llama.cpp*
 
 # remove -march=native from cmake files
 atomic_patch -p1 ../patches/cmake-remove-mcpu-native.patch
-# fix compilation (includes) on w64-mingw32
-atomic_patch -p1 ../patches/fix-windows-mingw32-includes.patch
 
 EXTRA_CMAKE_ARGS=
 if [[ "${target}" == *-linux-* ]]; then

--- a/L/llama_cpp/build_tarballs.jl
+++ b/L/llama_cpp/build_tarballs.jl
@@ -7,8 +7,6 @@ version = v"0.0.6"  # fake version number
 # description = "Port of Facebook's LLaMA model in C/C++"
 
 # TODO
-# - w64-mingw32 fails since master-02c5b27 (fake v0.0.6) because of
-#   missing mmap support
 # - missing architectures: powerpc64le, armv6l, arm7vl
 
 # versions: fake_version to github_version mapping

--- a/L/llama_cpp/build_tarballs.jl
+++ b/L/llama_cpp/build_tarballs.jl
@@ -19,11 +19,11 @@ version = v"0.0.6"  # fake version number
 # 0.0.3           22.03.2023       master-d5850c5    https://github.com/ggerganov/llama.cpp/releases/tag/master-d5850c5
 # 0.0.4           25.03.2023       master-1972616    https://github.com/ggerganov/llama.cpp/releases/tag/master-1972616
 # 0.0.5           30.03.2023       master-3bcc129    https://github.com/ggerganov/llama.cpp/releases/tag/master-3bcc129
-# 0.0.6           31.03.2023       master-3525899    https://github.com/ggerganov/llama.cpp/releases/tag/master-3525899
+# 0.0.6           03.04.2023       master-437e778    https://github.com/ggerganov/llama.cpp/releases/tag/master-437e778
 
 sources = [
     GitSource("https://github.com/ggerganov/llama.cpp.git",
-              "3525899277d2e2bdc8ec3f0e6e40c47251608700"),
+              "437e77855a54e69c86fe03bc501f63d9a3fddb0e"),
     DirectorySource("./bundled"),
 ]
 
@@ -32,6 +32,8 @@ cd $WORKSPACE/srcdir/llama.cpp*
 
 # remove -march=native from cmake files
 atomic_patch -p1 ../patches/cmake-remove-mcpu-native.patch
+# fix compilation (include Windows.h) on w64-mingw32
+atomic_patch -p1 ../patches/fix-mingw32-windows-include.patch
 
 EXTRA_CMAKE_ARGS=
 if [[ "${target}" == *-linux-* ]]; then
@@ -79,7 +81,7 @@ done
 install_license ../LICENSE
 """
 
-platforms = supported_platforms(; exclude = p -> Sys.iswindows(p) || arch(p) ∉ ["i686", "x86_64", "aarch64"])
+platforms = supported_platforms(; exclude = p -> arch(p) ∉ ["i686", "x86_64", "aarch64"])
 platforms = expand_cxxstring_abis(platforms)
 
 products = [

--- a/L/llama_cpp/bundled/patches/fix-mingw32-windows-include.patch
+++ b/L/llama_cpp/bundled/patches/fix-mingw32-windows-include.patch
@@ -1,0 +1,19 @@
+diff --git a/llama.cpp b/llama.cpp
+index 854bb89..896b95b 100644
+--- a/llama.cpp
++++ b/llama.cpp
+@@ -13,9 +13,14 @@
+ #include <cstring>
+ 
+ #if defined(_WIN32) && !defined(_POSIX_MAPPED_FILES)
++#if !defined(__MINGW32__)
+ #define WIN32_LEAN_AND_MEAN
+ #include <Windows.h>
+ #else
++// ref: https://github.com/ggerganov/whisper.cpp/issues/168
++#include <windows.h>
++#endif
++#else
+ #include <sys/types.h>
+ #include <sys/mman.h>
+ #include <unistd.h>

--- a/L/llama_cpp/bundled/patches/fix-mingw32-windows-include.patch
+++ b/L/llama_cpp/bundled/patches/fix-mingw32-windows-include.patch
@@ -1,19 +1,13 @@
 diff --git a/llama.cpp b/llama.cpp
-index 854bb89..896b95b 100644
+index 854bb89..78cf939 100644
 --- a/llama.cpp
 +++ b/llama.cpp
-@@ -13,9 +13,14 @@
- #include <cstring>
+@@ -14,7 +14,7 @@
  
  #if defined(_WIN32) && !defined(_POSIX_MAPPED_FILES)
-+#if !defined(__MINGW32__)
  #define WIN32_LEAN_AND_MEAN
- #include <Windows.h>
- #else
-+// ref: https://github.com/ggerganov/whisper.cpp/issues/168
+-#include <Windows.h>
 +#include <windows.h>
-+#endif
-+#else
+ #else
  #include <sys/types.h>
  #include <sys/mman.h>
- #include <unistd.h>


### PR DESCRIPTION
This version enables a new mmap-friendly model weights file
format. Unfortunately w64-mingw32 fails to build after these changes,
so disable it for now (no Windows.h or sys/mman.h).