### PR TITLE
[aws_c_common] Update to version 0.9.21

### DIFF
--- a/A/aws_c_common/build_tarballs.jl
+++ b/A/aws_c_common/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_common"
-version = v"0.9.20"
+version = v"0.9.21"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-common.git", "06cf4d82adad52723305dc2aeb06bb6439b5df7f"),
+    GitSource("https://github.com/awslabs/aws-c-common.git", "4f874cea50a70bc6ebcd85c6ce1c6c0016b5aff4"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_c_common to version 0.9.21. cc: @quinnj @Octogonapus