### PR TITLE
[Libtool] Use `@SHELL@` in `libtoolize`

### DIFF
--- a/L/Libtool/build_tarballs.jl
+++ b/L/Libtool/build_tarballs.jl
@@ -9,11 +9,18 @@ version = v"2.4.7"
 sources = [
     ArchiveSource("https://ftpmirror.gnu.org/libtool/libtool-$(version).tar.gz",
                   "04e96c2404ea70c590c546eba4202a4e12722c640016c12b9b2f1ce3d481e9a8"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/libtool-*
+cd ${WORKSPACE}/srcdir/libtool-*
+for patch in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 ${patch}
+done
+# Prevent `help2man` needing to be run because we patched `libtoolize`
+touch doc/libtoolize.1
+
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} SHELL=/bin/bash
 make
 make install

--- a/L/Libtool/bundled/patches/shell_for_libtoolize.patch
+++ b/L/Libtool/bundled/patches/shell_for_libtoolize.patch
@@ -1,0 +1,10 @@
+diff --git a/libtoolize.in b/libtoolize.in
+index 0c40fed..8938405 100644
+--- a/libtoolize.in
++++ b/libtoolize.in
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env sh
++#! /bin/bash
+ 
+ # Prepare a package to use libtool.
+ # Written by Gary V. Vaughan <gary@gnu.org>, 2003


### PR DESCRIPTION
We were fixing the shell shebang in `libtool` previously with [0], but failing to set the shell shebang for `libtoolize` as well.

[0] https://github.com/JuliaPackaging/Yggdrasil/pull/8923