### PR TITLE
[Pango] Update to v1.52.2

### DIFF
--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "Pango"
-version = v"1.52.1"
+version = v"1.52.2"
 
-# Collection of sources required to build Pango
+# Collection of sources required to build Pango: https://download.gnome.org/sources/pango/
 sources = [
     ArchiveSource("http://ftp.gnome.org/pub/GNOME/sources/pango/$(version.major).$(version.minor)/pango-$(version).tar.xz",
-                  "58728a0a2d86f60761208df9493033d18ecb2497abac80ee1a274ad0c6e55f0f"),
+                  "d0076afe01082814b853deec99f9349ece5f2ce83908b8e58ff736b41f78a96b"),
     ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v11.0.0.tar.bz2",
                   "bd0ea1633bd830204cc23a696889335e9d4a32b8619439ee17f22188695fcc5f"),
 ]
@@ -32,7 +32,7 @@ if [[ "${target}" == *-mingw* ]]; then
     make install
 fi
 
-cd $WORKSPACE/srcdir/pango-*/
+cd $WORKSPACE/srcdir/pango*/
 
 if [[ "${target}" == "${MACHTYPE}" ]]; then
     # When building for the host platform, the system libexpat is picked up
@@ -68,7 +68,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Cairo_jll"; compat="1.16.1"),
+    Dependency("Cairo_jll"; compat="1.18.0"),
     Dependency("Fontconfig_jll"),
     Dependency("FreeType2_jll"; compat="2.10.4"),
     Dependency("FriBidi_jll"),

--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -57,7 +57,7 @@ install_license ../COPYING
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter!(p -> arch(p) != "armv6l", supported_platforms())
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
@@ -70,7 +70,7 @@ products = [
 dependencies = [
     Dependency("Cairo_jll"; compat="1.18.0"),
     Dependency("Fontconfig_jll"),
-    Dependency("FreeType2_jll"; compat="2.10.4"),
+    Dependency("FreeType2_jll"; compat="2.13.1"),
     Dependency("FriBidi_jll"),
     Dependency("Glib_jll"; compat="2.68.1"),
     Dependency("HarfBuzz_jll"; compat="2.8.1"),

--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -72,7 +72,7 @@ dependencies = [
     Dependency("Fontconfig_jll"),
     Dependency("FreeType2_jll"; compat="2.13.1"),
     Dependency("FriBidi_jll"),
-    Dependency("Glib_jll"; compat="2.68.1"),
+    Dependency("Glib_jll"; compat="2.74.0"),
     Dependency("HarfBuzz_jll"; compat="2.8.1"),
     BuildDependency("Xorg_xorgproto_jll"; platforms=filter(p->Sys.islinux(p)||Sys.isfreebsd(p), platforms)),
 ]


### PR DESCRIPTION
Also, update dependency on Cairo_jll.  #7454 changed the build system to the newer meson, but this changed the compatibility version in the macOS binaries, which means that libraries built against Cairo 1.16 require a compatibility version way larger than what's recorded in our builds of Cairo 1.18: https://github.com/JuliaGraphics/Cairo.jl/issues/362.  This is non-sense, but this is a reminder that changing build systems has a cost: most of the time they don't produce 100% compatible binaries.

For the record, the problem with the macOS compatibility arises only on macOS < 12 and `-mmacosx-version-min` is set to a value < 10.14 (we use 10.12 for x86_64-darwin builds, and 11.0 for aarch64-darwin builds): https://github.com/giordano/macos-compatibility-version