### PR TITLE
[BLIS] Update to v1.0

### DIFF
--- a/B/blis/blis/build_tarballs.jl
+++ b/B/blis/blis/build_tarballs.jl
@@ -7,7 +7,6 @@ script = blis_script(blis32=false)
 products = [
     LibraryProduct("libblis", :blis)
 ]
-
-
+ 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"11", lock_microarchitecture=false, julia_compat="1.6")

--- a/B/blis/blis32/build_tarballs.jl
+++ b/B/blis/blis32/build_tarballs.jl
@@ -7,6 +7,6 @@ script = blis_script(blis32=true)
 products = [
     LibraryProduct("libblis32", :blis32)
 ]
-
+ 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"11", lock_microarchitecture=false, julia_compat="1.6")

--- a/B/blis/blis32/build_tarballs.jl
+++ b/B/blis/blis32/build_tarballs.jl
@@ -7,6 +7,8 @@ script = blis_script(blis32=true)
 products = [
     LibraryProduct("libblis32", :blis32)
 ]
- 
+
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"11", lock_microarchitecture=false, julia_compat="1.6")
+
+# Build trigger: 1               

--- a/B/blis/bundled/patches/a64fx_config_screen_sector_cache.patch
+++ b/B/blis/bundled/patches/a64fx_config_screen_sector_cache.patch
@@ -1,4 +1,4 @@
-105c105
+104c104
 < #if !defined(CACHE_SECTOR_SIZE_READONLY)
 ---
 > #if 0

--- a/B/blis/bundled/patches/a64fx_config_screen_sector_cache.patch
+++ b/B/blis/bundled/patches/a64fx_config_screen_sector_cache.patch
@@ -1,4 +1,4 @@
-145c145
+105c105
 < #if !defined(CACHE_SECTOR_SIZE_READONLY)
 ---
 > #if 0

--- a/B/blis/bundled/patches/armsve_kernels_unscreen_arm_sve_h.patch
+++ b/B/blis/bundled/patches/armsve_kernels_unscreen_arm_sve_h.patch
@@ -1,4 +1,13 @@
-48c48
-< #if !defined(BLIS_FAMILY_A64FX)
----
-> #if 1
+diff --git a/kernels/armsve/bli_kernels_armsve.h b/kernels/armsve/bli_kernels_armsve.h
+index 46a39e85..d2711cb2 100644
+--- a/kernels/armsve/bli_kernels_armsve.h
++++ b/kernels/armsve/bli_kernels_armsve.h
+@@ -45,7 +45,7 @@ GEMM_UKR_PROT( dcomplex, z, gemm_armsve_asm_2vx10_unindexed )
+ //GEMMSUP_KER_PROT( double,   d, gemmsup_rv_armsve_10x2v_unindexed )
+ 
+ // Use SVE intrinsics only for referred cases.
+-#if !defined(BLIS_FAMILY_A64FX)
++#if 1
+ PACKM_KER_PROT( double,   d, packm_armsve256_int_8x10 )
+ #endif
+ PACKM_KER_PROT( double,   d, packm_armsve512_asm_16x10 )

--- a/B/blis/bundled/patches/armsve_kernels_unscreen_armsve256_int_8x10.patch
+++ b/B/blis/bundled/patches/armsve_kernels_unscreen_armsve256_int_8x10.patch
@@ -1,0 +1,13 @@
+diff --git a/kernels/armsve/1m/bli_dpackm_armsve256_int_8x10.c b/kernels/armsve/1m/bli_dpackm_armsve256_int_8x10.c
+index 1665b539..1d67e6cb 100644
+--- a/kernels/armsve/1m/bli_dpackm_armsve256_int_8x10.c
++++ b/kernels/armsve/1m/bli_dpackm_armsve256_int_8x10.c
+@@ -35,7 +35,7 @@
+ 
+ #include "blis.h"
+ 
+-#if !defined(BLIS_FAMILY_A64FX)
++#if 1
+ #include <arm_sve.h>
+ 
+ // assumption:

