### PR TITLE
pandoc-crossref 0.3.17.1a

### DIFF
--- a/P/pandoc_crossref/build_tarballs.jl
+++ b/P/pandoc_crossref/build_tarballs.jl
@@ -1,10 +1,12 @@
 using BinaryBuilder
+using Pkg: PackageSpec
 
 # Collection of pre-build pandoc binaries
 name = "pandoc_crossref"
 
 crossref_ver = "0.3.17.1a"
-version = v"0.3.18"
+panddoc_jll_version = v"3.2.0"
+version = v"0.3.17"
 
 url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v$(crossref_ver)/pandoc-crossref"
 sources = [
@@ -45,6 +47,14 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     HostBuildDependency("p7zip_jll"),
+
+    # Each `pandoc-crossref` release is built with a specific pandoc version and using
+    # another version can be problematic. In order to avoid compatibility issues we specify
+    # the exact version which `pandoc-crossref` was built with.
+    #
+    # TODO: Should actually be a `RuntimeDependency`:
+    # https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/1330
+    Dependency(PackageSpec(name="pandoc_jll"), compat="=$panddoc_jll_version"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/P/pandoc_crossref/build_tarballs.jl
+++ b/P/pandoc_crossref/build_tarballs.jl
@@ -3,15 +3,15 @@ using BinaryBuilder
 # Collection of pre-build pandoc binaries
 name = "pandoc_crossref"
 
-crossref_ver = "0.3.17.0"
-version = v"0.3.17"
+crossref_ver = "0.3.17.1a"
+version = v"0.3.17-1a"
 
 url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v$(crossref_ver)/pandoc-crossref"
 sources = [
-    ArchiveSource("$(url_prefix)-Linux.tar.xz", "15a49a07ac99696d58cf36fe717810d71172311b6f0ddff63a991b4402f3ebcd"; unpack_target = "x86_64-linux-gnu"),
-    ArchiveSource("$(url_prefix)-macOS.tar.xz", "d8629ac747709869342fce00e56b56eca06b7d6a17541cf9a026530874a9fffe"; unpack_target = "x86_64-apple-darwin14"),
-    ArchiveSource("$(url_prefix)-macOS.tar.xz", "d8629ac747709869342fce00e56b56eca06b7d6a17541cf9a026530874a9fffe"; unpack_target = "aarch64-apple-darwin20"),
-    FileSource("$(url_prefix)-Windows.7z", "4fa210feb55265f87e255c8c176caa8de906dad224c9d3cd482609c6070d8e5c"; filename = "x86_64-w64-mingw32"),
+    ArchiveSource("$(url_prefix)-Linux.tar.xz", "0eb261d03929921224c26feec96335f814065b84760ca0ecafe8a2f2d5794d4b"; unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$(url_prefix)-macOS.tar.xz", "f2dc7dd5af6b6270c0fbc0814f2f46f40aa015a761472aa1225d02abb34e4427"; unpack_target = "x86_64-apple-darwin14"),
+    ArchiveSource("$(url_prefix)-macOS.tar.xz", "f2dc7dd5af6b6270c0fbc0814f2f46f40aa015a761472aa1225d02abb34e4427"; unpack_target = "aarch64-apple-darwin20"),
+    FileSource("$(url_prefix)-Windows.7z", "4990bcb174165a3e32383f0833f0e32179442fb71e056593c2a8f96ceddd6f93"; filename = "x86_64-w64-mingw32"),
     FileSource("https://raw.githubusercontent.com/lierdakil/pandoc-crossref/v$(crossref_ver)/LICENSE", "39db8f9acf036595a2566ea3fe560bc7bd65d8749f088e0f4a4ef2f8a6cb4b34"),
 ]
 

--- a/P/pandoc_crossref/build_tarballs.jl
+++ b/P/pandoc_crossref/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder
 name = "pandoc_crossref"
 
 crossref_ver = "0.3.17.1a"
-version = v"0.3.17-1a"
+version = v"0.3.18"
 
 url_prefix = "https://github.com/lierdakil/pandoc-crossref/releases/download/v$(crossref_ver)/pandoc-crossref"
 sources = [


### PR DESCRIPTION
@giordano should I just bump the version to 0.3.18? That doesn't seem quite right because it's still pandoc-crossref 0.3.17, but the build number is important to distinguish which version of pandoc it was compiled against (and that's why 0.3.17 already exists as a JLL -- it was compiled against an older version of pandoc)