### PR TITLE
[libcifpp] Remove non-functional static library only built on windows

### DIFF
--- a/L/libcifpp/build_tarballs.jl
+++ b/L/libcifpp/build_tarballs.jl
@@ -113,6 +113,14 @@ fi
 
 make install
 
+if [[ "${target}" == *-w64-mingw* ]]; then
+    # libcifpp v5.1.0
+    # On windows, there is a non-functional static library that also gets
+    # built and installed, which can mess up packages that try to link
+    # against it.
+    rm "${prefix}"/lib/libcifpp.dll.a
+fi
+
 install_license ../LICENSE
 """
 


### PR DESCRIPTION
Even though the build specifies to build shared libraries to cmake via `-DBUILD_SHARED_LIBS=ON`, on `*-w64-mingw32` a small non-functional static library gets built and installed.

This can mess up other builds that then try to link against this static library, e.g. `DSSP_jll`, as the static library is non-functional and lacks most symbols the shared library has.

This should hopefully help with https://github.com/JuliaPackaging/Yggdrasil/pull/6998