### PR TITLE
Add llvm 16 shard

### DIFF
--- a/0_RootFS/LLVMBootstrap@16/build_tarballs.jl
+++ b/0_RootFS/LLVMBootstrap@16/build_tarballs.jl
@@ -1,0 +1,16 @@
+# Include everything common between our LLVM versions (That's a lot)
+include("../llvm_common.jl")
+
+# Build the tarballs, then upload to Yggdrasil releases
+
+name = "LLVMBootstrap"
+version = v"16.0.6"
+sources, script, products, dependencies = llvm_build_args(;version=version)
+ndARGS, deploy_target = find_deploy_arg(ARGS)
+# Earlier versions of GCC can cause Clang to fail with `error: unknown target CPU 'x86-64'`
+# https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/112#issuecomment-776940748
+build_info = build_tarballs(ndARGS, name, version, sources, script, [host_platform], products, dependencies;
+                            skip_audit=true, preferred_gcc_version=v"8")
+if deploy_target !== nothing
+    upload_and_insert_shards(deploy_target, name, version, build_info)
+end

--- a/0_RootFS/LLVMBootstrap@16/bundled/libcxx_patches/0002-llvm8_libcxx_musl.patch
+++ b/0_RootFS/LLVMBootstrap@16/bundled/libcxx_patches/0002-llvm8_libcxx_musl.patch
@@ -1,0 +1,22 @@
+diff --git a/include/locale b/include/locale
+index 874866f69822..8206013a0719 100644
+--- a/include/locale
++++ b/include/locale
+@@ -758,7 +758,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end,
+         __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        long long __ll = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        long long __ll = strtoll(__a, &__p2, __base);
+         __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;
+@@ -798,7 +798,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end,
+         __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        unsigned long long __ll = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        unsigned long long __ll = strtoull(__a, &__p2, __base);
+         __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;

--- a/0_RootFS/LLVMBootstrap@16/bundled/patches/0004-enable-emutls-for-mingw.patch
+++ b/0_RootFS/LLVMBootstrap@16/bundled/patches/0004-enable-emutls-for-mingw.patch
@@ -1,0 +1,11 @@
+--- a/llvm/include/llvm/TargetParser/Triple.h
++++ b/llvm/include/llvm/TargetParser/Triple.h
+@@ -952,7 +952,7 @@
+
+   /// Tests whether the target uses emulated TLS as default.
+   bool hasDefaultEmulatedTLS() const {
+-    return isAndroid() || isOSOpenBSD() || isWindowsCygwinEnvironment();
++    return isAndroid() || isOSOpenBSD() || isOSCygMing();
+   }
+
+   /// Tests whether the target uses -data-sections as default.

