### PR TITLE
[CUDSS] Add a platform

### DIFF
--- a/C/CUDA/CUDSS/build_tarballs.jl
+++ b/C/CUDA/CUDSS/build_tarballs.jl
@@ -44,6 +44,7 @@ products = [
 dependencies = [RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll"))]
 
 platforms = [Platform("x86_64", "linux"),
+             Platform("aarch64", "linux"),
              Platform("x86_64", "windows")]
 
 builds = []


### PR DESCRIPTION
With the release 0.2.0, cuDSS is also available on `aarch64-linux`.