### PR TITLE
oneAPI: Make sure the loader uses the correct tracing library.

### DIFF
--- a/O/oneAPI_Level_Zero/oneAPI_Level_Zero_Loader/build_tarballs.jl
+++ b/O/oneAPI_Level_Zero/oneAPI_Level_Zero_Loader/build_tarballs.jl
@@ -32,6 +32,7 @@ platforms = expand_cxxstring_abis(platforms)
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libze_loader", :libze_loader),
+    LibraryProduct("libze_tracing_layer", :libze_tracing_layer),
     LibraryProduct("libze_validation_layer", :libze_validation_layer),
 ]
 


### PR DESCRIPTION
Addresses part of https://github.com/JuliaGPU/oneAPI.jl/issues/399.

These libraries don't have an explicit dependency, and get loaded dynamically. If we haven't `dlopen`ed the library first, we may pick up a system copy, which is bad.

This isn't great; let's hope loading any of these libraries doesn't actually trigger a change in behavior, but AFAIU it's the best we can do given how JLLs/the dynamic loader works.