### PR TITLE
Bump LLVM to 15.0.7+6.

### DIFF
--- a/L/LLVM/LLVM_full@15/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@15/build_tarballs.jl
@@ -4,4 +4,3 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.10")
-#Let's build!!

--- a/L/LLVM/LLVM_full_assert@15/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@15/build_tarballs.jl
@@ -4,4 +4,3 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
                preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.10")
-#It's building time!!

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -15,7 +15,7 @@ const llvm_tags = Dict(
     v"12.0.1" => "980d2f60a8524c5546397db9e8bbb7d6ea56c1b7", # julia-12.0.1-4
     v"13.0.1" => "8a2ae8c8064a0544814c6fac7dd0c4a9aa29a7e6", # julia-13.0.1-3
     v"14.0.6" => "5c82f5309b10fab0adf6a94969e0dddffdb3dbce", # julia-14.0.6-3
-    v"15.0.7" => "3089b0b526eed060bc1c0ed582dabe2a06801226", # julia-15.0.7-5
+    v"15.0.7" => "e42aaf192bf5a8a2b55ac520cad9a70f5aab3348", # julia-15.0.7-6
 )
 
 const buildscript = raw"""


### PR DESCRIPTION
Bump LLVM to 15.0.7+6 in order to include https://github.com/llvm/llvm-project/commit/af39acda8873cc75db116e326588447f018a99d9 / https://github.com/JuliaLang/llvm-project/commit/01d07e22c2a35ec93c3faef6e1d1af405d5e96a1, ref https://github.com/JuliaLang/julia/issues/50448#issuecomment-1636019331.

cc @vchuravy 