### PR TITLE
[CompilerSupportLibraries] Get new build of GCC 12 for Windows with libgomp fix

### DIFF
--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.0/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.0/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"1.0.4"; preferred_gcc_version=v"12", windows_staticlibs=true, julia_compat="1.9")
+build_csl(ARGS, v"1.0.5"; preferred_gcc_version=v"12", windows_staticlibs=true, julia_compat="1.9")
 
 # Build trigger: 2


### PR DESCRIPTION
Follow up to https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/313 and https://github.com/JuliaPackaging/Yggdrasil/pull/6871