### PR TITLE
[XGBoost] Upgrade to v2.0

### DIFF
--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -22,13 +22,15 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/xgboost
 git submodule update --init
 
-# Patch dmlc-core to use case-sensitive windows.h includes: https://github.com/dmlc/dmlc-core/pull/673
+# Patch dmlc-core to use case-sensitive windows.h includes: 
+# https://github.com/dmlc/dmlc-core/pull/673
 (cd dmlc-core; atomic_patch -p1 "../../patches/dmlc_windows.patch")
 
 mkdir build && cd build
 
 # https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/193
-# error: 'any_cast<std::shared_ptr<xgboost::data::CSRArrayAdapter>>' is unavailable: introduced in macOS 10.14
+# error: 'any_cast<std::shared_ptr<xgboost::data::CSRArrayAdapter>>' 
+# is unavailable: introduced in macOS 10.14
 # `std::filesystem` support was introduced in macOS 10.15
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
     pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
@@ -119,8 +121,10 @@ for cuda_version in versions_to_build, platform in platforms
     dependencies = AbstractDependency[
         # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
         # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
-        Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, [augmented_platform])),
-        Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, [augmented_platform])),
+        Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); 
+            platforms=filter(!Sys.isbsd, [augmented_platform])),
+        Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); 
+            platforms=filter(Sys.isbsd, [augmented_platform])),
     ]
 
     if !isnothing(cuda_version)

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -81,13 +81,13 @@ augment_platform_block = CUDA.augment
 
 versions_to_build = [
     nothing,
-    v"11.0",
+    v"11.4",
     v"12.0",
 ]
 
 cuda_preambles = Dict(
     nothing => "",
-    v"11.0" => "CUDA_ARCHS=\"60;70;75;80\";",
+    v"11.4" => "CUDA_ARCHS=\"60;70;75;80\";",
     v"12.0" => "CUDA_ARCHS=\"60;70;75;80;89;90\";",
 )
 

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -26,7 +26,12 @@ git submodule update --init
 # https://github.com/dmlc/dmlc-core/pull/673
 (cd dmlc-core; atomic_patch -p1 "../../patches/dmlc_windows.patch")
 
-mkdir build && cd build
+# XGBoost fails to compile on mac due to `std::make_shared`
+# being bugged with some apple clang versions
+# https://github.com/dmlc/xgboost/issues/9601
+if [[ "${target}" == *-apple-* ]]; then
+    atomic_patch -p1 "../patches/mac_make_shared.patch"
+fi
 
 # https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/193
 # error: 'any_cast<std::shared_ptr<xgboost::data::CSRArrayAdapter>>' 
@@ -40,6 +45,8 @@ if [[ "${target}" == x86_64-apple-darwin* ]]; then
     export MACOSX_DEPLOYMENT_TARGET=10.15
     popd
 fi
+
+mkdir build && cd build
 
 if  [[ $bb_full_target == *-linux*cuda+1* ]]; then
     # nvcc writes to /tmp, which is a small tmpfs in our sandbox.

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -11,7 +11,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 # Collection of sources required to build XGBoost
 sources = [
-    GitSource("https://github.com/dmlc/xgboost.git","4301558a5711e63bbf004d2b6fca003906fb743c"),
+    GitSource("https://github.com/dmlc/xgboost.git","096047c547aa71af7d53a507cecdd2a1d3124651"),
     DirectorySource("./bundled"),
     ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
     "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62")

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -29,15 +29,16 @@ mkdir build && cd build
 
 # https://github.com/JuliaPackaging/Yggdrasil/pull/4106
 # error: 'any_cast<std::shared_ptr<xgboost::data::CSRArrayAdapter>>' is unavailable: introduced in macOS 10.14
+# `std::filesystem` support was introduced in macOS 10.15
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
     export MACOSX_DEPLOYMENT_TARGET=10.15
-    #install a newer SDK which supports `std::filesystem`
     pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
     rm -rf /opt/${target}/${target}/sys-root/System
     cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
     cp -ra System "/opt/${target}/${target}/sys-root/."
     popd
 fi
+
 if  [[ $bb_full_target == *-linux*cuda+1* ]]; then
     # nvcc writes to /tmp, which is a small tmpfs in our sandbox.
     # make it use the workspace instead

--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -27,15 +27,15 @@ git submodule update --init
 
 mkdir build && cd build
 
-# https://github.com/JuliaPackaging/Yggdrasil/pull/4106
+# https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/193
 # error: 'any_cast<std::shared_ptr<xgboost::data::CSRArrayAdapter>>' is unavailable: introduced in macOS 10.14
 # `std::filesystem` support was introduced in macOS 10.15
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
-    export MACOSX_DEPLOYMENT_TARGET=10.15
     pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
     rm -rf /opt/${target}/${target}/sys-root/System
     cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
     cp -ra System "/opt/${target}/${target}/sys-root/."
+    export MACOSX_DEPLOYMENT_TARGET=10.15
     popd
 fi
 

--- a/X/XGBoost/bundled/patches/mac_make_shared.patch
+++ b/X/XGBoost/bundled/patches/mac_make_shared.patch
@@ -1,0 +1,10 @@
++++ xgboost/src/common/io.h
+@@ -384,7 +384,7 @@
+    * @param length    See the `length` parameter of `mmap` for details.
+    */
+   explicit PrivateMmapConstStream(std::string path, std::size_t offset, std::size_t length)
+-      : AlignedResourceReadStream{std::make_shared<MmapResource>(path, offset, length)} {}
++      : AlignedResourceReadStream{std::shared_ptr<MmapResource>(new MmapResource(path, offset, length))} {}
+   ~PrivateMmapConstStream() noexcept(false) override;
+ };
+ 


### PR DESCRIPTION
[Release notes](https://github.com/dmlc/xgboost/releases/tag/v2.0.0)

Here are the changes that I have made:
- Bump the XGBoost version to 2.0 and updated the build to the corresponding commit 
- Bump `preferred_gcc_version` from `v8` to `v9` for `std::filesystem` support (from my research, this was the best fix that I found, and the builds worked with this change)
- Add MacOS upgrade to support new C++ features such as `any_cast` in macOS 10.14+ and `std::filesystem` in macOS 10.15+
- Patch to fix MacOS compiling with `std::make_shared`
