### PR TITLE
Update casacore dependency cfitsio 4.0.0 -> 4.3.0

### DIFF
--- a/C/casacore/build_tarballs.jl
+++ b/C/casacore/build_tarballs.jl
@@ -4,7 +4,7 @@
 using BinaryBuilder, Pkg
 
 name = "casacore"
-version = v"3.5.0+1"
+version = v"3.5.1"
 
 # Collection of sources required to complete build
 sources = [

--- a/C/casacore/build_tarballs.jl
+++ b/C/casacore/build_tarballs.jl
@@ -4,7 +4,7 @@
 using BinaryBuilder, Pkg
 
 name = "casacore"
-version = v"3.5.0"
+version = v"3.5.0+1"
 
 # Collection of sources required to complete build
 sources = [

--- a/C/casacore/build_tarballs.jl
+++ b/C/casacore/build_tarballs.jl
@@ -105,7 +105,7 @@ products = Product[
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"); compat = "3.3.10")
-    Dependency(PackageSpec(name="CFITSIO_jll", uuid="b3e40c51-02ae-5482-8a39-3ace5868dcf4"); compat = "4.0.0")
+    Dependency(PackageSpec(name="CFITSIO_jll", uuid="b3e40c51-02ae-5482-8a39-3ace5868dcf4"); compat = "4.3.1")
     Dependency(PackageSpec(name="WCS_jll", uuid="550c8279-ae0e-5d1b-948f-937f2608a23e"); compat = "7.7.0")
     Dependency(PackageSpec(name="Readline_jll", uuid="05236dd9-4125-5232-aa7c-9ec0c9b2c25a"); compat = "8.1.1")
     Dependency(PackageSpec(name="GSL_jll", uuid="1b77fbbe-d8ee-58f0-85f9-836ddc23a7a4"); compat = "2.7.2")


### PR DESCRIPTION
Need to trigger a rebuild with the new dependency requirement since CFITSIO_jll seem to have broken semver.