### PR TITLE
[SpFFT] fix build_tarballs.jl

### DIFF
--- a/S/SpFFT/build_tarballs.jl
+++ b/S/SpFFT/build_tarballs.jl
@@ -89,4 +89,4 @@ append!(dependencies, platform_dependencies)
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version = v"8")
+               augment_platform_block, julia_compat="1.6", preferred_gcc_version = v"8")


### PR DESCRIPTION
PR #8186 introduced the new SpFFT package with a broken build_tarballs.jl script (MPI). This is the fixed version of it.