### PR TITLE
Git: Upgrade to 2.44 and make Windows git more complete

### DIFF
--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -3,16 +3,16 @@
 using BinaryBuilder
 
 name = "Git"
-version = v"2.43.0"
+version = v"2.44.0"
 
 # Collection of sources required to build Git
 sources = [
     ArchiveSource("https://mirrors.edge.kernel.org/pub/software/scm/git/git-$(version).tar.xz",
-                  "5446603e73d911781d259e565750dcd277a42836c8e392cac91cf137aa9b76ec"),
+                  "e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3"),
     ArchiveSource("https://github.com/git-for-windows/git/releases/download/v$(version).windows.1/Git-$(version)-32-bit.tar.bz2",
-                  "192f58080247f1eea2845fb61e37e91c05a89b44260c7e045b936ca3e45ac7f6"; unpack_target = "i686-w64-mingw32"),
+                  "14541119fe97b4d34126ee136cbdba8da171b8cbd42543185a259128a3eed6b3"; unpack_target = "i686-w64-mingw32"),
     ArchiveSource("https://github.com/git-for-windows/git/releases/download/v$(version).windows.1/Git-$(version)-64-bit.tar.bz2",
-                  "4c19cc73003e55ec71d6f1ce4a961ab32ca22f9c57217d224982535161123f79"; unpack_target = "x86_64-w64-mingw32"),
+                  "d78c40d768eb7af7e14d5cd47dac89a2e50786c89a67be6249e1a041ae5eb20d"; unpack_target = "x86_64-w64-mingw32"),
 ]
 
 # Bash recipe for building across all platforms
@@ -21,7 +21,7 @@ install_license ${WORKSPACE}/srcdir/git-*/COPYING
 
 if [[ "${target}" == *-ming* ]]; then
     # Fast path for Windows: just copy the content of the tarball to the prefix
-    cp -r ${WORKSPACE}/srcdir/${target}/mingw${nbits}/* ${prefix}
+    cp -r ${WORKSPACE}/srcdir/${target}/* ${prefix}
     exit
 fi
 


### PR DESCRIPTION
In addition to bumping Git to 2.44.0, this PR changes the Windows bundle to include the git bash parts. See https://github.com/JuliaVersionControl/Git.jl/issues/50 for rationale.
