### PR TITLE
Bump SPIRV to LLVM translator.

### DIFF
--- a/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
@@ -107,6 +107,6 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, build.script,
                    build.platforms, products, build.dependencies;
-                   preferred_gcc_version=v"7", julia_compat="1.6",
+                   preferred_gcc_version=v"8", julia_compat="1.6",
                    augment_platform_block, lazy_artifacts=true)
 end

--- a/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
@@ -7,17 +7,19 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
 
 name = "SPIRV_LLVM_Translator_unified"
 repo = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git"
-version = v"0.3"
+version = v"0.4"
 
-llvm_versions = [v"11.0.1", v"12.0.1", v"13.0.1", v"14.0.6", v"15.0.7"]
+llvm_versions = [v"11.0.1", v"12.0.1", v"13.0.1", v"14.0.6", v"15.0.7", v"16.0.6", v"17.0.6"]
 
 # Collection of sources required to build SPIRV_LLVM_Translator
 sources = Dict(
-    v"11.0.1" => [GitSource(repo, "474cc8f991e5208fa805720250f0901a4d5265ec")],
-    v"12.0.1" => [GitSource(repo, "a14a95a92e1a358e58b1a544f00c413508308b70")],
-    v"13.0.1" => [GitSource(repo, "828bdebefa56d34d72a3fe7bb59e53f13953ecaf")],
-    v"14.0.6" => [GitSource(repo, "60c0cb0078658e0bc33d93724ffbe70ed4be6c51")],
-    v"15.0.7" => [GitSource(repo, "e82ecc2bd7295604fcf1824e47c95fa6a09c6e63")],
+    v"11.0.1" => [GitSource(repo, "72214e0bd45bf59da4319b0f8b558d2feab401b2")],
+    v"12.0.1" => [GitSource(repo, "f06ef6d5ecaa5aac700a17430e18b591c80c3e50")],
+    v"13.0.1" => [GitSource(repo, "6fbace895422d2b2d8b8eda1a3f6aef3729fc9f4")],
+    v"14.0.6" => [GitSource(repo, "e7f5440a40117cc11799b9306c7ea489b8596e55")],
+    v"15.0.7" => [GitSource(repo, "6b82481abc6df8de5b67c72ba1da57bcb58b75b0")],
+    v"16.0.6" => [GitSource(repo, "d1c69c3365dffed67124eb1692cb941cbae5bb2e")],
+    v"17.0.6" => [GitSource(repo, "52b3a5f12d23ce0145fc8e0b8882e5d9bb31c664")],
 )
 
 # These are the platforms we will build for by default, unless further

--- a/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
@@ -9,12 +9,10 @@ name = "SPIRV_LLVM_Translator_unified"
 repo = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git"
 version = v"0.4"
 
-llvm_versions = [v"11.0.1", v"12.0.1", v"13.0.1", v"14.0.6", v"15.0.7", v"16.0.6", v"17.0.6"]
+llvm_versions = [v"13.0.1", v"14.0.6", v"15.0.7", v"16.0.6", v"17.0.6"]
 
 # Collection of sources required to build SPIRV_LLVM_Translator
 sources = Dict(
-    v"11.0.1" => [GitSource(repo, "72214e0bd45bf59da4319b0f8b558d2feab401b2")],
-    v"12.0.1" => [GitSource(repo, "f06ef6d5ecaa5aac700a17430e18b591c80c3e50")],
     v"13.0.1" => [GitSource(repo, "6fbace895422d2b2d8b8eda1a3f6aef3729fc9f4")],
     v"14.0.6" => [GitSource(repo, "e7f5440a40117cc11799b9306c7ea489b8596e55")],
     v"15.0.7" => [GitSource(repo, "6b82481abc6df8de5b67c72ba1da57bcb58b75b0")],

--- a/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
@@ -51,6 +51,9 @@ CMAKE_FLAGS+=(-DBUILD_SHARED_LIBS=ON)
 # Use our LLVM version
 CMAKE_FLAGS+=(-DBASE_LLVM_VERSION=""" * string(Base.thisminor(llvm_version)) * raw""")
 
+# Suppress certain errors
+CMAKE_FLAGS+=(-DCMAKE_CXX_FLAGS="-Wno-enum-constexpr-conversion")
+
 cmake -B build -S . -GNinja ${CMAKE_FLAGS[@]}
 ninja -C build -j ${nproc} llvm-spirv install
 install -Dm755 build/tools/llvm-spirv/llvm-spirv${exeext} -t ${bindir}

--- a/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
@@ -107,6 +107,6 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, build.script,
                    build.platforms, products, build.dependencies;
-                   preferred_gcc_version=v"8", julia_compat="1.6",
+                   preferred_gcc_version=v"10", julia_compat="1.6",
                    augment_platform_block, lazy_artifacts=true)
 end


### PR DESCRIPTION
Bumps the commits, and includes builds for LLVM 16 and 17.