### PR TITLE
[libsigc++] Bump to v3.4.0 and add v2.12.0

### DIFF
--- a/L/libsigcpp/libsigcpp@2.12.0/build_tarballs.jl
+++ b/L/libsigcpp/libsigcpp@2.12.0/build_tarballs.jl
@@ -1,0 +1,38 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libsigcpp"
+version = v"2.12.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://download.gnome.org/sources/libsigc++/2.12/libsigc%2B%2B-$(version).tar.xz",
+                  "1c466d2e64b34f9b118976eb21b138c37ed124d0f61497df2a90ce6c3d9fa3b5")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libsigc++*/
+mkdir meson
+cd meson
+meson --cross-file=${MESON_TARGET_TOOLCHAIN%.*}_gcc.meson
+ninja -j${nproc}
+ninja install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct(["libsigc-2.0", "libsigc-2"], :libsigc)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7.1.0")

--- a/L/libsigcpp/libsigcpp@3.4.0/build_tarballs.jl
+++ b/L/libsigcpp/libsigcpp@3.4.0/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "libsigcpp"
-version = v"3.0.7"
+version = v"3.4.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://download.gnome.org/sources/libsigc++/3.0/libsigc%2B%2B-$(version).tar.xz",
-                  "bfbe91c0d094ea6bbc6cbd3909b7d98c6561eea8b6d9c0c25add906a6e83d733")
+    ArchiveSource("https://download.gnome.org/sources/libsigc++/3.4/libsigc%2B%2B-$(version).tar.xz",
+                  "02e2630ffb5ce93cd52c38423521dfe7063328863a6e96d41d765a6116b8707e")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
libsigc++-2.0 and libsigc++-3.0 are "parallel-installable" ABI's used with GTK3 and GTK4, respectively.

Rather unintuitively, the entire `*mm` stack is split on this ABI even for libraries (e.g. Pango) whose C bindings have no such breaking ABI change. This means that the minor version of every GTK-upstream library must be constrained to respect the `libsigc++` ABI bifurcation.