### PR TITLE
[libwebp] v1.4.0

### DIFF
--- a/L/libwebp/build_tarballs.jl
+++ b/L/libwebp/build_tarballs.jl
@@ -3,18 +3,17 @@
 using BinaryBuilder
 
 name = "libwebp"
-version = v"1.3.2"
+version = v"1.4.0"
 
 # Collection of sources required to build libwebp
 sources = [
     GitSource("https://chromium.googlesource.com/webm/libwebp",
-                  "ca332209cb5567c9b249c86788cb2dbf8847e760"),
+              "a443170fc0ebdfc3abbf89ac81f35e7eb656a3da"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libwebp
-export CFLAGS="-std=c99"
 export CPPFLAGS="-I${includedir}"
 export LDFLAGS="-L${libdir}"
 ./autogen.sh
@@ -55,4 +54,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")


### PR DESCRIPTION
This PR bumps libwebp to v1.4.0 and improves the performance by leveraging a newer compiler. This change could potentially fix https://github.com/stemann/WebP.jl/issues/12.
```julia
using Images
using TestImages
using WebP

using BenchmarkTools

const libwebp_jll = "lib/libwebp.so" 

function webp_encode(img::AbstractMatrix{RGB{N0f8}}; quality=75)
    img1 = permutedims(img, (2, 1))
    width, height = size(img1)
    stride = width * sizeof(RGB{N0f8})
    output_ptr = Ref{Ptr{UInt8}}()
    output_length = ccall((:WebPEncodeRGB, libwebp_jll), 
        Csize_t, (Ptr{UInt8}, Cint, Cint, Cint, Cfloat, Ptr{Ptr{UInt8}}), 
        pointer(img1), width, height, stride, quality, output_ptr)
    output_view = unsafe_wrap(Vector{UInt8}, output_ptr[], output_length)
    output = collect(output_view)
    WebP.Wrapper.WebPFree(output_ptr[])
    return output
end

julia> img = testimage("lighthouse")

julia> x1 = @btime WebP.encode(img; lossy=true) # libwebp-v1.3.2 based on GCC 4
  262.137 ms (5 allocations: 1.17 MiB)
48128-element Vector{UInt8}

julia> x2 = @btime webp_encode(img) # libwebp-v1.4.0 based on GCC 5
  35.971 ms (5 allocations: 1.17 MiB)
48128-element Vector{UInt8}:

julia> x1 == x2
true
```