### PR TITLE
CMake: Add support for libblastrampoline

### DIFF
--- a/C/CMake/build_tarballs.jl
+++ b/C/CMake/build_tarballs.jl
@@ -8,13 +8,22 @@ version = v"3.29.3"
 # Collection of sources required to build CMake
 sources = [
     GitSource("https://github.com/Kitware/CMake", "b39fb31bf411c3925bd937f8cffbc471c2588c34"),
+    DirectorySource("bundled/"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd ${WORKSPACE}/srcdir/CMake
 
-cmake \
+# Add support for libblastrampoline to the FindBLAS/FindLAPACK modules
+# Upstream PR https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9557
+# It will be included in 3.30
+atomic_patch -p1 $WORKSPACE/srcdir/patches/01_libblastrampoline.patch
+
+mkdir build
+cd build/
+
+cmake -B . -S .. \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_BUILD_TYPE:STRING=Release \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/C/CMake/bundled/patches/01_libblastrampoline.patch
+++ b/C/CMake/bundled/patches/01_libblastrampoline.patch
@@ -1,0 +1,82 @@
+From 7ab02cdd05efb35539b40f58821d415165d8620f Mon Sep 17 00:00:00 2001
+From: Ian McInerney <i.mcinerney17@imperial.ac.uk>
+Date: Wed, 29 May 2024 11:19:01 +0100
+Subject: [PATCH] Add libblastrampoline support to FindBLAS/FindLAPACK
+
+libblastrampoline is a BLAS/LAPACK demuxing layer to allow selecting a
+BLAS/LAPACK library at runtime.
+---
+ Modules/FindBLAS.cmake   | 30 ++++++++++++++++++++++++++++++
+ Modules/FindLAPACK.cmake |  8 ++++++++
+ 2 files changed, 38 insertions(+)
+
+diff --git a/Modules/FindBLAS.cmake b/Modules/FindBLAS.cmake
+index e9b118f243..2fc01d0c79 100644
+--- a/Modules/FindBLAS.cmake
++++ b/Modules/FindBLAS.cmake
+@@ -164,6 +164,11 @@ BLAS/LAPACK Vendors
+ 
+   Intel MKL v10+ 64 bit, single dynamic library
+ 
++``libblastrampoline``
++  .. versionadded:: 3.30
++
++  A BLAS/LAPACK demuxing library using PLT trampolines
++
+ ``NVHPC``
+   .. versionadded:: 3.21
+ 
+@@ -1352,6 +1357,31 @@ if(BLA_VENDOR STREQUAL "NVHPC" OR BLA_VENDOR STREQUAL "All")
+   unset(_blas_nvhpc_lib)
+ endif()
+ 
++# libblastrampoline? (https://github.com/JuliaLinearAlgebra/libblastrampoline/tree/main)
++if(BLA_VENDOR STREQUAL "libblastrampoline" OR BLA_VENDOR STREQUAL "All")
++  set(_blas_libblastrampoline_lib "blastrampoline")
++
++  if(WIN32)
++    # Windows appends the version number to the library
++    string(APPEND _blas_libblastrampoline_lib "-5")
++  endif()
++
++  if(NOT BLAS_LIBRARIES)
++    check_blas_libraries(
++      BLAS_LIBRARIES
++      BLAS
++      sgemm
++      ""
++      "${_blas_libblastrampoline_lib}"
++      ""
++      ""
++      ""
++      )
++  endif()
++
++  unset(_blas_libblastrampoline_lib)
++endif()
++
+ # Generic BLAS library?
+ if(BLA_VENDOR STREQUAL "Generic" OR
+    BLA_VENDOR STREQUAL "All")
+diff --git a/Modules/FindLAPACK.cmake b/Modules/FindLAPACK.cmake
+index e142516cf2..bbf25b68b6 100644
+--- a/Modules/FindLAPACK.cmake
++++ b/Modules/FindLAPACK.cmake
+@@ -742,6 +742,14 @@ if(NOT LAPACK_NOT_FOUND_MESSAGE)
+     unset(_lapack_nvhpc_flags)
+   endif()
+ 
++  # libblastrampoline? (https://github.com/JuliaLinearAlgebra/libblastrampoline/tree/main)
++  if(NOT LAPACK_LIBRARIES
++      AND (BLA_VENDOR STREQUAL "libblastrampoline" OR BLA_VENDOR STREQUAL "All"))
++    if(BLAS_LIBRARIES MATCHES "blastrampoline.+")
++      set(LAPACK_LIBRARIES ${BLAS_LIBRARIES})
++    endif()
++  endif()
++
+   # Generic LAPACK library?
+   if(NOT LAPACK_LIBRARIES
+       AND (BLA_VENDOR STREQUAL "Generic"
+-- 
+2.45.0
+


### PR DESCRIPTION
This backports an upstream patch from https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9557 that adds libblastrampoline to the Find{BLAS,LAPACK} modules to allow packages to now say BLA_VENDOR="libblastrampoline" to properly build against libblastrampoline.

This patch will be included in 3.30, but it applies cleanly to 3.29 as well, so lets use it.