### PR TITLE
Reactant fix registration issue

### DIFF
--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -299,7 +299,7 @@ for platform in platforms
     should_build_platform(triplet(augmented_platform)) || continue
     push!(builds, (;
                    dependencies=[dependencies; cuda_deps], products, sources=platform_sources,
-        platforms=[augmented_platform], augment_platform_block::String, script=prefix*script
+        platforms=[augmented_platform], augment_platform_block=augment_platform_block::String, script=prefix*script
     ))
 end
 

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -292,7 +292,7 @@ for platform in platforms
         push!(cuda_deps, BuildDependency(PackageSpec(name="CUDNN_jll")))
         push!(cuda_deps, BuildDependency(PackageSpec(name="TensorRT_jll")))
         push!(cuda_deps, BuildDependency(PackageSpec(name="CUDA_full_jll")))
-        augment_platform_block=CUDA.augment
+        # augment_platform_block=CUDA.augment
         prefix = "export CUDA_VERSION=\"\"\n"
     end
 

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -292,14 +292,14 @@ for platform in platforms
         push!(cuda_deps, BuildDependency(PackageSpec(name="CUDNN_jll")))
         push!(cuda_deps, BuildDependency(PackageSpec(name="TensorRT_jll")))
         push!(cuda_deps, BuildDependency(PackageSpec(name="CUDA_full_jll")))
-        # augment_platform_block=CUDA.augment
+        augment_platform_block=CUDA.augment::String
         prefix = "export CUDA_VERSION=\"\"\n"
     end
 
     should_build_platform(triplet(augmented_platform)) || continue
     push!(builds, (;
                    dependencies=[dependencies; cuda_deps], products, sources=platform_sources,
-        platforms=[augmented_platform], augment_platform_block, script=prefix*script
+        platforms=[augmented_platform], augment_platform_block::String, script=prefix*script
     ))
 end
 
@@ -315,6 +315,6 @@ for (i,build) in enumerate(builds)
                    name, version, build.sources, build.script,
                    build.platforms, build.products, build.dependencies;
                    preferred_gcc_version=v"10", julia_compat="1.6",
-                   build.augment_platform_block, lazy_artifacts=true)
+                   augment_platform_block=build.augment_platform_block::String, lazy_artifacts=true)
 end
 


### PR DESCRIPTION
See https://buildkite.com/julialang/yggdrasil/builds/10149#018f3f9b-9218-438c-8bdd-79880854b42e

```

--> Uploading: Reactant-logs.v0.0.4.aarch64-apple-darwin.tar.gz
--
  | --> Uploading: Reactant-logs.v0.0.4.x86_64-linux-gnu-cxx03.tar.gz
  | ERROR: LoadError: TypeError: in keyword argument augment_platform_block, expected String, got a value of type Vector{String}
  | Stacktrace:
  | [1] top-level scope
  | @ /cache/build/yggy-amdci7-9/julialang/yggdrasil/.ci/register_package.jl:139
  | in expression starting at /cache/build/yggy-amdci7-9/julialang/yggdrasil/.ci/register_package.jl:139


```