### PR TITLE
[SDPLR] Add shared library

### DIFF
--- a/S/SDPLR/build_tarballs.jl
+++ b/S/SDPLR/build_tarballs.jl
@@ -3,7 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "SDPLR"
-version = v"1.0.3"
+upstream_version = v"1.0.3"
+version_offset = v"0.1.0" # reset to 0.0.0 once the upstream version changes
+version = VersionNumber(upstream_version.major * 100 + version_offset.major,
+                        upstream_version.minor * 100 + version_offset.minor,
+                        upstream_version.patch * 100 + version_offset.patch)
 
 # Collection of sources required to complete build
 sources = [

--- a/S/SDPLR/build_tarballs.jl
+++ b/S/SDPLR/build_tarballs.jl
@@ -17,13 +17,15 @@ sources = [
 # so we try both
 script = raw"""
 cd $WORKSPACE/srcdir/SDPLR*
-make LAPACK_LIB=-lopenblas BLAS_LIB=
+make CFLAGS="-O3 -fPIC" LAPACK_LIB=-lopenblas BLAS_LIB=
+${CC} -O3 -fPIC -shared -Llib -o libsdplr.${dlext} source/*.o -lgsl -lopenblas -lgfortran -lm
 for executable in sdplr sdplr${exeext}
 do
     if [[ -f ${executable} ]]; then
         install -Dvm 755 ${executable} "${bindir}/sdplr${exeext}"
     fi
 done
+install -Dvm 755 libsdplr.${dlext} "${libdir}/libsdplr.${dlext}"
 """
 
 # These are the platforms we will build for by default, unless further
@@ -32,7 +34,8 @@ platforms = expand_gfortran_versions(supported_platforms())
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("sdplr", :sdplr)
+    ExecutableProduct("sdplr", :sdplr),
+    LibraryProduct("libsdplr", :libsdplr),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
It turns out that the library has a nice `sdplrlib` function that would be quite helpful for the Julia wrapper.
This PR compiles a shared library in addition to the executable so that we can call this from the Julia wrapper.