### PR TITLE
LibSSH2: move to native crypto on Windows

### DIFF
--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -64,7 +64,7 @@ llvm_version = v"13.0.1"
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("OpenSSL_jll"; compat="3.0.8"),
+    Dependency("OpenSSL_jll"; compat="3.0.8", platforms=filter(!Sys.iswindows, platforms)),
     BuildDependency(PackageSpec(name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=llvm_version);
                     platforms=filter(p -> sanitize(p)=="memory", platforms)),
 ]

--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -27,7 +27,6 @@ fi
 
 BUILD_FLAGS=(
     -DCMAKE_BUILD_TYPE=Release
-    -DCRYPTO_BACKEND=OpenSSL
     -DBUILD_SHARED_LIBS=ON
     -DBUILD_STATIC_LIBS=OFF
     -DBUILD_EXAMPLES=OFF
@@ -36,6 +35,13 @@ BUILD_FLAGS=(
     -DCMAKE_INSTALL_PREFIX=${prefix}
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
 )
+
+# Use native backend on Windows, OpenSSL on others
+if [[ ${target} == *-mingw* ]]; then
+    BUILD_FLAGS+=(-DCRYPTO_BACKEND=WinCNG)
+else
+    BUILD_FLAGS+=(-DCRYPTO_BACKEND=OpenSSL)
+fi
 
 mkdir build && cd build
 

--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -20,11 +20,6 @@ if [[ ${bb_full_target} == *-sanitize+memory* ]]; then
     cp -rL ${libdir}/linux/* /opt/x86_64-linux-musl/lib/clang/*/lib/linux/
 fi
 
-# Necessary for cmake to find openssl on Windows
-if [[ ${target} == x86_64-*-mingw* ]]; then
-    export OPENSSL_ROOT_DIR=${prefix}/lib64
-fi
-
 BUILD_FLAGS=(
     -DCMAKE_BUILD_TYPE=Release
     -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
In Julia builds from source, the native Windows crypto backend is used instead of OpenSSL. This brings the binary builds in line (and I think it is good, one less dependency).