### PR TITLE
[geotiff] build with libtiff 4.5

### DIFF
--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -2,7 +2,7 @@ using BinaryBuilder, Pkg
 
 name = "libgeotiff"
 upstream_version = v"1.7.1"
-version_offset = v"0.0.0"
+version_offset = v"0.0.1"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
                         upstream_version.patch * 100 + version_offset.patch)
@@ -46,7 +46,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("PROJ_jll"; compat="~900.100"),
-    Dependency("Libtiff_jll"; compat="4.3"),
+    Dependency("Libtiff_jll"; compat="~4.5"),
     Dependency("LibCURL_jll"),
 ]
 

--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -45,9 +45,9 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("PROJ_jll"; compat="~900.100"),
-    Dependency("Libtiff_jll"; compat="~4.5"),
-    Dependency("LibCURL_jll"),
+    Dependency("PROJ_jll"; compat="~900.200.100"),
+    Dependency("Libtiff_jll"; compat="~4.5.1"),
+    Dependency("LibCURL_jll"; compat="7.73,8"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -46,7 +46,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("PROJ_jll"; compat="~900.200.100"),
-    Dependency("Libtiff_jll"; compat="~4.5.1"),
+    Dependency("Libtiff_jll"; compat="4.5.1"),
     Dependency("LibCURL_jll"; compat="7.73,8"),
 ]
 


### PR DESCRIPTION
Looks like the [upgrade](https://github.com/JuliaPackaging/Yggdrasil/pull/6924) from libtiff 4.4 to 4.5 was [breaking](https://github.com/JuliaBinaryWrappers/Libtiff_jll.jl/commit/fddff204e013fe40cff4fac05fa9289adaaa8034#diff-248757425c80d519c91e1be718766832fdd989ae7837c5c4b6e64f95931a4757) at least on Windows.

Reported in https://github.com/JuliaGeo/GDAL.jl/issues/158
Also addresses one case of #6857 in an effort to get nightly support working again (https://github.com/JuliaGeo/GDAL.jl/issues/152).
