### PR TITLE
[libadwaita] update to 1.3.6

### DIFF
--- a/L/libadwaita/build_tarballs.jl
+++ b/L/libadwaita/build_tarballs.jl
@@ -43,6 +43,9 @@ rm ${prefix}/lib/pkgconfig/gio-2.0.pc
 
 # post-install script is disabled when cross-compiling
 glib-compile-schemas ${prefix}/share/glib-2.0/schemas
+
+# Remove temporary links
+rm ${bindir}/gdk-pixbuf-pixdata ${bindir}/glib-compile-{resources,schemas}
 """
 
 # These are the platforms we will build for by default, unless further

--- a/L/libadwaita/build_tarballs.jl
+++ b/L/libadwaita/build_tarballs.jl
@@ -20,8 +20,6 @@ apk add glib-dev
 ln -sf /usr/bin/glib-compile-resources ${bindir}/glib-compile-resources
 ln -sf /usr/bin/glib-compile-schemas ${bindir}/glib-compile-schemas
 ln -sf /usr/bin/gdk-pixbuf-pixdata ${bindir}/gdk-pixbuf-pixdata
-# Remove gio-2.0 pkgconfig file so that it isn't picked up by post-install script.
-rm ${prefix}/lib/pkgconfig/gio-2.0.pc
 
 # oldest version that works, due to use of "@available" macro
 export MACOSX_DEPLOYMENT_TARGET=10.14
@@ -39,6 +37,9 @@ meson .. \
     --cross-file="${MESON_TARGET_TOOLCHAIN}"
 ninja -j${nproc}
 ninja install
+
+# Remove gio-2.0 pkgconfig file so that it isn't picked up by post-install script.
+rm ${prefix}/lib/pkgconfig/gio-2.0.pc
 
 # post-install script is disabled when cross-compiling
 glib-compile-schemas ${prefix}/share/glib-2.0/schemas
@@ -62,4 +63,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", clang_use_lld=false)

--- a/L/libadwaita/build_tarballs.jl
+++ b/L/libadwaita/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder
 
 name = "libadwaita"
-version = v"1.2.0"
+version = v"1.3.6"
 
 sources = [
     ArchiveSource("https://download.gnome.org/sources/libadwaita/$(version.major).$(version.minor)/libadwaita-$(version).tar.xz",
-                  "322f3e1be39ba67981d9fe7228a85818eccaa2ed0aa42bcafe263af881c6460c"),
+                  "cb8313dabe78a128415b93891d9aff2aba88ad58e3d5a54562e1f05fc9222979"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Also remove symlinks. Should fix #7935

The latest version, 1.4.2, depends on appstream which is not currently in Yggdrasil.