### PR TITLE
Add recipe for RustFFT

### DIFF
--- a/R/rustfft/build_tarballs.jl
+++ b/R/rustfft/build_tarballs.jl
@@ -33,7 +33,7 @@ int main(int argc, char**argv)
     return 0;
 }
 EOF
-${CC_BUILD} -I${WORKSPACE}/destdir/include -Wall version.c -o julia_version
+${CC_BUILD} -I${includedir} -Wall version.c -o julia_version
 julia_version=$(./julia_version)
 
 cargo build --features yggdrasil,${julia_version} --release --verbose

--- a/R/rustfft/build_tarballs.jl
+++ b/R/rustfft/build_tarballs.jl
@@ -1,0 +1,65 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+# See https://github.com/JuliaLang/Pkg.jl/issues/2942
+# Once this Pkg issue is resolved, this must be removed
+uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
+delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
+
+name = "rustfft"
+version = v"0.0.1"
+julia_versions = [v"1.6.3", v"1.7", v"1.8", v"1.9"]
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/Taaitaaiger/rustfft-jl.git",
+              "933c83750f03cc6323b47ffe45c209c1a6b976ff"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/rustfft-jl
+
+# This program prints the version feature that must be passed to `cargo build`
+# Adapted from ../../G/GAP/build_tarballs.jl
+# HACK: determine Julia version
+cat > version.c <<EOF
+#include <stdio.h>
+#include "julia/julia_version.h"
+int main(int argc, char**argv)
+{
+    printf("julia-%d-%d", JULIA_VERSION_MAJOR, JULIA_VERSION_MINOR);
+    return 0;
+}
+EOF
+${CC_BUILD} -I${WORKSPACE}/destdir/include -Wall version.c -o julia_version
+julia_version=$(./julia_version)
+
+cargo build --features yggdrasil,${julia_version} --release --verbose
+install_license LICENSE
+install -Dvm 0755 "target/${rust_target}/release/"*rustfft_jl".${dlext}" "${libdir}/librustfft.${dlext}"
+"""
+
+include("../../L/libjulia/common.jl")
+platforms = vcat(libjulia_platforms.(julia_versions)...)
+
+# Successfully building for i686 Windows requires raw-dylib linkage, which is currently only
+# supported for 64-bits Windows targets, or that libjulia.dll.a is available.
+is_excluded(p) = Sys.iswindows(p) && nbits(p) == 32
+filter!(!is_excluded, platforms)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("librustfft", :libjlrs_ledger),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    BuildDependency("libjulia_jll"),
+    Dependency("Libiconv_jll"; platforms=filter(Sys.isapple, platforms)),
+]
+
+# Build the tarballs.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"10", julia_compat="1.6", compilers=[:c, :rust])

--- a/R/rustfft/build_tarballs.jl
+++ b/R/rustfft/build_tarballs.jl
@@ -46,12 +46,12 @@ platforms = vcat(libjulia_platforms.(julia_versions)...)
 
 # Successfully building for i686 Windows requires raw-dylib linkage, which is currently only
 # supported for 64-bits Windows targets, or that libjulia.dll.a is available.
-is_excluded(p) = Sys.iswindows(p) && nbits(p) == 32
+is_excluded(p) = !(Sys.iswindows(p) && nbits(p) != 32)
 filter!(!is_excluded, platforms)
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("librustfft", :libjlrs_ledger),
+    LibraryProduct("librustfft", :librustfft),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/R/rustfft/build_tarballs.jl
+++ b/R/rustfft/build_tarballs.jl
@@ -46,7 +46,7 @@ platforms = vcat(libjulia_platforms.(julia_versions)...)
 
 # Successfully building for i686 Windows requires raw-dylib linkage, which is currently only
 # supported for 64-bits Windows targets, or that libjulia.dll.a is available.
-is_excluded(p) = !(Sys.iswindows(p) && nbits(p) != 32)
+is_excluded(p) = Sys.iswindows(p) && nbits(p) == 32
 filter!(!is_excluded, platforms)
 
 # The products that we will ensure are always built


### PR DESCRIPTION
Many variations of this warning appear during the audit phase when building for Windows locally:

    BFD: librustfft.dll: Unrecognized storage class 106 for *UND* symbol `jl_unionall_type'

The DLL works correctly, though.