### PR TITLE
update SEAL to 4.1.1

### DIFF
--- a/S/SEAL/build_tarballs.jl
+++ b/S/SEAL/build_tarballs.jl
@@ -1,45 +1,51 @@
+
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
 name = "SEAL"
-version = v"4.1.1"
+version = v"3.6.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/microsoft/SEAL.git", "206648d0e4634e5c61dcf9370676630268290b59")
+    ArchiveSource("https://github.com/microsoft/SEAL/archive/v$(version).tar.gz",
+                  "1e2a97deb1f5b543640fc37d7b4737cab2a9849f616c13ff40ad3be4cf29fb9c")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd SEAL/
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release -DSEAL_USE_MSGSL=OFF -DSEAL_USE_ZLIB=OFF -DSEAL_BUILD_SEAL_C=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DSEAL_USE___BUILTIN_CLZLL=OFF 
-cmake --build build
-cmake --install build
-install_license LICENSE
-"""
+cd $WORKSPACE/srcdir/SEAL-*
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = [
-    Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("aarch64", "linux"; libc = "musl"),
-    Platform("x86_64", "linux"; libc = "musl"),
-    Platform("aarch64", "linux"; libc = "glibc")
-]
+# Collect target-specific flags
+# Note: The '-DSEAL_USE__*' and `-DSEAL*_EXITCODE*` flags are required to circumvent
+# cross-compilation issues
+TARGET_FLAGS=""
+if [[ "${target}" == *-darwin* ]]; then
+  # C++17 is disabled on MacOS due to the environment being too old.
+  TARGET_FLAGS="$TARGET_FLAGS -DSEAL_MEMSET_S_FOUND_EXITCODE=1"
+  TARGET_FLAGS="$TARGET_FLAGS -DSEAL_MEMSET_S_FOUND_EXITCODE__TRYRUN_OUTPUT=1"
+  TARGET_FLAGS="$TARGET_FLAGS -DSEAL_USE_CXX17=OFF"
+elif [[ "${target}" == *-freebsd* ]]; then
+  TARGET_FLAGS="$TARGET_FLAGS -DSEAL_MEMSET_S_FOUND_EXITCODE=1"
+  TARGET_FLAGS="$TARGET_FLAGS -DSEAL_MEMSET_S_FOUND_EXITCODE__TRYRUN_OUTPUT=1"
+elif [[ "${target}" == aarch64* ]]; then
+  TARGET_FLAGS="$TARGET_FLAGS -DSEAL_ARM64_EXITCODE=1"
+  TARGET_FLAGS="$TARGET_FLAGS -DSEAL_ARM64_EXITCODE__TRYRUN_OUTPUT=1"
+fi
 
-platforms = expand_cxxstring_abis(platforms)
-
-# The products that we will ensure are always built
-products = [
-    LibraryProduct("libsealc", :libsealc)
-]
-
-# Dependencies that must be installed before this package can be built
-dependencies = Dependency[
-]
-
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"10.2.0")
-
+cmake -S . -B build \
+  -DCMAKE_INSTALL_PREFIX=$prefix \
+  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DSEAL_BUILD_SEAL_C=ON \
+  -DSEAL_USE___BUILTIN_CLZLL=OFF \
+  -DSEAL___BUILTIN_CLZLL_FOUND_EXITCODE=1 \
+  -DSEAL___BUILTIN_CLZLL_FOUND_EXITCODE__TRYRUN_OUTPUT=1 \
+  -DSEAL_USE__ADDCARRY_U64=OFF \
+  -DSEAL__ADDCARRY_U64_FOUND_EXITCODE=1 \
+  -DSEAL__ADDCARRY_U64_FOUND_EXITCODE__TRYRUN_OUTPUT=1 \
+  -DSEAL_USE__SUBBORROW_U64=OFF \
+  -DSEAL__SUBBORROW_U64_FOUND_EXITCODE=1 \
+  -DSEAL__SUBBORROW_U64_FOUND_EXITCODE__TRYRUN_OUTPUT=1 \
+  $TARGET_FLAGS

--- a/S/SEAL/build_tarballs.jl
+++ b/S/SEAL/build_tarballs.jl
@@ -80,4 +80,3 @@ dependencies = Dependency[
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version = v"7.1.0")
-

--- a/S/SEAL/build_tarballs.jl
+++ b/S/SEAL/build_tarballs.jl
@@ -79,4 +79,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version = v"7.1.0")
+               preferred_gcc_version = v"10.2.0")


### PR DESCRIPTION
@sloede upon your recommendation I played around with the build and I changed to git cloning instead of downloading the tarball due to the github change (recommended by julia binary builder). Next, I tested this jll with Seal.jl, and the output of the tests there is below. I think its due https://github.com/microsoft/SEAL/releases/tag/v4.0.0 and we could proceed fixing Seal.jl after this is merged probably. This build completes using BinaryBuilder
```
     Testing Running tests...
Test Summary: | Pass  Total  Time
1_bfv_basics  |   64     64  1.2s
batch_encoder: Error During Test at /home/zhanibek/Projects/SEAL.jl/test/test_2_encoders.jl:2
  Got exception outside of a @test
  could not load symbol "CoeffModulus_Create":
  /home/zhanibek/.julia/artifacts/084d3d63dee2715e4d178c8e6eba44fcb0c01b00/lib/libsealc.so: undefined symbol: CoeffModulus_Create
  Stacktrace:
    [1] coeff_modulus_create(poly_modulus_degree::Int64, bit_sizes::Vector{Int64})
      @ SEAL ~/Projects/SEAL.jl/src/modulus.jl:64
    [2] plain_modulus_batching(poly_modulus_degree::Int64, bit_size::Int64)
      @ SEAL ~/Projects/SEAL.jl/src/modulus.jl:93
    [3] macro expansion
      @ ~/Projects/SEAL.jl/test/test_2_encoders.jl:7 [inlined]
    [4] macro expansion
      @ ~/.julia/juliaup/julia-1.9.4+0.x64.linux.gnu/share/julia/stdlib/v1.9/Test/src/Test.jl:1498 [inlined]
    [5] macro expansion
      @ ~/Projects/SEAL.jl/test/test_2_encoders.jl:3 [inlined]
    [6] macro expansion
      @ ~/.julia/juliaup/julia-1.9.4+0.x64.linux.gnu/share/julia/stdlib/v1.9/Test/src/Test.jl:1498 [inlined]
    [7] top-level scope
      @ ~/Projects/SEAL.jl/test/test_2_encoders.jl:2
    [8] include(fname::String)
      @ Base.MainInclude ./client.jl:478
    [9] top-level scope
      @ ~/Projects/SEAL.jl/test/runtests.jl:6
   [10] include(fname::String)
      @ Base.MainInclude ./client.jl:478
   [11] top-level scope
      @ none:6
   [12] eval
      @ ./boot.jl:370 [inlined]
   [13] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:280
   [14] _start()
      @ Base ./client.jl:522
Test Summary:   | Error  Total  Time
2_encoders      |     1      1  0.9s
  batch_encoder |     1      1  0.9s
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
in expression starting at /home/zhanibek/Projects/SEAL.jl/test/test_2_encoders.jl:1
in expression starting at /home/zhanibek/Projects/SEAL.jl/test/runtests.jl:6
ERROR: Package SEAL errored during testing
```