### PR TITLE
[libcxxwrap_julia] retry: rebuild for julia nightly changes

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -56,4 +56,4 @@ dependencies = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
     preferred_gcc_version = v"9", julia_compat = "1.6")
 
-# rebuild trigger: 3
+# rebuild trigger: 4


### PR DESCRIPTION
Retrying #7290 because the job on master [failed](https://buildkite.com/julialang/yggdrasil/builds/4924#018a6c0d-0967-4b54-addd-b3d1c49964e3) with some weird errors:
```
$ buildkite-agent artifact upload **/products/libcxxwrap_julia*.tar.gz
--
  | 2023-09-06 21:23:49 INFO   No files matched paths: **/products/libcxxwrap_julia*.tar.gz
  | 🚨 Error: The plugin julia pre-command hook exited with status 1
```

