### PR TITLE
[DSSP] Use upstream pre-built binaries on windows

### DIFF
--- a/D/DSSP/build_tarballs.jl
+++ b/D/DSSP/build_tarballs.jl
@@ -23,8 +23,14 @@ sources = [
 # NOTE
 # On Windows we install pre-compiled binaries from github, as
 # currently the executable built from source has a bug where it
-# annotates every residue as a loop.
-# See: https://github.com/PDB-REDO/dssp/issues/63
+# segfaults on any nontrivial operation.  This might be due to
+# std::regex segfault issues for g++ mentioned in the libcifpp build
+# instructions, so in the future it might be worthwile investigating
+# compilation choices there.  The libcifpp cmake build tries to check
+# for a std::regex segfault during build time, but this check has to
+# be disabled here as we are cross-compiling.
+#
+# See also: https://github.com/PDB-REDO/dssp/issues/63
 
 # NOTE
 # We don't use libcifpp_jll, as linking to the shared library from

--- a/D/DSSP/build_tarballs.jl
+++ b/D/DSSP/build_tarballs.jl
@@ -63,12 +63,18 @@ cd $WORKSPACE/srcdir/
 # Install pre-built binary on windows
 if [[ "${target}" == *-w64-mingw* ]]; then
     apk add p7zip
-    mkdir tmp && cd tmp
+    mkdir tmp-windows && cd tmp-windows
     7z x ../mkdssp-${DSSP_VERSION}.exe
-    find bin/ -type f -exec install -Dm 755 "{}" "${bindir}" \;
-    find lib/ -type f -exec install -Dm 755 "{}" "${prefix}/lib/" \;
-    find include/ -type f -exec install -Dm 755 "{}" "${includedir}" \;
+    find bin/ -type f -exec install -Dvm 755 "{}" "${bindir}" \;
+    find lib/ -type f -exec install -Dvm 755 "{}" "${prefix}/lib/" \;
+    find include/ -type f -exec install -Dvm 644 "{}" "${includedir}" \;
+    # needs zlib.dll library
     cp "${bindir}/libz.dll" "${bindir}/zlib.dll"
+    # install mmcif dictionaries
+    for dir in ../libcifpp/ ../dssp/; do
+        find "${dir}" -type f -name '*.dic' -exec sh -c \
+            'install -Dvm 644 "{}" "${prefix}/share/libcifpp/$(basename "{}")"' \;
+    done
     install_license ../dssp/LICENSE
     exit 0
 fi
@@ -173,6 +179,10 @@ platforms = expand_cxxstring_abis(platforms)
 
 products = [
     ExecutableProduct("mkdssp", :mkdssp),
+    FileProduct("share/libcifpp/dssp-extension.dic", :dssp_extension_dic),
+    FileProduct("share/libcifpp/mmcif_ddl.dic", :mmcif_ddl_dic),
+    FileProduct("share/libcifpp/mmcif_ma.dic", :mmcif_ma_dic),
+    FileProduct("share/libcifpp/mmcif_pdbx.dic", :mmcif_pdbx_dic),
 ]
 
 dependencies = [


### PR DESCRIPTION
Unfortunately the binaries we build for windows in this build script crash on any non-trivial operation, so use pre-built upstream binaries for now.

Also added are `FileProduct`s for more reliable installation of mmcif dictionaries necessary at runtime.

cc: @lmiq 

Ref: https://github.com/m3g/ProteinSecondaryStructures.jl/issues/8