### PR TITLE
[ginkgo] Add CUDAsupport

### DIFF
--- a/G/ginkgo/build_tarballs.jl
+++ b/G/ginkgo/build_tarballs.jl
@@ -1,6 +1,13 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder, Pkg
+using BinaryBuilder, Pkg, BinaryBuilderBase
+using Base.BinaryPlatforms
+
+using Base.BinaryPlatforms: arch, os, tags
+
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "ginkgo"
 version = v"1.6.0"
@@ -12,30 +19,49 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
+# nvcc writes to /tmp, which is a small tmpfs in our sandbox.
+# make it use the workspace instead
+export TMPDIR=${WORKSPACE}/tmpdir
+mkdir ${TMPDIR}
+export PATH=$PATH:${prefix}/cuda/bin
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${prefix}/cuda/lib64
+export CUDA_HOME=${prefix}/cuda
+
 cd $WORKSPACE/srcdir/ginkgo/
+rm -rf .git
 mkdir build && cd build
 cmake \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_CUDA_COMPILER=${prefix}/cuda/bin/nvcc \
+    -DCMAKE_CUDA_ARCHITECTURES='50;60;70;75;80;86' \
     -DGINKGO_BUILD_TESTS=OFF \
     -DGINKGO_BUILD_BENCHMARKS=OFF \
     -DGINKGO_BUILD_EXAMPLES=OFF \
     -DGINKGO_DOC_GENERATE_EXAMPLES=OFF \
     -DGINKGO_BUILD_REFERENCE=ON \
     -DGINKGO_BUILD_OMP=ON \
-    -DGINKGO_BUILD_CUDA=OFF \
+    -DGINKGO_BUILD_CUDA=ON \
     -DGINKGO_BUILD_HIP=OFF \
     -DGINKGO_BUILD_SYCL=OFF \
     -DGINKGO_BUILD_HWLOC=OFF \
     -DGINKGO_BUILD_MPI=OFF \
+    -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON \
     -G "Ninja" ../
 ninja -j${nproc} 
 ninja install
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = expand_cxxstring_abis(filter!(Sys.islinux, supported_platforms()))
+augment_platform_block = CUDA.augment
+
+platforms = CUDA.supported_platforms()
+filter!(p -> arch(p) == "x86_64", platforms)
+
+# some platforms need a newer glibc, because the default one is too old
+glibc_platforms = filter(platforms) do p
+    libc(p) == "glibc" && proc_family(p) in ["intel", "power"]
+end
+
 
 # The products that we will ensure are always built
 products = [
@@ -48,10 +74,35 @@ products = [
     LibraryProduct("libginkgo_hip", :libginkgo_hip)
 ]
 
-# Dependencies that must be installed before this package can be built
-dependencies = [
-    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
-]
 
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7.1.0")
+function required_dependencies(platform; static_sdk=false)
+    dependencies = Dependency[]
+    if !haskey(tags(platform), "cuda") || tags(platform)["cuda"] == "none"
+        return BinaryBuilder.AbstractDependency[]
+    end
+    release = VersionNumber(tags(platform)["cuda"])
+    deps = BinaryBuilder.AbstractDependency[
+        BuildDependency(PackageSpec(name="CUDA_full_jll", version=CUDA.full_version(release))),
+        RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll"))
+    ]
+
+    if static_sdk
+        push!(deps, BuildDependency(PackageSpec(name="CUDA_SDK_static_jll", version=CUDA.full_version(release))))
+    end
+
+    return deps
+end
+
+
+for platform in platforms
+    should_build_platform(triplet(platform)) || continue
+
+    cuda_deps = required_dependencies(platform)
+    "cuda_deps = CUDA.required_dependencies(platform; static_sdk=true)"
+
+    dependencies = [
+        Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+    ]
+
+    build_tarballs(ARGS, name, version, sources, script, [platform], products, [dependencies; cuda_deps]; julia_compat="1.6", augment_platform_block, preferred_gcc_version=v"7.1.0")
+end

--- a/G/ginkgo/build_tarballs.jl
+++ b/G/ginkgo/build_tarballs.jl
@@ -34,7 +34,7 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_CUDA_COMPILER=${prefix}/cuda/bin/nvcc \
-    -DCMAKE_CUDA_ARCHITECTURES='50;60;70;75;80;86' \
+    -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES} \
     -DGINKGO_BUILD_TESTS=OFF \
     -DGINKGO_BUILD_BENCHMARKS=OFF \
     -DGINKGO_BUILD_EXAMPLES=OFF \
