### PR TITLE
[MKL_Headers] Rebuild 2023.2.0 to fix missing CMake files

### DIFF
--- a/M/MKL_Headers/build_tarballs.jl
+++ b/M/MKL_Headers/build_tarballs.jl
@@ -2,53 +2,68 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
+# Note: 2024.0.0 has already been built, but 2023.2.0 is being built to fix a bug in the packaging where the CMake/pkgconfig scripts were missing.
+# When updating to the next 2024.x.x release, the following must be done again (in addition to updating the sources):
+# * Bump the Julia compat to 1.6
+# * Remove the macos x86_64 platform and source files
+
 name = "MKL_Headers"
-version = v"2024.0.0"
+version = v"2023.2.0"
 
 # Collection of sources required to complete build
 sources = [
     # Archives for the headers
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-include/2024.0.0/download/win-32/mkl-include-2024.0.0-intel_49657.tar.bz2",
-        "9359c55d2fcf26b7cd879362504416fb5cd924af07f29e763c9dab980c19f783";
+        "https://anaconda.org/intel/mkl-include/2023.2.0/download/win-32/mkl-include-2023.2.0-intel_49496.tar.bz2",
+        "0ed907ecc2eaae0ed8c280814392b5b80cc19df78838d9688273a12bd72c7bf8";
         unpack_target = "mkl-include-i686-w64-mingw32"
     ),
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-include/2024.0.0/download/win-64/mkl-include-2024.0.0-intel_49657.tar.bz2",
-        "8f4215100f4360017721ce154c0fd9fa1628c78ac733e4cbd863d1bf3ab4f21d";
+        "https://anaconda.org/intel/mkl-include/2023.2.0/download/win-64/mkl-include-2023.2.0-intel_49496.tar.bz2",
+        "daa93c899e6c7627232fa60e67a2b6079cd29752e8ba1251ae895a57e51defa7";
         unpack_target = "mkl-include-x86_64-w64-mingw32"
     ),
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-include/2024.0.0/download/linux-32/mkl-include-2024.0.0-intel_49656.tar.bz2",
-        "6a55c84a4a3088b36d507ee6de019c52c164a7756f4e14275cf0bf16aac9e87d";
+        "https://anaconda.org/intel/mkl-include/2023.2.0/download/linux-32/mkl-include-2023.2.0-intel_49495.tar.bz2",
+        "b4433c6839bb7f48951b2dcf409dec7306aee3649c539ee0513d8bfb1a1ea283";
         unpack_target = "mkl-include-i686-linux-gnu"
     ),
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-include/2024.0.0/download/linux-64/mkl-include-2024.0.0-intel_49656.tar.bz2",
-        "fcbdf5d4197f18fb91fa1d9648f35a45628cc1131ff58c83dcbafe2767490571";
+        "https://anaconda.org/intel/mkl-include/2023.2.0/download/linux-64/mkl-include-2023.2.0-intel_49495.tar.bz2",
+        "0dfb6ca3c17d99641f20877579c78155cf95aa0b22363bcc91b1d57df4646318";
         unpack_target = "mkl-include-x86_64-linux-gnu"
+    ),
+    ArchiveSource(
+        "https://anaconda.org/intel/mkl-include/2023.2.0/download/osx-64/mkl-include-2023.2.0-intel_49499.tar.bz2",
+        "c3940a33498df821821c28dc292f7d7a739b11892856fd9fbbc3de5cf0990b00";
+        unpack_target = "mkl-include-x86_64-apple-darwin14"
     ),
 
     # Archives for the CMake/pkgconfig files
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-devel/2024.0.0/download/win-32/mkl-devel-2024.0.0-intel_49657.tar.bz2",
-        "6d7ce2dd7660e31251621e4b5d22049e0bace07b650831db8b4e7b1a78981dc5";
+        "https://anaconda.org/intel/mkl-devel/2023.2.0/download/win-32/mkl-devel-2023.2.0-intel_49496.tar.bz2",
+        "15653969e64579e7bfb098fcc3e994590b6f7f7fcf9f2ac6447884e8f0ffb027";
         unpack_target = "mkl-devel-i686-w64-mingw32"
     ),
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-devel/2024.0.0/download/win-64/mkl-devel-2024.0.0-intel_49657.tar.bz2",
-        "05e43480b2bf0a4f6e6f3208aa88e613b0b44e6639c7c5e52bef518193364dba";
+        "https://anaconda.org/intel/mkl-devel/2023.2.0/download/win-64/mkl-devel-2023.2.0-intel_49496.tar.bz2",
+        "caaf632783636e8434216f37978b0942e0aa18c9fd3a4bb4a0444aa48ac07323";
         unpack_target = "mkl-devel-x86_64-w64-mingw32"
     ),
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-devel/2024.0.0/download/linux-32/mkl-devel-2024.0.0-intel_49656.tar.bz2",
-        "6e57d8f98ab904b55d8e5bb810c06d8d889308f774a6ec08cac76c53b6024256";
+        "https://anaconda.org/intel/mkl-devel/2023.2.0/download/linux-32/mkl-devel-2023.2.0-intel_49495.tar.bz2",
+        "09302cd45ff9252e862abe8bc01cefc1f4afa8339237129f847620784f1fd93e";
         unpack_target = "mkl-devel-i686-linux-gnu"
     ),
     ArchiveSource(
-        "https://anaconda.org/intel/mkl-devel/2024.0.0/download/linux-64/mkl-devel-2024.0.0-intel_49656.tar.bz2",
-        "f6c37ade3153a0a98cf1f50346af32be1b87c4c3cb09e4f7b94dcb77b4896bd7";
+        "https://anaconda.org/intel/mkl-devel/2023.2.0/download/linux-64/mkl-devel-2023.2.0-intel_49495.tar.bz2",
+        "f3e2b7063b28b280602fea4005408ee74cf6a376bc99c0e05fc67531f2c03ace";
         unpack_target = "mkl-devel-x86_64-linux-gnu"
+    ),
+    ArchiveSource(
+        "https://anaconda.org/intel/mkl-devel/2023.2.0/download/osx-64/mkl-devel-2023.2.0-intel_49499.tar.bz2",
+        "0f1f7da2fb79d40257c9a15496c84036771cb265c6e3c82ed8b5852c64bdeed0";
+        unpack_target = "mkl-devel-x86_64-apple-darwin14"
     ),
 ]
 
@@ -77,6 +92,7 @@ fi
 platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
     Platform("i686", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
     Platform("i686", "windows"),
     Platform("x86_64", "windows"),
 ]
@@ -91,4 +107,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.0")


### PR DESCRIPTION
We have already built 2024.0.0, and that has been fixed to include these CMake/pkgconfig files, but because 2023.2.0 is the last version that is installable on macOS, in order to compile for macOS targets, we should also add these build system files to the 2023.2.0 headers package as well.

I believe this should work with the registry and create a new version for 2023.2.0 and not kill 2024.0.0. I have also restored the old Julia compatibility that 2023.2.0 had, so this should be a transparent change.