### PR TITLE
Remove indirect MbedTLS_jll dependency from a few packages

### DIFF
--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -15,13 +15,13 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/aria2-*/
 
-export CPPFLAGS="-I${includedir}"
-export LDFLAGS="-L${libdir}"
-
+# Note: we explicitly set `LIBSSH2_LIBS` to avoid pulling in mbedtls when
+# linking to older builds of libssh2.
 ./configure \
     --prefix=${prefix} --build=${MACHTYPE} --host=${target} \
     --with-pic --enable-shared --enable-libaria2 \
-    --with-openssl --with-libxml2 --with-libz --with-libssh2
+    --with-openssl --with-libxml2 --with-libz --with-libssh2 \
+    LIBSSH2_LIBS="-L${libdir} -lssh2 "
 
 make -j${nproc}
 make install
@@ -45,11 +45,6 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="Cares_jll")),
     Dependency(PackageSpec(name="LibSSH2_jll")),
-    # `MbedTLS_jll` is a dependency of `LibSSH2_jll`.  Strangely, we
-    # are getting a newer version in the build than the one
-    # `LibSSH2_jll` was compiled with.  So we explicitly select the
-    # right version here.
-    BuildDependency(PackageSpec(name="MbedTLS_jll", version=v"2.28")),
     Dependency(PackageSpec(name="OpenSSL_jll"); compat="3.0.8"),
     Dependency(PackageSpec(name="XML2_jll")),
     Dependency(PackageSpec(name="Zlib_jll")),

--- a/A/AzStorage/build_tarballs.jl
+++ b/A/AzStorage/build_tarballs.jl
@@ -46,10 +46,6 @@ dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
     Dependency("LibCURL_jll", v"7.73.0"),
-    # MbedTLS is only an indirect dependency (through LibCURL), but we want to
-    # be sure to have the right version of MbedTLS for the corresponding version
-    # of Julia.
-    BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),
 ]
 
 #=

--- a/I/IOAPI/build_tarballs.jl
+++ b/I/IOAPI/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "IOAPI"
-version = v"3.2.0"
+version = v"3.2.1"
 
 # Collection of sources required to complete build
 sources = [
@@ -140,13 +140,11 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.701.400 - 400.799")
-    Dependency(PackageSpec(name="NetCDFF_jll", uuid="78e728a9-57fe-5d11-897c-5014b89e5f84"))
+    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.902.208 - 400.999")
+    Dependency(PackageSpec(name="NetCDFF_jll", uuid="78e728a9-57fe-5d11-897c-5014b89e5f84"); compat="4.6.0")
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
-    # `MbedTLS_jll` is an indirect dependency through NetCDF, we need to specify
-    # a compatible build version for this to work.
-    BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version=v"5")

--- a/I/IOAPI/build_tarballs.jl
+++ b/I/IOAPI/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "IOAPI"
-version = v"3.2.1"
+version = v"3.2.0"
 
 # Collection of sources required to complete build
 sources = [
@@ -140,11 +140,13 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.902.208 - 400.999")
-    Dependency(PackageSpec(name="NetCDFF_jll", uuid="78e728a9-57fe-5d11-897c-5014b89e5f84"); compat="4.6.0")
+    Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.701.400 - 400.799")
+    Dependency(PackageSpec(name="NetCDFF_jll", uuid="78e728a9-57fe-5d11-897c-5014b89e5f84"))
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
+    # `MbedTLS_jll` is an indirect dependency through NetCDF, we need to specify
+    # a compatible build version for this to work.
+    BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"5")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)

--- a/N/NetCDFF/build_tarballs.jl
+++ b/N/NetCDFF/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "NetCDFF"
-version = v"4.6.0"
+version = v"4.6.1"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/Unidata/netcdf-fortran/archive/refs/tags/v$(version).tar.gz",
-                  "8194aa70e400c0adfc456127c1d97af2c6489207171d13b10cd754a16da8b0ca"),
+    ArchiveSource("https://downloads.unidata.ucar.edu/netcdf-fortran/$(version)/netcdf-fortran-$(version).tar.gz",
+                  "b50b0c72b8b16b140201a020936aa8aeda5c79cf265c55160986cd637807a37a"),
 ]
 
 # Bash recipe for building across all platforms
