### PR TITLE
[Exodus] update to 8.19.1; update compat for hdf5

### DIFF
--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -73,7 +73,7 @@ make install
 #
 # The build process has far too many CMake files to track this down.
 #
-rm -r lib/cmake/Seacas/
+rm -r "${prefix}/lib/cmake/Seacas"
 """
 
 # These are the platforms we will build for by default, unless further

--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "Exodus"
-version = v"8.19.0"
+version = v"8.19.1"
 
 # Collection of sources required to complete build
 sources = [

--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -73,7 +73,6 @@ make install
 #
 # The build process has far too many CMake files to track this down.
 #
-cd $WORKSPACE/destdir
 rm -r lib/cmake/Seacas/
 """
 

--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -64,6 +64,18 @@ cmake \
 
 make -j${nproc}
 make install
+
+# below is an absolute hack to fix a tree hash mismatch on macos
+# this is due to a case insensitivity issue. 
+#
+# The issue is caused by a duplicate folder in destdir/lib/cmake
+# called "Seacas" which is a duplibcate of "SEACAS".
+#
+# The build process has far too many CMake files to track this down.
+#
+cd $WORKSPACE/destdir
+rm -r lib/cmake/Seacas/
+
 """
 
 # These are the platforms we will build for by default, unless further
@@ -92,7 +104,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="Fmt_jll", uuid="5dc1e892-f187-50dd-85f3-7dff85c47fc5"))
     # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="HDF5_jll", uuid="0234f1f7-429e-5d53-9886-15a909be8d59"); compat="~1.12")
+    Dependency(PackageSpec(name="HDF5_jll", uuid="0234f1f7-429e-5d53-9886-15a909be8d59"); compat="~1.14")
     Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"))
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]

--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -75,7 +75,6 @@ make install
 #
 cd $WORKSPACE/destdir
 rm -r lib/cmake/Seacas/
-
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
…king changes MBedTLS_jll). Also adding a hack to the build process to fix a tree hash mismatch caused on mac with a comment describing the hack in the script.