### PR TITLE
[louvain_jll] Adding macOS aarch64

### DIFF
--- a/L/louvain/build_tarballs.jl
+++ b/L/louvain/build_tarballs.jl
@@ -7,13 +7,13 @@ version = v"0.2.0" # Rebuilding louvain_jll to include macOS aarch64
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/KrainskiL/louvain.git", "9e3e081f054e531e32af38fe71d2991f954ea347")
+    GitSource("https://github.com/KrainskiL/louvain.git", "3e9efdb930efc4a3715d0978ea08ed52172f7231")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/louvain/
-make -j${nproc} CXX="${CXX}"
+make -j${nproc}
 for exe in hierarchy louvain matrix convert; do
     install -Dvm 755 "${exe}" "${bindir}/${exe}${exeext}"
 done

--- a/L/louvain/build_tarballs.jl
+++ b/L/louvain/build_tarballs.jl
@@ -37,4 +37,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/louvain/build_tarballs.jl
+++ b/L/louvain/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/louvain/
-make -j${nproc}
+make -j${nproc} CXX="${CXX}"
 for exe in hierarchy louvain matrix convert; do
     install -Dvm 755 "${exe}" "${bindir}/${exe}${exeext}"
 done

--- a/L/louvain/build_tarballs.jl
+++ b/L/louvain/build_tarballs.jl
@@ -14,9 +14,8 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/louvain/
 make -j${nproc}
-mkdir -p ${bindir}
 for exe in hierarchy louvain matrix convert; do
-    mv "${exe}" "${bindir}/${exe}${exeext}"
+    install -Dvm 755 "${exe}" "${bindir}/${exe}${exeext}"
 done
 install_license *gpl*.txt
 """

--- a/L/louvain/build_tarballs.jl
+++ b/L/louvain/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "louvain"
-version = v"0.1.0"
+version = v"0.2.0" # Rebuilding louvain_jll to include macOS aarch64
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
Looks like louvain_jll long time ago was not built for M-Series Macs and it's causing an issue now.