### PR TITLE
Add recipe for object_store_ffi

### DIFF
--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -10,7 +10,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd ${WORKSPACE}/srcdir/
+cd ${WORKSPACE}/srcdir/object_store_ffi/
 cargo rustc --release --lib --crate-type=cdylib
 install -Dvm 755 "target/${rust_target}/release/libobject_store_ffi.${dlext}" "${libdir}/libobject_store_ffi.${dlext}"
 """

--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -4,8 +4,8 @@ name = "object_store_ffi"
 version = v"0.1.0"
 
 sources = [
-    # https://github.com/RelationalAI/object_store_ffi/commit/c03a55e65512136c91b6f74787191d34ce2c48b3
-    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "c03a55e65512136c91b6f74787191d34ce2c48b3")
+    # https://github.com/RelationalAI/object_store_ffi/commit/b7b55f31d217b0360858ac1fd5471651d3e73784
+    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "b7b55f31d217b0360858ac1fd5471651d3e73784")
 ]
 
 # Bash recipe for building across all platforms

--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -21,7 +21,6 @@ platforms = [
     Platform("aarch64", "macos"),
     Platform("x86_64",  "linux"),
     Platform("x86_64",  "macos"),
-    Platform("aarch64", "linux"),
 ]
 
 # The products that we will ensure are always built

--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -4,8 +4,8 @@ name = "object_store_ffi"
 version = v"0.1.0"
 
 sources = [
-    # https://github.com/RelationalAI/object_store_ffi/commit/b87c4f4747bfa2b54b03a6f4edad9c1ff1cf58b9
-    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "b87c4f4747bfa2b54b03a6f4edad9c1ff1cf58b9")
+    # https://github.com/RelationalAI/object_store_ffi/commit/ca78c608b6e573ddfd72931c8f6c551ce3cb6862
+    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "ca78c608b6e573ddfd72931c8f6c551ce3cb6862")
 ]
 
 # Bash recipe for building across all platforms
@@ -21,6 +21,7 @@ platforms = [
     Platform("aarch64", "macos"),
     Platform("x86_64",  "linux"),
     Platform("x86_64",  "macos"),
+    Platform("aarch64", "linux"),
 ]
 
 # The products that we will ensure are always built

--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -36,5 +36,5 @@ dependencies = [
 # Build the tarballs
 build_tarballs(
     ARGS, name, version, sources, script, platforms, products, dependencies;
-    compilers=[:c, :rust], julia_compat="1.6"
+    compilers=[:c, :rust], julia_compat="1.6", preferred_gcc_version=v"5",
 )

--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -4,8 +4,8 @@ name = "object_store_ffi"
 version = v"0.1.0"
 
 sources = [
-    # https://github.com/RelationalAI/object_store_ffi/commit/b7b55f31d217b0360858ac1fd5471651d3e73784
-    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "b7b55f31d217b0360858ac1fd5471651d3e73784")
+    # https://github.com/RelationalAI/object_store_ffi/commit/b87c4f4747bfa2b54b03a6f4edad9c1ff1cf58b9
+    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "b87c4f4747bfa2b54b03a6f4edad9c1ff1cf58b9")
 ]
 
 # Bash recipe for building across all platforms

--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -29,7 +29,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Build the tarballs

--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -4,8 +4,8 @@ name = "object_store_ffi"
 version = v"0.1.0"
 
 sources = [
-    # https://github.com/RelationalAI/object_store_ffi/commit/ca78c608b6e573ddfd72931c8f6c551ce3cb6862
-    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "ca78c608b6e573ddfd72931c8f6c551ce3cb6862")
+    # https://github.com/RelationalAI/object_store_ffi/commit/7c2c08524a548acee35ccd3e40166b0e0efcb37c
+    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "7c2c08524a548acee35ccd3e40166b0e0efcb37c")
 ]
 
 # Bash recipe for building across all platforms

--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -1,0 +1,40 @@
+using BinaryBuilder
+
+name = "object_store_ffi"
+version = v"0.1.0"
+
+sources = [
+    # https://github.com/RelationalAI/object_store_ffi/commit/c03a55e65512136c91b6f74787191d34ce2c48b3
+    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "c03a55e65512136c91b6f74787191d34ce2c48b3")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/
+cargo rustc --release --lib --crate-type=cdylib
+install -Dvm 755 "target/${rust_target}/release/libobject_store_ffi.${dlext}" "${libdir}/libobject_store_ffi.${dlext}"
+"""
+
+# We could potentially support more platforms, if required.
+# Except perhaps i686 Windows and Musl systems.
+platforms = [
+    Platform("aarch64", "macos"),
+    Platform("x86_64",  "linux"),
+    Platform("x86_64",  "macos"),
+    Platform("aarch64", "linux"),
+]
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libobject_store_ffi", :libobject_store_ffi),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs
+build_tarballs(
+    ARGS, name, version, sources, script, platforms, products, dependencies;
+    compilers=[:c, :rust], julia_compat="1.6"
+)


### PR DESCRIPTION
- `object_store_ffi` (https://github.com/relationalAI/object_store_ffi) defines a C interface for the Rust crate `object_store` (https://github.com/apache/arrow-rs/tree/master/object_store), which we then use in `ObjectStore.jl` (https://github.com/RelationalAI/ObjectStore.jl/) 