### PR TITLE
[iso_codes] Copy symlinks to avoid installation issues.

### DIFF
--- a/I/iso_codes/build_tarballs.jl
+++ b/I/iso_codes/build_tarballs.jl
@@ -30,6 +30,13 @@ apk add gettext
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
+
+# Windows has issues with the symlinks so replace
+# them with copies
+# https://stackoverflow.com/questions/7167424/replace-all-symlinks-with-original
+rsync ${prefix}/share/ ${prefix}/share2/ -a --copy-links -v
+rm -rf ${prefix}/share
+mv ${prefix}/share2 ${prefix}/share
 """
 
 # These are the platforms we will build for by default, unless further

--- a/I/iso_codes/build_tarballs.jl
+++ b/I/iso_codes/build_tarballs.jl
@@ -32,16 +32,6 @@ apk add gettext
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
-
-if [[ "${target}" == *-mingw* ]]; then
-    # Windows has issues with the symlinks so replace
-    # them with copies
-    # https://stackoverflow.com/questions/7167424/replace-all-symlinks-with-original
-    no_link_temp=`mktemp -d`
-    rsync ${prefix}/share ${no_link_temp} -a --copy-links -v
-    rm -rf ${prefix}/share
-    mv ${no_link_temp}/share ${prefix}/share
-fi
 """
 
 # These are the platforms we will build for by default, unless further

--- a/I/iso_codes/build_tarballs.jl
+++ b/I/iso_codes/build_tarballs.jl
@@ -36,7 +36,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = Product[

--- a/I/iso_codes/build_tarballs.jl
+++ b/I/iso_codes/build_tarballs.jl
@@ -34,9 +34,10 @@ make install
 # Windows has issues with the symlinks so replace
 # them with copies
 # https://stackoverflow.com/questions/7167424/replace-all-symlinks-with-original
-rsync ${prefix}/share/ ${prefix}/share2/ -a --copy-links -v
+no_link_temp=`mktemp -d`
+rsync ${prefix}/share ${no_link_temp} -a --copy-links -v
 rm -rf ${prefix}/share
-mv ${prefix}/share2 ${prefix}/share
+mv ${no_link_temp}/share ${prefix}/share
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
This should fix the Windows installation issue.
The tarball is about 6 MB larger. I have tested this version locally with the automated tests in `Gtk.jl` and `Countries.jl` and they both passed, though I don't know what those packages are doing.
The new artifact tree hash is `1719102ef324df43b9fe123a231c2ee630931a03` which matches the tree hash of the old artifact if it is extracted with `copy_symlinks=true`