### PR TITLE
[platforms] Add CUDA_SDK_static as an optional dependency in the generator

### DIFF
--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -153,20 +153,27 @@ function is_supported(platform)
 end
 
 """
-    required_dependencies(platform)
+    required_dependencies(platform; static_sdk=false)
 
 Return a list of dependencies required to build and use CUDA artifacts for a given platform.
+Optionally include the CUDA static libraries with `static_sdk` for toolchains that require them.
 """
-function required_dependencies(platform)
+function required_dependencies(platform; static_sdk=false)
     dependencies = Dependency[]
     if !haskey(tags(platform), "cuda") || tags(platform)["cuda"] == "none"
         return BinaryBuilder.AbstractDependency[]
     end
     release = VersionNumber(tags(platform)["cuda"])
-    return BinaryBuilder.AbstractDependency[
+    deps = BinaryBuilder.AbstractDependency[
         BuildDependency(PackageSpec(name="CUDA_SDK_jll", version=CUDA.full_version(release))),
         RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll"))
     ]
+
+    if static_sdk
+        push!(deps, BuildDependency(PackageSpec(name="CUDA_SDK_static_jll", version=CUDA.full_version(release))))
+    end
+
+    return deps
 end
 
 end


### PR DESCRIPTION
This will allow easy addition of the static libraries when using the platform dependency generator, since the consuming build_tarballs can just do `CUDA.required_dependencies(platform, static_sdk=true)` instead of having to build the `BuildDependency` themselves.

@maleadt, this look good to you?