### PR TITLE
expand_gfortran_versions(platforms) for Microsoft-MPI

### DIFF
--- a/M/MicrosoftMPI/build_tarballs.jl
+++ b/M/MicrosoftMPI/build_tarballs.jl
@@ -86,6 +86,7 @@ install_license $WORKSPACE/destdir/share/licenses/MicrosoftMPI/* $WORKSPACE/srcd
 """
 
 platforms = filter!(Sys.iswindows, supported_platforms())
+platforms = expand_gfortran_versions(platforms)
 
 products = [
     # MicrosoftMPI


### PR DESCRIPTION
I recompiled Microsoft-MPI to generate Fortran module files in #6525 but I forgot to update the `platforms`.
When I tried to use the `mpi.mod` with another package, I had the following error:
```shell
[15:36:56]    15 |   use mpi
[15:36:56]       |      1
[15:36:56] Fatal Error: Cannot read module file ‘mpi.mod’ opened at (1), because it was created by a different version of GNU Fortran
[15:36:56] compilation terminated.
