### PR TITLE
[strace] Don't build static anymore, avoid `aarch64-linux-musl`

### DIFF
--- a/S/strace/build_tarballs.jl
+++ b/S/strace/build_tarballs.jl
@@ -20,19 +20,18 @@ cp ${host_bindir}/date /usr/local/bin/
 ./bootstrap
 
 # Disable multiple personalities as our 64-bit compilers do not have 32-bit capabilities
-# Also build as a static executable so that the libc is embedded within `strace`.
 # Disable -Werror
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
             --enable-mpers=no \
-            --disable-gcc-Werror \
-            LDFLAGS='-static -pthread'
+            --disable-gcc-Werror
 make -j${nproc}
 make install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter(p -> Sys.islinux(p) && libc(p) == "glibc", supported_platforms())
+platforms = filter(p -> Sys.islinux(p), supported_platforms())
+platforms = filter(p -> !(libc(p) == "musl" && arch(p) == "aarch64"), platforms)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
It appears that old glibc has a bug when reading locale data that makes this particular version of glibc useless for building statically with. Sigh.  Instead, we'll just build normal versions and build for musl as well, but it appears that `aarch64-linux-musl` has a problem that I'm not going to patch right now.