### PR TITLE
[SDPA] rebuild with no changes for latest libcxxwrap

### DIFF
--- a/S/SDPA/build_tarballs.jl
+++ b/S/SDPA/build_tarballs.jl
@@ -2,7 +2,6 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 
 using BinaryBuilder, Pkg
-
 # See https://github.com/JuliaLang/Pkg.jl/issues/2942
 # Once this Pkg issue is resolved, this must be removed
 uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")


### PR DESCRIPTION
SDPA is failing on Julia v1.10 with the error:
```
(...)/lib/libcxxwrap_julia.so: undefined symbol: small_typeof, version JL_LIBJULIA_1.10
```
Fixing this seems to have been the goal of https://github.com/JuliaPackaging/Yggdrasil/pull/7484 so I assume a rebuild should fix it.