### PR TITLE
Revert to the older version of VMEC due to bug

### DIFF
--- a/V/VMEC/build_tarballs.jl
+++ b/V/VMEC/build_tarballs.jl
@@ -4,11 +4,12 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "VMEC"
-upstream_version = v"1.3.1"
+upstream_version = v"1.2.0"
+jll_version = v"1.3.1"
 version_patch_offset = 0
-version = VersionNumber(upstream_version.major,
-                        upstream_version.minor,
-                        upstream_version.patch * 100 + version_patch_offset)
+version = VersionNumber(jll_version.major,
+                        jll_version.minor,
+                        jll_version.patch * 100 + version_patch_offset)
 
 sources = [
     ArchiveSource("https://gitlab.com/wistell/VMEC2000/-/archive/v$(upstream_version).tar",

--- a/V/VMEC/build_tarballs.jl
+++ b/V/VMEC/build_tarballs.jl
@@ -4,7 +4,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "VMEC"
-upstream_version = v"1.3.0"
+upstream_version = v"1.3.1"
 version_patch_offset = 0
 version = VersionNumber(upstream_version.major,
                         upstream_version.minor,
@@ -12,7 +12,7 @@ version = VersionNumber(upstream_version.major,
 
 sources = [
     ArchiveSource("https://gitlab.com/wistell/VMEC2000/-/archive/v$(upstream_version).tar",
-                  "4c13c0312a6b4061357be35122ac507b0a25c2d5cd0dd03dd1b9e31818318528"),
+                  "58a99cd0e7b4add481124e75ed7b8ccd5452e83b07230aefe4c4334de020b1cf"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
Need to revert to an older version of the underlying VMEC due to a bug introduced in the latest version that requires a much larger fix.