### PR TITLE
[libjulia] update 1.11-DEV to latest master, update 1.10 to beta2

### DIFF
--- a/L/libjulia/build_tarballs.jl
+++ b/L/libjulia/build_tarballs.jl
@@ -31,7 +31,7 @@ function Pkg.Types.is_stdlib(uuid::Base.UUID, julia_version::VersionNumber)
     return false
 end
 
-jllversion=v"1.10.4"
+jllversion=v"1.10.5"
 for ver in julia_full_versions
     build_julia(ARGS, ver; jllversion)
 end

--- a/L/libjulia/bundled/patches/1.11.0-DEV/nonative.patch
+++ b/L/libjulia/bundled/patches/1.11.0-DEV/nonative.patch
@@ -1,0 +1,15 @@
+diff --git a/Make.inc b/Make.inc
+index d5965ee4f4..8dc96eeff5 100644
+--- a/Make.inc
++++ b/Make.inc
+@@ -898,8 +898,8 @@ ISX86:=0
+ endif
+ 
+ 
+-#If nothing is set default to native
+-ifeq ($(MARCH)$(MCPU)$(MTUNE)$(JULIA_CPU_TARGET),)
++#If nothing is set default to native unless we are cross-compiling
++ifeq ($(MARCH)$(MCPU)$(MTUNE)$(JULIA_CPU_TARGET)$(XC_HOST),)
+ ifeq ($(ARCH),aarch64) #ARM recommends only setting MCPU for AArch64
+ MCPU=native
+ else

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -5,7 +5,7 @@ using BinaryBuilder, Pkg
 include("../../fancy_toys.jl") # for get_addable_spec
 
 # list of supported Julia versions
-julia_full_versions = [v"1.6.3", v"1.7.0", v"1.8.2", v"1.9.0", v"1.10.0-DEV", v"1.11.0-DEV"]
+julia_full_versions = [v"1.6.3", v"1.7.0", v"1.8.2", v"1.9.0", v"1.10.0-beta2", v"1.11.0-DEV"]
 if ! @isdefined julia_versions
     julia_versions = Base.thispatch.(julia_full_versions)
 end
@@ -50,14 +50,14 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         v"1.9.0" => "48f4c8a7d5f33d0bc6ce24226df20ab49e385c2d0c3767ec8dfdb449602095b2",
     )
 
-    if version == v"1.10.0-DEV"
+    if version == v"1.10.0-beta2"
         sources = [
-            GitSource("https://github.com/JuliaLang/julia.git", "0ba6ec2d2282937a084d7e5e5a0b026dc953bb31"),
+            GitSource("https://github.com/JuliaLang/julia.git", "a468aa198d030bd77efd7cb3e4069684af622dcc"),
             DirectorySource("./bundled"),
         ]
     elseif version == v"1.11.0-DEV"
         sources = [
-            GitSource("https://github.com/JuliaLang/julia.git", "ce1b420ff12454e3414c8f37dea7c00979224ba5"),
+            GitSource("https://github.com/JuliaLang/julia.git", "8e14322b5aa344639dd86bf9eabb84afe831fcba"),
             DirectorySource("./bundled"),
         ]
     else
@@ -78,6 +78,8 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
     # Bash recipe for building across all platforms
     script = raw"""
     apk add coreutils libuv-dev utf8proc
+    # we need a more recent cmake version for suitesparse and use the jll instead
+    apk del cmake
 
     # WORKAROUND for mingw: remove the fake `uname` binary, it throws off the
     # Julia buildsystem
@@ -100,6 +102,7 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
     if [[ "${version}" == 1.9.* ]] || [[ "${version}" == 1.1[0-9].* ]]; then
         if [[ "${target}" == *mingw* ]]; then
             sed -i -e 's/-lblastrampoline"/-lblastrampoline-5"/g' deps/libsuitesparse.mk
+            sed -i -e 's/libblastrampoline\./libblastrampoline-5./g' deps/libsuitesparse.mk
         fi
     fi
 
@@ -345,6 +348,8 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         BuildDependency("MPFR_jll"),
         BuildDependency("GMP_jll"),
         BuildDependency("Objconv_jll"),
+        # needed for suitesparse >= 7.2.0
+        HostBuildDependency(PackageSpec(; name="CMake_jll", version = v"3.24.3"))
     ]
 
     # HACK: we can't install LLVM 12 JLLs for Julia 1.7 from within Julia 1.6. Similar
@@ -378,17 +383,17 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
         push!(dependencies, Dependency(get_addable_spec("LLVMLibUnwind_jll", v"12.0.1+0"); platforms=filter(Sys.isapple, platforms)))
         push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"14.0.6+2")))
     elseif version.major == 1 && version.minor == 10
-        push!(dependencies, BuildDependency(get_addable_spec("SuiteSparse_jll", v"5.10.1+6")))
-        push!(dependencies, Dependency(get_addable_spec("LibUV_jll", v"2.0.1+13")))
-        push!(dependencies, Dependency(get_addable_spec("LibUnwind_jll", v"1.5.0+4"); platforms=filter(!Sys.isapple, platforms)))
+        push!(dependencies, BuildDependency(get_addable_spec("SuiteSparse_jll", v"7.2.0+1")))
+        push!(dependencies, Dependency(get_addable_spec("LibUV_jll", v"2.0.1+14")))
+        push!(dependencies, Dependency(get_addable_spec("LibUnwind_jll", v"1.5.0+5"); platforms=filter(!Sys.isapple, platforms)))
         push!(dependencies, Dependency(get_addable_spec("LLVMLibUnwind_jll", v"12.0.1+0"); platforms=filter(Sys.isapple, platforms)))
-        push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"15.0.7+5")))
+        push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"15.0.7+8")))
     elseif version.major == 1 && version.minor == 11
-        push!(dependencies, BuildDependency(get_addable_spec("SuiteSparse_jll", v"5.10.1+6")))
-        push!(dependencies, Dependency(get_addable_spec("LibUV_jll", v"2.0.1+13")))
-        push!(dependencies, Dependency(get_addable_spec("LibUnwind_jll", v"1.5.0+4"); platforms=filter(!Sys.isapple, platforms)))
+        push!(dependencies, BuildDependency(get_addable_spec("SuiteSparse_jll", v"7.2.0+1")))
+        push!(dependencies, Dependency(get_addable_spec("LibUV_jll", v"2.0.1+14")))
+        push!(dependencies, Dependency(get_addable_spec("LibUnwind_jll", v"1.5.0+5"); platforms=filter(!Sys.isapple, platforms)))
         push!(dependencies, Dependency(get_addable_spec("LLVMLibUnwind_jll", v"12.0.1+0"); platforms=filter(Sys.isapple, platforms)))
-        push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"15.0.7+5")))
+        push!(dependencies, BuildDependency(get_addable_spec("LLVM_full_jll", v"15.0.7+8")))
     else
         error("Unsupported Julia version")
     end


### PR DESCRIPTION
To prepare for rebuilds to fix small_typeof errors, see https://github.com/JuliaInterop/CxxWrap.jl/pull/368:
```
libcxxwrap_julia.so: undefined symbol: small_typeof, version JL_LIBJULIA_1.11
```

This includes the patch from https://github.com/JuliaLang/julia/pull/51172 to remove the `native` flag.

We might want to wait a bit with this to also rebuild 1.10 in one go once https://github.com/JuliaLang/julia/pull/50892 is backported?
I have updated it to 1.10.0-beta2 for now to see if there are any other errors but he small_typeof change is not included yet.

cc: @fingolfin @barche 

closes #7043