### PR TITLE
Upgrade to Wayland v1.23

### DIFF
--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -16,17 +16,10 @@ script = raw"""
 cd $WORKSPACE/srcdir/wayland-*/
 
 # Build a native version of wayland-scanner
-
-cat - >host_pkgconfig.meson <<EOF
-[binaries]
-pkgconfig = ['/usr/bin/pkg-config', '--define-variable=prefix=\${pcfiledir}/../..']
-EOF
-
 PKG_CONFIG_SYSROOT_DIR='' \
 PKG_CONFIG_PATH="${host_libdir}/pkgconfig" \
 meson setup host_build . \
     --native-file="${MESON_HOST_TOOLCHAIN}" \
-    --native-file=host_pkgconfig.meson \
     --buildtype=plain \
     -Ddtd_validation=false \
     -Dlibraries=false \
@@ -45,7 +38,6 @@ fi
 meson setup build . \
     --cross-file="${MESON_TARGET_TOOLCHAIN}" \
     --buildtype=release \
-    --pkgconfig.relocatable \
     -Dlibraries=true \
     -Dscanner=true \
     -Ddocumentation=false \
@@ -69,7 +61,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    HostBuildDependency("Expat_jll"),
+    HostBuildDependency("Expat_jll"#=; compat="2.6.4"=#),  # fixed pkg-config prefix
     Dependency("Expat_jll"; compat="2.2.10"),
     Dependency("Libffi_jll"; compat="~3.2.2"),
     Dependency("XML2_jll"),


### PR DESCRIPTION
and at the same time, try to resolve a bootstrap issue with `wayland-scanner` being a build-time dependency of building the other libraries.

~~N.B. I don't have a FreeBSD system to test against, so I'm not sure if/how this preserves/breaks #7381, which to me seems like it introduce an chicken-vs-egg bootstrap problem.~~ Latest build seems to cross-compile correctly.