### PR TITLE
Update CoverM to 0.7.0

### DIFF
--- a/C/CoverM/build_tarballs.jl
+++ b/C/CoverM/build_tarballs.jl
@@ -26,7 +26,7 @@ platforms = filter!(supported_platforms()) do platform
     # Windows can't compile the dep htslib-rust for now, and I don't care about
     # other platforms
     (Sys.isapple(platform) || Sys.islinux(platform)) &&
-    in(arch(platform), ("x86_64", "aarch64")) &&
+    in(arch(platform), ("x86_64", "aarch64"))
 end
 
 # The products that we will ensure are always built

--- a/C/CoverM/build_tarballs.jl
+++ b/C/CoverM/build_tarballs.jl
@@ -8,8 +8,8 @@ version = v"0.7.0"
 # Collection of sources required to complete build
 sources = [
     GitSource(
-        "https://github.com/jakobnissen/CoverM",
-        "75cf1f91e8078c10c65829f30f99c60fc94bdb11"),
+        "https://github.com/wwood/CoverM",
+        "5edadabe744b3b92911179614468c43630450699"),
 ]
 
 # Bash recipe for building across all platforms

--- a/C/CoverM/build_tarballs.jl
+++ b/C/CoverM/build_tarballs.jl
@@ -8,8 +8,8 @@ version = v"0.7.0"
 # Collection of sources required to complete build
 sources = [
     GitSource(
-        "https://github.com/wwood/CoverM",
-        "5edadabe744b3b92911179614468c43630450699"),
+        "https://github.com/jakobnissen/CoverM",
+        "75cf1f91e8078c10c65829f30f99c60fc94bdb11"),
 ]
 
 # Bash recipe for building across all platforms

--- a/C/CoverM/build_tarballs.jl
+++ b/C/CoverM/build_tarballs.jl
@@ -26,7 +26,10 @@ platforms = filter!(supported_platforms()) do platform
     # Windows can't compile the dep htslib-rust for now, and I don't care about
     # other platforms
     (Sys.isapple(platform) || Sys.islinux(platform)) &&
-    in(arch(platform), ("x86_64", "aarch64"))
+    in(arch(platform), ("x86_64", "aarch64")) &&
+
+    # aarch64 linux errors, https://github.com/rust-bio/rust-htslib/issues/425
+    !(arch(platform) == "aarch64" && Sys.islinux(platform))
 end
 
 # The products that we will ensure are always built

--- a/C/CoverM/build_tarballs.jl
+++ b/C/CoverM/build_tarballs.jl
@@ -3,13 +3,13 @@
 using BinaryBuilder, BinaryBuilderBase
 
 name = "CoverM"
-version = v"0.6.1"
+version = v"0.7.0"
 
 # Collection of sources required to complete build
 sources = [
     GitSource(
         "https://github.com/wwood/CoverM",
-        "0056336d4b245064a23e5b40197b29607fb1fe56"),
+        "5edadabe744b3b92911179614468c43630450699"),
 ]
 
 # Bash recipe for building across all platforms
@@ -27,10 +27,6 @@ platforms = filter!(supported_platforms()) do platform
     # other platforms
     (Sys.isapple(platform) || Sys.islinux(platform)) &&
     in(arch(platform), ("x86_64", "aarch64")) &&
-
-    # aarch64 linux errors, see https://github.com/rust-bio/rust-htslib/issues/352
-    # will be fixed in an upcoming release
-    !(arch(platform) == "aarch64" && Sys.islinux(platform))
 end
 
 # The products that we will ensure are always built


### PR DESCRIPTION
This update has bumped dependencies, which should allow it to compile on aarch64 Linux.