### PR TITLE
Fix crash in t8code_jll: bump preferred gcc version to 12.0.1.

### DIFF
--- a/T/t8code/build_tarballs.jl
+++ b/T/t8code/build_tarballs.jl
@@ -108,4 +108,4 @@ append!(dependencies, platform_dependencies)
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.6", preferred_gcc_version = v"8.1.0")
+               augment_platform_block, julia_compat="1.6", preferred_gcc_version = v"12.1.0")


### PR DESCRIPTION
This PR fixes a crash on the `x86_64-w64-mingw32` platform when loading `t8code_jll` in Julia. The error message
was something like this:
```
Mingw-w64 runtime failure:
32 bit pseudo relocation at 00007FF6E40F66A1 out of range, targeting 00007FFAB9EEDA10, yielding the value 00000003D5DF736B.
```

Bumping the preferred gcc version to a newer version fixes the problem.