### PR TITLE
[libwebp] Bump to v1.2.4 with CVE fix

### DIFF
--- a/L/libwebp/build_tarballs.jl
+++ b/L/libwebp/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "libwebp"
-version = v"1.2.0"
+version = v"1.2.4"
 
 # Collection of sources required to build libwebp
 sources = [
-    ArchiveSource("https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-$(version).tar.gz",
-                  "2fc8bbde9f97f2ab403c0224fb9ca62b2e6852cbc519e91ceaa7c153ffd88a0c"),
+    ArchiveSource("https://chromium.googlesource.com/webm/libwebp",
+                  "8bacd63a6de1cc091f85a1692390401e7bbf55ac"),
 ]
 
 # Bash recipe for building across all platforms
@@ -28,7 +28,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libwebp/build_tarballs.jl
+++ b/L/libwebp/build_tarballs.jl
@@ -7,13 +7,13 @@ version = v"1.2.4"
 
 # Collection of sources required to build libwebp
 sources = [
-    ArchiveSource("https://chromium.googlesource.com/webm/libwebp",
+    GitSource("https://chromium.googlesource.com/webm/libwebp",
                   "8bacd63a6de1cc091f85a1692390401e7bbf55ac"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/libwebp-*/
+cd $WORKSPACE/srcdir/libwebp
 export CFLAGS="-std=c99"
 export CPPFLAGS="-I${includedir}"
 export LDFLAGS="-L${libdir}"

--- a/L/libwebp/build_tarballs.jl
+++ b/L/libwebp/build_tarballs.jl
@@ -17,6 +17,7 @@ cd $WORKSPACE/srcdir/libwebp
 export CFLAGS="-std=c99"
 export CPPFLAGS="-I${includedir}"
 export LDFLAGS="-L${libdir}"
+./autogen.sh
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --enable-swap-16bit-csp \
     --enable-experimental \


### PR DESCRIPTION
CVE reference: https://nvd.nist.gov/vuln/detail/CVE-2023-5129

Good news is that the binaries which depend on this one are not version pinned...

Wonder if the previous versions should be yanked from the registry??
