### PR TITLE
Bump aws_c_auth cal dep version

### DIFF
--- a/A/aws_c_auth/build_tarballs.jl
+++ b/A/aws_c_auth/build_tarballs.jl
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("aws_c_cal_jll"; compat="0.6.2"),
+    Dependency("aws_c_cal_jll"; compat="0.7.1"),
     Dependency("aws_c_http_jll"; compat="0.8.1"),
     Dependency("aws_c_sdkutils_jll"; compat="0.1.12"),
     BuildDependency("aws_lc_jll"),


### PR DESCRIPTION
@giordano, could you help me know what else I need to do to get a correct new release out this time? I know as-is, this PR isn't enough to just bump the dep version.