### PR TITLE
[Cairo] Rebuild fixing compat with Pixman

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,7 @@ steps:
     if: build.message !~ /\[skip tests\]/
     timeout_in_minutes: 20
     env:
-      JULIA_PKG_SERVER: pkg.julia.csail.mit.edu
+      JULIA_PKG_SERVER: us-east.pkg.julialang.org
       # Use eager registry to not have to wait for updates of the conservative registry
       JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       # Forward JOB_ID_SECRET

--- a/.buildkite/pipeline.yml.signature
+++ b/.buildkite/pipeline.yml.signature
@@ -1,1 +1,2 @@
-Salted__rãlip`·;Ž"S º¸ÛÓ9—½ÎÉwòt…€t	š¢‘{íQQ’²ê˜WpnE8ƒIÊŸV“k[™Ö­î„pŠ>’ù#>£>P[«¼C|NÊ(›» 
+Salted__€ïQz
+‡È]­”ÅÕÅ  £'²ÙÇºO¿gÐ&Áq•4yÞE“áTÊe«x|¢‹›VÜáp·cwjI2­©é²@¸4­{s7Ø0®®l`†ªÑÎŒ}

--- a/.buildkite/utils.jl
+++ b/.buildkite/utils.jl
@@ -39,7 +39,7 @@ plugins() = Pair{String, Union{Nothing, Dict}}[
 ]
 
 env(NAME, PROJECT) = Dict(
-    "JULIA_PKG_SERVER" => "pkg.julia.csail.mit.edu",
+    "JULIA_PKG_SERVER" => "us-east.pkg.julialang.org",
     "JULIA_PKG_SERVER_REGISTRY_PREFERENCE" => "eager",
     "NAME" => NAME,
     "PROJECT" => PROJECT,

--- a/C/Cairo/build_tarballs.jl
+++ b/C/Cairo/build_tarballs.jl
@@ -71,7 +71,7 @@ linux_freebsd = filter(p->Sys.islinux(p)||Sys.isfreebsd(p), platforms)
 dependencies = [
     BuildDependency("Xorg_xorgproto_jll"; platforms=linux_freebsd),
     Dependency("Glib_jll"),
-    Dependency("Pixman_jll"),
+    Dependency("Pixman_jll"; compat="0.43.4"),
     Dependency("libpng_jll"),
     Dependency("Fontconfig_jll"),
     Dependency("FreeType2_jll"; compat="2.13.1"),


### PR DESCRIPTION
Once again, changing the build system of a package (Pixman, #8654) had the side effect of changing randomly the compatibility version number ast in the macOS libraries, which is relevant on macOS < 12.  Same as #8665 and #8497.