### PR TITLE
[libblastrampoline] Make using libblastrampoline easier from CMake

### DIFF
--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -1,6 +1,7 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder
+using BinaryBuilder, Pkg
+using BinaryBuilderBase: sanitize
 
 name = "libblastrampoline"
 version = v"5.8.0"
@@ -9,6 +10,7 @@ version = v"5.8.0"
 sources = [
     GitSource("https://github.com/JuliaLinearAlgebra/libblastrampoline.git",
               "81316155d4838392e8462a92bcac3eebe9acd0c7"),
+    DirectorySource("./bundled/")
 ]
 
 # Bash recipe for building across all platforms
@@ -21,6 +23,8 @@ if [[ ${bb_full_target} == *-sanitize+memory* ]]; then
 fi
 
 make -j${nproc} prefix=${prefix} install
+
+install -Dvm755 ../../cmake/yggdrasilenv.cmake ${libdir}/cmake/blastrampoline/yggdrasilenv.cmake
 install_license ../LICENSE
 """
 

--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -24,7 +24,7 @@ fi
 
 make -j${nproc} prefix=${prefix} install
 
-install -Dvm755 ../../cmake/yggdrasilenv.cmake ${libdir}/cmake/blastrampoline/yggdrasilenv.cmake
+install -Dvm644 ../../cmake/yggdrasilenv.cmake ${libdir}/cmake/blastrampoline/yggdrasilenv.cmake
 install_license ../LICENSE
 """
 

--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -34,12 +34,15 @@ products = [
     LibraryProduct("libblastrampoline", :libblastrampoline)
 ]
 
