### PR TITLE
MAGEMin v1.3.6

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -60,45 +60,20 @@ augment_platform_block = """
     augment_platform!(platform::Platform) = augment_mpi!(platform)
 """
 
-## These are the platforms we will build for by default, unless further
-## platforms are passed in on the command line
-#platforms = supported_platforms()
-#platforms = expand_gfortran_versions(platforms)
-
-#platforms, platform_dependencies = MPI.augment_platforms(platforms)
-
-## Avoid platforms where the MPI implementation isn't supported
-## OpenMPI
-#platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)
-## MPItrampoline
-#platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)
-#1platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
-
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
+platforms = supported_platforms()
+platforms = expand_gfortran_versions(platforms)
 
-#Platform("i686", "windows"),
-platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686","linux"; libc="musl"),
-                                                                  Platform("i686","linux"; libc="gnu"),
-                                                                  Platform("x86_64","freebsd"),
-                                                                  Platform("armv6l","linux"; libc="musl"),
-                                                                  Platform("armv7l","linux"; libc="musl"),
-                                                                  Platform("armv7l","linux"; libc="gnu"),
-                                                                  Platform("aarch64","linux"; libc="musl")]))
-platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat=MPItrampoline_compat_version)
+platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.3.1", OpenMPI_compat="4.1.6, 5")
 
 # Avoid platforms where the MPI implementation isn't supported
 # OpenMPI
 platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)
-platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv7l" && libc(p) == "glibc"), platforms)
-platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "x86_64" && libc(p) == "musl"), platforms)
-platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "i686"), platforms)
 
 # MPItrampoline
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
-
-
 
 # The products that we will ensure are always built
 products = [

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -58,19 +58,45 @@ augment_platform_block = """
     augment_platform!(platform::Platform) = augment_mpi!(platform)
 """
 
+## These are the platforms we will build for by default, unless further
+## platforms are passed in on the command line
+#platforms = supported_platforms()
+#platforms = expand_gfortran_versions(platforms)
+
+#platforms, platform_dependencies = MPI.augment_platforms(platforms)
+
+## Avoid platforms where the MPI implementation isn't supported
+## OpenMPI
+#platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)
+## MPItrampoline
+#platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)
+#1platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
+
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-platforms = expand_gfortran_versions(platforms)
 
-platforms, platform_dependencies = MPI.augment_platforms(platforms)
+#Platform("i686", "windows"),
+platforms = expand_gfortran_versions(supported_platforms(exclude=[Platform("i686","linux"; libc="musl"),
+                                                                  Platform("i686","linux"; libc="gnu"),
+                                                                  Platform("x86_64","freebsd"),
+                                                                  Platform("armv6l","linux"; libc="musl"),
+                                                                  Platform("armv7l","linux"; libc="musl"),
+                                                                  Platform("armv7l","linux"; libc="gnu"),
+                                                                  Platform("aarch64","linux"; libc="musl")]))
+platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat=MPItrampoline_compat_version)
 
 # Avoid platforms where the MPI implementation isn't supported
 # OpenMPI
 platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)
+platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv7l" && libc(p) == "glibc"), platforms)
+platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "x86_64" && libc(p) == "musl"), platforms)
+platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "i686"), platforms)
+
 # MPItrampoline
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
+
+
 
 # The products that we will ensure are always built
 products = [

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -8,6 +8,8 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 name = "MAGEMin"
 version = v"1.3.6" 
 
+MPItrampoline_compat_version="5.2.1"  
+
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
                     "0a4106a9c9f070b300d64a877c02e425ac0f1d05")                 ]

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,11 +6,11 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.3.5" 
+version = v"1.3.6" 
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "eab44bb6dcc9987e17a9529b550d62e9f3c2e8d6")                 ]
+                    "0a4106a9c9f070b300d64a877c02e425ac0f1d05")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Largely reworked solver to stabilize and improve general performances
- Added PT paths to the matlab GUI
- Added trace elements calculation to the matlab GUI
- Free H2O for metapelite and metabasite database is now properly considered as a fluid in the output structure
- Corrected wrong cordierite formulation of metapelite database (White et al., 2014)
- Corrected mol fraction sum for phases composition that was not summing to 1.0
- Corrected segfault and memory deallocation when using the Julia wrapper (MAGEMin_C)
- Corrected site fraction issue with liq of igneous database
