### PR TITLE
[LibPQ] Bump to 16 and align OpenSSL with HDF5

### DIFF
--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -89,7 +89,7 @@ products = [
 dependencies = [
     Dependency("OpenSSL_jll"; compat="3.0.8"),
     Dependency("Kerberos_krb5_jll"; platforms=filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), platforms)),
-    Dependency("ICU_jll"),
+    Dependency("ICU_jll"; compat="69.1")
     HostBuildDependency("Bison_jll"),
     Dependency("Zstd_jll"),
 ]

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -43,7 +43,7 @@ meson setup meson_build --prefix=$prefix \
     -Dplpython=disabled \
     -Dplperl=disabled \
     -Dnls=disabled \
-    -Dc_args=-fno-stack-check # Mac needs this
+    -Dc_args='-fno-stack-check -std=c99' # Mac needs this
 
 cd meson_build
 ninja -j${nproc}

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -42,7 +42,8 @@ meson setup meson_build --prefix=$prefix \
     -Dtap_tests=disabled \
     -Dplpython=disabled \
     -Dplperl=disabled \
-    -Dnls=disabled
+    -Dnls=disabled \
+    -Dc_args=-fno-stack-check # Mac needs this
 
 cd meson_build
 ninja -j${nproc}

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -4,14 +4,13 @@ using BinaryBuilder
 
 name = "LibPQ"
 version = v"16.0"