@@ -50,6 +50,29 @@ cmake \
     -G "Ninja" ../
 ninja -j${nproc} 
 ninja install
+
+cd .. && mkdir build-stubs && mkdir stubs && cd build-stubs
+cmake \
+    -DCMAKE_INSTALL_PREFIX=`pwd`/../stubs \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DGINKGO_BUILD_TESTS=OFF \
+    -DGINKGO_BUILD_BENCHMARKS=OFF \
+    -DGINKGO_BUILD_EXAMPLES=OFF \
+    -DGINKGO_DOC_GENERATE_EXAMPLES=OFF \
+    -DGINKGO_BUILD_REFERENCE=OFF \
+    -DGINKGO_BUILD_OMP=OFF \
+    -DGINKGO_BUILD_CUDA=OFF \
+    -DGINKGO_BUILD_HIP=OFF \
+    -DGINKGO_BUILD_SYCL=OFF \
+    -DGINKGO_BUILD_HWLOC=OFF \
+    -DGINKGO_BUILD_MPI=OFF \
+    -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON \
+    -G "Ninja" ../
+ninja -j${nproc}
+ninja install
+
+mkdir ${prefix}/lib/stubs
+cp -P ../stubs/lib/lib* ${prefix}/lib/stubs
 """
 
 augment_platform_block = CUDA.augment
@@ -75,34 +98,33 @@ products = [
 ]
 
 
-function required_dependencies(platform; static_sdk=false)
-    dependencies = Dependency[]
-    if !haskey(tags(platform), "cuda") || tags(platform)["cuda"] == "none"
-        return BinaryBuilder.AbstractDependency[]
-    end
-    release = VersionNumber(tags(platform)["cuda"])
-    deps = BinaryBuilder.AbstractDependency[
-        BuildDependency(PackageSpec(name="CUDA_full_jll", version=CUDA.full_version(release))),
-        RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll"))
-    ]
-
-    if static_sdk
-        push!(deps, BuildDependency(PackageSpec(name="CUDA_SDK_static_jll", version=CUDA.full_version(release))))
-    end
-
-    return deps
-end
+cuda_archs = Dict(
+    v"10.2.89" => "60;61;70;75",
+    v"11.4.4" => "60;61;70;75;80;86",
+    v"11.5.2" => "60;61;70;75;80;86",
+    v"11.6.2" => "60;61;70;75;80;86",
+    v"11.7.1" => "60;61;70;75;80;86",
+    v"11.8.0" => "60;61;70;75;80;86;89",
+    v"12.0.1" => "60;61;70;75;80;86;89;90",
+    v"12.1.1" => "60;61;70;75;80;86;89;90",
+    v"12.2.2" => "60;61;70;75;80;86;89;90",
+    v"12.3.2" => "60;61;70;75;80;86;89;90",
+)
 
 
 for platform in platforms
     should_build_platform(triplet(platform)) || continue
 
-    cuda_deps = required_dependencies(platform)
-    "cuda_deps = CUDA.required_dependencies(platform; static_sdk=true)"
+    release = CUDA.full_version(VersionNumber(tags(platform)["cuda"]))
 
     dependencies = [
         Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+        BuildDependency(PackageSpec(name="CUDA_full_jll", version=release)),
     ]
 
-    build_tarballs(ARGS, name, version, sources, script, [platform], products, [dependencies; cuda_deps]; julia_compat="1.6", augment_platform_block, preferred_gcc_version=v"7.1.0")
+    preamble = """
+    CUDA_ARCHITECTURES="$(cuda_archs[release])"
+    """
+
+    build_tarballs(ARGS, name, version, sources, preamble * script, [platform], products, dependencies; julia_compat="1.6", augment_platform_block, preferred_gcc_version=v"7.1.0")
 end


### PR DESCRIPTION
This adds CUDA support to the compilation. Due to the structure of Ginkgo, this doesn't need to be a runtime dependency, as we can also use the stub library instead.

Still some TODOs before I can mark this ready to review.

- [ ] Check for consistency in `libginkgo.so` stub and non-stub build
- [ ] Test interoperability between stub and backend libraries
- [ ] HIP support