### PR TITLE
[XGBoost] Recompile XGBoost to trigger new registration of v2

### DIFF
--- a/X/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/build_tarballs.jl
@@ -27,7 +27,7 @@ git submodule update --init
 (cd dmlc-core; atomic_patch -p1 "../../patches/dmlc_windows.patch")
 
 # XGBoost fails to compile on mac due to `std::make_shared`
-# being bugged with some apple clang versions
+# being bugged on apple with some clang versions 
 # https://github.com/dmlc/xgboost/issues/9601
 if [[ "${target}" == *-apple-* ]]; then
     atomic_patch -p1 "../patches/mac_make_shared.patch"


### PR DESCRIPTION
[Ref](https://github.com/JuliaPackaging/Yggdrasil/pull/7422)

`CUDA.augment` prevented the build for XGBoost_jll v2.0 from being registered. I just added a commit that changed no code in the build to push through another build of XGBoost_jllwith the patched `CUDA.augment`. 

[Here](https://github.com/JuliaRegistries/General/pull/92047) is the XGBoost_jll v2 registration with the broken import. 