--- a/0_RootFS/LLVMBootstrap@16/bundled/patches/0009-compiler-rt-build-crt-in-runtimes-build.patch
+++ b/0_RootFS/LLVMBootstrap@16/bundled/patches/0009-compiler-rt-build-crt-in-runtimes-build.patch
@@ -1,0 +1,618 @@
+From b47beecc817155fa065272ceecdf5486e2bef36e Mon Sep 17 00:00:00 2001
+From: Petr Hosek <phosek@google.com>
+Date: Wed, 28 Jun 2023 07:14:00 +0000
+Subject: [PATCH] [compiler-rt] Move crt into builtins
+
+On Linux crt is typically use in combination with builtins. In the Clang
+driver the use of builtins and crt is controlled by the --rtlib option.
+Both builtins and crt also have similar build requirements where they
+need to be built before any other runtimes and must avoid dependencies.
+We also want builtins and crt these to be buildable separately from the
+rest of compiler-rt for bootstrapping purposes. Given how simple crt is,
+rather than maintaining a separate directory with its own separate build
+setup, it's more efficient to just move crt into builtins. We still use
+separate CMake option to control whether to built crt same as before.
+
+This is an alternative to D89492 and D136664.
+
+Differential Revision: https://reviews.llvm.org/D153989
+---
+ compiler-rt/CMakeLists.txt                    |  4 -
+ compiler-rt/cmake/builtin-config-ix.cmake     | 17 ++++
+ compiler-rt/lib/CMakeLists.txt                |  4 -
+ compiler-rt/lib/builtins/CMakeLists.txt       | 52 ++++++++--
+ compiler-rt/lib/{crt => builtins}/crtbegin.c  |  0
+ compiler-rt/lib/{crt => builtins}/crtend.c    |  0
+ compiler-rt/lib/crt/CMakeLists.txt            | 63 ------------
+ compiler-rt/test/CMakeLists.txt               |  3 -
+ compiler-rt/test/builtins/CMakeLists.txt      |  4 +
+ .../test/{crt => builtins/Unit}/ctor_dtor.c   |  2 +
+ .../{crt => builtins/Unit}/dso_handle.cpp     |  6 +-
+ compiler-rt/test/builtins/Unit/lit.cfg.py     | 57 +++++++++++
+ .../test/builtins/Unit/lit.site.cfg.py.in     |  1 +
+ compiler-rt/test/crt/CMakeLists.txt           | 41 --------
+ compiler-rt/test/crt/lit.cfg.py               | 95 -------------------
+ compiler-rt/test/crt/lit.site.cfg.py.in       | 14 ---
+ 16 files changed, 129 insertions(+), 234 deletions(-)
+ rename compiler-rt/lib/{crt => builtins}/crtbegin.c (100%)
+ rename compiler-rt/lib/{crt => builtins}/crtend.c (100%)
+ delete mode 100644 compiler-rt/lib/crt/CMakeLists.txt
+ rename compiler-rt/test/{crt => builtins/Unit}/ctor_dtor.c (97%)
+ rename compiler-rt/test/{crt => builtins/Unit}/dso_handle.cpp (79%)
+ delete mode 100644 compiler-rt/test/crt/CMakeLists.txt
+ delete mode 100644 compiler-rt/test/crt/lit.cfg.py
+ delete mode 100644 compiler-rt/test/crt/lit.site.cfg.py.in
+
+diff --git a/compiler-rt/CMakeLists.txt b/compiler-rt/CMakeLists.txt
+index 6489aa17c2292ca..d004474028ab302 100644
+--- a/compiler-rt/CMakeLists.txt
++++ b/compiler-rt/CMakeLists.txt
+@@ -39,10 +39,6 @@ option(COMPILER_RT_BUILD_BUILTINS "Build builtins" ON)
+ mark_as_advanced(COMPILER_RT_BUILD_BUILTINS)
+ option(COMPILER_RT_DISABLE_AARCH64_FMV "Disable AArch64 Function Multi Versioning support" OFF)
+ mark_as_advanced(COMPILER_RT_DISABLE_AARCH64_FMV)
+-option(COMPILER_RT_BUILD_CRT "Build crtbegin.o/crtend.o" ON)
+-mark_as_advanced(COMPILER_RT_BUILD_CRT)
+-option(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY "Use eh_frame in crtbegin.o/crtend.o" ON)
+-mark_as_advanced(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY)
+ option(COMPILER_RT_BUILD_SANITIZERS "Build sanitizers" ON)
+ mark_as_advanced(COMPILER_RT_BUILD_SANITIZERS)
+ option(COMPILER_RT_BUILD_XRAY "Build xray" ON)
+diff --git a/compiler-rt/cmake/builtin-config-ix.cmake b/compiler-rt/cmake/builtin-config-ix.cmake
+index 3638cff56eb08f9..9cf4877baf48953 100644
+--- a/compiler-rt/cmake/builtin-config-ix.cmake
++++ b/compiler-rt/cmake/builtin-config-ix.cmake
+@@ -13,6 +13,11 @@ builtin_check_c_compiler_flag(-fvisibility=hidden   COMPILER_RT_HAS_VISIBILITY_H
+ builtin_check_c_compiler_flag(-fomit-frame-pointer  COMPILER_RT_HAS_OMIT_FRAME_POINTER_FLAG)
+ builtin_check_c_compiler_flag(-ffreestanding        COMPILER_RT_HAS_FFREESTANDING_FLAG)
+ builtin_check_c_compiler_flag(-fxray-instrument     COMPILER_RT_HAS_XRAY_COMPILER_FLAG)
++builtin_check_c_compiler_flag(-fno-lto              COMPILER_RT_HAS_FNO_LTO_FLAG)
++builtin_check_c_compiler_flag(-fno-profile-generate COMPILER_RT_HAS_FNO_PROFILE_GENERATE_FLAG)
++builtin_check_c_compiler_flag(-fno-profile-instr-generate COMPILER_RT_HAS_FNO_PROFILE_INSTR_GENERATE_FLAG)
++builtin_check_c_compiler_flag(-fno-profile-instr-use COMPILER_RT_HAS_FNO_PROFILE_INSTR_USE_FLAG)
++builtin_check_c_compiler_flag(-Wno-pedantic         COMPILER_RT_HAS_WNO_PEDANTIC)
+
+ builtin_check_c_compiler_source(COMPILER_RT_HAS_ATOMIC_KEYWORD
+ "
+@@ -28,6 +28,12 @@ asm(\".arch armv8-a+lse\");
+ asm(\"cas w0, w1, [x2]\");
+ ")
+
++if(ANDROID)
++  set(OS_NAME "Android")
++else()
++  set(OS_NAME "${CMAKE_SYSTEM_NAME}")
++endif()
++
+ set(ARM64 aarch64)
+ set(ARM32 arm armhf armv4t armv5te armv6 armv6m armv7m armv7em armv7 armv7s armv7k armv8m.main armv8.1m.main)
+ set(AVR avr)
+@@ -214,4 +225,10 @@ else()
+     ${ALL_BUILTIN_SUPPORTED_ARCH})
+ endif()
+
++if (OS_NAME MATCHES "Linux" AND NOT LLVM_USE_SANITIZER)
++  set(COMPILER_RT_HAS_CRT TRUE)
++else()
++  set(COMPILER_RT_HAS_CRT FALSE)
++endif()
++
+ message(STATUS "Builtin supported architectures: ${BUILTIN_SUPPORTED_ARCH}")
+diff --git a/compiler-rt/lib/CMakeLists.txt b/compiler-rt/lib/CMakeLists.txt
+index a9a5b1c10090556..43ba9a102c84871 100644
+--- a/compiler-rt/lib/CMakeLists.txt
++++ b/compiler-rt/lib/CMakeLists.txt
+@@ -17,10 +17,6 @@ if(COMPILER_RT_BUILD_BUILTINS)
+   add_subdirectory(builtins)
+ endif()
+
+-if(COMPILER_RT_BUILD_CRT)
+-  add_subdirectory(crt)
+-endif()
+-
+ function(compiler_rt_build_runtime runtime)
+   string(TOUPPER ${runtime} runtime_uppercase)
+   if(COMPILER_RT_HAS_${runtime_uppercase})
+diff --git a/compiler-rt/lib/builtins/CMakeLists.txt b/compiler-rt/lib/builtins/CMakeLists.txt
+index 66d11938d38ac7d..45d68fdc841db36 100644
+--- a/compiler-rt/lib/builtins/CMakeLists.txt
++++ b/compiler-rt/lib/builtins/CMakeLists.txt
+@@ -51,12 +51,9 @@ if (COMPILER_RT_STANDALONE_BUILD)
+ endif()
+
+ include(builtin-config-ix)
++include(CMakeDependentOption)
+ include(CMakePushCheckState)
+
+-if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+-  include(CompilerRTAIXUtils)
+-endif()
+-
+ option(COMPILER_RT_BUILTINS_HIDE_SYMBOLS
+   "Do not export any symbols from the static library." ON)
+
+@@ -690,7 +687,7 @@ set(powerpc64_SOURCES
+   ${GENERIC_SOURCES}
+ )
+ # These routines require __int128, which isn't supported on AIX.
+-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
++if (NOT OS_NAME MATCHES "AIX")
+   set(powerpc64_SOURCES
+     ppc/floattitf.c
+     ppc/fixtfti.c
+@@ -855,6 +852,8 @@ else ()
+   endforeach ()
+ endif ()
+
++add_dependencies(compiler-rt builtins)
++
+ option(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC
+   "Build standalone shared atomic library."
+   OFF)
+@@ -862,8 +861,9 @@ option(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC
+ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
+   add_custom_target(builtins-standalone-atomic)
+   set(BUILTIN_DEPS "")
+   set(BUILTIN_TYPE SHARED)
+-  if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
++  if(OS_NAME MATCHES "AIX")
++    include(CompilerRTAIXUtils)
+     if(NOT COMPILER_RT_LIBATOMIC_LINK_FLAGS)
+       get_aix_libatomic_default_link_flags(COMPILER_RT_LIBATOMIC_LINK_FLAGS
+         "${CMAKE_CURRENT_SOURCE_DIR}/ppc/atomic.exp")
+@@ -887,7 +887,7 @@ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
+   # FIXME: On AIX, we have to archive built shared libraries into a static
+   # archive, i.e., libatomic.a. Once cmake adds support of such usage for AIX,
+   # this ad-hoc part can be removed.
+-  if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
++  if(OS_NAME MATCHES "AIX")
+     archive_aix_libatomic(clang_rt.atomic libatomic
+                           ARCHS ${BUILTIN_SUPPORTED_ARCH}
+                           PARENT_TARGET builtins-standalone-atomic)
+@@ -895,4 +895,40 @@ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
+   add_dependencies(compiler-rt builtins-standalone-atomic)
+ endif()
+
+-add_dependencies(compiler-rt builtins)
++cmake_dependent_option(COMPILER_RT_BUILD_CRT "Build crtbegin.o/crtend.o" ON "COMPILER_RT_HAS_CRT" OFF)
++
++if(COMPILER_RT_BUILD_CRT)
++  add_compiler_rt_component(crt)
++
++  option(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY "Use eh_frame in crtbegin.o/crtend.o" ON)
++
++  include(CheckSectionExists)
++  check_section_exists(".init_array" COMPILER_RT_HAS_INITFINI_ARRAY
++    SOURCE "volatile int x;\n__attribute__((constructor)) void f(void) {x = 0;}\nint main(void) { return 0; }\n")
++
++  append_list_if(COMPILER_RT_HAS_STD_C11_FLAG -std=c11 CRT_CFLAGS)
++  append_list_if(COMPILER_RT_HAS_INITFINI_ARRAY -DCRT_HAS_INITFINI_ARRAY CRT_CFLAGS)
++  append_list_if(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY -DEH_USE_FRAME_REGISTRY CRT_CFLAGS)
++  append_list_if(COMPILER_RT_HAS_FPIC_FLAG -fPIC CRT_CFLAGS)
++  append_list_if(COMPILER_RT_HAS_WNO_PEDANTIC -Wno-pedantic CRT_CFLAGS)
++  if (COMPILER_RT_HAS_FCF_PROTECTION_FLAG)
++    append_list_if(COMPILER_RT_ENABLE_CET -fcf-protection=full CRT_CFLAGS)
++  endif()
++
++  foreach(arch ${BUILTIN_SUPPORTED_ARCH})
++    add_compiler_rt_runtime(clang_rt.crtbegin
++      OBJECT
++      ARCHS ${arch}
++      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtbegin.c
++      CFLAGS ${CRT_CFLAGS}
++      PARENT_TARGET crt)
++    add_compiler_rt_runtime(clang_rt.crtend
++      OBJECT
++      ARCHS ${arch}
++      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtend.c
++      CFLAGS ${CRT_CFLAGS}
++      PARENT_TARGET crt)
++  endforeach()
++
++  add_dependencies(compiler-rt crt)
++endif()
+diff --git a/compiler-rt/lib/crt/CMakeLists.txt b/compiler-rt/lib/crt/CMakeLists.txt
+deleted file mode 100644
+index 771652f438f8..000000000000
+--- a/compiler-rt/lib/crt/CMakeLists.txt
++++ /dev/null
+@@ -1,70 +0,0 @@
+-if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+-  cmake_minimum_required(VERSION 3.13.4)
+-  if ("${CMAKE_VERSION}" VERSION_LESS "3.20.0")
+-    message(WARNING
+-      "Your CMake version is ${CMAKE_VERSION}. Starting with LLVM 17.0.0, the "
+-      "minimum version of CMake required to build LLVM will become 3.20.0, and "
+-      "using an older CMake will become an error. Please upgrade your CMake to "
+-      "at least 3.20.0 now to avoid issues in the future!")
+-  endif()
+-
+-  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+-  project(CompilerRTCRT C)
+-  set(COMPILER_RT_STANDALONE_BUILD TRUE)
+-  set(COMPILER_RT_CRT_STANDALONE_BUILD TRUE)
+-
+-  set(COMPILER_RT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+-
+-  set(LLVM_COMMON_CMAKE_UTILS "${COMPILER_RT_SOURCE_DIR}/../cmake")
+-
+-  # Add path for custom modules
+-  list(INSERT CMAKE_MODULE_PATH 0
+-    "${COMPILER_RT_SOURCE_DIR}/cmake"
+-    "${COMPILER_RT_SOURCE_DIR}/cmake/Modules"
+-    "${LLVM_COMMON_CMAKE_UTILS}"
+-    "${LLVM_COMMON_CMAKE_UTILS}/Modules"
+-    )
+-
+-  include(base-config-ix)
+-  include(CompilerRTUtils)
+-
+-  load_llvm_config()
+-  construct_compiler_rt_default_triple()
+-
+-  include(SetPlatformToolchainTools)
+-  include(AddCompilerRT)
+-endif()
+-
+-include(crt-config-ix)
+-
+-if(COMPILER_RT_HAS_CRT)
+-  add_compiler_rt_component(crt)
+-
+-  include(CheckSectionExists)
+-  check_section_exists(".init_array" COMPILER_RT_HAS_INITFINI_ARRAY
+-    SOURCE "volatile int x;\n__attribute__((constructor)) void f(void) {x = 0;}\nint main(void) { return 0; }\n")
+-
+-  append_list_if(COMPILER_RT_HAS_STD_C11_FLAG -std=c11 CRT_CFLAGS)
+-  append_list_if(COMPILER_RT_HAS_INITFINI_ARRAY -DCRT_HAS_INITFINI_ARRAY CRT_CFLAGS)
+-  append_list_if(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY -DEH_USE_FRAME_REGISTRY CRT_CFLAGS)
+-  append_list_if(COMPILER_RT_HAS_FPIC_FLAG -fPIC CRT_CFLAGS)
+-  append_list_if(COMPILER_RT_HAS_WNO_PEDANTIC -Wno-pedantic CRT_CFLAGS)
+-  if (COMPILER_RT_HAS_FCF_PROTECTION_FLAG)
+-    append_list_if(COMPILER_RT_ENABLE_CET -fcf-protection=full CRT_CFLAGS)
+-  endif()
+-
+-  foreach(arch ${CRT_SUPPORTED_ARCH})
+-    add_compiler_rt_runtime(clang_rt.crtbegin
+-      OBJECT
+-      ARCHS ${arch}
+-      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtbegin.c
+-      CFLAGS ${CRT_CFLAGS}
+-      PARENT_TARGET crt)
+-    add_compiler_rt_runtime(clang_rt.crtend
+-      OBJECT
+-      ARCHS ${arch}
+-      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtend.c
+-      CFLAGS ${CRT_CFLAGS}
+-      PARENT_TARGET crt)
+-  endforeach()
+-endif()
+diff --git a/compiler-rt/test/CMakeLists.txt b/compiler-rt/test/CMakeLists.txt
+index 3106ab73e9c228a..bc37c85a140adcd 100644
+--- a/compiler-rt/test/CMakeLists.txt
++++ b/compiler-rt/test/CMakeLists.txt
+@@ -103,9 +103,6 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
+   if(COMPILER_RT_BUILD_ORC)
+     compiler_rt_Test_runtime(orc)
+   endif()
+-  if(COMPILER_RT_BUILD_CRT)
+-    add_subdirectory(crt)
+-  endif()
+   # ShadowCallStack does not yet provide a runtime with compiler-rt, the tests
+   # include their own minimal runtime
+   add_subdirectory(shadowcallstack)
+diff --git a/compiler-rt/test/builtins/CMakeLists.txt b/compiler-rt/test/builtins/CMakeLists.txt
+index 466a715dbbcfe01..2d0cc24ac6e746d 100644
+--- a/compiler-rt/test/builtins/CMakeLists.txt
++++ b/compiler-rt/test/builtins/CMakeLists.txt
+@@ -13,6 +13,10 @@ configure_lit_site_cfg(
+
+ include(builtin-config-ix)
+
++if (COMPILER_RT_HAS_CRT)
++  list(APPEND BUILTINS_TEST_DEPS crt)
++endif()
++
+ # Indicate if this is an MSVC environment.
+ pythonize_bool(MSVC)
+
+diff --git a/compiler-rt/test/crt/ctor_dtor.c b/compiler-rt/test/builtins/Unit/ctor_dtor.c
+similarity index 97%
+rename from compiler-rt/test/crt/ctor_dtor.c
+rename to compiler-rt/test/builtins/Unit/ctor_dtor.c
+index 2bea05073b4d2ab..2fdd2f7bea23758 100644
+--- a/compiler-rt/test/crt/ctor_dtor.c
++++ b/compiler-rt/test/builtins/Unit/ctor_dtor.c
+@@ -1,3 +1,5 @@
++// REQUIRES: linux
++
+ // RUN: %clang -fno-use-init-array -g -c %s -o %t.o
+ // RUN: %clang -o %t -no-pie -nostdlib %crt1 %crti %crtbegin %t.o -lc %libgcc %crtend %crtn
+ // RUN: %run %t 2>&1 | FileCheck %s
+diff --git a/compiler-rt/test/crt/dso_handle.cpp b/compiler-rt/test/builtins/Unit/dso_handle.cpp
+similarity index 79%
+rename from compiler-rt/test/crt/dso_handle.cpp
+rename to compiler-rt/test/builtins/Unit/dso_handle.cpp
+index 46d36531386a8a8..00c54915c816658 100644
+--- a/compiler-rt/test/crt/dso_handle.cpp
++++ b/compiler-rt/test/builtins/Unit/dso_handle.cpp
+@@ -1,5 +1,7 @@
+-// RUN: %clangxx -g -DCRT_SHARED -c %s -fPIC -o %tshared.o
+-// RUN: %clangxx -g -c %s -fPIC -o %t.o
++// REQUIRES: linux
++
++// RUN: %clangxx -g -fno-exceptions -DCRT_SHARED -c %s -fPIC -o %tshared.o
++// RUN: %clangxx -g -fno-exceptions -c %s -fPIC -o %t.o
+ // RUN: %clangxx -g -shared -o %t.so -nostdlib %crti %crtbegin %tshared.o %libstdcxx -lc -lm %libgcc %crtend %crtn
+ // RUN: %clangxx -g -o %t -fno-pic -no-pie -nostdlib %crt1 %crti %crtbegin %t.o %libstdcxx -lc -lm %libgcc %t.so %crtend %crtn
+ // RUN: %run %t 2>&1 | FileCheck %s
+diff --git a/compiler-rt/test/builtins/Unit/lit.cfg.py b/compiler-rt/test/builtins/Unit/lit.cfg.py
+index fa6dc86783d3..a531175ba8e9 100644
+--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
++++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
+@@ -2,6 +2,8 @@
+
+ import os
+ import platform
++import shlex
++import subprocess
+
+ import lit.formats
+
+@@ -25,6 +27,40 @@ def get_required_attr(config, attr_name):
+       "to lit.site.cfg.py " % attr_name)
+   return attr_value
+
++def get_library_path(file):
++    cmd = subprocess.Popen(
++        [config.clang.strip(), "-print-file-name=%s" % file]
++        + shlex.split(config.target_cflags),
++        stdout=subprocess.PIPE,
++        env=config.environment,
++        universal_newlines=True,
++    )
++    if not cmd.stdout:
++        lit_config.fatal("Couldn't find the library path for '%s'" % file)
++    dir = cmd.stdout.read().strip()
++    if sys.platform in ["win32"] and execute_external:
++        # Don't pass dosish path separator to msys bash.exe.
++        dir = dir.replace("\\", "/")
++    return dir
++
++
++def get_libgcc_file_name():
++    cmd = subprocess.Popen(
++        [config.clang.strip(), "-print-libgcc-file-name"]
++        + shlex.split(config.target_cflags),
++        stdout=subprocess.PIPE,
++        env=config.environment,
++        universal_newlines=True,
++    )
++    if not cmd.stdout:
++        lit_config.fatal("Couldn't find the library path for '%s'" % file)
++    dir = cmd.stdout.read().strip()
++    if sys.platform in ["win32"] and execute_external:
++        # Don't pass dosish path separator to msys bash.exe.
++        dir = dir.replace("\\", "/")
++    return dir
++
++
+ # Setup config name.
+ config.name = 'Builtins' + config.name_suffix
+
+@@ -51,6 +87,27 @@ else:
+     base_lib = base_lib.replace('\\', '/')
+   config.substitutions.append( ("%librt ", base_lib + ' -lc -lm ') )
+
++  if config.host_os == "Linux":
++      base_obj = os.path.join(
++          config.compiler_rt_libdir, "clang_rt.%%s%s.o" % config.target_suffix
++      )
++      if sys.platform in ["win32"] and execute_external:
++          # Don't pass dosish path separator to msys bash.exe.
++          base_obj = base_obj.replace("\\", "/")
++
++      config.substitutions.append(("%crtbegin", base_obj % "crtbegin"))
++      config.substitutions.append(("%crtend", base_obj % "crtend"))
++
++      config.substitutions.append(("%crt1", get_library_path("crt1.o")))
++      config.substitutions.append(("%crti", get_library_path("crti.o")))
++      config.substitutions.append(("%crtn", get_library_path("crtn.o")))
++
++      config.substitutions.append(("%libgcc", get_libgcc_file_name()))
++
++      config.substitutions.append(
++          ("%libstdcxx", "-l" + config.sanitizer_cxx_lib.lstrip("lib"))
++      )
++
+ builtins_source_dir = os.path.join(
+   get_required_attr(config, "compiler_rt_src_root"), "lib", "builtins")
+ if sys.platform in ['win32'] and execute_external:
+diff --git a/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in b/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in
+index e55dd5d51f3dce0..920c915feb08b6d 100644
+--- a/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in
++++ b/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in
+@@ -4,6 +4,7 @@ config.name_suffix = "@BUILTINS_TEST_CONFIG_SUFFIX@"
+ config.builtins_lit_source_dir = "@BUILTINS_LIT_SOURCE_DIR@/Unit"
+ config.target_cflags = "@BUILTINS_TEST_TARGET_CFLAGS@"
+ config.target_arch = "@BUILTINS_TEST_TARGET_ARCH@"
++config.sanitizer_cxx_lib = "@SANITIZER_TEST_CXX_LIBNAME@"
+ config.is_msvc = @MSVC_PYBOOL@
+ config.builtins_is_msvc = @BUILTINS_IS_MSVC_PYBOOL@
+ config.builtins_lit_source_features = "@BUILTINS_LIT_SOURCE_FEATURES@"
+diff --git a/compiler-rt/test/crt/CMakeLists.txt b/compiler-rt/test/crt/CMakeLists.txt
+deleted file mode 100644
+index f539be34f6ca2cf..000000000000000
+--- a/compiler-rt/test/crt/CMakeLists.txt
++++ /dev/null
+@@ -1,41 +0,0 @@
+-include(crt-config-ix)
+-
+-if (COMPILER_RT_HAS_CRT)
+-  set(CRT_LIT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+-
+-  if(NOT COMPILER_RT_STANDALONE_BUILD)
+-    list(APPEND CRT_TEST_DEPS crt)
+-  endif()
+-  if(NOT COMPILER_RT_STANDALONE_BUILD AND NOT LLVM_RUNTIMES_BUILD)
+-    # Use LLVM utils and Clang from the same build tree.
+-    list(APPEND CRT_TEST_DEPS
+-      clang clang-resource-headers FileCheck not llvm-config)
+-  endif()
+-
+-  set(CRT_TEST_ARCH ${CRT_SUPPORTED_ARCH})
+-  foreach(arch ${CRT_TEST_ARCH})
+-    set(CRT_TEST_TARGET_ARCH ${arch})
+-    string(TOLOWER "-${arch}-${OS_NAME}" CRT_TEST_CONFIG_SUFFIX)
+-    get_test_cc_for_arch(${arch} CRT_TEST_TARGET_CC CRT_TEST_TARGET_CFLAGS)
+-    string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-    set(CONFIG_NAME ${ARCH_UPPER_CASE}${OS_NAME}Config)
+-
+-    if (COMPILER_RT_ENABLE_CET)
+-      if (${arch} MATCHES "i386|x86_64")
+-        list(APPEND CRT_TEST_TARGET_CFLAGS -fcf-protection=full)
+-        string(REPLACE ";" " " CRT_TEST_TARGET_CFLAGS "${CRT_TEST_TARGET_CFLAGS}")
+-      else()
+-        message(FATAL_ERROR "The target arch ${arch} doesn't support CET")
+-      endif()
+-    endif()
+-    configure_lit_site_cfg(
+-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg.py)
+-    list(APPEND CRT_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME})
+-  endforeach()
+-
+-  add_lit_testsuite(check-crt "Running the CRT tests"
+-    ${CRT_TESTSUITES}
+-    DEPENDS ${CRT_TEST_DEPS})
+-  set_target_properties(check-crt PROPERTIES FOLDER "Compiler-RT Misc")
+-endif()
+diff --git a/compiler-rt/test/crt/lit.cfg.py b/compiler-rt/test/crt/lit.cfg.py
+deleted file mode 100644
+index d5a6aa9862d9..000000000000
+--- a/compiler-rt/test/crt/lit.cfg.py
++++ /dev/null
+@@ -1,95 +0,0 @@
+-# -*- Python -*-
+-
+-import os
+-import subprocess
+-import shlex
+-
+-# Setup config name.
+-config.name = 'CRT' + config.name_suffix
+-
+-# Setup source root.
+-config.test_source_root = os.path.dirname(__file__)
+-
+-
+-# Choose between lit's internal shell pipeline runner and a real shell.  If
+-# LIT_USE_INTERNAL_SHELL is in the environment, we use that as an override.
+-use_lit_shell = os.environ.get("LIT_USE_INTERNAL_SHELL")
+-if use_lit_shell:
+-    # 0 is external, "" is default, and everything else is internal.
+-    execute_external = (use_lit_shell == "0")
+-else:
+-    # Otherwise we default to internal on Windows and external elsewhere, as
+-    # bash on Windows is usually very slow.
+-    execute_external = (not sys.platform in ['win32'])
+-
+-def get_library_path(file):
+-    cmd = subprocess.Popen([config.clang.strip(),
+-                            '-print-file-name=%s' % file] +
+-                           shlex.split(config.target_cflags),
+-                           stdout=subprocess.PIPE,
+-                           env=config.environment,
+-                           universal_newlines=True)
+-    if not cmd.stdout:
+-      lit_config.fatal("Couldn't find the library path for '%s'" % file)
+-    dir = cmd.stdout.read().strip()
+-    if sys.platform in ['win32'] and execute_external:
+-        # Don't pass dosish path separator to msys bash.exe.
+-        dir = dir.replace('\\', '/')
+-    return dir
+-
+-
+-def get_libgcc_file_name():
+-    cmd = subprocess.Popen([config.clang.strip(),
+-                            '-print-libgcc-file-name'] +
+-                           shlex.split(config.target_cflags),
+-                           stdout=subprocess.PIPE,
+-                           env=config.environment,
+-                           universal_newlines=True)
+-    if not cmd.stdout:
+-      lit_config.fatal("Couldn't find the library path for '%s'" % file)
+-    dir = cmd.stdout.read().strip()
+-    if sys.platform in ['win32'] and execute_external:
+-        # Don't pass dosish path separator to msys bash.exe.
+-        dir = dir.replace('\\', '/')
+-    return dir
+-
+-
+-def build_invocation(compile_flags):
+-    return ' ' + ' '.join([config.clang] + compile_flags) + ' '
+-
+-
+-# Setup substitutions.
+-config.substitutions.append(
+-    ('%clang ', build_invocation([config.target_cflags])))
+-config.substitutions.append(
+-    ('%clangxx ',
+-     build_invocation(config.cxx_mode_flags + [config.target_cflags])))
+-
+-base_lib = os.path.join(
+-    config.compiler_rt_libdir, "clang_rt.%%s%s.o" % config.target_suffix)
+-
+-if sys.platform in ['win32'] and execute_external:
+-    # Don't pass dosish path separator to msys bash.exe.
+-    base_lib = base_lib.replace('\\', '/')
+-
+-config.substitutions.append(('%crtbegin', base_lib % "crtbegin"))
+-config.substitutions.append(('%crtend', base_lib % "crtend"))
+-
+-config.substitutions.append(
+-    ('%crt1', get_library_path('crt1.o')))
+-config.substitutions.append(
+-    ('%crti', get_library_path('crti.o')))
+-config.substitutions.append(
+-    ('%crtn', get_library_path('crtn.o')))
+-
+-config.substitutions.append(
+-    ('%libgcc', get_libgcc_file_name()))
+-
+-config.substitutions.append(
+-    ('%libstdcxx', '-l' + config.sanitizer_cxx_lib.lstrip('lib')))
+-
+-# Default test suffixes.
+-config.suffixes = ['.c', '.cpp']
+-
+-if config.host_os not in ['Linux']:
+-    config.unsupported = True
+diff --git a/compiler-rt/test/crt/lit.site.cfg.py.in b/compiler-rt/test/crt/lit.site.cfg.py.in
+deleted file mode 100644
+index 53eda0c45948b71..000000000000000
+--- a/compiler-rt/test/crt/lit.site.cfg.py.in
++++ /dev/null
+@@ -1,14 +0,0 @@
+-@LIT_SITE_CFG_IN_HEADER@
+-
+-# Tool-specific config options.
+-config.name_suffix = "@CRT_TEST_CONFIG_SUFFIX@"
+-config.crt_lit_source_dir = "@CRT_LIT_SOURCE_DIR@"
+-config.target_cflags = "@CRT_TEST_TARGET_CFLAGS@"
+-config.target_arch = "@CRT_TEST_TARGET_ARCH@"
+-config.sanitizer_cxx_lib = "@SANITIZER_TEST_CXX_LIBNAME@"
+-
+-# Load common config for all compiler-rt lit tests
+-lit_config.load_config(config, "@COMPILER_RT_BINARY_DIR@/test/lit.common.configured")
+-
+-# Load tool-specific config that would do the real work.
+-lit_config.load_config(config, "@CRT_LIT_SOURCE_DIR@/lit.cfg.py")
+diff --git a/compiler-rt/lib/crt/crtbegin.c b/compiler-rt/lib/builtins/crtbegin.c
+similarity index 100%
+rename from compiler-rt/lib/crt/crtbegin.c
+rename to compiler-rt/lib/builtins/crtbegin.c
+diff --git a/compiler-rt/lib/crt/crtend.c b/compiler-rt/lib/builtins/crtend.c
+similarity index 100%
+rename from compiler-rt/lib/crt/crtend.c
+rename to compiler-rt/lib/builtins/crtend.c

--- a/0_RootFS/LLVMBootstrap@16/bundled/patches/0010-add-musl-triples.patch
+++ b/0_RootFS/LLVMBootstrap@16/bundled/patches/0010-add-musl-triples.patch
@@ -1,0 +1,57 @@
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 4f2340316654..e2e835243e74 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2218,7 +2218,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
+   static const char *const AArch64Triples[] = {
+       "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
+-      "aarch64-suse-linux"};
++      "aarch64-suse-linux", "aarch64-linux-musl"};
+   static const char *const AArch64beLibDirs[] = {"/lib"};
+   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
+                                                  "aarch64_be-linux-gnu"};
+@@ -2229,6 +2229,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+                                              "armv7hl-redhat-linux-gnueabi",
+                                              "armv6hl-suse-linux-gnueabi",
+                                              "armv7hl-suse-linux-gnueabi"};
++  static const char *const ARMHFMuslTriples[] = {"arm-linux-musleabihf", "armv7l-linux-musleabihf",
++                                            "armv6l-linux-musleabihf"};
+   static const char *const ARMebLibDirs[] = {"/lib"};
+   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi"};
+   static const char *const ARMebHFTriples[] = {
+@@ -2248,7 +2250,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "x86_64-redhat-linux",    "x86_64-suse-linux",
+       "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
+       "x86_64-slackware-linux", "x86_64-unknown-linux",
+-      "x86_64-amazon-linux"};
++      "x86_64-amazon-linux",  "x86_64-linux-musl"};
+   static const char *const X32Triples[] = {"x86_64-linux-gnux32",
+                                            "x86_64-pc-linux-gnux32"};
+   static const char *const X32LibDirs[] = {"/libx32", "/lib"};
+@@ -2257,6 +2259,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "i586-linux-gnu",      "i686-linux-gnu",        "i686-pc-linux-gnu",
+       "i386-redhat-linux6E", "i686-redhat-linux",     "i386-redhat-linux",
+       "i586-suse-linux",     "i686-montavista-linux", "i686-gnu",
++      "i686-linux-musl"
+   };
+
+   static const char *const LoongArch64LibDirs[] = {"/lib64", "/lib"};
+@@ -2462,6 +2465,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     LibDirs.append(begin(ARMLibDirs), end(ARMLibDirs));
+     if (TargetTriple.getEnvironment() == llvm::Triple::GNUEABIHF) {
+       TripleAliases.append(begin(ARMHFTriples), end(ARMHFTriples));
++    } else if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++      TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
+     } else {
+       TripleAliases.append(begin(ARMTriples), end(ARMTriples));
+     }
+@@ -2471,6 +2476,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     LibDirs.append(begin(ARMebLibDirs), end(ARMebLibDirs));
+     if (TargetTriple.getEnvironment() == llvm::Triple::GNUEABIHF) {
+       TripleAliases.append(begin(ARMebHFTriples), end(ARMebHFTriples));
++    } else if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++      TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
+     } else {
+       TripleAliases.append(begin(ARMebTriples), end(ARMebTriples));
+     }

