### PR TITLE
[GDAL] Remove giflib to fix Windows

### DIFF
--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder, Pkg
 
 name = "GDAL"
 upstream_version = v"3.9.1"
-version_offset = v"1.1.0"
+version_offset = v"1.1.1"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
                         upstream_version.patch * 100 + version_offset.patch)
@@ -64,7 +64,7 @@ CMAKE_FLAGS=(-DCMAKE_INSTALL_PREFIX=${prefix}
     -DGDAL_USE_EXPAT=ON
     -DGDAL_USE_GEOS=ON
     -DGDAL_USE_GEOTIFF=ON
-    -DGDAL_USE_GIF=ON
+    -DGDAL_USE_GIF=OFF  # Breaks GDAL on Windows as of Giflib_jll v5.2.2 (#8781)
     -DGDAL_USE_LIBLZMA=ON
     -DGDAL_USE_LIBXML2=ON
     -DGDAL_USE_LZ4=ON
@@ -189,7 +189,6 @@ dependencies = [
     Dependency("Blosc_jll"; compat="1.21.1"),
     Dependency("Expat_jll"; compat="2.2.10"),
     Dependency("GEOS_jll"; compat="3.11.2"),
-    Dependency("Giflib_jll"; compat="5.2.1"),
     Dependency("HDF5_jll"; compat="~1.14.3", platforms=hdf5_platforms),
     Dependency("LibCURL_jll"; compat="7.73,8"),
     Dependency("LibPQ_jll"),


### PR DESCRIPTION
Fixes #8781. I rebuilt with different combinations of the 7 dependencies added in #8749 to find that giflib breaks GDAL on Windows. So I suggest removing this dependency for now. @eschnett are you ok with this? I should add that installing the older Giflib_jll v5.2.1 (not [the newly built v5.2.2](#8986)) with the current GDAL_jll also didn't help.
