### PR TITLE
ADIOS2: Require zfp >= 1

### DIFF
--- a/A/ADIOS2/build_tarballs.jl
+++ b/A/ADIOS2/build_tarballs.jl
@@ -146,7 +146,7 @@ dependencies = [
     Dependency(PackageSpec(name="SZ_jll")),
     Dependency(PackageSpec(name="ZeroMQ_jll")),
     Dependency(PackageSpec(name="libpng_jll")),
-    Dependency(PackageSpec(name="zfp_jll")),
+    Dependency(PackageSpec(name="zfp_jll"); compat="1"),
 ]
 append!(dependencies, platform_dependencies)
 


### PR DESCRIPTION
The recent update to zfp_jll 1.0 broke ADIOS2_jll because it didn't specify a compat bound for zfp.