### PR TITLE
[GR] Restrict compat with libtiff

### DIFF
--- a/G/GR/build_tarballs.jl
+++ b/G/GR/build_tarballs.jl
@@ -102,7 +102,7 @@ dependencies = [
     Dependency("GLFW_jll"),
     Dependency("JpegTurbo_jll"),
     Dependency("libpng_jll"),
-    Dependency("Libtiff_jll"; compat="4.3.0"),
+    Dependency("Libtiff_jll"; compat="~4.3, ~4.4"),
     Dependency("Pixman_jll"),
 #    Dependency("Qhull_jll"),
     Dependency("Qt5Base_jll"),


### PR DESCRIPTION
Mirror change in https://github.com/JuliaRegistries/General/pull/87537.  Next version should be changed to use libtiff 2.5.1.

CC: @jheinen 