### PR TITLE
[MicrosoftMPI] Update mpif.h

### DIFF
--- a/M/MicrosoftMPI/build_tarballs.jl
+++ b/M/MicrosoftMPI/build_tarballs.jl
@@ -47,6 +47,9 @@ mv *.txt *.rtf share/licenses/MicrosoftMPI
 cd $includedir
 gfortran -I. ../src/mpi.f90 -fsyntax-only -fno-range-check
 
+# Replace an unknown character in mpif.h by a space
+sed -i '/Copyright Notice/!b;n;c!    + 2002 University of Chicago' mpif.h
+
 ################################################################################
 # Install MPIconstants
 ################################################################################


### PR DESCRIPTION
The header file `mpif.h` provided by `MicrosoftMPI` contains a special character that breaks the compilation of a project with the Meson build system because it is unable to read this character.
I checked the file `mpi.h` and they replaced already this character by a normal space.

I suppose that the number of users of `MicrosoftMPI` for Fortran projects is quite small...