### PR TITLE
CUDA: Make use of a local toolkit require a separate preference.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.8.0"
+version = v"0.9.0"
 
 augment_platform_block = """
     $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))

--- a/C/CUDA/CUDA_Runtime/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Runtime/platform_augmentation.jl
@@ -4,113 +4,207 @@ using Base: thismajor, thisminor
 
 using Libdl
 
+# platform augmentation hooks run in an ill-defined environment, where:
+# - CUDA_Driver_jll may not be available
+# - the wrong version of CUDA_Driver_jll may be available
+#
+# because of that, we need to be very careful about using that dependency.
+# currently, we support all existing versions of CUDA_Driver_jll, but if we
+# ever need to introduce a breaking change, we'll need some way to identify
+# the version of CUDA_Driver_jll from its module (e.g. a global constant).
+#
+# ref: https://github.com/JuliaLang/Pkg.jl/issues/3225
 try
     using CUDA_Driver_jll
 catch err
-    # during initial package installation, CUDA_Driver_jll may not be available.
-    # in that case, we just won't select an artifact (unless the user has set a preference).
-    # see also: https://github.com/JuliaLang/Pkg.jl/issues/3225
+    # we'll handle this below
 end
 
-# Can't use Preferences for the same reason
+# can't use Preferences for the same reason
 const CUDA_Runtime_jll_uuid = Base.UUID("76a88914-d11a-5bdc-97e0-2f5a05c973a2")
 const preferences = Base.get_preferences(CUDA_Runtime_jll_uuid)
 Base.record_compiletime_preference(CUDA_Runtime_jll_uuid, "version")
-
-# returns the value for the "cuda" tag we should use in the platform.
-# possible values:
-#  - "$MAJOR.$MINOR": a VersionNumber-like string
-#  - "local": the user has requested to use the local CUDA installation
-#  - "none": no compatible CUDA toolkit was found.
-#    note that we don't just leave off the platform tag or Pkg would select *any* artifact.
-function cuda_toolkit_tag()
-    # check if the user requested a specific version
-    if haskey(preferences, "version") && isa(preferences["version"], String)
-        @debug "CUDA version override: $(preferences["version"])"
+Base.record_compiletime_preference(CUDA_Runtime_jll_uuid, "local")
+const version_preference = if haskey(preferences, "version")
+    if isa(preferences["version"], String)
         version = tryparse(VersionNumber, preferences["version"])
         if version === nothing
-            @debug "CUDA version override is not a valid version number; returning as-is"
-            return preferences["version"]
+            @error "CUDA version preference is not valid; expected a version number, but got '$(preferences["version"])'"
+            missing
+        else
+            version
         end
-        cuda_version_override = version
+    else
+        @error "CUDA version preference is not valid; expected a version number, but got '$(preferences["version"])'"
+        missing
+    end
+else
+    missing
+end
+const local_preference = if haskey(preferences, "local")
+    if isa(preferences["local"], String)
+        use_local = tryparse(Bool, preferences["local"])
+        if use_local === nothing
+            @error "CUDA local preference is not valid; expected a boolean, but got '$(preferences["local"])'"
+            missing
+        else
+            use_local
+        end
+    else
+        @error "CUDA local preference is not valid; expected a boolean, but got '$(preferences["local"])'"
+        missing
+    end
+else
+    missing
+end
+
+# get the version of the local CUDA toolkit by querying the system libcudart
+function get_runtime_version()
+    cuda_runtime = if Sys.iswindows()
+        Libdl.find_library(["cudart64_12", "cudart64_110"])
+    else
+        Libdl.find_library(["libcudart.so", "libcudart.so.12", "libcudart.so.11.0"])
+    end
+    if cuda_runtime == ""
+        # no runtime library found
+        @debug "No system CUDA runtime library found"
+        return nothing
+    end
+    @debug "Found CUDA runtime library at '$cuda_runtime'"
+
+    # minimal API call wrappers we need
+    function cudaRuntimeGetVersion(library_handle)
+        function_handle = Libdl.dlsym(library_handle, "cudaRuntimeGetVersion"; throw_error=false)
+        if function_handle === nothing
+            @debug "Runtime library seems invalid (does not contain 'cudaRuntimeGetVersion')"
+            return nothing
+        end
+        version_ref = Ref{Cint}()
+        status = ccall(function_handle, Cint, (Ptr{Cint},), version_ref)
+        if status != 0
+            @debug "Call to 'cudaRuntimeGetVersion' failed with status $status"
+            return nothing
+        end
+        major, ver = divrem(version_ref[], 1000)
+        minor, patch = divrem(ver, 10)
+        return VersionNumber(major, minor, patch)
+    end
+
+    runtime_handle = Libdl.dlopen(cuda_runtime; throw_error=false)
+    if runtime_handle === nothing
+        @debug "Failed to load CUDA runtime library"
+        return nothing
+    end
+
+    cudaRuntimeGetVersion(runtime_handle)
+end
+
+# get the version of the available CUDA driver by querying either CUDA_Driver_jll's
+# driver, or the system driver if CUDA_Driver_jll is not available
+function get_driver_version()
+    if !@isdefined(CUDA_Driver_jll)
+        # driver JLL not available because we're in the middle of installing packages
+        @debug "CUDA_Driver_jll not available; not selecting an artifact"
+        return nothing
+    end
+
+    cuda_driver = if CUDA_Driver_jll.is_available()
+        @debug "Using CUDA_Driver_jll for driver discovery"
+
+        if !isdefined(CUDA_Driver_jll, :libcuda) || # CUDA_Driver_jll@0.4-compat
+            isnothing(CUDA_Driver_jll.libcuda)      # https://github.com/JuliaLang/julia/issues/48999
+            # no driver found
+            @debug "CUDA_Driver_jll reports no driver found"
+            return nothing
+        end
+        CUDA_Driver_jll.libcuda
+    else
+        # CUDA_Driver_jll only kicks in for supported platforms, so fall back to
+        # a system search if the artifact isn't available (JLLWrappers.jl#50)
+        @debug "CUDA_Driver_jll unavailable, falling back to system search"
+
+        driver_name = if Sys.iswindows()
+            Libdl.find_library("nvcuda")
+        else
+            Libdl.find_library(["libcuda.so.1", "libcuda.so"])
+        end
+        if driver_name == ""
+            # no driver found
+            @debug "CUDA_Driver_jll unavailable, and no system CUDA driver found"
+            return nothing
+        end
+
+        driver_name
+    end
+    @debug "Found CUDA driver at '$cuda_driver'"
+
+    # minimal API call wrappers we need
+    function cuDriverGetVersion(library_handle)
+        function_handle = Libdl.dlsym(library_handle, "cuDriverGetVersion"; throw_error=false)
+        if function_handle === nothing
+            @debug "Driver library seems invalid (does not contain 'cuDriverGetVersion')"
+            return nothing
+        end
+        version_ref = Ref{Cint}()
+        status = ccall(function_handle, Cint, (Ptr{Cint},), version_ref)
+        if status != 0
+            @debug "Call to 'cuDriverGetVersion' failed with status $status"
+            return nothing
+        end
+        major, ver = divrem(version_ref[], 1000)
+        minor, patch = divrem(ver, 10)
+        return VersionNumber(major, minor, patch)
+    end
+
+    driver_handle = Libdl.dlopen(cuda_driver; throw_error=false)
+    if driver_handle === nothing
+        @debug "Failed to load CUDA driver"
+        return nothing
+    end
+
+    cuDriverGetVersion(driver_handle)
+end
+
+# returns the value for the "cuda" tag we should use in the platform ("$MAJOR.$MINOR")
+# or nothing if no compatible CUDA toolkit was found.
+function cuda_toolkit_tag()
+    # check if the user requested a specific version
+    if version_preference !== missing
+        @debug "CUDA version override: $version_preference"
+        cuda_version_override = version_preference
+    end
+
+    # check if the user requested to use a local version
+    if local_preference !== missing
+        @debug "CUDA local preference: $(local_preference)"
+        if local_preference && !@isdefined(cuda_version_override)
+            # the user didn't specify a version, so try quering it
+            version = get_runtime_version()
+            if version === nothing
+                @error """Local CUDA version requested, but could not query the runtime version.
+                          Either make sure CUDA is available, or set the CUDA version explicitly."""
+                return nothing
+            end
+            @debug "Local CUDA runtime version: $version"
+            cuda_version_override = version
+        end
     end
 
     # if not, we need to be able to use the driver to determine the version.
     # note that we only require this when there's no override, to support
     # precompiling with a fixed version without having the driver available.
     if !@isdefined(cuda_version_override)
-        if !@isdefined(CUDA_Driver_jll)
-            # driver JLL not available because we're in the middle of installing packages
-            @debug "CUDA_Driver_jll not available; not selecting an artifact"
-            return "none"
-        end
-
-        cuda_driver = if CUDA_Driver_jll.is_available()
-            @debug "Using CUDA_Driver_jll for driver discovery"
-
-            if !isdefined(CUDA_Driver_jll, :libcuda) || # CUDA_Driver_jll@0.4-compat; https://github.com/JuliaLang/Pkg.jl/issues/3225#issuecomment-1511306014
-                isnothing(CUDA_Driver_jll.libcuda)      # https://github.com/JuliaLang/julia/issues/48999
-                # no driver found
-                @debug "CUDA_Driver_jll reports no driver found"
-                return "none"
-            end
-            CUDA_Driver_jll.libcuda
-        else
-            # CUDA_Driver_jll only kicks in for supported platforms, so fall back to
-            # a system search if the artifact isn't available (JLLWrappers.jl#50)
-            @debug "CUDA_Driver_jll unavailable, falling back to system search"
-
-            driver_name = if Sys.iswindows()
-                Libdl.find_library("nvcuda")
-            else
-                Libdl.find_library(["libcuda.so.1", "libcuda.so"])
-            end
-            if driver_name == ""
-                # no driver found
-                @debug "CUDA_Driver_jll unavailable, and no system CUDA driver found"
-                return "none"
-            end
-
-            driver_name
-        end
-        @debug "Found CUDA driver at '$cuda_driver'"
-
-        # minimal API call wrappers we need
-        function driver_version(library_handle)
-            function_handle = Libdl.dlsym(library_handle, "cuDriverGetVersion"; throw_error=false)
-            if function_handle === nothing
-                @debug "Driver library seems invalid (does not contain 'cuDriverGetVersion')"
-                return nothing
-            end
-            version_ref = Ref{Cint}()
-            status = ccall(function_handle, Cint, (Ptr{Cint},), version_ref)
-            if status != 0
-                @debug "Call to 'cuDriverGetVersion' failed with status $status"
-                return nothing
-            end
-            major, ver = divrem(version_ref[], 1000)
-            minor, patch = divrem(ver, 10)
-            return VersionNumber(major, minor, patch)
-        end
-
-        driver_handle = Libdl.dlopen(cuda_driver; throw_error=false)
-        if driver_handle === nothing
-            @debug "Failed to load CUDA driver"
-            return "none"
-        end
-
-        cuda_driver_version = driver_version(driver_handle)
+        cuda_driver_version = get_driver_version()
         if cuda_driver_version === nothing
             @debug "Failed to query CUDA driver version"
-            return "none"
+            return nothing
         end
-
         @debug "CUDA driver version: $cuda_driver_version"
     end
 
     # "[...] applications built against any of the older CUDA Toolkits always continued
     #  to function on newer drivers due to binary backward compatibility"
-    filter!(cuda_toolkits) do toolkit
+    compatible_toolkits = filter(cuda_toolkits) do toolkit
         if @isdefined(cuda_version_override)
             thisminor(toolkit) == thisminor(cuda_version_override)
         elseif cuda_driver_version >= v"11"
@@ -124,18 +218,44 @@ function cuda_toolkit_tag()
             thisminor(toolkit) <= thisminor(cuda_driver_version)
         end
     end
-    if isempty(cuda_toolkits)
-        @debug "No compatible CUDA toolkit found"
-        return "none"
+    if isempty(compatible_toolkits)
+        # the user either has a functional CUDA driver set-up, or requested a specific
+        # toolkit version, so complain loudly if we aren't compatible with it.
+        if @isdefined(cuda_version_override)
+            @error "Requested CUDA version $(cuda_version_override) does not match any supported CUDA toolkit ($(join(cuda_toolkits, ", ", " or ")))"
+        else
+            @error "CUDA driver $(cuda_driver_version) is not compatible with any supported CUDA toolkit ($(join(cuda_toolkits, ", ", " or ")))"
+        end
+        return nothing
     end
 
-    cuda_toolkit = last(cuda_toolkits)
+    cuda_toolkit = last(compatible_toolkits)
     @debug "Selected CUDA toolkit: $cuda_toolkit"
     "$(cuda_toolkit.major).$(cuda_toolkit.minor)"
 end
 
+function cuda_comparison_strategy(a::String, b::String, a_requested::Bool, b_requested::Bool)
+    # we don't actually need a comparison strategy, as the tag is known to exactly match
+    # whatever toolkit artifacts we have available. however, we use one so that we can
+    # bail out from downloading artifacts if the user requested a local toolkit
+    if local_preference !== missing && local_preference
+        return false
+    end
+
+    return a == b
+end
+
 function augment_platform!(platform::Platform)
-    haskey(platform, "cuda") && return platform
-    platform["cuda"] = cuda_toolkit_tag()
+    if !haskey(platform, "cuda")
+        platform["cuda"] = something(cuda_toolkit_tag(), "none")
+        # XXX: use "none" when we couldn't find a compatible toolkit.
+        #      we can't just leave off the platform tag or Pkg would select *any* artifact.
+    end
+    BinaryPlatforms.set_compare_strategy!(platform, "cuda", cuda_comparison_strategy)
+
+    # store the fact that we're using a local CUDA toolkit, so that we can more easily
+    # query it from CUDA.jl without having to parse the preference again.
+    platform["cuda_local"] = string(local_preference !== missing && local_preference)
+
     return platform
 end


### PR DESCRIPTION
That way, the 'version' preference is always set to a valid version number, and not to the `"local"` string. This makes it so that CUDA.jl will know the version of the local toolkit. The exception is of course still the `"none"` entry, but that's to work around BinaryBuilder limitations.

To make this feature more powerful, add some libcudart-based detection of the local toolkit's version. This should make setting `local = "true"` behave similar to using artifacts, i.e., if the driver/runtime are available during precompilation, the version will be auto-detected. Only for environments without CUDA (such as containers, log-in nodes, etc) the user will need to set the `version` preference to inform the system what version of CUDA is being used.

This PR also adds / changes artifact comparison strategies to always bail out when using a local toolkit. This should prevent downloading useless artifacts when using system libraries.

It's expected that this will require some iterations to be fully robust and cover all corner cases. As such, it will be part of a breaking release of CUDA.jl.

cc @vchuravy 