### PR TITLE
[boostpython] upgrade to 1.79.0 (w/ Python 3.10)

### DIFF
--- a/B/boostpython/build_tarballs.jl
+++ b/B/boostpython/build_tarballs.jl
@@ -3,17 +3,17 @@
 using BinaryBuilder, Pkg
 
 name = "boostpython"
-version = v"1.76.0"
+version = v"1.79.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/boostorg/python.git", "68fa9dccdec75d59ac28d3ff98d70c659e12326d")
+    GitSource("https://github.com/boostorg/python.git", "8dd151177374dbf0aa5cb86bd350cf1ad13e2160")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/python
-c++ -fPIC -o $libdir/libboost_python38.$dlext -O3 -shared -L$libdir -lpython3.8 -I$includedir -I$includedir/python3.8 $(find src ! -path src/numpy/\* -name \*.cpp)
+c++ -fPIC -o $libdir/libboost_python310.$dlext -O3 -shared -L$libdir -lpython3.10 -I$includedir -I$includedir/python3.10 $(find src ! -path src/numpy/\* -name \*.cpp)
 cp -r include/* $includedir
 install_license LICENSE_1_0.txt
 """
@@ -24,13 +24,13 @@ platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libboost_python38", :libboost_python)
+    LibraryProduct("libboost_python310", :libboost_python)
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"); compat="=1.76.0")
-    Dependency(PackageSpec(name="Python_jll"), v"3.8.1"; compat="~3.8")
+    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"); compat="=1.79.0")
+    Dependency(PackageSpec(name="Python_jll"), v"3.10.8"; compat="~3.10")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
My newbie attempt to upgrade boostpython to 1.79.0, consistent with the latest boost we have in Yggdrasil (also 1.79.0), and using the latest Python (3.10.8).

(Renders the discussion at the end of https://github.com/JuliaPackaging/Yggdrasil/pull/6228 moot, unless someone _really_ wants a 1.76.0 with newer Python. That person is no longer me though)