### PR TITLE
[librdkafka] rebuild with freebsd support

### DIFF
--- a/L/librdkafka/build_tarballs.jl
+++ b/L/librdkafka/build_tarballs.jl
@@ -9,6 +9,7 @@ version = v"2.3.0"
 sources = [
     # git rev-list -n 1 v2.3.0
     GitSource("https://github.com/confluentinc/librdkafka.git", "95a542c87c61d2c45b445f91c73dd5442eb04f3c",),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
@@ -19,8 +20,12 @@ if [[ "${target}" != *-freebsd* ]]; then
     rm -f /opt/${target}/${target}/sys-root/usr/lib/libssl.*
     rm -f /opt/${target}/${target}/sys-root/usr/lib/libsasl2.*
 fi
+
+atomic_patch -p1 ../patches/bsd_posix.patch
+
 mkdir build
 cd build/
+
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
@@ -33,7 +38,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = expand_cxxstring_abis(supported_platforms(exclude = Sys.isfreebsd))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 
 # The products that we will ensure are always built

--- a/L/librdkafka/bundled/patches/bsd_posix.patch
+++ b/L/librdkafka/bundled/patches/bsd_posix.patch
@@ -1,0 +1,17 @@
+diff --git a/src/rd.h b/src/rd.h
+index fd6c307f..7a7984d4 100644
+--- a/src/rd.h
++++ b/src/rd.h
+@@ -40,10 +40,12 @@
+ #endif
+ 
+ #define __need_IOV_MAX
++#if !defined(__FreeBSD__)
+ #ifndef _POSIX_C_SOURCE
+ #define _POSIX_C_SOURCE 200809L /* for timespec on solaris */
+ #endif
+ #endif
++#endif
+ 
+ #include <stdio.h>
+ #include <stdlib.h>


### PR DESCRIPTION
So the reason for the build failure seems to be that librdkafka [defines](https://github.com/confluentinc/librdkafka/blob/95a542c87c61d2c45b445f91c73dd5442eb04f3c/src/rd.h#L44) `_POSIX_C_SOURCE` everywhere except windows:
```
#ifndef _POSIX_C_SOURCE
#define _POSIX_C_SOURCE 200809L /* for timespec on solaris */
#endif
```

But this define causes FreeBSD to hide various other defines, including `gettimeofday` and `alloca` (via `__XSI_VISIBLE` and `__BSD_VISIBLE`). We probably need to end up in the default block here to have these available: https://github.com/freebsd/freebsd-src/blob/61b15e6dfc963a0c67dbaeae7f4590674976111f/sys/sys/cdefs.h#L765

PS: The logs from the previous jll version (2.0.3) contain:
```
/workspace/srcdir/librdkafka/src/rdtime.h:118:9: warning: implicit declaration of function 'gettimeofday' is invalid in C99 [-Wimplicit-function-declaration]
        rd_gettimeofday(&tv, NULL);
        ^
/workspace/srcdir/librdkafka/src/rdposix.h:155:33: note: expanded from macro 'rd_gettimeofday'
#define rd_gettimeofday(tv, tz) gettimeofday(tv, tz)
                                ^
/workspace/srcdir/librdkafka/src/rdkafka_metadata.c:1353:18: warning: implicitly declaring library function 'alloca' with type 'void *(unsigned long)' [-Wimplicit-function-declaration]
        topics = rd_alloca(sizeof(*topics) * topic_cnt);
                 ^
/workspace/srcdir/librdkafka/src/rdposix.h:73:22: note: expanded from macro 'rd_alloca'
#define rd_alloca(N) alloca(N)
                     ^
/workspace/srcdir/librdkafka/src/rdkafka_metadata.c:1353:18: note: include the header <stdlib.h> or explicitly provide a declaration for 'alloca'
/workspace/srcdir/librdkafka/src/rdposix.h:73:22: note: expanded from macro 'rd_alloca'
#define rd_alloca(N) alloca(N)
                     ^
2 warnings generated.
```
Same issues but non-fatal, so I guess this was also broken for FreeBSD?

x-ref: #7574
cc: @bluesmoon 