### PR TITLE
[open62541] specify desired gcc version; fixes segfaults on Windows + Linux.

### DIFF
--- a/O/open62541/open62541@1.3/build_tarballs.jl
+++ b/O/open62541/open62541@1.3/build_tarballs.jl
@@ -11,6 +11,14 @@ sources = [
 ]
 # Bash recipe for building across all platforms
 script = raw"""
+# Deactivates stack protector under i686-linux-musl; necessary to avoid 
+# "undefined reference to `__stack_chk_fail_local`
+if [[ ${target} == i686-linux-musl ]]; then 
+    extraflags="-DUA_ENABLE_HARDENING=OFF" 
+else
+    extraflags=""
+fi 
+
 cd $WORKSPACE/srcdir/open62541/
 mkdir build && cd build/
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
@@ -25,6 +33,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DUA_ENABLE_HISTORIZING=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DUA_FORCE_WERROR=OFF \
+    ${extraflags} \
     ..
 make -j${nproc}
 make install

--- a/O/open62541/open62541@1.3/build_tarballs.jl
+++ b/O/open62541/open62541@1.3/build_tarballs.jl
@@ -41,4 +41,4 @@ products = [
 dependencies = Dependency[
 ]
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"7")

--- a/O/open62541/open62541@1.4/build_tarballs.jl
+++ b/O/open62541/open62541@1.4/build_tarballs.jl
@@ -19,6 +19,14 @@ if [[ ${target} == x86_64-*-mingw* ]]; then
     export OPENSSL_ROOT_DIR=${prefix}/lib64 
 fi 
 
+# Deactivates stack protector under i686-linux-musl; necessary to avoid 
+# "undefined reference to `__stack_chk_fail_local`
+if [[ ${target} == i686-linux-musl ]]; then 
+    extraflags="-DUA_ENABLE_HARDENING=OFF" 
+else
+    extraflags=""
+fi 
+
 cd $WORKSPACE/srcdir/open62541/
 if [[ "${target}" == *-freebsd* ]]; then
     # https://github.com/open62541/open62541/issues/6414
@@ -38,6 +46,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DUA_ENABLE_HISTORIZING=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DUA_FORCE_WERROR=OFF \
+    ${extraflags} \
     ..
 make -j${nproc}
 make install

--- a/O/open62541/open62541@1.4/build_tarballs.jl
+++ b/O/open62541/open62541@1.4/build_tarballs.jl
@@ -59,4 +59,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"7")


### PR DESCRIPTION
Increases gcc version. When compiling with v4, v5, or v6, the library produced is not usable, due to segfaults occurring on Windows (with basic functionality). Building with v7 and above makes tests within Open62541.jl pass.

Issue described here: https://discourse.julialang.org/t/a-plea-for-help-with-open62541-opc-ua-binaries/114702
Diagnosed further here: https://github.com/martinkosch/Open62541.jl/pull/22

I know that using the lowest possible gcc version is advised for compatibility reasons, but this fix seems to do the job and resolving the issues while keeping gcc v4 might be a task that is beyond my (current) capabilities.

I hope this workaround is acceptable.