### PR TITLE
[MiniZinc] build with HiGHS

### DIFF
--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -28,7 +28,7 @@ cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_FLAGS="-I${includedir}" \
+    -DCMAKE_CXX_FLAGS="-I${includedir}/highs" \
     ..
 
 if [[ "${target}" == *-linux-* ]]; then

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -30,7 +30,7 @@ export LDFLAGS="-L${libdir}"
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_FLAGS="-I${includedir}/highs" \
+    -DHIGHS_INCLUDE_DIRS="-I${includedir}/highs" \
     ..
 
 if [[ "${target}" == *-linux-* ]]; then

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -29,7 +29,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_FLAGS="-I${includedir}/highs" \
-    -DFAST_BUILD=ON \  # This is needed, because HiGHS_jll is compiled with FAST_BUILD also 
+    -DFAST_BUILD=ON \
     ..
 
 if [[ "${target}" == *-linux-* ]]; then

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -25,6 +25,8 @@ find .. -type f -exec sed -i 's/Windows.h/windows.h/g' {} +
 mkdir -p build
 cd build
 
+# FAST_BUILD is needed when linking HiGHS, because that's what
+# we used when compiling HiGHS_jll.
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
@@ -57,7 +59,7 @@ platforms = filter(!Sys.iswindows, platforms)
 
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("HiGHS_jll"),
+    Dependency("HiGHS_jll"; compat="1.5.1"),
 ]
 
 build_tarballs(

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -22,9 +22,6 @@ atomic_patch -p1 ${WORKSPACE}/srcdir/patches/fixes.patch
 # Patch for MinGW toolchain
 find .. -type f -exec sed -i 's/Windows.h/windows.h/g' {} +
 
-# Install open-source solvers
-./download_vendor
-
 mkdir -p build
 cd build
 
@@ -58,6 +55,7 @@ platforms = filter(!Sys.iswindows, platforms)
 
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
+    Dependency("HiGHS_jll"),
 ]
 
 build_tarballs(

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -25,12 +25,11 @@ find .. -type f -exec sed -i 's/Windows.h/windows.h/g' {} +
 mkdir -p build
 cd build
 
-export LDFLAGS="-L${libdir}"
-
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_FLAGS="-I${includedir}/highs" \
+    -DFAST_BUILD=ON \  # This is needed, because HiGHS_jll is compiled with FAST_BUILD also 
     ..
 
 if [[ "${target}" == *-linux-* ]]; then

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -30,7 +30,7 @@ export LDFLAGS="-L${libdir}"
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DHIGHS_INCLUDE_DIRS="-I${includedir}/highs" \
+    -DHIGHS_INCLUDE_DIRS="${includedir}/highs" \
     ..
 
 if [[ "${target}" == *-linux-* ]]; then

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -25,10 +25,12 @@ find .. -type f -exec sed -i 's/Windows.h/windows.h/g' {} +
 mkdir -p build
 cd build
 
+export LDFLAGS="-L${libdir}"
+
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_FLAGS="-I${includedir}/highs -L${libdir}" \
+    -DCMAKE_CXX_FLAGS="-I${includedir}/highs" \
     ..
 
 if [[ "${target}" == *-linux-* ]]; then

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -28,6 +28,7 @@ cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-I${includedir}" \
     ..
 
 if [[ "${target}" == *-linux-* ]]; then

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -22,6 +22,9 @@ atomic_patch -p1 ${WORKSPACE}/srcdir/patches/fixes.patch
 # Patch for MinGW toolchain
 find .. -type f -exec sed -i 's/Windows.h/windows.h/g' {} +
 
+# Install open-source solvers
+./download_vendor
+
 mkdir -p build
 cd build
 

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -30,7 +30,7 @@ export LDFLAGS="-L${libdir}"
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DHIGHS_INCLUDE_DIRS="${includedir}/highs" \
+    -DCMAKE_CXX_FLAGS="-I${includedir}/highs" \
     ..
 
 if [[ "${target}" == *-linux-* ]]; then

--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -28,7 +28,7 @@ cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_FLAGS="-I${includedir}/highs" \
+    -DCMAKE_CXX_FLAGS="-I${includedir}/highs -L${libdir}" \
     ..
 
 if [[ "${target}" == *-linux-* ]]; then


### PR DESCRIPTION
https://github.com/JuliaPackaging/Yggdrasil/pull/6801 rebuild v2.7.4, but it didn't actually build with HiGHS because the `vendor` directory isn't downloaded by default. 

We could potentially use `HiGHS_jll` here, but let's see if libminizinc's vendored version works first.

cc @chriscoey