### PR TITLE
[libpolymake_julia] rebuild for julia 1.12 (reverting to flint 2.9 for now)

### DIFF
--- a/L/libpolymake_julia/build_tarballs.jl
+++ b/L/libpolymake_julia/build_tarballs.jl
@@ -13,7 +13,7 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 include("../../L/libjulia/common.jl")
 
 name = "libpolymake_julia"
-version = v"0.11.3"
+version = v"0.11.4"
 
 # reminder: change the above version when changing the supported julia versions
 # julia_versions is now taken from libjulia/common.jl
@@ -67,18 +67,18 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.8")),
+    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.9")),
     BuildDependency("GMP_jll"),
     BuildDependency("MPFR_jll"),
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("FLINT_jll", compat = "~300.000.000"),
+    Dependency("FLINT_jll", compat = "~200.900.004"),
     Dependency("TOPCOM_jll"; compat = "~0.17.8"),
     Dependency("lib4ti2_jll"; compat = "^1.6.10"),
     Dependency("libcxxwrap_julia_jll"; compat = "~0.11.2"),
-    Dependency("polymake_jll"; compat = "~400.1100.2"),
+    Dependency("polymake_jll"; compat = "~400.1100.1"),
 
     HostBuildDependency(PackageSpec(name="Perl_jll", version=v"5.34.1")),
-    HostBuildDependency(PackageSpec(name="polymake_jll", version=v"400.1100.2")),
+    HostBuildDependency(PackageSpec(name="polymake_jll", version=v"400.1100.1")),
     HostBuildDependency(PackageSpec(name="lib4ti2_jll", version=v"1.6.10")),
     HostBuildDependency(PackageSpec(name="TOPCOM_jll", version=v"0.17.8")),
 ]


### PR DESCRIPTION
Use FLINT 2.9 until FLINT 3.1 is released, and the corresponding polymake_jll version.