### PR TITLE
MAGEMin v1.4.8

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.4.7"
+version = v"1.4.8"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "631e24861bab4913bb6c020d3e2c5213f229d665")                 ]
+                    "0c96d794aa2db79c2f77167b5e17b469bda3bb5c")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- fully corrects the problem affecting MAGEMin_jll due to discrepancies between number of site fractions and array of site mixing names

Because I cannot reproduce the issue locally (only appears with released MAGEMin_jll) it was tricky to locate all possible places where the segfault could appear.  The segfault happens in another place in version 1.4.7 (with respect to v1.4.6). This allowed me to find the pattern and fully fix the problem in this version.
