### PR TITLE
TempestRemap: add explicit HDF5 dependency

### DIFF
--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -90,7 +90,7 @@ products = [
 dependencies = [
     Dependency("OpenBLAS32_jll"),
     Dependency("HDF5_jll", compat="~1.14"),
-    Dependency("NetCDF_jll", compat="400.902.5"),
+    Dependency("NetCDF_jll", compat="400.902.5 - 400.999"),
     # The following is adapted from NetCDF_jll
     BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),
 ]

--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -89,7 +89,7 @@ products = [
 
 dependencies = [
     Dependency("OpenBLAS32_jll"),
-    Dependency("HDF5_jll", compat="~1.12"),
+    Dependency("HDF5_jll", compat="~1.12.2"),
     Dependency("NetCDF_jll", compat="400.902.5 - 400.999"),
     # The following is adapted from NetCDF_jll
     BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),

--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -89,7 +89,7 @@ products = [
 
 dependencies = [
     Dependency("OpenBLAS32_jll"),
-    Dependency("HDF5_jll", compat="~1.14"),
+    Dependency("HDF5_jll", compat="~1.12"),
     Dependency("NetCDF_jll", compat="400.902.5 - 400.999"),
     # The following is adapted from NetCDF_jll
     BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),

--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -89,7 +89,7 @@ products = [
 
 dependencies = [
     Dependency("OpenBLAS32_jll"),
-    Dependency("HDF5_jll", compat="~1.12"),
+    Dependency("HDF5_jll", compat="~1.14"),
     Dependency("NetCDF_jll", compat="400.902.5 - 400.999"),
     # The following is adapted from NetCDF_jll
     BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),

--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -90,7 +90,7 @@ products = [
 dependencies = [
     Dependency("OpenBLAS32_jll"),
     Dependency("HDF5_jll", compat="~1.14"),
-    Dependency("NetCDF_jll", compat="400.902.5 - 400.999"),
+    Dependency("NetCDF_jll", compat="400.902.5"),
     # The following is adapted from NetCDF_jll
     BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),
 ]

--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -89,6 +89,7 @@ products = [
 
 dependencies = [
     Dependency("OpenBLAS32_jll"),
+    Dependency("HDF5_jll", compat="~1.12"),
     Dependency("NetCDF_jll", compat="400.902.5 - 400.999"),
     # The following is adapted from NetCDF_jll
     BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),

--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -5,8 +5,8 @@ using BinaryBuilder, Pkg
 name = "TempestRemap"
 version = v"2.1.6"
 sources = [
-    ArchiveSource("https://github.com/ClimateGlobalChange/tempestremap/archive/refs/tags/v$(version).tar.gz",
-                  "d2208b5d6952eba5003ee7abcf22f46a254ba03f6b76dcc4d246068573d424e2"),
+    GitSource("https://github.com/ClimateGlobalChange/tempestremap.git",
+        "531da6298b8924b56776ecf30cce0af60d7a8144"), # v2.1.6
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
HDF5 is linked to directly, so should be added as a dependency.

Recent HDF5 update broke TempestRemap:
```
julia> using TempestRemap_jll
ERROR: InitError: could not load library "/Users/simon/.julia/artifacts/a3391a5a73004bf491bf9f164cdc8fa1eba7a81e/lib/libTempestRemap.0.dylib"
dlopen(/Users/simon/.julia/artifacts/a3391a5a73004bf491bf9f164cdc8fa1eba7a81e/lib/libTempestRemap.0.dylib, 0x0001): Library not loaded: @rpath/libhdf5.200.dylib
  Referenced from: <7A43AE80-1BEC-396B-A80F-45E43008B804> /Users/simon/.julia/artifacts/a3391a5a73004bf491bf9f164cdc8fa1eba7a81e/lib/libTempestRemap.0.dylib
  Reason: tried: '/Users/simon/.julia/artifacts/a3391a5a73004bf491bf9f164cdc8fa1eba7a81e/lib/./libhdf5.200.dylib' (no such file), '/Users/simon/.julia/artifacts/a3391a5a73004bf491bf9f164cdc8fa1eba7a81e/lib/./libhdf5.200.dylib' (no such file), '/Applications/Julia-1.8.app/Contents/Resources/julia/lib/julia/libhdf5.200.dylib' (no such file), '/Applications/Julia-1.8.app/Contents/Resources/julia/lib/libhdf5.200.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS@rpath/libhdf5.200.dylib' (no such file), '/Users/simon/.julia/artifacts/a3391a5a73004bf491bf9f164cdc8fa1eba7a81e/lib/./libhdf5.200.dylib' (no such file), '/Users/simon/.julia/artifacts/a3391a5a73004bf491bf9f164cdc8fa1eba7a81e/lib/./libhdf5.200.dylib' (no such file), '/Applications/Julia-1.8.app/Contents/Resources/julia/lib/julia/libhdf5.200.dylib' (no such file), '/Applications/Julia-1.8.app/Contents/Resources/julia/lib/libhdf5.200.dylib' (no such file), '/usr/local/lib/libhdf5.200.dylib' (no such file), '/usr/lib/libhdf5.200.dylib' (no such file, not in dyld cache)
```

See also
https://github.com/CliMA/ClimaCore.jl/actions/runs/5083514095/jobs/9134608368#step:6:362

Not sure if this is correct: @mkitti @giordano ?