### PR TITLE
CUDA: Separate compiler bits from the runtime JLL.

### DIFF
--- a/C/CUDA/CUDA_JIT/build_tarballs.jl
+++ b/C/CUDA/CUDA_JIT/build_tarballs.jl
@@ -33,8 +33,6 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     mv cuda_nvdisasm/bin/nvdisasm ${bindir}
 
-    mv libnvjitlink/lib/libnvJitLink.so* ${libdir}
-
     # Convert the static compiler library to a dynamic one
     ${CC} -std=c99 -fPIC -shared -lm \
           -L cuda_nvcc/lib -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
@@ -73,7 +71,6 @@ platforms = [Platform("x86_64", "linux"),
 
 function get_products(platform)
     products = [
-        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_124"], :libnvrtc_builtins),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
@@ -98,7 +95,6 @@ for platform in platforms
         "cuda_nvcc",
         "cuda_nvrtc",
         "cuda_nvdisasm",
-        "libnvjitlink"
     ]
     sources = get_sources("cuda", components; version, platform)
     products = get_products(platform)

--- a/C/CUDA/CUDA_JIT/build_tarballs.jl
+++ b/C/CUDA/CUDA_JIT/build_tarballs.jl
@@ -59,6 +59,7 @@ function get_products(platform)
     products = [
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_124"], :libnvrtc_builtins),
+        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),
         ExecutableProduct("nvdisasm", :nvdisasm),

--- a/C/CUDA/CUDA_JIT/build_tarballs.jl
+++ b/C/CUDA/CUDA_JIT/build_tarballs.jl
@@ -32,11 +32,6 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv cuda_nvrtc/lib/libnvrtc-builtins.so* ${libdir}
 
     mv cuda_nvdisasm/bin/nvdisasm ${bindir}
-
-    # Convert the static compiler library to a dynamic one
-    ${CC} -std=c99 -fPIC -shared -lm \
-          -L cuda_nvcc/lib -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
-          -o ${libdir}/libnvPTXCompiler.so
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv cuda_cudart/lib/x64/cudadevrt.lib ${prefix}/lib
 
@@ -49,15 +44,6 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv cuda_nvrtc/bin/nvrtc-builtins64_* ${bindir}
 
     mv cuda_nvdisasm/bin/nvdisasm.exe ${bindir}
-
-    mv libnvjitlink/bin/nvJitLink_*.dll ${bindir}
-
-    # Convert the static compiler library to a dynamic one
-    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
-    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
-    #${CC} -std=c99 -shared -lm \
-    #      -L cuda_nvcc/lib -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
-    #      -o ${libdir}/nvPTXCompiler.dll
 
     # Fix permissions
     chmod +x ${bindir}/*.{exe,dll}
@@ -78,9 +64,6 @@ function get_products(platform)
         ExecutableProduct("nvdisasm", :nvdisasm),
         ExecutableProduct("nvlink", :nvlink),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
     return products
 end
 

--- a/C/CUDA/CUDA_JIT/build_tarballs.jl
+++ b/C/CUDA/CUDA_JIT/build_tarballs.jl
@@ -57,8 +57,6 @@ platforms = [Platform("x86_64", "linux"),
 
 function get_products(platform)
     products = [
-        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_124"], :libnvrtc_builtins),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_JIT/build_tarballs.jl
+++ b/C/CUDA/CUDA_JIT/build_tarballs.jl
@@ -1,0 +1,120 @@
+using BinaryBuilder, Pkg
+
+include("../common.jl")
+
+const YGGDRASIL_DIR = "../../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+
+name = "CUDA_JIT"
+version = v"12.4.1"
+
+script = raw"""
+# rename directories, stripping the architecture and version suffix
+for dir in *-archive; do
+    base=$(echo $dir | cut -d '-' -f 1)
+    mv $dir $base
+done
+
+# license
+install_license cuda_nvcc/LICENSE
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    mv cuda_cudart/lib/libcudadevrt.a ${libdir}
+
+    mkdir ${prefix}/share/libdevice
+    mv cuda_nvcc/bin/ptxas ${bindir}
+    mv cuda_nvcc/bin/nvlink ${bindir}
+    mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    mv cuda_nvrtc/lib/libnvrtc.so* ${libdir}
+    mv cuda_nvrtc/lib/libnvrtc-builtins.so* ${libdir}
+
+    mv cuda_nvdisasm/bin/nvdisasm ${bindir}
+
+    mv libnvjitlink/lib/libnvJitLink.so* ${libdir}
+
+    # Convert the static compiler library to a dynamic one
+    ${CC} -std=c99 -fPIC -shared -lm \
+          -L cuda_nvcc/lib -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+          -o ${libdir}/libnvPTXCompiler.so
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    mv cuda_cudart/lib/x64/cudadevrt.lib ${prefix}/lib
+
+    mkdir ${prefix}/share/libdevice
+    mv cuda_nvcc/bin/ptxas.exe ${bindir}
+    mv cuda_nvcc/bin/nvlink.exe ${bindir}
+    mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    mv cuda_nvrtc/bin/nvrtc64_* ${bindir}
+    mv cuda_nvrtc/bin/nvrtc-builtins64_* ${bindir}
+
+    mv cuda_nvdisasm/bin/nvdisasm.exe ${bindir}
+
+    mv libnvjitlink/bin/nvJitLink_*.dll ${bindir}
+
+    # Convert the static compiler library to a dynamic one
+    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
+    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
+    #${CC} -std=c99 -shared -lm \
+    #      -L cuda_nvcc/lib -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
+    #      -o ${libdir}/nvPTXCompiler.dll
+
+    # Fix permissions
+    chmod +x ${bindir}/*.{exe,dll}
+fi
+"""
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("powerpc64le", "linux"),
+             Platform("aarch64", "linux"),
+             Platform("x86_64", "windows")]
+
+function get_products(platform)
+    products = [
+        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
+        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_124"], :libnvrtc_builtins),
+        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+        ExecutableProduct("ptxas", :ptxas),
+        ExecutableProduct("nvdisasm", :nvdisasm),
+        ExecutableProduct("nvlink", :nvlink),
+    ]
+    if !Sys.iswindows(platform)
+        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
+    end
+    return products
+end
+
+dependencies = []
+
+builds = []
+for platform in platforms
+    should_build_platform(triplet(platform)) || continue
+
+    components = [
+        "cuda_cudart",
+        "cuda_nvcc",
+        "cuda_nvrtc",
+        "cuda_nvdisasm",
+        "libnvjitlink"
+    ]
+    sources = get_sources("cuda", components; version, platform)
+    products = get_products(platform)
+    push!(builds, (; platforms=[platform], sources, products))
+end
+
+# don't allow `build_tarballs` to override platform selection based on ARGS.
+# we handle that ourselves by calling `should_build_platform`
+non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
+
+# `--register` should only be passed to the latest `build_tarballs` invocation
+non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
+
+for (i,build) in enumerate(builds)
+    build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
+                   name, version, build.sources, script,
+                   build.platforms, build.products, dependencies;
+                   julia_compat="1.6", preferred_gcc_version = v"6.1.0")
+end

--- a/C/CUDA/CUDA_Runtime/build_10.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_10.2.jl
@@ -97,18 +97,14 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
 fi
 """
 
-get_products() = [
-    LibraryProduct(["libcudart", "cudart64_102"], :libcudart),
-    LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm),
-    LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
-    LibraryProduct(["libcublas", "cublas64_10"], :libcublas),
-    LibraryProduct(["libcusparse", "cusparse64_10"], :libcusparse),
-    LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
-    LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-    LibraryProduct(["libcupti", "cupti64_102"], :libcupti),
-    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-    ExecutableProduct("ptxas", :ptxas),
-    ExecutableProduct("nvdisasm", :nvdisasm),
-    ExecutableProduct("nvlink", :nvlink),
-]
+function get_products(platform)
+    [
+        LibraryProduct(["libcudart", "cudart64_102"], :libcudart),
+        LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_10"], :libcublas),
+        LibraryProduct(["libcusparse", "cusparse64_10"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_102"], :libcupti),
+    ]
+end

--- a/C/CUDA/CUDA_Runtime/build_11.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.4.jl
@@ -11,6 +11,5 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2021.2.2"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.4.jl
@@ -1,9 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_114"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_11"], :libcublasLt),
@@ -14,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2021.2.2"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_11.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.5.jl
@@ -11,6 +11,5 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2021.3.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.5.jl
@@ -1,9 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_115"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_11"], :libcublasLt),
@@ -14,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2021.3.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_11.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.6.jl
@@ -11,6 +11,5 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.1.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.6.jl
@@ -1,9 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_116"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_11"], :libcublasLt),
@@ -14,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.1.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_11.7.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.7.jl
@@ -11,6 +11,5 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.2.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.7.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.7.jl
@@ -1,9 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_117"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_11"], :libcublasLt),
@@ -14,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.2.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_11.8.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.8.jl
@@ -11,6 +11,5 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.3.0"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.8.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.8.jl
@@ -1,9 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_110"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_118"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_11"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_11"], :libcublasLt),
@@ -14,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.3.0"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_12.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.0.jl
@@ -12,6 +12,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.0.jl
@@ -1,10 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_12"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_120"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_11"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_12"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_12"], :libcublasLt),
@@ -15,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.4.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_12.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.0.jl
@@ -11,6 +11,7 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.4.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.1.jl
@@ -11,6 +11,7 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2023.1.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.1.jl
@@ -12,6 +12,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.1.jl
@@ -1,10 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_12"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_121"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_11"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_12"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_12"], :libcublasLt),
@@ -15,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2023.1.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_12.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.2.jl
@@ -11,6 +11,7 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2023.2.2"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.2.jl
@@ -12,6 +12,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.2.jl
@@ -1,10 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_12"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_122"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_11"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_12"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_12"], :libcublasLt),
@@ -15,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2023.2.2"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_12.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.3.jl
@@ -11,6 +11,7 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2023.3.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.3.jl
@@ -1,10 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_12"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_123"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_11"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_12"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_12"], :libcublasLt),
@@ -15,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2023.3.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_12.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.3.jl
@@ -12,6 +12,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.4.jl
@@ -11,6 +11,7 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2024.1.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.4.jl
@@ -1,10 +1,6 @@
 function get_products(platform)
-    products = [
+    [
         LibraryProduct(["libcudart", "cudart64_12"], :libcudart),
-        LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-        LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
-        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_124"], :libnvrtc_builtins),
         LibraryProduct(["libcufft", "cufft64_11"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_12"], :libcublas),
         LibraryProduct(["libcublasLt", "cublasLt64_12"], :libcublasLt),
@@ -15,15 +11,6 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2024.1.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
         ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
-    if !Sys.iswindows(platform)
-        push!(products, LibraryProduct("libnvPTXCompiler", :libnvPTXCompiler))
-    end
-    return products
 end

--- a/C/CUDA/CUDA_Runtime/build_12.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.4.jl
@@ -12,6 +12,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        ExecutableProduct("compute-sanitizer", :compute_sanitizer),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -64,7 +64,7 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv cuda_cupti/bin/nvperf_target.dll* ${libdir}
 
     if [[ -d libnvjitlink ]]; then
-        mv libnvjitlink/lib/libnvJitLink.so* ${libdir}
+        mv libnvjitlink/bin/nvJitLink_*.dll ${bindir}
     fi
 
     mv libcufft/bin/cufft64_*.dll libcufft/bin/cufftw64_*.dll ${bindir}

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -65,6 +65,10 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     rm -r cuda_sanitizer_api/compute-sanitizer/{docs,include}
     mv cuda_sanitizer_api/compute-sanitizer/* ${bindir}
 
+    if [[ -d libnvjitlink ]]; then
+        mv libnvjitlink/lib/libnvJitLink.so* ${libdir}
+    fi
+
     mv libcufft/bin/cufft64_*.dll libcufft/bin/cufftw64_*.dll ${bindir}
 
     mv libcublas/bin/cublas64_*.dll libcublas/bin/cublasLt64_*.dll ${bindir}
@@ -98,6 +102,9 @@ for version in CUDA.cuda_full_versions
         "libcusolver",
         "libcusparse",
     ]
+    if version >= v"12"
+        push!(components, "libnvjitlink")
+    end
 
     for platform in platforms
         augmented_platform = deepcopy(platform)

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -78,7 +78,7 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv libcurand/bin/curand64_*.dll ${bindir}
 
     # Fix permissions
-    chmod +x ${bindir}/*.{exe,dll}
+    chmod +x ${bindir}/*.dll
 fi
 """
 

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -37,9 +37,6 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv cuda_cupti/lib/libnvperf_host.so* ${libdir}
     mv cuda_cupti/lib/libnvperf_target.so* ${libdir}
 
-    rm -r cuda_sanitizer_api/compute-sanitizer/{docs,include}
-    mv cuda_sanitizer_api/compute-sanitizer/* ${bindir}
-
     if [[ -d libnvjitlink ]]; then
         mv libnvjitlink/lib/libnvJitLink.so* ${libdir}
     fi
@@ -65,9 +62,6 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv cuda_cupti/bin/cupti64_*.dll ${bindir}
     mv cuda_cupti/bin/nvperf_host.dll* ${libdir}
     mv cuda_cupti/bin/nvperf_target.dll* ${libdir}
-
-    rm -r cuda_sanitizer_api/compute-sanitizer/{docs,include}
-    mv cuda_sanitizer_api/compute-sanitizer/* ${bindir}
 
     if [[ -d libnvjitlink ]]; then
         mv libnvjitlink/lib/libnvJitLink.so* ${libdir}

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -40,6 +40,10 @@ if [[ ${target} == *-linux-gnu ]]; then
     rm -r cuda_sanitizer_api/compute-sanitizer/{docs,include}
     mv cuda_sanitizer_api/compute-sanitizer/* ${bindir}
 
+    if [[ -d libnvjitlink ]]; then
+        mv libnvjitlink/lib/libnvJitLink.so* ${libdir}
+    fi
+
     mv libcufft/lib/libcufft.so* libcufft/lib/libcufftw.so* ${libdir}
 
     mv libcublas/lib/libcublas.so* libcublas/lib/libcublasLt.so* ${libdir}

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.12.1"
+version = v"0.13.0"
 
 augment_platform_block = """
     $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))
@@ -31,29 +31,14 @@ install_license cuda_cudart/LICENSE
 # binaries
 mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
 if [[ ${target} == *-linux-gnu ]]; then
-    mv cuda_cudart/lib/libcudart.so* cuda_cudart/lib/libcudadevrt.a ${libdir}
+    mv cuda_cudart/lib/libcudart.so* ${libdir}
 
     mv cuda_cupti/lib/libcupti.so* ${libdir}
     mv cuda_cupti/lib/libnvperf_host.so* ${libdir}
     mv cuda_cupti/lib/libnvperf_target.so* ${libdir}
 
-    mkdir ${prefix}/share/libdevice
-    mv cuda_nvcc/nvvm/lib64/libnvvm.so* ${libdir}
-    mv cuda_nvcc/bin/ptxas ${bindir}
-    mv cuda_nvcc/bin/nvlink ${bindir}
-    mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
-
-    mv cuda_nvrtc/lib/libnvrtc.so* ${libdir}
-    mv cuda_nvrtc/lib/libnvrtc-builtins.so* ${libdir}
-
-    mv cuda_nvdisasm/bin/nvdisasm ${bindir}
-
     rm -r cuda_sanitizer_api/compute-sanitizer/{docs,include}
     mv cuda_sanitizer_api/compute-sanitizer/* ${bindir}
-
-    if [[ -d libnvjitlink ]]; then
-        mv libnvjitlink/lib/libnvJitLink.so* ${libdir}
-    fi
 
     mv libcufft/lib/libcufft.so* libcufft/lib/libcufftw.so* ${libdir}
 
@@ -64,11 +49,6 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv libcusolver/lib/libcusolver.so* libcusolver/lib/libcusolverMg.so* ${libdir}
 
     mv libcurand/lib/libcurand.so* ${libdir}
-
-    # Convert the static compiler library to a dynamic one
-    ${CC} -std=c99 -fPIC -shared -lm \
-          -L cuda_nvcc/lib -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
-          -o ${libdir}/libnvPTXCompiler.so
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # older versions of the redist binaries had DLLs in the lib folder; correct that
     for dir in */; do
@@ -77,33 +57,13 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     done
 
     mv cuda_cudart/bin/cudart64_*.dll ${bindir}
-    if [[ -d cuda_cudart/lib/x64 ]]; then
-        mv cuda_cudart/lib/x64/cudadevrt.lib ${prefix}/lib
-    else
-        mv cuda_cudart/lib/cudadevrt.lib ${prefix}/lib
-    fi
 
     mv cuda_cupti/bin/cupti64_*.dll ${bindir}
     mv cuda_cupti/bin/nvperf_host.dll* ${libdir}
     mv cuda_cupti/bin/nvperf_target.dll* ${libdir}
 
-    mkdir ${prefix}/share/libdevice
-    mv cuda_nvcc/nvvm/bin/nvvm64_*.dll ${bindir}
-    mv cuda_nvcc/bin/ptxas.exe ${bindir}
-    mv cuda_nvcc/bin/nvlink.exe ${bindir}
-    mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
-
-    mv cuda_nvrtc/bin/nvrtc64_* ${bindir}
-    mv cuda_nvrtc/bin/nvrtc-builtins64_* ${bindir}
-
-    mv cuda_nvdisasm/bin/nvdisasm.exe ${bindir}
-
     rm -r cuda_sanitizer_api/compute-sanitizer/{docs,include}
     mv cuda_sanitizer_api/compute-sanitizer/* ${bindir}
-
-    if [[ -d libnvjitlink ]]; then
-        mv libnvjitlink/bin/nvJitLink_*.dll ${bindir}
-    fi
 
     mv libcufft/bin/cufft64_*.dll libcufft/bin/cufftw64_*.dll ${bindir}
 
@@ -114,13 +74,6 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv libcusolver/bin/cusolver64_*.dll libcusolver/bin/cusolverMg64_*.dll ${bindir}
 
     mv libcurand/bin/curand64_*.dll ${bindir}
-
-    # Convert the static compiler library to a dynamic one
-    # XXX: nvptxcompiler_static.lib is a MSVC-generated library, which doesn't work with
-    #      our toolchain (__GSHandlerCheck and __security_check_cookie are missing)
-    #${CC} -std=c99 -shared -lm \
-    #      -L cuda_nvcc/lib -Wl,--whole-archive -lnvptxcompiler_static -Wl,--no-whole-archive \
-    #      -o ${libdir}/nvPTXCompiler.dll
 
     # Fix permissions
     chmod +x ${bindir}/*.{exe,dll}
@@ -137,9 +90,6 @@ for version in CUDA.cuda_full_versions
     components = [
         "cuda_cudart",
         "cuda_cupti",
-        "cuda_nvcc",
-        "cuda_nvrtc",
-        "cuda_nvdisasm",
         "cuda_sanitizer_api",
 
         "libcublas",
@@ -148,9 +98,6 @@ for version in CUDA.cuda_full_versions
         "libcusolver",
         "libcusparse",
     ]
-    if version >= v"12"
-        push!(components, "libnvjitlink")
-    end
 
     for platform in platforms
         augmented_platform = deepcopy(platform)
@@ -163,7 +110,7 @@ for version in CUDA.cuda_full_versions
                         Dependency("CUDA_Driver_jll"; compat="0.8"),
                         BuildDependency(PackageSpec(name="CUDA_SDK_jll", version=v"10.2.89")),
                     ],
-                    script=get_script(), platforms=[augmented_platform], products=get_products(),
+                    script=get_script(), platforms=[augmented_platform], products=get_products(platform),
                     sources=[]
             ))
         else
@@ -187,6 +134,5 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, build.script,
                    build.platforms, build.products, build.dependencies;
-                   julia_compat="1.6", preferred_gcc_version = v"6.1.0",
-                   lazy_artifacts=true, augment_platform_block)
+                   julia_compat="1.6",lazy_artifacts=true, augment_platform_block)
 end

--- a/C/CUDA/libNVVM/build_tarballs.jl
+++ b/C/CUDA/libNVVM/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "libNVVM"
-version = v"4.0.1"
+version = v"4.0.2"
 cuda_version = v"12.4.1"
 
 script = raw"""
@@ -31,7 +31,6 @@ platforms = [Platform("x86_64", "linux"),
 
 products = [
     LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm),
-    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
 ]
 
 dependencies = []


### PR DESCRIPTION
This makes it possible to always redistribute the latest compiler, while keeping the flexibility of using different runtime libraries (e.g. for driver compatibility). It is also needed for use with NVVM, because using the latest version of that library assumes the latest version of the rest of the compiler stack (i.e., ptxas) is also used.