### PR TITLE
RustFFT: New version 0.3.2

### DIFF
--- a/R/rustfft/build_tarballs.jl
+++ b/R/rustfft/build_tarballs.jl
@@ -8,7 +8,7 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "rustfft"
-version = v"0.3.1"
+version = v"0.3.2"
 julia_versions = [v"1.6.3", v"1.7", v"1.8", v"1.9", v"1.10"]
 
 # Collection of sources required to complete build


### PR DESCRIPTION
Like the previous update, a rebuild is sufficient to pick up the latest version of jlrs. 