### PR TITLE
[libcifpp] Add build script for libcifpp v5.1.0

### DIFF
--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -14,11 +14,6 @@ sources = [
 ]
 
 # TODO
-# - the installed file etc/cron.weekly/update-libcifpp-data contains
-#   hardcoded paths with /workspace/destdir/...
-#   It is used to update components.cif, which should probably be done
-#   in a different way.
-#
 # - the CCD (chemical components dictionary) normally gets downloaded
 #   by default and saved under share/libcifpp/components.cif, but we
 #   don't do this

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -117,8 +117,7 @@ install_license ../LICENSE
 """
 
 platforms = supported_platforms()
-# Only FreeBSD uses clang in this build
-platforms = expand_cxxstring_abis(platforms; skip=Sys.isfreebsd)
+platforms = expand_cxxstring_abis(platforms)
 
 products = [
     LibraryProduct("libcifpp", :libcifpp),

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -113,4 +113,4 @@ dependencies = [
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version = v"10")
+               julia_compat="1.6", preferred_gcc_version = v"9")

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -69,6 +69,11 @@ if [[ "${bb_full_target}" == "${MACHTYPE_FULL}" ]]; then
     CFG_TESTING="-DENABLE_TESTING=ON"
 fi
 
+# use gcc/g++ on apple
+if [[ "${target}" == *-apple-darwin* ]]; then
+    CMAKE_TARGET_TOOLCHAIN="$(dirname "${CMAKE_TARGET_TOOLCHAIN}")/target_${target}_gcc.cmake"
+fi
+
 cmake .. \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
@@ -93,7 +98,8 @@ install_license ../LICENSE
 """
 
 platforms = supported_platforms()
