### PR TITLE
[XML2] Switch back to Autotools

### DIFF
--- a/X/XML2/build_tarballs.jl
+++ b/X/XML2/build_tarballs.jl
@@ -20,14 +20,11 @@ cd ${WORKSPACE}/srcdir/libxml2-*
 atomic_patch -p1 ../patches/0001-fix-pthread-weak-references-in-globals.c.patch
 atomic_patch -p1 ../patches/0002-fix-more-pthread-weak-references-in-globals.c.patch
 
-mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
-      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DLIBXML2_WITH_PYTHON=OFF \
-      -DLIBXML2_WITH_LZMA=OFF \
-      -DLIBXML2_WITH_TRIO=ON \
-      ..
+./autogen.sh --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
+    --without-python \
+    --disable-static \
+    --with-zlib=${prefix} \
+    --with-iconv=${prefix}
 make -j${nproc}
 make install
 

--- a/X/XML2/build_tarballs.jl
+++ b/X/XML2/build_tarballs.jl
@@ -20,11 +20,19 @@ cd ${WORKSPACE}/srcdir/libxml2-*
 atomic_patch -p1 ../patches/0001-fix-pthread-weak-references-in-globals.c.patch
 atomic_patch -p1 ../patches/0002-fix-more-pthread-weak-references-in-globals.c.patch
 
+# Work around https://gitlab.gnome.org/GNOME/libxml2/-/issues/625
+if [[ "${target}" == i686-*-mingw* ]]; then
+   # Testing for `snprintf` and `vsnprintf` fails on this platform, but the
+   # functions are actually available, inform configure that we can use them.
+   EXTRA_ARGS=( ac_cv_func_snprintf=yes ac_cv_func_vsnprintf=yes )
+fi
+
 ./autogen.sh --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --without-python \
     --disable-static \
     --with-zlib=${prefix} \
-    --with-iconv=${prefix}
+    --with-iconv=${prefix} \
+    "${EXTRA_ARGS[@]}"
 make -j${nproc}
 make install
 


### PR DESCRIPTION
Using CMake breaks ABI compatibility on Windows as the library would have a different soname.

Also, blocked by https://gitlab.gnome.org/GNOME/libxml2/-/issues/625.