### PR TITLE
[GAP] rebuild for updated libjulia

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -29,7 +29,7 @@ name = "GAP"
 upstream_version = v"4.12.2"
 version = v"400.1200.200"
 
-julia_versions = [v"1.6.3", v"1.7", v"1.8", v"1.9", v"1.10"]
+julia_versions = [v"1.6.3", v"1.7", v"1.8", v"1.9", v"1.10", v"1.11"]
 
 # Collection of sources required to complete build
 sources = [
@@ -134,7 +134,7 @@ dependencies = [
     Dependency("GMP_jll"),
     Dependency("Readline_jll"),
     Dependency("Zlib_jll"),
-    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.3")),
+    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.4")),
 ]
 
 # Build the tarballs.


### PR DESCRIPTION
This PR is "too early" as `libjulia_jll` 1.10.4 did not yet complete
its release cycle. But I thought I'd use the opportunity to verify
that the version specification for the build dependency works as
expect (i.e., makes the CI for this PR fail).