### PR TITLE
[picotool] Add picotool_jll

### DIFF
--- a/P/picotool/build_tarballs.jl
+++ b/P/picotool/build_tarballs.jl
@@ -14,6 +14,8 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/picotool/
+cp udev/99-picotool.rules $prefix/99-picotool.rules
+install_license LICENSE.TXT
 mkdir build
 cd build
 PICO_SDK_PATH=$WORKSPACE/srcdir/pico-sdk cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" -DCMAKE_BUILD_TYPE=Release ..
@@ -23,11 +25,12 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude=!Sys.islinux)
+platforms = supported_platforms(; exclude= p -> !Sys.islinux(p) || libc(p) == "musl")
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("picotool", :picotool)
+    ExecutableProduct("picotool", :picotool),
+    FileProduct("99-picotool.rules", :pico_udev)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/P/picotool/build_tarballs.jl
+++ b/P/picotool/build_tarballs.jl
@@ -25,7 +25,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude= p -> !Sys.islinux(p))
+platforms = supported_platforms(; exclude= p -> !Sys.islinux(p) || libc(p) == "musl")
 
 # The products that we will ensure are always built
 products = [

--- a/P/picotool/build_tarballs.jl
+++ b/P/picotool/build_tarballs.jl
@@ -18,14 +18,14 @@ cp udev/99-picotool.rules $prefix/99-picotool.rules
 install_license LICENSE.TXT
 mkdir build
 cd build
-PICO_SDK_PATH=$WORKSPACE/srcdir/pico-sdk cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" -DCMAKE_BUILD_TYPE=Release ..
+PICO_SDK_PATH=$WORKSPACE/srcdir/pico-sdk cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" -DCMAKE_BUILD_TYPE=Release ..
 make
 make install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude= p -> !Sys.islinux(p) || libc(p) == "musl")
+platforms = supported_platforms(; exclude= p -> !Sys.islinux(p))
 
 # The products that we will ensure are always built
 products = [

--- a/P/picotool/build_tarballs.jl
+++ b/P/picotool/build_tarballs.jl
@@ -1,0 +1,39 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "picotool"
+version = v"1.1.2"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/raspberrypi/picotool.git", "f6fe6b7c321a2def8950d2a440335dfba19e2eab"),
+    GitSource("https://github.com/raspberrypi/pico-sdk.git", "6a7db34ff63345a7badec79ebea3aaef1712f374")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/picotool/
+mkdir build
+cd build
+PICO_SDK_PATH=$WORKSPACE/srcdir/pico-sdk cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" -DCMAKE_BUILD_TYPE=Release ..
+make
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; exclude=!Sys.islinux)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("picotool", :picotool)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="libusb_jll", uuid="a877fdc9-fe69-5ed6-b93d-11ecd0dc2d49"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"13")


### PR DESCRIPTION
This is for building the [`picotool`](https://github.com/raspberrypi/picotool) binary, a program used to flash & inspect the Raspberry Pi family of microcontrollers.

The binary is linked statically with libstdc & libstdc++, because _apparently_ their SDK can only be built with GCC13, and pretty much noone is going to already have that around. For my purposes, this will (likely) be good enough.

For future reference, the flags for linking came from [here](https://github.com/arduino/rp2040tools/blob/d6e368bde164286b24a6b647f4a78d49622af457/.github/workflows/release.yml#L77-L91).