### PR TITLE
[WIP] add ROOT

### DIFF
--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -8,7 +8,8 @@ version_slug = "6.28.08"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://root.cern.ch/download/root_v$(version_slug).source.tar.gz", "a3e64b4c01f87cd9bbe57e61ef96b41626e49b0446095070d41d9bfba3526862")
+    ArchiveSource("https://root.cern.ch/download/root_v$(version_slug).source.tar.gz",
+    "a3e64b4c01f87cd9bbe57e61ef96b41626e49b0446095070d41d9bfba3526862")
 ]
 
 # Bash recipe for building across all platforms
@@ -16,7 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
+cmake -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
 make
 """
 
@@ -61,4 +62,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8")

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -45,7 +45,9 @@ dependencies = [
     Dependency("Xorg_libX11_jll")
     BuildDependency("Xorg_xorgproto_jll")
     Dependency("Xorg_libXpm_jll")
+    Dependency("VDT_jll")
     Dependency("Xorg_libXft_jll")
+    Dependency("XRootD_jll")
     Dependency(PackageSpec(name="LAPACK_jll", uuid="51474c39-65e3-53ba-86ba-03b1b862ec14"))
     Dependency("Lz4_jll")
     Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))
@@ -58,4 +60,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -44,8 +44,8 @@ products = Product[
 dependencies = [
     Dependency("Xorg_libX11_jll")
     BuildDependency("Xorg_xorgproto_jll")
-    BuildDependency("Xorg_libXpm_jll")
-    BuildDependency("Xorg_libXft_jll")
+    Dependency("Xorg_libXpm_jll")
+    Dependency("Xorg_libXft_jll")
     Dependency(PackageSpec(name="LAPACK_jll", uuid="51474c39-65e3-53ba-86ba-03b1b862ec14"))
     Dependency("Lz4_jll")
     Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -17,7 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
+cmake -Dbuiltin_llvm=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
 make
 """
 