+llvm_version = v"13.0.1"
+
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency("LLVMCompilerRT_jll"; platforms=[Platform("x86_64", "linux"; sanitize="memory")]),
+    BuildDependency(PackageSpec(name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=llvm_version);
+    platforms=filter(p -> sanitize(p)=="memory", platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.10"
+               julia_compat="1.10",  preferred_llvm_version=llvm_version
 )

--- a/L/libblastrampoline/bundled/cmake/yggdrasilenv.cmake
+++ b/L/libblastrampoline/bundled/cmake/yggdrasilenv.cmake
@@ -5,7 +5,7 @@ set( BB_NBITS  $ENV{nbits} )
 set( BB_TARGET $ENV{target} )
 set( BB_DLLEXT $ENV{dlext} )
 set( BB_LIBDIR $ENV{libdir} )
-set( BB_INCDIR "$ENV{prefix}/include" )
+set( BB_INCDIR "$ENV{includedir}" )
 
 # Allow modifying the library name of libblastrampoline to link to. This isn't
 # going to be a standard option people use, but allow it just in case.

--- a/L/libblastrampoline/bundled/cmake/yggdrasilenv.cmake
+++ b/L/libblastrampoline/bundled/cmake/yggdrasilenv.cmake
@@ -1,0 +1,54 @@
+# Environment setup for libblastrampoline to allow the CMake FindBLAS and FindLAPACK
+# scripts work with this library in the Yggdrasil environment.
+
+set( BB_NBITS  $ENV{nbits} )
+set( BB_TARGET $ENV{target} )
+set( BB_DLLEXT $ENV{dlext} )
+set( BB_LIBDIR $ENV{libdir} )
+set( BB_INCDIR "$ENV{prefix}/include" )
+
+# Allow modifying the library name of libblastrampoline to link to. This isn't
+# going to be a standard option people use, but allow it just in case.
+if( NOT BLASTRAMPOLINE_LIB )
+    # Windows encodes the library version in the pre-extension library name
+    if( BB_TARGET MATCHES ".*-mingw.*" )
+        set( BLASTRAMPOLINE_LIB "blastrampoline-5" )
+    else()
+        set( BLASTRAMPOLINE_LIB "blastrampoline" )
+    endif()
+endif()
+
+# BLASTRAMPOLINE_INTEGER can be overriden to always specify a specific integer type,
+# however this will only affect the include files since libblastrampoline exports both
+# ILP64 and LP64 symbols.
+if( NOT BLASTRAMPOLINE_INTEGER )
+    if( BB_NBITS STREQUAL "64" )
+        set( BLASTRAMPOLINE_INTEGER "ILP64" )
+    else()
+        set( BLASTRAMPOLINE_INTEGER "LP64" )
+    endif()
+endif()
+
+set( BLA_VENDOR "blastrampoline" )
+
+# FindBLAS overrides
+set( BLAS_FOUND 1 )
+set( BLAS_LIBRARIES "${BB_LIBDIR}/lib${BLASTRAMPOLINE_LIB}.${BB_DLLEXT}" )
+set( BLAS_LINKER_FLAGS "${BLASTRAMPOLINE_LIB}" )
+
+# FindLAPACK overrides
+set( LAPACK_FOUND 1 )
+set( LAPACK_LIBRARIES "${BB_LIBDIR}/lib${BLASTRAMPOLINE_LIB}.${BB_DLLEXT}" )
+set( LAPACK_LINKER_FLAGS "${BLASTRAMPOLINE_LIB}" )
+
+# These are not actually part of the FindBLAS/FindLAPACK packages, but they will
+# make life easier for consumers if they want the header files
+set( BLAS_INCLUDE_DIRS "${BB_INCDIR}/libblastrampoline/${BLASTRAMPOLINE_INTEGER}/${BB_TARGET}" )
+set( LAPACK_INCLUDE_DIRS "${BB_INCDIR}/libblastrampoline/${BLASTRAMPOLINE_INTEGER}/${BB_TARGET}" )
+
+# Cleanup temporary variables so they don't leak into the user CMake
+unset( BB_NBITS )
+unset( BB_DLLEXT )
+unset( BB_LIBDIR )
+unset( BB_INCDIR )
+unset( BB_TARGET )

--- a/L/libblastrampoline/bundled/cmake/yggdrasilenv.cmake
+++ b/L/libblastrampoline/bundled/cmake/yggdrasilenv.cmake
@@ -1,10 +1,10 @@
 # Environment setup for libblastrampoline to allow the CMake FindBLAS and FindLAPACK
 # scripts work with this library in the Yggdrasil environment.
 
-set( BB_NBITS  $ENV{nbits} )
-set( BB_TARGET $ENV{target} )
-set( BB_DLLEXT $ENV{dlext} )
-set( BB_LIBDIR $ENV{libdir} )
+set( BB_NBITS  "$ENV{nbits}" )
+set( BB_TARGET "$ENV{target}" )
+set( BB_DLLEXT "$ENV{dlext}" )
+set( BB_LIBDIR "$ENV{libdir}" )
 set( BB_INCDIR "$ENV{includedir}" )
 
 # Allow modifying the library name of libblastrampoline to link to. This isn't
@@ -46,9 +46,22 @@ set( LAPACK_LINKER_FLAGS "${BLASTRAMPOLINE_LIB}" )
 set( BLAS_INCLUDE_DIRS "${BB_INCDIR}/libblastrampoline/${BLASTRAMPOLINE_INTEGER}/${BB_TARGET}" )
 set( LAPACK_INCLUDE_DIRS "${BB_INCDIR}/libblastrampoline/${BLASTRAMPOLINE_INTEGER}/${BB_TARGET}" )
 
+# CBLAS and LAPACKE don't have upstream CMake Find modules, but blastrampoline is complex
+# enough in its pathing that it is nice to define these for possible consumers.
+set( CBLAS_FOUND 1 )
+set( CBLAS_LIBRARIES "${BB_LIBDIR}/lib${BLASTRAMPOLINE_LIB}.${BB_DLLEXT}" )
+set( CBLAS_LINKER_FLAGS "${BLASTRAMPOLINE_LIB}" )
+set( CBLAS_INCLUDE_DIRS "${BB_INCDIR}/libblastrampoline/${BLASTRAMPOLINE_INTEGER}/${BB_TARGET}" )
+
+set( LAPACKE_FOUND 1 )
+set( LAPACKE_LIBRARIES "${BB_LIBDIR}/lib${BLASTRAMPOLINE_LIB}.${BB_DLLEXT}" )
+set( LAPACKE_LINKER_FLAGS "${BLASTRAMPOLINE_LIB}" )
+set( LAPACKE_INCLUDE_DIRS "${BB_INCDIR}/libblastrampoline/${BLASTRAMPOLINE_INTEGER}/${BB_TARGET}" )
+
 # Cleanup temporary variables so they don't leak into the user CMake
 unset( BB_NBITS )
 unset( BB_DLLEXT )
 unset( BB_LIBDIR )
 unset( BB_INCDIR )
 unset( BB_TARGET )
+


### PR DESCRIPTION
This PR adds a new CMake file that setups the environment for libblastrampoline to be used with the CMake FindBLAS and FindLAPACK by setting up the various CMake variables those find modules provide to point to the appropriate library in the buildroot.

This replaces the need for setting all the `-DBLAS*` and `-DLAPACK*` variables on the CMake command line each time. Instead, each CMake invocation that will use libblastrampoline should add
```
-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${libdir}/cmake/blastrampoline/yggdrasilenv.cmake" \
```
to the command line, and ensure that they declare a dependency on at least version 3.24 of the CMake JLL.

This does expose two extra variables that aren't actually defined by the find scripts normally, `BLAS_INCLUDE_DIRS` and `LAPACK_INCLUDE_DIRS`, which point to the target-specific include directory provided by libblastrampoline. While not defined by the docs for the targets, I felt it was useful to include because libblastrampoline does put all the include files into a bit of a weird place (and some CMake scripts do refer to these variables, such as the SuiteSparse CMake, even if they aren't required).

