### PR TITLE
[libtakum] Update to v0.1.2

### DIFF
--- a/L/libtakum/build_tarballs.jl
+++ b/L/libtakum/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "libtakum"
-version = v"0.1.1"
+version = v"0.1.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/takum-arithmetic/libtakum.git", "fd1f336b5ec21c689d4d9777be29ea4119d151bf")
+    GitSource("https://github.com/takum-arithmetic/libtakum.git", "6ca06437eb2a4328045b95409c2a8faa36b62e5c")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This release contains more bugfixes for the handling of NaR and inter-takum conversions.