### PR TITLE
[P4est] disable OpenMPI again

### DIFF
--- a/P/P4est/build_tarballs.jl
+++ b/P/P4est/build_tarballs.jl
@@ -77,6 +77,10 @@ platforms = filter(p -> !(Sys.iswindows(p) && nbits(p) == 32), platforms)
 
 platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.2.1")
 
+# Disable OpenMPI since the build is broken. This could probably be fixed
+# via more explicit MPI configuration options.
+platforms = filter(p -> p["mpi"] ≠ "openmpi", platforms)
+
 # Avoid platforms where the MPI implementation isn't supported
 # OpenMPI
 platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)


### PR DESCRIPTION
Enabling OpenMPI for P4est.jl in #7500 was breaking the JLL, see e.g. https://github.com/trixi-framework/P4est.jl/pull/88. As a hot fix, we first revert the change and disable OpenMPI again.

cc @ranocha, @sloede 