### PR TITLE
[minify] lower `julia_compat` version

### DIFF
--- a/M/minify/build_tarballs.jl
+++ b/M/minify/build_tarballs.jl
@@ -43,5 +43,5 @@ build_tarballs(
     products,
     dependencies;
     compilers = [:c, :go],
-    julia_compat = "1.6",
+    julia_compat = "1.3",
 )


### PR DESCRIPTION
Set the minimum supported Julia version to 1.3 (required for a project I am currently working on).