### PR TITLE
[MUMPS_seq] Add the 64-bit integer version

### DIFF
--- a/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
@@ -108,7 +108,7 @@ make_args_64+=(PLAT="64"
                LIBBLAS="${BLAS_LAPACK}"
                LAPACK="${BLAS_LAPACK}")
 
-make -j${nproc} allshared "${make_args_64[@]}"
+make allshared "${make_args_64[@]}"
 
 cp lib/*.${dlext} ${libdir}
 """

--- a/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
@@ -135,4 +135,4 @@ dependencies = [
 ]
 
 # Build the tarballs
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.9", preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.9", preferred_gcc_version=v"6")

--- a/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
@@ -135,4 +135,4 @@ dependencies = [
 ]
 
 # Build the tarballs
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.9", preferred_gcc_version=v"6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.9", preferred_gcc_version=v"8")

--- a/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS_seq@5/build_tarballs.jl
@@ -80,10 +80,10 @@ cp lib/*.${dlext} ${libdir}
 make clean
 
 for sym in isamax idamax ilaenv slamch dlamch \
-           saxpy scopy sgemm sgemv slarfg snrm2 sorgqr sscal sswap strsm \
-           daxpy dcopy dgemm dgemv dlarfg dnrm2 dorgqr dscal dswap dtrsm \
-           caxpy ccopy cgemm cgemv clarfg scnrm2 cungqr cscal cswap ctrsm \
-           zaxpy zcopy zgemm zgemv zlarfg dznrm2 zungqr zscal zswap ztrsm
+           saxpy scopy sgemm sgemv slarfg sorgqr sscal sswap strsv strsm snrm2 \
+           daxpy dcopy dgemm dgemv dlarfg dorgqr dscal dswap dtrsv dtrsm dnrm2 \
+           caxpy ccopy cgemm cgemv clarfg cungqr cscal cswap ctrsv ctrsm scnrm2 \
+           zaxpy zcopy zgemm zgemv zlarfg zungqr zscal zswap ztrsv ztrsm dznrm2
 do
     FFLAGS+=("-D${sym}=${sym}_64")
 done


### PR DESCRIPTION
Some packages like PETSc can be compiled with the 64-bit integer version.
I propose to add it in `MUMPS_seq_jll.jl`.