### PR TITLE
Blosc: New version 1.21.4

### DIFF
--- a/B/Blosc/build_tarballs.jl
+++ b/B/Blosc/build_tarballs.jl
@@ -35,7 +35,7 @@ install_license ../LICENSES/*.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental = true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/B/Blosc/build_tarballs.jl
+++ b/B/Blosc/build_tarballs.jl
@@ -1,17 +1,17 @@
 using BinaryBuilder
 
 name = "Blosc"
-version = v"1.21.2"
+version = v"1.21.4"
 
 # Collection of sources required to build Blosc
 sources = [
-    ArchiveSource("https://github.com/Blosc/c-blosc/archive/v$(version).tar.gz", "e5b4ddb4403cbbad7aab6e9ff55762ef298729c8a793c6147160c771959ea2aa"),
+    GitSource("https://github.com/Blosc/c-blosc.git", "2c2f9bd936b1340ad92a6da6c2a52adf4254c241"),
     DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/c-blosc-*
+cd $WORKSPACE/srcdir/c-blosc
 if [[ "${target}" == *mingw* ]]; then
   atomic_patch -p1 ../patches/mingw.patch
 fi
@@ -26,7 +26,6 @@ CMAKE_FLAGS+=(-DCMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS="")
 CMAKE_FLAGS+=(-DPREFER_EXTERNAL_ZLIB=ON)
 CMAKE_FLAGS+=(-DPREFER_EXTERNAL_ZSTD=ON)
 CMAKE_FLAGS+=(-DPREFER_EXTERNAL_LZ4=ON)
-#CMAKE_FLAGS+=(-DPREFER_EXTERNAL_SNAPPY=ON)
 cmake ${CMAKE_FLAGS[@]} ..
 make -j${nproc}
 make install
@@ -36,7 +35,7 @@ install_license ../LICENSES/*.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(; experimental = true))
+platforms = supported_platforms(; experimental = true)
 
 # The products that we will ensure are always built
 products = [
@@ -48,7 +47,6 @@ dependencies = [
 	Dependency("Zlib_jll"),
 	Dependency("Zstd_jll"),
 	Dependency("Lz4_jll"),
-	# Dependency("Snappy_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
- Don't expand C++ ABI (not needed)