### PR TITLE
[MPFR] 4.2.1 again

### DIFF
--- a/M/MPFR/build_tarballs.jl
+++ b/M/MPFR/build_tarballs.jl
@@ -46,3 +46,4 @@ dependencies = [
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version=v"5", julia_compat="1.6")
+


### PR DESCRIPTION
For some reason 4.2.1 never made it into the General registry. So rebuild it in the hopes that this will resolve the situation.

See also discussion in PR #8993 

CC @benlorenz @giordano @hannes14 
