### PR TITLE
MAGEMin v1.3.9

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.3.8"
+version = v"1.3.9"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "a61317a2486efe3b6eea1464d6c8d946a146af75")                 ]
+                    "681d11bd589952b137d062d4fc3567fa5ba3bc28")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- removed O2 pure phase
- added metastable phases to the output structure
- added LP initial guess to the output structure´
- saves fO2 as log10(fO2)
- corrected computation of driving force threshold for pseudocompounds
- added calculation of volume fraction

