### PR TITLE
[MKL] Require same version of IntelOpenMP

### DIFF
--- a/M/MKL/build_tarballs.jl
+++ b/M/MKL/build_tarballs.jl
@@ -43,7 +43,11 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="IntelOpenMP_jll", uuid="1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0")),
+    # MKL should use the corresponding version of IntelOpenMP, otherwise there may
+    # occasionally be incompatibilities, e.g. x86_64 macOS builds were removed in v2024,
+    # using MKL v2023 with IntelOpenMP v2024 would be problematic:
+    # <https://github.com/JuliaMath/FFTW.jl/issues/281>.
+    Dependency(PackageSpec(name="IntelOpenMP_jll", uuid="1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"); compat=string(version)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
MKL should really go hand-in-hand with Intel OpenMP.  See for example https://github.com/JuliaMath/FFTW.jl/issues/281.

Opening as draft because this should be fixed in the registry first, but don't have the time to do that right now.  ***Edit***: done in https://github.com/JuliaRegistries/General/pull/96745.