### PR TITLE
[CUDA_Runtime] only add include_dependency if version not specified

### DIFF
--- a/C/CUDA/CUDA_Runtime/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Runtime/platform_augmentation.jl
@@ -280,5 +280,3 @@ function augment_platform!(platform::Platform)
 
     return platform
 end
-
-const cuda_toolkits = VersionNumber[v"11.4.4", v"11.5.2", v"11.6.2", v"11.7.1", v"11.8.0", v"12.0.1", v"12.1.1", v"12.2.2"]

--- a/C/CUDA/CUDA_Runtime/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Runtime/platform_augmentation.jl
@@ -86,6 +86,7 @@ function get_runtime_version()
         return nothing
     end
     @debug "Found CUDA runtime library at '$cuda_runtime'"
+
     # minimal API call wrappers we need
     function cudaRuntimeGetVersion(library_handle)
         function_handle = Libdl.dlsym(library_handle, "cudaRuntimeGetVersion"; throw_error=false)

--- a/C/CUDA/CUDA_Runtime/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Runtime/platform_augmentation.jl
@@ -4,23 +4,6 @@ using Base: thismajor, thisminor
 
 using Libdl
 
-# platform augmentation hooks run in an ill-defined environment, where:
-# - CUDA_Driver_jll may not be available
-# - the wrong version of CUDA_Driver_jll may be available
-#
-# because of that, we need to be very careful about using that dependency.
-# currently, we support all existing versions of CUDA_Driver_jll, but if we
-# ever need to introduce a breaking change, we'll need some way to identify
-# the version of CUDA_Driver_jll from its module (e.g. a global constant).
-#
-# ref: https://github.com/JuliaLang/Pkg.jl/issues/3225
-try
-    using CUDA_Driver_jll
-catch err
-    # we'll handle this below
-end
-
-# can't use Preferences for the same reason
 const CUDA_Runtime_jll_uuid = Base.UUID("76a88914-d11a-5bdc-97e0-2f5a05c973a2")
 const preferences = Base.get_preferences(CUDA_Runtime_jll_uuid)
 Base.record_compiletime_preference(CUDA_Runtime_jll_uuid, "version")
@@ -47,6 +30,7 @@ elseif haskey(preferences, "version") && preferences["version"] == "local"
 else
     missing
 end
+
 function parse_version_preference(key)
     if haskey(preferences, key)
         if isa(preferences[key], String)
@@ -71,6 +55,45 @@ const version_preference = if haskey(preferences, "version") && preferences["ver
     parse_version_preference("actual_version")
 else
     parse_version_preference("version")
+end
+
+if ismissing(version_preference)
+    # before loading CUDA_Driver_jll, try to find out where the system driver is located.
+    let
+        name = if Sys.iswindows()
+            Libdl.find_library("nvcuda")
+        else
+            Libdl.find_library(["libcuda.so.1", "libcuda.so"])
+        end
+
+        # if we've found a system driver, put a dependency on it,
+        # so that we get recompiled if the driver changes.
+        if name != ""
+            handle = Libdl.dlopen(name)
+            path = Libdl.dlpath(handle)
+            Libdl.dlclose(handle)
+
+            @debug "Adding include dependency on $path"
+            Base.include_dependency(path)
+        end
+    end
+end
+
+# platform augmentation hooks run in an ill-defined environment, where:
+# - CUDA_Driver_jll may not be available
+# - the wrong version of CUDA_Driver_jll may be available
+#
+# because of that, we need to be very careful about using that dependency.
+# currently, we support all existing versions of CUDA_Driver_jll, but if we
+# ever need to introduce a breaking change, we'll need some way to identify
+# the version of CUDA_Driver_jll from its module (e.g. a global constant).
+#
+# ref: https://github.com/JuliaLang/Pkg.jl/issues/3225
+# can't use Preferences for the same reason
+try
+    using CUDA_Driver_jll
+catch err
+    # we'll handle this below
 end
 
 # get the version of the local CUDA toolkit by querying the system libcudart
@@ -110,9 +133,6 @@ function get_runtime_version()
         @debug "Failed to load CUDA runtime library"
         return nothing
     end
-    runtime_path = Libdl.dlpath(runtime_handle)
-    @debug "Adding include dependency on $runtime_path"
-    Base.include_dependency(runtime_path)
 
     cudaRuntimeGetVersion(runtime_handle)
 end
@@ -179,9 +199,6 @@ function get_driver_version()
         @debug "Failed to load CUDA driver"
         return nothing
     end
-    driver_path = Libdl.dlpath(driver_handle)
-    @debug "Adding include dependency on $driver_path"
-    Base.include_dependency(driver_path)
 
     cuDriverGetVersion(driver_handle)
 end


### PR DESCRIPTION
We were hitting an issue where precompiling on a node with a GPU driver installed would then retrigger precompilation when used on a non-GPU node.

This should avoid the problem when the CUDA runtime version is concretely specified

cc @maleadt @vchuravy 