### PR TITLE
[OpenJpeg] Allow libtiff >= 4.5.1 rather than pinning it to that version

### DIFF
--- a/O/OpenJpeg/build_tarballs.jl
+++ b/O/OpenJpeg/build_tarballs.jl
@@ -46,4 +46,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", clang_use_lld=false)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"6")

--- a/O/OpenJpeg/build_tarballs.jl
+++ b/O/OpenJpeg/build_tarballs.jl
@@ -18,7 +18,8 @@ cd $WORKSPACE/srcdir/openjpeg/
 for f in ${WORKSPACE}/srcdir/patches/*.patch; do
     atomic_patch -p1 ${f}
 done
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIBS=OFF
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIBS=OFF
 make -j${nproc}
 make install
 """
@@ -39,7 +40,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="LittleCMS_jll", uuid="d3a379c0-f9a3-5b72-a4c0-6bf4d2e8af0f"))
     Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f"))
-    Dependency("Libtiff_jll"; compat="~4.5.1")
+    Dependency("Libtiff_jll"; compat="4.5.1")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/O/OpenJpeg/build_tarballs.jl
+++ b/O/OpenJpeg/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"2.5.0"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/uclouvain/openjpeg.git",
-                  "a5891555eb49ed7cc26b2901ea680acda136d811"),
+              "a5891555eb49ed7cc26b2901ea680acda136d811"),
     DirectorySource("./bundled")
 ]
 
@@ -18,8 +18,10 @@ cd $WORKSPACE/srcdir/openjpeg/
 for f in ${WORKSPACE}/srcdir/patches/*.patch; do
     atomic_patch -p1 ${f}
 done
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-      -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIBS=OFF
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_STATIC_LIBS=OFF
 make -j${nproc}
 make install
 """
@@ -38,10 +40,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="LittleCMS_jll", uuid="d3a379c0-f9a3-5b72-a4c0-6bf4d2e8af0f"))
-    Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f"))
+    Dependency("LittleCMS_jll")
+    Dependency("libpng_jll")
     Dependency("Libtiff_jll"; compat="4.5.1")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", clang_use_lld=false)


### PR DESCRIPTION
Make it possible to use newer versions of Libtiff with openjpeg.