### PR TITLE
[AMGCL_C] new build_tarballs for C Wrapper to AMGCL

### DIFF
--- a/A/AMGCL_C/build_tarballs.jl
+++ b/A/AMGCL_C/build_tarballs.jl
@@ -10,10 +10,6 @@
 #
 # During the build, AMGCL_C downloads AMGCL via ExternalProject_Add() 
 #
-# AMGCL_C uses OpenMP. Unfortunately, on Apple, CMake is unable to find it
-# so currently, OpenMP probably won't be available on MacOS.
-#
-#
 # CMake parameters:
 #   BUILD_DI_INTERFACE: Build interface for double + int
 #   BUILD_DL_INTERFACE: Build interface for double + long

--- a/A/AMGCL_C/build_tarballs.jl
+++ b/A/AMGCL_C/build_tarballs.jl
@@ -55,7 +55,9 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix\
       $(interfaces)\
       -DBLOCKSIZES="BLOCKSIZE(2) BLOCKSIZE(3) BLOCKSIZE(4) BLOCKSIZE(5) BLOCKSIZE(6) BLOCKSIZE(7) BLOCKSIZE(8)"\
       -B build .
-make -C build install
+cd build
+make -j${nprocs}
+make install
 """
 
 # These are the platforms we will build for by default, unless further

--- a/A/AMGCL_C/build_tarballs.jl
+++ b/A/AMGCL_C/build_tarballs.jl
@@ -30,7 +30,7 @@ version = v"0.1.0"
 # Collection of sources required to complete build
 # This accesses AMGCL version 1.4.4 and AMGCL_C 0.1.2
 sources = [
-    GitSource("https://github.com/j-fu/amgcl_c.git", "afe76c46d2bd68aadccd04f56d55e5f7ce78a4b1")
+    GitSource("https://github.com/j-fu/amgcl_c.git", "aab4d220948c0ea269ac624f540f836c8047fb0f")
 ]
 
 # Bash recipe for building across all platform

--- a/A/AMGCL_C/build_tarballs.jl
+++ b/A/AMGCL_C/build_tarballs.jl
@@ -30,7 +30,7 @@ version = v"0.1.0"
 # Collection of sources required to complete build
 # This accesses AMGCL version 1.4.4 and AMGCL_C 0.1.2
 sources = [
-    GitSource("https://github.com/j-fu/amgcl_c.git", "6604079edbb76f18a5a73a07b7638eb26b39fafe")
+    GitSource("https://github.com/j-fu/amgcl_c.git", "afe76c46d2bd68aadccd04f56d55e5f7ce78a4b1")
 ]
 
 # Bash recipe for building across all platform

--- a/A/AMGCL_C/build_tarballs.jl
+++ b/A/AMGCL_C/build_tarballs.jl
@@ -30,7 +30,7 @@ version = v"0.1.0"
 # Collection of sources required to complete build
 # This accesses AMGCL version 1.4.4 and AMGCL_C 0.1.2
 sources = [
-    GitSource("https://github.com/j-fu/amgcl_c.git", "aab4d220948c0ea269ac624f540f836c8047fb0f")
+    GitSource("https://github.com/j-fu/amgcl_c.git", "6c8c3bcdd793cf3098b866e261ee3008a555a41c")
 ]
 
 # Bash recipe for building across all platform

--- a/A/AMGCL_C/build_tarballs.jl
+++ b/A/AMGCL_C/build_tarballs.jl
@@ -76,7 +76,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
+    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
+    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
+    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"))
 ]
 

--- a/A/AMGCL_C/build_tarballs.jl
+++ b/A/AMGCL_C/build_tarballs.jl
@@ -75,7 +75,7 @@ dependencies = [
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"),v"1.79.0")
+    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"); compat="=1.79.0")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/AMGCL_C/build_tarballs.jl
+++ b/A/AMGCL_C/build_tarballs.jl
@@ -26,16 +26,15 @@
 # https://github.com/JuliaSparse/SparseArrays.jl/blob/feb54ee5e49008bd157227099cafe604a67c36fb/src/solvers/umfpack.jl#L145
 # https://github.com/JuliaSparse/SparseArrays.jl/blob/feb54ee5e49008bd157227099cafe604a67c36fb/src/solvers/umfpack.jl#L578
 #
-
 using BinaryBuilder, Pkg
 
 name = "AMGCL_C"
 version = v"0.1.0"
 
 # Collection of sources required to complete build
-# This accesses AMGCL version 1.4.4
+# This accesses AMGCL version 1.4.4 and AMGCL_C 0.1.2
 sources = [
-    GitSource("https://github.com/j-fu/amgcl_c.git", "0225d19d2fe53bb855307aca0dfaac9a8257dde1")
+    GitSource("https://github.com/j-fu/amgcl_c.git", "6604079edbb76f18a5a73a07b7638eb26b39fafe")
 ]
 
 # Bash recipe for building across all platform
@@ -52,7 +51,7 @@ fi
 cmake -DCMAKE_INSTALL_PREFIX=$prefix\
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}\
       -DCMAKE_BUILD_TYPE=Release\
-      $(interfaces)\
+      $interfaces\
       -DBLOCKSIZES="BLOCKSIZE(2) BLOCKSIZE(3) BLOCKSIZE(4) BLOCKSIZE(5) BLOCKSIZE(6) BLOCKSIZE(7) BLOCKSIZE(8)"\
       -B build .
 cd build
@@ -80,8 +79,8 @@ dependencies = [
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"))
+    Dependency(PackageSpec(name="boost_jll", uuid="28df3c45-c428-5900-9ff8-a3135698ca75"),v"1.79.0")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"10.2.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")

--- a/A/AMGCL_C/build_tarballs.jl
+++ b/A/AMGCL_C/build_tarballs.jl
@@ -25,7 +25,7 @@
 using BinaryBuilder, Pkg
 
 name = "AMGCL_C"
-version = v"0.1.0"
+version = v"0.1.2"
 
 # Collection of sources required to complete build
 # This accesses AMGCL version 1.4.4 and AMGCL_C 0.1.2


### PR DESCRIPTION
Build script for [AMGCL_C](https://github.com/j-fu/amgcl_c) which is a C wrapper to [AMGCL](https://github.com/ddemidov/amgcl), an algebraic multigrid (AMG) based iterative solver library.

Intended to serve as the backend to [AMGCLWrap.jl](https://github.com/j-fu/AMGCLWrap.jl) intended to be registered once this PR is approved.
