### PR TITLE
[GCC] Add `libgomp` patch for NULL `environ` (v13.2.0)

### DIFF
--- a/0_RootFS/GCCBootstrap@13/bundled/patches/gcc-libgomp-environ.patch
+++ b/0_RootFS/GCCBootstrap@13/bundled/patches/gcc-libgomp-environ.patch
@@ -1,0 +1,302 @@
+From c128ad8e830e90a429eaeccc3fb000a73fd6779c Mon Sep 17 00:00:00 2001
+From: Jakub Jelinek <jakub@redhat.com>
+Date: Tue, 19 Sep 2023 09:26:35 +0200
+Subject: [PATCH] libgomp: Handle NULL environ like pointer to NULL pointer
+ [PR111413]
+
+clearenv function just sets environ to NULL (after sometimes freeing it),
+rather than setting it to a pointer to NULL, and our code was assuming
+it is always non-NULL.
+
+Fixed thusly, the change seems to be large but actually is just
++  if (environ)
+     for (env = environ; *env != 0; env++)
+plus reindentation.  I've also noticed the block after this for loop
+was badly indented (too much) and fixed that too.
+
+No testcase added, as it needs clearenv + dlopen.
+
+2023-09-19  Jakub Jelinek  <jakub@redhat.com>
+
+	PR libgomp/111413
+	* env.c (initialize_env): Don't dereference environ if it is NULL.
+	Reindent.
+
+(cherry picked from commit 15345980633c502f0486a2e40e96224f49134130)
+---
+ libgomp/env.c | 251 +++++++++++++++++++++++++-------------------------
+ 1 file changed, 126 insertions(+), 125 deletions(-)
+
+diff --git a/libgomp/env.c b/libgomp/env.c
+index e7a035b593c..65088f2fe18 100644
+--- a/libgomp/env.c
++++ b/libgomp/env.c
+@@ -2059,139 +2059,140 @@ initialize_env (void)
+   none = gomp_get_initial_icv_item (GOMP_DEVICE_NUM_FOR_NO_SUFFIX);
+   initialize_icvs (&none->icvs);
+ 
+-  for (env = environ; *env != 0; env++)
+-    {
+-      if (!startswith (*env, "OMP_"))
+-	continue;
+-
+-     /* Name of the environment variable without suffix "OMP_".  */
+-     char *name = *env + sizeof ("OMP_") - 1;
+-     for (omp_var = 0; omp_var < OMP_VAR_CNT; omp_var++)
+-	{
+-	  if (startswith (name, envvars[omp_var].name))
+-	    {
+-	      pos = envvars[omp_var].name_len;
+-	      if (name[pos] == '=')
+-		{
+-		  pos++;
+-		  flag_var_addr
+-		    = add_initial_icv_to_list (GOMP_DEVICE_NUM_FOR_NO_SUFFIX,
+-					       envvars[omp_var].flag_vars[0],
+-					       params);
+-		}
+-	      else if (startswith (&name[pos], "_DEV=")
+-		       && envvars[omp_var].flag & GOMP_ENV_SUFFIX_DEV)
+-		{
+-		  pos += 5;
+-		  flag_var_addr
+-		    = add_initial_icv_to_list (GOMP_DEVICE_NUM_FOR_DEV,
+-					       envvars[omp_var].flag_vars[0],
+-					       params);
+-		}
+-	      else if (startswith (&name[pos], "_ALL=")
+-		       && envvars[omp_var].flag & GOMP_ENV_SUFFIX_ALL)
+-		{
+-		  pos += 5;
+-		  flag_var_addr
+-		    = add_initial_icv_to_list (GOMP_DEVICE_NUM_FOR_ALL,
+-					       envvars[omp_var].flag_vars[0],
+-					       params);
+-		}
+-	      else if (startswith (&name[pos], "_DEV_")
+-		       && envvars[omp_var].flag & GOMP_ENV_SUFFIX_DEV_X)
+-		{
+-		  pos += 5;
+-		  if (!get_device_num (*env, &name[pos], &dev_num,
+-				       &dev_num_len))
+-		    break;
+-
+-		  pos += dev_num_len + 1;
+-		  flag_var_addr
+-		    = add_initial_icv_to_list (dev_num,
+-					       envvars[omp_var].flag_vars[0],
+-					       params);
+-		}
+-	      else
+-		{
+-		  gomp_error ("Invalid environment variable in %s", *env);
+-		  break;
+-		}
+-	      env_val = &name[pos];
++  if (environ)
++    for (env = environ; *env != 0; env++)
++      {
++	if (!startswith (*env, "OMP_"))
++	  continue;
+ 
+-	      if (envvars[omp_var].parse_func (*env, env_val, params))
+-		{
+-		  for (i = 0; i < 3; ++i)
+-		    if (envvars[omp_var].flag_vars[i])
+-		      gomp_set_icv_flag (flag_var_addr,
+-					 envvars[omp_var].flag_vars[i]);
+-		    else
++       /* Name of the environment variable without suffix "OMP_".  */
++       char *name = *env + sizeof ("OMP_") - 1;
++       for (omp_var = 0; omp_var < OMP_VAR_CNT; omp_var++)
++	  {
++	    if (startswith (name, envvars[omp_var].name))
++	      {
++		pos = envvars[omp_var].name_len;
++		if (name[pos] == '=')
++		  {
++		    pos++;
++		    flag_var_addr
++		      = add_initial_icv_to_list (GOMP_DEVICE_NUM_FOR_NO_SUFFIX,
++						 envvars[omp_var].flag_vars[0],
++						 params);
++		  }
++		else if (startswith (&name[pos], "_DEV=")
++			 && envvars[omp_var].flag & GOMP_ENV_SUFFIX_DEV)
++		  {
++		    pos += 5;
++		    flag_var_addr
++		      = add_initial_icv_to_list (GOMP_DEVICE_NUM_FOR_DEV,
++						 envvars[omp_var].flag_vars[0],
++						 params);
++		  }
++		else if (startswith (&name[pos], "_ALL=")
++			 && envvars[omp_var].flag & GOMP_ENV_SUFFIX_ALL)
++		  {
++		    pos += 5;
++		    flag_var_addr
++		      = add_initial_icv_to_list (GOMP_DEVICE_NUM_FOR_ALL,
++						 envvars[omp_var].flag_vars[0],
++						 params);
++		  }
++		else if (startswith (&name[pos], "_DEV_")
++			 && envvars[omp_var].flag & GOMP_ENV_SUFFIX_DEV_X)
++		  {
++		    pos += 5;
++		    if (!get_device_num (*env, &name[pos], &dev_num,
++					 &dev_num_len))
+ 		      break;
+-		}
+ 
+-	      break;
+-	    }
+-	}
+-    }
++		    pos += dev_num_len + 1;
++		    flag_var_addr
++		      = add_initial_icv_to_list (dev_num,
++						 envvars[omp_var].flag_vars[0],
++						 params);
++		  }
++		else
++		  {
++		    gomp_error ("Invalid environment variable in %s", *env);
++		    break;
++		  }
++		env_val = &name[pos];
+ 
+-    all = gomp_get_initial_icv_item (GOMP_DEVICE_NUM_FOR_ALL);
+-    for (omp_var = 0; omp_var < OMP_HOST_VAR_CNT; omp_var++)
+-      {
+-	if (none != NULL
+-	    && gomp_get_icv_flag (none->flags, host_envvars[omp_var].flag_var))
+-	  get_icv_member_addr (&none->icvs,
+-			       host_envvars[omp_var].flag_var, params);
+-	else if (all != NULL
+-		 && gomp_get_icv_flag (all->flags,
+-				       host_envvars[omp_var].flag_var))
+-	  get_icv_member_addr (&all->icvs, host_envvars[omp_var].flag_var,
+-			       params);
+-	else
+-	  continue;
++		if (envvars[omp_var].parse_func (*env, env_val, params))
++		  {
++		    for (i = 0; i < 3; ++i)
++		      if (envvars[omp_var].flag_vars[i])
++			gomp_set_icv_flag (flag_var_addr,
++					   envvars[omp_var].flag_vars[i]);
++		      else
++			break;
++		  }
+ 
+-	switch (host_envvars[omp_var].type_code)
+-	  {
+-	  case PARSE_INT:
+-	    for (i = 0; i < 3; ++i)
+-	      if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
+-		*(int *) (host_envvars[omp_var].dest[i]) = *(int *) params[i];
+-	    break;
+-	  case PARSE_BOOL:
+-	    for (i = 0; i < 3; ++i)
+-	      if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
+-		*(bool *) (host_envvars[omp_var].dest[i]) = *(bool *) params[i];
+-	    break;
+-	  case PARSE_UINT:
+-	    for (i = 0; i < 3; ++i)
+-	      if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
+-		*(unsigned int *) (host_envvars[omp_var].dest[i])
+-		  = *(unsigned int *) params[i];
+-	    break;
+-	  case PARSE_ULONG:
+-	    for (i = 0; i < 3; ++i)
+-	      if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
+-		*(unsigned long *) (host_envvars[omp_var].dest[i])
+-		  = *(unsigned long *) params[i];
+-	    break;
+-	  case PARSE_UCHAR:
+-	    for (i = 0; i < 3; ++i)
+-	      if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
+-		*(unsigned char *) (host_envvars[omp_var].dest[i])
+-		  = *(unsigned char *) params[i];
+-	    break;
+-	  case PARSE_SCHEDULE:
+-	    *(enum gomp_schedule_type *) (host_envvars[omp_var].dest[0])
+-	      = *(enum gomp_schedule_type *) params[0];
+-	    *(int *) (host_envvars[omp_var].dest[1]) = *(int *) params[1];
+-	    break;
+-	  case PARSE_BIND:
+-	    *(char *) (host_envvars[omp_var].dest[0]) = *(char *) params[0];
+-	    *(char **) (host_envvars[omp_var].dest[1]) = *(char **) params[1];
+-	    *(unsigned long *) (host_envvars[omp_var].dest[2])
+-	      = *(unsigned long *) params[2];
+-	    break;
++		break;
++	      }
+ 	  }
+       }
+ 
++  all = gomp_get_initial_icv_item (GOMP_DEVICE_NUM_FOR_ALL);
++  for (omp_var = 0; omp_var < OMP_HOST_VAR_CNT; omp_var++)
++    {
++      if (none != NULL
++	  && gomp_get_icv_flag (none->flags, host_envvars[omp_var].flag_var))
++	get_icv_member_addr (&none->icvs,
++			     host_envvars[omp_var].flag_var, params);
++      else if (all != NULL
++	       && gomp_get_icv_flag (all->flags,
++				     host_envvars[omp_var].flag_var))
++	get_icv_member_addr (&all->icvs, host_envvars[omp_var].flag_var,
++			     params);
++      else
++	continue;
++
++      switch (host_envvars[omp_var].type_code)
++	{
++	case PARSE_INT:
++	  for (i = 0; i < 3; ++i)
++	    if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
++	      *(int *) (host_envvars[omp_var].dest[i]) = *(int *) params[i];
++	  break;
++	case PARSE_BOOL:
++	  for (i = 0; i < 3; ++i)
++	    if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
++	      *(bool *) (host_envvars[omp_var].dest[i]) = *(bool *) params[i];
++	  break;
++	case PARSE_UINT:
++	  for (i = 0; i < 3; ++i)
++	    if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
++	      *(unsigned int *) (host_envvars[omp_var].dest[i])
++		= *(unsigned int *) params[i];
++	  break;
++	case PARSE_ULONG:
++	  for (i = 0; i < 3; ++i)
++	    if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
++	      *(unsigned long *) (host_envvars[omp_var].dest[i])
++		= *(unsigned long *) params[i];
++	  break;
++	case PARSE_UCHAR:
++	  for (i = 0; i < 3; ++i)
++	    if (host_envvars[omp_var].dest[i] != NULL && params[i] != NULL)
++	      *(unsigned char *) (host_envvars[omp_var].dest[i])
++		= *(unsigned char *) params[i];
++	  break;
++	case PARSE_SCHEDULE:
++	  *(enum gomp_schedule_type *) (host_envvars[omp_var].dest[0])
++	    = *(enum gomp_schedule_type *) params[0];
++	  *(int *) (host_envvars[omp_var].dest[1]) = *(int *) params[1];
++	  break;
++	case PARSE_BIND:
++	  *(char *) (host_envvars[omp_var].dest[0]) = *(char *) params[0];
++	  *(char **) (host_envvars[omp_var].dest[1]) = *(char **) params[1];
++	  *(unsigned long *) (host_envvars[omp_var].dest[2])
++	    = *(unsigned long *) params[2];
++	  break;
++	}
++    }
++
+   if (((none != NULL && gomp_get_icv_flag (none->flags, GOMP_ICV_BIND))
+        || (all != NULL && gomp_get_icv_flag (all->flags, GOMP_ICV_BIND)))
+       && gomp_global_icv.bind_var == omp_proc_bind_false)
+-- 
+2.34.1
+


### PR DESCRIPTION
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111413, this is a fix for https://github.com/JuliaLang/julia/issues/53363 

It's actually a workaround for a deeper issue (https://github.com/python/cpython/issues/116015) that Python is built without `-fPIC` by many maintainers, causing libraries like `libgomp` when loaded with `RTLD_DEEPBIND` not to see the correct `environ` that should have been initialized by glibc. However, the bugfix is also required for `clearenv()` so it's worth carrying anyway.