### PR TITLE
[GMP] Add version 6.3.0

### DIFF
--- a/G/GMP/GMP@6.3.0/build_tarballs.jl
+++ b/G/GMP/GMP@6.3.0/build_tarballs.jl
@@ -1,0 +1,7 @@
+version = v"6.3.0"
+
+include("../common.jl")
+
+# Build the tarballs!
+build_tarballs(ARGS, configure(version)...;
+               preferred_gcc_version=v"6", julia_compat="1.7")

--- a/G/GMP/GMP@6.3.0/bundled/patches/gmp-exception.patch
+++ b/G/GMP/GMP@6.3.0/bundled/patches/gmp-exception.patch
@@ -1,0 +1,14 @@
+diff --git a/errno.c b/errno.c
+index b4be555..3f772a5 100644
+--- a/errno.c
++++ b/errno.c
+@@ -68,5 +68,8 @@ __gmp_sqrt_of_negative (void)
+ void
+ __gmp_divide_by_zero (void)
+ {
++  /* try to force a division by zero system exception */
++  __gmp_junk = 10 / __gmp_0;
++
+   __gmp_exception (GMP_ERROR_DIVISION_BY_ZERO);
+ }
+

--- a/G/GMP/GMP@6.3.0/bundled/patches/gmp_alloc_overflow_func.patch
+++ b/G/GMP/GMP@6.3.0/bundled/patches/gmp_alloc_overflow_func.patch
@@ -1,0 +1,111 @@
+diff --git a/errno.c b/errno.c
+index d71c146..40d83bd 100644
+--- a/errno.c
++++ b/errno.c
+@@ -38,8 +38,11 @@ see https://www.gnu.org/licenses/.  */
+ 
+ #include "gmp-impl.h"
+ 
++static void __gmp_default_alloc_overflow(void);
++
+ int gmp_errno = 0;
+ 
++static void   (*__gmp_alloc_overflow_func) (void) = __gmp_default_alloc_overflow;
+ 
+ /* Use SIGFPE on systems which have it. Otherwise, deliberate divide
+    by zero, which triggers an exception on most systems. On those
+@@ -72,6 +75,29 @@ __gmp_divide_by_zero (void)
+ }
+ void
+ __gmp_overflow_in_mpz (void)
++{
++  (*__gmp_alloc_overflow_func)();
++}
++
++static void
++__gmp_default_alloc_overflow(void)
+ {
+   __gmp_exception (GMP_ERROR_MPZ_OVERFLOW);
+ }
++
++void
++mp_get_alloc_overflow_function(
++        void (**alloc_overflow_func) (void)) __GMP_NOTHROW
++{
++  if (alloc_overflow_func != NULL)
++    *alloc_overflow_func = __gmp_alloc_overflow_func;
++}
++
++void
++mp_set_alloc_overflow_function(
++             void (*alloc_overflow_func) (void)) __GMP_NOTHROW
++{
++  if (alloc_overflow_func == 0)
++    alloc_overflow_func = __gmp_default_alloc_overflow;
++  __gmp_alloc_overflow_func = alloc_overflow_func;
++}
+diff --git a/gmp-h.in b/gmp-h.in
+index 8598e97..6e0ef78 100644
+--- a/gmp-h.in
++++ b/gmp-h.in
+@@ -487,6 +487,13 @@ __GMP_DECLSPEC void mp_get_memory_functions (void *(**) (size_t),
+ 				      void *(**) (void *, size_t, size_t),
+ 				      void (**) (void *, size_t)) __GMP_NOTHROW;
+ 
++#define mp_set_alloc_overflow_function __gmp_set_alloc_overflow_function
++__GMP_DECLSPEC void mp_set_alloc_overflow_function (void (*) (void)) __GMP_NOTHROW;
++
++#define mp_get_alloc_overflow_function __gmp_get_alloc_overflow_function
++__GMP_DECLSPEC void mp_get_alloc_overflow_function (void (**) (void)) __GMP_NOTHROW;
++
++
+ #define mp_bits_per_limb __gmp_bits_per_limb
+ __GMP_DECLSPEC extern const int mp_bits_per_limb;
+ 
+diff --git a/tests/mpz/t-pow.c b/tests/mpz/t-pow.c
+index ff41721..36674f9 100644
+--- a/tests/mpz/t-pow.c
++++ b/tests/mpz/t-pow.c
+@@ -194,6 +194,34 @@ check_random (int reps)
+   mpz_clear (want);
+ }
+ 
++jmp_buf env;
++
++void
++alloc_overflow_handler (void)
++{
++  longjmp(env, 1);
++}
++
++void
++check_overflow (void)
++{
++  mpz_t x;
++  mpz_init (x);
++  int overflow_intercepted = 0;
++  if (setjmp (env) == 0) {
++    mp_set_alloc_overflow_function (&alloc_overflow_handler);
++    mpz_ui_pow_ui (x, 3, 7625597484987LL);
++  } else {
++    ++overflow_intercepted;
++  }
++  if (overflow_intercepted != 1) {
++    printf ("overflow not intercepted\n");
++    abort ();
++  }
++  mpz_clear (x);
++}
++
++
+ int
+ main (int argc, char **argv)
+ {
+@@ -211,6 +239,7 @@ main (int argc, char **argv)
+ 
+   check_various ();
+   check_random (reps);
++  check_overflow ();
+ 
+   tests_end ();
+   exit (0);

--- a/G/GMP/common.jl
+++ b/G/GMP/common.jl
@@ -10,6 +10,7 @@ function configure(version)
         v"6.1.2" => "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2",
         v"6.2.0" => "f51c99cb114deb21a60075ffb494c1a210eb9d7cb729ed042ddb7de9534451ea",
         v"6.2.1" => "eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c",
+        v"6.3.0" => "ac28211a7cfb609bae2e2c8d6058d66c8fe96434f740cf6fe2e47b000d1c20cb",
     )
 
     # Collection of sources required to complete build


### PR DESCRIPTION
A few weeks ago, GMP 6.3.0 was released. Besides integrating some of the patches we already used, it has some other nice improvements.

However, since this is used by Julia itself, handling it is a bit delicate... or at least that's how I remember it... We also need to coordinate this with the Julia side. So for now this is just a draft.