### PR TITLE
[libtakum] Update to v0.2.0

### DIFF
--- a/L/libtakum/build_tarballs.jl
+++ b/L/libtakum/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "libtakum"
-version = v"0.1.2"
+version = v"0.2.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/takum-arithmetic/libtakum.git", "6ca06437eb2a4328045b95409c2a8faa36b62e5c")
+    GitSource("https://github.com/takum-arithmetic/libtakum.git", "ed7eb168bccedf816d5cfa885ab5414bdf435394")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This release fixes the computation of takums whose magnitude is larger than the dynamic range of float32 and improves the performance of addition and subtraction by around 50%.

A new interface is added: The functions takum*_precision() return the number of mantissa bits for a given takum.