### PR TITLE
MAGEMin v1.4.2

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.4.1"
+version = v"1.4.2"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "9381221d0cb50a2b9f866f1b966d267ef38a1400")                 ]
+                    "b0f6f0e2e9bb623e22845033dbe21d714bb3afa6")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -12,7 +12,7 @@ MPItrampoline_compat_version="5.2.1"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "b0f6f0e2e9bb623e22845033dbe21d714bb3afa6")                 ]
+                    "2790b7ea0f0d331e3de686e1e699a3b3f59466c0")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Corrects issue when maximum of PC is reached
- Switch from PGE to LP solver is more aggressive now (catches when norm(gamma) goes crazy)
- Uses the right julia wrapper method to copy bulk_rock and avoid (rare) related segfaults
- Improved initialization of the different solvers
- Extended clean up of allocated but unused arrays