### PR TITLE
add XicTools build script

### DIFF
--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -103,4 +103,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "XicTools"
-version = v"0.1.0"
+version = v"4.3.19"
 
 # Collection of sources required to complete build
 sources = [

--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -25,29 +25,53 @@ make prefix="${prefix}/usr" install
 install_license ${WORKSPACE}/srcdir/xictools/license/LICENSE-2.0.txt
 cd ${prefix}/usr/xictools
 install -Dvm 755 wrspice.current/bin/mmjco "${bindir}/mmjco"
+rm wrspice.current/bin/mmjco
 install -Dvm 755 wrspice.current/bin/multidec "${bindir}/multidec"
+rm wrspice.current/bin/multidec
 install -Dvm 755 wrspice.current/bin/printtoraw "${bindir}/printtoraw"
+rm wrspice.current/bin/printtoraw
 install -Dvm 755 wrspice.current/bin/proc2mod "${bindir}/proc2mod"
+rm wrspice.current/bin/proc2mod
 install -Dvm 755 wrspice.current/bin/wrspice "${bindir}/wrspice"
+rm wrspice.current/bin/wrspice
 install -Dvm 755 wrspice.current/bin/wrspiced "${bindir}/wrspiced"
+rm wrspice.current/bin/wrspiced
 install -Dvm 755 bin/admsXml "${bindir}/admsXml"
+rm bin/admsXml
 install -Dvm 755 bin/busgen "${bindir}/busgen"
+rm bin/busgen
 install -Dvm 755 bin/capgen "${bindir}/capgen"
+rm bin/capgen
 install -Dvm 755 bin/cubegen "${bindir}/cubegen"
+rm bin/cubegen
 install -Dvm 755 bin/fastcap "${bindir}/fastcap"
+rm bin/fastcap
 install -Dvm 755 bin/fasthenry "${bindir}/fasthenry"
+rm bin/fasthenry
 install -Dvm 755 bin/fcpp "${bindir}/fcpp"
+rm bin/fcpp
 install -Dvm 755 bin/lstpack "${bindir}/lstpack"
+rm bin/lstpack
 install -Dvm 755 bin/lstunpack "${bindir}/lstunpack"
+rm bin/lstunpack
 install -Dvm 755 bin/mrouter "${bindir}/mrouter"
+rm bin/mrouter
 install -Dvm 755 bin/pipedgen "${bindir}/pipedgen"
+rm bin/pipedgen
 install -Dvm 755 bin/pyragen "${bindir}/pyragen"
+rm bin/pyragen
 install -Dvm 755 bin/vl "${bindir}/vl"
+rm bin/vl
 install -Dvm 755 xic.current/bin/wrdecode "${bindir}/wrdecode"
+rm xic.current/bin/wrdecode
 install -Dvm 755 xic.current/bin/wrencode "${bindir}/wrencode"
+rm xic.current/bin/wrencode
 install -Dvm 755 xic.current/bin/wrsetpass "${bindir}/wrsetpass"
+rm xic.current/bin/wrsetpass
 install -Dvm 755 xic.current/bin/xic "${bindir}/xic"
+rm xic.current/bin/xic
 install -Dvm 755 bin/zbuf "${bindir}/zbuf"
+rm bin/zbuf
 """
 
 
@@ -95,10 +119,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Libtiff_jll""; compat="4.5.1"),
+    Dependency("Libtiff_jll"; compat="4.5.1"),
     Dependency("libpng_jll"),
     Dependency("JpegTurbo_jll"),
-    Dependency("GSL_jll; compat="~2.7.2""),
+    Dependency("GSL_jll"; compat="~2.7.2"),
     Dependency("CompilerSupportLibraries_jll"),
 ]
 

--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -95,7 +95,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Libtiff_jll"),
+    Dependency("Libtiff_jll""; compat="4.5.1"),
     Dependency("libpng_jll"),
     Dependency("JpegTurbo_jll"),
     Dependency("GSL_jll; compat="~2.7.2""),

--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -98,7 +98,7 @@ dependencies = [
     Dependency("Libtiff_jll"),
     Dependency("libpng_jll"),
     Dependency("JpegTurbo_jll"),
-    Dependency("GSL_jll"),
+    Dependency("GSL_jll; compat="~2.7.2""),
     Dependency("CompilerSupportLibraries_jll"),
 ]
 

--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -20,7 +20,7 @@ sed -i "s|GFXLOC = --enable-gtk2=yes|#GFXLOC = --enable-gtk2=yes|g" Makefile
 sed -i "766c\#include <malloc.h>" xt_base/malloc/malloc-2.8.6.c
 update_configure_scripts
 make config
-make all -j$(nproc)
+make all -j${nproc}
 make prefix="${prefix}/usr" install
 install_license ${WORKSPACE}/srcdir/xictools/license/LICENSE-2.0.txt
 cd ${prefix}/usr/xictools

--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -24,54 +24,35 @@ make all -j${nproc}
 make prefix="${prefix}/usr" install
 install_license ${WORKSPACE}/srcdir/xictools/license/LICENSE-2.0.txt
 cd ${prefix}/usr/xictools
-install -Dvm 755 wrspice.current/bin/mmjco "${bindir}/mmjco"
-rm wrspice.current/bin/mmjco
-install -Dvm 755 wrspice.current/bin/multidec "${bindir}/multidec"
-rm wrspice.current/bin/multidec
-install -Dvm 755 wrspice.current/bin/printtoraw "${bindir}/printtoraw"
-rm wrspice.current/bin/printtoraw
-install -Dvm 755 wrspice.current/bin/proc2mod "${bindir}/proc2mod"
-rm wrspice.current/bin/proc2mod
-install -Dvm 755 wrspice.current/bin/wrspice "${bindir}/wrspice"
-rm wrspice.current/bin/wrspice
-install -Dvm 755 wrspice.current/bin/wrspiced "${bindir}/wrspiced"
-rm wrspice.current/bin/wrspiced
-install -Dvm 755 bin/admsXml "${bindir}/admsXml"
-rm bin/admsXml
-install -Dvm 755 bin/busgen "${bindir}/busgen"
-rm bin/busgen
-install -Dvm 755 bin/capgen "${bindir}/capgen"
-rm bin/capgen
-install -Dvm 755 bin/cubegen "${bindir}/cubegen"
-rm bin/cubegen
-install -Dvm 755 bin/fastcap "${bindir}/fastcap"
-rm bin/fastcap
-install -Dvm 755 bin/fasthenry "${bindir}/fasthenry"
-rm bin/fasthenry
-install -Dvm 755 bin/fcpp "${bindir}/fcpp"
-rm bin/fcpp
-install -Dvm 755 bin/lstpack "${bindir}/lstpack"
-rm bin/lstpack
-install -Dvm 755 bin/lstunpack "${bindir}/lstunpack"
-rm bin/lstunpack
-install -Dvm 755 bin/mrouter "${bindir}/mrouter"
-rm bin/mrouter
-install -Dvm 755 bin/pipedgen "${bindir}/pipedgen"
-rm bin/pipedgen
-install -Dvm 755 bin/pyragen "${bindir}/pyragen"
-rm bin/pyragen
-install -Dvm 755 bin/vl "${bindir}/vl"
-rm bin/vl
-install -Dvm 755 xic.current/bin/wrdecode "${bindir}/wrdecode"
-rm xic.current/bin/wrdecode
-install -Dvm 755 xic.current/bin/wrencode "${bindir}/wrencode"
-rm xic.current/bin/wrencode
-install -Dvm 755 xic.current/bin/wrsetpass "${bindir}/wrsetpass"
-rm xic.current/bin/wrsetpass
-install -Dvm 755 xic.current/bin/xic "${bindir}/xic"
-rm xic.current/bin/xic
-install -Dvm 755 bin/zbuf "${bindir}/zbuf"
-rm bin/zbuf
+FILES="wrspice.current/bin/mmjco
+wrspice.current/bin/multidec
+wrspice.current/bin/printtoraw
+wrspice.current/bin/proc2mod
+wrspice.current/bin/wrspice
+wrspice.current/bin/wrspiced
+bin/admsXml
+bin/busgen
+bin/capgen
+bin/cubegen
+bin/fastcap
+bin/fasthenry
+bin/fcpp
+bin/lstpack
+bin/lstunpack
+bin/mrouter
+bin/pipedgen
+bin/pyragen
+bin/vl
+xic.current/bin/wrencode
+xic.current/bin/wrdecode
+xic.current/bin/wrsetpass
+xic.current/bin/xic
+bin/zbuf"
+for file in $FILES; do
+    install -Dvm 755 "${file}" "${bindir}/$(basename ${file})"
+    rm "${file}"
+    ln -s "${bindir}/$(basename ${file})" "${file}"
+done
 """
 
 

--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -19,7 +19,7 @@ atomic_patch -p0 ${WORKSPACE}/srcdir/patches/Makefile.patch
 atomic_patch -p0 ${WORKSPACE}/srcdir/patches/malloc-2.8.6.c.patch
 update_configure_scripts
 make config
-make all -j${nproc}
+make all
 make prefix="${prefix}/usr" install
 install_license ${WORKSPACE}/srcdir/xictools/license/LICENSE-2.0.txt
 cd ${prefix}/usr/xictools

--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -1,0 +1,106 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "XicTools"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/wrcad/xictools", "c7a50a5fcd71966730e45a5358b8507227ae098c"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/xictools/
+cp Makefile.sample Makefile
+sed -i "s|enable-itopok=no|enable-itopok=yes|g" Makefile
+sed -i "s|GFXLOC = --enable-gtk2=yes|#GFXLOC = --enable-gtk2=yes|g" Makefile
+#sed -i "s|^SUBDIRS =.*|SUBDIRS = xt_base adms KLU vl wrspice|g" Makefile
+sed -i "766c\#include <malloc.h>" xt_base/malloc/malloc-2.8.6.c
+update_configure_scripts
+make config
+make all -j$(nproc)
+make prefix="${prefix}/usr" install
+install_license ${WORKSPACE}/srcdir/xictools/license/LICENSE-2.0.txt
+cd ${prefix}/usr/xictools
+install -Dvm 755 wrspice.current/bin/mmjco "${bindir}/mmjco"
+install -Dvm 755 wrspice.current/bin/multidec "${bindir}/multidec"
+install -Dvm 755 wrspice.current/bin/printtoraw "${bindir}/printtoraw"
+install -Dvm 755 wrspice.current/bin/proc2mod "${bindir}/proc2mod"
+install -Dvm 755 wrspice.current/bin/wrspice "${bindir}/wrspice"
+install -Dvm 755 wrspice.current/bin/wrspiced "${bindir}/wrspiced"
+install -Dvm 755 bin/admsXml "${bindir}/admsXml"
+install -Dvm 755 bin/busgen "${bindir}/busgen"
+install -Dvm 755 bin/capgen "${bindir}/capgen"
+install -Dvm 755 bin/cubegen "${bindir}/cubegen"
+install -Dvm 755 bin/fastcap "${bindir}/fastcap"
+install -Dvm 755 bin/fasthenry "${bindir}/fasthenry"
+install -Dvm 755 bin/fcpp "${bindir}/fcpp"
+install -Dvm 755 bin/lstpack "${bindir}/lstpack"
+install -Dvm 755 bin/lstunpack "${bindir}/lstunpack"
+install -Dvm 755 bin/mrouter "${bindir}/mrouter"
+install -Dvm 755 bin/pipedgen "${bindir}/pipedgen"
+install -Dvm 755 bin/pyragen "${bindir}/pyragen"
+install -Dvm 755 bin/vl "${bindir}/vl"
+install -Dvm 755 xic.current/bin/wrdecode "${bindir}/wrdecode"
+install -Dvm 755 xic.current/bin/wrencode "${bindir}/wrencode"
+install -Dvm 755 xic.current/bin/wrsetpass "${bindir}/wrsetpass"
+install -Dvm 755 xic.current/bin/xic "${bindir}/xic"
+install -Dvm 755 bin/zbuf "${bindir}/zbuf"
+"""
+
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+
+# Linux builds only for now. Windows and MacOS builds possible
+# but those require a different set of commands and tooling. 
+# See https://github.com/wrcad/xictools/blob/master/README
+platforms = [Platform("x86_64", "linux")]
+
+# Contains std::string values!  This causes incompatibilities across
+# the GCC 4/5 version boundary. To remedy this, you must build a
+# tarball for both GCC 4 and GCC 5.  To do this, immediately after
+# your `platforms` definition in your `build_tarballs.jl` file, 
+# add the line: platforms = expand_cxxstring_abis(platforms)
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+	    ExecutableProduct("mmjco", :mmjco),
+	    ExecutableProduct("multidec", :multidec),
+	    ExecutableProduct("printtoraw", :printtoraw),
+	    ExecutableProduct("proc2mod", :proc2mod),
+	    ExecutableProduct("wrspice", :wrspice),
+	    ExecutableProduct("wrspiced", :wrspiced),
+	    ExecutableProduct("admsXml", :admsXml),
+	    ExecutableProduct("busgen", :busgen),
+	    ExecutableProduct("capgen", :capgen),
+	    ExecutableProduct("cubegen", :cubegen),
+	    ExecutableProduct("fastcap", :fastcap),
+	    ExecutableProduct("fasthenry", :fasthenry),
+	    ExecutableProduct("fcpp", :fcpp),
+	    ExecutableProduct("lstpack", :lstpack),
+	    ExecutableProduct("lstunpack", :lstunpack),
+	    ExecutableProduct("mrouter", :mrouter),
+	    ExecutableProduct("pipedgen", :pipedgen),
+	    ExecutableProduct("pyragen", :pyragen),
+	    ExecutableProduct("vl", :vl),
+	    ExecutableProduct("wrdecode", :wrdecode),
+	    ExecutableProduct("wrencode", :wrencode),
+	    ExecutableProduct("xic", :xic),
+	    ExecutableProduct("zbuf", :zbuf),
+	    ]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Libtiff_jll"),
+    Dependency("libpng_jll"),
+    Dependency("JpegTurbo_jll"),
+    Dependency("GSL_jll"),
+    Dependency("CompilerSupportLibraries_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/X/XicTools/build_tarballs.jl
+++ b/X/XicTools/build_tarballs.jl
@@ -8,16 +8,15 @@ version = v"4.3.19"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/wrcad/xictools", "c7a50a5fcd71966730e45a5358b8507227ae098c"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd ${WORKSPACE}/srcdir/xictools/
 cp Makefile.sample Makefile
-sed -i "s|enable-itopok=no|enable-itopok=yes|g" Makefile
-sed -i "s|GFXLOC = --enable-gtk2=yes|#GFXLOC = --enable-gtk2=yes|g" Makefile
-#sed -i "s|^SUBDIRS =.*|SUBDIRS = xt_base adms KLU vl wrspice|g" Makefile
-sed -i "766c\#include <malloc.h>" xt_base/malloc/malloc-2.8.6.c
+atomic_patch -p0 ${WORKSPACE}/srcdir/patches/Makefile.patch
+atomic_patch -p0 ${WORKSPACE}/srcdir/patches/malloc-2.8.6.c.patch
 update_configure_scripts
 make config
 make all -j${nproc}

--- a/X/XicTools/bundled/patches/Makefile.patch
+++ b/X/XicTools/bundled/patches/Makefile.patch
@@ -1,0 +1,20 @@
+--- ../xictools-master/Makefile	2024-02-23 08:47:58.384498499 -0500
++++ Makefile	2024-02-23 08:55:56.681812877 -0500
+@@ -31,7 +31,7 @@
+ # all files in their local space with the PREFIX variable set
+ # appropriately and this variable set to "yes" instead of "no".
+ #
+-ITOPOK = --enable-itopok=no
++ITOPOK = --enable-itopok=yes
+ 
+ # The licensing system for Xic and WRspice is disabled by default, but
+ # can be enabled by uncommenting the assignment below.  The code for
+@@ -81,7 +81,7 @@
+ #GFXLOC = --enable-qt5=/opt/local/libexec/qt5
+ #GFXLOC = --enable-qt5=/usr/lib64/qt5
+ #GFXLOC = --enable-qt5=yes
+-GFXLOC = --enable-gtk2=yes
++#GFXLOC = --enable-gtk2=yes
+ 
+ # OpenAccess support, Linux only.
+ # If you have an OpenAccess source tree, specify its location in this

--- a/X/XicTools/bundled/patches/malloc-2.8.6.c.patch
+++ b/X/XicTools/bundled/patches/malloc-2.8.6.c.patch
@@ -1,0 +1,11 @@
+--- ../xictools-master/xt_base/malloc/malloc-2.8.6.c	2024-02-18 20:19:53.000000000 -0500
++++ xt_base/malloc/malloc-2.8.6.c	2024-02-23 08:57:12.595927930 -0500
+@@ -763,7 +763,7 @@
+ /* #define HAVE_USR_INCLUDE_MALLOC_H */
+ 
+ #ifdef HAVE_USR_INCLUDE_MALLOC_H
+-#include "/usr/include/malloc.h"
++#include <malloc.h>
+ #else /* HAVE_USR_INCLUDE_MALLOC_H */
+ #ifndef STRUCT_MALLINFO_DECLARED
+ /* HP-UX (and others?) redefines mallinfo unless _STRUCT_MALLINFO is defined */


### PR DESCRIPTION
XicTools contains the electronic design editor Xic and the circuit simulator WRspice. This build_tarballs builds the Linux version without a GUI.