### PR TITLE
Update FFMPEG to 6.1.1

### DIFF
--- a/F/FFMPEG/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/FFMPEG/build_tarballs.jl
@@ -12,7 +12,6 @@ products = [
     LibraryProduct(["libavdevice", "avdevice"], :libavdevice),
     LibraryProduct(["libavfilter", "avfilter"], :libavfilter),
     LibraryProduct(["libavformat", "avformat"], :libavformat),
-    LibraryProduct(["libavresample", "avresample"], :libavresample),
     LibraryProduct(["libavutil", "avutil"], :libavutil),
     LibraryProduct(["libpostproc", "postproc"], :libpostproc),
     LibraryProduct(["libswresample", "swresample"], :libswresample),
@@ -20,28 +19,39 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built.
-# TODO: Theora once it's available
+# TODO: Theora once it's available 
 dependencies = [
     HostBuildDependency("YASM_jll"),
     BuildDependency("nv_codec_headers_jll"),
-    Dependency("libass_jll"; compat="0.15.1"),
+    Dependency("libass_jll"; compat = "0.15.1"),
     Dependency("libfdk_aac_jll"),
     Dependency("FriBidi_jll"),
-    Dependency("FreeType2_jll"; compat="2.10.4"),
+    Dependency("FreeType2_jll"; compat = "2.10.4"),
     Dependency("LAME_jll"),
     Dependency("libvorbis_jll"),
     Dependency("libaom_jll"),
     Dependency("Ogg_jll"),
     BuildDependency("LibVPX_jll"), # We use the static archive
-    Dependency("x264_jll"; compat="~2021.05.05"),
-    Dependency("x265_jll"; compat="~3.5"),
-    Dependency("Bzip2_jll"; compat="1.0.8"),
+    Dependency("x264_jll"; compat = "~2021.05.05"),
+    Dependency("x265_jll"; compat = "~3.5"),
+    Dependency("Bzip2_jll"; compat = "1.0.8"),
     Dependency("Zlib_jll"),
-    Dependency("OpenSSL_jll"; compat="3.0.9"),
+    Dependency("OpenSSL_jll"; compat = "3.0.9"),
     Dependency("Opus_jll"),
-    Dependency("PCRE2_jll"; compat="10.35"),
+    Dependency("PCRE2_jll"; compat = "10.35"),
+    Dependency("Xorg_xproto_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script(; ffplay=false), platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=preferred_gcc_version)
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script(; ffplay = false),
+    platforms,
+    products,
+    dependencies;
+    julia_compat = "1.6",
+    preferred_gcc_version = preferred_gcc_version,
+)

--- a/F/FFMPEG/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/FFMPEG/build_tarballs.jl
@@ -43,4 +43,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script(; ffplay=false), platforms, products, dependencies;
-    julia_compat="1.6", preferred_gcc_version=preferred_gcc_version)
+    julia_compat="1.6", preferred_gcc_version=preferred_gcc_version, clang_use_lld=false)

