### PR TITLE
[MKL_Headers] Upgrade to v2024.0.0

### DIFF
--- a/M/MKL_Headers/build_tarballs.jl
+++ b/M/MKL_Headers/build_tarballs.jl
@@ -8,30 +8,25 @@ version = v"2023.2.0"
 # Collection of sources required to complete build
 sources = [
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-include/2023.2.0/download/win-32/mkl-include-2023.2.0-intel_49496.tar.bz2",
-        "0ed907ecc2eaae0ed8c280814392b5b80cc19df78838d9688273a12bd72c7bf8";
+        "https://anaconda.org/intel/mkl-include/2024.0.0/download/win-32/mkl-include-2024.0.0-intel_49657.tar.bz2",
+        "9359c55d2fcf26b7cd879362504416fb5cd924af07f29e763c9dab980c19f783";
         unpack_target = "mkl-include-i686-w64-mingw32"
     ),
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-include/2023.2.0/download/win-64/mkl-include-2023.2.0-intel_49496.tar.bz2",
-        "daa93c899e6c7627232fa60e67a2b6079cd29752e8ba1251ae895a57e51defa7";
+        "https://anaconda.org/intel/mkl-include/2024.0.0/download/win-64/mkl-include-2024.0.0-intel_49657.tar.bz2",
+        "8f4215100f4360017721ce154c0fd9fa1628c78ac733e4cbd863d1bf3ab4f21d";
         unpack_target = "mkl-include-x86_64-w64-mingw32"
     ),
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-include/2023.2.0/download/linux-32/mkl-include-2023.2.0-intel_49495.tar.bz2",
-        "b4433c6839bb7f48951b2dcf409dec7306aee3649c539ee0513d8bfb1a1ea283";
+        "https://anaconda.org/intel/mkl-include/2024.0.0/download/linux-32/mkl-include-2024.0.0-intel_49656.tar.bz2",
+        "6a55c84a4a3088b36d507ee6de019c52c164a7756f4e14275cf0bf16aac9e87d";
         unpack_target = "mkl-include-i686-linux-gnu"
     ),
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-include/2023.2.0/download/linux-64/mkl-include-2023.2.0-intel_49495.tar.bz2",
-        "0dfb6ca3c17d99641f20877579c78155cf95aa0b22363bcc91b1d57df4646318";
+        "https://anaconda.org/intel/mkl-include/2024.0.0/download/linux-64/mkl-include-2024.0.0-intel_49656.tar.bz2",
+        "fcbdf5d4197f18fb91fa1d9648f35a45628cc1131ff58c83dcbafe2767490571";
         unpack_target = "mkl-include-x86_64-linux-gnu"
     ),
-    ArchiveSource(
-        "https://anaconda.org/intel/mkl-include/2023.2.0/download/osx-64/mkl-include-2023.2.0-intel_49499.tar.bz2",
-        "c3940a33498df821821c28dc292f7d7a739b11892856fd9fbbc3de5cf0990b00";
-        unpack_target = "mkl-include-x86_64-apple-darwin14"
-    )
 ]
 
 # Bash recipe for building across all platforms
@@ -50,7 +45,6 @@ install_license info/licenses/*.txt
 platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
     Platform("i686", "linux"; libc="glibc"),
-    Platform("x86_64", "macos"),
     Platform("i686", "windows"),
     Platform("x86_64", "windows"),
 ]
@@ -65,4 +59,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
Mac is not anymore supported (see [here](https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-macos/2024-0/overview.html)).