### PR TITLE
SHTns: Upgrade to v3.6.6

### DIFF
--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/shtns/
+cd $WORKSPACE/srcdir/shtns*/
 export CFLAGS="-fPIC -O3" #only -fPIC produces slow code on linux x86 and MacOS x86 (maybe others)
 
 #remove lfftw3_omp library references, as FFTW_jll does not provide it

--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -5,13 +5,12 @@ using BinaryBuilder, Pkg
 include(joinpath(@__DIR__, "..", "..", "platforms", "microarchitectures.jl"))
 
 name = "SHTns"
-version = v"3.6.6"
-sha256sum = "f060757ed6914c837cc2b251d370078e4c92b6894fef7aac189a9a1f5f1521a2"
-url = "https://gricad-gitlab.univ-grenoble-alpes.fr/schaeffn/shtns/-/archive/v3.6.6/shtns-v$(version).tar.gz"
+version = v"3.6.5"
 
-# Collection of sources required to complete build
+# Collection of sources required to complete build (use `sha256sum` to generate the checksum from tarball) 
 sources = [
-    ArchiveSource(url, sha256sum)
+    ArchiveSource("https://gricad-gitlab.univ-grenoble-alpes.fr/schaeffn/shtns/-/archive/v$(version)/shtns-v$(version).tar.gz",
+                  "54ff487df9cf6d682150109746dd621e205b7b360d291b9fbb24d51627256dc9")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -5,11 +5,12 @@ using BinaryBuilder, Pkg
 include(joinpath(@__DIR__, "..", "..", "platforms", "microarchitectures.jl"))
 
 name = "SHTns"
-version = v"3.5.2"
+version = v"3.6.1"
+sha256sum = "6609041baa2faa4199b1b09892748ffc0e5ee04d0c89fc17c34dc1c1e9193d41"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://bitbucket.org/nschaeff/shtns/downloads/shtns-$(version).tar.gz", "dc4ac08c09980e47c71d79d38696c5d1d631f86c2af1ce8aad5d21f7fd2c05b9")
+    ArchiveSource("https://bitbucket.org/nschaeff/shtns/downloads/shtns-$(version).tar.gz", sha256sum)
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -5,12 +5,12 @@ using BinaryBuilder, Pkg
 include(joinpath(@__DIR__, "..", "..", "platforms", "microarchitectures.jl"))
 
 name = "SHTns"
-version = v"3.6.5"
+version = v"3.6.6"
 
-# Collection of sources required to complete build (use `sha256sum` to generate the checksum from tarball) 
+# Collection of sources required to complete build (note to self: use `sha256sum` to generate the checksum from tarball) 
 sources = [
     ArchiveSource("https://gricad-gitlab.univ-grenoble-alpes.fr/schaeffn/shtns/-/archive/v$(version)/shtns-v$(version).tar.gz",
-                  "54ff487df9cf6d682150109746dd621e205b7b360d291b9fbb24d51627256dc9")
+                  "f060757ed6914c837cc2b251d370078e4c92b6894fef7aac189a9a1f5f1521a2")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SHTns/build_tarballs.jl
+++ b/S/SHTns/build_tarballs.jl
@@ -5,12 +5,13 @@ using BinaryBuilder, Pkg
 include(joinpath(@__DIR__, "..", "..", "platforms", "microarchitectures.jl"))
 
 name = "SHTns"
-version = v"3.6.1"
-sha256sum = "6609041baa2faa4199b1b09892748ffc0e5ee04d0c89fc17c34dc1c1e9193d41"
+version = v"3.6.6"
+sha256sum = "f060757ed6914c837cc2b251d370078e4c92b6894fef7aac189a9a1f5f1521a2"
+url = "https://gricad-gitlab.univ-grenoble-alpes.fr/schaeffn/shtns/-/archive/v3.6.6/shtns-v$(version).tar.gz"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://bitbucket.org/nschaeff/shtns/downloads/shtns-$(version).tar.gz", sha256sum)
+    ArchiveSource(url, sha256sum)
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
The current version (3.5.3) of SHTns_jll does not have batched transforms, introduced in v3.6.