### PR TITLE
[aws_c_common] Update to version 0.9.23

### DIFF
--- a/A/aws_c_common/build_tarballs.jl
+++ b/A/aws_c_common/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_common"
-version = v"0.9.22"
+version = v"0.9.23"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-common.git", "0cb24e1c7e02f56cab43ffb6636cd58fd771fc55"),
+    GitSource("https://github.com/awslabs/aws-c-common.git", "6d974f92c1d86391c1dcb1173239adf757c52b2d"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_c_common to version 0.9.23. cc: @quinnj @Octogonapus