### PR TITLE
libpicosat: fork PicoSAT, only provide libpicosat, support Windows

### DIFF
--- a/L/libpicosat/build_tarballs.jl
+++ b/L/libpicosat/build_tarballs.jl
@@ -1,0 +1,39 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libpicosat"
+version = v"965.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("http://fmv.jku.at/picosat/picosat-965.tar.gz", "15169b4f28ba8f628f353f6f75a100845cdef4a2244f101a02b6e5a26e46a754"),
+    DirectorySource("./bundled")
+    ]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/picosat*
+cp ../{Makefile,config.h} .
+if [[ ${target} == *musl* ]]; then
+    sed -i 's!sys/unistd.h!unistd.h!g' picosat.c
+fi
+make libpicosat.${dlext}
+make install
+install_license LICENSE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; experimental=true)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libpicosat", :libpicosat),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"5.2.0", julia_compat="1.6")

--- a/L/libpicosat/bundled/Makefile
+++ b/L/libpicosat/bundled/Makefile
@@ -1,0 +1,59 @@
+CFLAGS += -DNDEBUG -O3 -fPIC
+CFLAGS += -DTRACE -DNGETRUSAGE -DNALLSIGNALS
+
+all: picosat picomcs picomus picogcnf libpicosat.$(dlext)
+
+clean:
+	rm -f picosat picomcs picomus picogcnf
+	rm -f *.exe *.s *.o *.a *.so *.plist
+	rm -f Makefile config.h
+	rm -f gmon.out *~
+
+analyze:
+	clang --analyze $(CFLAGS) *.c *.h
+
+picosat: libpicosat.$(dlext) app.o main.o
+	$(CC) $(CFLAGS) -o $@ main.o app.o -L. -lpicosat
+
+picomcs: libpicosat.$(dlext) picomcs.o
+	$(CC) $(CFLAGS) -o $@ picomcs.o -L. -lpicosat
+
+picomus: libpicosat.$(dlext) picomus.o
+	$(CC) $(CFLAGS) -o $@ picomus.o -L. -lpicosat
+
+picogcnf: libpicosat.$(dlext) picogcnf.o
+	$(CC) $(CFLAGS) -o $@ picogcnf.o -L. -lpicosat
+
+app.o: app.c picosat.h Makefile
+	$(CC) $(CFLAGS) -c $<
+
+picomcs.o: picomcs.c picosat.h Makefile
+	$(CC) $(CFLAGS) -c $<
+
+picomus.o: picomus.c picosat.h Makefile
+	$(CC) $(CFLAGS) -c $<
+
+picogcnf.o: picogcnf.c picosat.h Makefile
+	$(CC) $(CFLAGS) -c $<
+
+main.o: main.c picosat.h Makefile
+	$(CC) $(CFLAGS) -c $<
+
+picosat.o: picosat.c picosat.h Makefile
+	$(CC) $(CFLAGS) -c $<
+
+version.o: version.c config.h Makefile
+	$(CC) $(CFLAGS) -c $<
+
+config.h: Makefile VERSION mkconfig.sh # and actually picosat.c
+	rm -f $@; sed -i -e 's$PICOSAT_CC$PICOSAT_CC "${CC}"$g' -e 's$PICOSAT_CFLAGS "${CFLAGS}"$g'
+
+libpicosat.$(dlext): picosat.o version.o
+	$(CC) $(CFLAGS) -shared -o $@ picosat.o version.o
+
+install: libpicosat.$(dlext)
+	install -d $(libdir) $(includedir)
+	install libpicosat.$(dlext) $(libdir)
+	install picosat.h $(includedir)
+
+.PHONY: all clean install

--- a/L/libpicosat/bundled/config.h
+++ b/L/libpicosat/bundled/config.h
@@ -1,0 +1,3 @@
+#define PICOSAT_CC
+#define PICOSAT_CFLAGS
+#define PICOSAT_VERSION "965"


### PR DESCRIPTION
I want to use libpicosat in Pkg (see https://github.com/StefanKarpinski/Resolver.jl) and I need it to work on all platforms. The library libpicosat.{so,dll,dylib} is pretty easy to compile for all platforms but the programs rely on a lot of POSIX stuff. This forked JLL provides just the dylib and adds Windows support. We also want what Pkg uses to be as minimal as possible, so this seems worth having as a separate JLL.