### PR TITLE
Update FreeBSD from 12.2 to 13.2

### DIFF
--- a/0_RootFS/PlatformSupport/build_tarballs.jl
+++ b/0_RootFS/PlatformSupport/build_tarballs.jl
@@ -10,7 +10,7 @@
 #     if Sys.isapple(platform)
 #         suffix = arch(platform) == "aarch64" ? "20" : "14"
 #     elseif Sys.isfreebsd(platform)
-#         suffix = "12.2"
+#         suffix = "13.2"
 #     else
 #         suffix = ""
 #     end
@@ -51,8 +51,8 @@ sources = [
                   "b5de28fd594a01edacd06e53491ad0890293e5fbf98329346426cf6030ef1ea6"),
     ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v7.0.0.tar.bz2",
                   "aa20dfff3596f08a7f427aab74315a6cb80c2b086b4a107ed35af02f9496b628"),
-    ArchiveSource("https://download.freebsd.org/ftp/releases/amd64/12.2-RELEASE/base.txz",
-                  "8bd49ce35c340a04029266fbbe82b1fdfeb914263e39579eecafb2e67d00693a"),
+    ArchiveSource("http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.2-RELEASE/base.txz",
+                  "3a9250f7afd730bbe274691859756948b3c57a99bcda30d65d46ae30025906f0"),
     ArchiveSource("https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/libcxx-8.0.1.src.tar.xz",
                   "7f0652c86a0307a250b5741ab6e82bb10766fb6f2b5a5602a63f30337e629b78"),
 ]
@@ -100,6 +100,7 @@ case "${COMPILER_TARGET}" in
         cd $WORKSPACE/srcdir/linux-*/
 
         # Grumble, grumble, need gcc just to install some headers...
+        apk update
         apk add gcc musl-dev
 
         # The kernel make system can't deal with spaces (for things like ccache) very well
@@ -143,6 +144,7 @@ case "${COMPILER_TARGET}" in
         mv System "${sysroot}/"
 
         # Grumble, grumble, need gcc just to install some headers...
+        apk update
         apk add gcc g++ musl-dev
 
         # Also deploy libcxx headers

--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -21,7 +21,7 @@
 #   `--deploy` flag to the `build_tarballs.jl` script.  You can either build &
 #   deploy the compilers one by one or run something like
 #
-#      for p in i686-linux-gnu x86_64-linux-gnu aarch64-linux-gnu armv7l-linux-gnueabihf powerpc64le-linux-gnu i686-linux-musl x86_64-linux-musl aarch64-linux-musl armv7l-linux-musleabihf x86_64-apple-darwin14 x86_64-unknown-freebsd12.2 i686-w64-mingw32 x86_64-w64-mingw32; do julia build_tarballs.jl --debug --verbose --deploy "${p}"; done
+#      for p in i686-linux-gnu x86_64-linux-gnu aarch64-linux-gnu armv7l-linux-gnueabihf powerpc64le-linux-gnu i686-linux-musl x86_64-linux-musl aarch64-linux-musl armv7l-linux-musleabihf x86_64-apple-darwin14 x86_64-unknown-freebsd13.2 i686-w64-mingw32 x86_64-w64-mingw32; do julia build_tarballs.jl --debug --verbose --deploy "${p}"; done
 
 include("./common.jl")
 include("./gcc_sources.jl")

--- a/0_RootFS/gcc_sources.jl
+++ b/0_RootFS/gcc_sources.jl
@@ -250,8 +250,8 @@ function gcc_sources(gcc_version::VersionNumber, compiler_target::Platform; kwar
         end
     elseif Sys.isfreebsd(compiler_target)
         libc_sources = [
-            ArchiveSource("http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/12.2-RELEASE/base.txz",
-                          "8bd49ce35c340a04029266fbbe82b1fdfeb914263e39579eecafb2e67d00693a"),
+            ArchiveSource("http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.2-RELEASE/base.txz",
+                          "3a9250f7afd730bbe274691859756948b3c57a99bcda30d65d46ae30025906f0"),
         ]
     elseif Sys.iswindows(compiler_target)
         libc_sources = [

--- a/RootFS.md
+++ b/RootFS.md
@@ -6,7 +6,7 @@ This document details some of the journey we have embarked upon to create a Linu
 * glibc Linux: `i686-linux-gnu`, `x86_64-linux-gnu`, `aarch64-linux-gnu`, `armv7l-linux-gnueabihf`, `powerpc64le-linux-gnu`, `armv6l-linux-gnueabihf`
 * musl Linux: `i686-linux-musl`, `x86_64-linux-musl`, `aarch64-linux-musl`, `armv7l-linux-musleabihf`, `armv6l-linux-musleabihf`
 * MacOS: `x86_64-apple-darwin`, `aarch64-apple-darwin`
-* FreeBSD: `x86_64-unknown-freebsd12.2`
+* FreeBSD: `x86_64-unknown-freebsd13.2`
 * Windows: `i686-w64-mingw32`, `x86_64-w64-mingw32`
 
 These target platforms are compiled for by building a suite a cross-compilers (`gcc`, `gfortran`, `clang`, `binutils`, etc...) that run on `x86-64-linux-musl`, but target the specific platform.  Unfortunately, it is not sufficient to simply build these compilers once per target, because of incompatibilities between the generated code and the user's system where this code may eventually be running.

--- a/Z/zig/build_tarballs.jl
+++ b/Z/zig/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
     ArchiveSource("$(url_prefix)-macos-aarch64-$(version).tar.xz", "8c473082b4f0f819f1da05de2dbd0c1e891dff7d85d2c12b6ee876887d438287"; unpack_target = "aarch64-apple-darwin20"),
     ArchiveSource("$(url_prefix)-windows-x86_64-$(version).zip", "443da53387d6ae8ba6bac4b3b90e9fef4ecbe545e1c5fa3a89485c36f5c0e3a2"; unpack_target = "x86_64-w64-mingw32"),
     ArchiveSource("$(url_prefix)-windows-i386-$(version).zip", "74a640ed459914b96bcc572183a8db687bed0af08c30d2ea2f8eba03ae930f69"; unpack_target = "i686-w64-mingw32"),
-    ArchiveSource("$(url_prefix)-freebsd-x86_64-$(version).tar.xz", "4e06009bd3ede34b72757eec1b5b291b30aa0d5046dadd16ecb6b34a02411254"; unpack_target = "x86_64-unknown-freebsd12.2"),
+    ArchiveSource("$(url_prefix)-freebsd-x86_64-$(version).tar.xz", "4e06009bd3ede34b72757eec1b5b291b30aa0d5046dadd16ecb6b34a02411254"; unpack_target = "x86_64-unknown-freebsd13.2"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
The FreeBSD toolchain will need to be updated before this is ready, opening now as draft so I don't forget.