### PR TITLE
Rebuild LibTracyClient and Objconv

### DIFF
--- a/L/LibTracyClient/LibTracyClient@0.9.1/build_tarballs.jl
+++ b/L/LibTracyClient/LibTracyClient@0.9.1/build_tarballs.jl
@@ -47,6 +47,6 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[]
 
-# Build the tarballs, and possibly a `build.jl` as well.
+# Build the tarballs, and possibly a `build.jl` as well
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.6", preferred_gcc_version=v"7")

--- a/O/Objconv/build_tarballs.jl
+++ b/O/Objconv/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "Objconv"
-version = v"2.49.1"
+version = v"2.53.0"
 
 # Collection of sources required to build objconv
 sources = [
-    ArchiveSource("https://github.com/staticfloat/objconv/archive/v2.49.tar.gz",
-                  "5fcdf0eda828fbaf4b3d31ba89b5011f649df3a7ef0cc7520d08fe481cac4e9f"),
+    GitSource("https://github.com/staticfloat/objconv",
+              "ae54df67e0c4ac2c78f3a7ece486ed4e92d098af")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
I missed that Julia uses these as well. Rebuilding to use the 13.2 sysroot on FreeBSD.