### PR TITLE
[MiniZinc] update to 2.7.4

### DIFF
--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder, Pkg
 
 name = "MiniZinc"
 
-version = v"2.6.2"
+version = v"2.7.4"
 
 sources = [
     GitSource(
         "https://github.com/MiniZinc/libminizinc.git",
-        "a56602765b4294b796c063664733b28f5a663af7",
+        "834c8c1da9816322d4dcad52ae067fbf584ac6b9",
     ),
     DirectorySource("./bundled"),
 ]

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -51,7 +51,7 @@ products = [
 platforms = expand_cxxstring_abis(supported_platforms())
 
 # TODO(odow): fix build issues on Windows
-# platforms = filter(!Sys.iswindows, platforms)
+platforms = filter(!Sys.iswindows, platforms)
 
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -51,7 +51,7 @@ products = [
 platforms = expand_cxxstring_abis(supported_platforms())
 
 # TODO(odow): fix build issues on Windows
-platforms = filter(!Sys.iswindows, platforms)
+# platforms = filter(!Sys.iswindows, platforms)
 
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),


### PR DESCRIPTION
cc @chriscoey

Quite a bit changed since the last build: https://github.com/MiniZinc/libminizinc/compare/2.6.2...2.7.4

So not sure if this will succeed. I didn't try locally.