There are two configuration points for this:
* `BLASTRAMPOLINE_LIB` - set to the desired library name (without the `lib` prefix). This is automatically set appropriately based on the platform if left blank.
* `BLASTRAMPOLINE_INTEGER` - set to either `ILP64` or `LP64` to force a specific interface spec. This is automatically set based on the `nbits` of the target, so a 64 bit target gets `ILP64` and a 32-bit target gets `LP64`. This only affects the directory used in the include path though, since the actual library is the same for both.

I am tempted to add sets of variables for `LAPACKE` and `CBLAS` as well, but there aren't actually upstream find modules for those, but they seem like they might be useful anyway.


I have tested this by modifying the SuiteSparse recipe locally, and it finds the BLAS/LAPACK libraries properly still during the build phase:

64-bit Linux:

```
[16:44:29] -- LAPACK libraries:    /workspace/destdir/lib/libblastrampoline.so
[16:44:29] -- LAPACK include:      /workspace/destdir/include/libblastrampoline/ILP64/x86_64-linux-gnu
[16:44:29] -- LAPACK linker flags: blastrampoline
[16:44:29] -- BLAS libraries:      /workspace/destdir/lib/libblastrampoline.so
[16:44:29] -- BLAS include:        /workspace/destdir/include/libblastrampoline/ILP64/x86_64-linux-gnu
[16:44:29] -- BLAS linker flags:   blastrampoline
```

32-bit Linux:
```
[16:45:51] -- LAPACK libraries:    /workspace/destdir/lib/libblastrampoline.so
[16:45:51] -- LAPACK include:      /workspace/destdir/include/libblastrampoline/LP64/i686-linux-gnu
[16:45:51] -- LAPACK linker flags: blastrampoline
[16:45:51] -- BLAS libraries:      /workspace/destdir/lib/libblastrampoline.so
[16:45:51] -- BLAS include:        /workspace/destdir/include/libblastrampoline/LP64/i686-linux-gnu
[16:45:51] -- BLAS linker flags:   blastrampoline
```

64-bit Windows:
```
[17:12:21] -- LAPACK libraries:    /workspace/destdir/bin/libblastrampoline-5.dll
[17:12:21] -- LAPACK include:      /workspace/destdir/include/libblastrampoline/ILP64/x86_64-w64-mingw32
[17:12:21] -- LAPACK linker flags: blastrampoline-5
[17:12:21] -- BLAS libraries:      /workspace/destdir/bin/libblastrampoline-5.dll
[17:12:21] -- BLAS include:        /workspace/destdir/include/libblastrampoline/ILP64/x86_64-w64-mingw32
[17:12:21] -- BLAS linker flags:   blastrampoline-5
```

32-bit Windows:
```
[17:13:45] -- LAPACK libraries:    /workspace/destdir/bin/libblastrampoline-5.dll
[17:13:45] -- LAPACK include:      /workspace/destdir/include/libblastrampoline/LP64/i686-w64-mingw32
[17:13:45] -- LAPACK linker flags: blastrampoline-5
[17:13:45] -- BLAS libraries:      /workspace/destdir/bin/libblastrampoline-5.dll
[17:13:45] -- BLAS include:        /workspace/destdir/include/libblastrampoline/LP64/i686-w64-mingw32
[17:13:45] -- BLAS linker flags:   blastrampoline-5
```