### PR TITLE
[PROJ] build v9.3.0

### DIFF
--- a/P/PROJ/build_tarballs.jl
+++ b/P/PROJ/build_tarballs.jl
@@ -3,8 +3,8 @@
 using BinaryBuilder, Pkg
 
 name = "PROJ"
-upstream_version = v"9.2.1"
-version_offset = v"0.0.0"
+upstream_version = v"9.3.0"
+version_offset = v"1.0.0"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
                         upstream_version.patch * 100 + version_offset.patch)
@@ -12,7 +12,7 @@ version = VersionNumber(upstream_version.major * 100 + version_offset.major,
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://download.osgeo.org/proj/proj-$upstream_version.tar.gz",
-        "15ebf4afa8744b9e6fccb5d571fc9f338dc3adcf99907d9e62d1af815d4971a1")
+        "91a3695a004ea28db0448a34460bed4cc3b130e5c7d74339ec999efdab0e547d")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
The PROJ_SOVERSION stays at 25, but since the minor version is in the DLL filename, this also bumps the major version via the offset, to avoid breakage.

https://github.com/search?q=repo%3AJuliaBinaryWrappers%2FPROJ_jll.jl%20dll&type=code

This means that e.g. libgeotiff > GDAL > GMT also need updating to work with this.

PROJ release notes: https://proj.org/en/9.3/news.html

