### PR TITLE
CUDA: Bump 12.2 SDKs.

### DIFF
--- a/C/CUDA/CUDA_SDK@12.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK@12.2/build_tarballs.jl
@@ -15,3 +15,5 @@ platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "windows")]
 
 build_sdk(name, version, platforms; static=false)
+
+# bump

--- a/C/CUDA/CUDA_SDK_static@12.2/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK_static@12.2/build_tarballs.jl
@@ -15,3 +15,5 @@ platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "windows")]
 
 build_sdk(name, version, platforms; static=true)
+
+# bump

--- a/C/CUDA/common.jl
+++ b/C/CUDA/common.jl
@@ -80,7 +80,7 @@ if [[ ${target} == *-linux-gnu ]]; then
     find ${prefix}/cuda -type d -empty -delete
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     for project in *-archive; do
-        cp -a ${project}/*/* ${prefix}/cuda
+        cp -a ${project}/* ${prefix}/cuda
     done
 
     # keep or remove static libraries


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/2066

I'll have to bump the other SDK JLLs as well, but those shouldn't be merged immediately, as that otherwise results in conflicts in General.