### PR TITLE
[Extrae] Fix compat bound with Binutils

### DIFF
--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -58,7 +58,7 @@ platforms = [
     Platform("aarch64", "linux"; libc="glibc"),
 ]
 
-cuda_versions_to_build = Any[v"11.0", nothing] #= v"12.1", =#
+cuda_versions_to_build = Any[v"11.4", nothing] #= v"12.1", =#
 
 products = [
     LibraryProduct("libseqtrace", :libseqtrace),
@@ -73,7 +73,7 @@ cuda_products = [
 ]
 
 dependencies = BinaryBuilder.AbstractDependency[
-    Dependency("Binutils_jll"),
+    Dependency("Binutils_jll"; compat="~2.39"),
     Dependency("LibUnwind_jll"),
     Dependency("PAPI_jll"),
     Dependency("XML2_jll"),


### PR DESCRIPTION
`libbfd` in binutils embeds version number in its soname, so we have to have a stricter compat bound.  Same as https://github.com/JuliaRegistries/General/pull/106245.  CC: @mofeing.