### PR TITLE
[SuiteSparse_GPU] Update products to only contain GPU libraries

### DIFF
--- a/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
@@ -4,8 +4,6 @@ name = "SuiteSparse"
 version = v"7.4.0"
 
 sources = suitesparse_sources(version)
-
-sources = suitesparse_sources(version)
 push!(sources, DirectorySource("./bundled"))
 
 # Bash recipe for building across all platforms

--- a/S/SuiteSparse/SuiteSparse_GPU@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse_GPU@7/build_tarballs.jl
@@ -99,10 +99,6 @@ install_license LICENSE.txt
 platforms = CUDA.supported_platforms()
 filter!(p -> arch(p) == "x86_64", platforms)
 
-# Add products
-push!(products, LibraryProduct("libgpuqrengine", :libgpuqrengine))
-push!(products, LibraryProduct("libsuitesparse_gpuruntime", :libsuitesparse_gpuruntime))
-
 # Add dependency on SuiteSparse_jll
 push!(dependencies, Dependency("SuiteSparse_jll"))
 
@@ -113,7 +109,7 @@ for platform in platforms
     cuda_deps = CUDA.required_dependencies(platform)
 
     build_tarballs(ARGS, name, version, sources, script, [platform],
-                   products, [dependencies; cuda_deps]; lazy_artifacts=true,
+                   gpu_products, [dependencies; cuda_deps]; lazy_artifacts=true,
                    julia_compat="1.10",preferred_gcc_version=v"9",
                    augment_platform_block=CUDA.augment,
                    skip_audit=true, dont_dlopen=true)

--- a/S/SuiteSparse/SuiteSparse_GPU@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse_GPU@7/build_tarballs.jl
@@ -6,6 +6,7 @@ name = "SuiteSparse_GPU"
 version = v"7.4.0"
 
 sources = suitesparse_sources(version)
+push!(sources, DirectorySource("./bundled"))
 
 const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
@@ -17,6 +18,9 @@ cd $WORKSPACE/srcdir/SuiteSparse
 
 # Needs cmake >= 3.22 provided by jll
 apk del cmake
+
+# Apply upstream patch to fix BLAS calls (backported from 7.5.0 dev branch)
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/blas_suffix.patch
 
 # Ensure CUDA is on the path
 export CUDA_HOME=${WORKSPACE}/destdir/cuda;
@@ -105,7 +109,7 @@ for platform in platforms
 
     build_tarballs(ARGS, name, version, sources, script, [platform],
                    gpu_products, [dependencies; cuda_deps]; lazy_artifacts=true,
-                   julia_compat="1.10",preferred_gcc_version=v"9",
+                   julia_compat="1.11",preferred_gcc_version=v"9",
                    augment_platform_block=CUDA.augment,
                    skip_audit=true, dont_dlopen=true)
 end

--- a/S/SuiteSparse/SuiteSparse_GPU@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse_GPU@7/build_tarballs.jl
@@ -3,7 +3,7 @@ include("../common.jl")
 using Base.BinaryPlatforms: arch, os
 
 name = "SuiteSparse_GPU"
-version = v"7.3.0"
+version = v"7.4.0"
 
 sources = suitesparse_sources(version)
 
@@ -17,6 +17,14 @@ cd $WORKSPACE/srcdir/SuiteSparse
 
 # Needs cmake >= 3.22 provided by jll
 apk del cmake
+
+# Ensure CUDA is on the path
+export CUDA_HOME=${WORKSPACE}/destdir/cuda;
+export PATH=$PATH:$CUDA_HOME/bin
+export CUDACXX=$CUDA_HOME/bin/nvcc
+
+# nvcc thinks the libraries are located inside lib64, but the SDK actually has them in lib
+ln -s ${CUDA_HOME}/lib ${CUDA_HOME}/lib64
 
 # Disable OpenMP as it will probably interfere with blas threads and Julia threads
 FLAGS+=(INSTALL="${prefix}" INSTALL_LIB="${libdir}" INSTALL_INCLUDE="${prefix}/include" CFOPENMP=)
@@ -38,59 +46,45 @@ fi
 if [[ ${nbits} == 64 ]]; then
     CMAKE_OPTIONS=(
         -DBLAS64_SUFFIX="_64"
-        -DALLOW_64BIT_BLAS=YES
+        -DSUITESPARSE_USE_64BIT_BLAS=YES
     )
 else
     CMAKE_OPTIONS=(
-        -DALLOW_64BIT_BLAS=NO
+        -DSUITESPARSE_USE_64BIT_BLAS=NO
     )
 fi
 
