### PR TITLE
[libsigc++] Expand C++ string ABI for all systems

### DIFF
--- a/L/libsigcpp/libsigcpp@2.12.0/build_tarballs.jl
+++ b/L/libsigcpp/libsigcpp@2.12.0/build_tarballs.jl
@@ -23,7 +23,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true); skip=Returns(false))
+platforms = expand_cxxstring_abis(supported_platforms(); skip=Returns(false))
 
 # The products that we will ensure are always built
 products = [

--- a/L/libsigcpp/libsigcpp@2.12.0/build_tarballs.jl
+++ b/L/libsigcpp/libsigcpp@2.12.0/build_tarballs.jl
@@ -23,7 +23,7 @@ ninja install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true); skip=Returns(false))
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
See https://github.com/JuliaPackaging/Yggdrasil/pull/6688#discussion_r1183640855

Unfortunately, it looks like several of the libraries in the GTK4mm dependency chain also do not build with `clang++` so we'll probably have to switch to GCC and fully-expand string ABI's for `libsigc++-3.0` too