### PR TITLE
[XGBoost] Add cxxstring_abi back in, prevent augmenting Windows with a `cuda=none` tag

### DIFF
--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -89,20 +89,20 @@ platforms = expand_cxxstring_abis(supported_platforms())
 
 for cuda_version in versions_to_build, platform in platforms
 
-    build_cuda = (os(platform) == "linux") && (arch(platform) in ["x86_64"])
-    if !isnothing(cuda_version) && !build_cuda
+    cuda_platform = (os(platform) == "linux") && (arch(platform) in ["x86_64"])
+    if !isnothing(cuda_version) && !cuda_platform
         continue
     end
     
-    # For Windows, we want to avoid adding cuda=none
+    # For platforms we can't create cuda builds on, we want to avoid adding cuda=none
     # https://github.com/JuliaPackaging/Yggdrasil/issues/6911#issuecomment-1599350319
-    if os(platform) == "windows"
-        augmented_platform = deepcopy(platform)
-    else
+    if cuda_platform
         augmented_platform = Platform(arch(platform), os(platform);
             cxxstring_abi = cxxstring_abi(platform),
             cuda=isnothing(cuda_version) ? "none" : CUDA.platform(cuda_version)
         )
+    else
+        augmented_platform = deepcopy(platform)
     end
     should_build_platform(triplet(augmented_platform)) || continue
 

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -93,10 +93,17 @@ for cuda_version in versions_to_build, platform in platforms
     if !isnothing(cuda_version) && !build_cuda
         continue
     end
-
-    augmented_platform = Platform(arch(platform), os(platform);
-        cuda=isnothing(cuda_version) ? "none" : CUDA.platform(cuda_version)
-    )
+    
+    # For Windows, we want to avoid adding cuda=none
+    # https://github.com/JuliaPackaging/Yggdrasil/issues/6911#issuecomment-1599350319
+    if os(platform) == "windows"
+        augmented_platform = deepcopy(platform)
+    else
+        augmented_platform = Platform(arch(platform), os(platform);
+            cxxstring_abi = cxxstring_abi(platform),
+            cuda=isnothing(cuda_version) ? "none" : CUDA.platform(cuda_version)
+        )
+    end
     should_build_platform(triplet(augmented_platform)) || continue
 
     dependencies = AbstractDependency[


### PR DESCRIPTION
Ref: https://github.com/JuliaPackaging/Yggdrasil/pull/6746 and https://github.com/JuliaPackaging/Yggdrasil/issues/6911#issuecomment-1599350319

This PR accomplishes 2 things. The first is that it adds the `cxxstring_abi` back into the builds. I forgot to add it to the platform when porting the CUDA build format from AMGX and other libraries with multiple CUDA versions, where the `cxxstring_abi` is not added to the `augmented_platform`. 

The second thing is that I dropped the `cuda=none` tags on all Windows builds.

