### PR TITLE
[Ipopt] Upgrade to version 3.14.3

### DIFF
--- a/C/Coin-OR/Ipopt/build_tarballs.jl
+++ b/C/Coin-OR/Ipopt/build_tarballs.jl
@@ -45,7 +45,7 @@ fi
     --disable-dependency-tracking \
     lt_cv_deplibs_check_method=pass_all \
     --with-lapack-lflags="-L${libdir} ${LBT}" \
-    --with-mumps-cflags="-I${includedir}" \
+    --with-mumps-cflags="-I${includedir}/libseq" \
     --with-mumps-lflags="-L${libdir} -ldmumps" \
     --with-spral-cflags="-I${includedir}" \
     --with-spral-lflags="-L${libdir} -lspral" \

--- a/C/Coin-OR/Ipopt/build_tarballs.jl
+++ b/C/Coin-OR/Ipopt/build_tarballs.jl
@@ -41,7 +41,6 @@ fi
     --build=${MACHTYPE} \
     --host=${target} \
     --enable-shared \
-    --enable-static \
     --with-pic \
     --disable-dependency-tracking \
     lt_cv_deplibs_check_method=pass_all \

--- a/C/Coin-OR/Ipopt/build_tarballs.jl
+++ b/C/Coin-OR/Ipopt/build_tarballs.jl
@@ -86,5 +86,6 @@ build_tarballs(
     products,
     dependencies;
     preferred_gcc_version = gcc_version,
+    preferred_llvm_version = llvm_version,
     julia_compat = "1.9"
 )

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -20,6 +20,9 @@ end
 # GCC version for building the whole system
 gcc_version = v"8.1.0"
 
+# LLVM version for building the whole system
+llvm_version = v"13.0.1"
+
 # Versions of various COIN-OR libraries
 
 Bonmin_upstream_version = v"1.8.9"
@@ -78,8 +81,8 @@ ASL_version = v"0.1.3"
 METIS_version = v"5.1.2"
 MUMPS_seq_version = v"5.4.1"
 MUMPS_seq_version_LBT = v"500.600.200"
-SPRAL_version_LBT = v"2023.09.07"
-OpenBLAS32_version = v"0.3.24"
+SPRAL_version_LBT = v"2023.11.15"
+OpenBLAS32_version = v"0.3.25"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -18,7 +18,7 @@ function offset_version(upstream, offset)
 end
 
 # GCC version for building the whole system
-gcc_version = v"8"
+gcc_version = v"8.1.0"
 
 # Versions of various COIN-OR libraries
 
@@ -46,8 +46,8 @@ CoinUtils_version = offset_version(v"2.11.6", v"0.0.0")
 CoinUtils_gitsha = "26e9639ed9897e13e89169870dbe910296a9783b"
 
 Ipopt_upstream_version = v"3.14.13"
-Ipopt_gitsha = "1e0a5df94e3b71ce6bde972352f1b2f72f342af7"
-Ipopt_verson_offset = v"0.0.2"
+Ipopt_gitsha = "4262e538feb1909036cecf9d8720454896cdc23c"
+Ipopt_verson_offset = v"0.0.3"
 Ipopt_version = offset_version(Ipopt_upstream_version, Ipopt_verson_offset)
 
 ALPS_upstream_version = v"1.5.7"
@@ -77,9 +77,9 @@ Julia_compat_version = "1.6"
 ASL_version = v"0.1.3"
 METIS_version = v"5.1.2"
 MUMPS_seq_version = v"5.4.1"
-MUMPS_seq_version_LBT = v"500.600.100"
-SPRAL_version_LBT = v"2023.8.2"
-OpenBLAS32_version = v"0.3.21"
+MUMPS_seq_version_LBT = v"500.600.200"
+SPRAL_version_LBT = v"2023.09.07"
+OpenBLAS32_version = v"0.3.24"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line


### PR DESCRIPTION
I also removed the static library `libipopt.a` to reduce the size of the tarballs.