### PR TITLE
[MicrosoftMPI] Update import libraries

### DIFF
--- a/M/MicrosoftMPI/build_tarballs.jl
+++ b/M/MicrosoftMPI/build_tarballs.jl
@@ -85,6 +85,16 @@ fi
 cmake --build . --config RelWithDebInfo --parallel $nproc
 cmake --build . --config RelWithDebInfo --parallel $nproc --target install
 
+if [[ ${target} == i686-w64-* ]]; then
+    # Remove 64-bit import libraries
+    rm $prefix/lib/*64.lib
+else
+    # Rename 64-bit import libraries
+    mv -f $prefix/lib/msmpifmc64.lib $prefix/lib/msmpifmc.lib
+    mv -f $prefix/lib/msmpifec64.lib $prefix/lib/msmpifec.lib
+    mv -f $prefix/lib/msmpi64.lib $prefix/lib/msmpi.lib
+fi
+
 install_license $WORKSPACE/destdir/share/licenses/MicrosoftMPI/* $WORKSPACE/srcdir/MPIconstants*/LICENSE.md
 """
 


### PR DESCRIPTION
`MicrosoftMPI` provides two shared libraries msmpi.dll and msmpi64.dll and associated import libraries.
We renamed `msmpi64.dll` into `msmpi.dll` but we forgot to also rename the import libraries.