### PR TITLE
[libpostal] add build script for libpostal

### DIFF
--- a/L/libpostal/build_tarballs.jl
+++ b/L/libpostal/build_tarballs.jl
@@ -34,9 +34,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-# aarch64-linux has an assembler error: "Error: conditional branch out of range"
-# This is a rare enough platform we just exclude for now
-platforms = expand_cxxstring_abis(supported_platforms(; exclude=p -> p.tags["os"] == "linux" && p.tags["arch"] == "aarch64"))
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [
@@ -50,4 +48,5 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version=v"8")

--- a/L/libpostal/build_tarballs.jl
+++ b/L/libpostal/build_tarballs.jl
@@ -1,0 +1,53 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libpostal"
+version = v"1.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/openvenues/libpostal.git", "8f2066b1d30f4290adf59cacc429980f139b8545")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libpostal
+flags=""
+
+if [[ "${proc_family}" != "intel" ]]; then
+    # SSE2 doesn't apply on ARM or PowerPC
+    flags="${flags} --disable-sse2"
+fi
+
+# BinaryBuilder notes that the w64 binaries use the AVX2 instruction set. I haven't
+# been able to fix this, as you can't use -march with BinaryBuilder, and -mno-avx2
+# does not solve the problem.
+
+./bootstrap.sh
+
+# data download handled in Julia
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-data-download ${flags}
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+# aarch64-linux has an assembler error: "Error: conditional branch out of range"
+# This is a rare enough platform we just exclude for now
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true, exclude=p -> p.tags["os"] == "linux" && p.tags["arch"] == "aarch64"))
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libpostal", :libpostal)
+    # libpostal_data not available on Windows.
+    #ExecutableProduct("libpostal_data", :libpostal_data)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/libpostal/build_tarballs.jl
+++ b/L/libpostal/build_tarballs.jl
@@ -36,7 +36,7 @@ make install
 # platforms are passed in on the command line
 # aarch64-linux has an assembler error: "Error: conditional branch out of range"
 # This is a rare enough platform we just exclude for now
-platforms = expand_cxxstring_abis(supported_platforms(; experimental=true, exclude=p -> p.tags["os"] == "linux" && p.tags["arch"] == "aarch64"))
+platforms = expand_cxxstring_abis(supported_platforms(; exclude=p -> p.tags["os"] == "linux" && p.tags["arch"] == "aarch64"))
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
This adds a build script for [libpostal](https://github.com/openvenues/libpostal), an address-parsing library. I intend to write a Julia wrapper for it (WIP at [mattwigway/Postal.jl](https://github.com/mattwigway/Postal.jl])).

I do have two questions about how to package this:
1. libpostal doesn't really follow a versioning scheme; the last release was seven years ago and everyone seems to just use master. I'm not sure how to version the JLL.
2. I'm getting a warning about the binaries using avx2 instructions on the w64 builds. I tried adding -mno-avx2 to CFLAGS but that didn't solve the problem, I'm not sure what else to try.