### PR TITLE
[argtable] reattempt libargtable2 build

### DIFF
--- a/A/argtable/argtable@2.13/build_tarballs.jl
+++ b/A/argtable/argtable@2.13/build_tarballs.jl
@@ -24,7 +24,7 @@ make -j${nproc}
 make install
 """
 
-# These are the platforms we will build for by default, unless further
+# These are the platforms that we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms(; exclude = Sys.iswindows)
 platforms = expand_cxxstring_abis(platforms)


### PR DESCRIPTION
[libargtable](https://sourceforge.net/projects/argtable/) v2.13.

Possible merge conflict was found when pulling both versions to the General registry (see [#86914](https://github.com/JuliaRegistries/General/pull/86914)),
most likely due to trying to register two versions of the same package at once (my bad :c).
