### PR TITLE
[SuiteSparse] Update to v7.4.0

### DIFF
--- a/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
@@ -1,7 +1,7 @@
 include("../common.jl")
 
 name = "SuiteSparse"
-version = v"7.3.0"
+version = v"7.4.0"
 
 sources = suitesparse_sources(version)
 
@@ -37,29 +37,32 @@ else
     )
 fi
 
-for proj in SuiteSparse_config AMD BTF CAMD CCOLAMD COLAMD CHOLMOD LDL KLU UMFPACK RBio SPQR; do
-    cd ${proj}/build
-    cmake .. -DCMAKE_BUILD_TYPE=Release \
-             -DCMAKE_INSTALL_PREFIX=${prefix} \
-             -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-             -DENABLE_CUDA=0 \
-             -DNFORTRAN=1 \
-             -DNOPENMP=1 \
-             -DNPARTITION=0 \
-             -DNSTATIC=1 \
-             -DBLAS_FOUND=1 \
-             -DBLAS_LIBRARIES="${libdir}/lib${BLAS_NAME}.${dlext}" \
-             -DBLAS_LINKER_FLAGS="${BLAS_NAME}" \
-             -DBLAS_UNDERSCORE=ON \
-             -DBLA_VENDOR="${BLAS_NAME}" \
-             -DLAPACK_FOUND=1 \
-             -DLAPACK_LIBRARIES="${libdir}/lib${BLAS_NAME}.${dlext}" \
-             -DLAPACK_LINKER_FLAGS="${BLAS_NAME}" \
-             "${CMAKE_OPTIONS[@]}"
-    make -j${nproc}
-    make install
-    cd ../..
-done
+PROJECTS_TO_BUILD="suitesparse_config;amd;btf;camd;ccolamd;colamd;cholmod;klu;ldl;umfpack;rbio;spqr"
+
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DBUILD_STATIC_LIBS=OFF \
+      -DBUILD_TESTING=OFF \
+      -DSUITESPARSE_ENABLE_PROJECTS=${PROJECTS_TO_BUILD} \
+      -DSUITESPARSE_DEMOS=OFF \
+      -DSUITESPARSE_USE_STRICT=ON \
+      -DSUITESPARSE_USE_CUDA=OFF \
+      -DSUITESPARSE_USE_FORTRAN=OFF \
+      -DSUITESPARSE_USE_OPENMP=OFF \
+      -DNPARTITION=OFF \
+      -DBLAS_FOUND=1 \
+      -DBLAS_LIBRARIES="${libdir}/lib${BLAS_NAME}.${dlext}" \
+      -DBLAS_LINKER_FLAGS="${BLAS_NAME}" \
+      -DBLAS_UNDERSCORE=ON \
+      -DBLA_VENDOR="${BLAS_NAME}" \
+      -DLAPACK_FOUND=1 \
+      -DLAPACK_LIBRARIES="${libdir}/lib${BLAS_NAME}.${dlext}" \
+      -DLAPACK_LINKER_FLAGS="${BLAS_NAME}" \
+      "${CMAKE_OPTIONS[@]}" \
+      .
+make -j${nproc}
+make install
 
 # For now, we'll have to adjust the name of the Lbt library on macOS and FreeBSD.
 # Eventually, this should be fixed upstream

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -19,6 +19,10 @@ function suitesparse_sources(version::VersionNumber; kwargs...)
         v"7.3.0" => [
             GitSource("https://github.com/DrTimothyAldenDavis/SuiteSparse.git",
                       "fad1f30fa260975466bb0ad7da1aabf054517399")
+        ],
+        v"7.4.0" => [
+            GitSource("https://github.com/DrTimothyAldenDavis/SuiteSparse.git",
+                      "df91d7be262e6b5cddf5dd23ff42dec1713e7947")
         ]
     )
     return Any[


### PR DESCRIPTION
This release had a large refactor in how the build system was configured, with the introduction of an overarching CMake file in the root directory that now can select the projects to build, and also the renaming of a lot of the SuiteSparse options we need to configure.