### PR TITLE
bump AzStorage preferred gcc version to 5

### DIFF
--- a/A/AzStorage/build_tarballs.jl
+++ b/A/AzStorage/build_tarballs.jl
@@ -52,5 +52,10 @@ dependencies = [
     BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),
 ]
 
+#=
+The motivation for the preferred gcc version here is compatability with the libgomp that nvc 23.5 ships with. If we use a gcc version prior to 5,
+then AzStorage seg-faults in one of its OpenMP blocks.
+=#
+
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")


### PR DESCRIPTION
Hello,

We recently were made aware of an issue where on a machine with nvc (installed via the NVidia HPC toolkit), AzStorage would crash via a seg-fault.  It turns out the seg-fault was from an [OpenMP loop in AzStorage.c](https://github.com/ChevronETC/AzStorage.jl/blob/feecaf93eb172499d5d32578a2e5d9e4556df3a9/src/AzStorage.c#L968), and that with NVidia HPC toolkit installed, we were linking to the libgomp shipped with the NVidia HPC toolkit.  It looks like the seg-fault goes away if we build AzStorage with gcc 5 rather than gcc 4 (the default).  We think this is due to compatability issues between the openmp shipped with the NVidia HPC toolkit vs that shipped with gcc 4.

I wasn't sure what to do about the version number in this package.  I decided to leave it as since the source code for AzStorage has not changed; but, let me know if it is better practice to bump the version number.

Thanks!

Sam