### PR TITLE
MAGEMin 1.4.6

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.4.5"
+version = v"1.4.6"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "26f7fdbb81c7b7ba3359c56ec8bbc06d4dc4e428")                 ]
+                    "33333991fb19a63922401b9b97702043e9bc3a9c")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- corrected volume fraction nomalization mistake when buffer are used
- set buffer fraction = 0 and renormalize outputed phase fractions accordingly
- added site fraction names for out_matlab option and for the julia wrapper
