### PR TITLE
Add recipe for libssh 0.10.6

### DIFF
--- a/L/libssh/build_tarballs.jl
+++ b/L/libssh/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 # Necessary for cmake to find openssl on Windows
-if [[ ${target} == *w64* ]]; then
+if [[ ${target} == x86_64-*-mingw* ]]; then
     export OPENSSL_ROOT_DIR=${prefix}/lib64
 fi
 

--- a/L/libssh/build_tarballs.jl
+++ b/L/libssh/build_tarballs.jl
@@ -1,0 +1,65 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libssh"
+version = v"0.10.6"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://www.libssh.org/files/$(version.major).$(version.minor)/libssh-$(version).tar.xz", "1861d498f5b6f1741b6abc73e608478491edcf9c9d4b6630eef6e74596de9dc1")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+# Necessary for cmake to find openssl on Windows
+export OPENSSL_ROOT_DIR=$WORKSPACE/destdir/lib64
+export DOC_DIR=${prefix}/usr/share/doc/libssh
+
+# Build and install library
+cd $WORKSPACE/srcdir/libssh-*
+mkdir build
+cd build/
+
+# Kerberos_krb5_jll is only built for Linux and FreeBSD, so GSSAPI support is
+# only available on those platforms.
+if [[ ${target} == *linux* || ${target} == *freebsd* ]]; then
+    export GSSAPI_ENABLED=ON
+else
+    export GSSAPI_ENABLED=OFF
+fi
+
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+                                     -DCMAKE_BUILD_TYPE=Release \
+                                     -DWITH_GSSAPI=${GSSAPI_ENABLED} \
+                                     -DWITH_EXAMPLES=OFF \
+                                     -DDOXYGEN_GENERATE_TAGFILE='tags.xml' ..
+make -j${nproc}
+make docs install
+
+# Install Doxygen tagfile
+mkdir -p ${DOC_DIR}
+cp ../doc/tags.xml ${DOC_DIR}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(; experimental=true)
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libssh", :libssh),
+    FileProduct("usr/share/doc/libssh/tags.xml", :doxygen_tags)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    HostBuildDependency("Doxygen_jll"),
+    Dependency("Kerberos_krb5_jll"),
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95")),
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/libssh/build_tarballs.jl
+++ b/L/libssh/build_tarballs.jl
@@ -61,7 +61,7 @@ dependencies = [
     HostBuildDependency("Doxygen_jll"),
     Dependency("Kerberos_krb5_jll"; compat="1.19.3"),
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.8"),
-    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"); compat="1.2.13")
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"); compat="1.2.12")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libssh/build_tarballs.jl
+++ b/L/libssh/build_tarballs.jl
@@ -13,8 +13,11 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 # Necessary for cmake to find openssl on Windows
-export OPENSSL_ROOT_DIR=$WORKSPACE/destdir/lib64
-export DOC_DIR=${prefix}/usr/share/doc/libssh
+if [[ ${target} == *w64* ]]; then
+    export OPENSSL_ROOT_DIR=${prefix}/lib64
+fi
+
+DOC_DIR=${prefix}/usr/share/doc/libssh
 
 # Build and install library
 cd $WORKSPACE/srcdir/libssh-*
@@ -39,12 +42,12 @@ make docs install
 
 # Install Doxygen tagfile
 mkdir -p ${DOC_DIR}
-cp ../doc/tags.xml ${DOC_DIR}
+install -Dv ../doc/tags.xml "${DOC_DIR}/tags.xml"
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 
 # The products that we will ensure are always built
@@ -56,9 +59,9 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     HostBuildDependency("Doxygen_jll"),
-    Dependency("Kerberos_krb5_jll"),
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95")),
-    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
+    Dependency("Kerberos_krb5_jll"; compat="1.19.3"),
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.8"),
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"); compat="1.2.13")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Package for https://www.libssh.org.

Some oddities:
- This has an extra `FileProduct` for the Doxygen tag file (useful when generating docs)
- GSSAPI support is only enabled on Linux and freebsd because our Kerberos is only built for those platforms. This causes some warnings on OSX/windows about the dependency not having a product, but I think they can be safely ignored since the library won't try to use it anyway.
- Windows builds show this warning: `Minimum instruction set detected for bin/libssh.dll is avx2, not x86_64 as desired`. I've looked through the code to try to see where those instructions might be coming from but didn't find anything. Not sure how serious it is.