--- a/0_RootFS/LLVMBootstrap@16/bundled/patches/0100-llvm-13-musl-bb.patch
+++ b/0_RootFS/LLVMBootstrap@16/bundled/patches/0100-llvm-13-musl-bb.patch
@@ -1,0 +1,24 @@
+From f1901de14ff1f1abcc729c4adccfbd5017e30357 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 7 May 2021 13:54:41 -0400
+Subject: [PATCH] [Compiler-RT] Fix compilation on musl
+
+---
+ compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp                    | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+index b87798603fda..452a08aafe0e 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+@@ -26,6 +26,7 @@
+ 
+ #include <cassert>
+ #include <cstdint>
++#include <stddef.h>
+ #include <dlfcn.h> // for dlsym()
+ 
+ static void *getFuncAddr(const char *name, uintptr_t wrapper_addr) {
+-- 
+2.31.1
+

--- a/0_RootFS/LLVMBootstrap@16/bundled/patches/install-prefix.patch
+++ b/0_RootFS/LLVMBootstrap@16/bundled/patches/install-prefix.patch
@@ -1,0 +1,31 @@
+starting from llvm14 the install prefix breaks via symlinks;
+/usr/lib/llvm14/lib/cmake/llvm/LLVMConfig.cmake goes up 3 directories to find
+/usr/lib/llvm14/include as LLVM_INCLUDE_DIRS, but to even use this cmake folder
+at all it has to be symlinked to /usr/lib/cmake/llvm .. so the directory it
+instead uses is just /usr/include, which is not where the cmake includes are.
+this hardcodes them to the install prefix we pass via cmake, which should
+always be correct, and what cmake tries to autodetect anyway.
+
+also see: https://reviews.llvm.org/D29969
+
+this is supposedly fixed now, but for some reason it still isn't
+--- a/llvm/cmake/modules/CMakeLists.txt
++++ b/llvm/cmake/modules/CMakeLists.txt
+@@ -41,6 +41,8 @@
+ #
+
+ set(LLVM_CONFIG_CODE "
++# this is wrong when automatically detected
++set(LLVM_INSTALL_PREFIX \"${CMAKE_INSTALL_PREFIX}\")
+ # LLVM_BUILD_* values available only from LLVM build tree.
+ set(LLVM_BUILD_BINARY_DIR \"${LLVM_BINARY_DIR}\")
+ set(LLVM_BUILD_LIBRARY_DIR \"${LLVM_LIBRARY_DIR}\")
+@@ -109,8 +111,6 @@
+ #
+ # Generate LLVMConfig.cmake for the install tree.
+ #
+-
+-find_prefix_from_config(LLVM_CONFIG_CODE LLVM_INSTALL_PREFIX "${LLVM_INSTALL_PACKAGE_DIR}")
+
+ extend_path(LLVM_CONFIG_MAIN_INCLUDE_DIR "\${LLVM_INSTALL_PREFIX}" "${CMAKE_INSTALL_INCLUDEDIR}")
+ # This is the same as the above because the handwritten and generated headers

--- a/0_RootFS/LLVMBootstrap@16/bundled/patches/normalize-cmake-triple.patch
+++ b/0_RootFS/LLVMBootstrap@16/bundled/patches/normalize-cmake-triple.patch
@@ -1,0 +1,102 @@
+diff --git a/cmake/Modules/HandleOutOfTreeLLVM.cmake b/cmake/Modules/HandleOutOfTreeLLVM.cmake
+index edffe572e091..ea7f3aab7e8a 100644
+--- a/cmake/Modules/HandleOutOfTreeLLVM.cmake
++++ b/cmake/Modules/HandleOutOfTreeLLVM.cmake
+@@ -32,6 +32,21 @@ message(STATUS "Configuring for standalone build.")
+ include(GetHostTriple)
+ get_host_triple(LLVM_INFERRED_HOST_TRIPLE)
+ set(LLVM_HOST_TRIPLE "${LLVM_INFERRED_HOST_TRIPLE}" CACHE STRING "Host on which LLVM binaries will run")
++#NOTE: we must normalize specified target triple to a fully specified triple,
++# including the vendor part. It is necessary to synchronize the runtime library
++# installation path and operable target triple by Clang to get a correct runtime
++# path through `-print-runtime-dir` Clang option.
++string(REPLACE "-" ";" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++list(LENGTH LLVM_HOST_TRIPLE LLVM_HOST_TRIPLE_LEN)
++if (LLVM_HOST_TRIPLE_LEN LESS 3)
++  message(FATAL_ERROR "invalid target triple")
++endif()
++# We suppose missed vendor's part.
++if (LLVM_HOST_TRIPLE_LEN LESS 4)
++  list(INSERT LLVM_HOST_TRIPLE 1 "unknown")
++endif()
++string(REPLACE ";" "-" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++
+ set(LLVM_DEFAULT_TARGET_TRIPLE "${LLVM_HOST_TRIPLE}" CACHE STRING "Target triple used by default.")
+
+ # Add LLVM Functions --------------------------------------------------------
+diff --git a/llvm/cmake/config-ix.cmake b/llvm/cmake/config-ix.cmake
+index b78c1b34ab8b..d3786c3ea611 100644
+--- a/llvm/cmake/config-ix.cmake
++++ b/llvm/cmake/config-ix.cmake
+@@ -446,6 +446,21 @@ get_host_triple(LLVM_INFERRED_HOST_TRIPLE)
+ set(LLVM_HOST_TRIPLE "${LLVM_INFERRED_HOST_TRIPLE}" CACHE STRING
+     "Host on which LLVM binaries will run")
+
++  #NOTE: we must normalize specified target triple to a fully specified triple,
++  # including the vendor part. It is necessary to synchronize the runtime library
++  # installation path and operable target triple by Clang to get a correct runtime
++  # path through `-print-runtime-dir` Clang option.
++string(REPLACE "-" ";" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++list(LENGTH LLVM_HOST_TRIPLE LLVM_HOST_TRIPLE_LEN)
++if (LLVM_HOST_TRIPLE_LEN LESS 3)
++  message(FATAL_ERROR "invalid target triple")
++endif()
++# We suppose missed vendor's part.
++if (LLVM_HOST_TRIPLE_LEN LESS 4)
++  list(INSERT LLVM_HOST_TRIPLE 1 "unknown")
++endif()
++string(REPLACE ";" "-" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++
+ # Determine the native architecture.
+ string(TOLOWER "${LLVM_TARGET_ARCH}" LLVM_NATIVE_ARCH)
+ if( LLVM_NATIVE_ARCH STREQUAL "host" )
+diff --git a/llvm/cmake/modules/SetTargetTriple.cmake b/llvm/cmake/modules/SetTargetTriple.cmake
+index ed0a53ca3ec9..8485c5f1c354 100644
+--- a/llvm/cmake/modules/SetTargetTriple.cmake
++++ b/llvm/cmake/modules/SetTargetTriple.cmake
+@@ -8,6 +8,20 @@ macro(set_llvm_target_triple)
+   else()
+     set(LLVM_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
+   endif()
++  #NOTE: we must normalize specified target triple to a fully specified triple,
++# including the vendor part. It is necessary to synchronize the runtime library
++# installation path and operable target triple by Clang to get a correct runtime
++# path through `-print-runtime-dir` Clang option.
++string(REPLACE "-" ";" LLVM_TARGET_TRIPLE "${LLVM_TARGET_TRIPLE}")
++list(LENGTH LLVM_TARGET_TRIPLE LLVM_TARGET_TRIPLE_LEN)
++if (LLVM_TARGET_TRIPLE_LEN LESS 3)
++  message(FATAL_ERROR "invalid target triple")
++endif()
++# We suppose missed vendor's part.
++if (LLVM_TARGET_TRIPLE_LEN LESS 4)
++  list(INSERT LLVM_TARGET_TRIPLE 1 "unknown")
++endif()
++string(REPLACE ";" "-" LLVM_TARGET_TRIPLE "${LLVM_TARGET_TRIPLE}")
+   message(STATUS "LLVM host triple: ${LLVM_HOST_TRIPLE}")
+   message(STATUS "LLVM default target triple: ${LLVM_DEFAULT_TARGET_TRIPLE}")
+ endmacro()
+diff --git a/runtimes/CMakeLists.txt b/runtimes/CMakeLists.txt
+index 50f782205ab4..7c6006d7946a 100644
+--- a/runtimes/CMakeLists.txt
++++ b/runtimes/CMakeLists.txt
+@@ -161,6 +161,21 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter)
+ # Host triple is used by tests to check if they are running natively.
+ include(GetHostTriple)
+ get_host_triple(LLVM_HOST_TRIPLE)
++#NOTE: we must normalize specified target triple to a fully specified triple,
++# including the vendor part. It is necessary to synchronize the runtime library
++# installation path and operable target triple by Clang to get a correct runtime
++# path through `-print-runtime-dir` Clang option.
++string(REPLACE "-" ";" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++list(LENGTH LLVM_HOST_TRIPLE LLVM_HOST_TRIPLE_LEN)
++if (LLVM_HOST_TRIPLE_LEN LESS 3)
++  message(FATAL_ERROR "invalid target triple")
++endif()
++# We suppose missed vendor's part.
++if (LLVM_HOST_TRIPLE_LEN LESS 4)
++  list(INSERT LLVM_HOST_TRIPLE 1 "unknown")
++endif()
++string(REPLACE ";" "-" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++
+ set(LLVM_DEFAULT_TARGET_TRIPLE "${LLVM_HOST_TRIPLE}" CACHE STRING
+   "Default target for which the runtimes will be built.")

--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -52,7 +52,7 @@ function llvm_script(;version = v"8.0.1", llvm_build_type = "Release", kwargs...
     """ *
     raw"""
     apk update
-    apk add build-base python3 python3-dev linux-headers musl-dev zlib-dev musl-dev
+    apk add build-base python3 python3-dev linux-headers musl-dev zlib-dev
 
     # We need the XML2, iconv, Zlib libraries in our LLVMBootstrap artifact,
     # and we also need them in target-prefixed directories, so they stick

--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -33,6 +33,7 @@ llvm_tags = Dict(
     v"11.0.1" => "43ff75f2c3feef64f9d73328230d34dac8832a91",
     v"12.0.0" => "d28af7c654d8db0b68c175db5ce212d74fb5e9bc",
     v"13.0.1" => "75e33f71c2dae584b13a7d1186ae0a038ba98838",
+    v"16.0.6" => "7cbf1a2591520c2491aa35339f227775f4d3adf6",
 )
 
 function llvm_sources(;version = "v8.0.1", kwargs...)
@@ -51,7 +52,7 @@ function llvm_script(;version = v"8.0.1", llvm_build_type = "Release", kwargs...
     """ *
     raw"""
     apk update
-    apk add build-base python3 python3-dev linux-headers musl-dev zlib-dev
+    apk add build-base python3 python3-dev linux-headers musl-dev zlib-dev musl-dev
 
     # We need the XML2, iconv, Zlib libraries in our LLVMBootstrap artifact,
     # and we also need them in target-prefixed directories, so they stick
@@ -77,7 +78,36 @@ function llvm_script(;version = v"8.0.1", llvm_build_type = "Release", kwargs...
 
     cd ${WORKSPACE}/srcdir/llvm-project
     # Apply all our patches
+    if [ -d $WORKSPACE/srcdir/llvm_patches ]; then
+    for f in $WORKSPACE/srcdir/llvm_patches/*.patch; do
+        echo "Applying patch ${f}"
+        atomic_patch -p1 ${f}
+    done
+    fi
+    if [ -d $WORKSPACE/srcdir/clang_patches ]; then
+    cd ${WORKSPACE}/srcdir/llvm-project/clang
+    for f in $WORKSPACE/srcdir/clang_patches/*.patch; do
+        echo "Applying patch ${f}"
+        atomic_patch -p1 ${f}
+    done
+    fi
+    if [ -d $WORKSPACE/srcdir/crt_patches ]; then
+    cd ${WORKSPACE}/srcdir/llvm-project/compiler-rt
+    for f in $WORKSPACE/srcdir/crt_patches/*.patch; do
+        echo "Applying patch ${f}"
+        atomic_patch -p1 ${f}
+    done
+    fi
+    if [ -d $WORKSPACE/srcdir/libcxx_patches ]; then
+    cd ${WORKSPACE}/srcdir/llvm-project/libcxx
+    for f in $WORKSPACE/srcdir/libcxx_patches/*.patch; do
+        echo "Applying patch ${f}"
+        atomic_patch -p1 ${f}
+    done
+    fi
+    # Patches from the monorepo
     if [ -d $WORKSPACE/srcdir/patches ]; then
+    cd ${WORKSPACE}/srcdir/llvm-project
     for f in $WORKSPACE/srcdir/patches/*.patch; do
         echo "Applying patch ${f}"
         atomic_patch -p1 ${f}
@@ -97,7 +127,10 @@ function llvm_script(;version = v"8.0.1", llvm_build_type = "Release", kwargs...
     CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=${LLVM_BUILD_TYPE})
 
     # We want a lot of projects
-    CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;libcxx;libcxxabi;libunwind;polly')
+    CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='clang;polly;lld')
+
+    # Build runtimes
+    CMAKE_FLAGS+=(-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind')
 
     # We want a build with no bindings
     CMAKE_FLAGS+=(-DLLVM_BINDINGS_LIST=)


### PR DESCRIPTION
LLVM changed the way runtimes are built, and that big patch is needed because otherwise the build fails. There is also https://reviews.llvm.org/D140925 which will replace [normalize-cmake-triple.patch](https://github.com/JuliaPackaging/Yggdrasil/compare/gb/new-llvm-boot?expand=1#diff-6ecca0277e7bf3d27fe870887a8fb45c4593a8b6614291eaab310b0c9c00cf0d)