### PR TITLE
[aws_lc] Update to version 1.29.0

### DIFF
--- a/A/aws_lc/build_tarballs.jl
+++ b/A/aws_lc/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_lc"
-version = v"1.28.0"
+version = v"1.29.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-lc.git", "92bf53276029a71f01303e5adb1c5dbc379f1150"),
+    GitSource("https://github.com/awslabs/aws-lc.git", "4e54dd8363396f257d7a2317c48101e18170e6fb"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
This PR updates aws_lc to version 1.29.0. cc: @quinnj @Octogonapus