### PR TITLE
oneAPI: Revert NEO bump, but enable PVC support.

### DIFF
--- a/N/NEO/build_tarballs.jl
+++ b/N/NEO/build_tarballs.jl
@@ -7,12 +7,12 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "NEO"
-version = v"23.30.26918"#.9
+version = v"23.17.26241"#.22
 
 # Collection of sources required to build this package.
 sources = [
     GitSource("https://github.com/intel/compute-runtime.git",
-              "6d516e54b2c3d920e371f8622980fa911621fa59"),
+              "0bb5b3408e6cb61b477e7cad296fd278b11e73be"),
 ]
 
 # Bash recipe for building across all platforms
@@ -84,8 +84,8 @@ products = [
 #       https://github.com/intel/compute-runtime/blob/master/manifests/manifest.yml.
 dependencies = [
     Dependency("gmmlib_jll"; compat="=22.3.0"),
-    Dependency("libigc_jll"; compat="=1.0.14828"),
-    Dependency("oneAPI_Level_Zero_Headers_jll", v"1.7.0"; compat="1.7.0"),
+    Dependency("libigc_jll"; compat="=1.0.13822"),
+    Dependency("oneAPI_Level_Zero_Headers_jll", v"1.6.3"; compat="1.5.8"),
 ]
 
 augment_platform_block = raw"""


### PR DESCRIPTION
The new version is broken.

This partially reverts commit 59c0a69f980a670482559924b49ce444c9fdf827.