### PR TITLE
[Hugo] add recipe

### DIFF
--- a/H/Hugo/build_tarballs.jl
+++ b/H/Hugo/build_tarballs.jl
@@ -1,0 +1,47 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message
+using BinaryBuilder, Pkg
+
+name = "Hugo"
+version = v"0.118.2"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource(
+        "https://github.com/gohugoio/hugo.git",
+        "da7983ac4b94d97d776d7c2405040de97e95c03d",
+    ),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/hugo
+install_license LICENSE
+mkdir -p ${bindir}
+CGO_ENABLED=1 go build -o ${bindir}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [ExecutableProduct("hugo", :hugo)]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+# Build the tarballs, and possibly a `build.jl` as well
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    julia_compat = "1.6",
+    compilers = [:go, :c],
+)
+

--- a/H/Hugo/build_tarballs.jl
+++ b/H/Hugo/build_tarballs.jl
@@ -1,6 +1,6 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message
-using BinaryBuilder, Pkg
+using BinaryBuilder
 
 name = "Hugo"
 version = v"0.118.2"

--- a/H/Hugo/build_tarballs.jl
+++ b/H/Hugo/build_tarballs.jl
@@ -1,5 +1,5 @@
 # Note that this script can accept some limited command-line arguments, run
-# `julia build_tarballs.jl --help` to see a usage message
+# `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 
 name = "Hugo"


### PR DESCRIPTION
- Name: Hugo
- Version: v0.118.2 (da7983ac4b94d97d776d7c2405040de97e95c03d)
- Source: https://github.com/gohugoio/hugo.git
- Language(s): Go
- Build System: go
- Depends: None
- Depends (optional): None
- Description: "The world's fastest framework for building websites."

Requires Go v1.20 to build above v0.118
Windows builds work on my machine though buildkite throws "unable to initialize decompress status for section .zdebug_abbrev" which looks similar to https://github.com/golang/go/issues/28697. It seems to build and work fine so I'm not sure if this is an issue?