### PR TITLE
Libtiff: Update to 4.5.1

### DIFF
--- a/L/Libtiff/build_tarballs.jl
+++ b/L/Libtiff/build_tarballs.jl
@@ -3,19 +3,18 @@
 using BinaryBuilder
 
 name = "Libtiff"
-version = v"4.4.0"
+version = v"4.5.1"
 
 # Collection of sources required to build Libtiff
 sources = [
-    ArchiveSource("https://download.osgeo.org/libtiff/tiff-$(version).tar.gz",
-                  "917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed")
+    ArchiveSource("https://download.osgeo.org/libtiff/tiff-$(version).tar.xz",
+                  "3c080867114c26edab3129644a63b708028a90514b7fe3126e38e11d24f9f88a"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/tiff-*/
-export CPPFLAGS="-I${includedir}"
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+cd $WORKSPACE/srcdir/tiff-*
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --docdir=/tmp
 make -j${nproc}
 make install
 """
@@ -33,8 +32,10 @@ products = [
 dependencies = [
     Dependency("JpegTurbo_jll"),
     Dependency("LERC_jll"),
+    Dependency("XZ_jll"),
     Dependency("Zlib_jll"),
     Dependency("Zstd_jll"),
+    Dependency("libwebp_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Also support xz and webp compression formats.