### PR TITLE
New Recipe: sox v14.4.2

### DIFF
--- a/S/sox/build_tarballs.jl
+++ b/S/sox/build_tarballs.jl
@@ -1,0 +1,49 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "sox"
+version = v"14.4.2"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/chirlu/sox.git", "45b161d73ec087a8e003747b1aed07cd33589bca")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd sox/
+autoreconf -i
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+make
+make install
+exit
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("i686", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("armv6l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc"),
+    Platform("powerpc64le", "linux"; libc = "glibc"),
+    Platform("x86_64", "freebsd"; ),
+    Platform("i686", "windows"; ),
+    Platform("x86_64", "windows"; )
+]
+
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("sox", :sox)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
When using (the absolutely amazing) `run_wizard` the following failed to work:
```
 - Linux armv7l {call_abi=eabihf, libc=musl}
 - Linux i686 {libc=musl}
 - Linux armv6l {call_abi=eabihf, libc=musl}
 - Linux x86_64 {libc=musl}
 - Linux aarch64 {libc=musl}
 - macOS x86_64
 - macOS aarch64
 ```
I guess it can be updated later to support at least `macOS`?