### PR TITLE
[LightGBM]: Rebuild v3.3.5

### DIFF
--- a/L/LightGBM/build_tarballs.jl
+++ b/L/LightGBM/build_tarballs.jl
@@ -3,11 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "LightGBM"
-version = v"4.0.0"
+version = v"3.3.5"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/microsoft/LightGBM.git", "d73c6b530b39a18a3cacaafc4e42550be853c036"),
+    GitSource("https://github.com/characat0/LightGBM", "ca035b2ee0c2be85832435917b1e0c8301d2e0e0"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
@@ -24,6 +25,10 @@ fi
 FLAGS=()
 
 if [[ "${target}" == *-mingw* ]]; then
+  # Parches windows
+  for p in $WORKSPACE/srcdir/patches/windows/*.patch; do
+    atomic_patch -p1 "${p}"
+  done
   cmake_extra_args="-DWIN32=1 -DMINGW=1"
   FLAGS+=(LDFLAGS="-no-undefined")
 fi
@@ -57,4 +62,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"8.1.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7.1.0")

--- a/L/LightGBM/build_tarballs.jl
+++ b/L/LightGBM/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"3.3.5"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/characat0/LightGBM", "ca035b2ee0c2be85832435917b1e0c8301d2e0e0"),
+    GitSource("https://github.com/microsoft/LightGBM", "ca035b2ee0c2be85832435917b1e0c8301d2e0e0"),
     DirectorySource("./bundled"),
 ]
 

--- a/L/LightGBM/build_tarballs.jl
+++ b/L/LightGBM/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"3.3.5"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/microsoft/LightGBM", "ca035b2ee0c2be85832435917b1e0c8301d2e0e0"),
+    GitSource("https://github.com/microsoft/LightGBM.git", "ca035b2ee0c2be85832435917b1e0c8301d2e0e0"),
     DirectorySource("./bundled"),
 ]
 

--- a/L/LightGBM/build_tarballs.jl
+++ b/L/LightGBM/build_tarballs.jl
@@ -62,4 +62,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"7.1.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"8.1.0")

--- a/L/LightGBM/bundled/patches/windows/Ws2_32-iphlpapi.patch
+++ b/L/LightGBM/bundled/patches/windows/Ws2_32-iphlpapi.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 95610d55..9d272e38 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -490,10 +490,10 @@ endif(USE_HDFS)
+ 
+ if(WIN32)
+     if(MINGW OR CYGWIN)
+-      TARGET_LINK_LIBRARIES(lightgbm Ws2_32)
+-      TARGET_LINK_LIBRARIES(_lightgbm Ws2_32)
+-      TARGET_LINK_LIBRARIES(lightgbm IPHLPAPI)
+-      TARGET_LINK_LIBRARIES(_lightgbm IPHLPAPI)
++      TARGET_LINK_LIBRARIES(lightgbm ws2_32)
++      TARGET_LINK_LIBRARIES(_lightgbm ws2_32)
++      TARGET_LINK_LIBRARIES(lightgbm iphlpapi)
++      TARGET_LINK_LIBRARIES(_lightgbm iphlpapi)
+     endif(MINGW OR CYGWIN)
+ endif(WIN32)


### PR DESCRIPTION
The commit for this version is lost in the original repo, so I'm using a fork of the project I made.
I'm rebuilding this since we found a crash in Windows for Julia 1.8, this is related to https://github.com/JuliaLang/julia/issues/48187 and https://discourse.julialang.org/t/issue-with-xgboost-jl-and-libsvm-jl-when-julia-1-8-4/92396.
This build now should work since it was fixed in https://github.com/JuliaLang/julia/pull/50135.

Also, is it okey to just overwrite build_tarballs.jl?
I saw other projects using Package@version folders inside the main package folder but I'm assuming this works too.