### PR TITLE
GLEW: Use correct installation convention for MinGW targets

### DIFF
--- a/G/GLEW/build_tarballs.jl
+++ b/G/GLEW/build_tarballs.jl
@@ -18,7 +18,11 @@ EXTRA_VARS=()
 if [[ "${target}" == *-linux-* ]] || [[ "${target}" == *-freebsd* ]]; then
     # On Linux and FreeBSD this variable by default does `-L/usr/lib`
     EXTRA_VARS+=(LDFLAGS.EXTRA="")
+elif [[ "${target}" == *-mingw* ]]; then
+    # On MinGW targets this is incorrectly detected as "msys"
+    EXTRA_VARS+=(SYSTEM="mingw")
 fi
+
 make INCLUDE="-Iinclude -I${includedir}" \
     GLEW_DEST="${prefix}" \
     "${EXTRA_VARS[@]}" \
@@ -27,7 +31,7 @@ make INCLUDE="-Iinclude -I${includedir}" \
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
 
 # The products that we will ensure are always built
 products = [
@@ -42,4 +46,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/G/GLEW/build_tarballs.jl
+++ b/G/GLEW/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "GLEW"
-version = v"2.1.0"
+version = v"2.2.0"
 
 # Collection of sources required to build GLEW
 sources = [
     ArchiveSource("https://github.com/nigels-com/glew/releases/download/glew-$(version)/glew-$(version).tgz",
-                  "04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95")
+                  "d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
The existing artifacts have `libglew32.a` in bin and an empty lib directory (except for pkgconfig).

This commit overrides the auto-detection script so that MinGW is correctly configured as the target system, which means that `libglew32.a` and `libglew32.dll.a` are installed into `lib` as expected.