@@ -47,6 +47,7 @@ dependencies = [
     Dependency("Xorg_libX11_jll")
     BuildDependency("Xorg_xorgproto_jll")
     Dependency("Xorg_libXpm_jll")
+    Dependency("LLVM_jll")
     Dependency("VDT_jll")
     Dependency("Xorg_libXft_jll")
     Dependency("XRootD_jll")

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -17,7 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
+cmake -DLLVM_INCLUDE_TESTS=OFF -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
 make -j${nproc}
 make install
 """

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -14,12 +14,16 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-apk add coreutils findutils dateutils
+apk add util-linux pciutils usbutils coreutils binutils findutils grep iproute2
+apk add dateutils
+apk add bash bash-completion
+apk add cmake extra-cmake-modules
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
 cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Droot7=OFF -Droofit=OFF -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-*
 make -j${nproc}
+make
 make install
 """
 

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -17,7 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
+cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
 make -j${nproc}
 make install
 """

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -14,6 +14,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
+apk add coreutils findutils dateutils
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -8,7 +8,6 @@ version_slug = "6.28.08"
 
 # Collection of sources required to complete build
 sources = [
-    # GitSource("https://github.com/root-project/root.git", "1e20055be7ed0707e2c2401ab9405cae8eb892e8")
     ArchiveSource("https://root.cern.ch/download/root_v$(version_slug).source.tar.gz", "a3e64b4c01f87cd9bbe57e61ef96b41626e49b0446095070d41d9bfba3526862")
 ]
 
@@ -17,7 +16,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -Dbuiltin_llvm=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
+cmake -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
 make
 """
 
@@ -47,7 +46,6 @@ dependencies = [
     Dependency("Xorg_libX11_jll")
     BuildDependency("Xorg_xorgproto_jll")
     Dependency("Xorg_libXpm_jll")
-    Dependency("LLVM_jll")
     Dependency("VDT_jll")
     Dependency("Xorg_libXft_jll")
     Dependency("XRootD_jll")

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -15,7 +15,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -Dbuiltin_gtest=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root/
+cmake -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root/
 make
 """
 

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -1,0 +1,62 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "ROOT"
+version = v"6.28.8"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/root-project/root.git", "1e20055be7ed0707e2c2401ab9405cae8eb892e8")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mkdir build
+cd build/
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root/
+make
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    # Platform("i686", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "glibc"),
+    # Platform("aarch64", "linux"; libc = "glibc"),
+    # Platform("armv6l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    # Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    # Platform("powerpc64le", "linux"; libc = "glibc"),
+    # Platform("i686", "linux"; libc = "musl"),
+    # Platform("x86_64", "linux"; libc = "musl"),
+    # Platform("aarch64", "linux"; libc = "musl"),
+    # Platform("armv6l", "linux"; call_abi = "eabihf", libc = "musl"),
+    # Platform("armv7l", "linux"; call_abi = "eabihf", libc = "musl")
+]
+
+
+# The products that we will ensure are always built
+products = Product[
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Xorg_libX11_jll")
+    BuildDependency("Xorg_xorgproto_jll")
+    BuildDependency("Xorg_libXpm_jll")
+    BuildDependency("Xorg_libXft_jll")
+    Dependency(PackageSpec(name="LAPACK_jll", uuid="51474c39-65e3-53ba-86ba-03b1b862ec14"))
+    Dependency("Lz4_jll")
+    Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))
+    Dependency(PackageSpec(name="Giflib_jll", uuid="59f7168a-df46-5410-90c8-f2779963d0ec"))
+    Dependency(PackageSpec(name="Python_jll", uuid="93d3a430-8e7c-50da-8e8d-3dfcfb3baf05"))
+    Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4"))
+    Dependency(PackageSpec(name="PCRE_jll", uuid="2f80f16e-611a-54ab-bc61-aa92de5b98fc"))
+    Dependency(PackageSpec(name="Graphviz_jll", uuid="3c863552-8265-54e4-a6dc-903eb78fde85"))
+    Dependency(PackageSpec(name="xxHash_jll", uuid="5fdcd639-92d1-5a06-bf6b-28f2061df1a9"))
+    Dependency(PackageSpec(name="Librsvg_jll", uuid="925c91fb-5dd6-59dd-8e8c-345e74382d89"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -18,7 +18,7 @@ apk add coreutils findutils dateutils
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-*
+cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Droofit=OFF -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-*
 make -j${nproc}
 make install
 """
@@ -60,8 +60,9 @@ dependencies = [
     Dependency(PackageSpec(name="PCRE_jll", uuid="2f80f16e-611a-54ab-bc61-aa92de5b98fc"))
     Dependency(PackageSpec(name="Graphviz_jll", uuid="3c863552-8265-54e4-a6dc-903eb78fde85"))
     Dependency(PackageSpec(name="xxHash_jll", uuid="5fdcd639-92d1-5a06-bf6b-28f2061df1a9"))
+    Dependency("XZ_jll")
     Dependency(PackageSpec(name="Librsvg_jll", uuid="925c91fb-5dd6-59dd-8e8c-345e74382d89"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"13")

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -3,13 +3,13 @@
 using BinaryBuilder, Pkg
 
 name = "ROOT"
-version = v"6.28.8"
-version_slug = "6.28.08"
+version = v"6.00.00"
+version_slug = "6.30.00"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://root.cern.ch/download/root_v$(version_slug).source.tar.gz",
-    "a3e64b4c01f87cd9bbe57e61ef96b41626e49b0446095070d41d9bfba3526862")
+    "0592c066954cfed42312957c9cb251654456064fe2d8dabdcb8826f1c0099d71")
 ]
 
 # Bash recipe for building across all platforms
@@ -17,7 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -DLLVM_INCLUDE_TESTS=OFF -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
+cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-*
 make -j${nproc}
 make install
 """

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -18,7 +18,8 @@ cd $WORKSPACE/srcdir
 mkdir build
 cd build/
 cmake -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
-make
+make -j${nproc}
+make install
 """
 
 # These are the platforms we will build for by default, unless further

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -15,7 +15,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root/
+cmake -Dbuiltin_gtest=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root/
 make
 """
 
@@ -50,7 +50,6 @@ dependencies = [
     Dependency("Lz4_jll")
     Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))
     Dependency(PackageSpec(name="Giflib_jll", uuid="59f7168a-df46-5410-90c8-f2779963d0ec"))
-    Dependency(PackageSpec(name="Python_jll", uuid="93d3a430-8e7c-50da-8e8d-3dfcfb3baf05"))
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4"))
     Dependency(PackageSpec(name="PCRE_jll", uuid="2f80f16e-611a-54ab-bc61-aa92de5b98fc"))
     Dependency(PackageSpec(name="Graphviz_jll", uuid="3c863552-8265-54e4-a6dc-903eb78fde85"))

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -81,9 +81,10 @@ dependencies = [
     BuildDependency("Xorg_xorgproto_jll")
     Dependency("Xorg_libX11_jll")
     Dependency("Xorg_libXpm_jll")
-    Dependency("Xorg_libXft_jll")    
+    Dependency("Xorg_libXft_jll")
 
     #Optionnal dependencies (if absent, either a feature will be disabled or a built-in version will be compiled)
+    Dependency("oneTBB_jll")
     Dependency("VDT_jll")
     Dependency("XRootD_jll")
     Dependency(PackageSpec(name="LAPACK_jll", uuid="51474c39-65e3-53ba-86ba-03b1b862ec14"))

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "ROOT"
-version = v"6.00.00"
+version = v"6.30.00"
 version_slug = "6.30.00"
 
 # Collection of sources required to complete build
@@ -18,7 +18,7 @@ apk add coreutils findutils dateutils
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Droofit=OFF -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-*
+cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -Droot7=OFF -Droofit=OFF -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-*
 make -j${nproc}
 make install
 """
@@ -53,6 +53,8 @@ dependencies = [
     Dependency("Xorg_libXft_jll")
     Dependency("XRootD_jll")
     Dependency(PackageSpec(name="LAPACK_jll", uuid="51474c39-65e3-53ba-86ba-03b1b862ec14"))
+    HostBuildDependency(PackageSpec(name="LLVM_full_jll", version=v"13.0.1"))
+    BuildDependency(PackageSpec(name="LLVM_full_jll", version=v"13.0.1"))
     Dependency("Lz4_jll")
     Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))
     Dependency(PackageSpec(name="Giflib_jll", uuid="59f7168a-df46-5410-90c8-f2779963d0ec"))
