### PR TITLE
Rebuild libgit2

### DIFF
--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -62,7 +62,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("MbedTLS_jll"; compat="~2.28.0"),
-    Dependency("LibSSH2_jll"; compat="^1.10.1"),
+    Dependency("LibSSH2_jll"; compat="1.11.0"),
     BuildDependency("LLVMCompilerRT_jll",platforms=[Platform("x86_64", "linux"; sanitize="memory")]),
 ]
 

--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -62,7 +62,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("MbedTLS_jll"; compat="~2.28.0"),
-    Dependency("LibSSH2_jll"; compat="1.10.1"),
+    Dependency("LibSSH2_jll"; compat="^1.10.1"),
     BuildDependency("LLVMCompilerRT_jll",platforms=[Platform("x86_64", "linux"; sanitize="memory")]),
 ]
 

--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder
 
 name = "LibGit2"
-version = v"1.6.1"
+version = v"1.6.4"
 
 # Collection of sources required to build libgit2
 sources = [
     GitSource("https://github.com/libgit2/libgit2.git",
-              "8a871d13b7f4e186b8ad943ae5a7fcf30be52e67")
+              "e6325351ceee58cf56f58bdce61b38907805544f")
 ]
 
 # Bash recipe for building across all platforms

--- a/L/LibGit2/build_tarballs.jl
+++ b/L/LibGit2/build_tarballs.jl
@@ -30,7 +30,7 @@ fi
 
 # Special windows flags
 if [[ ${target} == *-mingw* ]]; then
-    BUILD_FLAGS+=(-DWIN32=ON -DMINGW=ON -DBUILD_CLAR=OFF)
+    BUILD_FLAGS+=(-DWIN32=ON -DMINGW=ON -DBUILD_TESTS=OFF)
     if [[ ${target} == i686-* ]]; then
         BUILD_FLAGS+=(-DCMAKE_C_FLAGS="-mincoming-stack-boundary=2")
     fi


### PR DESCRIPTION
The quest continues to rebuild Julia's dependencies with the FreeBSD 13.2 sysroot. I attemped libgit2 as part of https://github.com/JuliaPackaging/Yggdrasil/pull/7133 but ended up removing it from that PR since there were issues I couldn't figure out. This PR will try to fix them.