--- a/B/blis/bundled/patches/armsve_kernels_unscreen_armsve512_int_12xk.patch
+++ b/B/blis/bundled/patches/armsve_kernels_unscreen_armsve512_int_12xk.patch
@@ -1,0 +1,13 @@
+diff --git a/kernels/armsve/1m/old/bli_dpackm_armsve512_int_12xk.c b/kernels/armsve/1m/old/bli_dpackm_armsve512_int_12xk.c
+index 47b15b43..53e172be 100644
+--- a/kernels/armsve/1m/old/bli_dpackm_armsve512_int_12xk.c
++++ b/kernels/armsve/1m/old/bli_dpackm_armsve512_int_12xk.c
+@@ -36,7 +36,7 @@
+ #include "blis.h"
+ #include <stdio.h>
+ 
+-#if !defined(BLIS_FAMILY_A64FX)
++#if 1
+ #include <arm_sve.h>
+ 
+ // assumption:

--- a/B/blis/bundled/patches/bli_macro_defs.h.f77suffix64.patch
+++ b/B/blis/bundled/patches/bli_macro_defs.h.f77suffix64.patch
@@ -1,10 +1,29 @@
-88,91c88,91
-< #define PASTEF770(name)                                      name ## _
-< #define PASTEF77(ch1,name)                     ch1        ## name ## _
-< #define PASTEF772(ch1,ch2,name)                ch1 ## ch2 ## name ## _
-< #define PASTEF773(ch1,ch2,ch3,name)     ch1 ## ch2 ## ch3 ## name ## _
----
-> #define PASTEF770(name)                                      name ## _64_
-> #define PASTEF77(ch1,name)                     ch1        ## name ## _64_
-> #define PASTEF772(ch1,ch2,name)                ch1 ## ch2 ## name ## _64_
-> #define PASTEF773(ch1,ch2,ch3,name)     ch1 ## ch2 ## ch3 ## name ## _64_
+diff --git a/frame/include/bli_macro_defs.h b/frame/include/bli_macro_defs.h
+index 8af3f5a2..ac10d383 100644
+--- a/frame/include/bli_macro_defs.h
++++ b/frame/include/bli_macro_defs.h
+@@ -70,15 +70,15 @@
+ #define PASTECH(...) PASTECH_(__VA_ARGS__)(__VA_ARGS__)
+ 
+ // Fortran-77 name-mangling macros.
+-#define PASTEF770_(op)                         op  ## _
+-#define PASTEF771_(ch,op)                      ch  ## op ## _
+-#define PASTEF772_(ch1,ch2,op)                 ch1 ## ch2 ## op ## _
+-#define PASTEF773_(ch1,ch2,ch3,op)             ch1 ## ch2 ## ch3 ## op ## _
+-#define PASTEF774_(ch1,ch2,ch3,ch4,op)         ch1 ## ch2 ## ch3 ## ch4 ## op ## _
+-#define PASTEF775_(ch1,ch2,ch3,ch4,ch5,op)     ch1 ## ch2 ## ch3 ## ch4 ## ch5 ## op ## _
+-#define PASTEF776_(ch1,ch2,ch3,ch4,ch5,ch6,op) ch1 ## ch2 ## ch3 ## ch4 ## ch5 ## ch6 ## op ## _
+-
+-#define PASTEF77__(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,...) PASTEF77 ## arg8 ## _
++#define PASTEF770_(op)                         op  ## _64_
++#define PASTEF771_(ch,op)                      ch  ## op ## _64_
++#define PASTEF772_(ch1,ch2,op)                 ch1 ## ch2 ## op ## _64_
++#define PASTEF773_(ch1,ch2,ch3,op)             ch1 ## ch2 ## ch3 ## op ## _64_
++#define PASTEF774_(ch1,ch2,ch3,ch4,op)         ch1 ## ch2 ## ch3 ## ch4 ## op ## _64_
++#define PASTEF775_(ch1,ch2,ch3,ch4,ch5,op)     ch1 ## ch2 ## ch3 ## ch4 ## ch5 ## op ## _64_
++#define PASTEF776_(ch1,ch2,ch3,ch4,ch5,ch6,op) ch1 ## ch2 ## ch3 ## ch4 ## ch5 ## ch6 ## op ## _64_
++
++#define PASTEF77__(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,...) PASTEF77 ## arg8 ## _
+ #define PASTEF77_(...) PASTEF77__(__VA_ARGS__, 6, 5, 4, 3, 2, 1, 0, XXX)
+ #define PASTEF77(...) PASTEF77_(__VA_ARGS__)(__VA_ARGS__)
+ 

