### PR TITLE
Upgrade x86_64 and i686 linux GCC shares to Glibc v2.17+

### DIFF
--- a/0_RootFS/GCCBootstrap@12/bundled/patches/glibc_movq_fix.patch
+++ b/0_RootFS/GCCBootstrap@12/bundled/patches/glibc_movq_fix.patch
@@ -1,0 +1,22 @@
+diff --git a/nptl/sysdeps/x86_64/tls.h b/nptl/sysdeps/x86_64/tls.h
+index f3b76495b3..c4e5d7a59a 100644
+--- a/nptl/sysdeps/x86_64/tls.h
++++ b/nptl/sysdeps/x86_64/tls.h
+@@ -264,7 +264,7 @@ typedef struct
+ 	   abort ();							      \
+ 									      \
+ 	 asm volatile ("movq %q0,%%fs:%P1" :				      \
+-		       : IMM_MODE ((uint64_t) cast_to_integer (value)),	      \
++		       : "er" ((uint64_t) cast_to_integer (value)),	      \
+ 			 "i" (offsetof (struct pthread, member)));	      \
+        }})
+ 
+@@ -289,7 +289,7 @@ typedef struct
+ 	   abort ();							      \
+ 									      \
+ 	 asm volatile ("movq %q0,%%fs:%P1(,%q2,8)" :			      \
+-		       : IMM_MODE ((uint64_t) cast_to_integer (value)),	      \
++		       : "er" ((uint64_t) cast_to_integer (value)),	      \
+ 			 "i" (offsetof (struct pthread, member[0])),	      \
+ 			 "r" (idx));					      \
+        }})

--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -332,11 +332,16 @@ function gcc_script(compiler_target::Platform)
             atomic_patch -p1 ${p} || true;
         done
 
+        # Patch bad `movq` argument in glibc 2.17, adapted from:
+        # https://github.com/bminor/glibc/commit/b1ec623ed50bb8c7b9b6333fa350c3866dbde87f
+        # X-ref: https://github.com/crosstool-ng/crosstool-ng/issues/1825#issuecomment-1437918391
+        atomic_patch -p1 $WORKSPACE/srcdir/patches/glibc_movq_fix.patch
+
         # Various configure overrides
         GLIBC_CONFIGURE_OVERRIDES=( libc_cv_forced_unwind=yes libc_cv_c_cleanup=yes )
 
-        # We have problems with libssp on ppc64le
-        if [[ ${COMPILER_TARGET} == powerpc64le-* ]]; then
+        # We have problems with libssp on ppc64le, x86_64 and i686
+        if [[ ${COMPILER_TARGET} == powerpc64le-* ]] || [[ ${COMPILER_TARGET} == x86_64-* ]] || [[ ${COMPILER_TARGET} == i686-* ]]; then
             GLIBC_CONFIGURE_OVERRIDES+=( libc_cv_ssp=no libc_cv_ssp_strong=no )
         fi
 

--- a/0_RootFS/gcc_sources.jl
+++ b/0_RootFS/gcc_sources.jl
@@ -213,17 +213,12 @@ function gcc_sources(gcc_version::VersionNumber, compiler_target::Platform; kwar
 
     if Sys.islinux(compiler_target) && libc(compiler_target) == "glibc"
         # Depending on our architecture, we choose different versions of glibc
-        if arch(compiler_target) in ["x86_64", "i686"]
-            libc_sources = [
-                ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.12.2.tar.xz",
-                              "0eb4fdf7301a59d3822194f20a2782858955291dd93be264b8b8d4d56f87203f"),
-            ]
-        elseif arch(compiler_target) in ["armv7l", "aarch64"]
+        if arch(compiler_target) in ["armv7l", "aarch64"]
             libc_sources = [
                 ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.19.tar.xz",
                               "2d3997f588401ea095a0b27227b1d50cdfdd416236f6567b564549d3b46ea2a2"),
             ]
-        elseif arch(compiler_target) in ["powerpc64le"]
+        elseif arch(compiler_target) in ["x86_64", "i686", "powerpc64le"]
             libc_sources = [
                 ArchiveSource("https://mirrors.kernel.org/gnu/glibc/glibc-2.17.tar.xz",
                               "6914e337401e0e0ade23694e1b2c52a5f09e4eda3270c67e7c3ba93a89b5b23e"),


### PR DESCRIPTION
This is necessary to build for LLVM 16 and libuv.