### PR TITLE
[VARNA] Add 'build' for VARNA-3.93 jar file

### DIFF
--- a/V/VARNA/build_tarballs.jl
+++ b/V/VARNA/build_tarballs.jl
@@ -1,0 +1,34 @@
+using BinaryBuilder, Pkg
+
+name = "VARNA"
+version = v"3.93.0"
+
+# url = "https://varna.lisn.upsaclay.fr/"
+# description = "Java component and applet for drawing RNA secondary structure"
+
+sources = [
+    FileSource("https://varna.lisn.upsaclay.fr/bin/VARNAv$(version.major)-$(version.minor).jar",
+               "276996b0eb54ab7bdbf92a113f0c23d8d3ed8e497d85b6577b3f2065a0dbcf87"),
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir/
+
+install -Dvm 644 VARNA*.jar ${prefix}/share/VARNA.jar
+
+# VARNA uses GPL as stated here: https://varna.lisn.upsaclay.fr/
+install_license /usr/share/licenses/GPL-3.0+
+"""
+
+platforms = supported_platforms()
+
+products = [
+    FileProduct("share/VARNA.jar", :VARNA_jar)
+]
+
+dependencies = Dependency[
+    # TODO: depends on java
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")


### PR DESCRIPTION
Used in https://github.com/marcom/PlotRNA.jl

Having this as a jll avoids trying to load this at first package load time (it is cached though).

My main issue is that it is downloaded on every CI run, which might not be nice for the upstream server: https://github.com/marcom/PlotRNA.jl/issues/11.