### PR TITLE
[libadwaita] v1.4.0

### DIFF
--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "Glib"
-version = v"2.76.5"
+version = v"2.77.3"
 
 # Collection of sources required to build Glib
 sources = [

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -6,7 +6,7 @@ version = v"2.77.3"
 # Collection of sources required to build Glib
 sources = [
     ArchiveSource("https://ftp.gnome.org/pub/gnome/sources/glib/$(version.major).$(version.minor)/glib-$(version).tar.xz",
-                  "ed3a9953a90b20da8e5578a79f7d1c8a532eacbe2adac82aa3881208db8a3abe"),
+                  "1753f963bb680b28a83d6e2095f63d0d4b94244675bcd2603850b2ebc1ac6a61"),
     DirectorySource("./bundled"),
 ]
 

--- a/L/libadwaita/build_tarballs.jl
+++ b/L/libadwaita/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"1.4.0"
 
 sources = [
     ArchiveSource("https://download.gnome.org/sources/libadwaita/$(version.major).$(version.minor)/libadwaita-$(version).tar.xz",
-                  "322f3e1be39ba67981d9fe7228a85818eccaa2ed0aa42bcafe263af881c6460c"),
+                  "e51a098a54d43568218fc48fcf52e80e36f469b3ce912d8ce9c308a37e9f47c2"),
 ]
 
 # Bash recipe for building across all platforms

--- a/L/libadwaita/build_tarballs.jl
+++ b/L/libadwaita/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "libadwaita"
-version = v"1.2.0"
+version = v"1.4.0"
 
 sources = [
     ArchiveSource("https://download.gnome.org/sources/libadwaita/$(version.major).$(version.minor)/libadwaita-$(version).tar.xz",


### PR DESCRIPTION
Updates libadwaita to v1.4 and glib to 2.77.3, which are the latest stable version published by GNOME.