### PR TITLE
CUDA: Make driver JLL's not use lazy artifacts.

### DIFF
--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -65,11 +65,11 @@ non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 if should_build_platform("x86_64-linux-gnu")
     build_tarballs(non_reg_ARGS, name, version, sources_linux_x86, script,
                    [Platform("x86_64", "linux")], products, dependencies;
-                   lazy_artifacts=true, skip_audit=true, init_block)
+                   skip_audit=true, init_block)
 end
 
 if should_build_platform("aarch64-linux-gnu")
     build_tarballs(ARGS, name, version, sources_linux_aarch64, script,
                    [Platform("aarch64", "linux")], products, dependencies;
-                   lazy_artifacts=true, skip_audit=true, init_block)
+                   skip_audit=true, init_block)
 end


### PR DESCRIPTION
The artifact is tiny, and is going to be used whenever CUDA_Driver_jll is imported, so now that we have package extensions (and CUDA_Driver_jll thus won't be unconditionally depended on) I think it's fine to make it eager.

Hopefully helps with https://github.com/JuliaGPU/CUDA.jl/issues/2415