### PR TITLE
[libjulia] build new nightly for Memory changes, bump 1.10 to rc1

### DIFF
--- a/L/libjulia/build_tarballs.jl
+++ b/L/libjulia/build_tarballs.jl
@@ -31,7 +31,7 @@ function Pkg.Types.is_stdlib(uuid::Base.UUID, julia_version::VersionNumber)
     return false
 end
 
-jllversion=v"1.10.6"
+jllversion=v"1.10.7"
 for ver in julia_full_versions
     build_julia(ARGS, ver; jllversion)
 end


### PR DESCRIPTION
This is needed to rebuild libcxxwrap (+ maybe more) for the latest julia nightly, see https://github.com/JuliaInterop/libcxxwrap-julia/pull/137.

I bumped the preferred gcc to version 9 for julia 1.11. Older versions (7 and 8) crash in the bfloat instrinsics on `aarch64-linux-{gnu,musl}`:
```
sandbox:${WORKSPACE}/srcdir/julia/src #  aarch64-linux-gnu-gcc -fasynchronous-unwind-tables -fno-tree-tail-merge -DSYSTEM_LIBUNWIND -DSYSTEM_LLVM -DJULIA_NUM_THREADS=1 -DJL_USE_INTEL_JITEVENTS -DJL_USE_PERF_JITEVENTS -std=gnu11 -pipe -fPIC -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -fno-gnu-unique -DSYSTEM_LIBUNWIND -I/workspace/destdir/include -Wold-style-definition -Wstrict-prototypes -Wc++-compat  -O3 -ggdb2 -falign-functions -D_GNU_SOURCE -I. -I/workspace/srcdir/julia/src -I/workspace/srcdir/julia/src/flisp -I/workspace/srcdir/julia/src/support -I/workspace/destdir/include -I/workspace/srcdir/julia/usr/include -I/workspace/srcdir/julia/deps/valgrind -Wall -Wno-strict-aliasing -fno-omit-frame-pointer -fvisibility=hidden -fno-common -Wno-comment -Wpointer-arith -Wundef -Wno-unused-result -DJL_BUILD_ARCH='"aarch64"' -DJL_BUILD_UNAME='"Linux"' -I -DLLVM_SHLIB "-DJL_SYSTEM_IMAGE_PATH=\"../lib/julia/sys.so\"" "-DJL_LIBJULIA_SONAME=\"libjulia.so.1.11\"" -DJL_LIBRARY_EXPORTS_INTERNAL -DNDEBUG -DJL_NDEBUG -c /workspace/srcdir/julia/src/runtime_intrinsics.c -o runtime_intrinsics.o
/workspace/srcdir/julia/src/runtime_intrinsics.c: In function ‘jl_copysign_float’:
/workspace/srcdir/julia/src/runtime_intrinsics.c:813:11: internal compiler error: Segmentation fault
     float R = OP(A, B); \
           ^
/workspace/srcdir/julia/src/runtime_intrinsics.c:1262:5: note: in expansion of macro ‘bi_intrinsic_bfloa ’
     bi_intrinsic_bfloat(OP, name) \
     ^~~~~~~~~~~~~~~~~~~
/workspace/srcdir/julia/src/runtime_intrinsics.c:1667:1: note: in expansion of macro ‘bi_fintrinsic’
 bi_fintrinsic(copysign_float,copysign_float)
 ^~~~~~~~~~~~~
0x9ee476 crash_signal
        /workspace/srcdir/gcc-7.1.0/gcc/toplev.c:337
0x14e752a491de ???
        /workspace/srcdir/musl-1.2.2/src/signal/x86_64/restore.s:1
Please submit a full bug report,
with preprocessed source if appropriate.
Please include the complete backtrace with any bug report.
See <https://gcc.gnu.org/bugs/> for instructions.
```

Also bumped a few dependencies according to the julia deps for 1.11.

_Edit:_ Reverted to bfd linker for julia 1.6 on freebsd due to slightly wrong old libraries.

cc: @fingolfin @barche 