### PR TITLE
Update CImGuiPack

### DIFF
--- a/C/CImGuiPack/build_tarballs.jl
+++ b/C/CImGuiPack/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "CImGuiPack"
-version = v"0.1.2"
+version = v"0.1.3"
 
 # Collection of sources required to build CImGuiPack
 sources = [
     GitSource("https://github.com/JuliaImGui/cimgui-pack.git",
-              "ecc93265e2f0f916462a2bef427f5f6b024ad6b2")
+              "af96d7d92c8b430af35e4b87c1260b234ccf9b5a")
 ]
 
 # Bash recipe for building across all platforms
@@ -37,4 +37,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")


### PR DESCRIPTION
Other changes:
- Use GCC 5, the default GCC 4 was giving compiler errors.
- ~~Enable 32bit vertex indices, as recommended by ImPlot: https://github.com/epezent/implot#extremely-important-note~~

~~*Do not merge this yet!* I'm opening it for transparency, https://github.com/JuliaImGui/cimgui-pack/pull/1 needs to be merged first and the repo link in `build_tarballs.jl` set back to the original repo instead of my fork.~~

CC @Gnimuc 