### PR TITLE
[HDF5] Update to 1.14.3, disable Fortran

### DIFF
--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -378,7 +378,7 @@ platforms = expand_cxxstring_abis(platforms)
 #platforms = expand_gfortran_versions(platforms)
 
 # TODO: Don't require MPI for Windows since we're using the non-MPI msys libraries there.
-platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.3.0")
+platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.3.0", OpenMPI_compat="4.1.6")
 
 # Avoid platforms where the MPI implementation isn't supported
 # OpenMPI

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -13,24 +13,6 @@ sources = [
     ArchiveSource("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$(version.major).$(version.minor)/hdf5-$(version)/src/hdf5-$(version).tar.bz2",
                   "9425f224ed75d1280bb46d6f26923dd938f9040e7eaebf57e66ec7357c08f917"),
     DirectorySource("./bundled"),
-
-    # We don't build HDF5 on Windows; instead, we use packages from msys there:
-
-    # 32-bit Windows from https://packages.msys2.org/package/mingw-w64-i686-hdf5
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-hdf5-1.14.3-1-any.pkg.tar.zst",
-                  "09c6bf048eada4d3ad945c641111e7394169aa69904e5c4dd8de5c4b41143440"; unpack_target="i686-w64-mingw32"),
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-zlib-1.3-1-any.pkg.tar.zst",
-                  "21bacf3a43073749a4cbdf407c7f1da92bab56c80925b1205f7c4cb289c724a1"; unpack_target="i686-w64-mingw32"),
-    # We need some special compiler support libraries from mingw for i686 (libgcc_s_dw2)
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-libs-13.2.0-2-any.pkg.tar.zst",
-                  "2dae8189318a91067cca895572b2b46183bfd2ee97a55127a84f4f418f0b32f3"; unpack_target="i686-w64-mingw32"),
-
-    # 64-bit Windows from https://packages.msys2.org/package/mingw-w64-x86_64-hdf5
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-hdf5-1.14.3-1-any.pkg.tar.zst",
-                  "a6a69866725504cba9212a616c8734ade54c8de7d5f42074e33a7b62c7a31428"; unpack_target="x86_64-w64-mingw32"),
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-zlib-1.3-1-any.pkg.tar.zst",
-                  "254a6c5a8a27d1b787377a3e70a39cceb200b47c5f15f4ab5bfa1431b718ef98"; unpack_target="x86_64-w64-mingw32"),
-
 ]
 
 # Bash recipe for building across all platforms
