### PR TITLE
[libsigc++] Use `gcc` to compile `libsigc++-3.0`

### DIFF
--- a/L/libsigcpp/libsigcpp@3.4.0/build_tarballs.jl
+++ b/L/libsigcpp/libsigcpp@3.4.0/build_tarballs.jl
@@ -16,14 +16,14 @@ script = raw"""
 cd $WORKSPACE/srcdir/libsigc++*/
 mkdir meson
 cd meson
-meson --cross-file=${MESON_TARGET_TOOLCHAIN}
+meson --cross-file=${MESON_TARGET_TOOLCHAIN%.*}_gcc.meson
 ninja -j${nproc}
 ninja install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+platforms = expand_cxxstring_abis(supported_platforms(); skip=Returns(false))
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
Several of the libraries in the GTK4mm dependency chain do not build with clang++ so we have to switch to GCC and fully-expand the string ABI for `libsigc++-3.0` just like we do for `libsigc++-2.0`