### PR TITLE
update LibTexPrintf to v1.18

### DIFF
--- a/L/LibTeXPrintf/build_tarballs.jl
+++ b/L/LibTeXPrintf/build_tarballs.jl
@@ -15,7 +15,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/libtexprintf/
 ./autogen.sh
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-static=no --enable-shared=yes --enable-fast-install=yes
-make -j${nproc}
+make # -j${nproc}
 make install
 install_license COPYING
 """

--- a/L/LibTeXPrintf/build_tarballs.jl
+++ b/L/LibTeXPrintf/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "LibTeXPrintf"
-version = v"1.17"
+version = v"1.18"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/bartp5/libtexprintf.git", "77595060141ac1da3d146c62eed5fe3113811cc7"),
+    GitSource("https://github.com/bartp5/libtexprintf.git", "52d2ef31944858c58d48a9e33c35471fa23218e1"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Upstream merged two new API functions `texstring` and `texerrors_str` that should make it easier to wrap from Julia.  Also should fix the random build failures we were seeing previously.

cc @Suavesito-Olimpiada 