### PR TITLE
Kokkos: Bump to 4.1.00

### DIFF
--- a/K/Kokkos/build_tarballs.jl
+++ b/K/Kokkos/build_tarballs.jl
@@ -56,4 +56,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"9")

--- a/K/Kokkos/build_tarballs.jl
+++ b/K/Kokkos/build_tarballs.jl
@@ -56,5 +56,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-#minimum supported gcc on x86_64 is 5.3.0, BB only has 5.2.0 so we bump up to 6
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"8")

--- a/K/Kokkos/build_tarballs.jl
+++ b/K/Kokkos/build_tarballs.jl
@@ -3,13 +3,13 @@
 using BinaryBuilder, Pkg
 
 name = "Kokkos"
-version_string = "3.7.02"
+version_string = "4.1.00"
 version = VersionNumber(version_string)
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/kokkos/kokkos.git",
-	      "1a0c2ff6daf1068c65529ec04c2c046177847869"),
+	      "1a3ea28f6e97b4c9dd2c8ceed53ad58ed5f94dfe"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
In prepration of trying to use it directly in the Trilinos jll (See #7386 #7384).

cc (FYI): @dannys4 @eschnett @Crghilardi