### PR TITLE
Update LibTeXPrintf to upstream v1.21

### DIFF
--- a/L/LibTeXPrintf/build_tarballs.jl
+++ b/L/LibTeXPrintf/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "LibTeXPrintf"
-version = v"1.18"
+version = v"1.21"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/bartp5/libtexprintf.git", "52d2ef31944858c58d48a9e33c35471fa23218e1"),
+    GitSource("https://github.com/bartp5/libtexprintf.git", "8bdbf8afdcbf305a5f1a1cef8fcaedab6c26d6fa"),
 ]
 
 # Bash recipe for building across all platforms
@@ -15,7 +15,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/libtexprintf/
 ./autogen.sh
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --enable-static=no --enable-shared=yes --enable-fast-install=yes
-make # -j${nproc}
+make -j${nproc}
 make install
 install_license COPYING
 """


### PR DESCRIPTION
cc @Suavesito-Olimpiada

I'm not sure why the version jumped from v1.18 to v1.21, but that's upstream.

(the previous issues with parallel builds should now be fixed, I hope!)