### PR TITLE
MAGEMin v1.4.5

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.4.4"
+version = v"1.4.5"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "7e7e2e85d438ef54dcb2d71169782053880efe57")                 ]
+                    "26f7fdbb81c7b7ba3359c56ec8bbc06d4dc4e428")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- added the option to use aH2O, aO2, aTiO2, aMgO, aFeO and aAl2O3 as buffers
- corrected normalization when hitting liquidus
