### PR TITLE
[ecCodes] Update ecCodes to 2.28.0 and add libaec

### DIFF
--- a/E/eccodes/build_tarballs.jl
+++ b/E/eccodes/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "eccodes"
-version = v"2.25.0"
+version = v"2.28.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://confluence.ecmwf.int/download/attachments/45757960/eccodes-$version-Source.tar.gz", "8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e"),
+    ArchiveSource("https://confluence.ecmwf.int/download/attachments/45757960/eccodes-$version-Source.tar.gz", "2831347b1517af9ebd70dd3cad88ae818a8448d4e6c8671aa728617e73431cd5"),
     DirectorySource("./bundled"),
 ]
 
@@ -31,7 +31,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DENABLE_PNG=ON \
     -DENABLE_FORTRAN=ON \
     -DENABLE_ECCODES_THREADS=ON \
-    -DENABLE_AEC=OFF \
+    -DENABLE_AEC=ON \
     ..
 make -j${nproc}
 make install
@@ -53,6 +53,7 @@ dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f")),
     Dependency(PackageSpec(name="OpenJpeg_jll", uuid="643b3616-a352-519d-856d-80112ee9badc")),
+    Dependency(PackageSpec(name="libaec_jll", uuid="477f73a3-ac25-53e9-8cc3-50b2fa2566f0")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
ECMWF recently switched to AEC compression in their grib2 files with cycle 48r1. This means the current version provided by eccodes_jll can't read these grib files anymore.

Thankfully we now have [libaec_jll](https://github.com/JuliaBinaryWrappers/libaec_jll.jl) so we can just enable AEC here.

I tried bumping the version as well, but building the tarballs locally the latest version I managed to build on all platforms without further changes was 2.28.0. This might might provide a good stopgap measure for everyone using GRIB.jl etc with ECMWF data before moving further. Version 2.30.2 is available but has dropped 32 bit support requiring dropping some platforms which I didn't want to do without some feedback first.
