### PR TITLE
NetCDF: Build against HDF5 1.14

### DIFF
--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -11,7 +11,7 @@ name = "NetCDF"
 upstream_version = v"4.9.2"
 
 # Offset to add to the version number.  Remember to always bump this.
-version_offset = v"0.2.6"
+version_offset = v"0.2.7"
 
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
@@ -20,13 +20,13 @@ version = VersionNumber(upstream_version.major * 100 + version_offset.major,
 # Collection of sources required to build NetCDF
 sources = [
     ArchiveSource("https://downloads.unidata.ucar.edu/netcdf-c/$(upstream_version)/netcdf-c-$(upstream_version).tar.gz",
-                  "38f62cc5d9f0409205b20ff8ff01d7cc36659993"),
+                  "cf11babbbdb9963f09f55079e0b019f6d0371f52f8e1264a5ba8e9fdab1a6c48"),
 ]
 
 # HDF5.h in /workspace/artifacts/805ccba77cd286c1afc127d1e45aae324b507973/include
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/netcdf-c
+cd $WORKSPACE/srcdir/netcdf-c*
 
 export CPPFLAGS="-I${includedir}"
 export LDFLAGS="-L${libdir}"
@@ -34,7 +34,8 @@ export LDFLAGS_MAKE="${LDFLAGS}"
 CONFIGURE_OPTIONS=""
 
 if [[ ${target} == *-mingw* ]]; then
-    export LIBS="-lhdf5-0 -lhdf5_hl-0 -lcurl-4 -lz"
+    # we should determine the dll version (?) automatically
+    export LIBS="-lhdf5-310 -lhdf5_hl-310 -lcurl-4 -lz"
     # linking fails with: "libtool:   error: can't build x86_64-w64-mingw32 shared library unless -no-undefined is specified"
     # unless -no-undefined is added to LDFLAGS
     LDFLAGS_MAKE="${LDFLAGS} ${LIBS} -no-undefined -Wl,--export-all-symbols"
@@ -42,9 +43,6 @@ if [[ ${target} == *-mingw* ]]; then
     # additional configure options from
     # https://github.com/Unidata/netcdf-c/blob/5df5539576c5b2aa8f31d4b50c4f8258925589dd/.github/workflows/run_tests_win_mingw.yml#L38
     CONFIGURE_OPTIONS="--disable-byterange"
-elif [[ "${target}" == *-apple-* ]]; then
-    # this file is referenced by hdf.h by not installed
-    touch ${includedir}/features.h
 fi
 
 if [[ ${target} -ne x86_64-linux-gnu ]]; then
@@ -77,19 +75,7 @@ nc-config --all
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-# Set equal to the supported platforms in HDF5
-platforms = [
-    Platform("x86_64", "linux"),
-    # HDF5_jll on armv7l should use the same glibc as the root filesystem
-    # before it can be used
-    # https://github.com/JuliaPackaging/Yggdrasil/pull/1090#discussion_r432683488
-    # Platform("armv7l", "linux"; libc="glibc"),
-    Platform("aarch64", "linux"; libc="glibc"),
-    Platform("x86_64", "macos"),
-    Platform("aarch64","macos"),
-    Platform("x86_64", "windows"),
-    Platform("i686", "windows"),
-]
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
@@ -98,12 +84,13 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="HDF5_jll"), compat="~1.12.2"),
-    Dependency("Zlib_jll"),
-    Dependency("XML2_jll"),
+    Dependency("Bzip2_jll"),
+    Dependency("HDF5_jll"; compat = "1.14"),
     Dependency("LibCURL_jll"; compat = "7.73.0"),
+    Dependency("XML2_jll"),
+    Dependency("Zlib_jll"),
+    Dependency("Zstd_jll"),
 ]
-
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;

--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -85,7 +85,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Bzip2_jll"),
-    Dependency("HDF5_jll"; compat = "1.14"),
+    Dependency("HDF5_jll"; compat = "~1.14"),
     Dependency("LibCURL_jll"; compat = "7.73.0"),
     Dependency("XML2_jll"),
     Dependency("Zlib_jll"),


### PR DESCRIPTION
- update version_offset
- correct tarball checksum
- correct Windows build instruction
- remove outdated Apple work-around
- build on more platforms
- add new dependencies bzip2 (necessary) and zstd (because we can)