### PR TITLE
CUDA: Put NVRTC back in the runtime.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_11.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.4.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2021.2.2"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_114"], :libnvrtc_builtins),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.5.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2021.3.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_115"], :libnvrtc_builtins),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.6.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.1.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_116"], :libnvrtc_builtins),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.7.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.7.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.2.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_117"], :libnvrtc_builtins),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_11.8.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.8.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.3.0"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_118"], :libnvrtc_builtins),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_12.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.0.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2022.4.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_120"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),

--- a/C/CUDA/CUDA_Runtime/build_12.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.1.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2023.1.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_121"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),

--- a/C/CUDA/CUDA_Runtime/build_12.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.2.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2023.2.2"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_122"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),

--- a/C/CUDA/CUDA_Runtime/build_12.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.3.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2023.3.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_123"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),

--- a/C/CUDA/CUDA_Runtime/build_12.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.4.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2024.1.1"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_124"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),

--- a/C/CUDA/CUDA_Runtime/build_12.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.5.jl
@@ -11,6 +11,8 @@ function get_products(platform)
         LibraryProduct(["libcupti", "cupti64_2024.2.0"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_125"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -43,6 +43,9 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv cuda_nvcc/bin/nvlink ${bindir}
     mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
 
+    mv cuda_nvrtc/lib/libnvrtc.so* ${libdir}
+    mv cuda_nvrtc/lib/libnvrtc-builtins.so* ${libdir}
+
     mv cuda_nvdisasm/bin/nvdisasm ${bindir}
 
     if [[ -d libnvjitlink ]]; then
@@ -81,6 +84,9 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv cuda_nvcc/bin/ptxas.exe ${bindir}
     mv cuda_nvcc/bin/nvlink.exe ${bindir}
     mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    mv cuda_nvrtc/bin/nvrtc64_* ${bindir}
+    mv cuda_nvrtc/bin/nvrtc-builtins64_* ${bindir}
 
     mv cuda_nvdisasm/bin/nvdisasm.exe ${bindir}
 


### PR DESCRIPTION
Apparently some CUDA toolkit libraries use it, so we need to make sure we've loaded the library to prevent system pollution.