### PR TITLE
[NetCDF] Set compat bounds for HDF5_jll up to patch, ~1.12.2 [skip build]

### DIFF
--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -98,7 +98,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="HDF5_jll"), compat="~1.12"),
+    Dependency(PackageSpec(name="HDF5_jll"), compat="~1.12.2"),
     Dependency("Zlib_jll"),
     Dependency("XML2_jll"),
     Dependency("LibCURL_jll"; compat = "7.73.0"),


### PR DESCRIPTION
Set compat bounds for HDF5_jll

NetCDF_jll probably should be ~1.12.2 unless established otherwise

Otherwise, this hould finish out the diff for #6707 except that I skip build.