-for proj in SuiteSparse_config SuiteSparse_GPURuntime GPUQREngine CHOLMOD SPQR; do
-    cd ${proj}/build
-    cmake .. -DCMAKE_BUILD_TYPE=Release \
-             -DCMAKE_INSTALL_PREFIX=${prefix} \
-             -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-             -DENABLE_CUDA=1 \
-             -DNFORTRAN=1 \
-             -DNOPENMP=1 \
-             -DNSTATIC=1 \
-             -DBLAS_FOUND=1 \
-             -DBLAS_LIBRARIES="${libdir}/lib${BLAS_NAME}.${dlext}" \
-             -DBLAS_LINKER_FLAGS="${BLAS_NAME}" \
-             -DBLAS_UNDERSCORE=ON \
-             -DBLA_VENDOR="${BLAS_NAME}" \
-             -DLAPACK_FOUND=1 \
-             -DLAPACK_LIBRARIES="${libdir}/lib${BLAS_NAME}.${dlext}" \
-             -DLAPACK_LINKER_FLAGS="${BLAS_NAME}" \
-             "${CMAKE_OPTIONS[@]}"
-    make -j${nproc}
-    make install
-    cd ../..
-done
+PROJECTS_TO_BUILD="cholmod;spqr"
 
-# For now, we'll have to adjust the name of the Lbt library on macOS and FreeBSD.
-# Eventually, this should be fixed upstream
-if [[ ${target} == *-apple-* ]] || [[ ${target} == *freebsd* ]]; then
-    echo "-- Modifying library name for Lbt"
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_RELEASE_POSTFIX="_cuda" \
+      -DBUILD_STATIC_LIBS=OFF \
+      -DBUILD_TESTING=OFF \
+      -DSUITESPARSE_ENABLE_PROJECTS=${PROJECTS_TO_BUILD} \
+      -DSUITESPARSE_DEMOS=OFF \
+      -DSUITESPARSE_USE_STRICT=ON \
+      -DSUITESPARSE_USE_CUDA=ON \
+      -DSUITESPARSE_USE_FORTRAN=OFF \
+      -DSUITESPARSE_USE_OPENMP=OFF \
+      -DSUITESPARSE_USE_SYSTEM_SUITESPARSE_CONFIG=ON \
+      -DSUITESPARSE_USE_SYSTEM_AMD=ON \
+      -DSUITESPARSE_USE_SYSTEM_COLAMD=ON \
+      -DSUITESPARSE_USE_SYSTEM_CAMD=ON \
+      -DSUITESPARSE_USE_SYSTEM_CCOLAMD=ON \
+      -DCHOLMOD_PARTITION=ON \
+      -DBLAS_FOUND=1 \
+      -DBLAS_LIBRARIES="${libdir}/lib${BLAS_NAME}.${dlext}" \
+      -DBLAS_LINKER_FLAGS="${BLAS_NAME}" \
+      -DBLA_VENDOR="${BLAS_NAME}" \
+      -DLAPACK_LIBRARIES="${libdir}/lib${BLAS_NAME}.${dlext}" \
+      -DLAPACK_LINKER_FLAGS="${BLAS_NAME}" \
+      "${CMAKE_OPTIONS[@]}" \
+      .
 
