### PR TITLE
OpenImageIO: Tighten OpenEXR compat bounds

### DIFF
--- a/O/OpenImageIO/build_tarballs.jl
+++ b/O/OpenImageIO/build_tarballs.jl
@@ -50,7 +50,7 @@ dependencies = [
     Dependency("Giflib_jll"; compat="5.2.1"),
     Dependency("JpegTurbo_jll"; compat="3.0.1"),
     Dependency("Libtiff_jll"; compat="4.5.1"),
-    Dependency("OpenEXR_jll"; compat="3.1.4"),
+    Dependency("OpenEXR_jll"; compat="~3.2.4"),
     Dependency("OpenJpeg_jll"; compat="2.5.0"),
     Dependency("Zlib_jll"; compat="1.2.12"),
     Dependency("boost_jll"; compat="=1.76.0"),


### PR DESCRIPTION
Note that `OpenImageIO_jll` did not make it into the registry yet https://github.com/JuliaRegistries/General/pull/107018.