### PR TITLE
Build version 4.0.2 of DSSP

### DIFF
--- a/D/DSSP/build_tarballs.jl
+++ b/D/DSSP/build_tarballs.jl
@@ -2,14 +2,14 @@ using BinaryBuilder, Pkg
 using BinaryBuilderBase: default_host_platform
 
 name = "DSSP"
-version = v"4.4.0"
+version = v"4.0.2"
 
 # url = "https://github.com/PDB-REDO/dssp"
 # description = "Application to assign secondary structure to proteins"
 
 sources = [
     GitSource("https://github.com/PDB-REDO/dssp",
-              "c5ec1f2ddc800e7054d47a952b1ce21449f1d6b8"),
+              "d115298091d0d3fdc5235bb8ed6d39b1828c776c"),
     GitSource("https://github.com/PDB-REDO/libcifpp",
               "836aed6ea9a227b37e5b0d9cbcb1253f545d0778"), # v5.1.0 (git-tag v5.1.0.1)
     ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",


### PR DESCRIPTION
The DSSP version 4.0.2 produces different results from the 4.4.0 version, and is sometimes needed to reproduce results from previous publications. Thus, this commit builds the 4.0.2 binaries of DSSP such that they can be used.