### PR TITLE
CUDA: Revert lilbNVVM version number bump.

### DIFF
--- a/C/CUDA/libNVVM/build_tarballs.jl
+++ b/C/CUDA/libNVVM/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "libNVVM"
-version = v"5.0"
+version = v"4.0"
 cuda_version = v"12.4.1"
 
 script = raw"""


### PR DESCRIPTION
I mistakenly bumped the version number, assuming it was decoupled from the upstream version.

Should I revert of yank the v5 JLL? Nobody is depending on it yet, so reverting should be safe, but it's not a common thing with General.