-pg_version = string(version.major, '.', version.minor)
 tzcode_version = "2023c"
 
 # Collection of sources required to build LibPQ
 sources = [
-    ArchiveSource(
-        "https://ftp.postgresql.org/pub/source/v$pg_version/postgresql-$pg_version.tar.gz",
-        "58bd3a265a279a2754905ddf072a54d64d6236dcf786f20f92b5d30b916df516",
+    GitSource(
+        "https://github.com/postgres/postgres.git",
+        "c372fbbd8e911f2412b80a8c39d7079366565d67",
     ),
     ArchiveSource(
         "https://data.iana.org/time-zones/releases/tzcode$tzcode_version.tar.gz",
@@ -32,7 +31,7 @@ mv zic ../ && cd ../ && rm -rf zic-build
 export ZIC=$WORKSPACE/srcdir/zic
 export PATH=$WORKSPACE/srcdir:$PATH
 
-cd postgresql-*
+cd postgresql
 
 meson ../meson_build --prefix=$prefix \
     --cross-file="${MESON_TARGET_TOOLCHAIN}" \

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -22,7 +22,6 @@ sources = [
 # Bash recipe for building across all platforms
 # NOTE: readline and zlib are not used by libpq
 script = raw"""
-apk add glib-dev
 cd zic-build
 make CC=$BUILD_CC VERSION_DEPS= zic
 mv zic ../ && cd ../ && rm -rf zic-build

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -30,7 +30,7 @@ export PATH=$WORKSPACE/srcdir:$PATH
 
 cd postgres
 
-meson meson_build --prefix=$prefix \
+CC=$BUILD_CC meson setup meson_build --prefix=$prefix \
     --cross-file="${MESON_TARGET_TOOLCHAIN}" \
     --bindir=${bindir} \
     --libdir=${libdir} \
@@ -47,6 +47,10 @@ cd meson_build
 ninja -j${nproc}
 ninja install
 cd ../
+
+if [[ ${target} == *-w64-mingw32 ]]; then
+    mv -v meson_build/src/interfaces/libpq/* ${prefix}/lib
+fi
 
 # Delete static library
 rm ${prefix}/lib/libpq.a

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -22,18 +22,15 @@ sources = [
 # Bash recipe for building across all platforms
 # NOTE: readline and zlib are not used by libpq
 script = raw"""
-apk add perl-ipc-system-simple
-apk add tcl
-
 cd zic-build
 make CC=$BUILD_CC VERSION_DEPS= zic
 mv zic ../ && cd ../ && rm -rf zic-build
 export ZIC=$WORKSPACE/srcdir/zic
 export PATH=$WORKSPACE/srcdir:$PATH
 
-cd postgresql
+cd postgres
 
-meson ../meson_build --prefix=$prefix \
+meson meson_build --prefix=$prefix \
     --cross-file="${MESON_TARGET_TOOLCHAIN}" \
     --bindir=${bindir} \
     --libdir=${libdir} \
@@ -46,9 +43,9 @@ meson ../meson_build --prefix=$prefix \
     -Dplperl=disabled \
     -Dnls=disabled
 
+cd meson_build
 ninja -j${nproc}
 ninja install
-    
 cd ../
 
 # Delete static library

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -27,10 +27,11 @@ make CC=$BUILD_CC VERSION_DEPS= zic
 mv zic ../ && cd ../ && rm -rf zic-build
 export ZIC=$WORKSPACE/srcdir/zic
 export PATH=$WORKSPACE/srcdir:$PATH
+export CFLAGS="-std=c99"
 
 cd postgres
 
-CC=$BUILD_CC meson setup meson_build --prefix=$prefix \
+meson setup meson_build --prefix=$prefix \
     --cross-file="${MESON_TARGET_TOOLCHAIN}" \
     --bindir=${bindir} \
     --libdir=${libdir} \

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -28,6 +28,7 @@ mv zic ../ && cd ../ && rm -rf zic-build
 export ZIC=$WORKSPACE/srcdir/zic
 export PATH=$WORKSPACE/srcdir:$PATH
 export CFLAGS="-std=c99"
+
 cd postgres
 
 if [[ ${target} == *-apple-* ]]; then
@@ -94,4 +95,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7")

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "LibPQ"
-version = v"15.4"
+version = v"16.0"
 pg_version = string(version.major, '.', version.minor)
 tzcode_version = "2023c"
 
@@ -12,7 +12,6 @@ sources = [
     ArchiveSource(
         "https://ftp.postgresql.org/pub/source/v$pg_version/postgresql-$pg_version.tar.gz",
         "58bd3a265a279a2754905ddf072a54d64d6236dcf786f20f92b5d30b916df516",
-        unpack_target="postgres",
     ),
     ArchiveSource(
         "https://data.iana.org/time-zones/releases/tzcode$tzcode_version.tar.gz",
@@ -33,7 +32,7 @@ mv zic ../ && cd ../ && rm -rf zic-build
 export ZIC=$WORKSPACE/srcdir/zic
 export PATH=$WORKSPACE/srcdir:$PATH
 
-cd $WORKSPACE/srcdir/postgresql
+cd postgresql-*
 
 meson ../meson_build --prefix=$prefix \
     --cross-file="${MESON_TARGET_TOOLCHAIN}" \

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -27,7 +27,7 @@ make CC=$BUILD_CC VERSION_DEPS= zic
 mv zic ../ && cd ../ && rm -rf zic-build
 export ZIC=$WORKSPACE/srcdir/zic
 export PATH=$WORKSPACE/srcdir:$PATH
-
+export CFLAGS="-std=c99"
 cd postgres
 
 if [[ ${target} == *-apple-* ]]; then

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -89,7 +89,7 @@ products = [
 dependencies = [
     Dependency("OpenSSL_jll"; compat="3.0.8"),
     Dependency("Kerberos_krb5_jll"; platforms=filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), platforms)),
-    Dependency("ICU_jll"; compat="69.1")
+    Dependency("ICU_jll"; compat="69.1"),
     HostBuildDependency("Bison_jll"),
     Dependency("Zstd_jll"),
 ]

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -47,18 +47,17 @@ if [[ ${target} == *-apple-* ]]; then
 
 else
     meson setup meson_build --prefix=$prefix \
-    --cross-file="${MESON_TARGET_TOOLCHAIN}" \
-    --bindir=${bindir} \
-    --libdir=${libdir} \
-    --includedir=${includedir} \
-    --buildtype=release \
-    -Dssl=openssl \
-    -Dzlib=disabled \
-    -Dreadline=disabled \
-    -Dtap_tests=disabled \
-    -Dplpython=disabled \
-    -Dplperl=disabled \
-    -Dnls=disabled
+        --cross-file="${MESON_TARGET_TOOLCHAIN}" \
+        --bindir=${bindir} \
+        --libdir=${libdir} \
+        --includedir=${includedir} \
+        -Dssl=openssl \
+        -Dzlib=disabled \
+        -Dreadline=disabled \
+        -Dtap_tests=disabled \
+        -Dplpython=disabled \
+        -Dplperl=disabled \
+        -Dnls=disabled
 
     cd meson_build
     ninja -j${nproc}

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -84,4 +84,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"11")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"5")

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -3,9 +3,9 @@
 using BinaryBuilder
 
 name = "LibPQ"
-version = v"14.3"
+version = v"15.3"
 pg_version = string(version.major, '.', version.minor)
-tzcode_version = "2021e"
+tzcode_version = "2023c"
 
 # Collection of sources required to build LibPQ
 sources = [
@@ -72,7 +72,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("OpenSSL_jll"; compat="1.1.10"),
+    Dependency("OpenSSL_jll"; compat="3.0.8"),
     Dependency("Kerberos_krb5_jll"; platforms=filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), platforms)),
 ]
 

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -25,6 +25,8 @@ script = raw"""
 cd $WORKSPACE/srcdir
 make CC=$BUILD_CC VERSION_DEPS= zic
 export ZIC=$WORKSPACE/srcdir/zic
+export LDFLAGS="-L${libdir}/libcrypto.${dlext}"
+
 cd $WORKSPACE/srcdir/postgresql-*/
 if [[ "${target}" == i686-linux-musl ]]; then
     # Small hack: swear that we're cross-compiling.  Our `i686-linux-musl` is

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -84,4 +84,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"5")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"11")

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -83,4 +83,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"5")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"6")

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -50,7 +50,7 @@ fi
     --with-libraries=${libdir} \
     --without-readline \
     --without-zlib \
-    --with-openssl \
+    --with-ssl=openssl \
     "${FLAGS[@]}"
 make -C src/interfaces/libpq -j${nproc}
 make -C src/interfaces/libpq install

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -25,7 +25,11 @@ script = raw"""
 cd $WORKSPACE/srcdir
 make CC=$BUILD_CC VERSION_DEPS= zic
 export ZIC=$WORKSPACE/srcdir/zic
-export LDFLAGS="-L${libdir}/libcrypto.${dlext}"
+
+# Fix "cannot find openssl" under Windows
+if [[ ${target} == x86_64-w64-mingw32 ]]; then
+    export OPENSSL_ROOT_DIR=${prefix}/lib64/
+fi
 
 cd $WORKSPACE/srcdir/postgresql-*/
 if [[ "${target}" == i686-linux-musl ]]; then

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
     ),
     ArchiveSource(
         "https://data.iana.org/time-zones/releases/tzcode$tzcode_version.tar.gz",
-        "584666393a5424d13d27ec01183da17703273664742e049d4f62f62dab631775",
+        "46d17f2bb19ad73290f03a203006152e0fa0d7b11e5b71467c4a823811b214e7",
     ),
 ]
 

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -77,4 +77,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"5")

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -11,7 +11,7 @@ tzcode_version = "2023c"
 sources = [
     ArchiveSource(
         "https://ftp.postgresql.org/pub/source/v$pg_version/postgresql-$pg_version.tar.gz",
-        "18eff30438703dd7a5f2a7ca916741bce3c99eadb4025bc6268af268e8e909c5"
+        "086d38533e28747966a4d5f1e78ea432e33a78f21dcb9133010ecb5189fad98c"
     ),
     ArchiveSource(
         "https://data.iana.org/time-zones/releases/tzcode$tzcode_version.tar.gz",

--- a/L/LibPQ/build_tarballs.jl
+++ b/L/LibPQ/build_tarballs.jl
@@ -29,6 +29,7 @@ export ZIC=$WORKSPACE/srcdir/zic
 # Fix "cannot find openssl" under Windows
 if [[ ${target} == x86_64-w64-mingw32 ]]; then
     export OPENSSL_ROOT_DIR=${prefix}/lib64/
+    export OPENSSL_LIBS="-L${libdir} -lssl -lcrypto"
 fi
 
 cd $WORKSPACE/srcdir/postgresql-*/
@@ -83,4 +84,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"5")


### PR DESCRIPTION
NOTE: at the moment, super ugly compromise where `./configure` old build system is used for apple, new `meson` build system is used for everything else. As the `meson` build system was just launched, I expect future releases are likely to be easier to build on apple and we can go back to using one consistent build system (`./configure` builds don't work on windows).