### PR TITLE
OpenSSL: install libraries in lib not lib64

### DIFF
--- a/O/OpenSSL/OpenSSL@3.0/build_tarballs.jl
+++ b/O/OpenSSL/OpenSSL@3.0/build_tarballs.jl
@@ -20,3 +20,5 @@ products = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+
+# Build trigger: 1

--- a/O/OpenSSL/OpenSSL@3.0/build_tarballs.jl
+++ b/O/OpenSSL/OpenSSL@3.0/build_tarballs.jl
@@ -21,4 +21,4 @@ products = [
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
 
-# Build trigger: 1
+# Build trigger: 2

--- a/O/OpenSSL/common.jl
+++ b/O/OpenSSL/common.jl
@@ -42,6 +42,10 @@ function translate_target()
 ./Configure shared --prefix=$prefix --libdir=${libdir} $(translate_target)
 make -j${nproc}
 make install_sw
+
+# Manually delete static libraries, not possible to skip them:
+# <https://github.com/openssl/openssl/issues/8823>.
+rm -v ${libdir}/lib{crypto,ssl}.a
 """
 
 # These are the platforms we will build for by default, unless further
@@ -51,4 +55,3 @@ platforms = supported_platforms(; experimental=true)
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[
 ]
-

--- a/O/OpenSSL/common.jl
+++ b/O/OpenSSL/common.jl
@@ -39,7 +39,7 @@ function translate_target()
     fi
 }
 
-./Configure shared --prefix=$prefix $(translate_target)
+./Configure shared --prefix=$prefix --libdir=${libdir} $(translate_target)
 make -j${nproc}
 make install_sw
 """


### PR DESCRIPTION
To be consistent with other libraries, libcrypto and libssl should be installed in `lib/` (not `lib64/`) on x86_64-linux. I found out about this because of https://github.com/JuliaLang/julia/pull/53891