### PR TITLE
LLVM: Bump JLLs for LLVM 17 to include additional patch.

### DIFF
--- a/L/LLVM/LLVM_full@17/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@17/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.12")
-# Build trigger: 5
+# Build trigger: 6

--- a/L/LLVM/LLVM_full_assert@17/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@17/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.12")
-# Build trigger: 5
+# Build trigger: 6

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -17,7 +17,7 @@ const llvm_tags = Dict(
     v"14.0.6" => "5c82f5309b10fab0adf6a94969e0dddffdb3dbce", # julia-14.0.6-3
     v"15.0.7" => "2593167b92dd2d27849e8bc331db2072a9b4bd7f", # julia-15.0.7-10
     v"16.0.6" => "499f87882a4ba1837ec12a280478cf4cb0d2753d", # julia-16.0.6-2
-    v"17.0.6" => "0424864b3ac348210aab171668eea1a669956a31", # julia-17.0.6-3
+    v"17.0.6" => "d01c08cf0a22ea586aa427cf30b9049f236187da", # julia-17.0.6-4
 )
 
 const buildscript = raw"""


### PR DESCRIPTION
Specifically, https://github.com/llvm/llvm-project/pull/92383, which is needed for GPU back-ends on LLVM 17.

cc @gbaraldi @vchuravy 