### PR TITLE
LLVM: Bump LLVMExtra

### DIFF
--- a/L/LLVMExtra/build_tarballs.jl
+++ b/L/LLVMExtra/build_tarballs.jl
@@ -7,14 +7,14 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
 
 name = "LLVMExtra"
 repo = "https://github.com/maleadt/LLVM.jl.git"
-version = v"0.0.24"
+version = v"0.0.25"
 
-llvm_versions = [v"11.0.1", v"12.0.1", v"13.0.1", v"14.0.6", v"15.0.7"]
+llvm_versions = [v"13.0.1", v"14.0.6", v"15.0.7"]
 
 
 # Collection of sources required to build LLVMExtra
 sources = [
-    GitSource(repo, "4b27d03e2fe439f1f70aced906654f176b70a3d7"),
+    GitSource(repo, "51094f8"),
     ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz",
     "0f03869f72df8705b832910517b47dd5b79eb4e160512602f593ed243b28715f"),
 ]

--- a/L/LLVMExtra/build_tarballs.jl
+++ b/L/LLVMExtra/build_tarballs.jl
@@ -14,7 +14,7 @@ llvm_versions = [v"13.0.1", v"14.0.6", v"15.0.7"]
 
 # Collection of sources required to build LLVMExtra
 sources = [
-    GitSource(repo, "51094f8"),
+    GitSource(repo, "51094f89c6b84bca1198c75d22c16b032ee98f2d"),
     ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz",
     "0f03869f72df8705b832910517b47dd5b79eb4e160512602f593ed243b28715f"),
 ]


### PR DESCRIPTION
This time, using the correct hash. Also gets rid of older LLVM versions.