### PR TITLE
[Cairomm] Bump to v1.16.2

### DIFF
--- a/C/Cairomm/Cairomm@1.16.2/build_tarballs.jl
+++ b/C/Cairomm/Cairomm@1.16.2/build_tarballs.jl
@@ -3,26 +3,32 @@
 using BinaryBuilder, Pkg
 
 name = "Cairomm"
-version = v"1.16.1"
+version = v"1.16.2"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://www.cairographics.org/releases/cairomm-$(version).tar.xz",
-                  "6f6060d8e98dd4b8acfee2295fddbdd38cf487c07c26aad8d1a83bb9bff4a2c6")
+                  "6a63bf98a97dda2b0f55e34d1b5f3fb909ef8b70f9b8d382cb1ff3978e7dc13f")
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/cairomm*/
+atomic_patch -p1 ../patches/disable-quartz-aarch64-apple-darwin.patch
 mkdir output && cd output/
-meson --cross-file=${MESON_TARGET_TOOLCHAIN} ..
+meson --cross-file=${MESON_TARGET_TOOLCHAIN%.*}_gcc.meson ..
 ninja -j${nproc}
 ninja install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
+
+# armv6l is not supported by Cairo_jll yet
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
+
+platforms = expand_cxxstring_abis(platforms; skip=Returns(false))
 
 # The products that we will ensure are always built
 products = [
@@ -31,8 +37,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="libsigcpp_jll", uuid="8855df87-3ca1-5a3d-a68b-4f0ddc198ba8"))
-    Dependency(PackageSpec(name="Cairo_jll", uuid="83423d85-b0ee-5818-9007-b63ccbeb887a"); compat=string(version))
+    Dependency(PackageSpec(name="Cairo_jll", uuid="83423d85-b0ee-5818-9007-b63ccbeb887a"); compat="1.16.1")
+    Dependency(PackageSpec(name="libsigcpp_jll", uuid="8855df87-3ca1-5a3d-a68b-4f0ddc198ba8"), v"3.0.7"; compat="3")
     BuildDependency(PackageSpec(name="Xorg_xorgproto_jll", uuid="c4d99508-4286-5418-9131-c86396af500b"))
 ]
 

--- a/C/Cairomm/Cairomm@1.16.2/bundled/patches/disable-quartz-aarch64-apple-darwin.patch
+++ b/C/Cairomm/Cairomm@1.16.2/bundled/patches/disable-quartz-aarch64-apple-darwin.patch
@@ -1,0 +1,34 @@
+diff --git a/cairomm/quartz_font.h b/cairomm/quartz_font.h
+index 16fd479..32872d4 100644
+--- a/cairomm/quartz_font.h
++++ b/cairomm/quartz_font.h
+@@ -20,6 +20,12 @@
+
+ #include <cairo-features.h>
+
++// GCC does not work with parts of the new macOS SDK used on Apple Silicon
++// due to missing __BLOCKS__ guards
++#if (defined(__APPLE__) && (defined(__arm64__) || defined(__aarch64__)))
++#undef CAIRO_HAS_QUARTZ_FONT
++#endif
++
+ #ifdef CAIRO_HAS_QUARTZ_FONT
+ #include <cairo-quartz.h>
+ #include <cairomm/fontface.h>
+diff --git a/cairomm/quartz_surface.h b/cairomm/quartz_surface.h
+index 31737f7..489fb51 100644
+--- a/cairomm/quartz_surface.h
++++ b/cairomm/quartz_surface.h
+@@ -21,6 +21,12 @@
+
+ #include <cairomm/surface.h>
+
++// GCC does not work with parts of the new macOS SDK used on Apple Silicon
++// due to missing __BLOCKS__ guards
++#if (defined(__APPLE__) && (defined(__arm64__) || defined(__aarch64__)))
++#undef CAIRO_HAS_QUARTZ_SURFACE
++#endif
++
+ #ifdef CAIRO_HAS_QUARTZ_SURFACE
+ #include <cairo-quartz.h>
+ #endif


### PR DESCRIPTION
This is the latest version with libsigc++-3.0, for use with GTK4.