### PR TITLE
[ViennaRNA] update to ViennaRNA-2.6.2, fix shared lib linking on julia-1.6

### DIFF
--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -64,10 +64,7 @@ else
 fi
 
 
-# configure script fails (only in sandbox) without
-# setting ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes
-ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes \
-    ./configure \
+./configure \
     --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-pic --disable-c11 \
     --with-mpfr --with-json --with-svm --with-gsl \

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -93,6 +93,11 @@ make install
 # BLAS/LAPACK, and PCRE on windows
 cd src/RNAxplorer
 
+# remove -fno-lto from CFLAGS for clang (option doesn't exist)
+if [[ "${target}" == *-apple-darwin* || "${target}" == *-unknown-freebsd* ]]; then
+    sed -i -e 's/-fno-lto//' configure
+fi
+
 LIBS_RNAxplorer="$LIBS"
 if [[ "${target}" == *-w64-mingw32* ]]; then
     # work around there not being a regex.h on w64-mingw32

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -18,12 +18,6 @@ sources = [
 # - windows and gcc-8: internal compiler error during lto on gcc-8,
 #   which is why we use gcc-9
 
-# Post-build problems
-# - on julia-1.6 on x86_64-linux, can't run RNAxplorer program
-#   julia> run(`$(ViennaRNA_jll.RNAxplorer()) -h`)
-#   .../bin/RNAxplorer: error while loading shared libraries: libblastrampoline.so.5: cannot open shared object file: No such file or directory
-#   works fine on julia-1.9
-
 # TODO
 # - build shared library for RNAxplorer? (other programs like RNAforester etc?)
 #   configure script seems to indicate there is a python interface
@@ -31,6 +25,8 @@ sources = [
 # Notes
 # - we build RNAxplorer separately, because only it needs to link to
 #   BLAS/LAPACK, and PCRE on windows
+# - we use the LAPACK implementation from OpenBLAS_jll
+# - we don't use libblastrampoline as that requires julia-1.9 or newer
 
 script = raw"""
 cd $WORKSPACE/srcdir/ViennaRNA*/

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder, Pkg
 
 name = "ViennaRNA"
-version = v"2.6.1"
+version = v"2.6.2"
 
 # url = "https://github.com/ViennaRNA/ViennaRNA"
 # description = "Library and programs for the prediction and comparison of RNA secondary structures"
@@ -9,7 +9,7 @@ version = v"2.6.1"
 sources = [
     ArchiveSource("https://www.tbi.univie.ac.at/RNA/download/sourcecode/" *
                   "$(version.major)_$(version.minor)_x/ViennaRNA-$(version).tar.gz",
-                  "f778876bbe8e6c85725a633819b26468307c919635e82b278ba820eff8badf76"),
+                  "2ce1f69f4ff87e90f50e8de704e33db7818c7d2f0dfb427a08e0eafc9da9b627"),
     DirectorySource("./bundled")
 ]
 
@@ -231,4 +231,4 @@ dependencies = [
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version = v"9")
+               julia_compat="1.9", preferred_gcc_version = v"9")

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -18,6 +18,12 @@ sources = [
 # - windows and gcc-8: internal compiler error during lto on gcc-8,
 #   which is why we use gcc-9
 
+# Post-build problems
+# - on julia-1.6 on x86_64-linux, can't run RNAxplorer program
+#   julia> run(`$(ViennaRNA_jll.RNAxplorer()) -h`)
+#   .../bin/RNAxplorer: error while loading shared libraries: libblastrampoline.so.5: cannot open shared object file: No such file or directory
+#   works fine on julia-1.9
+
 # Notes
 # - we build RNAxplorer separately, because only it needs to link to
 #   BLAS/LAPACK, and PCRE on windows

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -70,14 +70,13 @@ if [[ "${target}" == *-w64-mingw32* ]]; then
     export LIBS="-lwinmm"
 fi
 
-# avoid compile errors on some targets with unknown references to rpl_malloc
-CONFIGURE_WORKAROUND=
 if [[ "${target}" == *-linux-musl* || "${target}" == *-apple-darwin* ]]; then
-    CONFIGURE_WORKAROUND="ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes"
+    # avoid linking errors on some targets, undefined references to rpl_malloc, rpl_realloc
+    export ac_cv_func_malloc_0_nonnull=yes
+    export ac_cv_func_realloc_0_nonnull=yes
 fi
 
-$CONFIGURE_WORKAROUND \
-    ./configure \
+./configure \
     --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-pic --disable-c11 \
     --with-mpfr --with-json --with-svm --with-gsl \

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -24,6 +24,10 @@ sources = [
 #   .../bin/RNAxplorer: error while loading shared libraries: libblastrampoline.so.5: cannot open shared object file: No such file or directory
 #   works fine on julia-1.9
 
+# TODO
+# - build shared library for RNAxplorer?
+#   configure script seems to indicate there is a python interface
+
 # Notes
 # - we build RNAxplorer separately, because only it needs to link to
 #   BLAS/LAPACK, and PCRE on windows

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -3,6 +3,9 @@ using BinaryBuilder, Pkg
 name = "ViennaRNA"
 version = v"2.6.1"
 
+# url = "https://github.com/ViennaRNA/ViennaRNA"
+# description = "Library and programs for the prediction and comparison of RNA secondary structures"
+
 sources = [
     ArchiveSource("https://www.tbi.univie.ac.at/RNA/download/sourcecode/" *
                   "$(version.major)_$(version.minor)_x/ViennaRNA-$(version).tar.gz",

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -34,6 +34,11 @@ export CXX=c++
 export CPPFLAGS="-I${includedir}"
 export LDFLAGS="-L${libdir}"
 
+# fix missing include for size_t, this fixes header parsing with
+# Clang.jl when generating bindings
+# upstream PR: https://github.com/ViennaRNA/ViennaRNA/pull/189
+atomic_patch -p1 ../patches/missing-include-for-size_t.patch
+
 if [[ "${target}" == *-w64-mingw32* ]]; then
     # time measurement in RNAforester doesn't compile on windows (mingw32),
     # so we disable it

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -70,7 +70,14 @@ if [[ "${target}" == *-w64-mingw32* ]]; then
     export LIBS="-lwinmm"
 fi
 
-./configure \
+# avoid compile errors on some targets with unknown references to rpl_malloc
+CONFIGURE_WORKAROUND=
+if [[ "${target}" == *-linux-musl* || "${target}" == *-apple-darwin* ]]; then
+    CONFIGURE_WORKAROUND="ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes"
+fi
+
+$CONFIGURE_WORKAROUND \
+    ./configure \
     --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-pic --disable-c11 \
     --with-mpfr --with-json --with-svm --with-gsl \

--- a/V/ViennaRNA/build_tarballs.jl
+++ b/V/ViennaRNA/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder, Pkg
 
 name = "ViennaRNA"
-version = v"2.6.2"
+version = v"2.6.1"
 
 # url = "https://github.com/ViennaRNA/ViennaRNA"
 # description = "Library and programs for the prediction and comparison of RNA secondary structures"
@@ -9,7 +9,7 @@ version = v"2.6.2"
 sources = [
     ArchiveSource("https://www.tbi.univie.ac.at/RNA/download/sourcecode/" *
                   "$(version.major)_$(version.minor)_x/ViennaRNA-$(version).tar.gz",
-                  "2ce1f69f4ff87e90f50e8de704e33db7818c7d2f0dfb427a08e0eafc9da9b627"),
+                  "f778876bbe8e6c85725a633819b26468307c919635e82b278ba820eff8badf76"),
     DirectorySource("./bundled")
 ]
 

--- a/V/ViennaRNA/bundled/patches/missing-include-for-size_t.patch
+++ b/V/ViennaRNA/bundled/patches/missing-include-for-size_t.patch
@@ -1,0 +1,26 @@
+From 355567871e97b68ad38a69821ecb63f66d2cc6a2 Mon Sep 17 00:00:00 2001
+From: Marco Matthies <71844+marcom@users.noreply.github.com>
+Date: Mon, 19 Jun 2023 10:16:26 +0200
+Subject: [PATCH] Fix missing include for size_t, breaks parsing of header
+ files
+
+---
+ src/ViennaRNA/constraints/soft.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/ViennaRNA/constraints/soft.h b/src/ViennaRNA/constraints/soft.h
+index 88f6ada1..85c597d6 100644
+--- a/src/ViennaRNA/constraints/soft.h
++++ b/src/ViennaRNA/constraints/soft.h
+@@ -25,6 +25,8 @@
+  */
+ typedef struct  vrna_sc_s vrna_sc_t;
+ 
++#include <stdlib.h>
++
+ #include <ViennaRNA/datastructures/basic.h>
+ #include <ViennaRNA/fold_compound.h>
+ #include <ViennaRNA/constraints/basic.h>
+-- 
+2.34.1
+


### PR DESCRIPTION
To help with https://github.com/marcom/ViennaRNA.jl/pull/15

- update to ViennaRNA-2.6.2

- only link RNAxplorer to BLAS/LAPACK (and PCRE on windows), not the other programs or shared library

- add patch to fix missing include in headers, causes problems when parsing headers with Clang.jl to build bindings

