### PR TITLE
[SCS] update to 3.2.4 and fix dependencies of SCS_GPU and SCS_MKL

### DIFF
--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -1,11 +1,11 @@
 using BinaryBuilder
 
 name = "SCS"
-version = v"3.2.3"
+version = v"3.2.4"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "f0c23340da03bcd663072dc4a90cf1aab8968c61")
+    GitSource("https://github.com/cvxgrp/scs.git", "9024b8ccc1bba6ee797440fb22354cadb9c81839")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -40,7 +40,6 @@ products = [
 
 dependencies = [
     Dependency("OpenBLAS32_jll", v"0.3.10"),
-    Dependency("CUDA_jll"),
 ]
 
 for platform in platforms

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -41,7 +41,6 @@ products = [
 dependencies = [
     Dependency("OpenBLAS32_jll", v"0.3.10"),
     Dependency("CUDA_jll"),
-    Dependency("SCS_jll"; compat = "=$version"),
 ]
 
 for platform in platforms

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -6,11 +6,11 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "SCS_GPU"
-version = v"3.2.3"
+version = v"3.2.4"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "f5f054be7dd71ee0d80c4c0eec0df1e9f0ccb123")
+    GitSource("https://github.com/cvxgrp/scs.git", "9024b8ccc1bba6ee797440fb22354cadb9c81839")
 ]
 
 # Bash recipe for building across all platforms
@@ -39,7 +39,9 @@ products = [
 ]
 
 dependencies = [
-    Dependency("OpenBLAS32_jll", v"0.3.10")
+    Dependency("OpenBLAS32_jll", v"0.3.10"),
+    Dependency("CUDA_jll"),
+    Dependency("SCS_jll"; compat = "=$version"),
 ]
 
 for platform in platforms

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -39,7 +39,6 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(;name="MKL_jll", version=v"2023.1")),
-    Dependency("SCS_jll"; compat = "=$version"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -2,11 +2,11 @@ using Pkg
 using BinaryBuilder
 
 name = "SCS_MKL"
-version = v"3.2.3"
+version = v"3.2.4"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "f0c23340da03bcd663072dc4a90cf1aab8968c61")
+    GitSource("https://github.com/cvxgrp/scs.git", "9024b8ccc1bba6ee797440fb22354cadb9c81839")
 ]
 
 # Bash recipe for building across all platforms
@@ -38,7 +38,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(;name="MKL_jll", version=v"2023.1")),
+    Dependency(PackageSpec(;name="MKL_jll", version=v"2023.1")),
+    Dependency("SCS_jll"; compat = "=$version"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well


### PR DESCRIPTION
cc @kalmarek 

SCS.jl currently has an unusual setup for lazy loading.

It has a package dependency on `SCS_GPU_jll` and `SCS_MKL_jll`:
https://github.com/jump-dev/SCS.jl/blob/e24ac32e585357a584c379eec41a601fb93b7cb9/Project.toml#L18-L19
and then lazily loads them using `Requires` if `CUDA_jll` or `MKL_jll` is loaded:
https://github.com/jump-dev/SCS.jl/blob/e24ac32e585357a584c379eec41a601fb93b7cb9/src/SCS.jl#L17-L36

This is back-to-front. The `SCS_xxx_jll` packages should have dependencies on CUDA_jll and MKL_jll, and the user should load them via `using SCS_GPU_jll`, not `using CUDA_jll`.

I think this design was chosen in the olde-times so that we wouldn't have to download the heavy CUDA_jll or MKL_jll, and so that we could also enforce strict compat bounds on which versions were supported.

My work-around is to add `SCS_jll` as a dependency, so that SCS.jl can declare a compat on SCS_jll and it will transitively apply to SCS_GPU_jll and SCS_MKL_jll.

This will require some changes to SCS.jl, but we're safe to do this because SCS is pinned to `3.2.3`:
https://github.com/jump-dev/SCS.jl/blob/e24ac32e585357a584c379eec41a601fb93b7cb9/Project.toml#L20

I'm not sure if one can build dependent packages like this, so I probably need to build 3.2.4 or SCS_jll first, and then the GPU and MKL versions?