### PR TITLE
[CUDSS] Upgrade to v0.3.0

### DIFF
--- a/C/CUDA/CUDSS/build_tarballs.jl
+++ b/C/CUDA/CUDSS/build_tarballs.jl
@@ -8,8 +8,8 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDSS"
-version = v"0.2.1"
-full_version = "0.2.1.3"
+version = v"0.3.0"
+full_version = "0.3.0.9"
 
 script = raw"""
 mkdir -p ${libdir} ${prefix}/include
@@ -44,7 +44,7 @@ products = [
 dependencies = [RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll"))]
 
 platforms = [Platform("x86_64", "linux"),
-             Platform("aarch64", "linux"),
+             Platform("aarch64", "linux"; cuda_platform="sbsa"),
              Platform("x86_64", "windows")]
 
 builds = []

--- a/C/CUDA/CUDSS/build_tarballs.jl
+++ b/C/CUDA/CUDSS/build_tarballs.jl
@@ -44,6 +44,7 @@ products = [
 dependencies = [RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll"))]
 
 platforms = [Platform("x86_64", "linux"),
+             Platform("aarch64", "linux"; cuda_platform="jetson"),
              Platform("aarch64", "linux"; cuda_platform="sbsa"),
              Platform("x86_64", "windows")]
 


### PR DESCRIPTION
@maleadt 
It seems that NVIDIA added a new build for `aarch64`.
It's not `sbsa` or `jetson`: https://developer.download.nvidia.com/compute/cudss/redist/redistrib_0.3.0.json
How do we handle it with Yggdrasil?