### PR TITLE
[openfhe_julia] update to version v0.3.3

### DIFF
--- a/O/openfhe_julia/build_tarballs.jl
+++ b/O/openfhe_julia/build_tarballs.jl
@@ -8,12 +8,12 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "openfhe_julia"
-version = v"0.3.2"
+version = v"0.3.3"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/hpsc-lab/openfhe-julia.git",
-              "f5c3e83bb2e2b44b37f80423552e9db7069dd15d"),
+              "bf374dd537fdd9cd39e71c50ae959d4340345e07"),
 ]
 
 # Bash recipe for building across all platforms
@@ -79,7 +79,7 @@ products = [
 dependencies = [
     BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.9")),
     Dependency(PackageSpec(name="libcxxwrap_julia_jll", uuid="3eaa8342-bff7-56a5-9981-c04077f7cee7"); compat="0.13.0"),
-    Dependency(PackageSpec(name="OpenFHE_jll", uuid="a2687184-f17b-54bc-b2bb-b849352af807")),
+    Dependency(PackageSpec(name="OpenFHE_jll", uuid="a2687184-f17b-54bc-b2bb-b849352af807"); compat="1.2.0"),
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");


### PR DESCRIPTION
I updated openfhe-julia and set compat settings for OpenFHE_jll to v1.2.0, because in https://github.com/hpsc-lab/openfhe-julia/commit/bf374dd537fdd9cd39e71c50ae959d4340345e07, I had to change some names for compatibility with newest OpenFHE v1.2.0