### PR TITLE
LLVM: Bump downgrader JLL

### DIFF
--- a/L/LLVMDowngrader/build_tarballs.jl
+++ b/L/LLVMDowngrader/build_tarballs.jl
@@ -15,8 +15,8 @@ llvm_versions = [v"13.0.1", v"14.0.6", v"15.0.7", v"16.0.6", v"17.0.6"]
 sources = Dict(
     v"13.0.1" => [GitSource(repo, "5538d5106dd4779c9aa475a78cfbe9f70053f44c")],
     v"14.0.6" => [GitSource(repo, "07810b82a167176a9e81f59435a6ac551dfd52e9")],
-    v"15.0.7" => [GitSource(repo, "c3d9214a27a6be9e91d4a94bf3ef065fc824a684")],
-    v"16.0.6" => [GitSource(repo, "8cd16f6e88cd5b253e841d4646421f0830b0f9a3")],
+    v"15.0.7" => [GitSource(repo, "cbfa9715397a7707b6c1ff94ab325af1fab99220")],
+    v"16.0.6" => [GitSource(repo, "c74dc63cd74b1e92919d8f9df1ce7897a9db4e7f")],
     v"17.0.6" => [GitSource(repo, "c09ff8ef76ddc5adb4169a12e3e5ceb1b1a23df5")],
 )
 


### PR DESCRIPTION
There were bugs, of course: https://github.com/JuliaGPU/llvm-downgrade/commit/cbfa9715397a7707b6c1ff94ab325af1fab99220