### PR TITLE
Update mpi.jl to respect platform argument

### DIFF
--- a/H/HDF5/build_tarballs.jl
+++ b/H/HDF5/build_tarballs.jl
@@ -303,3 +303,5 @@ ENV["MPITRAMPOLINE_DELAY_INIT"] = "1"
 # GCC 5 reports an ICE on i686-linux-gnu-libgfortran3-cxx11-mpi+mpich
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                augment_platform_block, clang_use_lld=false, julia_compat="1.6", preferred_gcc_version=v"6")
+
+# Trigger build: 1

--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -11,7 +11,7 @@ const augment = raw"""
     function augment_mpi!(platform)
         # Doesn't need to be `const` since we depend on MPIPreferences so we
         # invalidate the cache when it changes.
-        binary = get(preferences, "binary", Sys.iswindows() ? "MicrosoftMPI_jll" : "MPICH_jll")
+        binary = get(preferences, "binary", Sys.iswindows(platform) ? "MicrosoftMPI_jll" : "MPICH_jll")
 
         abi = if binary == "system"
             let abi = get(preferences, "abi", nothing)

--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -11,6 +11,7 @@ const augment = raw"""
     function augment_mpi!(platform)
         # Doesn't need to be `const` since we depend on MPIPreferences so we
         # invalidate the cache when it changes.
+        # Note: MPIPreferences uses `Sys.iswindows()` without the `platform` argument.
         binary = get(preferences, "binary", Sys.iswindows(platform) ? "MicrosoftMPI_jll" : "MPICH_jll")
 
         abi = if binary == "system"


### PR DESCRIPTION
This PR makes the MPI platform augmentation respect the `platform` argument.

The change fixes a rather niche bug, which is that e.g. `Pkg.instantiate(platform=Windows(:x86_64))` from a non-windows machine doesn't install any artifacts that use this augmentation (I don't know if this claim is fully true, but it is true for HDF5).  I discovered this through https://github.com/JuliaComputing/DepotDelivery.jl, a package for bundling a depot as a software deliverable.


Looks like this would [affect quite a few JLLs](https://github.com/search?q=org%3AJuliaBinaryWrappers+augment_mpi%21&type=code).

Is it possible to trigger all these builds without the dummy e.g. `# Trigger build` changes to the `build_tarballs.jl` files?
