### PR TITLE
[PETSc] version 3.18.8

### DIFF
--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -4,7 +4,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "PETSc"
-version = v"3.18.7"
+version = v"3.18.8"
 petsc_version = v"3.18.6"
 MUMPS_COMPAT_VERSION = "5.6.2"
 SUPERLUDIST_COMPAT_VERSION = "8.1.2"   


### PR DESCRIPTION
In `PETSc_jll v3.18.7+1`, merged yesterday, we removed SuiteSparse as a dependency.  Because it was a dependency in version `PETSc_jll 3.18.7+0`, we have problems linking it with other codes [see here](https://github.com/JuliaGeodynamics/LaMEM.jl/actions/runs/7636728953/job/20804282693#step:6:427) as it is looking for SuiteSparse files.

I should really have bumped the version number which is done with this PR.