### PR TITLE
Use new keyword argument `clang_use_lld` where possible

### DIFF
--- a/A/AMReX/build_tarballs.jl
+++ b/A/AMReX/build_tarballs.jl
@@ -51,15 +51,6 @@ else
     mpiopts=
 fi
 
-if [[ "${target}" == x86_64-apple-darwin* ]]; then
-    # See <https://github.com/JuliaPackaging/Yggdrasil/issues/7745>:
-    # Remove the new fancy linkers which don't work yet
-    rm /opt/bin/${bb_full_target}/ld64.lld
-    rm /opt/bin/${bb_full_target}/ld64.${target}
-    rm /opt/bin/${bb_full_target}/${target}-ld64.lld
-    rm /opt/${MACHTYPE}/bin/ld64.lld
-fi
-
 if [[ "${target}" == *-mingw32* ]]; then
     # AMReX requires a parallel HDF5 library
     hdf5opts="-DAMReX_HDF5=OFF"
@@ -134,4 +125,4 @@ append!(dependencies, platform_dependencies)
 # - AMReX requires C++17, and at least GCC 8 to provide the <filesystem> header
 # - GCC 8.1.0 suffers from an ICE, so we use GCC 9 instead
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.6", preferred_gcc_version = v"9")
+               augment_platform_block, julia_compat="1.6", preferred_gcc_version = v"9", clang_use_lld=false)

--- a/C/CFITSIO/build_tarballs.jl
+++ b/C/CFITSIO/build_tarballs.jl
@@ -14,15 +14,6 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-if [[ "${target}" == aarch64-apple-darwin* ]]; then
-    # See <https://github.com/JuliaPackaging/Yggdrasil/issues/7745>:
-    # Remove the new fancy linkers which don't work yet
-    rm /opt/bin/${bb_full_target}/ld64.lld
-    rm /opt/bin/${bb_full_target}/ld64.${target}
-    rm /opt/bin/${bb_full_target}/${target}-ld64.lld
-    rm /opt/${MACHTYPE}/bin/ld64.lld
-fi
-
 cd $WORKSPACE/srcdir/cfitsio*
 atomic_patch -p1 ../patches/configure_in.patch
 atomic_patch -p1 ../patches/Makefile_in.patch
@@ -66,4 +57,7 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               # When using lld for AArch64 macOS, linking fails with
+               #     ld64.lld: error: -dylib_current_version 10.4.3.1: malformed version
+               julia_compat="1.6", clang_use_lld=false)

--- a/G/GraphicsMagick/build_tarballs.jl
+++ b/G/GraphicsMagick/build_tarballs.jl
@@ -17,12 +17,6 @@ cd $WORKSPACE/srcdir/GraphicsMagick*
 # Don't use `clock_realtime` if it isn't available
 atomic_patch -p1 ../patches/check-have-clock-realtime.patch
 
-LDFLAGS=()
-if [[ $target = *-darwin* ]]; then
-    # See <https://github.com/JuliaPackaging/Yggdrasil/issues/7745>
-    LDFLAGS=('-fuse-ld=ld')
-fi
-
 # While all libraries are available, only the last set of header files
 # (here depth=8) remain available.
 for depth in 32 16 8; do
@@ -44,8 +38,7 @@ for depth in 32 16 8; do
         --without-gs \
         --without-frozenpaths \
         --without-perl \
-        --without-x \
-        LDFLAGS="${LDFLAGS[@]}"
+        --without-x
     make -j${nproc}
     make install
     popd
@@ -110,4 +103,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", clang_use_lld=false)

