### PR TITLE
MbedTLS: New version 3.5.2

### DIFF
--- a/M/MbedTLS/MbedTLS@3.5.2/build_tarballs.jl
+++ b/M/MbedTLS/MbedTLS@3.5.2/build_tarballs.jl
@@ -1,0 +1,5 @@
+version = v"3.5.2"
+include("../common.jl")
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.9", preferred_llvm_version=llvm_version)

--- a/M/MbedTLS/MbedTLS@3.5.2/bundled/patches/conditional/0001-Remove-flags-not-supported-by-ranlib.patch
+++ b/M/MbedTLS/MbedTLS@3.5.2/bundled/patches/conditional/0001-Remove-flags-not-supported-by-ranlib.patch
@@ -1,0 +1,1 @@
+../../../../MbedTLS@2.24.0/bundled/patches/conditional/0001-Remove-flags-not-supported-by-ranlib.patch

--- a/M/MbedTLS/common.jl
+++ b/M/MbedTLS/common.jl
@@ -44,6 +44,11 @@ sources_by_version = Dict(
                   "3a91dad9dceb484eea8b41f8941facafc4520021"),
         DirectorySource("./bundled"; follow_symlinks=true),
     ],
+    v"3.5.2" => [
+        GitSource("https://github.com/Mbed-TLS/mbedtls.git",
+                  "daca7a3979c22da155ec9dce49ab1abf3b65d3a9"),
+        DirectorySource("./bundled"; follow_symlinks=true),
+    ],
 )
 sources = sources_by_version[version]
 


### PR DESCRIPTION
MbedTLS 3.6 branch (which does not have a release yet, but will soon) is to become the next LTS version. So I figure it makes sense to check that we can compile the latest released version, namely 3.5.2.