### PR TITLE
LLVM: Build IR downgrader for all platforms.

### DIFF
--- a/L/LLVMDowngrader/build_tarballs.jl
+++ b/L/LLVMDowngrader/build_tarballs.jl
@@ -21,11 +21,7 @@ sources = Dict(
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("x86_64", "macos"; ),
-    Platform("aarch64", "macos"; )
-]
-platforms = expand_cxxstring_abis(platforms)
+platforms = expand_cxxstring_abis(supported_platforms(; experimental=true))
 
 # Bash recipe for building across all platforms
 script = raw"""

--- a/L/LLVMDowngrader/build_tarballs.jl
+++ b/L/LLVMDowngrader/build_tarballs.jl
@@ -114,6 +114,7 @@ for llvm_version in llvm_versions, llvm_assertions in (false, true)
             dependencies,
             sources=sources[llvm_version],
             platforms=[augmented_platform],
+            preferred_gcc_version=(llvm_version >= v"16" ? v"10" : v"7")
         ))
     end
 end
@@ -129,6 +130,6 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, script,
                    build.platforms, products, build.dependencies;
-                   preferred_gcc_version=v"7", julia_compat="1.6",
+                   build.preferred_gcc_version, julia_compat="1.6",
                    augment_platform_block, lazy_artifacts=true)
 end


### PR DESCRIPTION
We were previously only using this for Metal/AIR, but it may be useful for NVIDIA/NVVM too.