### PR TITLE
[SDPA] rebuild for Julia 1.10

### DIFF
--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -66,6 +66,7 @@ autoreconf -vi
 export CPPFLAGS="${CPPFLAGS} -I${prefix}/include -I$prefix/include/coin"
 export CXXFLAGS="${CXXFLAGS} -std=c++11"
 if [[ ${target} == *mingw* ]]; then
+    # Needed for https://github.com/JuliaLang/julia/issues/48081
     export LDFLAGS="-L$prefix/bin -L/opt/*-w64-mingw32/*-w64-mingw32/sys-root/lib"
 elif [[ ${target} == *linux* ]]; then
     export LDFLAGS="-ldl -lrt"

--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -73,7 +73,6 @@ fi
 
 # work around missing strtoll strtoull, see https://github.com/JuliaLang/julia/issues/48081
 if [[ "${target}" == *mingw* ]]; then
-    make -C deps install-csl
     cp /opt/*-w64-mingw32/*-w64-mingw32/sys-root/lib/libmsvcrt.a ./usr/lib/libmsvcrt.a
 fi
 

--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -144,4 +144,5 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
     preferred_gcc_version = v"8",
+    clang_use_lld = false,
     julia_compat)

--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -73,7 +73,7 @@ fi
 
 # work around missing strtoll strtoull, see https://github.com/JuliaLang/julia/issues/48081
 if [[ "${target}" == *mingw* ]]; then
-    cp /opt/*-w64-mingw32/*-w64-mingw32/sys-root/lib/libmsvcrt.a ./usr/lib/libmsvcrt.a
+    cp /opt/*-w64-mingw32/*-w64-mingw32/sys-root/lib/libmsvcrt.a /usr/lib/libmsvcrt.a
 fi
 
 ./configure --prefix=$prefix --with-pic --disable-pkg-config --build=${MACHTYPE} --host=${target} \

--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -71,6 +71,12 @@ elif [[ ${target} == *linux* ]]; then
     export LDFLAGS="-ldl -lrt"
 fi
 
+# work around missing strtoll strtoull, see https://github.com/JuliaLang/julia/issues/48081
+if [[ "${target}" == *mingw* ]]; then
+    make -C deps install-csl
+    cp /opt/*-w64-mingw32/*-w64-mingw32/sys-root/lib/libmsvcrt.a ./usr/lib/libmsvcrt.a
+fi
+
 ./configure --prefix=$prefix --with-pic --disable-pkg-config --build=${MACHTYPE} --host=${target} \
 --enable-shared lt_cv_deplibs_check_method=pass_all \
 --with-blas="-lopenblas" --with-lapack="-lopenblas" \

--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -27,7 +27,7 @@ julia_compat = join("~" .* string.(getfield.(julia_versions, :major)) .* "." .* 
 
 name = "SDPA"
 upstream_version = v"7.3.8"
-version_offset = v"0.1.0" # reset to 0.0.0 once the upstream version changes
+version_offset = v"0.1.1" # reset to 0.0.0 once the upstream version changes
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
                         upstream_version.patch * 100 + version_offset.patch)

--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -66,14 +66,9 @@ autoreconf -vi
 export CPPFLAGS="${CPPFLAGS} -I${prefix}/include -I$prefix/include/coin"
 export CXXFLAGS="${CXXFLAGS} -std=c++11"
 if [[ ${target} == *mingw* ]]; then
-    export LDFLAGS="-L$prefix/bin"
+    export LDFLAGS="-L$prefix/bin -L/opt/*-w64-mingw32/*-w64-mingw32/sys-root/lib"
 elif [[ ${target} == *linux* ]]; then
     export LDFLAGS="-ldl -lrt"
-fi
-
-# work around missing strtoll strtoull, see https://github.com/JuliaLang/julia/issues/48081
-if [[ "${target}" == *mingw* ]]; then
-    cp /opt/*-w64-mingw32/*-w64-mingw32/sys-root/lib/libmsvcrt.a /usr/lib/libmsvcrt.a
 fi
 
 ./configure --prefix=$prefix --with-pic --disable-pkg-config --build=${MACHTYPE} --host=${target} \


### PR DESCRIPTION
I get this error with Julia 1.10 https://github.com/jump-dev/SDPA.jl/pull/57, https://github.com/jump-dev/SDPA.jl/issues/56: 
```julia
LoadError: InitError: could not load library "/home/runner/.julia/artifacts/beeb384c8ba60497d81e26a28f74ed99aef88791/lib/libcxxwrap_julia.so"
/home/runner/.julia/artifacts/beeb384c8ba60497d81e26a28f74ed99aef88791/lib/libcxxwrap_julia.so: undefined symbol: small_typeof, version JL_LIBJULIA_1.10
```
Which I assume means I just need to recompile things. I don't really understand `cxxwrap`.