### PR TITLE
Automated update of aws_checksums to version 0.1.18

### DIFF
--- a/A/aws_checksums/build_tarballs.jl
+++ b/A/aws_checksums/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "aws_checksums"
-version = v"0.1.17"
+version = v"0.1.18"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/awslabs/aws-checksums.git",
-              "321b805559c8e911be5bddba13fcbd222a3e2d3a"),
+              "aac442a2dbbb5e72d0a3eca8313cf65e7e1cac2f"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_checksums to version 0.1.18. cc: @quinnj @Octogonapus