@@ -38,21 +20,6 @@ script = raw"""
 cd ${WORKSPACE}/srcdir
 
 # We don't build HDF5 on Windows; instead, we use packages from msys there:
-if [[ ${target} == *mingw* ]]; then
-    cd ${target}/mingw${nbits}
-
-    mkdir -p ${libdir} ${includedir}
-    rm -f lib/{*_cpp*,*fortran*,*f90*} # we do not need these
-    rm -f bin/{*_cpp*,*fortran*,*f90*} # we do not need these
-    
-    mv -v lib/libhdf5*.dll.a ${prefix}/lib
-    mv -v bin/*.dll ${libdir}
-    mv -v include/* ${includedir}
-
-    install_license share/doc/hdf5/COPYING
-    exit 0
-fi
-
 cd hdf5-*
 
 if [[ ${target} == *-mingw* ]]; then
@@ -282,6 +249,8 @@ elif grep -q MSMPI_VER ${prefix}/include/mpi.h; then
         ln -s msmpi.dll ${libdir}/libmsmpi.dll
         export FCFLAGS="$FCFLAGS -I${prefix}/src -I${prefix}/include -fno-range-check"
         export LIBS="-L${libdir} -lmsmpi"
+        # Allows configure to find libcrypto for ROS3-VFD
+        export CFLAGS="$CLFAGS -L${prefix}/lib64"
     fi
 elif grep -q OMPI_MAJOR_VERSION ${prefix}/include/mpi.h; then
     # OpenMPI
@@ -389,35 +358,31 @@ platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), plat
 
 # The products that we will ensure are always built
 products = [
-    # Since we use the msys binaries for Windows, we can only define
-    # those products that are provided by msys as well. These are
-    # just the regular and the high-level libraries.
-
     # # HDF5 tools
-    # ExecutableProduct("h5clear", :h5clear),
-    # ExecutableProduct("h5copy", :h5copy),
-    # ExecutableProduct("h5debug", :h5debug),
-    # ExecutableProduct("h5delete", :h5delete),
-    # ExecutableProduct("h5diff", :h5diff),
-    # ExecutableProduct("h5dump", :h5dump),
-    # ExecutableProduct("h5format_convert", :h5format_convert),
-    # ExecutableProduct("h5import", :h5import),
-    # ExecutableProduct("h5jam",:h5jam),
-    # ExecutableProduct("h5ls", :h5ls),
-    # ExecutableProduct("h5mkgrp", :h5mkgrp),
-    # ExecutableProduct("h5perf_serial",:h5perf_serial),
-    # ExecutableProduct("h5repack", :h5repack),
-    # ExecutableProduct("h5repart", :h5repart),
-    # ExecutableProduct("h5stat", :h5stat),
-    # ExecutableProduct("h5unjam", :h5unjam),
-    # ExecutableProduct("h5watch", :h5watch),
+    ExecutableProduct("h5clear", :h5clear),
+    ExecutableProduct("h5copy", :h5copy),
+    ExecutableProduct("h5debug", :h5debug),
+    ExecutableProduct("h5delete", :h5delete),
+    ExecutableProduct("h5diff", :h5diff),
+    ExecutableProduct("h5dump", :h5dump),
+    ExecutableProduct("h5format_convert", :h5format_convert),
+    ExecutableProduct("h5import", :h5import),
+    ExecutableProduct("h5jam",:h5jam),
+    ExecutableProduct("h5ls", :h5ls),
+    ExecutableProduct("h5mkgrp", :h5mkgrp),
+    ExecutableProduct("h5perf_serial",:h5perf_serial),
+    ExecutableProduct("h5repack", :h5repack),
+    ExecutableProduct("h5repart", :h5repart),
+    ExecutableProduct("h5stat", :h5stat),
+    ExecutableProduct("h5unjam", :h5unjam),
+    ExecutableProduct("h5watch", :h5watch),
 
     # HDF5 libraries
     LibraryProduct("libhdf5", :libhdf5),
-    # LibraryProduct("libhdf5_cpp", :libhdf5_cpp),
+     LibraryProduct("libhdf5_cpp", :libhdf5_cpp),
     # LibraryProduct("libhdf5_fortran", :libhdf5_fortran),
     LibraryProduct("libhdf5_hl", :libhdf5_hl),
-    # LibraryProduct("libhdf5_hl_cpp", :libhdf5_hl_cpp),
+     LibraryProduct("libhdf5_hl_cpp", :libhdf5_hl_cpp),
     # LibraryProduct("libhdf5hl_fortran", :libhdf5_hl_fortran),
 ]
 

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -375,7 +375,7 @@ augment_platform_block = """
 platforms = supported_platforms()
 # TODO: Don't expand ABIs for Windows since we're not providing either C++ or Fortran bindings there.
 platforms = expand_cxxstring_abis(platforms)
-platforms = expand_gfortran_versions(platforms)
+#platforms = expand_gfortran_versions(platforms)
 
 # TODO: Don't require MPI for Windows since we're using the non-MPI msys libraries there.
 platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.3.0")
@@ -439,4 +439,4 @@ ENV["MPITRAMPOLINE_DELAY_INIT"] = "1"
 # Build the tarballs, and possibly a `build.jl` as well.
 # GCC 5 reports an ICE on i686-linux-gnu-libgfortran3-cxx11-mpi+mpich
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.6", preferred_gcc_version=v"6")
+               augment_platform_block, clang_use_lld=false, julia_compat="1.6", preferred_gcc_version=v"6")

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -423,12 +423,6 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD 
-    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else. 
-    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
-               platforms=filter(!Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
-               platforms=filter(Sys.isbsd, platforms)),
     Dependency("LibCURL_jll"),
     # The msys Windows libraries require OpenSSL@3
     Dependency("OpenSSL_jll"; compat="3.0.8"),

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -356,6 +356,9 @@ platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
 
