### PR TITLE
Update AcousticsToolbox to v2022_4_20

### DIFF
--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -8,7 +8,7 @@ version = VersionNumber(replace(version_string, "_" => "."))
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("http://oalib.hlsresearch.com/AcousticsToolbox/at_2022_4_20.zip", "ff3494c8a0c696dca17ddacb9a2a412eaf664c3204f4a424afe77e66edefc950")
+    ArchiveSource("http://oalib.hlsresearch.com/AcousticsToolbox/at_$(version_string).zip", "ff3494c8a0c696dca17ddacb9a2a412eaf664c3204f4a424afe77e66edefc950")
 ]
 
 # Bash recipe for building across all platforms

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -3,7 +3,8 @@
 using BinaryBuilder, Pkg
 
 name = "AcousticsToolbox"
-version = v"2022.4.20"
+version_string = "2022_4_20"
+version = VersionNumber(replace(version_string, "_" => "."))
 
 # Collection of sources required to complete build
 sources = [

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "AcousticsToolbox"
-version = v"2020.11.4"
+version = v"2022.4.20"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("http://oalib.hlsresearch.com/AcousticsToolbox/at_2020_11_4.zip", "6f9fe5d3d7fd99fc34fb2a2c3308f2e660a1cc0ea93f0651111af698acf442f0")
+    ArchiveSource("http://oalib.hlsresearch.com/AcousticsToolbox/at_2022_4_20.zip", "ff3494c8a0c696dca17ddacb9a2a412eaf664c3204f4a424afe77e66edefc950")
 ]
 
 # Bash recipe for building across all platforms

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/at_*
+cd $WORKSPACE/srcdir/at
 rm -rf ../__MACOSX
 perl -p -i -e 's/\-march=native//; s/\-ffast\-math//; s/\-mtune=native//;' Makefile
 find . -name *.exe -exec rm {} \;


### PR DESCRIPTION
Version update for OALIB to support `AcousticsToolbox`

OALIB:
http://oalib.hlsresearch.com/AcousticsToolbox/at_2022_4_20.zip

Upstream issue:
https://github.com/org-arl/AcousticsToolbox.jl/issues/7
