### PR TITLE
[spla] fix build_tarballs.jl

### DIFF
--- a/S/spla/build_tarballs.jl
+++ b/S/spla/build_tarballs.jl
@@ -94,4 +94,4 @@ append!(dependencies, platform_dependencies)
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version = v"7")
+               augment_platform_block, julia_compat="1.6", preferred_gcc_version = v"7")


### PR DESCRIPTION
PR #8185 introduced the new spla package with a broken `build_tarballs.jl` script (MPI). This is the fixed version of it.