### PR TITLE
Kokkos: Also enable serial execution space

### DIFF
--- a/K/Kokkos/build_tarballs.jl
+++ b/K/Kokkos/build_tarballs.jl
@@ -27,7 +27,8 @@ cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
     -DCMAKE_CXX_STANDARD=17 \
-    -DKokkos_ENABLE_OPENMP=ON
+    -DKokkos_ENABLE_OPENMP=ON \
+    -DKokkos_ENABLE_SERIAL=ON
 
 make -j${nproc}
 make install


### PR DESCRIPTION
For downstream users that may not want to require OpenMP