### PR TITLE
[Qt6] Add Qt6Wayland (host build)

### DIFF
--- a/Q/Qt6Wayland/build_tarballs.jl
+++ b/Q/Qt6Wayland/build_tarballs.jl
@@ -1,0 +1,90 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Qt6Wayland"
+version = v"6.4.2"
+
+# Set this to true first when updating the version. It will build only for the host (linux musl).
+# After that JLL is in the registyry, set this to false to build for the other platforms, using
+# this same package as host build dependency.
+const host_build = true
+
+# Collection of sources required to build qt6
+sources = [
+    ArchiveSource("https://download.qt.io/official_releases/qt/$(version.major).$(version.minor)/$version/submodules/qtwayland-everywhere-src-$version.tar.xz",
+                  "24cf1a0af751ab1637b4815d5c5f3704483d5fa7bedbd3519e6fc020d8be135f"),
+    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.0-11.1/MacOSX11.1.sdk.tar.xz",
+                  "9b86eab03176c56bb526de30daa50fa819937c54b280364784ce431885341bf6"),
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir
+
+mkdir build
+cd build/
+qtsrcdir=`ls -d ../qtwayland-*`
+
+case "$bb_full_target" in
+
+    x86_64-linux-musl-libgfortran5-cxx11)
+        cmake -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_BUILD_TYPE=Release $qtsrcdir
+    ;;
+
+    *apple-darwin*)
+        apple_sdk_root=$WORKSPACE/srcdir/MacOSX11.1.sdk
+        sed -i "s!/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root!$apple_sdk_root!" $CMAKE_TARGET_TOOLCHAIN
+        cmake -DQT_HOST_PATH=$host_prefix \
+            -DPython_ROOT_DIR=/usr \
+            -DCMAKE_INSTALL_PREFIX=${prefix} \
+            -DCMAKE_PREFIX_PATH=$host_prefix \
+            -DCMAKE_FIND_ROOT_PATH=$prefix \
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+            -DCMAKE_SYSROOT=$apple_sdk_root -DCMAKE_FRAMEWORK_PATH=$apple_sdk_root/System/Library/Frameworks -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
+            -DCMAKE_BUILD_TYPE=Release \
+        $qtsrcdir
+    ;;
+
+    *)
+        cmake -DQT_HOST_PATH=$host_prefix -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release $qtsrcdir
+    ;;
+
+esac
+
+cmake --build . --parallel ${nproc}
+cmake --install .
+install_license $WORKSPACE/srcdir/qt*-src-*/LICENSES/LGPL-3.0-only.txt
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+if host_build
+    platforms = [Platform("x86_64", "linux",cxxstring_abi=:cxx11,libc="musl")]
+else
+    platforms = expand_cxxstring_abis(filter(p -> arch(p) != "armv6l" &&
+                                                  Sys.islinux(p) ||
+                                                  (Sys.isbsd(p) && !Sys.isapple(p)),
+        supported_platforms()))
+end
+
+# The products that we will ensure are always built
+products = [
+    FileProduct("plugins", :qt6plugins_dir),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    HostBuildDependency("Qt6Base_jll"),
+    Dependency("Qt6Base_jll"),
+    HostBuildDependency("Qt6Declarative_jll"),
+    Dependency("Qt6Declarative_jll"),
+    BuildDependency("Xorg_xproto_jll"),
+]
+
+if !host_build
+    push!(dependencies, HostBuildDependency("Qt6Wayland_jll"))
+end
+
+include("../../fancy_toys.jl")
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"9", julia_compat="1.6")


### PR DESCRIPTION
This will also allow gksqt (the GR plot window) to run on Wayland natively when using the Qt6 version and when PR https://github.com/jheinen/GR.jl/pull/518 is integrated. Supersedes https://github.com/JuliaPackaging/Yggdrasil/pull/3555 (which I could never get to work). CC @mkitti 