### PR TITLE
[GMT] Rebuild artifact to allow access to the new grdpaste option

### DIFF
--- a/G/GMT/build_tarballs.jl
+++ b/G/GMT/build_tarballs.jl
@@ -10,7 +10,7 @@ DCW_VERSION="2.1.1"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/GenericMappingTools/gmt", 
-    "02d24df3402a20e23100920ede49285a9594e2a7"),
+    "02adf702a73d5e2ce0772fc6be69a934ff5b4719"),
     
     ArchiveSource("https://github.com/GenericMappingTools/gshhg-gmt/releases/download/$GSHHG_VERSION/gshhg-gmt-$GSHHG_VERSION.tar.gz",
         "9bb1a956fca0718c083bef842e625797535a00ce81f175df08b042c2a92cfe7f"),


### PR DESCRIPTION
New -S grdpaste option gives back info necessary to implement the grdpaste functionality in pure Julia