### PR TITLE
CUDA: Bump libNVVM (again).

### DIFF
--- a/C/CUDA/libNVVM/build_tarballs.jl
+++ b/C/CUDA/libNVVM/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "libNVVM"
-version = v"4.0"
+version = v"4.0.1"
 cuda_version = v"12.4.1"
 
 script = raw"""


### PR DESCRIPTION
Although libNVVM's upstream version number did not change between the CUDA 12.2 version we used to distribute, and the current CUDA 12.4 one, there _are_ differences in what the library supports and how it behaves. Upstream should probably have changed a minor version, but lacking that let's just bump the patch number on our side.