### PR TITLE
[MiniZinc] pin the compat version of HiGHS dependency

### DIFF
--- a/M/MiniZinc/build_tarballs.jl
+++ b/M/MiniZinc/build_tarballs.jl
@@ -59,7 +59,9 @@ platforms = filter(!Sys.iswindows, platforms)
 
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("HiGHS_jll"; compat="1.5.1"),
+    # Use an exact version for HiGHS. @odow has observed segfaults with
+    # HiGHS_jll v1.5.3 when libminizinc compiled with v1.5.1.
+    Dependency("HiGHS_jll"; compat="=1.5.3"),
 ]
 
 build_tarballs(


### PR DESCRIPTION
x-ref https://github.com/jump-dev/MiniZinc.jl/pull/35

<img width="1035" alt="image" src="https://github.com/JuliaPackaging/Yggdrasil/assets/8177701/92840e01-2f22-4301-b867-29df7f409361">

We're not using the official binaries, so I'm hesitant to file upstream. Reverting to the version of HiGHS that we compiled with works fine.