### PR TITLE
[adwaita_icon_theme] fix windows installation issues.

### DIFF
--- a/A/adwaita_icon_theme/build_tarballs.jl
+++ b/A/adwaita_icon_theme/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "adwaita_icon_theme"
-version = v"43"
+version = v"43.0.1"
 
 # Collection of sources required to build adwaita-icon-theme
 sources = [
@@ -24,7 +24,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [AnyPlatform()]
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = Product[
@@ -37,4 +37,4 @@ dependencies = [
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/A/adwaita_icon_theme/build_tarballs.jl
+++ b/A/adwaita_icon_theme/build_tarballs.jl
@@ -24,7 +24,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = Product[


### PR DESCRIPTION
The current artifact contains symlinks inside the `share/icons/Adwaita/cursors` directory. These cannot be correctly installed on a typical Windows machine.
`adwaita_icon_theme` has a special process for dealing with installing cursors on Windows that removes the symlinks. (Though that may also be broken in v45 https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/issues/261).