### PR TITLE
update llama to commit 2d5db48 (19 May 2023)

### DIFF
--- a/L/llama_cpp/build_tarballs.jl
+++ b/L/llama_cpp/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder, Pkg
 
 name = "llama_cpp"
-version = v"0.0.9"  # fake version number
+version = v"0.0.10"  # fake version number
 
 # url = "https://github.com/ggerganov/llama.cpp"
 # description = "Port of Facebook's LLaMA model in C/C++"
@@ -34,10 +34,11 @@ version = v"0.0.9"  # fake version number
 # 0.0.7           24.04.2023       master-c4fe84f    https://github.com/ggerganov/llama.cpp/releases/tag/master-c4fe84f
 # 0.0.8           02.05.2023       master-e216aa0    https://github.com/ggerganov/llama.cpp/releases/tag/master-e216aa0
 # 0.0.9           19.05.2023       master-6986c78    https://github.com/ggerganov/llama.cpp/releases/tag/master-6986c78
+# 0.0.10          19.05.2023       master-2d5db48    https://github.com/ggerganov/llama.cpp/releases/tag/master-2d5db48
 
 sources = [
     GitSource("https://github.com/ggerganov/llama.cpp.git",
-              "6986c7835adc13ba3f9d933b95671bb1f3984dc6"),
+              "2d5db48371052087a83974abda3767d1aedec598"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
This updates llama_cpp_jll to support ggml file format v3. 