### PR TITLE
Fix GDAL and bump version of DGGRID7

### DIFF
--- a/D/DGGRID7/build_tarballs.jl
+++ b/D/DGGRID7/build_tarballs.jl
@@ -20,7 +20,7 @@ if [[ "${target}" == x86_64-linux-musl ]]; then
     # Remove libexpat to avoid it being picked up by mistake
     rm /usr/lib/libexpat.so*
 fi
-make -j${nproc} CCOMP="${CC}" CPPCOMP="${CXX}"
+make -j${nproc}
 install -Dvm 755 "src/apps/dggrid/dggrid${exeext}" "${bindir}/dggrid${exeext}"
 """
 

--- a/D/DGGRID7/build_tarballs.jl
+++ b/D/DGGRID7/build_tarballs.jl
@@ -15,7 +15,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/DGGRID
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ..
 if [[ "${target}" == x86_64-linux-musl ]]; then
     # Remove libexpat to avoid it being picked up by mistake
     rm /usr/lib/libexpat.so*
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"))
+    Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"), v"v301.600.200"; compat="v301.600.200")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/D/DGGRID7/build_tarballs.jl
+++ b/D/DGGRID7/build_tarballs.jl
@@ -7,24 +7,28 @@ version = v"0.9.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/allixender/DGGRID.git", "0dabdfd3f8fd6ac27626064a94c483e610d578bb")
+    GitSource("https://github.com/sahrk/DGGRID.git", "4f24e9de46f9e669af4cba94d9d148b557a1de11")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/DGGRID/src/
+cd $WORKSPACE/srcdir/DGGRID
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
 if [[ "${target}" == x86_64-linux-musl ]]; then
     # Remove libexpat to avoid it being picked up by mistake
     rm /usr/lib/libexpat.so*
 fi
 make -j${nproc} CCOMP="${CC}" CPPCOMP="${CXX}"
-cp "apps/dggrid/dggrid${exeext}" "${bindir}/."
+mkdir -p ${bindir}
+cp "src/apps/dggrid/dggrid${exeext}" "${bindir}/."
 """
+
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
-
 
 # The products that we will ensure are always built
 products = [
@@ -37,4 +41,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8.1.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8.1.0", julia_compat="v1.6.0")

--- a/D/DGGRID7/build_tarballs.jl
+++ b/D/DGGRID7/build_tarballs.jl
@@ -21,8 +21,7 @@ if [[ "${target}" == x86_64-linux-musl ]]; then
     rm /usr/lib/libexpat.so*
 fi
 make -j${nproc} CCOMP="${CC}" CPPCOMP="${CXX}"
-mkdir -p ${bindir}
-cp "src/apps/dggrid/dggrid${exeext}" "${bindir}/."
+install -Dvm 755 "src/apps/dggrid/dggrid${exeext}" "${bindir}/dggrid${exeext}"
 """
 
 

--- a/D/DGGRID7/build_tarballs.jl
+++ b/D/DGGRID7/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "DGGRID7"
-version = v"0.9.0"
+version = v"0.9.1"
 
 # Collection of sources required to complete build
 sources = [

--- a/D/DGGRID7/build_tarballs.jl
+++ b/D/DGGRID7/build_tarballs.jl
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"), v"v301.600.200"; compat="v301.600.200")
+    Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"); compat="v301.600.200")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This PR aims to fix a version mismatch of DGGRID7_jll and GDAL_jll by updating DGGRID7_jll to the latest official release 7.7 of [DGGRID](https://github.com/sahrk/DGGRID/) that works with BinaryBuilder. @allixender what do you think?

## Error

Executing in docker image julia:1.8.5-bullseye :

```{julia}
using Pkg
Pkg.add("DGGRID7_jll")

using DGGRID7_jll

download("https://raw.githubusercontent.com/sahrk/DGGRID/4f24e9de46f9e669af4cba94d9d148b557a1de11/examples/icosahedron/icosahedron.meta", "meta.txt")
mkdir("outputfiles")

DGGRID7_jll.dggrid() do dggrid_path
    run(`$dggrid_path meta.txt`)
end
```

results in error

```
/root/.julia/artifacts/3381b9f883af7e984906191545c4fa939e07e91b/bin/dggrid: error while loading shared libraries: libgdal.so.28: cannot open shared object file: No such file or directory
```

Indeed, dggrid requires libgdal.so.28, but package GDAL_jll provides libgdal.so.32.3.6.2:

```
root@6e8b0f893490:~/.julia/artifacts# find ~/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/pkgconfig
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/pkgconfig/gdal.pc
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/libgdal.so.32
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/gdalplugins
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/gdalplugins/drivers.ini
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/libgdal.so
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/cmake
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/cmake/gdal
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/cmake/gdal/GDALConfig.cmake
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/cmake/gdal/GDALConfigVersion.cmake
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/cmake/gdal/GDAL-targets.cmake
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/cmake/gdal/GDAL-targets-release.cmake
/root/.julia/artifacts/6f97fbb4bedf23ccd1d7757586cb7659222a0465/lib/libgdal.so.32.3.6.2
```

## Fix

This PR uses the latest official release 7.7 of [DGGRID](https://github.com/sahrk/DGGRID/) that works with BinaryBuilder.

Version 7.8 of DGGRID results in error `/workspace/srcdir/DGGRID/src/lib/dglib/lib/DgZOrderRF.cpp:96:24: error: expected ‘)’ before ‘PRIx64‘`

## Test

julia build_tarballs.jl successed to run on a local Linux machine.
Furthermore, products/DGGRID7.v0.9.0.x86_64-linux-gnu-cxx11.tar.gz was tested by integration test [doexamples.sh](https://github.com/sahrk/DGGRID/blob/4f24e9de46f9e669af4cba94d9d148b557a1de11/examples/doexamples.sh). Exit code was 0, but output files still contain these errors:

```
$ find ~/repos/Yggdrasil/D/DGGRID7/DGGRID/examples -type f | grep outputfiles | xargs -i grep -H ERROR {}

Yggdrasil/D/DGGRID7/DGGRID/examples/planetRiskGridGen/outputfiles/planetRiskGridGen.txt:FATAL ERROR: Invalid parameter data in parameter:
Yggdrasil/D/DGGRID7/DGGRID/examples/planetRiskClipHiRes/outputfiles/planetRiskClipHiRes.txt:FATAL ERROR: Invalid parameter data in parameter:
Yggdrasil/D/DGGRID7/DGGRID/examples/gdalCollection/outputfiles/gdalCollection.txt:FATAL ERROR: DgParamList::setParam() unknown parameter collection_output_gdal_format
Yggdrasil/D/DGGRID7/DGGRID/examples/gdalExample/outputfiles/gdalExample.txt:FATAL ERROR: Invalid parameter data in parameter:
Yggdrasil/D/DGGRID7/DGGRID/examples/holes/outputfiles/holes.txt:FATAL ERROR: Invalid parameter data in parameter:
Yggdrasil/D/DGGRID7/DGGRID/examples/planetRiskClipMulti/outputfiles/planetRiskClipMulti.txt:FATAL ERROR: Invalid parameter data in parameter:
Yggdrasil/D/DGGRID7/DGGRID/examples/planetRiskGridNoWrap/outputfiles/planetRiskGridNoWrap.txt:FATAL ERROR: Invalid parameter data in parameter:
```