### PR TITLE
CUDA: Add backwards-compatible support for old runtime preferences.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.9.1"
+version = v"0.9.2"
 
 augment_platform_block = """
     $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))


### PR DESCRIPTION
We now accept version=local again, in which case the actual_version preference can optionally be used to configure the actual toolkit version. The new way of doing this is to set local=true and optionally set the version preference, but that is not backwards compatible with older versions of this JLL.

cc @simonbyrne 