+# TEMPORARY, just test Windows for CI
+platforms = filter(p -> Sys.iswindows(p), platforms)
+
 # The products that we will ensure are always built
 products = [
     # # HDF5 tools

--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -6,19 +6,19 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "HDF5"
-version = v"1.14.2"
+version = v"1.14.3"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$(version.major).$(version.minor)/hdf5-$(version)/src/hdf5-$(version).tar.bz2",
-                  "ea3c5e257ef322af5e77fc1e52ead3ad6bf3bb4ac06480dd17ee3900d7a24cfb"),
+                  "9425f224ed75d1280bb46d6f26923dd938f9040e7eaebf57e66ec7357c08f917"),
     DirectorySource("./bundled"),
 
     # We don't build HDF5 on Windows; instead, we use packages from msys there:
 
     # 32-bit Windows from https://packages.msys2.org/package/mingw-w64-i686-hdf5
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-hdf5-1.14.2-2-any.pkg.tar.zst",
-                  "ab053fdafb3e0c456751fed9fe5cc2fa339042046b4de677ce2848cd8b6d3b3f"; unpack_target="i686-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-hdf5-1.14.3-1-any.pkg.tar.zst",
+                  "09c6bf048eada4d3ad945c641111e7394169aa69904e5c4dd8de5c4b41143440"; unpack_target="i686-w64-mingw32"),
     ArchiveSource("https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-zlib-1.3-1-any.pkg.tar.zst",
                   "21bacf3a43073749a4cbdf407c7f1da92bab56c80925b1205f7c4cb289c724a1"; unpack_target="i686-w64-mingw32"),
     # We need some special compiler support libraries from mingw for i686 (libgcc_s_dw2)
@@ -26,8 +26,8 @@ sources = [
                   "2dae8189318a91067cca895572b2b46183bfd2ee97a55127a84f4f418f0b32f3"; unpack_target="i686-w64-mingw32"),
 
     # 64-bit Windows from https://packages.msys2.org/package/mingw-w64-x86_64-hdf5
-    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-hdf5-1.14.2-2-any.pkg.tar.zst",
-                  "19a0a28d32c8990a29e001b77fe2deeb4946ff6c7d0949dbf756dfe1b9b40e8a"; unpack_target="x86_64-w64-mingw32"),
+    ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-hdf5-1.14.3-1-any.pkg.tar.zst",
+                  "a6a69866725504cba9212a616c8734ade54c8de7d5f42074e33a7b62c7a31428"; unpack_target="x86_64-w64-mingw32"),
     ArchiveSource("https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-zlib-1.3-1-any.pkg.tar.zst",
                   "254a6c5a8a27d1b787377a3e70a39cceb200b47c5f15f4ab5bfa1431b718ef98"; unpack_target="x86_64-w64-mingw32"),
 
@@ -211,6 +211,7 @@ case "${target}" in
 esac
 cp ../files/get_config_setting saved
 
+
 env \
     HDF5_ACLOCAL=/usr/bin/aclocal \
     HDF5_AUTOHEADER=/usr/bin/autoheader \
@@ -298,7 +299,7 @@ fi
     --host=${target} \
     --enable-cxx=yes \
     --enable-direct-vfd="$ENABLE_DIRECT_VFD" \
-    --enable-fortran=yes \
+    --enable-fortran=no \
     --enable-hl=yes \
     --enable-mirror-vfd="$ENABLE_MIRROR_VFD" \
     --enable-parallel="$ENABLE_PARALLEL" \
@@ -337,6 +338,7 @@ fi
     "$(../saved/get_config_setting H5CONFIG_F_NUM_IKIND ../saved/config.status)" \
     "$(../saved/get_config_setting H5CONFIG_F_IKIND ../saved/config.status)"
 
+
 # Patch the generated `Makefile`:
 # (We could instead patch `Makefile.in`, or maybe even `Makefile.am`.)
 # - HDF5 would also try to build and run `H5detect` to collect ABI information.
@@ -344,7 +346,7 @@ fi
 # - HDF5 would try to build and run `H5make_libsettings` to collect
 #   build-time information. That information seems entirely optional, so
 #   we do mostly nothing instead.
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/src-Makefile.patch
+#atomic_patch -p1 ${WORKSPACE}/srcdir/patches/src-Makefile.patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/fortran-src-Makefile.patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/hl-fortran-src-Makefile.patch
 


### PR DESCRIPTION
This updates the HDF5 sources to 1.14.3

The HDF5 C library no longer runs an executable at compile time for configuration.
The HDF5 Fortran library may still require this.

TODO: See if we can build Windows binaries
