### PR TITLE
[OpenSSL] Select working part of mkitti/openssl_compat

### DIFF
--- a/B/BerkeleyDB/build_tarballs.jl
+++ b/B/BerkeleyDB/build_tarballs.jl
@@ -7,7 +7,8 @@ version = v"18.1.40"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://download.oracle.com/berkeley-db/db-$(version).tar.gz", "0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8")
+    ArchiveSource("https://download.oracle.com/berkeley-db/db-$(version).tar.gz",
+                  "0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8"),
 ]
 
 # Bash recipe for building across all platforms
@@ -31,7 +32,10 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(!Sys.iswindows, supported_platforms())
+platforms = supported_platforms(; exclude=Sys.iswindows)
+# Exclude "experimental" platforms
+filter!(p -> arch(p) != "armv6l", platforms)
+filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -55,7 +59,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"))
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libevent/build_tarballs.jl
+++ b/L/libevent/build_tarballs.jl
@@ -31,7 +31,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("OpenSSL_jll"),
+    Dependency("OpenSSL_jll"; compat="1.1.10"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/MariaDB_Connector_ODBC/build_tarballs.jl
+++ b/M/MariaDB_Connector_ODBC/build_tarballs.jl
@@ -104,7 +104,7 @@ dependencies = [
     Dependency("iODBC_jll"),
     Dependency("Libiconv_jll"),
     Dependency("unixODBC_jll"),
-    Dependency("OpenSSL_jll"),
+    Dependency("OpenSSL_jll"; compat="1.1.10"),
     Dependency("Zlib_jll"),
 ]
 

--- a/M/MongoC/build_tarballs.jl
+++ b/M/MongoC/build_tarballs.jl
@@ -71,7 +71,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"))
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4"))
     Dependency(PackageSpec(name="snappy_jll", uuid="fe1e1685-f7be-5f59-ac9f-4ca204017dfd"), v"1.1.9")

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -35,7 +35,7 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
-    Dependency("OpenSSL_jll"),
+    Dependency("OpenSSL_jll"; compat="1.1.10"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/Q/Qt/build_tarballs.jl
+++ b/Q/Qt/build_tarballs.jl
@@ -287,7 +287,7 @@ dependencies = [
     Dependency("Glib_jll", v"2.59.0"; compat="2.59.0"),
     Dependency("Zlib_jll"),
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("OpenSSL_jll"),
+    Dependency("OpenSSL_jll"; compat="1.1.10"),
 ]
 
 include("../../fancy_toys.jl")

--- a/Q/Qt6Base/build_tarballs.jl
+++ b/Q/Qt6Base/build_tarballs.jl
@@ -165,7 +165,7 @@ dependencies = [
     Dependency("Glib_jll", v"2.59.0"; compat="2.59.0"),
     Dependency("Zlib_jll"),
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("OpenSSL_jll"),
+    Dependency("OpenSSL_jll"; compat="1.1.10"),
     BuildDependency(PackageSpec(name="LLVM_full_jll", version=v"11.0.1")),
     BuildDependency(PackageSpec(name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=llvm_version);
                     platforms=filter(p -> Sys.isapple(p) && arch(p) == "x86_64", platforms_macos)),

--- a/Q/qwtw/build_tarballs.jl
+++ b/Q/qwtw/build_tarballs.jl
@@ -45,7 +45,7 @@ dependencies = [
     Dependency(PackageSpec(name="qwt_jll", uuid="ed0789fa-10db-50b3-94da-03266d70be0f"))
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
     Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"))
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"))
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10")
     Dependency(PackageSpec(name="marble_jll", uuid="678d7417-9a84-558b-a975-2deb8d71bebc"))
     Dependency(PackageSpec(name="MathGL_jll", uuid="6834ddeb-87f2-5bbb-bfa4-c37572f854d4"))
 ]

--- a/R/ruby/build_tarballs.jl
+++ b/R/ruby/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"2.7.1"
 # Collection of sources required to complete build
 sources = [
     ArchiveSource(
-        "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz",
+        "https://cache.ruby-lang.org/pub/ruby/$(version.major).$(version.minor)/ruby-$(version).tar.gz",
         "d418483bdd0000576c1370571121a6eb24582116db0b7bb2005e90e250eae418",
     ),
 ]
@@ -43,6 +43,8 @@ done
 platforms = filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
 # TODO: fix armv7l musl. Probably an upstream issue though
 filter!(!=(Platform("armv7l", "linux"; libc="musl")), platforms)
+# Remove "experimental" architecture
+filter!(p -> arch(p) != "armv6l", platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -67,7 +69,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
     Dependency("Libiconv_jll"),
-    Dependency("OpenSSL_jll"),
+    Dependency("OpenSSL_jll"; compat="1.1.10"),
     Dependency("Readline_jll"),
     Dependency("Zlib_jll"),
     Dependency("Gdbm_jll"),

--- a/S/S2Geometry/build_tarballs.jl
+++ b/S/S2Geometry/build_tarballs.jl
@@ -44,7 +44,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95")),
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/SQLCipher/build_tarballs.jl
+++ b/S/SQLCipher/build_tarballs.jl
@@ -60,7 +60,7 @@ products = [
 dependencies = [
     # Required for amalgamation, could not build without it
     HostBuildDependency("Tcl_jll"),
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95")),
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/systemd/build_tarballs.jl
+++ b/S/systemd/build_tarballs.jl
@@ -88,7 +88,7 @@ dependencies = [
     #Dependency("Glib_jll"),
     #Dependency("Dbus_jll"),
     #Dependency("xkbcommon_jll"),
-    #Dependency("OpenSSL_jll"),
+    #Dependency("OpenSSL_jll"; compat="1.1.10"),
     #Dependency("XSLT_jll"),
     #Dependency("Libbpf_jll"),
     #Dependency("LibCURL_jll"),

--- a/V/VerizonEctoken/build_tarballs.jl
+++ b/V/VerizonEctoken/build_tarballs.jl
@@ -7,21 +7,18 @@ version = v"0.1.0"
 
 # Collection of sources required to complete build
 sources = [
-    "https://github.com/VerizonDigital/ectoken.git" =>
-    "7b8812d476f5be5b290fe2832859b9b7636f43ae",
+    GitSource("https://github.com/VerizonDigital/ectoken.git",
+              "7b8812d476f5be5b290fe2832859b9b7636f43ae"),
 
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-export OPENSSL_INCLUDE="-I $prefix/include"
+export OPENSSL_INCLUDE="-I${includedir}"
 export OPENSSL_LIBS="-lssl -lcrypto"
 cd ectoken/c-ectoken/ecencrypt/
-gcc -m64 -O2 -Wall -Werror -std=gnu99 ec_encrypt.c ectoken_v3.c base64.c -o 64/ectoken3 $OPENSSL_LIBS $OPENSSL_INCLUDE -lm -lpthread -ldl
-cp 64/ectoken3 $prefix/bin/
-exit
-
+cc -m64 -O2 -Wall -Werror -std=gnu99 ec_encrypt.c ectoken_v3.c base64.c -o ${bindir}/ectoken3${exeext} $OPENSSL_LIBS $OPENSSL_INCLUDE -lm -lpthread -ldl
 """
 
 # These are the platforms we will build for by default, unless further
@@ -37,7 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-  "OpenSSL_jll"
+    Dependency("OpenSSL_jll"; compat="1.1.10")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
[skip build]

Working part of #6312 

Sets compat="1.1.10" for OpenSSL

* BerkeleyDB
* libevent
* MariaDB_Connector_ODBC
* MongoC
* Oxigraph_server
* QT
* Qt6Base
* qwtw
* ruby
* S2Geometry
* SQLCipher
* systemd
* VerizonEctoken