@@ -65,4 +67,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"13")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8")

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -17,7 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
+cmake -Dclad=OFF -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
 make -j${nproc}
 make install
 """

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -4,10 +4,12 @@ using BinaryBuilder, Pkg
 
 name = "ROOT"
 version = v"6.28.8"
+version_slug = "6.28.08"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/root-project/root.git", "1e20055be7ed0707e2c2401ab9405cae8eb892e8")
+    # GitSource("https://github.com/root-project/root.git", "1e20055be7ed0707e2c2401ab9405cae8eb892e8")
+    ArchiveSource("https://root.cern.ch/download/root_v$(version_slug).source.tar.gz", "a3e64b4c01f87cd9bbe57e61ef96b41626e49b0446095070d41d9bfba3526862")
 ]
 
 # Bash recipe for building across all platforms
@@ -15,7 +17,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 mkdir build
 cd build/
-cmake -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root/
+cmake -Dpyroot=OFF -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release ../root-6.28.08
 make
 """
 

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -1,3 +1,4 @@
+
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
@@ -9,49 +10,122 @@ rootgithash = Dict(v"6.30.4" => "ebd5b65997c3dff10fc38472a40ddffc26fb982a")
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/root-project/root.git", rootgithash[version])
+    GitSource("https://github.com/root-project/root.git", rootgithash[version]),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-
-if echo "$target" | grep musl; then #build wih musl library
+cd $WORKSPACE
+cat > script.sh <<EOF
+if echo "\$target" | grep -q musl; then #build wih musl library
 # Disabling what is not working with musl:
-    CMAKE_EXTRA_OPTS="-Ddavix=OFF -Dxrootd=OFF -Dssl=OFF"
+    CMAKE_EXTRA_OPTS="-Ddavix=OFF -Dxrootd=OFF -Dssl=OFF -Druntime_cxxmodules=OFF -Droofit=OFF"
+else
+    CMAKE_EXTRA_OPTS=-Druntime_cxxmodules=OFF
 fi
+
+#Uncomment for a minimal build for debugging purposes
+#CMAKE_EXTRA_OPTS="\$CMAKE_EXTRA_OPTS -Dclad=OFF -Dhtml=OFF -Dwebgui=OFF -Dcxxmodules=OFF -Dproof=OFF -Dtmva=OFF -Drootfit=OFF -Dxproofd=OFF -Dxrootd=OFF -Dssl=OFF -Dpyroot=OFF -Dtesting=OFF -Droot7=OFF -Dspectrum=OFF -Dunfold=OFF -Dasimage=OFF -Dgviz=OFF -Dfitiso=OFF -Dcocoa=OFF -Dopengl=OFF -Dproof=OFF -Dxml=OFF -Dgfal=OFF -Dmpi=OFF"
+
+export SYSTEM_INCLUDE_PATH="\`\$BUILD_CXX --sysroot="/opt/\$target/\$target/sys-root" -E -x c++ -v /dev/null  2>&1  | awk '{gsub("^ ", "")} /End of search list/{a=0} {if(a==1){s=s d \$0;d=":"}} /#include <...> search starts here/{a=1} END{print s}'\`"
 
 # build-in compilation of the libAfterImage library needs this directory
 mkdir -p /tmp/user/0
 
-cd $WORKSPACE/srcdir
+cd /
+[ -f /opt/bin/x86_64-linux-gnu-libgfortran5-cxx11/x86_64-linux-gnu-g++ ] && atomic_patch -p1 \${WORKSPACE}/srcdir/patches/x86_64-linux-gnu-g++.patch
+
+cd "\$WORKSPACE"
 
 # For the cross-compiling, LLVM needs to compile the llvm-tblgen tool
 # for the host. The ROOT LLVM code tree does not include the test and
 # benchmark directories cmake will need to configure for the host for
-# this bootstrap. We need to disable the build of the test and benchmarks
+# this bootstrap. Therefore, we need to disable the build of the test and
+# benchmarks.
 sed -i 's/\(option(LLVM_INCLUDE_TESTS[[:space:]].*[[:space:]]\)on)\(.*\)/\1OFF)\2/i
