### PR TITLE
[CUDA] Build 12.3.1 SDK

### DIFF
--- a/C/CUDA/CUDA_SDK@12.3/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK@12.3/build_tarballs.jl
@@ -15,3 +15,5 @@ platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "windows")]
 
 build_sdk(name, version, platforms; static=false)
+
+# Bump for 12.3.1 build

--- a/C/CUDA/CUDA_SDK_static@12.3/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK_static@12.3/build_tarballs.jl
@@ -15,3 +15,5 @@ platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "windows")]
 
 build_sdk(name, version, platforms; static=true)
+
+# Bump for 12.3.1 build


### PR DESCRIPTION
The SDK part of CUDA 12.3.1 was missed in the version bump PR https://github.com/JuliaPackaging/Yggdrasil/pull/7707, so touch the files to rebuild them with the new version.