### PR TITLE
Convert `local_tookit` to `String` in the CUDA platform augmentation

### DIFF
--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -74,7 +74,7 @@ const augment = """
         BinaryPlatforms.set_compare_strategy!(platform, "cuda", cuda_comparison_strategy)
 
         # store the fact that we're using a local CUDA toolkit, for debugging purposes
-        platform["cuda_local"] = local_toolkit
+        platform["cuda_local"] = string(local_toolkit)
 
         return platform
     end"""


### PR DESCRIPTION
In the CUDA platform augmentation, `setindex!` fails on Julia `v1.9` because `local_toolkit` is a `Bool` instead of a `String`. This is causing the latest XGBoost to [fail](https://github.com/JuliaRegistries/General/pull/92047) on Julia `v1.9`+. I have tested this patch in [my fork](https://github.com/tylerjthomas9/XGBoost_jll.jl) of `XGBoost_jll`

This small update was from @maleadt. I just created the PR.  