### PR TITLE
[libspatialite] Update to v5.1.0

### DIFF
--- a/L/libspatialite/build_tarballs.jl
+++ b/L/libspatialite/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "libspatialite"
-version = v"5.0.1"
+version = v"5.1.0"
 
 # Collection of sources required to complete build
 sources = [
@@ -88,7 +88,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("SQLite_jll")
-    Dependency("GEOS_jll"; compat="~3.9")
+    Dependency("GEOS_jll")
     Dependency(PackageSpec(name="PROJ_jll", uuid="58948b4f-47e0-5654-a9ad-f609743f8632"))
     Dependency(PackageSpec(name="Libiconv_jll", uuid="94ce4f54-9a6c-5748-9c1c-f9c7231a4531"))
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))


### PR DESCRIPTION
Also removes the GEOS compat constraint here, since that was restricting LibGEOS installation.