### PR TITLE
[LibSSH2] Re-build to lock compatibility with OpenSSL v3.0.14+

### DIFF
--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -3,12 +3,13 @@ using Pkg
 using BinaryBuilderBase: sanitize
 
 name = "LibSSH2"
+# This is a lie, we actually build 1.11.0, but we needed to bump the patch version to change our compat below
 version = v"1.11.1"
 
 # Collection of sources required to build LibSSH2
 sources = [
     DirectorySource("./bundled"),
-    ArchiveSource("https://github.com/libssh2/libssh2/releases/download/libssh2-$(version)/libssh2-$(version).tar.gz",
+    ArchiveSource("https://github.com/libssh2/libssh2/releases/download/libssh2-1.11.0/libssh2-1.11.0.tar.gz",
                   "3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461"),
 ]
 

--- a/L/LibSSH2/build_tarballs.jl
+++ b/L/LibSSH2/build_tarballs.jl
@@ -3,7 +3,7 @@ using Pkg
 using BinaryBuilderBase: sanitize
 
 name = "LibSSH2"
-version = v"1.11.0"
+version = v"1.11.1"
 
 # Collection of sources required to build LibSSH2
 sources = [
@@ -63,7 +63,7 @@ llvm_version = v"13.0.1"
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("OpenSSL_jll"; compat="3.0.8", platforms=filter(!Sys.iswindows, platforms)),
+    Dependency("OpenSSL_jll"; compat="3.0.14", platforms=filter(!Sys.iswindows, platforms)),
     BuildDependency(PackageSpec(name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=llvm_version);
                     platforms=filter(p -> sanitize(p)=="memory", platforms)),
 ]


### PR DESCRIPTION
In https://github.com/JuliaPackaging/Yggdrasil/pull/8393 we changed the layout of OpenSSL to put libraries in `${prefix}/lib` rather than `${prefix}/lib64`.  While this doesn't effect Julia much, if one uses a tool such a `JLLPrefixes` to plop a bunch of JLL's artifacts in a single prefix and then try to use the binaries directly, the RPATHs no longer work.  This rebuild will create a new version of LibSSH2 that will work with the new OpenSSL binaries.