### PR TITLE
[micromamba] Update to v1.4.7

### DIFF
--- a/M/micromamba/build_tarballs.jl
+++ b/M/micromamba/build_tarballs.jl
@@ -45,6 +45,7 @@ else
 fi
 
 # install the licenses
+install_license info/licenses/*.txt
 install_license info/licenses/mamba/*
 """
 

--- a/M/micromamba/build_tarballs.jl
+++ b/M/micromamba/build_tarballs.jl
@@ -45,7 +45,7 @@ else
 fi
 
 # install the licenses
-install_license info/licenses/*
+install_license info/licenses/mamba/*
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/micromamba/build_tarballs.jl
+++ b/M/micromamba/build_tarballs.jl
@@ -3,29 +3,29 @@
 using BinaryBuilder
 
 name = "micromamba"
-version = v"1.4.3"
+version = v"1.4.7"
 build = "0"
 
 # Collection of sources required to build micromamba
 # These are actually just the conda packages for each platform
 sources = [
     FileSource("https://conda.anaconda.org/conda-forge/linux-64/micromamba-$version-$build.tar.bz2",
-        "faf0a6af6d0676050a7ec535a3d10c50c9c03bbf0bb554732151cf62f3417379",
+        "e1ccd696909e196dc02b96610525384513d75dfc1491418492b991916b5abe0c",
         filename="micromamba-x86_64-linux-gnu.tar.bz2"),
     FileSource("https://conda.anaconda.org/conda-forge/linux-aarch64/micromamba-$version-$build.tar.bz2",
-        "1044323557ea4677c54c2cb643f0f36786da7085e1c2930a9f36521aae686388",
+        "dc8d62884090194cd10ac031668dfd9a9823d328f0209ed4e138123618b07f4f",
         filename="micromamba-aarch64-linux-gnu.tar.bz2"),
     FileSource("https://conda.anaconda.org/conda-forge/linux-ppc64le/micromamba-$version-$build.tar.bz2",
-        "6157e877bc63f8f3081c0904075ef47952a86106870aa6f94f6116a6e951a50d",
+        "2961da1e5c6504aee47faaea30ce5e1934c17c69df2df22072416d73ddb71f11",
         filename="micromamba-powerpc64le-linux-gnu.tar.bz2"),
     FileSource("https://conda.anaconda.org/conda-forge/osx-64/micromamba-$version-$build.tar.bz2",
-        "36c437a03c7cc72b4366d5225afa86d65e21f5100bd30cdb5b602465e812a02a",
+        "b851e196f52b9c810e3096b54cf1981ade790188624ab2033cf2c583c1da65ba",
         filename="micromamba-x86_64-apple-darwin14.tar.bz2"),
     FileSource("https://conda.anaconda.org/conda-forge/osx-arm64/micromamba-$version-$build.tar.bz2",
-        "93dee34f603cc189e9d1ac99ed2938bedd8de81fab350fce128bd453a04bd73b",
+        "52f19a26f8a999776ca99508a6622637991e13446b003af09d58188ce92a04e2",
         filename="micromamba-aarch64-apple-darwin20.tar.bz2"),
     FileSource("https://conda.anaconda.org/conda-forge/win-64/micromamba-$version-$build.tar.bz2",
-        "173d2a8dd8e324611fa7331992896ebf7ea2f953c61559c10772ee377af27d05",
+        "e3fd81a240425bb4277634ce928519b38c84d65ab99842357322fdaf729c4238",
         filename="micromamba-x86_64-w64-mingw32.tar.bz2"),
 ]
 


### PR DESCRIPTION
[Release notes](https://github.com/mamba-org/mamba/releases/tag/2023.07.06)

`v1.4.3` has some [issues](https://github.com/mamba-org/mamba/issues/2546) with Windows, but this version has a fix (the fix came in [`v1.4.5`](https://github.com/mamba-org/mamba/releases/tag/2023.06.27)). 

