### PR TITLE
[UserNSSandbox] Fix race condition

### DIFF
--- a/U/UserNSSandbox/build_tarballs.jl
+++ b/U/UserNSSandbox/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "UserNSSandbox"
-version = v"2023.08.08"
+version = v"2023.09.26"
 
 # Collection of sources required to complete build
 sources = [

--- a/U/UserNSSandbox/build_tarballs.jl
+++ b/U/UserNSSandbox/build_tarballs.jl
@@ -6,7 +6,7 @@ version = v"2023.08.08"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/staticfloat/Sandbox.jl.git",
-              "67745ce72662e61ded7cd52db7a6329dae8adf69"),
+              "a0a0950a06aeef388bbe55abaa2d0dc386c5dbe6"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
The current sandbox code has a race condition. If the child exits before the sigwait signal mask is setup, we will hang forever waiting for a signal. This has been observed in practice in Yggdrasil.