### PR TITLE
[SPRAL] Recompile SPRAL to trigger the registration

### DIFF
--- a/S/SPRAL/build_tarballs.jl
+++ b/S/SPRAL/build_tarballs.jl
@@ -42,7 +42,8 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_gfortran_versions(supported_platforms())
+platforms = supported_platforms()
+platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
@giordano 
Is it possible to trigger the registration of  `SPRAL-v2023.3.29+0` again?
Otherwise, we probably just need to remove the release [SPRAL-v2023.3.29+0](https://github.com/JuliaBinaryWrappers/SPRAL_jll.jl/releases/tag/SPRAL-v2023.3.29%2B0) and merge this PR.

`SPRAL` is the last package that I compiled with LBT before the release 1.9.
MUMPS and PROPACK are already fixed.
