### PR TITLE
[LLVMCompilerRT] Update to v16.0.6

### DIFF
--- a/L/LLVMCompilerRT/build_tarballs.jl
+++ b/L/LLVMCompilerRT/build_tarballs.jl
@@ -3,12 +3,16 @@
 using BinaryBuilder
 
 name = "LLVMCompilerRT"
-version = v"13.0.1"
+version = v"16.0.6"
 
 sources = [
     ArchiveSource(
         "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/compiler-rt-$(version).src.tar.xz",
-        "7b33955031f9a9c5d63077dedb0f99d77e4e7c996266952c1cec55626dca5dfc"
+        "7911a2a9cca10393a17f637c01a6f5555b0a38f64ff47dc9168413a4190bc2db"
+    ),
+    ArchiveSource(
+        "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/cmake-$(version).src.tar.xz",
+        "39d342a4161095d2f28fb1253e4585978ac50521117da666e2b1f6f28b62f514"
     ),
     DirectorySource("./bundled"),
 ]
@@ -35,6 +39,18 @@ fi
 EOF
     chmod +x /usr/libexec/PlistBuddy
 
+    # Create official Apple-blessed `xcrun`
+    cat > $(which xcrun) << EOF
+#!/bin/bash
+if [[ "\${@}" == *"--show-sdk-path"* ]]; then
+   echo /opt/${target}/${target}/sys-root
+elif [[ "\${@}" == *"--show-sdk-version"* ]]; then
+   echo 10.12
+else
+   exec "\${@}"
+fi
+EOF
+
     # We use could use `${MACOSX_DEPLOYMENT_TARGET}` to specify the SDK version, but it's
     # set to 10.10 on x86_64, but compiler-rt requires at least 10.12 and we actually use
     # 10.12.  On aarch64 it's 11.0, but the CMake script doesn't seem to like values greater
@@ -49,10 +65,15 @@ mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_MODULE_PATH=$(realpath ../../cmake-*.src/Modules) \
+    -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=${target} \
+    -DCMAKE_LIBTOOL=$(which libtool) \
     "${FLAGS[@]}" \
     ..
 make -j${nproc}
 make install
+
+install_license ../LICENSE.TXT
 """
 
 # These are the platforms we will build for by default, unless further
@@ -62,7 +83,7 @@ platforms = supported_platforms()
 # some packages on aarch64-apple-darwin, so there is little need to spend time on getting
 # this to build for _all_ platforms.  The long-term plan is to have these libraries as part
 # of LLVMBootstrap: https://github.com/JuliaPackaging/Yggdrasil/pull/1681
-filter!(p -> arch(p) != "powerpc64le" && !(BinaryBuilder.proc_family(p) == "intel" && libc(p) == "musl"), platforms)
+filter!(p -> arch(p) == "aarch64" && Sys.isapple(p), platforms)
 
 # The products that we will ensure are always built
 products = LibraryProduct[

--- a/L/LLVMCompilerRT/bundled/patches/do-not-codesign.patch
+++ b/L/LLVMCompilerRT/bundled/patches/do-not-codesign.patch
@@ -1,11 +1,19 @@
 --- a/cmake/Modules/AddCompilerRT.cmake
 +++ b/cmake/Modules/AddCompilerRT.cmake
-@@ -370,7 +370,7 @@
-         # Ad-hoc sign the dylibs
-         add_custom_command(TARGET ${libname}
-           POST_BUILD  
--          COMMAND codesign --sign - $<TARGET_FILE:${libname}>
-+          # COMMAND codesign --sign - $<TARGET_FILE:${libname}>
-           WORKING_DIRECTORY ${COMPILER_RT_OUTPUT_LIBRARY_DIR}
-         )
+@@ -420,11 +420,11 @@
+           endif()
+         endif()
+         if (NEED_EXPLICIT_ADHOC_CODESIGN)
+-          add_custom_command(TARGET ${libname}
+-            POST_BUILD
+-            COMMAND codesign --sign - $<TARGET_FILE:${libname}>
+-            WORKING_DIRECTORY ${COMPILER_RT_OUTPUT_LIBRARY_DIR}
+-          )
++          # add_custom_command(TARGET ${libname}
++          #   POST_BUILD
++          #   COMMAND codesign --sign - $<TARGET_FILE:${libname}>
++          #   WORKING_DIRECTORY ${COMPILER_RT_OUTPUT_LIBRARY_DIR}
++          # )
+         endif()
        endif()
+     endif()


### PR DESCRIPTION
This took way longer than I'd like to admit, but I should be able to build `libclang_rt.osx.a` for `aarch64-apple-darwin` (needed for the symbol `__divdc3`)