### PR TITLE
[libsingular] update to latest version, add Julia 1.11

### DIFF
--- a/L/libsingular_julia/build_tarballs.jl
+++ b/L/libsingular_julia/build_tarballs.jl
@@ -9,15 +9,11 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "libsingular_julia"
-version = v"0.34.0"
-
-# reminder: change the above version if restricting the supported julia versions
-julia_versions = [v"1.6.3", v"1.7", v"1.8", v"1.9", v"1.10"]
-julia_compat = join("~" .* string.(getfield.(julia_versions, :major)) .* "." .* string.(getfield.(julia_versions, :minor)), ", ")
+version = v"0.35.0"
 
 # Collection of sources required to build libsingular-julia
 sources = [
-    GitSource("https://github.com/oscar-system/Singular.jl.git", "72fe8fe6d464bfc6fda4329dbfe3ffa2c52a506c"),
+    GitSource("https://github.com/oscar-system/Singular.jl.git", "b09551a10b33c748aea46048a14387efd37f5d86"),
 ]
 
 # Bash recipe for building across all platforms
@@ -63,7 +59,6 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    preferred_gcc_version=v"8",
-    julia_compat = julia_compat)
+    preferred_gcc_version=v"8", julia_compat="1.6")
 
-# rebuild trigger: 2
+# rebuild trigger: 0


### PR DESCRIPTION
Also drop old julia_compat hack from pre-1.6 days -- at least I think that's where it came from (older Julia versions used to choke on the `julia_version` key in the platform)...