-    for nm in libcholmod libspqr; do
-        # Figure out what version it probably latched on to:
-        if [[ ${target} == *-apple-* ]]; then
-            LBT_LINK=$(otool -L ${libdir}/${nm}.dylib | grep lib${BLAS_NAME} | awk '{ print $1 }')
-            install_name_tool -change ${LBT_LINK} @rpath/lib${BLAS_NAME}.dylib ${libdir}/${nm}.dylib
-        elif [[ ${target} == *freebsd* ]]; then
-            LBT_LINK=$(readelf -d ${libdir}/${nm}.so | grep lib${BLAS_NAME} | sed -e 's/.*\[\(.*\)\].*/\1/')
-            patchelf --replace-needed ${LBT_LINK} lib${BLAS_NAME}.so ${libdir}/${nm}.so
-        fi
-    done
-fi
-
-# Delete the extra soversion libraries built. https://github.com/JuliaPackaging/Yggdrasil/issues/7
-if [[ "${target}" == *-mingw* ]]; then
-    rm -f ${libdir}/lib*.*.${dlext}
-    rm -f ${libdir}/lib*.*.*.${dlext}
-fi
+make -j${nproc}
+make install
 
 install_license LICENSE.txt
 """
@@ -106,7 +100,8 @@ push!(dependencies, Dependency("SuiteSparse_jll"))
 for platform in platforms
     should_build_platform(triplet(platform)) || continue
 
-    cuda_deps = CUDA.required_dependencies(platform)
+    # Need the static SDK to let CMake detect the compiler properly
+    cuda_deps = CUDA.required_dependencies(platform, static_sdk=true)
 
     build_tarballs(ARGS, name, version, sources, script, [platform],
                    gpu_products, [dependencies; cuda_deps]; lazy_artifacts=true,

--- a/S/SuiteSparse/SuiteSparse_GPU@7/bundled/patches/blas_suffix.patch
+++ b/S/SuiteSparse/SuiteSparse_GPU@7/bundled/patches/blas_suffix.patch
@@ -1,0 +1,40 @@
+From b936940aab08dc4bc60ccf2b9daec2105a960ad4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markus=20M=C3=BCtzel?= <markus.muetzel@gmx.de>
+Date: Mon, 1 Jan 2024 13:00:17 +0100
+Subject: [PATCH] Add preprocessor definitions also with user-supplied
+ BLAS_LIBRARIES
+
+---
+ SuiteSparse_config/cmake_modules/SuiteSparseBLAS.cmake   | 4 ++--
+ SuiteSparse_config/cmake_modules/SuiteSparseBLAS64.cmake | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/SuiteSparse_config/cmake_modules/SuiteSparseBLAS.cmake b/SuiteSparse_config/cmake_modules/SuiteSparseBLAS.cmake
+index ca241472d..be7cd2e73 100644
+--- a/SuiteSparse_config/cmake_modules/SuiteSparseBLAS.cmake
++++ b/SuiteSparse_config/cmake_modules/SuiteSparseBLAS.cmake
+@@ -36,9 +36,9 @@ if ( DEFINED BLAS_LIBRARIES OR DEFINED BLAS_INCLUDE_DIRS )
+     # User supplied variables for libraries and/or include directories.
+     # Use them as-is.
+     if ( SUITESPARSE_USE_64BIT_BLAS )
+-        set ( SuiteSparse_BLAS_integer "int64_t" )
++        include ( SuiteSparseBLAS64 )
+     else ( )
+-        set ( SuiteSparse_BLAS_integer "int32_t" )
++        include ( SuiteSparseBLAS32 )
+     endif ( )
+     return ( )
+ endif ( )
+diff --git a/SuiteSparse_config/cmake_modules/SuiteSparseBLAS64.cmake b/SuiteSparse_config/cmake_modules/SuiteSparseBLAS64.cmake
+index 744aaef91..1a5c63690 100644
+--- a/SuiteSparse_config/cmake_modules/SuiteSparseBLAS64.cmake
++++ b/SuiteSparse_config/cmake_modules/SuiteSparseBLAS64.cmake
+@@ -37,7 +37,7 @@ set ( SuiteSparse_BLAS_integer "int64_t" )
+ # https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/suite-sparse/package.py
+
+ if ( DEFINED BLAS64_SUFFIX )
+-    # append BLAS64_SUFFIX to each BLAS and LAPACK name
++    # append BLAS64_SUFFIX to each BLAS and LAPACK function name
+     string ( FIND ${BLAS64_SUFFIX} "_" HAS_UNDERSCORE )
+     message ( STATUS "BLAS64_suffix: ${BLAS64_SUFFIX}" )
+     if ( HAS_UNDERSCORE EQUAL -1 )

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -52,6 +52,15 @@ products = [
     LibraryProduct("libspqr",                :libspqr),
 ]
 
+# Products for the GPU builds of SuiteSparse
+gpu_products = [
+    LibraryProduct("libsuitesparseconfig",      :libsuitesparseconfig),
+    LibraryProduct("libcholmod",                :libcholmod),
+    LibraryProduct("libspqr",                   :libspqr),
+    LibraryProduct("libgpuqrengine",            :libgpuqrengine),
+    LibraryProduct("libsuitesparse_gpuruntime", :libsuitesparse_gpuruntime),
+]
+
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("libblastrampoline_jll"; compat="5.8.0"),

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -54,11 +54,10 @@ products = [
 
 # Products for the GPU builds of SuiteSparse
 gpu_products = [
-    LibraryProduct("libsuitesparseconfig",      :libsuitesparseconfig),
-    LibraryProduct("libcholmod",                :libcholmod),
-    LibraryProduct("libspqr",                   :libspqr),
-    LibraryProduct("libgpuqrengine",            :libgpuqrengine),
-    LibraryProduct("libsuitesparse_gpuruntime", :libsuitesparse_gpuruntime),
+    LibraryProduct("libcholmod_cuda",                :libcholmod),
+    LibraryProduct("libspqr_cuda",                   :libspqr),
+    LibraryProduct("libgpuqrengine_cuda",            :libgpuqrengine),
+    LibraryProduct("libsuitesparse_gpuruntime_cuda", :libsuitesparse_gpuruntime),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
The registration for the v7 SuiteSparse GPU JLL failed because some SuiteSparse libraries (such as AMD) were declared as products in the recipe, but we weren't actually building them in the GPU JLL because we were going to be using the CPU-built ones in the normal JLL (since there isn't a GPU-specific version of those libraries.

Log file of the failure: https://buildkite.com/julialang/yggdrasil/builds/6438#018baa65-8284-4658-b64a-39baf25356f7, error:
```Julia
ERROR: LoadError: Unable to locate LibraryProduct(["libamd"], :libamd, String[], false, Symbol[]) within /tmp/jl_C9Wk2N for x86_64-linux-gnu-cuda+11.4
```

Instead, we need to declare only the GPU-accelerated libraries in the GPU recipe.