### PR TITLE
[LibCURL@7] Disable versioned symbols

### DIFF
--- a/L/LibCURL/LibCURL@7/build_tarballs.jl
+++ b/L/LibCURL/LibCURL@7/build_tarballs.jl
@@ -27,7 +27,7 @@ FLAGS=(
 
     # A few things we actually enable
     --with-libssh2=${prefix} --with-zlib=${prefix} --with-nghttp2=${prefix}
-    --enable-versioned-symbols
+    --disable-versioned-symbols
 )
 
 


### PR DESCRIPTION
We will not use this version in Julia (it's too old), but we use it as baseline for building packages depending on libcurl: by having this build without versioned symbols, it can be used to build packages that will link to libcurl with both with and without OpenSSL.