### PR TITLE
[GTK4] update to v4.10.4

### DIFF
--- a/G/GTK4/build_tarballs.jl
+++ b/G/GTK4/build_tarballs.jl
@@ -3,13 +3,14 @@
 using BinaryBuilder
 
 name = "GTK4"
-version = v"4.8.3"
+version = v"4.10.4"
 
 # Collection of sources required to build GTK
 sources = [
     # https://download.gnome.org/sources/gtk/
     ArchiveSource("https://download.gnome.org/sources/gtk/$(version.major).$(version.minor)/gtk-$(version).tar.xz",
-                  "b362f968d085b4d3d9340d4d38c706377ded9d5374e694a2b6b7e6292e3cba74"),
+                  "7725400482e0685e28265e226c62847f4e73cfca9e9b416ac5838207f5377a24"),
+    DirectorySource("./bundled"),
     ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v10.0.0.tar.bz2",
                   "ba6b430aed72c63a3768531f6a3ffc2b0fde2c57a3b251450dcf489a894f0894"),
 ]
@@ -47,6 +48,7 @@ fi
 FLAGS=()
 if [[ "${target}" == *-apple-* ]]; then
     FLAGS+=(-Dx11-backend=false -Dwayland-backend=false)
+    atomic_patch -p1 ../patches/NSPasteboard.patch
 elif [[ "${target}" == *-freebsd* ]]; then
     FLAGS+=(-Dwayland-backend=false)
 elif [[ "${target}" == *-mingw* ]]; then
@@ -75,6 +77,7 @@ meson .. \
     -Ddemos=false \
     -Dbuild-examples=false \
     -Dbuild-tests=false \
+    -Dbuild-testsuite=false \
     -Dgtk_doc=false \
     "${FLAGS[@]}" \
     --cross-file="${MESON_TARGET_TOOLCHAIN}"
@@ -107,7 +110,7 @@ dependencies = [
     # Need a host Wayland for wayland-scanner
     HostBuildDependency("Wayland_jll"; platforms=x11_platforms),
     BuildDependency("Xorg_xorgproto_jll"; platforms=x11_platforms),
-    Dependency("Glib_jll"; compat="2.68.3"),
+    Dependency("Glib_jll"; compat="2.74"),
     Dependency("Graphene_jll"; compat="1.10.6"),
     Dependency("Cairo_jll"),
     Dependency("Pango_jll"; compat="1.50.3"),

--- a/G/GTK4/build_tarballs.jl
+++ b/G/GTK4/build_tarballs.jl
@@ -85,6 +85,8 @@ meson .. \
 ninja -j${nproc}
 ninja install
 
+install_license ../COPYING
+
 # post-install script is disabled when cross-compiling
 glib-compile-schemas ${prefix}/share/glib-2.0/schemas
 

--- a/G/GTK4/build_tarballs.jl
+++ b/G/GTK4/build_tarballs.jl
@@ -20,6 +20,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/gtk*/
 
 # We need to run some commands with a native Glib
+apk update
 apk add glib-dev
 
 # This is awful, I know

--- a/G/GTK4/bundled/patches/NSPasteboard.patch
+++ b/G/GTK4/bundled/patches/NSPasteboard.patch
@@ -1,0 +1,59 @@
+From 90183b35889961774178cc332169c18591d0542e Mon Sep 17 00:00:00 2001
+From: Peter Williams <peter@newton.cx>
+Date: Mon, 10 Apr 2023 14:21:49 -0400
+Subject: [PATCH] gdk/macos: fix builds on macOS before 10.13
+
+Nothing profound here, just need to get some of the workarounds
+into the right places.
+---
+ gdk/macos/gdkmacosclipboard-private.h  | 4 ----
+ gdk/macos/gdkmacospasteboard-private.h | 4 ++++
+ gdk/macos/gdkmacospasteboard.c         | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/gdk/macos/gdkmacosclipboard-private.h b/gdk/macos/gdkmacosclipboard-private.h
+index 5679b13a36f..4866cf22e00 100644
+--- a/gdk/macos/gdkmacosclipboard-private.h
++++ b/gdk/macos/gdkmacosclipboard-private.h
+@@ -27,10 +27,6 @@
+ 
+ G_BEGIN_DECLS
+ 
+-#ifndef AVAILABLE_MAC_OS_X_VERSION_10_13_AND_LATER
+-typedef NSString *NSPasteboardType;
+-#endif
+-
+ #define GDK_TYPE_MACOS_CLIPBOARD (_gdk_macos_clipboard_get_type())
+ 
+ G_DECLARE_FINAL_TYPE (GdkMacosClipboard, _gdk_macos_clipboard, GDK, MACOS_CLIPBOARD, GdkClipboard)
+diff --git a/gdk/macos/gdkmacospasteboard-private.h b/gdk/macos/gdkmacospasteboard-private.h
+index cac18a8fde5..cc7f6b8e475 100644
+--- a/gdk/macos/gdkmacospasteboard-private.h
++++ b/gdk/macos/gdkmacospasteboard-private.h
+@@ -26,6 +26,10 @@
+ 
+ G_BEGIN_DECLS
+ 
++#ifndef AVAILABLE_MAC_OS_X_VERSION_10_13_AND_LATER
++typedef NSString *NSPasteboardType;
++#endif
++
+ @interface GdkMacosPasteboardItemDataProvider : NSObject <NSPasteboardItemDataProvider>
+ {
+   GdkContentProvider *_contentProvider;
+diff --git a/gdk/macos/gdkmacospasteboard.c b/gdk/macos/gdkmacospasteboard.c
+index 0903c5352ac..b26248a9548 100644
+--- a/gdk/macos/gdkmacospasteboard.c
++++ b/gdk/macos/gdkmacospasteboard.c
+@@ -400,7 +400,7 @@ _gdk_macos_pasteboard_register_drag_types (NSWindow *window)
+       gdk_content_formats_get_gtypes (formats, &n_gtypes);
+ 
+       if (n_gtypes)
+-        [ret addObject:NSPasteboardTypeURL];
++        [ret addObject:PTYPE(URL)];
+ 
+       gdk_content_formats_unref (formats);
+     }
+-- 
+GitLab
+


### PR DESCRIPTION
Includes patch to fix MacOS build: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5813

This version requires Glib 2.72, so I bumped that compat too.