### PR TITLE
[libsingular_julia] update to latest, drop Singular_jll compat entry

### DIFF
--- a/L/libsingular_julia/build_tarballs.jl
+++ b/L/libsingular_julia/build_tarballs.jl
@@ -9,11 +9,11 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "libsingular_julia"
-version = v"0.40.11"
+version = v"0.41.0"
 
 # Collection of sources required to build libsingular-julia
 sources = [
-    GitSource("https://github.com/oscar-system/Singular.jl.git", "99dc5160176fb81ff69064fe7a3fdddf84c95968"),
+    GitSource("https://github.com/oscar-system/Singular.jl.git", "b3295f802f1638bf85a5fd4fe127443b72727cce"),
 ]
 
 # Bash recipe for building across all platforms
@@ -54,7 +54,11 @@ dependencies = [
     BuildDependency("GMP_jll"),
     BuildDependency("MPFR_jll"),
     Dependency("libcxxwrap_julia_jll"; compat = "~0.11.2"),
-    Dependency("Singular_jll", compat = "^403.214.1400"),
+    # we do not set a compat entry for Singular_jll -- instead we leave it to
+    # Singular.jl to ensure the right versions of libsingular_julia_jll and
+    # Singular_jll are paired. This gives us flexibility in the development
+    # setup there.
+    Dependency("Singular_jll", v"403.214.1400"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
CC @hannes14 @ederc @benlorenz The change to turn Singular_jll into a bdep is as discussed previously:

Decoupling libsingular_julia_jll from Singular_jll is OK because Singular.jl also specifies a version of Singular_jll. The drawback is that one could end up accidentally using the wrong Singular_jll version. But the big advantage is that we are freed to work with newer Singular_jll release in Singular.jl which is safe when using the JLL override mechanism there (when changes in the C++ code is detected while in dev mode, the C++ code just gets compiled and used to replace the code in the JLL).

Dropping the explicit version for Singular_jll also removes the chance for forgetting to update that. Of course all this means that we have to pay close attention in Singular.jl to match what was actually used to build any `libsingular_julia` updates...