### PR TITLE
[ImageMagick] Update to 6.9.13

### DIFF
--- a/I/ImageMagick/ImageMagick@6/build_tarballs.jl
+++ b/I/ImageMagick/ImageMagick@6/build_tarballs.jl
@@ -67,4 +67,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", clang_use_lld=false)

--- a/I/ImageMagick/ImageMagick@6/build_tarballs.jl
+++ b/I/ImageMagick/ImageMagick@6/build_tarballs.jl
@@ -61,7 +61,7 @@ dependencies = [
     Dependency("Zlib_jll"),
     Dependency("libpng_jll"),
     Dependency("JpegTurbo_jll"),
-    Dependency("Libtiff_jll"; compat="4.6"),
+    Dependency("Libtiff_jll"; compat="4.5.1"),
     Dependency("Ghostscript_jll"),
     Dependency("OpenJpeg_jll"),
 ]

--- a/I/ImageMagick/ImageMagick@6/build_tarballs.jl
+++ b/I/ImageMagick/ImageMagick@6/build_tarballs.jl
@@ -2,13 +2,13 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 name = "ImageMagick"
-upstream_version = v"6.9.12-89"
+upstream_version = v"6.9.13-6"
 version = VersionNumber(upstream_version.major, upstream_version.minor, upstream_version.patch)
 
 # Collection of sources required to build imagemagick
 sources = [
     GitSource("https://github.com/ImageMagick/ImageMagick6",
-              "a8cd2a3216ae889b52e26db825ca1bae022bd6d0"),
+              "3da057d31756970cb50b1567922e9caf94d36d84"),
     DirectorySource("./bundled"),
 ]
 
@@ -61,7 +61,7 @@ dependencies = [
     Dependency("Zlib_jll"),
     Dependency("libpng_jll"),
     Dependency("JpegTurbo_jll"),
-    Dependency("Libtiff_jll"; compat="4.3.0"),
+    Dependency("Libtiff_jll"),
     Dependency("Ghostscript_jll"),
     Dependency("OpenJpeg_jll"),
 ]

--- a/I/ImageMagick/ImageMagick@6/build_tarballs.jl
+++ b/I/ImageMagick/ImageMagick@6/build_tarballs.jl
@@ -61,7 +61,7 @@ dependencies = [
     Dependency("Zlib_jll"),
     Dependency("libpng_jll"),
     Dependency("JpegTurbo_jll"),
-    Dependency("Libtiff_jll"),
+    Dependency("Libtiff_jll"; compat="4.6"),
     Dependency("Ghostscript_jll"),
     Dependency("OpenJpeg_jll"),
 ]


### PR DESCRIPTION
I am relaxing the compat on libtiff (which was set to v4.4), since it looks like [ubuntu and others are using libtiff >=4.5](https://packages.ubuntu.com/noble/libmagickcore-6.q16-7).