### PR TITLE
[Cares] Update to v1.19.1 (security update)

### DIFF
--- a/C/Cares/build_tarballs.jl
+++ b/C/Cares/build_tarballs.jl
@@ -3,14 +3,14 @@
 using BinaryBuilder, Pkg
 
 name = "Cares"
-version = v"1.19.0"
+version = v"1.19.1"
 
 # url = "https://c-ares.org/"
 # description = "C library for asynchronous DNS requests (including name resolves)"
 
 sources = [
     ArchiveSource("https://c-ares.org/download/c-ares-$(version).tar.gz",
-                  "bfceba37e23fd531293829002cac0401ef49a6dc55923f7f92236585b7ad1dd3"),
+                  "321700399b72ed0e037d0074c629e7741f6b2ec2dda92956abe3e9671d3e268e"),
 ]
 
 


### PR DESCRIPTION
This is a security and bugfix release.

Security fixes:

- CVE-2023-32067. High. 0-byte UDP payload causes Denial of Service
- CVE-2023-31147. Moderate. Insufficient randomness in generation of DNS query IDs
- CVE-2023-31130. Moderate. Buffer Underwrite in ares_inet_net_pton()
- CVE-2023-31124. Low. AutoTools does not set CARES_RANDOM_FILE during cross compilation

https://github.com/c-ares/c-ares/releases/tag/cares-1_19_1