### PR TITLE
oneAPI: Bump JLLs again.

### DIFF
--- a/L/libigc/build_tarballs.jl
+++ b/L/libigc/build_tarballs.jl
@@ -7,7 +7,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "libigc"
-version = v"1.0.13822"#.6
+version = v"1.0.14828"#.8
 
 # IGC depends on LLVM, a custom Clang, and a Khronos tool. Instead of building these pieces
 # separately, taking care to match versions and apply Intel-specific patches where needed
@@ -27,13 +27,13 @@ version = v"1.0.13822"#.6
 #       see https://github.com/intel/intel-graphics-compiler/blob/master/.github/workflows/build-IGC.yml
 #
 sources = [
-    GitSource("https://github.com/intel/intel-graphics-compiler.git", "aab3aac4f2e19f18db4a704002f08b41a2d2fff3"),
-    GitSource("https://github.com/intel/opencl-clang.git", "10237c7109d613ef1161065d140b76d92133062f" #= branch ocl-open-110 =#),
-    GitSource("https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git", "9a87ea4b0f2f9d5c505e2dcd20fbab01df12f599" #= branch llvm_release_110 =#),
+    GitSource("https://github.com/intel/intel-graphics-compiler.git", "2cfe79aac5ff74a4c278950caa1e7cbc20c57e70"),
+    GitSource("https://github.com/intel/opencl-clang.git", "cf95b338d14685e4f3402ab1828bef31d48f1fd6" #= branch ocl-open-140 =#),
+    GitSource("https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git", "23f398bf369093b1fd67459db8071ffcc6b92658" #= branch llvm_release_140 =#),
     GitSource("https://github.com/KhronosGroup/SPIRV-Tools.git", "63de608daeb7e91fbea6d7477a50debe7cac57ce" #= tag sdk-1.3.239.0 =#),
     GitSource("https://github.com/KhronosGroup/SPIRV-Headers.git", "d13b52222c39a7e9a401b44646f0ca3a640fbd47" #= tag sdk-1.3.239.0 =#),
-    GitSource("https://github.com/intel/vc-intrinsics.git", "cd3aecca329ecd41deab45e8a715fa555fc61bac" #= latest version: v0.12.3 =#),
-    GitSource("https://github.com/llvm/llvm-project.git", "1fdec59bffc11ae37eb51a1b9869f0696bfd5312" #= branch llvmorg-11.1.0 =#),
+    GitSource("https://github.com/intel/vc-intrinsics.git", "fe92a377338258b725cfbd0a1bd49a9cf5e2864c" #= latest version: v0.13.0 =#),
+    GitSource("https://github.com/llvm/llvm-project.git", "c12386ae247c0d46e1d513942e322e3a0510b126" #= branch llvmorg-14.0.5 =#),
     # patches
     DirectorySource("./bundled"),
 ]

--- a/N/NEO/build_tarballs.jl
+++ b/N/NEO/build_tarballs.jl
@@ -7,12 +7,12 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "NEO"
-version = v"23.17.26241"#.22
+version = v"23.30.26918"#.9
 
 # Collection of sources required to build this package.
 sources = [
     GitSource("https://github.com/intel/compute-runtime.git",
-              "0bb5b3408e6cb61b477e7cad296fd278b11e73be"),
+              "6d516e54b2c3d920e371f8622980fa911621fa59"),
 ]
 
 # Bash recipe for building across all platforms
@@ -84,8 +84,8 @@ products = [
 #       https://github.com/intel/compute-runtime/blob/master/manifests/manifest.yml.
 dependencies = [
     Dependency("gmmlib_jll"; compat="=22.3.0"),
-    Dependency("libigc_jll"; compat="=1.0.13822"),
-    Dependency("oneAPI_Level_Zero_Headers_jll", v"1.6.3"; compat="1.5.8"),
+    Dependency("libigc_jll"; compat="=1.0.14828"),
+    Dependency("oneAPI_Level_Zero_Headers_jll", v"1.7.0"; compat="1.7.0"),
 ]
 
 augment_platform_block = raw"""


### PR DESCRIPTION
Now that the platform augmentations are fixed (we were accidentally selecting debug artifacts with assertions enabled), let's try bumping again.