### PR TITLE
SPIRV Tools: fix typo in build recipe.

### DIFF
--- a/S/SPIRV_Tools/build_tarballs.jl
+++ b/S/SPIRV_Tools/build_tarballs.jl
@@ -63,7 +63,7 @@ products = [
     ExecutableProduct("spirv-opt", :spirv_opt),
     ExecutableProduct("spirv-cfg", :spirv_cfg),
     ExecutableProduct("spirv-link", :spirv_link),
-    ExecutableProduct("spirv-lint", :spirv_link),
+    ExecutableProduct("spirv-lint", :spirv_lint),
     ExecutableProduct("spirv-reduce", :spirv_reduce),
     LibraryProduct("libSPIRV-Tools-shared", :libSPIRV_Tools),
 ]


### PR DESCRIPTION
This broke precompilation (and thus registration) of the generated JLL:

```
┌ Warning: Replacing docs for `SPIRV_Tools_jll.spirv_link :: Tuple{Function}` in module `SPIRV_Tools_jll`
└ @ Base.Docs docs/Docs.jl:243
ERROR: LoadError: cannot set type for global SPIRV_Tools_jll.spirv_link_path. It already has a value or is already set to a different type.
```

Maybe something that should be caught by the auditor?