### PR TITLE
[Qhull] version update

### DIFF
--- a/Q/Qhull/build_tarballs.jl
+++ b/Q/Qhull/build_tarballs.jl
@@ -32,7 +32,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/Q/Qhull/build_tarballs.jl
+++ b/Q/Qhull/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "Qhull"
-version = v"8.0.1001" # alpha release of 8.1, but Julia Pkg doesn't support prerelease versions
+version = v"8.0.1003" # alpha-3 release of 8.1, but Julia Pkg doesn't support prerelease versions
 
 # Collection of sources required to build
 sources = [
     GitSource("https://github.com/qhull/qhull.git",
-              "0c8fc90d2037588024d9964515c1e684f6007ecc"), # v8.1-alpha1 + patches
+              "c2ef2209c28dc61ccfd22514971236587e820121"), # v8.1-alpha3 GitHub 2023/01/02
 ]
 
 # Bash recipe for building across all platforms

--- a/Q/QhullMiniWrapper/build_tarballs.jl
+++ b/Q/QhullMiniWrapper/build_tarballs.jl
@@ -16,7 +16,7 @@ cd $WORKSPACE/srcdir/
 ${CC} -fPIC -shared -o ${libdir}/qhullwrapper.${dlext} qhullwrapper.c -L${libdir} -lqhull_r
 """
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/Q/QhullMiniWrapper/build_tarballs.jl
+++ b/Q/QhullMiniWrapper/build_tarballs.jl
@@ -16,7 +16,7 @@ cd $WORKSPACE/srcdir/
 ${CC} -fPIC -shared -o ${libdir}/qhullwrapper.${dlext} qhullwrapper.c -L${libdir} -lqhull_r
 """
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
Update the version of Qhull and MiniQhullWrapper and also (hopefully) trigger the build for aarm64 architecture in the process.