### PR TITLE
[hdf5] Update HDF5 for SZIP support

### DIFF
--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -18,7 +18,7 @@ sources = [
 
     # 32-bit Windows from https://packages.msys2.org/package/mingw-w64-i686-hdf5
     ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-hdf5-1.14.2-2-any.pkg.tar.zst",
-                  "b3ac2c169ad089682970f9f5370b4d4368bcb89ab9b03658df741ab1d736937f"; unpack_target="i686-w64-mingw32"),
+                  "ab053fdafb3e0c456751fed9fe5cc2fa339042046b4de677ce2848cd8b6d3b3f"; unpack_target="i686-w64-mingw32"),
     ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-zlib-1.3-1-any.pkg.tar.zst",
                   "21bacf3a43073749a4cbdf407c7f1da92bab56c80925b1205f7c4cb289c724a1"; unpack_target="i686-w64-mingw32"),
     # We need some special compiler support libraries from mingw for i686 (libgcc_s_dw2)

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -17,8 +17,8 @@ sources = [
     # We don't build HDF5 on Windows; instead, we use packages from msys there:
 
     # 32-bit Windows from https://packages.msys2.org/package/mingw-w64-i686-hdf5
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-hdf5-1.14.2-1-any.pkg.tar.zst",
-                  "360a28199416c13fa5fd5240c3d9e11a4aeb0aeeff254cfdd7ef5c69ec34aedb"; unpack_target="i686-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-hdf5-1.14.2-2-any.pkg.tar.zst",
+                  "b3ac2c169ad089682970f9f5370b4d4368bcb89ab9b03658df741ab1d736937f"; unpack_target="i686-w64-mingw32"),
     ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-zlib-1.3-1-any.pkg.tar.zst",
                   "21bacf3a43073749a4cbdf407c7f1da92bab56c80925b1205f7c4cb289c724a1"; unpack_target="i686-w64-mingw32"),
     # We need some special compiler support libraries from mingw for i686 (libgcc_s_dw2)
@@ -26,8 +26,8 @@ sources = [
                   "2dae8189318a91067cca895572b2b46183bfd2ee97a55127a84f4f418f0b32f3"; unpack_target="i686-w64-mingw32"),
 
     # 64-bit Windows from https://packages.msys2.org/package/mingw-w64-x86_64-hdf5
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-hdf5-1.14.2-1-any.pkg.tar.zst",
-                  "5c9e0636c79edf6e7e4c03bc9ddf271b701cf601826761c7e8dc94f2ac92f3cc"; unpack_target="x86_64-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-hdf5-1.14.2-2-any.pkg.tar.zst",
+                  "19a0a28d32c8990a29e001b77fe2deeb4946ff6c7d0949dbf756dfe1b9b40e8a"; unpack_target="x86_64-w64-mingw32"),
     ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-zlib-1.3-1-any.pkg.tar.zst",
                   "254a6c5a8a27d1b787377a3e70a39cceb200b47c5f15f4ab5bfa1431b718ef98"; unpack_target="x86_64-w64-mingw32"),
 


### PR DESCRIPTION
This should restore libaec as a SZIP filter for HDF5 ON Windows.

Xref:
https://github.com/msys2/MINGW-packages/pull/18328