### PR TITLE
update utf8proc to 2.9.0

### DIFF
--- a/U/utf8proc/build_tarballs.jl
+++ b/U/utf8proc/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder
 
 name = "utf8proc"
-version = v"2.8.0"
+version = v"2.9.0"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/JuliaStrings/utf8proc.git",
-              "1cb28a66ca79a0845e99433fd1056257456cef8b"),
+              "34db3f7954e9298e89f42641ac78e0450f80a70d"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Support for Unicode 15.1 (https://github.com/JuliaStrings/utf8proc/pull/253), used in Julia 1.11 (https://github.com/JuliaLang/julia/pull/51799).