@@ -48,4 +48,7 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               # Note: for some reason GCC 4.8 is still linked to glibc 2.12, we
+               # need to use GCC 5 to have glibc 2.17.
+               julia_compat="1.6", preferred_gcc_version=v"5")

--- a/N/NetCDFF/build_tarballs.jl
+++ b/N/NetCDFF/build_tarballs.jl
@@ -29,10 +29,11 @@ rm ${prefix}/lib/*.a
 # platforms are passed in on the command line
 platforms = [
     Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("x86_64", "macos"),
     Platform("aarch64", "linux"; libc="glibc"),
-    Platform("x86_64", "windows"),
+    Platform("x86_64", "macos"),
+    Platform("aarch64", "macos"),
     Platform("i686", "windows"),
+    Platform("x86_64", "windows"),
 ]
 platforms = expand_gfortran_versions(platforms)
 

--- a/N/NetCDFF/build_tarballs.jl
+++ b/N/NetCDFF/build_tarballs.jl
@@ -45,9 +45,6 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.902.5"),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
-    # `MbedTLS_jll` is an indirect dependency through NetCDF, we need to specify
-    # a compatible build version for this to work.
-    BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/T/TempestModel/build_tarballs.jl
+++ b/T/TempestModel/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "TempestModel"
-version = v"0.1.1"
+version = v"0.1.2"
 tempestmodel_version = v"0.1"
 sources = [
     GitSource("https://github.com/paullric/tempestmodel",
@@ -83,7 +83,7 @@ platforms = [
 ] 
 platforms = expand_cxxstring_abis(platforms)
 
-platforms, platform_dependencies = MPI.augment_platforms(platforms)
+platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.3.1", OpenMPI_compat="4.1.6, 5")
 
 # Avoid platforms where the MPI implementation isn't supported
 # OpenMPI
@@ -124,16 +124,17 @@ products = [
 ]
 
 dependencies = [
-    Dependency("MKL_jll"),
-    Dependency("NetCDF_jll"; compat="400.701.400 - 400.799"),
+    # MKL 2023 is the last version which supports x86_64 macOS, so we use that version for
+    # building. We don't set compat bounds for the time being because apart from that MKL is
+    # moderately stable and their versioning scheme is calendar-based, rather than something
+    # semver-like.
+    Dependency("MKL_jll", v"2023.2.0"),
+    Dependency("NetCDF_jll"; compat="400.902.208 - 400.999"),
     # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
-    Dependency("HDF5_jll"; compat="~1.12"),
-    # `MbedTLS_jll` is an indirect dependency through NetCDF, we need to specify
-    # a compatible build version for this to work.
-    BuildDependency(PackageSpec(; name="MbedTLS_jll", version=v"2.24.0")),
+    Dependency("HDF5_jll"; compat="~1.14.3"),
 ]
 append!(dependencies, platform_dependencies)
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    augment_platform_block, julia_compat="1.6",
+    augment_platform_block, julia_compat="1.6", preferred_gcc_version=v"5",
 )

--- a/V/VMEC/build_tarballs.jl
+++ b/V/VMEC/build_tarballs.jl
@@ -101,8 +101,6 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # MbedTLS is an indirect dependency, fix the version for building 
-    BuildDependency(PackageSpec(name = "MbedTLS_jll")),
     Dependency("SCALAPACK_jll"),
     Dependency("OpenBLAS_jll"),
     Dependency("MKL_jll"), 


### PR DESCRIPTION
@fxcoudert I'm taking out of #8377 the commits which are only removing the unneeded dependency of MbedTLS from some packages, so that we can keep there only switching to OpenSSL for julia's stdlibs.  The two changesets are independent, what we have here doesn't require changing the SSL backend for the other packages.

This also reduces CI time, when I push new commits.