### PR TITLE
[SCOTCH] Delete libptesmumps on all platforms

### DIFF
--- a/S/SCOTCH/build_tarballs.jl
+++ b/S/SCOTCH/build_tarballs.jl
@@ -32,7 +32,8 @@ CC=${CC_BUILD} cmake .. \
     -DBUILD_PTSCOTCH=OFF \
     -DCMAKE_BUILD_TYPE=Release
 
-make -j${nproc}
+# make -j${nproc}
+make
 
 cd ${WORKSPACE}/srcdir/scotch*
 mkdir build
@@ -63,15 +64,17 @@ CFLAGS=$FLAGS cmake .. \
     -DBUILD_DUMMYSIZES=OFF \
     -DINSTALL_METIS_HEADERS=OFF
 
-make -j${nproc}
-# make install
+# make -j${nproc}
+make
 
+# make install
 if [[ "${target}" == *mingw* ]]; then
     rm bin/libptesmumps.dll
     rm lib/libptesmumps.dll.a
     cp bin/*.dll $libdir
     cp lib/*.dll.a $prefix/lib
 else
+    rm lib/libptesmumps.$dlext
     cp lib/*.${dlext} $libdir
 fi
 cd src/include


### PR DESCRIPTION
We will be able to compile PTSCOTCH 7.0.4 after that :crossed_fingers: 