### PR TITLE
[LAPACK] Regenerate the libaries with updated symbols

### DIFF
--- a/L/LAPACK/LAPACK/build_tarballs.jl
+++ b/L/LAPACK/LAPACK/build_tarballs.jl
@@ -16,4 +16,4 @@ filter!(p -> !(arch(p) == "aarch64" && Sys.islinux(p) && libgfortran_version(p) 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                clang_use_lld=false, julia_compat="1.9", preferred_gcc_version=v"6")
 
-# Build Trigger: 2
+# Build Trigger: 3


### PR DESCRIPTION
LAPACK was not compiled with the last commit of #8865.
The cached artifacts were used.