### PR TITLE
LLVM: Rebuild remaining deps for consistent version numbering.

### DIFF
--- a/L/LLVM/Clang@17/build_tarballs.jl
+++ b/L/LLVM/Clang@17/build_tarballs.jl
@@ -1,6 +1,6 @@
 name = "Clang"
-llvm_full_version = v"17.0.6+3"
-libllvm_version = v"17.0.6+3"
+llvm_full_version = v"17.0.6+4"
+libllvm_version = v"17.0.6+4"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms

--- a/L/LLVM/LLD@17/build_tarballs.jl
+++ b/L/LLVM/LLD@17/build_tarballs.jl
@@ -1,6 +1,6 @@
 name = "LLD"
-llvm_full_version = v"17.0.6+3"
-libllvm_version = v"17.0.6+3"
+llvm_full_version = v"17.0.6+4"
+libllvm_version = v"17.0.6+4"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms

--- a/L/LLVM/LLVM@17/build_tarballs.jl
+++ b/L/LLVM/LLVM@17/build_tarballs.jl
@@ -1,6 +1,6 @@
 name = "LLVM"
-llvm_full_version = v"17.0.6+3"
-libllvm_version = v"17.0.6+3"
+llvm_full_version = v"17.0.6+4"
+libllvm_version = v"17.0.6+4"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms

--- a/L/LLVM/MLIR@17/build_tarballs.jl
+++ b/L/LLVM/MLIR@17/build_tarballs.jl
@@ -1,6 +1,6 @@
 name = "MLIR"
-llvm_full_version = v"17.0.6+3"
-libllvm_version = v"17.0.6+3"
+llvm_full_version = v"17.0.6+4"
+libllvm_version = v"17.0.6+4"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms


### PR DESCRIPTION
As suggested by @giordano and @gbaraldi, rebuild the remaining LLVM deps after a recent patch bump to ensure consistent version numbering.