### PR TITLE
[FLINT] Update to 3.1

### DIFF
--- a/F/FLINT/build_tarballs.jl
+++ b/F/FLINT/build_tarballs.jl
@@ -25,7 +25,7 @@ using BinaryBuilder, Pkg
 # coordinated with corresponding changes to Singular_jll.jl, Nemo.jl and polymake_jll
 # and possibly other packages.
 name = "FLINT"
-upstream_version = v"3.0.0"
+upstream_version = v"3.1.1"
 version_offset = v"0.0.0"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
@@ -33,7 +33,7 @@ version = VersionNumber(upstream_version.major * 100 + version_offset.major,
 
 # Collection of sources required to build FLINT
 sources = [
-    GitSource("https://github.com/flintlib/flint2.git", "904aeb3752dae4f23b635f1633e9261dc042ffe2"), # v3.0.0 + a few commits, including the blas detection fix
+    GitSource("https://github.com/flintlib/flint.git", "f1ec31e79c1923823f87afa524a060a880da6afa"), # v3.1.1
 ]
 
 # Bash recipe for building across all platforms
@@ -63,7 +63,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("GMP_jll", v"6.2.0"),
+    Dependency("GMP_jll", v"6.2.1"),
     Dependency("MPFR_jll", v"4.1.1"),
     Dependency("OpenBLAS32_jll", v"0.3.10"),
 ]


### PR DESCRIPTION
This bumps the GMP version to 6.2.1 since this is now the minimum supported version by FLINT. It also bumps the MPFR version to 4.2.0 since the previous one was not compatible with GMP 6.2.1.

It also uses the new repository at https://github.com/flintlib/flint.git rather than the old one at https://github.com/flintlib/flint2.git.

@thofma, @benlorenz and @fingolfin I know you have been involved in updating this package before. Do you have any comments on this update?