### PR TITLE
[SCS] enable openmp

### DIFF
--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -1,3 +1,4 @@
+using Pkg
 using BinaryBuilder
 
 name = "SCS"
@@ -11,7 +12,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/scs*
-flags="DLONG=1 USE_OPENMP=0"
+flags="DLONG=1 USE_OPENMP=1"
 blasldflags="-L${prefix}/lib -lopenblas"
 
 make BLASLDFLAGS="${blasldflags}" ${flags} out/libscsdir.${dlext}
@@ -34,6 +35,12 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("OpenBLAS32_jll", v"0.3.10"),
+    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
+    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
+        platforms=filter(!Sys.isbsd, platforms)),
+    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
+        platforms=filter(Sys.isbsd, platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/scs*
-flags="DLONG=0 USE_OPENMP=0"
+flags="DLONG=0 USE_OPENMP=1"
 blasldflags="-L${libdir} -lopenblas"
 
 CUDA_PATH=$prefix/cuda make BLASLDFLAGS="${blasldflags}" ${flags} out/libscsgpuindir.${dlext}
@@ -37,7 +37,13 @@ products = [
 ]
 
 dependencies = [
-    Dependency("OpenBLAS32_jll", v"0.3.10")
+    Dependency("OpenBLAS32_jll", v"0.3.10"),
+    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
+    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
+        platforms=filter(!Sys.isbsd, platforms)),
+    # Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
+    #     platforms=filter(Sys.isbsd, platforms)),
 ]
 
 for platform in platforms

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/scs*
-scsflags="DLONG=1 USE_OPENMP=0 BLAS32=1 NOBLASSUFFIX=1"
+scsflags="DLONG=1 USE_OPENMP=1 BLAS32=1 NOBLASSUFFIX=1"
 mklflags="-L${prefix}/lib -Wl,--no-as-needed -lmkl_rt -lmkl_core -lpthread -lm -ldl"
 
 make ${scsflags} MKLFLAGS="${mklflags}" out/libscsmkl.${dlext}
@@ -39,6 +39,12 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("MKL_jll"; compat = "=2023.2.0"),
+    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
+    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
+        platforms=filter(!Sys.isbsd, platforms)),
+    # Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
+    #     platforms=filter(Sys.isbsd, platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well


### PR DESCRIPTION
Since SCS_GPU_jll and SCS_MKL_jll are available only on x86_64 platforms the LLVMOpenMP dep is disabled for them.

MKL can be also updated to v2024, but let's do it in another pull request.

@odow 