### PR TITLE
[Cairo] enable fontconfig for all platforms

### DIFF
--- a/C/Cairo/build_tarballs.jl
+++ b/C/Cairo/build_tarballs.jl
@@ -32,6 +32,7 @@ mkdir output && cd output/
 
 meson .. --cross-file=${MESON_TARGET_TOOLCHAIN} \
     -Dfreetype=enabled \
+    -Dfontconfig=enabled \
     -Dtee=enabled \
     -Dpng=enabled \
     -Dzlib=enabled \
@@ -88,4 +89,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"8", julia_compat="1.6", clang_use_lld=false)


### PR DESCRIPTION
Based on the discussion in #7508 I thought the issue with Cairo 1.18 was Pango's fault, but it turns out this fixes it without upgrading Pango.

Fixes #7508 (tested locally)
