### PR TITLE
Add compat for all FreeType2 dependants

### DIFF
--- a/C/Cairo/build_tarballs.jl
+++ b/C/Cairo/build_tarballs.jl
@@ -83,7 +83,7 @@ dependencies = [
     Dependency("Pixman_jll"),
     Dependency("libpng_jll"),
     Dependency("Fontconfig_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("Bzip2_jll", v"1.0.8"; compat="1.0.8"),
     Dependency("Xorg_libXext_jll"; platforms=linux_freebsd),
     Dependency("Xorg_libXrender_jll"; platforms=linux_freebsd),

--- a/C/Chafa/build_tarballs.jl
+++ b/C/Chafa/build_tarballs.jl
@@ -32,6 +32,9 @@ make install
 
 # Chafa itself does not support Windows
 platforms = filter!(!Sys.iswindows, supported_platforms())
+# Remove this when we build a newer version for which we can target the former
+# experimental platforms
+filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64") && arch(p) != "armv6l", platforms)
 
 products = [
     LibraryProduct("libchafa", :libchafa),
@@ -39,8 +42,8 @@ products = [
 ]
 
 dependencies = [
-    Dependency("FreeType2_jll"),
-    Dependency("Glib_jll", v"2.59.0"; compat="2.59.0"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
+    Dependency("Glib_jll"; compat="2.59.0"),
     Dependency("ImageMagick_jll"),
 ]
 

--- a/F/FLTK/build_tarballs.jl
+++ b/F/FLTK/build_tarballs.jl
@@ -56,7 +56,7 @@ x11_platforms = filter(p ->Sys.islinux(p) || Sys.isfreebsd(p), platforms)
 dependencies = [
     BuildDependency("Xorg_xorgproto_jll"; platforms=x11_platforms),
     Dependency("Fontconfig_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("JpegTurbo_jll"),
     Dependency("Libglvnd_jll"; platforms=x11_platforms),
     Dependency("libpng_jll"),

--- a/F/Fontconfig/build_tarballs.jl
+++ b/F/Fontconfig/build_tarballs.jl
@@ -70,7 +70,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     HostBuildDependency("gperf_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("Bzip2_jll", v"1.0.7"; compat="1.0.7"),
     Dependency("Zlib_jll"),
     Dependency("Libuuid_jll"),

--- a/G/GRASS/build_tarballs.jl
+++ b/G/GRASS/build_tarballs.jl
@@ -567,7 +567,7 @@ dependencies = [
     Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"))
     Dependency(PackageSpec(name="PROJ_jll", uuid="58948b4f-47e0-5654-a9ad-f609743f8632"))
     Dependency(PackageSpec(name="Cairo_jll", uuid="83423d85-b0ee-5818-9007-b63ccbeb887a"))
-    Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"))
+    Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"); compat="2.10.4")
     Dependency(PackageSpec(name="LAPACK_jll", uuid="51474c39-65e3-53ba-86ba-03b1b862ec14"))
     Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))
     Dependency(PackageSpec(name="Libiconv_jll", uuid="94ce4f54-9a6c-5748-9c1c-f9c7231a4531"))

--- a/G/GTK3/build_tarballs.jl
+++ b/G/GTK3/build_tarballs.jl
@@ -80,7 +80,7 @@ dependencies = [
     Dependency("Cairo_jll"),
     Dependency("Pango_jll"; compat="1.47.0"),
     Dependency("FriBidi_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("gdk_pixbuf_jll"),
     Dependency("Libepoxy_jll"),
     # Gtk 3.24.29 requires ATK 2.35.1

--- a/G/GTK4/build_tarballs.jl
+++ b/G/GTK4/build_tarballs.jl
@@ -118,7 +118,7 @@ dependencies = [
     Dependency("Cairo_jll"),
     Dependency("Pango_jll"; compat="1.50.3"),
     Dependency("FriBidi_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("gdk_pixbuf_jll"),
     Dependency("Libepoxy_jll"),
     Dependency("HarfBuzz_jll"),

--- a/G/GraphicsMagick/build_tarballs.jl
+++ b/G/GraphicsMagick/build_tarballs.jl
@@ -73,7 +73,7 @@ dependencies = [
     Dependency("CompilerSupportLibraries_jll"; platforms=filter(!Sys.isbsd, platforms)),
     Dependency("LLVMOpenMP_jll"; platforms=filter(Sys.isbsd, platforms)),
     Dependency("Bzip2_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     # Dependency("Ghostscript_jll"),
     Dependency("Graphviz_jll"),
     Dependency("JasPer_jll"),

--- a/G/gmsh/build_tarballs.jl
+++ b/G/gmsh/build_tarballs.jl
@@ -65,7 +65,7 @@ dependencies = [
     Dependency("Cairo_jll"),
     Dependency("CompilerSupportLibraries_jll"; platforms=filter(!Sys.isbsd, platforms)),
     Dependency("FLTK_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("GLU_jll"; platforms=x11_platforms),
     Dependency("GMP_jll"; compat="6.2"),
     # Updating to a newer HDF5 version requires rebuilding this package

--- a/H/HarfBuzz/common.jl
+++ b/H/HarfBuzz/common.jl
@@ -66,7 +66,7 @@ fi
     dependencies = [
         Dependency("Cairo_jll"),
         Dependency("Fontconfig_jll"),
-        Dependency("FreeType2_jll"),
+        Dependency("FreeType2_jll"; compat="2.10.4"),
         Dependency("Glib_jll"; compat="2.68.1"),
         Dependency("Graphite2_jll"),
         Dependency("Libffi_jll"; compat="~3.2.2"),

--- a/L/libass/build_tarballs.jl
+++ b/L/libass/build_tarballs.jl
@@ -30,7 +30,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("FriBidi_jll"),
     Dependency("HarfBuzz_jll"; compat="2.8.1"),
     Dependency("Bzip2_jll"; compat="1.0.8"),

--- a/L/libbluray/build_tarballs.jl
+++ b/L/libbluray/build_tarballs.jl
@@ -24,6 +24,9 @@ install_license COPYING
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms =  filter!(!Sys.iswindows, supported_platforms())
+# Remove this when we build a newer version for which we can target the former
+# experimental platforms
+filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64") && arch(p) != "armv6l", platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -36,7 +39,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
-    Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"))
+    Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"); compat="2.10.4")
     Dependency(PackageSpec(name="Fontconfig_jll", uuid="a3f928ae-7b40-5064-980b-68af3947d34b"))
     Dependency(PackageSpec(name="libudfread_jll", uuid="037e6697-03b9-52b7-b841-7aee0d773eb5"))
 ]

--- a/L/libgraphicsmagic/build_tarballs.jl
+++ b/L/libgraphicsmagic/build_tarballs.jl
@@ -37,7 +37,7 @@ dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
     Dependency(PackageSpec(name="libwebp_jll", uuid="c5f90fcd-3b7e-5836-afba-fc50a0988cb2"))
     Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f"))
-    Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"))
+    Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"); compat="2.10.4")
     Dependency(PackageSpec(name="Ghostscript_jll", uuid="61579ee1-b43e-5ca0-a5da-69d92c66a64b"))
     Dependency(PackageSpec(name="Xorg_libXext_jll", uuid="1082639a-0dae-5f34-9b06-72781eeb8cb3"))
     Dependency(PackageSpec(name="Xorg_libSM_jll", uuid="c834827a-8449-5923-a945-d239c165b7dd"))

--- a/O/OCCT/build_tarballs.jl
+++ b/O/OCCT/build_tarballs.jl
@@ -97,7 +97,7 @@ x11_platforms = filter(p ->Sys.islinux(p) || Sys.isfreebsd(p), platforms)
 # Dependencies that must be installed before this package can be built
 dependencies = [
     BuildDependency("Xorg_xorgproto_jll"; platforms=x11_platforms),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("Libglvnd_jll"; platforms=x11_platforms),
     Dependency("Xorg_libX11_jll"; platforms=x11_platforms),
     Dependency("Xorg_libXext_jll"; platforms=x11_platforms),

--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -38,7 +38,7 @@ products = [
 dependencies = [
     Dependency("Cairo_jll"; compat="1.16.1"),
     Dependency("Fontconfig_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("FriBidi_jll"),
     Dependency("Glib_jll"; compat="2.68.1"),
     Dependency("HarfBuzz_jll"; compat="2.8.1"),

--- a/P/Pathfinder/build_tarballs.jl
+++ b/P/Pathfinder/build_tarballs.jl
@@ -51,7 +51,7 @@ not_windows = filter(!Sys.iswindows, platforms)
 
 dependencies = [
     Dependency("Fontconfig_jll", platforms=not_windows),
-    Dependency("FreeType2_jll",  platforms=not_windows),
+    Dependency("FreeType2_jll",  platforms=not_windows, compat="2.10.4"),
     Dependency("HarfBuzz_jll",   platforms=not_windows),
     HostBuildDependency(PackageSpec(; name="cbindgen_jll", uuid="a52b955f-5256-5bb0-8795-313e28591558")),
 ]

--- a/Q/qwtw/build_tarballs.jl
+++ b/Q/qwtw/build_tarballs.jl
@@ -44,7 +44,7 @@ dependencies = [
     Dependency(PackageSpec(name="Qt_jll", uuid="ede63266-ebff-546c-83e0-1c6fb6d0efc8"))
     Dependency(PackageSpec(name="qwt_jll", uuid="ed0789fa-10db-50b3-94da-03266d70be0f"))
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
-    Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"))
+    Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"); compat="2.10.4")
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10")
     Dependency(PackageSpec(name="marble_jll", uuid="678d7417-9a84-558b-a975-2deb8d71bebc"))
     Dependency(PackageSpec(name="MathGL_jll", uuid="6834ddeb-87f2-5bbb-bfa4-c37572f854d4"))

--- a/R/RDKit/build_tarballs.jl
+++ b/R/RDKit/build_tarballs.jl
@@ -55,7 +55,7 @@ products = [
 ]
 
 dependencies = [
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("boost_jll"; compat="=1.76.0"),
     BuildDependency("Eigen_jll"),
     Dependency("Zlib_jll"),

--- a/S/SDL2_ttf/build_tarballs.jl
+++ b/S/SDL2_ttf/build_tarballs.jl
@@ -54,7 +54,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Bzip2_jll"; compat="1.0.8"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("Glib_jll"; compat="2.68.1"),
     Dependency("Graphite2_jll"),
     # The following libraries aren't needed for the build, but libSDL2_ttf is

--- a/S/SFML/build_tarballs.jl
+++ b/S/SFML/build_tarballs.jl
@@ -69,7 +69,7 @@ dependencies = [
     Dependency("Libglvnd_jll"),
     Dependency("Ogg_jll"),
     Dependency("FLAC_jll"; compat="~1.3.3"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("libvorbis_jll"),
     Dependency("Xorg_libXrandr_jll"),
     Dependency("Xorg_libX11_jll"),

--- a/T/TracyProfiler/build_tarballs.jl
+++ b/T/TracyProfiler/build_tarballs.jl
@@ -88,7 +88,7 @@ x11_platforms = filter(p ->Sys.islinux(p) || Sys.isfreebsd(p), platforms)
 
 dependencies = [
     Dependency("Capstone_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("Dbus_jll", platforms=filter(Sys.islinux, platforms)),
     Dependency("GLFW_jll"),
     # Needed for `pkg-config glfw3`

--- a/T/tectonic/build_tarballs.jl
+++ b/T/tectonic/build_tarballs.jl
@@ -39,7 +39,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Fontconfig_jll"),
-    Dependency("FreeType2_jll"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("Graphite2_jll"),
     Dependency("HarfBuzz_jll"; compat="2.8.1"),
     Dependency("HarfBuzz_ICU_jll"),


### PR DESCRIPTION
Similar to #7164, but we don't rebuild these packages, not needed at the moment.