### PR TITLE
[finufft] Set Cmake build type to Release

### DIFF
--- a/F/finufft/build_tarballs.jl
+++ b/F/finufft/build_tarballs.jl
@@ -22,10 +22,12 @@ cd $WORKSPACE/srcdir/finufft*/
 
 mkdir build && cd build
 cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH="${prefix}" \
     -DCMAKE_INSTALL_PREFIX="${prefix}" \
     -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
-    -DFINUFFT_FFTW_SUFFIX=""
+    -DFINUFFT_FFTW_SUFFIX="" \
+    -DFINUFFT_ARCH_FLAGS=""
 cmake --build . --parallel $nproc
 cmake --install .
 """


### PR DESCRIPTION
This fixes a performance problem created after the switch to Cmake building: The build type was not set to Release, thereby missing -O3 optimizations.
