### PR TITLE
[AzStorage] Rebuild with libcurl with unversioned symbols

### DIFF
--- a/A/AzStorage/build_tarballs.jl
+++ b/A/AzStorage/build_tarballs.jl
@@ -45,7 +45,7 @@ dependencies = [
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
-    Dependency("LibCURL_jll", v"7.73.0"),
+    Dependency("LibCURL_jll"; compat="7.73.0,8"),
 ]
 
 #=


### PR DESCRIPTION
This should be compatible with multiple versions of libcurl.  Ref #8407.