### PR TITLE
Rebuild libblastrampoline, libunwind 1.5.0, and pcre2

### DIFF
--- a/L/LibUnwind/LibUnwind@1.5.0/build_tarballs.jl
+++ b/L/LibUnwind/LibUnwind@1.5.0/build_tarballs.jl
@@ -5,9 +5,9 @@ name = "LibUnwind"
 version_string = "1.5"
 version = VersionNumber(version_string)
 
-# Collection of sources required to build libffi
+# Collection of sources required to build libunwind
 sources = [
-    ArchiveSource("https://github.com/libunwind/libunwind/releases/download/v$(version_string)/libunwind-$(version).tar.gz",
+    ArchiveSource("https://download.savannah.nongnu.org/releases/libunwind/libunwind-$(version).tar.gz",
                   "90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017"),
     DirectorySource("./bundled"),
 ]

--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency("LLVMCompilerRT_jll",platforms=[Platform("x86_64", "linux"; sanitize="memory")]),
+    BuildDependency("LLVMCompilerRT_jll"; platforms=[Platform("x86_64", "linux"; sanitize="memory")]),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/P/PCRE2/build_tarballs.jl
+++ b/P/PCRE2/build_tarballs.jl
@@ -21,6 +21,8 @@ if [[ ${bb_full_target} == *-sanitize+memory* ]]; then
     cp -rL ${libdir}/linux/* /opt/x86_64-linux-musl/lib/clang/*/lib/linux/
 fi
 
+./autogen.sh
+
 # Update configure scripts
 update_configure_scripts
 

--- a/P/PCRE2/build_tarballs.jl
+++ b/P/PCRE2/build_tarballs.jl
@@ -8,13 +8,13 @@ version = VersionNumber(version_string)
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$(version_string)/pcre2-$(version_string).tar.gz",
-                  "c33b418e3b936ee3153de2c61cc638e7e4fe3156022a5c77d0711bcbb9d64f1f"),
+    GitSource("https://github.com/PCRE2Project/pcre2",
+              "52c08847921a324c804cabf2814549f50bce1265"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/pcre2-*/
+cd $WORKSPACE/srcdir/pcre2*/
 
 if [[ ${bb_full_target} == *-sanitize+memory* ]]; then
     # Install msan runtime (for clang)


### PR DESCRIPTION
libunwind and pcre2 were getting their tarballs from GitHub releases but now libunwind uses nongnu for tarballs and pcre2 uses git.