### PR TITLE
[gap] ensure GAP is built against old readline

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -132,7 +132,7 @@ dependencies = [
     HostBuildDependency("Zlib_jll"),
 
     Dependency("GMP_jll"),
-    Dependency("Readline_jll"),
+    Dependency("Readline_jll", v"8.1.1"),
     Dependency("Zlib_jll"),
     BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.4")),
 ]


### PR DESCRIPTION
... to avoid issues loading it in situations were GAP_jll is new but Readline_jll is not.

CC @thofma @wdecker