### PR TITLE
[GoogleCodeSearch] bump julia_compat so it can build

### DIFF
--- a/G/GoogleCodeSearch/build_tarballs.jl
+++ b/G/GoogleCodeSearch/build_tarballs.jl
@@ -38,4 +38,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers = [:go, :c])
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers = [:go, :c], julia_compat="1.6")


### PR DESCRIPTION
This was required so the build of GoogleCodeSearch can continue on julia 1.6. There weren't any issues with julia 1.6 and building this.

This should wait to be merged until after https://github.com/JuliaPackaging/Yggdrasil/pull/8959
