### PR TITLE
[ViennaRNA] Take two for build script for ViennaRNA-1.8.5

### DIFF
--- a/V/ViennaRNA/ViennaRNA@1.8.5/build_tarballs.jl
+++ b/V/ViennaRNA/ViennaRNA@1.8.5/build_tarballs.jl
@@ -1,0 +1,80 @@
+using BinaryBuilder, Pkg
+
+name = "ViennaRNA"
+version = v"1.8.5"
+# released in 2011, ViennaRNA-1.8.5 was the last of the 1.x.y versions
+
+# url = "https://www.tbi.univie.ac.at/RNA/"
+# description = "Library and programs for the prediction and comparison of RNA secondary structures"
+
+# Build errors
+# - Kinfold causes build errors on FreeBSD and MacOS (clang?)
+# - RNAforester probably has build problems on Windows like in
+#   ViennaRNA-2.x.y, disabled for now
+
+sources = [
+    ArchiveSource("https://www.tbi.univie.ac.at/RNA/download/sourcecode/" *
+                  "$(version.major)_$(version.minor)_x/ViennaRNA-$(version).tar.gz",
+                  "f4e2d94beaf77165e8321758e4ab0ad1c5d49879cefa12e48b07d09ed2d0ecf9"),
+    DirectorySource("./bundled")
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir/ViennaRNA*/
+
+# fixes linking errors
+atomic_patch -p1 ../patches/fix-ViennaRNA-1.8.5-compile.patch
+
+update_configure_scripts --reconf
+
+./configure \
+    --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
+    --without-perl \
+    --with-cluster \
+    --without-kinfold --without-forester
+
+make -j${nproc}
+make install
+
+# create and install a shared library libRNA
+"${CC}" -g -O2 \
+    -shared -o "${libdir}/libRNA.${dlext}" \
+    -Wl,$(flagon --whole-archive) ./lib/libRNA.a -Wl,$(flagon --no-whole-archive)
+
+# install licenses
+# cp RNAforester/COPYING COPYING-RNAforester
+# install_license COPYING-RNAforester
+install_license COPYING
+"""
+
+platforms = supported_platforms()
+# platforms = expand_cxxstring_abis(platforms) # for RNAforester
+
+products = [
+    ExecutableProduct("AnalyseDists", :AnalyseDists),
+    ExecutableProduct("AnalyseSeqs", :AnalyseSeqs),
+    # ExecutableProduct("Kinfold", :Kinfold),
+    ExecutableProduct("RNAaliduplex", :RNAaliduplex),
+    ExecutableProduct("RNAalifold", :RNAalifold),
+    ExecutableProduct("RNAcofold", :RNAcofold),
+    ExecutableProduct("RNAdistance", :RNAdistance),
+    ExecutableProduct("RNAduplex", :RNAduplex),
+    ExecutableProduct("RNAeval", :RNAeval),
+    ExecutableProduct("RNAfold", :RNAfold),
+    # ExecutableProduct("RNAforester", :RNAforester),
+    ExecutableProduct("RNAheat", :RNAheat),
+    ExecutableProduct("RNAinverse", :RNAinverse),
+    ExecutableProduct("RNALfold", :RNALfold),
+    ExecutableProduct("RNApaln", :RNApaln),
+    ExecutableProduct("RNApdist", :RNApdist),
+    ExecutableProduct("RNAplfold", :RNAplfold),
+    ExecutableProduct("RNAplot", :RNAplot),
+    ExecutableProduct("RNAsubopt", :RNAsubopt),
+    ExecutableProduct("RNAup", :RNAup),
+    LibraryProduct("libRNA", :libRNA),
+]
+
+dependencies = Dependency[]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version = v"4")

--- a/V/ViennaRNA/ViennaRNA@1.8.5/bundled/patches/fix-ViennaRNA-1.8.5-compile.patch
+++ b/V/ViennaRNA/ViennaRNA@1.8.5/bundled/patches/fix-ViennaRNA-1.8.5-compile.patch
@@ -1,3 +1,45 @@
+diff --git a/Cluster/AS_main.c b/Cluster/AS_main.c
+index c516f32..74a6ba3 100644
+--- a/Cluster/AS_main.c
++++ b/Cluster/AS_main.c
+@@ -1,3 +1,5 @@
++#include <stdlib.h>
++#include <unistd.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include "distance_matrix.h"
+@@ -225,7 +227,8 @@ main(int argc, char *argv[])
+ 	    for(j=0;j<nn[i];j++) free(ss[i][j]);
+ 	    free(ss[i]);
+          }
+-	 free(ss);
++         // ss is on the stack, can't free
++	 //free(ss);
+       }
+       else {
+          printf_taxa_list();
+diff --git a/Cluster/statgeom.c b/Cluster/statgeom.c
+index 4bd03a5..d3ad0b2 100644
+--- a/Cluster/statgeom.c
++++ b/Cluster/statgeom.c
+@@ -6,6 +6,8 @@
+ 
+ #include <stdio.h>
+ #include <strings.h>
++#include <string.h>
++#include <stdlib.h>
+ #include <ctype.h>
+ #include "utils.h"
+ #include "PS3D.h"
+diff --git a/Cluster/treeplot.c b/Cluster/treeplot.c
+index 7a53260..2e9646c 100644
+--- a/Cluster/treeplot.c
++++ b/Cluster/treeplot.c
+@@ -1,3 +1,4 @@
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <math.h>
 diff --git a/lib/fold.c b/lib/fold.c
 index ff609d6..d26ce9d 100644
 --- a/lib/fold.c
@@ -15,10 +57,18 @@ index ff609d6..d26ce9d 100644
  #define PAREN
  
 diff --git a/lib/subopt.c b/lib/subopt.c
-index f2a04f9..148218c 100644
+index f2a04f9..ecf0a21 100644
 --- a/lib/subopt.c
 +++ b/lib/subopt.c
-@@ -191,7 +191,7 @@ PUBLIC  double print_energy = 9999; /* printing threshold for use with logML */
+@@ -80,6 +80,7 @@
+ #include <string.h>
+ #include <math.h>
+ #include "fold.h"
++#include "cofold.h"
+ #include "utils.h"
+ #include "energy_par.h"
+ #include "fold_vars.h"
+@@ -191,7 +192,7 @@ PUBLIC  double print_energy = 9999; /* printing threshold for use with logML */
  extern	int circ;
  PUBLIC	SOLUTION *subopt_circ(char *seq, char *sequence, int delta, FILE *fp);
  PRIVATE int *fM2;	 /* energies of M2 */

--- a/V/ViennaRNA/ViennaRNA@1.8.5/bundled/patches/fix-ViennaRNA-1.8.5-compile.patch
+++ b/V/ViennaRNA/ViennaRNA@1.8.5/bundled/patches/fix-ViennaRNA-1.8.5-compile.patch
@@ -1,0 +1,29 @@
+diff --git a/lib/fold.c b/lib/fold.c
+index ff609d6..d26ce9d 100644
+--- a/lib/fold.c
++++ b/lib/fold.c
+@@ -24,11 +24,7 @@
+ 
+ /*@unused@*/
+ static char rcsid[] UNUSED = "$Id: fold.c,v 1.38 2007/12/19 10:27:42 ivo Exp $";
+-#ifdef __GNUC__
+-#define INLINE inline
+-#else
+ #define INLINE
+-#endif
+ 
+ #define PAREN
+ 
+diff --git a/lib/subopt.c b/lib/subopt.c
+index f2a04f9..148218c 100644
+--- a/lib/subopt.c
++++ b/lib/subopt.c
+@@ -191,7 +191,7 @@ PUBLIC  double print_energy = 9999; /* printing threshold for use with logML */
+ extern	int circ;
+ PUBLIC	SOLUTION *subopt_circ(char *seq, char *sequence, int delta, FILE *fp);
+ PRIVATE int *fM2;	 /* energies of M2 */
+-PUBLIC	int	Fc, FcH, FcI, FcM;		/* parts of the exterior loop energies */
++PRIVATE	int	Fc, FcH, FcI, FcM;		/* parts of the exterior loop energies */
+ 
+ PRIVATE void encode_seq(char *sequence) {
+   unsigned int i,l;


### PR DESCRIPTION
Supersedes: #6949 

This is a build script for ViennaRNA-1.8.5 (from 2011), the last version of ViennaRNA-1.x.y.

I need it for some old projects of mine to make them easily reproducible.

I have placed the script in an extra directory so as not to mess up the build script for the current ViennaRNA-2.x.y.