-platforms = expand_cxxstring_abis(platforms)
+# Only FreeBSD uses clang in this build
+platforms = expand_cxxstring_abis(platforms; skip=Sys.isfreebsd)
 
 products = [
     LibraryProduct("libcifpp", :libcifpp),

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -33,15 +33,7 @@ sources = [
 # Note: test suite (`make test`) is run if we are building for the
 # build host platform BinaryBuilderBase.default_host_platform, which
 # is the case for `$target == $MACHTYPE` inside the shell script.
-
-# Note: cmake cache vars are set sometimes because we are
-# cross-compiling, normally cmake would try and run a program to
-# determine if a feature is available.
 #
-# -DSTD_REGEX_RUNNING=0               # std::regex works
-# -D_CXX_ATOMIC_BUILTIN_EXITCODE=0    # std::atomic works
-# -D_CXX_ATOMIC_BUILTIN_EXITCODE__TRYRUN_OUTPUT=0
-
 # The tests only pass with the correct cxxabi (-cxx11), so we create a
 # MACHTYPE_FULL variable to pass to the shell script which can there
 # be matched against to bb_full_target.
@@ -74,11 +66,20 @@ if [[ "${target}" == *-apple-darwin* ]]; then
     CMAKE_TARGET_TOOLCHAIN="$(dirname "${CMAKE_TARGET_TOOLCHAIN}")/target_${target}_gcc.cmake"
 fi
 
+# Set cmake cache vars because test programs can't be run during
+# cross-compilation
+#
+# -DSTD_REGEX_RUNNING=0               # std::regex works
+# -D_CXX_ATOMIC_BUILTIN_EXITCODE=0    # std::atomic works
+# -D_CXX_ATOMIC_BUILTIN_EXITCODE__TRYRUN_OUTPUT=0
+#
 cmake .. \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_FOR_CCP4=OFF \
     -DCIFPP_DOWNLOAD_CCD=OFF \
+    -DCIFPP_INSTALL_UPDATE_SCRIPT=OFF \
     -DBUILD_SHARED_LIBS=ON \
     -DSTD_REGEX_RUNNING=OFF \
     -D_CXX_ATOMIC_BUILTIN_EXITCODE=0 \

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -52,6 +52,13 @@ cd $WORKSPACE/srcdir/libcifpp*/
 # upstream PR: https://github.com/PDB-REDO/libcifpp/pull/45
 atomic_patch -p1 ../patches/mingw-no-ioctl.patch
 
+# fixes for clang and libc++ on macos for missing C++20 features,
+# like missing std::set::contains
+# Upstream issue: https://github.com/PDB-REDO/libcifpp/issues/39
+if [[ "${target}" == *-apple-darwin* ]]; then
+    atomic_patch -p1 ../patches/clang-libc++-fixes.patch
+fi
+
 mkdir build && cd build
 
 CFG_TESTING="-DENABLE_TESTING=OFF"

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -1,0 +1,93 @@
+using BinaryBuilder, Pkg
+using BinaryBuilderBase: default_host_platform
+
+name = "libcifpp"
+version = v"5.1.0"
+
+# url = "https://github.com/PDB-REDO/libcifpp"
+# description = "Library containing code to manipulate mmCIF and PDB files"
+
+sources = [
+    GitSource("https://github.com/PDB-REDO/libcifpp",
+              "836aed6ea9a227b37e5b0d9cbcb1253f545d0778"),
+]
+
+# TODO
+# - the installed file etc/cron.weekly/update-libcifpp-data contains
+#   hardcoded paths with /workspace/destdir/...
+#   It is used to update components.cif, which should probably be done
+#   in a different way.
+#
+# - the CCD (chemical components dictionary) normally gets downloaded
+#   by default and saved under share/libcifpp/components.cif, but we
+#   don't do this
+#
+#   This file is quite large (88MB gzipped, 380MB decompressed as of
+#   July 2023). Therefore, download and installation of this file is
+#   disabled for now, but not sure what functionality is impacted by
+#   this. We should maybe think of a better way of sharing
+#   components.cif between different packages that need it.
+#   Ref: https://www.wwpdb.org/data/ccd
+
+# Note: test suite (`make test`) is run if we are building for the
+# build host platform BinaryBuilderBase.default_host_platform, which
+# is the case for `$target == $MACHTYPE` inside the shell script.
+
+# Note: cmake cache vars are set sometimes because we are
+# cross-compiling, normally cmake would try and run a program to
+# determine if a feature is available.
+#
+# -DSTD_REGEX_RUNNING=0               # std::regex works
+# -D_CXX_ATOMIC_BUILTIN_EXITCODE=0    # std::atomic works
+# -D_CXX_ATOMIC_BUILTIN_EXITCODE__TRYRUN_OUTPUT=0
+
+script = raw"""
+cd $WORKSPACE/srcdir/libcifpp*/
+
+mkdir build && cd build
+
+CFG_TESTING="-DENABLE_TESTING=OFF"
+if [[ "${target}" == "${MACHTYPE}" ]]; then
+    # build the tests if we are building for the build host platform
+    CFG_TESTING="-DENABLE_TESTING=ON"
+fi
+
+cmake .. \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCIFPP_DOWNLOAD_CCD=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DSTD_REGEX_RUNNING=OFF \
+    -D_CXX_ATOMIC_BUILTIN_EXITCODE=0 \
+    -D_CXX_ATOMIC_BUILTIN_EXITCODE__TRYRUN_OUTPUT=0 \
+    ${CFG_TESTING}
+
+make -j${nproc}
+
+if [[ "${target}" == "${MACHTYPE}" ]]; then
+    # run the tests on the build host platform
+    make test
+fi
+
+make install
+
+install_license ../LICENSE
+"""
+
+platforms = supported_platforms()
+platforms = expand_cxxstring_abis(platforms)
+
+products = [
+    LibraryProduct("libcifpp", :libcifpp),
+]
+
+dependencies = [
+    Dependency("Eigen_jll"),
+    Dependency("Zlib_jll"),
+    # needed for make test, which we only run on the `default_host_platform`
+    HostBuildDependency("boost_jll"; platforms=[default_host_platform]),
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version = v"9")

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -49,6 +49,7 @@ MACHTYPE_FULL=$MACHTYPE_FULL
 cd $WORKSPACE/srcdir/libcifpp*/
 
 # mingw doesn't have ioctl
+# upstream PR: https://github.com/PDB-REDO/libcifpp/pull/45
 atomic_patch -p1 ../patches/mingw-no-ioctl.patch
 
 mkdir build && cd build

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -83,7 +83,7 @@ products = [
 ]
 
 dependencies = [
-    Dependency("Eigen_jll"),
+    BuildDependency("Eigen_jll"),
     Dependency("Zlib_jll"),
     # needed for make test, which we only run on the `default_host_platform`
     HostBuildDependency("boost_jll"; platforms=[default_host_platform]),

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -10,6 +10,7 @@ version = v"5.1.0"
 sources = [
     GitSource("https://github.com/PDB-REDO/libcifpp",
               "836aed6ea9a227b37e5b0d9cbcb1253f545d0778"),
+    DirectorySource("./bundled"),
 ]
 
 # TODO
@@ -43,6 +44,9 @@ sources = [
 
 script = raw"""
 cd $WORKSPACE/srcdir/libcifpp*/
+
+# mingw doesn't have ioctl
+atomic_patch -p1 ../patches/mingw-no-ioctl.patch
 
 mkdir build && cd build
 

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -25,6 +25,9 @@ sources = [
 #   components.cif between different packages that need it.
 #   Ref: https://www.wwpdb.org/data/ccd
 
+# Note: upstream seems to recommend gcc >= 10
+#       https://github.com/PDB-REDO/libcifpp/issues/39
+
 # Note: test suite (`make test`) is run if we are building for the
 # build host platform BinaryBuilderBase.default_host_platform, which
 # is the case for `$target == $MACHTYPE` inside the shell script.
@@ -109,4 +112,4 @@ dependencies = [
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version = v"9")
+               julia_compat="1.6", preferred_gcc_version = v"10")

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -28,7 +28,8 @@ sources = [
 #   Ref: https://www.wwpdb.org/data/ccd
 
 # Note: we use a newer MacOS SDK to compile on x86_64-apple-darwin
-# fixes missing `shared_timed_mutex` and linking problems for std::filesystem
+# fixes missing `shared_timed_mutex` and linking problems for
+# std::filesystem
 
 # Note: upstream seems to recommend gcc >= 10
 #       https://github.com/PDB-REDO/libcifpp/issues/39

--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -60,11 +60,6 @@ if [[ "${bb_full_target}" == "${MACHTYPE_FULL}" ]]; then
     CFG_TESTING="-DENABLE_TESTING=ON"
 fi
 
-# use gcc/g++ on apple
-if [[ "${target}" == *-apple-darwin* ]]; then
-    CMAKE_TARGET_TOOLCHAIN="$(dirname "${CMAKE_TARGET_TOOLCHAIN}")/target_${target}_gcc.cmake"
-fi
-
 # Set cmake cache vars because test programs can't be run during
 # cross-compilation
 #

--- a/L/libcifpp/bundled/patches/clang-libc++-fixes.patch
+++ b/L/libcifpp/bundled/patches/clang-libc++-fixes.patch
@@ -1,0 +1,60 @@
+diff --git a/include/cif++/symmetry.hpp b/include/cif++/symmetry.hpp
+index ebf1b3a..2b151d7 100644
+--- a/include/cif++/symmetry.hpp
++++ b/include/cif++/symmetry.hpp
+@@ -34,6 +34,10 @@
+ #include <cstdint>
+ #include <string>
+ 
++#if defined(__cpp_impl_three_way_comparison)
++#include <compare>
++#endif
++
+ /// \file cif++/symmetry.hpp
+ /// This file contains code to do symmetry operations based on the
+ /// operations as specified in the International Tables.
+diff --git a/src/category.cpp b/src/category.cpp
+index 04eb4db..4f52b3a 100644
+--- a/src/category.cpp
++++ b/src/category.cpp
+@@ -968,7 +968,7 @@ condition category::get_children_condition(row_handle rh, const category &childC
+ 
+ 			if (parentValue.empty())
+ 				cond = std::move(cond) and key(childKey) == null;
+-			else if (link->m_parent_keys.size() > 1 and not mandatoryChildFields.contains(childKey))
++			else if (link->m_parent_keys.size() > 1 and mandatoryChildFields.find(childKey) == mandatoryChildFields.end())
+ 				cond = std::move(cond) and (key(childKey) == parentValue.text() or key(childKey) == null);
+ 			else
+ 				cond = std::move(cond) and key(childKey) == parentValue.text();
+@@ -2076,4 +2076,4 @@ bool category::operator==(const category &rhs) const
+ 	return true;
+ }
+ 
+-} // namespace cif
+\ No newline at end of file
++} // namespace cif
+diff --git a/src/condition.cpp b/src/condition.cpp
+index b006133..d36fba0 100644
+--- a/src/condition.cpp
++++ b/src/condition.cpp
+@@ -66,12 +66,14 @@ namespace detail
+ 		m_item_ix = c.get_column_ix(m_item_tag);
+ 		m_icase = is_column_type_uchar(c, m_item_tag);
+ 
+-		if (c.get_cat_validator() != nullptr and
+-			c.key_field_indices().contains(m_item_ix) and
+-			c.key_field_indices().size() == 1)
+-		{
+-			m_single_hit = c[{ { m_item_tag, m_value } }];
+-		}
++                if (c.get_cat_validator() != nullptr and
++                        c.key_field_indices().size() == 1)
++                {
++                        const auto field_keys = c.key_field_indices();
++                        if (field_keys.find(m_item_ix) != field_keys.end()) {
++                                m_single_hit = c[{ { m_item_tag, m_value } }];
++                        }
++                }
+ 
+ 		return this;
+ 	}

--- a/L/libcifpp/bundled/patches/mingw-no-ioctl.patch
+++ b/L/libcifpp/bundled/patches/mingw-no-ioctl.patch
@@ -1,5 +1,5 @@
 diff --git a/src/utilities.cpp b/src/utilities.cpp
-index 5238a5b..f5e54a8 100644
+index 5238a5b..3aecc32 100644
 --- a/src/utilities.cpp
 +++ b/src/utilities.cpp
 @@ -43,7 +43,7 @@
@@ -7,7 +7,7 @@ index 5238a5b..f5e54a8 100644
  #include <thread>
  
 -#if not defined(_MSC_VER)
-+#if not (defined(_MSC_VER) || defined(__MINGW32__))
++#if not defined(_WIN32)
  #include <sys/ioctl.h>
  #include <termios.h>
  #endif
@@ -16,7 +16,7 @@ index 5238a5b..f5e54a8 100644
  // --------------------------------------------------------------------
  
 -#ifdef _MSC_VER
-+#if defined(_MSC_VER) || defined(__MINGW32__)
++#if defined(_WIN32)
  }
 -#include <Windows.h>
 +#include <windows.h>

--- a/L/libcifpp/bundled/patches/mingw-no-ioctl.patch
+++ b/L/libcifpp/bundled/patches/mingw-no-ioctl.patch
@@ -1,0 +1,25 @@
+diff --git a/src/utilities.cpp b/src/utilities.cpp
+index 5238a5b..f5e54a8 100644
+--- a/src/utilities.cpp
++++ b/src/utilities.cpp
+@@ -43,7 +43,7 @@
+ #include <sstream>
+ #include <thread>
+ 
+-#if not defined(_MSC_VER)
++#if not (defined(_MSC_VER) || defined(__MINGW32__))
+ #include <sys/ioctl.h>
+ #include <termios.h>
+ #endif
+@@ -68,9 +68,9 @@ std::string get_version_nr()
+ 
+ // --------------------------------------------------------------------
+ 
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) || defined(__MINGW32__)
+ }
+-#include <Windows.h>
++#include <windows.h>
+ #include <libloaderapi.h>
+ #include <wincon.h>
+ 


### PR DESCRIPTION
https://github.com/PDB-REDO/libcifpp

C++ library for reading and manipulating mmCIF and PDB files

This is a build requirement for DSSP: https://github.com/PDB-REDO/dssp

Note: the build wants to download components.cif, I have disabled this for the time being as the file is quite large (380 MB decompressed). I don't know what functionality is impacted by this, but the test suite passes at least. We should probably have a better way of sharing components.cif between different packages that need it.

cc: @lmiq

