### PR TITLE
Glib: change product order

### DIFF
--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -82,11 +82,11 @@ platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct(["libgio-2", "libgio-2.0"], :libgio),
     LibraryProduct(["libglib-2", "libglib-2.0"], :libglib),
     LibraryProduct(["libgmodule-2", "libgmodule-2.0"], :libgmodule),
     LibraryProduct(["libgobject-2", "libgobject-2.0"], :libgobject),
     LibraryProduct(["libgthread-2", "libgthread-2.0"], :libgthread),
+    LibraryProduct(["libgio-2", "libgio-2.0"], :libgio),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
If I'm not mistaken, the product declaration order in build_tarballs.jl seems to determine the load order in `__init__` (as in https://github.com/JuliaBinaryWrappers/Glib_jll.jl/blob/main/src/wrappers/x86_64-linux-gnu.jl#L18-L46).

This PR changes the product order so that `libglib` and others are loaded before `libgobject` (see the symbol dependency using `ldd -r libXXX.so`).

Fix https://discourse.julialang.org/t/julia-error-initerror-when-trying-to-use-plots-in-python-via-juliacall/112425, or https://discourse.julialang.org/t/libgobject-2-0-so-0-undefined-symbol-g-dir-unref/112301.

Needed for https://github.com/JuliaPlots/Plots.jl/pull/4914:

```
Test Summary:            | Pass  Total  Time
Preferences UnicodePlots |    2      2  0.6s
Test Summary:         | Pass  Total  Time
Persistent backend GR |    1      1  0.0s
Test Summary:                   | Pass  Total  Time
Persistent backend UnicodePlots |    1      1  0.0s
ERROR: LoadError: InitError: could not load library "[...]/lib/libgobject-2.0.so"
[...]/648a32a349aac06f19b6bfed47f0b822b4ef28c3/lib/libgobject-2.0.so: undefined symbol: g_dir_unref
```