### PR TITLE
[SLATEC] Updated build_tarballs.jl due BinaryBuilder updates

### DIFF
--- a/S/SLATEC/build_tarballs.jl
+++ b/S/SLATEC/build_tarballs.jl
@@ -30,13 +30,13 @@ if [[ $target == *"i686-w64-mingw32" ]]; then
 fi
 
 # libblastrampoline-5 required for mingw32
-if [[ $target == *"w64-mingw32" ]]; then 
-    # Change lapack library to libblastrampoline
-    sed -i -e 's/target_link_libraries( slatec_shared blas lapack )/target_link_libraries( slatec_shared blastrampoline-5 )/g' CMakeLists.txt
+if [[ $target == *"w64-mingw32" ]]; then
+    LBT=blastrampoline-5
 else
-    # Change lapack library to libblastrampoline
-    sed -i -e 's/target_link_libraries( slatec_shared blas lapack )/target_link_libraries( slatec_shared blastrampoline )/g' CMakeLists.txt
+    LBT=blastrampoline
 fi
+# Change lapack library to libblastrampoline
+sed -i -e "s/target_link_libraries( slatec_shared blas lapack )/target_link_libraries( slatec_shared ${LBT} )/g" CMakeLists.txt
 
 if [[ "${target}" == aarch64-apple-* ]]; then
     # Fix issue due to GCC 10+.

--- a/S/SLATEC/build_tarballs.jl
+++ b/S/SLATEC/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "SLATEC"
-version = v"4.1.0"
+version = v"4.1.1"
 
 # Collection of sources required to complete build
 sources = [
@@ -97,4 +97,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 # For the time being need LLVM 11 because of <https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/158>.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_llvm_version=v"11")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.9", preferred_llvm_version=v"11")

--- a/S/SLATEC/build_tarballs.jl
+++ b/S/SLATEC/build_tarballs.jl
@@ -91,7 +91,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="libblastrampoline_jll")),
+    Dependency(PackageSpec(name="libblastrampoline_jll"); compat="5.4"),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 

--- a/S/SLATEC/build_tarballs.jl
+++ b/S/SLATEC/build_tarballs.jl
@@ -14,18 +14,29 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
+cd $WORKSPACE/srcdir/slatec
+# BLAS/LAPACK is linked with libblastrampoline
+sed -i -e 's/"Link to the system BLAS library?" ON )/"Link to the system BLAS library?" OFF )/g' CMakeLists.txt
+# Do not build tests
+sed -i -e 's/"Build the SLATEC tests?" ON )/"Build the SLATEC tests?" OFF )/g' CMakeLists.txt
+
 cd $WORKSPACE/srcdir/slatec/src
 
-# Manually set LAPACK and BLAS libraries
-echo "list( REMOVE_ITEM SLATEC_SOURCE_FILES \${BLAS_SOURCE_FILES} )" >> CMakeLists.txt
-echo "list( APPEND SLATEC_SOURCE_FILES \${RETAINED_BLAS_SOURCE_FILES} )" >> CMakeLists.txt
-echo "list( REMOVE_ITEM SLATEC_SOURCE_FILES \${EXCLUDE_FROM_SHARED} )" >> CMakeLists.txt
-echo "include(\$ENV{prefix}/lib/cmake/lapack-3.9.0/lapack-config.cmake)" >> CMakeLists.txt
-echo "include(\$ENV{prefix}/lib/cmake/openblas/OpenBLASConfig.cmake)" >> CMakeLists.txt
-echo "add_library( slatec_shared SHARED \${SLATEC_SOURCE_FILES} )" >> CMakeLists.txt
-echo "target_link_libraries( slatec_shared \${LAPACK_LIBRARIES} \${OpenBLAS_LIBRARIES})" >> CMakeLists.txt
-echo "set_target_properties( slatec_shared PROPERTIES OUTPUT_NAME slatec )" >> CMakeLists.txt
-echo "install( TARGETS slatec_shared LIBRARY DESTINATION lib )" >> CMakeLists.txt
+# Prepend undscore to symbols with i686 mingw target
+if [[ $target == *"i686-w64-mingw32" ]]; then 
+    sed -i '/add_library( slatec_shared SHARED ${SLATEC_SOURCE_FILES} )/a\
+    target_compile_options(slatec_shared PUBLIC -fleading-underscore)
+    ' CMakeLists.txt
+fi
+
+# libblastrampoline-5 required for mingw32
+if [[ $target == *"w64-mingw32" ]]; then 
+    # Change lapack library to libblastrampoline
+    sed -i -e 's/target_link_libraries( slatec_shared blas lapack )/target_link_libraries( slatec_shared blastrampoline-5 )/g' CMakeLists.txt
+else
+    # Change lapack library to libblastrampoline
+    sed -i -e 's/target_link_libraries( slatec_shared blas lapack )/target_link_libraries( slatec_shared blastrampoline )/g' CMakeLists.txt
+fi
 
 if [[ "${target}" == aarch64-apple-* ]]; then
     # Fix issue due to GCC 10+.
@@ -50,14 +61,15 @@ if [[ "${target}" == aarch64-apple-* ]]; then
     export FFLAGS="-fallow-argument-mismatch"
 fi
 
+
 mkdir ../build
 cd ../build/
-# Above on the fly added CMake code buils shared library with OpenBLAS
+# Build shared library
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DUSE_OPTIMIZED_BLAS=0 \
-    -DBUILD_SHARED_LIBRARY=0 \
+    -DBUILD_SHARED_LIBRARY=1 \
     ..
 make -j${nproc}
 make install
@@ -67,7 +79,10 @@ install_license ../../LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
+
 platforms = expand_gfortran_versions(supported_platforms(; experimental=true))
+# lapack build by default only for gfortran5 on aarch64
+filter!(p -> !(arch(p) == "aarch64" && Sys.islinux(p) && libgfortran_version(p) != v"5"), platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -76,8 +91,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="LAPACK_jll", uuid="51474c39-65e3-53ba-86ba-03b1b862ec14")),
-    Dependency(PackageSpec(name="OpenBLAS_jll", uuid="4536629a-c528-5b80-bd46-f80d51c5b363")),
+    Dependency(PackageSpec(name="libblastrampoline_jll")),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 


### PR DESCRIPTION
BinaryBuilder failed with the current version of build_tarballs.jl.
build_tarballs.jl has been updated to work with current BinaryBuilder.