### PR TITLE
bump Expat to version 2.5.0

### DIFF
--- a/E/Expat/build_tarballs.jl
+++ b/E/Expat/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "Expat"
-version = v"2.4.8"
+version = v"2.5.0"
 
 # Collection of sources required to build Expat
 sources = [
     ArchiveSource("https://github.com/libexpat/libexpat/releases/download/R_$(version.major)_$(version.minor)_$(version.patch)/expat-$(version).tar.xz",
-                  "f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25"),
+                  "ef2420f0232c087801abf705e89ae65f6257df6b7931d37846a193ef2e8cdcbe"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
I just saw this could be updated, and I'd thought I'd test if I could do this with a small lib (I did successfully build locally first, with "--deploy=local")

Our [COPASI](http://copasi.org/) ([Compiling COPASI](https://github.com/copasi/COPASI#compiling-copasi)) software depends on Expat, and I've been thinking about buidling a jll for future Julia bindings to our command line simulation engine (CopasiSE).

But I also just really like the way this is designed. -such a nice use case for OverlayFS, etc., etc. I'm thinking we could even leverage this to make simple, automated builds for our currently unsupported ARM versions, etc.

Thanks for creating such a nice cross-compile system!