### PR TITLE
[LBT] Bump to v5.10.1

### DIFF
--- a/L/libblastrampoline/build_tarballs.jl
+++ b/L/libblastrampoline/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder, Pkg
 using BinaryBuilderBase: sanitize
 
 name = "libblastrampoline"
-version = v"5.10.0"
+version = v"5.10.1"
 
 # Collection of sources required to build libblastrampoline
 sources = [
     GitSource("https://github.com/JuliaLinearAlgebra/libblastrampoline.git",
-              "77227d280e5937a945ae86ec32cc300699d4b213"),
+              "ff05ebb4e450deda0aebe8dce4d4f054e23fecfc"),
     DirectorySource("./bundled/")
 ]
 


### PR DESCRIPTION
The previous release had a bug with the `LBT_USE_RTLD_DEEPBIND` environment variable