### PR TITLE
[oxigraph] Bump oxigraph to 3.18, use pre-built binaries

### DIFF
--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -26,7 +26,11 @@ install_license LICENSE.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude=p -> (Sys.isbsd(p) || (Sys.islinux(p) && libc(p) == "musl") || nbits(p) != 64 || arch(p) == "powerpc64le"))
+platforms = supported_platforms(; exclude=p -> (arch(p) == "powerpc64le" || Sys.isfreebsd(p) || (Sys.islinux(p) && libc(p) == "musl") || nbits(p) != 64))
+platforms = expand_cxxstring_abis(platforms)
+
+# Binaries are built upstream using GCC v9+, skip CXX03 string ABI
+platforms = filter(x -> cxxstring_abi(x) != "cxx03", platforms)
 
 # Rust toolchain for i686 Windows is unusable
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
@@ -43,4 +47,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6", preferred_gcc_version=v"5", lock_microarchitecture=false)
+    julia_compat="1.6", lock_microarchitecture=false)

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -41,6 +41,7 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
+    Dependency("CompilerSupportLibraries_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -26,7 +26,7 @@ install_license LICENSE.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude=p -> (Sys.isbsd(p) || libc(p) == "musl" || nbits(p) != 64 || arch(p) == "powerpc64le"))
+platforms = supported_platforms(; exclude=p -> (Sys.isbsd(p) || (Sys.islinux(p) && libc(p) == "musl") || nbits(p) != 64 || arch(p) == "powerpc64le"))
 
 # Rust toolchain for i686 Windows is unusable
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -48,4 +48,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6", lock_microarchitecture=false)
+    julia_compat="1.6")

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -20,10 +20,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd ${WORKSPACE}/srcdir/
-mkdir -p "${bindir}"
-mv oxigraph_server-${target} oxigraph_server${exeext}
-cp oxigraph_server${exeext} ${bindir}
-chmod +x ${bindir}/*
+install -Dvm 755 "oxigraph_server-${target}" "${bindir}/oxigraph_server${exeext}"
 install_license LICENSE.txt
 """
 

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -9,27 +9,28 @@ url_prefix = "https://github.com/oxigraph/oxigraph/releases/download/v$version/o
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("$(url_prefix)_aarch64_apple", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
-    ArchiveSource("$(url_prefix)_x86_64_apple", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
-    ArchiveSource("$(url_prefix)_aarch64_linux_gnu", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
-    ArchiveSource("$(url_prefix)_x86_64_linux_gnu", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
-    ArchiveSource("$(url_prefix)_x86_64_windows_msvc.exe", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
-    FileSource("https://raw.githubusercontent.com/oxigraph/oxigraph/v$version/LICENSE-MIT", "b98fbb37db5b23bc5cfdcd16793206a5a7120a7b01f75374e5e0888376e4691c")
+    FileSource("$(url_prefix)_aarch64_apple", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; filename = "oxigraph_server-arm64-apple-darwin"),
+    FileSource("$(url_prefix)_x86_64_apple", "c5d1229d1011d30ed55226545abc9f9caa5f40d34cecf3b7d0e6964db516df6b"; filename = "oxigraph_server-x86_64-apple-darwin"),
+    FileSource("$(url_prefix)_aarch64_linux_gnu", "be0ec046fe48adff38e08c235d8f3f56af8d278a0a672c7f438ab32504ecaa57"; filename = "oxigraph_server-aarch64-linux-gnu"),
+    FileSource("$(url_prefix)_x86_64_linux_gnu", "1d62d475516f85dc8ab548ed0f8d25572186cbaf91cf43805d415d310045ea1e"; filename = "oxigraph_server-x86_64-linux-gnu"),
+    FileSource("$(url_prefix)_x86_64_windows_msvc.exe", "232fab182aa30df0d004980b6d386fab3aabb89ec294386ee63df0f56622ccf1"; filename = "oxigraph_server-x86_64-w64-mingw32"),
+    FileSource("https://raw.githubusercontent.com/oxigraph/oxigraph/v$version/LICENSE-MIT", "1f4f6736adc52ebfda18bb84947e0ef492bd86a408c0e83872efb75ed5e02838"; filename = "LICENSE.txt")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd ${WORKSPACE}/srcdir/
 mkdir -p "${bindir}"
-mv ${target}/oxigraph* ${target}/oxigraph_server${exeext}
-cp ${target}/oxigraph_server${exeext} ${bindir}
+mv oxigraph_server-${target} oxigraph_server${exeext}
+cp oxigraph_server${exeext} ${bindir}
 chmod +x ${bindir}/*
-install_license LICENSE-MIT.txt
+install_license LICENSE.txt
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
+platforms = expand_cxxstring_abis(platforms)
 
 # Rust toolchain for i686 Windows is unusable
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -46,4 +46,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6", preferred_gcc_version=v"5")
+    julia_compat="1.6", preferred_gcc_version=v"5", lock_microarchitecture=false)

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -9,8 +9,8 @@ url_prefix = "https://github.com/oxigraph/oxigraph/releases/download/v$version/o
 
 # Collection of sources required to complete build
 sources = [
-    FileSource("$(url_prefix)_aarch64_apple", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; filename = "oxigraph_server-arm64-apple-darwin"),
-    FileSource("$(url_prefix)_x86_64_apple", "c5d1229d1011d30ed55226545abc9f9caa5f40d34cecf3b7d0e6964db516df6b"; filename = "oxigraph_server-x86_64-apple-darwin"),
+    FileSource("$(url_prefix)_aarch64_apple", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; filename = "oxigraph_server-aarch64-apple-darwin20"),
+    FileSource("$(url_prefix)_x86_64_apple", "c5d1229d1011d30ed55226545abc9f9caa5f40d34cecf3b7d0e6964db516df6b"; filename = "oxigraph_server-x86_64-apple-darwin14"),
     FileSource("$(url_prefix)_aarch64_linux_gnu", "be0ec046fe48adff38e08c235d8f3f56af8d278a0a672c7f438ab32504ecaa57"; filename = "oxigraph_server-aarch64-linux-gnu"),
     FileSource("$(url_prefix)_x86_64_linux_gnu", "1d62d475516f85dc8ab548ed0f8d25572186cbaf91cf43805d415d310045ea1e"; filename = "oxigraph_server-x86_64-linux-gnu"),
     FileSource("$(url_prefix)_x86_64_windows_msvc.exe", "232fab182aa30df0d004980b6d386fab3aabb89ec294386ee63df0f56622ccf1"; filename = "oxigraph_server-x86_64-w64-mingw32"),
@@ -43,6 +43,7 @@ products = Product[
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
     Dependency("CompilerSupportLibraries_jll"),
+    Dependency("Libiconv_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -5,7 +5,7 @@ using BinaryBuilder, Pkg
 name = "oxigraph_server"
 version = v"0.3.18"
 
-url_prefix = "https://github.com/oxigraph/oxigraph/releases/download/$version/oxigraph_server_v$version"
+url_prefix = "https://github.com/oxigraph/oxigraph/releases/download/v$version/oxigraph_server_v$version"
 
 # Collection of sources required to complete build
 sources = [

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -45,4 +45,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6")
+    julia_compat="1.6", preferred_gcc_version=v"5")

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -3,22 +3,28 @@
 using BinaryBuilder, Pkg
 
 name = "oxigraph_server"
-version = v"0.2.5"
+version = v"0.3.18"
+
+url_prefix = "https://github.com/oxigraph/oxigraph/releases/download/$version/oxigraph_server_v$version"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/oxigraph/oxigraph.git", "a21dcbb4f7355d7a00a86fbc5ad2c350a53629c4"),
+    ArchiveSource("$(url_prefix)_aarch64_apple", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
+    ArchiveSource("$(url_prefix)_x86_64_apple", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
+    ArchiveSource("$(url_prefix)_aarch64_linux_gnu", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
+    ArchiveSource("$(url_prefix)_x86_64_linux_gnu", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
+    ArchiveSource("$(url_prefix)_x86_64_windows_msvc.exe", "c0c2a64e7dc05cf9c24d4c29349baef583eead3e1f9984cdc2ac56a5beba9df7"; unpack_target = "arm64-apple-darwin"),
+    FileSource("https://raw.githubusercontent.com/oxigraph/oxigraph/v$version/LICENSE-MIT", "b98fbb37db5b23bc5cfdcd16793206a5a7120a7b01f75374e5e0888376e4691c")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/oxigraph/server
-
-cargo build --release --no-default-features --features=sled
-
-install_license $WORKSPACE/srcdir/oxigraph/LICENSE-MIT
-
-cp ../target/${rust_target}/release/oxigraph_server${exeext} ${bindir}/
+cd ${WORKSPACE}/srcdir/
+mkdir -p "${bindir}"
+mv ${target}/oxigraph* ${target}/oxigraph_server${exeext}
+cp ${target}/oxigraph_server${exeext} ${bindir}
+chmod +x ${bindir}/*
+install_license LICENSE-MIT.txt
 """
 
 # These are the platforms we will build for by default, unless further
@@ -35,9 +41,8 @@ products = Product[
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
-    Dependency("OpenSSL_jll"; compat="1.1.10"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-                compilers=[:c, :rust], preferred_gcc_version=v"7", lock_microarchitecture=false, julia_compat="1.6")
+    julia_compat="1.6")

--- a/O/oxigraph_server/build_tarballs.jl
+++ b/O/oxigraph_server/build_tarballs.jl
@@ -29,8 +29,7 @@ install_license LICENSE.txt
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-platforms = expand_cxxstring_abis(platforms)
+platforms = supported_platforms(; exclude=p -> (Sys.isbsd(p) || libc(p) == "musl" || nbits(p) != 64 || arch(p) == "powerpc64le"))
 
 # Rust toolchain for i686 Windows is unusable
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)


### PR DESCRIPTION
NOTE:

I get the `expand_cxxstring_abis` error, but I don't control the build process... is setting `preferred_gcc_version=v"5"` sufficient to deal with this issue?

```
┌ Warning: /workspaces/Yggdrasil/O/oxigraph_server/build/x86_64-linux-gnu/Ai70oVRW/x86_64-linux-gnu-libgfortran3-cxx03/destdir/bin/oxigraph_server contains std::string values!  This causes incompatibilities across the GCC 4/5 version boundary.  To remedy this, you must build a tarball for both GCC 4 and GCC 5.  To do this, immediately after your `platforms` definition in your `build_tarballs.jl` file, add the line:
│ 
│     platforms = expand_cxxstring_abis(platforms)
```