### PR TITLE
[Azurite] Bump to v3.24

### DIFF
--- a/A/azurite/build_tarballs.jl
+++ b/A/azurite/build_tarballs.jl
@@ -2,7 +2,7 @@ using BinaryBuilder
 
 # Set sources and other environment variables.
 name = "azurite"
-version = v"3.18.0"
+version = v"3.24.0"
 sources = GitSource[]
 
 script = "version=$(version)\n" * raw"""


### PR DESCRIPTION
Bump the version for Azurite to its current release, v3.24. 