--- a/B/blis/common.jl
+++ b/B/blis/common.jl
@@ -2,11 +2,11 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-version = v"0.9.0"
+version = v"0.9.1" # Not tagged as v0.9.1, but is a v1.0.0 release candidate
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/flame/blis.git", "14c86f66b20901b60ee276da355c1b62642c18d2"),
+    GitSource("https://github.com/flame/blis.git", "cad51491e8a0b306015a5a02881dc2a9b60dd8d9"),
     DirectorySource("../bundled")
 ]
 
@@ -86,10 +86,6 @@ function blis_script(;blis32::Bool=false)
 
         # Unscreen Arm SVE code for metaconfig.
         patch kernels/armsve/bli_kernels_armsve.h \
-            < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
-        patch kernels/armsve/1m/old/bli_dpackm_armsve512_int_12xk.c \
-            < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
-        patch kernels/armsve/1m/bli_dpackm_armsve256_int_8xk.c \
             < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
 
         # Screen out A64FX sector cache.

--- a/B/blis/common.jl
+++ b/B/blis/common.jl
@@ -2,11 +2,11 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-version = v"0.9.1" # Not tagged as v0.9.1, but is a v1.0.0 release candidate
+version = v"1.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/flame/blis.git", "cad51491e8a0b306015a5a02881dc2a9b60dd8d9"),
+    GitSource("https://github.com/flame/blis.git", "6d0ab74f6975fdf4d19cee06d946b09b6ca89656"),
     DirectorySource("../bundled")
 ]
 
@@ -75,22 +75,22 @@ function blis_script(;blis32::Bool=false)
     # For 64-bit builds, add _64 suffix to exported BLAS routines.
     # This corresponds to ILP64 handling of OpenBLAS thus Julia.
     if [[ ${nbits} == 64 ]] && [[ "${BLIS32}" != "true" ]]; then
-        patch frame/include/bli_macro_defs.h < ${WORKSPACE}/srcdir/patches/bli_macro_defs.h.f77suffix64.patch
-        patch frame/compat/cblas/src/cblas_f77.h < ${WORKSPACE}/srcdir/patches/cblas_f77suffix64.patch
+        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/bli_macro_defs.h.f77suffix64.patch
+        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/cblas_f77suffix64.patch
     fi
 
     # Include A64FX in Arm64 metaconfig.
     if [ ${BLI_CONFIG} = arm64 ]; then
         # Add A64FX to the registry.
-        patch config_registry < ${WORKSPACE}/srcdir/patches/config_registry.metaconfig+a64fx.patch
+        patch config_registry ${WORKSPACE}/srcdir/patches/config_registry.metaconfig+a64fx.patch
 
         # Unscreen Arm SVE code for metaconfig.
-        patch kernels/armsve/bli_kernels_armsve.h \
-            < ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
+        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_arm_sve_h.patch
+        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_armsve512_int_12xk.patch
+        atomic_patch -p1 ${WORKSPACE}/srcdir/patches/armsve_kernels_unscreen_armsve256_int_8x10.patch
 
         # Screen out A64FX sector cache.
-        patch config/a64fx/bli_cntx_init_a64fx.c \
-            < ${WORKSPACE}/srcdir/patches/a64fx_config_screen_sector_cache.patch
+        patch config/a64fx/bli_cntx_init_a64fx.c ${WORKSPACE}/srcdir/patches/a64fx_config_screen_sector_cache.patch
     fi
 
     # Import libblastrampoline-style nthreads setter.


### PR DESCRIPTION
Update BLIS library using `master` branch, but simultaneous with release point of version 1.0.0: https://github.com/flame/blis/releases/tag/1.0

As part of the update process, updated/omitted some of the more outdated patches.

Tested locally on `x86_64-apple-darwin` against Julia LinearAlgebra `blas` tests.