### PR TITLE
LibTracyClient: Don't use RTLD_LAZY for `dlopen`

### DIFF
--- a/L/LibTracyClient/LibTracyClient@0.9.1/build_tarballs.jl
+++ b/L/LibTracyClient/LibTracyClient@0.9.1/build_tarballs.jl
@@ -40,7 +40,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libTracyClient", :libTracyClient),
+    LibraryProduct("libTracyClient", :libTracyClient; dlopen_flags=[:RTLD_DEEPBIND]),
     FileProduct(["lib/libTracyClient.a", "lib/libTracyClient.lib"], :libTracyClient_static)
 ]
 


### PR DESCRIPTION
Resolves https://github.com/topolarity/Tracy.jl/issues/28

cc @staticfloat 