### PR TITLE
[htslib] Rebuild with libcurl with unversioned symbols

### DIFF
--- a/H/htslib/build_tarballs.jl
+++ b/H/htslib/build_tarballs.jl
@@ -49,7 +49,7 @@ products = [
 dependencies = [
     Dependency("Zlib_jll"),
     Dependency("Bzip2_jll"; compat="1.0.8"),
-    Dependency("XZ_jll"),
+    Dependency("XZ_jll"; compat="5.2.5"),
     Dependency("LibCURL_jll"; compat="7.73,8"),
     Dependency("OpenSSL_jll"; compat="3.0.8"),
 ]


### PR DESCRIPTION
This should be compatible with multiple versions of libcurl.  Also, set compat for XZ.  Ref #8407.