### PR TITLE
[HiGHSstatic] remove Zlib dependency

### DIFF
--- a/H/HiGHS/HiGHSstatic/build_tarballs.jl
+++ b/H/HiGHS/HiGHSstatic/build_tarballs.jl
@@ -1,6 +1,6 @@
 # To ensure a build, it isn't sufficient to modify highs_common.jl.
 # You also need to update a line in this file:
-#     Last updated: 2024-04-02
+#     Last updated: 2024-04-02, bump 2
 
 include("../highs_common.jl")
 

--- a/H/HiGHS/HiGHSstatic/build_tarballs.jl
+++ b/H/HiGHS/HiGHSstatic/build_tarballs.jl
@@ -1,8 +1,14 @@
 # To ensure a build, it isn't sufficient to modify highs_common.jl.
 # You also need to update a line in this file:
-#     Last updated: 2024-03-07
+#     Last updated: 2024-04-02
 
 include("../highs_common.jl")
+
+# !!! warning
+#     Temporarily over-ride the `version` so that we can make a new release that
+#     removes the Zlib_jll dependency. If you're updating HiGHS to a new version
+#     you should delete this line.
+version = v"1.7.1"
 
 script = build_script(shared_libs = "OFF")
 
@@ -19,7 +25,10 @@ dependencies = [
     # is a build-only dependency, in the other cases it's also a runtime one.
     Dependency("CompilerSupportLibraries_jll"; platforms=filter(!Sys.iswindows, platforms)),
     BuildDependency("CompilerSupportLibraries_jll"; platforms=filter(Sys.iswindows, platforms)),
-    Dependency("Zlib_jll"),
+    # !!! warning
+    #     TODOW(odow): temporarily disable Zlib_jll because it is not linked correctly.
+    #     Debug with upstream.
+    # Dependency("Zlib_jll"),
 ]
 
 build_tarballs(

--- a/H/HiGHS/HiGHSstatic/build_tarballs.jl
+++ b/H/HiGHS/HiGHSstatic/build_tarballs.jl
@@ -4,12 +4,6 @@
 
 include("../highs_common.jl")
 
-# !!! warning
-#     Temporarily over-ride the `version` so that we can make a new release that
-#     removes the Zlib_jll dependency. If you're updating HiGHS to a new version
-#     you should delete this line.
-version = v"1.7.1"
-
 script = build_script(shared_libs = "OFF")
 
 products = [
@@ -25,10 +19,8 @@ dependencies = [
     # is a build-only dependency, in the other cases it's also a runtime one.
     Dependency("CompilerSupportLibraries_jll"; platforms=filter(!Sys.iswindows, platforms)),
     BuildDependency("CompilerSupportLibraries_jll"; platforms=filter(Sys.iswindows, platforms)),
-    # !!! warning
-    #     TODOW(odow): temporarily disable Zlib_jll because it is not linked correctly.
-    #     Debug with upstream.
-    # Dependency("Zlib_jll"),
+    HostBuildDependency(PackageSpec(; name="CMake_jll")),
+    Dependency("Zlib_jll"),
 ]
 
 build_tarballs(

--- a/H/HiGHS/highs_common.jl
+++ b/H/HiGHS/highs_common.jl
@@ -22,6 +22,9 @@ function build_script(; shared_libs::String)
     return "BUILD_SHARED=$(shared_libs)\nBUILD_STATIC=$(build_static)\n" * raw"""
 cd $WORKSPACE/srcdir/HiGHS
 
+# Remove system CMake to use the jll version
+apk del cmake
+
 mkdir -p build
 cd build
 

--- a/H/HiGHS/highs_common.jl
+++ b/H/HiGHS/highs_common.jl
@@ -18,7 +18,8 @@ sources = [
 platforms = supported_platforms()
 
 function build_script(; shared_libs::String)
-    return "BUILD_SHARED=$(shared_libs)\n" * raw"""
+    build_static = shared_libs == "OFF" ? "ON" : "OFF"
+    return "BUILD_SHARED=$(shared_libs)\nBUILD_STATIC=$(build_static)\n" * raw"""
 cd $WORKSPACE/srcdir/HiGHS
 
 mkdir -p build
@@ -33,6 +34,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=${BUILD_SHARED} \
+    -DZLIB_USE_STATIC_LIBS=${BUILD_STATIC} \
     -DFAST_BUILD=ON \
     -DJULIA=ON ..
 


### PR DESCRIPTION
Closes https://github.com/JuliaPackaging/Yggdrasil/issues/8408

Let's just remove this for now. It was added in https://github.com/JuliaPackaging/Yggdrasil/pull/8071, and it's only needed for cases where the user wants to read compressed MPS files.