### PR TITLE
Fix version of GDAL_jll

### DIFF
--- a/D/DGGRID7/build_tarballs.jl
+++ b/D/DGGRID7/build_tarballs.jl
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"); compat="v301.600.200")
+    Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"); compat="=v301.600.200")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
`GDAL_jll` has been updated to v301.700.200+0 that produces the library file `libgdal.so.33`.
However, `DGGRID7_jlll` requires  `libgdal.so.32`:

```
julia> DGGRID7_jll.dggrid() do x run(`$x /dev/null`) end
/root/.julia/artifacts/f4aac71056880a075dd62fa9b9a65d44c6de441e/bin/dggrid: error while loading shared libraries: libgdal.so.32: cannot open shared object file: No such file or directory
ERROR: failed process: Process(`/root/.julia/artifacts/f4aac71056880a075dd62fa9b9a65d44c6de441e/bin/dggrid /dev/null`, ProcessExited(127)) [127]
```

This PR fixes the compat of GDAL that has non-standard version numbers.
See PR #6740 for previous work.