-        s/\(option(LLVM_INCLUDE_BENCHMARKS[[:space:]].*[[:space:]]\)on)\(.*\)/\1OFF)\2/i' \
-        root/interpreter/llvm-project/llvm/CMakeLists.txt
+        s/\(option(LLVM_INCLUDE_BENCHMARKS[[:space:]].*[[:space:]]\)on)\(.*\)/\1OFF)\2/i' \\
+        srcdir/root/interpreter/llvm-project/llvm/CMakeLists.txt
+echo "set(CXX_STANDARD 17)" >> srcdir/root/interpreter/llvm-project/llvm/CMakeLists.txt
 
 # N llvm links. LLVM link command needs 15GB
-LLVM_PARALLEL_LINK_JOBS=`grep MemTot /proc/meminfo  | awk '{a=int($2/15100000); if(a>'"$nproc"') a='"$nproc"'; if(a<1) a=1; print a;}'`
+njobs=\$((2*\`nproc\`))
+LLVM_PARALLEL_LINK_JOBS=\`grep MemTot /proc/meminfo  | awk '{a=int(\$2/15100000); if(a>'"\$njobs"') a='"\$njobs"'; if(a<1) a=1; print a;}'\`
 
-# For the rootcling execution performed during the build:
-echo "include_directories(SYSTEM /opt/$target/$target/sys-root/usr/include)" >> ${CMAKE_TARGET_TOOLCHAIN}
+#DEBUG# # For the rootcling execution performed during the build:
+#DEBUG# echo "include_directories(SYSTEM /opt/\$target/\$target/sys-root/usr/include)" >> \${CMAKE_TARGET_TOOLCHAIN}
 
 # Build with debug info, while we are debugging this script:
 BUILD_TYPE=Debug
 
-cmake -GNinja \
-      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-      -DCMAKE_INSTALL_PREFIX=$prefix \
-      -DLLVM_PARALLEL_LINK_JOBS=$LLVM_PARALLEL_LINK_JOBS \
-      $CMAKE_EXTRA_OPTS \
-      -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DLLVM_BUILD_TYPE=$BUILD_TYPE \
-      -B build -S root
+# Support to run programs linked with glibc
+#if [ $target = x86_64-linux-gnu ]; then
+#   ln -sf /opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+#fi
 
-cmake --build build -j${nproc} 
-cmake --install build --prefix $prefix
+#For gcc 9.1.0 (bug fixed with 9.3.0)
+#(cd / && atomic_patch -p1 \${WORKSPACE}/srcdir/patches/\$target-variant.patch)
+
+if [ $target != $MACHTYPE ]; then #cross compilation
+
+   (cd srcdir
+   # patch to fix cross-compilation with rootcling
+   #atomic_patch -p1 patches/rootcling-cross-compile.patch
+   atomic_patch -p1 patches/rootcling-cross-compile-v3.patch
+
+   # patch to fix cross-compilation for afterimage
+   atomic_patch -p1 patches/afterimage-cross-compile.patch
+   )
+
+   #sed -i 's@set(command \${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=\${CMAKE_BINARY_DIR}/lib:.*" \$<TARGET_FILE:rootcling_stage1>)@set(command \${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=\${CMAKE_BINARY_DIR}/lib:\$ENV{WORKSPACE}/x86_64-linux-gnu-libgfortran5-cxx11/destdir/lib" LLVM_SYMBOLIZER_PATH=\${CMAKE_BINARY_BUILD}/interpreter/llvm-project/llvm/NATIVE/tools/llvm-symbolizer \$<TARGET_FILE:rootcling_stage1>)@' \${WORKSPACE}/srcdir/root/cmake/modules/RootMacros.cmake
+
+   # Compile for the host binary used in the build process
+   mkdir NATIVE
+   cmake -GNinja \\
+         -DCMAKE_TOOLCHAIN_FILE=\${CMAKE_HOST_TOOLCHAIN} \\
+         -DLLVM_HOST_TRIPLE=\$MACHTYPE \\
+         -DLLVM_PARALLEL_LINK_JOBS=\$LLVM_PARALLEL_LINK_JOBS \\
+         -DCXX_STANDARD=c++17 \\
+         -DCLANG_DEFAULT_STD_CXX=cxx17 \\
+         \$CMAKE_EXTRA_OPTS \\
+         -DCMAKE_BUILD_TYPE=Release \\
+         -DCLING_CXX_PATH=g++ \\
+         -B NATIVE -S srcdir/root
+
+   ninja -C NATIVE -j\${njobs} rootcling_stage1 llvm-tblgen clang-tblgen llvm-config llvm-symbolizer
+
+   CMAKE_EXTRA_OPTS="\$CMAKE_EXTRA_OPTS -DNATIVE_BINARY_DIR=\$PWD/NATIVE \\
+      -DLLVM_TABLEGEN=\"\$PWD/NATIVE/interpreter/llvm-project/llvm/bin/llvm-tblgen\" \\
+      -DCLANG_TABLEGEN=\"\$PWD/NATIVE/interpreter/llvm-project/llvm/bin/clang-tblgen\" \\
+      -DLLVM_CONFIG_PATH=\"\$PWD/NATIVE/interpreter/llvm-project/llvm/bin/llvm-config\""
+fi
+
+# CPLUS_INCLUDE_PATH used to set system include path for rootcling in absence
+# of a -sysroot option. It should be transparent gcc and target build as it set the path 
+# to the value obtained from gcc itself before setting CPLUS_INCLUDE_PATH and using
+# the same sysroot option as for compilation.
+export CPLUS_INCLUDE_PATH="\$SYSTEM_INCLUDE_PATH"
+mkdir build
+cmake -GNinja \\
+      -DCMAKE_TOOLCHAIN_FILE=\${CMAKE_TARGET_TOOLCHAIN} \\
+      -DCMAKE_INSTALL_PREFIX=\$prefix \\
+      -DLLVM_HOST_TRIPLE=\$target \\
+      -DLLVM_PARALLEL_LINK_JOBS=\$LLVM_PARALLEL_LINK_JOBS \\
+      -DCXX_STANDARD=c++17 \\
+      -DCLANG_DEFAULT_STD_CXX=cxx17 \\
+      \$CMAKE_EXTRA_OPTS \\
+      -DCMAKE_BUILD_TYPE=\$BUILD_TYPE -DLLVM_BUILD_TYPE=\$BUILD_TYPE \\
+      -DCLING_CXX_PATH=g++ \\
+      -B build -S srcdir/root
+
+# Build the code
+cmake --build build -j\${njobs}
+
+# Install the binaries
+cmake --install build --prefix \$prefix
+cp -a build/core/rootcling_stage1/src/rootcling_stage1 \$prefix/bin/
+EOF
+bash -x -e script.sh
 """
 
 # These are the platforms we will build for by default, unless further
@@ -73,6 +147,9 @@ platforms = [
 
 # The products that we will ensure are always built
 products = Product[
+    ExecutableProduct("root", :root)
+    ExecutableProduct("rootcling", :rootcling)
+    ExecutableProduct("rootcling_stage1", :rootcling_stage1)
 ]
 
 # Dependencies that must be installed before this package can be built
@@ -84,7 +161,6 @@ dependencies = [
     Dependency("Xorg_libXft_jll")
 
     #Optionnal dependencies (if absent, either a feature will be disabled or a built-in version will be compiled)
-    Dependency("oneTBB_jll")
     Dependency("VDT_jll")
     Dependency("XRootD_jll")
     Dependency(PackageSpec(name="LAPACK_jll", uuid="51474c39-65e3-53ba-86ba-03b1b862ec14"))
@@ -110,7 +186,8 @@ dependencies = [
     Dependency("Xorg_libxkbfile_jll")
     Dependency("Libglvnd_jll")
     Dependency("OpenBLAS_jll")
+    Dependency("oneTBB_jll")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"11")

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -28,7 +28,7 @@ fi
 #Uncomment for a minimal build for debugging purposes
 #CMAKE_EXTRA_OPTS="\$CMAKE_EXTRA_OPTS -Dclad=OFF -Dhtml=OFF -Dwebgui=OFF -Dcxxmodules=OFF -Dproof=OFF -Dtmva=OFF -Drootfit=OFF -Dxproofd=OFF -Dxrootd=OFF -Dssl=OFF -Dpyroot=OFF -Dtesting=OFF -Droot7=OFF -Dspectrum=OFF -Dunfold=OFF -Dasimage=OFF -Dgviz=OFF -Dfitiso=OFF -Dcocoa=OFF -Dopengl=OFF -Dproof=OFF -Dxml=OFF -Dgfal=OFF -Dmpi=OFF"
 
-export SYSTEM_INCLUDE_PATH="\`\$BUILD_CXX --sysroot="/opt/\$target/\$target/sys-root" -E -x c++ -v /dev/null  2>&1  | awk '{gsub("^ ", "")} /End of search list/{a=0} {if(a==1){s=s d \$0;d=":"}} /#include <...> search starts here/{a=1} END{print s}'\`"
+export SYSTEM_INCLUDE_PATH="\`\$target-g++ --sysroot="/opt/\$target/\$target/sys-root" -E -x c++ -v /dev/null  2>&1  | awk '{gsub("^ ", "")} /End of search list/{a=0} {if(a==1){s=s d \$0;d=":"}} /#include <...> search starts here/{a=1} END{print s}'\`"
 
 # build-in compilation of the libAfterImage library needs this directory
 mkdir -p /tmp/user/0

--- a/R/ROOT/bundled/patches/afterimage-cross-compile.patch
+++ b/R/ROOT/bundled/patches/afterimage-cross-compile.patch
@@ -1,0 +1,10 @@
+--- a/root/cmake/modules/SearchInstalledSoftware.cmake	2024-06-28 12:55:26.471599664 +0200
++++ b/root/cmake/modules/SearchInstalledSoftware.cmake	2024-06-28 12:57:58.417875621 +0200
+@@ -499,6 +499,7 @@
+       DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/graf2d/asimage/src/libAfterImage AFTERIMAGE
+       INSTALL_DIR ${CMAKE_BINARY_DIR}
+       CONFIGURE_COMMAND ./configure --prefix <INSTALL_DIR>
++                        --host=$ENV{target}
+                         --libdir=<INSTALL_DIR>/lib
+                         --with-ttf ${_ttf_include} --with-afterbase=no
+                         --without-svg --disable-glx ${_after_mmx}

--- a/R/ROOT/bundled/patches/rootcling-cross-compile-v3.patch
+++ b/R/ROOT/bundled/patches/rootcling-cross-compile-v3.patch
@@ -1,0 +1,55 @@
+--- a/root/cmake/modules/RootMacros.cmake	2024-01-31 09:17:06.000000000 +0100
++++ c/root/cmake/modules/RootMacros.cmake	2024-06-29 18:12:28.081464326 +0200
+@@ -8,6 +8,8 @@
+ #  RootMacros.cmake
+ #---------------------------------------------------------------------------------------------------
+ 
++set(NATIVE_BINARY_DIR FALSE CACHE FILEPATH "Path of native built in case of cross compiling.")
++
+ if(WIN32)
+   set(libprefix lib)
+   set(ld_library_path PATH)
+@@ -603,20 +605,37 @@
+   #---what rootcling command to use--------------------------
+   if(ARG_STAGE1)
+     if(MSVC AND CMAKE_ROOTTEST_DICT)
+-      set(command ${CMAKE_COMMAND} -E ${CMAKE_BINARY_DIR}/bin/rootcling_stage1.exe)
++      if(NATIVE_BINARY_DIR)
++        set(command ${CMAKE_COMMAND} -E ${NATIVE_BINARY_DIR}/bin/rootcling_stage1.exe)
++      else()
++        set(command ${CMAKE_COMMAND} -E ${CMAKE_BINARY_DIR}/bin/rootcling_stage1.exe)
++      endif()
+     else()
+-      set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" $<TARGET_FILE:rootcling_stage1>)
++      if(NATIVE_BINARY_DIR)
++        set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${NATIVE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" ${NATIVE_BINARY_DIR}/core/rootcling_stage1/src/rootcling_stage1)
++      else()
++        set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" $<TARGET_FILE:rootcling_stage1>)
++      endif()
+     endif()
+     set(ROOTCINTDEP rconfigure)
+     set(pcm_name)
+   else()
+     if(CMAKE_PROJECT_NAME STREQUAL ROOT)
+       if(MSVC AND CMAKE_ROOTTEST_DICT)
+-        set(command ${CMAKE_COMMAND} -E env "ROOTIGNOREPREFIX=1" ${CMAKE_BINARY_DIR}/bin/rootcling.exe)
++        if(NATIVE_BINARY_DIR)
++          set(command ${CMAKE_COMMAND} -E env "ROOTIGNOREPREFIX=1" ${NATIVE_BINARY_DIR}/bin/rootcling.exe)
++        else()
++          set(command ${CMAKE_COMMAND} -E env "ROOTIGNOREPREFIX=1" ${CMAKE_BINARY_DIR}/core/rootcling_stage1/src/rootcling.exe)
++        endif()
+       else()
+-        set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
+-                    "ROOTIGNOREPREFIX=1" $<TARGET_FILE:rootcling> -rootbuild)
+-        # Modules need RConfigure.h copied into include/.
++        if(NATIVE_BINARY_DIR)
++          set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${NATIVE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
++            "ROOTIGNOREPREFIX=1" ${NATIVE_BINARY_DIR}/core/rootcling_stage1/src/rootcling -rootbuild)
++        else()
++          set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
++            "ROOTIGNOREPREFIX=1" $<TARGET_FILE:rootcling> -rootbuild)
++        endif()
++          # Modules need RConfigure.h copied into include/.
+         set(ROOTCINTDEP rootcling rconfigure)
+       endif()
+     elseif(TARGET ROOT::rootcling)

--- a/R/ROOT/bundled/patches/rootcling-cross-compile.patch
+++ b/R/ROOT/bundled/patches/rootcling-cross-compile.patch
@@ -1,0 +1,44 @@
+diff -u -r a/root/cmake/modules/RootMacros.cmake b/root/cmake/modules/RootMacros.cmake
+--- a/root/cmake/modules/RootMacros.cmake	2024-01-31 09:17:06.000000000 +0100
++++ b/root/cmake/modules/RootMacros.cmake	2024-03-29 00:53:33.340075505 +0100
+@@ -605,7 +605,7 @@
+     if(MSVC AND CMAKE_ROOTTEST_DICT)
+       set(command ${CMAKE_COMMAND} -E ${CMAKE_BINARY_DIR}/bin/rootcling_stage1.exe)
+     else()
+-      set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" $<TARGET_FILE:rootcling_stage1>)
++      set(command ${CMAKE_COMMAND} -E env LLVM_SYMBOLIZER_PATH=${CMAKE_BINARY_BUILD}/interpreter/llvm-project/llvm/NATIVE/tools/llvm-symbolizer CPLUS_INCLUDE_PATH=/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/include/c++/8.1.0:/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/include/c++/8.1.0/x86_64-linux-gnu:/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/include/c++/8.1.0/backward:/workspace/srcdir/build/etc/cling/lib/clang/13.0.0/include:/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/local/include:/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/include $<TARGET_FILE:rootcling_stage1>)
+     endif()
+     set(ROOTCINTDEP rconfigure)
+     set(pcm_name)
+@@ -615,7 +615,7 @@
+         set(command ${CMAKE_COMMAND} -E env "ROOTIGNOREPREFIX=1" ${CMAKE_BINARY_DIR}/bin/rootcling.exe)
+       else()
+         set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
+-                    "ROOTIGNOREPREFIX=1" $<TARGET_FILE:rootcling> -rootbuild)
++          "ROOTIGNOREPREFIX=1" CPLUS_INCLUDE_PATH=/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/include/c++/8.1.0:/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/include/c++/8.1.0/x86_64-linux-gnu:/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/include/c++/8.1.0/backward:/workspace/srcdir/build/etc/cling/lib/clang/13.0.0/include:/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/local/include:/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/include $<TARGET_FILE:rootcling> -rootbuild)
+         # Modules need RConfigure.h copied into include/.
+         set(ROOTCINTDEP rootcling rconfigure)
+       endif()
+@@ -623,7 +623,7 @@
+       if(APPLE)
+         set(command ${CMAKE_COMMAND} -E env "DYLD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:$ENV{DYLD_LIBRARY_PATH}" $<TARGET_FILE:ROOT::rootcling>)
+       else()
+-        set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}" $<TARGET_FILE:ROOT::rootcling>)
++        set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}" CPLUS_INCLUDE_PATH=/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/include/c++/8.1.0:/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/include/c++/8.1.0/x86_64-linux-gnu:/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/include/c++/8.1.0/backward:/workspace/srcdir/build/etc/cling/lib/clang/13.0.0/include:/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/local/include:/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/include $<TARGET_FILE:ROOT::rootcling>)
+       endif()
+     else()
+       set(command ${CMAKE_COMMAND} -E env rootcling)
+diff -u -r a/root/CMakeLists.txt b/root/CMakeLists.txt
+--- a/root/CMakeLists.txt	2024-01-31 09:17:06.000000000 +0100
++++ b/root/CMakeLists.txt	2024-04-01 15:50:12.827224904 +0200
+@@ -533,7 +533,9 @@
+       ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/build/unix/makepchinput.py
+       ${CMAKE_SOURCE_DIR} . ${pyroot_legacy} ${__cling_pch}
+     COMMAND
+-      ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE}
++      ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1
++      CPLUS_INCLUDE_PATH="$ENV{SYSTEM_INCLUDE_PATH}"
++      ${PYTHON_EXECUTABLE}
+       ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch
+       ${__allIncludes} -I${CMAKE_BINARY_DIR}/include -I${CMAKE_SOURCE_DIR}/core
+     DEPENDS

--- a/R/ROOT/bundled/patches/x86_64-linux-gnu-g++.patch
+++ b/R/ROOT/bundled/patches/x86_64-linux-gnu-g++.patch
@@ -1,0 +1,12 @@
+--- a/opt/bin/x86_64-linux-gnu-libgfortran5-cxx11/x86_64-linux-gnu-g++
++++ b/opt/bin/x86_64-linux-gnu-libgfortran5-cxx11/x86_64-linux-gnu-g++
+@@ -27,8 +27,7 @@
+ 
+ export LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:/lib64:/lib:/opt/x86_64-linux-musl/x86_64-linux-musl/lib64:/opt/x86_64-linux-musl/x86_64-linux-musl/lib:/opt/x86_64-linux-gnu/x86_64-linux-gnu/lib64:/opt/x86_64-linux-gnu/x86_64-linux-gnu/lib"
+ if [[ " ${ARGS[@]} " == *"-march="* ]]; then
+-    echo "BinaryBuilder: Cannot force an architecture via -march" >&2
+-    exit 1
++    echo "BinaryBuilder: warning architecture forced via -march" >&2
+ fi
+ 
+ if [[ "${ARGS[@]}" =~ "-Ofast"|"-ffast-math"|"-funsafe-math-optimizations" ]]; then


### PR DESCRIPTION
@grasph this is the first step to making ROOT.jl usable again. 

I've been using https://archlinux.org/packages/extra/x86_64/root/ as a reference for dependency and make dependency

Currently:

```julia
# you need BinaryBuilder.jl
julia --project=@hep build_tarballs.jl
```

```
-- Not building amdgpu-arch: hsa-runtime64 not found
CMake Error at tools/clang/CMakeLists.txt:556 (add_subdirectory):
  add_subdirectory given source "test" which is not an existing directory.


-- Registering Bye as a pass plugin (static build: OFF)
CMake Error: File /workspace/srcdir/root/interpreter/llvm/src/utils/lit/tests/lit.site.cfg.in does not exist.
CMake Error at cmake/modules/AddLLVM.cmake:1698 (configure_file):
  configure_file Problem configuring file
Call Stack (most recent call first):
  utils/lit/CMakeLists.txt:4 (configure_lit_site_cfg)


CMake Error at CMakeLists.txt:1022 (add_subdirectory):
  add_subdirectory given source "test" which is not an existing directory.


CMake Error at CMakeLists.txt:1023 (add_subdirectory):
  add_subdirectory given source "unittests" which is not an existing
  directory.


CMake Error at CMakeLists.txt:1025 (add_subdirectory):
  add_subdirectory given source "utils/unittest" which is not an existing
  directory.


-- Failed to find LLVM FileCheck
-- Version: 0.0.0
-- Performing Test HAVE_CXX_FLAG_STD_CXX11
-- Performing Test HAVE_CXX_FLAG_STD_CXX11 - Success
-- Performing Test HAVE_CXX_FLAG_WALL
-- Performing Test HAVE_CXX_FLAG_WALL - Success
-- Performing Test HAVE_CXX_FLAG_WEXTRA
-- Performing Test HAVE_CXX_FLAG_WEXTRA - Success
-- Performing Test HAVE_CXX_FLAG_WSHADOW
-- Performing Test HAVE_CXX_FLAG_WSHADOW - Success
-- Performing Test HAVE_CXX_FLAG_PEDANTIC
-- Performing Test HAVE_CXX_FLAG_PEDANTIC - Success
-- Performing Test HAVE_CXX_FLAG_PEDANTIC_ERRORS
-- Performing Test HAVE_CXX_FLAG_PEDANTIC_ERRORS - Success
-- Performing Test HAVE_CXX_FLAG_WSHORTEN_64_TO_32
-- Performing Test HAVE_CXX_FLAG_WSHORTEN_64_TO_32 - Failed
-- Performing Test HAVE_CXX_FLAG_WFLOAT_EQUAL
-- Performing Test HAVE_CXX_FLAG_WFLOAT_EQUAL - Success
-- Performing Test HAVE_CXX_FLAG_FSTRICT_ALIASING
-- Performing Test HAVE_CXX_FLAG_FSTRICT_ALIASING - Success
-- Performing Test HAVE_CXX_FLAG_FNO_EXCEPTIONS
-- Performing Test HAVE_CXX_FLAG_FNO_EXCEPTIONS - Success
-- Performing Test HAVE_CXX_FLAG_WNO_SUGGEST_OVERRIDE
-- Performing Test HAVE_CXX_FLAG_WNO_SUGGEST_OVERRIDE - Success
-- Performing Test HAVE_CXX_FLAG_WSTRICT_ALIASING
-- Performing Test HAVE_CXX_FLAG_WSTRICT_ALIASING - Success
-- Performing Test HAVE_CXX_FLAG_WD654
-- Performing Test HAVE_CXX_FLAG_WD654 - Failed
-- Performing Test HAVE_CXX_FLAG_WTHREAD_SAFETY
-- Performing Test HAVE_CXX_FLAG_WTHREAD_SAFETY - Failed
-- Performing Test HAVE_CXX_FLAG_COVERAGE
-- Performing Test HAVE_CXX_FLAG_COVERAGE - Success
-- Performing Test HAVE_GNU_POSIX_REGEX
-- Performing Test HAVE_GNU_POSIX_REGEX
-- Performing Test HAVE_GNU_POSIX_REGEX -- failed to compile
-- Performing Test HAVE_POSIX_REGEX
-- Performing Test HAVE_POSIX_REGEX
-- Performing Test HAVE_POSIX_REGEX -- success
-- Performing Test HAVE_STEADY_CLOCK
-- Performing Test HAVE_STEADY_CLOCK
-- Performing Test HAVE_STEADY_CLOCK -- success
CMake Error at CMakeLists.txt:1165 (add_subdirectory):
  add_subdirectory given source "benchmarks" which is not an existing
  directory.
```
