### PR TITLE
[blis] Add --enable-cblas flag to configuration

### DIFF
--- a/B/blis/common.jl
+++ b/B/blis/common.jl
@@ -104,7 +104,7 @@ function blis_script(;blis32::Bool=false)
     else
         export BLI_F77BITS=${nbits}
     fi
-    ./configure -p ${prefix} -t ${BLI_THREAD} -b ${BLI_F77BITS} ${BLI_CONFIG}
+    ./configure --enable-cblas -p ${prefix} -t ${BLI_THREAD} -b ${BLI_F77BITS} ${BLI_CONFIG}
     make -j${nproc}
     make install
 


### PR DESCRIPTION
This enables the CBLAS (and BLAS) compatibility layer, creating currently missing symbols starting with `cblas_`. These are accessed, for example, in the `LinearAlgebra` standard library `./julia/stdlib/LinearAlgebra/src/blas.jl` when using BLIS through `libblastrampoline`.

cf.  https://github.com/flame/blis/blob/c6546c1131b1ddd45ef13f9f2b620ce2e955dbf8/configure#L275-L279