--- a/F/FFMPEG/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/FFMPEG/build_tarballs.jl
@@ -19,40 +19,28 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built.
-# TODO: Theora once it's available 
+# TODO: Theora once it's available
 dependencies = [
     HostBuildDependency("YASM_jll"),
     BuildDependency("nv_codec_headers_jll"),
-    Dependency("libass_jll"; compat = "0.15.1"),
+    Dependency("libass_jll"; compat="0.15.1"),
     Dependency("libfdk_aac_jll"),
     Dependency("FriBidi_jll"),
-    Dependency("FreeType2_jll"; compat = "2.10.4"),
+    Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("LAME_jll"),
     Dependency("libvorbis_jll"),
     Dependency("libaom_jll"),
     Dependency("Ogg_jll"),
     BuildDependency("LibVPX_jll"), # We use the static archive
-    Dependency("x264_jll"; compat = "~2021.05.05"),
-    Dependency("x265_jll"; compat = "~3.5"),
-    Dependency("Bzip2_jll"; compat = "1.0.8"),
+    Dependency("x264_jll"; compat="~2021.05.05"),
+    Dependency("x265_jll"; compat="~3.5"),
+    Dependency("Bzip2_jll"; compat="1.0.8"),
     Dependency("Zlib_jll"),
-    Dependency("OpenSSL_jll"; compat = "3.0.9"),
+    Dependency("OpenSSL_jll"; compat="3.0.9"),
     Dependency("Opus_jll"),
-    Dependency("PCRE2_jll"; compat = "10.35"),
-    Dependency("Xorg_xproto_jll"),
+    Dependency("PCRE2_jll"; compat="10.35"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(
-    ARGS,
-    name,
-    version,
-    sources,
-    script(; ffplay = false),
-    platforms,
-    products,
-    dependencies;
-    julia_compat = "1.6",
-    preferred_gcc_version = preferred_gcc_version,
-    clang_use_lld=false,
-)
+build_tarballs(ARGS, name, version, sources, script(; ffplay=false), platforms, products, dependencies;
+    julia_compat="1.6", preferred_gcc_version=preferred_gcc_version)

--- a/F/FFMPEG/FFMPEG/build_tarballs.jl
+++ b/F/FFMPEG/FFMPEG/build_tarballs.jl
@@ -54,4 +54,5 @@ build_tarballs(
     dependencies;
     julia_compat = "1.6",
     preferred_gcc_version = preferred_gcc_version,
+    clang_use_lld=false,
 )

--- a/F/FFMPEG/FFplay/build_tarballs.jl
+++ b/F/FFMPEG/FFplay/build_tarballs.jl
@@ -5,9 +5,7 @@ include(joinpath("..", "common.jl"))
 name = "FFplay"
 
 # The products that we will ensure are always built
-products = [
-    ExecutableProduct("ffplay", :ffplay),
-]
+products = [ExecutableProduct("ffplay", :ffplay)]
 
 # Dependencies that must be installed before this package can be built
 # TODO: Theora once it's available
@@ -16,13 +14,20 @@ dependencies = [
     BuildDependency("nv_codec_headers_jll"),
     BuildDependency("Xorg_xorgproto_jll"),
     BuildDependency("LibVPX_jll"), # We use the static archive
-    Dependency("FFMPEG_jll"; compat=string(version)),
+    Dependency("FFMPEG_jll"; compat = string(version)),
     Dependency("SDL2_jll"),
 ]
 
-# FFplay 4.4.4 does not build on aarch64-apple
-filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
-
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script(; ffplay=true), platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=preferred_gcc_version)
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script(; ffplay = true),
+    platforms,
+    products,
+    dependencies;
+    julia_compat = "1.6",
+    preferred_gcc_version = preferred_gcc_version,
+)

--- a/F/FFMPEG/FFplay/build_tarballs.jl
+++ b/F/FFMPEG/FFplay/build_tarballs.jl
@@ -5,7 +5,9 @@ include(joinpath("..", "common.jl"))
 name = "FFplay"
 
 # The products that we will ensure are always built
-products = [ExecutableProduct("ffplay", :ffplay)]
+products = [
+    ExecutableProduct("ffplay", :ffplay),
+]
 
 # Dependencies that must be installed before this package can be built
 # TODO: Theora once it's available
@@ -14,20 +16,13 @@ dependencies = [
     BuildDependency("nv_codec_headers_jll"),
     BuildDependency("Xorg_xorgproto_jll"),
     BuildDependency("LibVPX_jll"), # We use the static archive
-    Dependency("FFMPEG_jll"; compat = string(version)),
+    Dependency("FFMPEG_jll"; compat=string(version)),
     Dependency("SDL2_jll"),
 ]
 
+# FFplay 4.4.4 does not build on aarch64-apple
+filter!(p -> !(Sys.isapple(p) && arch(p) == "aarch64"), platforms)
+
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(
-    ARGS,
-    name,
-    version,
-    sources,
-    script(; ffplay = true),
-    platforms,
-    products,
-    dependencies;
-    julia_compat = "1.6",
-    preferred_gcc_version = preferred_gcc_version,
-)
+build_tarballs(ARGS, name, version, sources, script(; ffplay=true), platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version=preferred_gcc_version)