--- a/L/Libtiff/build_tarballs.jl
+++ b/L/Libtiff/build_tarballs.jl
@@ -14,12 +14,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/tiff-*
-LDFLAGS=()
-if [[ $target = *-darwin* ]]; then
-    # See <https://github.com/JuliaPackaging/Yggdrasil/issues/7745>
-    LDFLAGS=('-fuse-ld=ld')
-fi
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --docdir=/tmp LDFLAGS="${LDFLAGS[@]}"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --docdir=/tmp
 make -j${nproc}
 make install
 """
@@ -43,4 +38,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", clang_use_lld=false)

--- a/M/MPICH/build_tarballs.jl
+++ b/M/MPICH/build_tarballs.jl
@@ -72,11 +72,6 @@ if [[ "${target}" == aarch64-apple-* ]]; then
     )
 fi
 
-if [[ $target = *-darwin* ]]; then
-    # See <https://github.com/JuliaPackaging/Yggdrasil/issues/7745>
-    EXTRA_FLAGS+=('lt_cv_apple_cc_single_mod=yes')
-fi
-
 # Do not install doc and man files which contain files which clashing names on
 # case-insensitive file systems:
 # * https://github.com/JuliaPackaging/Yggdrasil/pull/315
@@ -136,4 +131,4 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.6")
+               augment_platform_block, julia_compat="1.6", clang_use_lld=false)

--- a/M/MPItrampoline/build_tarballs.jl
+++ b/M/MPItrampoline/build_tarballs.jl
@@ -24,15 +24,6 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-if [[ "${bb_full_target}" == *-apple-darwin*-libgfortran[45]-* ]]; then
-    # See <https://github.com/JuliaPackaging/Yggdrasil/issues/7745>:
-    # Remove the new fancy linkers which don't work yet
-    rm /opt/bin/${bb_full_target}/ld64.lld
-    rm /opt/bin/${bb_full_target}/ld64.${target}
-    rm /opt/bin/${bb_full_target}/${target}-ld64.lld
-    rm /opt/${MACHTYPE}/bin/ld64.lld
-fi
-
 ################################################################################
 # MPItrampoline
 ################################################################################
@@ -301,4 +292,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.6")
+               augment_platform_block, julia_compat="1.6", clang_use_lld=false)

--- a/O/OpenMPI/build_tarballs.jl
+++ b/O/OpenMPI/build_tarballs.jl
@@ -20,15 +20,6 @@ script = raw"""
 # Enter the funzone
 cd ${WORKSPACE}/srcdir/openmpi-*
 
-if [[ "${bb_full_target}" == *-apple-darwin*-libgfortran[45]-* ]]; then
-    # See <https://github.com/JuliaPackaging/Yggdrasil/issues/7745>:
-    # Remove the new fancy linkers which don't work yet
-    rm /opt/bin/${bb_full_target}/ld64.lld
-    rm /opt/bin/${bb_full_target}/ld64.${target}
-    rm /opt/bin/${bb_full_target}/${target}-ld64.lld
-    rm /opt/${MACHTYPE}/bin/ld64.lld
-fi
-
 # Autotools doesn't add `${includedir}` as an include directory on some platforms
 export CPPFLAGS="-I${includedir}"
 
@@ -108,4 +99,4 @@ ENV["OPAL_PREFIX"] = artifact_dir
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               augment_platform_block, init_block, julia_compat="1.6", preferred_gcc_version=v"5")
+               augment_platform_block, init_block, julia_compat="1.6", preferred_gcc_version=v"5", clang_use_lld=false)

--- a/S/SCIP_PaPILO/build_tarballs.jl
+++ b/S/SCIP_PaPILO/build_tarballs.jl
@@ -23,15 +23,6 @@ export CXXFLAGS="-DTHREADLOCAL=''"
 # can be removed for scip 805
 echo "target_link_libraries(clusol gfortran)" >> papilo/CMakeLists.txt
 
-if [[ "${target}" == *apple-darwin* ]]; then
-    # See <https://github.com/JuliaPackaging/Yggdrasil/issues/7745>:
-    # Remove the new linkers which don't work yet
-    rm /opt/bin/${bb_full_target}/ld64.lld
-    rm /opt/bin/${bb_full_target}/ld64.${target}
-    rm /opt/bin/${bb_full_target}/${target}-ld64.lld
-    rm /opt/${MACHTYPE}/bin/ld64.lld
-fi
-
 mkdir build
 cd build/
 cmake -DCMAKE_INSTALL_PREFIX=$prefix\
@@ -102,4 +93,5 @@ build_tarballs(
     dependencies;
     preferred_gcc_version=v"7",
     julia_compat="1.6",
+    clang_use_lld=false,
 )

--- a/T/t8code/build_tarballs.jl
+++ b/T/t8code/build_tarballs.jl
@@ -49,11 +49,6 @@ else
   mpiopts="--enable-mpi"
 fi
 
-# Temporary fix according to: https://github.com/JuliaPackaging/Yggdrasil/issues/7745
-if [[ "${target}" == *-apple-* ]]; then
-  export LDFLAGS="$LDFLAGS -fuse-ld=ld"
-fi
-
 # Run configure
 ./configure \
   --prefix="${prefix}" \
@@ -108,4 +103,4 @@ append!(dependencies, platform_dependencies)
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.6", preferred_gcc_version = v"12.1.0")
+               augment_platform_block, julia_compat="1.6", preferred_gcc_version = v"12.1.0", clang_use_lld=false)


### PR DESCRIPTION
There are some cases where using `lld` as linker together with Clang is proving to be problematic (for example #7745), this new keyword argument lets you easily switch back to using `ld`.