### PR TITLE
relax LibCURL_jll compat to include v8

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -142,7 +142,7 @@ dependencies = [
     Dependency("Zstd_jll"),
     Dependency("Libtiff_jll"; compat="4.3"),
     Dependency("libgeotiff_jll"; compat="100.700.100"),
-    Dependency("LibCURL_jll"; compat="7.73"),
+    Dependency("LibCURL_jll"; compat="7.73,8"),
     Dependency("NetCDF_jll"; compat="400.902.5", platforms=hdf5_platforms),
     # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
     Dependency("HDF5_jll"; compat="~1.12", platforms=hdf5_platforms),

--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -85,7 +85,7 @@ readlink_f() {
         TARGET_FILE="$(basename "${TARGET_FILE}")"
     done
 
-    # Compute the canonicalized name by finding the physical path 
+    # Compute the canonicalized name by finding the physical path
     # for the directory we're in and appending the target file.
     PHYS_DIR="$(pwd -P)"
     echo "${PHYS_DIR}/${TARGET_FILE}"
@@ -112,7 +112,7 @@ products = [
 dependencies = [
     # Need a host gettext for msgfmt
     HostBuildDependency("Gettext_jll"),
-    Dependency("LibCURL_jll"; compat="7.73.0"),
+    Dependency("LibCURL_jll"; compat="7.73.0,8"),
     Dependency("Expat_jll"; compat="2.2.10"),
     Dependency("OpenSSL_jll"; compat="1.1.10"),
     Dependency("Libiconv_jll"),

--- a/M/MariaDB_Connector_C/build_tarballs.jl
+++ b/M/MariaDB_Connector_C/build_tarballs.jl
@@ -70,7 +70,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("LibCURL_jll"; compat="7.73.0"),
+    Dependency("LibCURL_jll"; compat="7.73.0,8"),
     Dependency("Libiconv_jll"),
     Dependency("OpenSSL_jll"; compat="1.1.10"),
     Dependency("Zlib_jll"),

--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -90,7 +90,7 @@ products = [
 dependencies = [
     Dependency("Bzip2_jll"),
     Dependency("HDF5_jll"; compat = "~1.14"),
-    Dependency("LibCURL_jll"; compat = "7.73.0"),
+    Dependency("LibCURL_jll"; compat = "7.73.0,8"),
     Dependency("XML2_jll"),
     Dependency("Zlib_jll"),
     Dependency("Zstd_jll"),


### PR DESCRIPTION
Fixes #6857.
Already fixed in the registry in https://github.com/JuliaRegistries/General/pull/88557.
[skip build]