--- a/F/FFMPEG/common.jl
+++ b/F/FFMPEG/common.jl
@@ -12,11 +12,16 @@ sources = [
         "https://ffmpeg.org/releases/ffmpeg-$(version_string).tar.xz",
         "8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968",
     ),
+    ## FFmpeg 6.1.1 does not work with macos 10.13 or earlier.
+    ArchiveSource(
+        "https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz",
+        "a3a077385205039a7c6f9e2c98ecdf2a720b2a819da715e03e0630c75782c1e4",
+    ),
 ]
 
 # Bash recipe for building across all platforms
 # TODO: Theora once it's available
-function script(; ffplay = false)
+function script(; ffplay=false)
     "FFPLAY=$(ffplay)\n" * raw"""
 cd $WORKSPACE/srcdir
 cd ffmpeg-*/
@@ -49,6 +54,15 @@ elif [[ "${target}" == powerpc64le-* ]]; then
 else
     export ccARCH="x86_64"
 fi
+
+if [[ "${target}" == x86_64-apple-darwin* ]]; then 
+    export MACOSX_DEPLOYMENT_TARGET=10.13 
+    pushd ${WORKSPACE}/srcdir/MacOSX10.*.sdk 
+    rm -rf /opt/${target}/${target}/sys-root/System 
+    cp -a usr/* "/opt/${target}/${target}/sys-root/usr/" 
+    cp -a System "/opt/${target}/${target}/sys-root/" 
+    popd
+fi 
 
 export CUDA_ARGS=""
 

--- a/F/FFMPEG/common.jl
+++ b/F/FFMPEG/common.jl
@@ -3,18 +3,20 @@
 using BinaryBuilder, Pkg
 
 name = "FFMPEG"
-version_string = "4.4.4"   # when patch number is zero, they use X.Y format
+version_string = "6.1.1"   # when patch number is zero, they use X.Y format
 version = VersionNumber(version_string)
 
 # Collection of sources required to build FFMPEG
 sources = [
-    ArchiveSource("https://ffmpeg.org/releases/ffmpeg-$(version_string).tar.xz",
-                  "e80b380d595c809060f66f96a5d849511ef4a76a26b76eacf5778b94c3570309"),
+    ArchiveSource(
+        "https://ffmpeg.org/releases/ffmpeg-$(version_string).tar.xz",
+        "8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968",
+    ),
 ]
 
 # Bash recipe for building across all platforms
 # TODO: Theora once it's available
-function script(; ffplay=false)
+function script(; ffplay = false)
     "FFPLAY=$(ffplay)\n" * raw"""
 cd $WORKSPACE/srcdir
 cd ffmpeg-*/
@@ -48,15 +50,7 @@ else
     export ccARCH="x86_64"
 fi
 
-if [[ "${target}" == arm-* ]]; then
-    export CUDA_ARGS=""
-elif [[ "${target}" == *-apple-* ]]; then
-    export CUDA_ARGS=""
-elif [[ "${target}" == *-unknown-freebsd* ]]; then
-    export CUDA_ARGS=""
-else
-    export CUDA_ARGS="--enable-nvenc --enable-cuda-llvm"
-fi
+export CUDA_ARGS=""
 
 EXTRA_FLAGS=()
 if [[ "${target}" == *-darwin* ]]; then
@@ -93,7 +87,6 @@ sed -i 's/cpuflags="-march=$cpu"/cpuflags=""/g' configure
   --enable-pic         \
   --disable-debug      \
   --disable-doc        \
-  --enable-avresample  \
   --enable-libaom      \
   --enable-libass      \
   --enable-libfdk-aac  \


### PR DESCRIPTION
- `libresample` is deprecated and was therefore removed.
- `CUDA_ARGS` was set but `ffnvcodec` (I could not find any jll except for https://github.com/JuliaPackaging/Yggdrasil/blob/master/N/nv_codec_headers/build_tarballs.jl ?) is not provided, resulting in an error when trying to compile it.

There seems to be an error on MacOS, mentioned [here](https://trac.macports.org/ticket/68720l) and indicate that MacOS > 10.13 is needed?