### PR TITLE
[quarto_jll] Bump version to v1.5.54

### DIFF
--- a/Q/quarto/build_tarballs.jl
+++ b/Q/quarto/build_tarballs.jl
@@ -2,14 +2,14 @@ using BinaryBuilder, Pkg
 
 # Collection of pre-build quarto binaries
 name = "quarto"
-quarto_ver = "1.4.549"
+quarto_ver = "1.5.54"
 version = VersionNumber(quarto_ver)
 
 url_prefix = "https://github.com/quarto-dev/quarto-cli/releases/download/v$(quarto_ver)/quarto-$(quarto_ver)"
 sources = [
-    ArchiveSource("$(url_prefix)-linux-amd64.tar.gz", "61e03d40a75a4b32ad823c9b573db6228a58202a9b95f94d13c9cdf23dd7af78"; unpack_target = "x86_64-linux-gnu"),
-    ArchiveSource("$(url_prefix)-macOS.tar.gz", "4d31524deddef13213e5c1fa89ef6d63ab10cc88e51f8daf180ec8e1dba159c4"; unpack_target = "x86_64-apple-darwin14"),
-    ArchiveSource("$(url_prefix)-win.zip", "c79fbff6e91ef77e439148a08d343beeee415c60c6c7fb498f3aa8633d176159"; unpack_target = "x86_64-w64-mingw32"),
+    ArchiveSource("$(url_prefix)-linux-amd64.tar.gz", "424a8c59a6b97cbaca9a0af98b1d3c157d447ddae3efca0340ab8bb65d900749"; unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$(url_prefix)-macOS.tar.gz", "391b1a095cfc7e8a3fb33f723e42d0449f0146babf1311ff73e5262bc1129503"; unpack_target = "x86_64-apple-darwin14"),
+    ArchiveSource("$(url_prefix)-win.zip", "fb00b52ae7a7c5f897e16d1b023b978a683ab1bc1db71948734cc67e83029c6c"; unpack_target = "x86_64-w64-mingw32"),
     FileSource("https://raw.githubusercontent.com/quarto-dev/quarto-cli/v$(quarto_ver)/COPYRIGHT", "490f3bfa035e325018ce9b0c8c2aec1f291c67ff55358a653d079488385af517"),
     FileSource("https://raw.githubusercontent.com/quarto-dev/quarto-cli/v$(quarto_ver)/COPYING.md", "54a55511991726b38e3867966ab14fd62919114670f2178654cced9394af78fd"),
 ]


### PR DESCRIPTION
This has the Julia QuartoNotebookRunner integration, meaning people building Quarto can simply add it as a dependency in their doc builds, and not need to build it on CI.