### PR TITLE
make MKL_jll a BuildDependency only for SCS_MKL

### DIFF
--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -1,3 +1,4 @@
+using Pkg
 using BinaryBuilder
 
 name = "SCS_MKL"
@@ -37,7 +38,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("MKL_jll"; compat="2022.2.0"),
+    BuildDependency(PackageSpec(;name="MKL_jll", version=v"2022.2")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -38,7 +38,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(;name="MKL_jll", version=v"2022.2")),
+    BuildDependency(PackageSpec(;name="MKL_jll", version=v"2023.1")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well


### PR DESCRIPTION
so that MKL_jll is a truly optional dependency for SCS ;)

@giordano does that require version bump, or is +1 fine?

cc: @odow