### PR TITLE
Set LLVM issue tracker URL to Julia's issue tracker

### DIFF
--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -360,6 +360,9 @@ CMAKE_FLAGS+=(-DCMAKE_C_COMPILER_TARGET=${CMAKE_TARGET})
 CMAKE_FLAGS+=(-DCMAKE_CXX_COMPILER_TARGET=${CMAKE_TARGET})
 CMAKE_FLAGS+=(-DCMAKE_ASM_COMPILER_TARGET=${CMAKE_TARGET})
 
+# Set the bug report URL to the Julia issue tracker
+CMAKE_FLAGS+=("-DBUG_REPORT_URL="https://github.com/julialang/julia")
+
 cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]} -DCMAKE_CXX_FLAGS=\"${CMAKE_CPP_FLAGS[*]} ${CMAKE_CXX_FLAGS[*]}\" -DCMAKE_C_FLAGS=\"${CMAKE_C_FLAGS[*]}\"
 ninja -j${nproc} -vv
 


### PR DESCRIPTION
This patch sets the default issue tracker URL for LLVM to Julia's issue tracker. LLVM issues coming from Julia should probably go through Julia's issue tracker first and then can be reported upstream if there is an issue with something in upstream LLVM. Having this set to the default is moderately confusing for users as it refers to the LLVM issue tracker, which probably isn't wanted.