### PR TITLE
[adwaita_icon_theme] fix windows installation issues for v3.

### DIFF
--- a/A/adwaita_icon_theme/build_tarballs.jl
+++ b/A/adwaita_icon_theme/build_tarballs.jl
@@ -4,16 +4,24 @@ using BinaryBuilder
 
 name = "adwaita_icon_theme"
 version = v"3.33.93" # new patch version to build for all platforms
+tag = v"3.33.92"
 
 # Collection of sources required to build adwaita-icon-theme
 sources = [
-    ArchiveSource("https://github.com/JuliaBinaryWrappers/adwaita_icon_theme_jll.jl/releases/download/adwaita_icon_theme-v3.33.92+4/adwaita_icon_theme.v3.33.92.any.tar.gz",
-    "f50f3c85710f7dfbd6959bfaa6cc3a940195cd09dadddefb3b5ae9a2f97adad3"),
+    ArchiveSource("https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/archive/$(tag)/adwaita-icon-theme-$(tag).tar.bz2",
+                  "9e2078bf9e4d28f2a921fa88159733fe83a1fd37f8cbd768a5de3b83f44f0973"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-rsync -a $WORKSPACE/srcdir/share ${prefix}
+cd $WORKSPACE/srcdir/adwaita-icon-theme-*/
+
+# Install native gtk+3.0 so that we get `gtk-encode-symbolic-svg`
+apk add gtk+3.0 librsvg
+./autogen.sh --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+make -j${nproc}
+make install
 """
 
 # These are the platforms we will build for by default, unless further

--- a/A/adwaita_icon_theme/build_tarballs.jl
+++ b/A/adwaita_icon_theme/build_tarballs.jl
@@ -3,23 +3,17 @@
 using BinaryBuilder
 
 name = "adwaita_icon_theme"
-version = v"43.0.1"
+version = v"3.33.93" # new patch version to build for all platforms
 
 # Collection of sources required to build adwaita-icon-theme
 sources = [
-    ArchiveSource("https://download.gnome.org/sources/adwaita-icon-theme/$(version.major)/adwaita-icon-theme-$(version.major).tar.xz",
-                  "2e3ac77d32a6aa5554155df37e8f0a0dd54fc5a65fd721e88d505f970da32ec6"),
+    ArchiveSource("https://github.com/JuliaBinaryWrappers/adwaita_icon_theme_jll.jl/releases/download/adwaita_icon_theme-v3.33.92+4/adwaita_icon_theme.v3.33.92.any.tar.gz",
+    "f50f3c85710f7dfbd6959bfaa6cc3a940195cd09dadddefb3b5ae9a2f97adad3"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/adwaita-icon-theme-*/
-
-# Install native gtk+3.0 so that we get `gtk-encode-symbolic-svg`
-apk add gtk+3.0 librsvg
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
-make -j${nproc}
-make install
+rsync -a $WORKSPACE/srcdir/share ${prefix}
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Apply the fix in #7930 for the old version of `adwaita_icon_theme_jll.jl` required by `Gtk.jl`

The difference in the tree sha is because the new version is missing the "logs" directory and a few icons are fixed in the "share" directory.

I assume after this PR is merged I should make a PR to undo the changes to go back to the new version?