### PR TITLE
Trilinos: Add one more patch for missing windows exports

### DIFF
--- a/T/Trilinos/build_tarballs.jl
+++ b/T/Trilinos/build_tarballs.jl
@@ -56,6 +56,7 @@ atomic_patch -p1 $WORKSPACE/srcdir/patches/kokkostpl.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/tekoepetraguard.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/teuchoswinexport.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/teuchoswinexport2.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/teuchoswinexport3.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/stratikimosnotpetra.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/muslunistd.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/muslmallinfo.patch

--- a/T/Trilinos/bundled/patches/teuchoswinexport3.patch
+++ b/T/Trilinos/bundled/patches/teuchoswinexport3.patch
@@ -1,0 +1,19 @@
+commit 7abc99081dc1abf45c162c99d344419deff79cfa
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Sun Oct 15 01:31:52 2023 +0000
+
+    One more missing teuchos windows export
+
+diff --git a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+index d228f2b5545..9019282f803 100644
+--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
++++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+@@ -218,7 +218,7 @@ protected:
+  * timer.report(std::cout); // dump to screen
+  *
+  */
+-class StackedTimer
++class TEUCHOSCOMM_LIB_DLL_EXPORT StackedTimer
+ {
+ protected:
+ 


### PR DESCRIPTION
Should hopefully allow the windows build of #7383 to go through.