### PR TITLE
[Bzip2] Build with `cc` instead of `gcc`

### DIFF
--- a/B/Bzip2/build_tarballs.jl
+++ b/B/Bzip2/build_tarballs.jl
@@ -20,8 +20,8 @@ sed -i 's/sys\\stat\.h/sys\/stat\.h/g' bzip2.c
 # Override stubborn makevars
 CFLAGS="-Wall -Winline -O2 -g -D_FILE_OFFSET_BITS=64 -fPIC"
 OBJS="blocksort.o huffman.o crctable.o randtable.o compress.o decompress.o bzlib.o"
-make CFLAGS="${CFLAGS}" -j${nproc} ${OBJS}
-make CFLAGS="${CFLAGS}" PREFIX=${prefix} install
+make CC=${CC} CFLAGS="${CFLAGS}" -j${nproc} ${OBJS}
+make CC=${CC} CFLAGS="${CFLAGS}" PREFIX=${prefix} install
 
 # Build dynamic library
 if [[ "${target}" == *-darwin* ]]; then
@@ -40,7 +40,7 @@ else
     ln -s "libbz2.so.${VERSION}" libbz2.so
 fi
 mkdir -p ${libdir}
-mv libbz2*.${dlext}* ${libdir}/.
+mv -v libbz2*.${dlext}* ${libdir}/.
 
 # Add pkg-config file
 mkdir -p ${prefix}/lib/pkgconfig
@@ -63,7 +63,7 @@ EOF
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line.
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
The x86_64-apple-darwin build of `bzip2` was linking to `libgcc_s`, causing errors like
```
dyld[5037]: Library not loaded: '@rpath/libgcc_s.1.dylib'
  Referenced from: '/Users/mose/.julia/artifacts/979f68ce65b087a39297a97d21aec04b1d4e9d24/bin/bzip2'
  Reason: tried: '/Users/mose/.julia/artifacts/fcce09ea10f6f2d6e185d17a8123a0054d18c1b4/lib/libgcc_s.1.dylib' (no such file), '/Users/mose/.julia/artifacts/979f68ce65b087a39297a97d21aec04b1d4e9d24/lib/libgcc_s.1.dylib' (no such file), '/Users/mose/.julia/artifacts/1e901863cf8fbb1ee50a5d0976114a2371899331/lib/libgcc_s.1.dylib' (no such file)
```
when trying to execute the program if `libgcc_s` isn't available anywhere by default in the system.