### PR TITLE
[tectonic] bump to v0.14.1

### DIFF
--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -44,7 +44,7 @@ dependencies = [
     Dependency("HarfBuzz_jll"; compat="2.8.1"),
     Dependency("HarfBuzz_ICU_jll"),
     Dependency("ICU_jll"; compat="69.1"),
-    Dependency("OpenSSL_jll"; compat="1.1.10"),
+    Dependency("OpenSSL_jll"; compat="3.0.8"),
     Dependency("Zlib_jll"),
     Dependency("libpng_jll"),
 ]

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "tectonic"
-version = v"0.13.1"
+version = v"0.14.1"
 
 # Collection of sources required to build tar
 sources = [
@@ -13,7 +13,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/tectonic
+cd ${WORKSPACE}/srcdir/tectonic
 
 if [[ "${target}" == *-mingw* ]]; then
     export RUSTFLAGS="-Clink-args=-L${libdir}"
@@ -24,7 +24,7 @@ install -Dvm 755 "target/${rust_target}/release/tectonic${exeext}" "${bindir}/te
 """
 
 # Some platforms disabled for now due issues with rust and musl cross compilation. See #1673.
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 # We dont have all dependencies for armv6l
 filter!(p -> arch(p) != "armv6l", platforms)
 # Rust toolchain for i686 Windows is unusable


### PR DESCRIPTION
@tpapp

Removed experimental as it's uneeded (no-op)

Closes #7065.