### PR TITLE
[aws_c_http] Update to version 0.8.3

### DIFF
--- a/A/aws_c_http/build_tarballs.jl
+++ b/A/aws_c_http/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_http"
-version = v"0.8.2"
+version = v"0.8.3"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-http.git", "d83f8d70143ddce5ab4e479175fbd44ba994211b"),
+    GitSource("https://github.com/awslabs/aws-c-http.git", "652e2febf2242d6b3562267dc0dd982375ed698e"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_c_http to version 0.8.3. cc: @quinnj @Octogonapus