### PR TITLE
[Xorg_xkeyboard_config] Initialize XKB_CONFIG_ROOT [skip build]

### DIFF
--- a/X/Xorg_xkeyboard_config/build_tarballs.jl
+++ b/X/Xorg_xkeyboard_config/build_tarballs.jl
@@ -34,5 +34,9 @@ dependencies = [
     Dependency("Xorg_xkbcomp_jll"),
 ]
 
+init_block = raw"""
+ENV["XKB_CONFIG_ROOT"] = get(ENV, "XKB_CONFIG_ROOT", joinpath(artifact_dir, "share", "X11", "xkb"))
+"""
+
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", init_block)


### PR DESCRIPTION
I also had to add `julia_compat` because of an error about experimental platforms, not sure if the `skip build` is still OK then @giordano ?