### PR TITLE
[P4est] Enable OpenMPI

### DIFF
--- a/P/P4est/build_tarballs.jl
+++ b/P/P4est/build_tarballs.jl
@@ -78,8 +78,8 @@ platforms = filter(p -> !(Sys.iswindows(p) && nbits(p) == 32), platforms)
 platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.2.1")
 
 # Disable OpenMPI since it doesn't build. This could probably be fixed
-# via more explicit MPI configuraiton options.
-platforms = filter(p -> p["mpi"] ≠ "openmpi", platforms)
+# via more explicit MPI configuraton options.
+# platforms = filter(p -> p["mpi"] ≠ "openmpi", platforms)
 
 # Avoid platforms where the MPI implementation isn't supported
 # OpenMPI

--- a/P/P4est/build_tarballs.jl
+++ b/P/P4est/build_tarballs.jl
@@ -77,10 +77,6 @@ platforms = filter(p -> !(Sys.iswindows(p) && nbits(p) == 32), platforms)
 
 platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.2.1")
 
-# Disable OpenMPI since it doesn't build. This could probably be fixed
-# via more explicit MPI configuraton options.
-# platforms = filter(p -> p["mpi"] ≠ "openmpi", platforms)
-
 # Avoid platforms where the MPI implementation isn't supported
 # OpenMPI
 platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)


### PR DESCRIPTION
Currently, OpenMPI is disabled for P4est_jll.