### PR TITLE
Add Powsybl julia binaries building script

### DIFF
--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -38,7 +38,7 @@ cmake -B build \
     -DBUILD_PYTHON_BINDINGS=OFF \
     -DPYPOWSYBL_JAVA_LIBRARY_DIR=${prefix}/lib \
     -DPYPOWSYBL_JAVA_INCLUDE_DIR=${prefix}/include \
-    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_INSTALL_PREFIX=${prefix}
 cmake --build build --parallel ${nproc}
 cmake --install build
 

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -16,13 +16,13 @@ sources = [
     GitSource("https://github.com/powsybl/pypowsybl.git", "cd5fea41bbfb2897fd71a6e63b2d07a465055699"),
     ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-windows.zip",
                   "82d3cee44992dcceaee7549f17351155e91c9eb2bdce97b1cf6c0107155991e8",
-                  "powsybl-java-windows"),
+                  "powsybl-java-x86_64-w64-mingw32"),
     ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-linux.zip",
                   "8832e1ff432e97807dc6dfddb4b001dd2c3c05a7411fc3748c8af3854a3b448c",
-                  "powsybl-java-linux"),
+                  "powsybl-java-x86_64-linux-gnu"),
     ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-darwin.zip",
                   "d541eb07a334d9272b167cb30f7d846ff109db49ac61a9776593c1aface18324",
-                  "powsybl-java-darwin")
+                  "powsybl-java-x86_64-apple-darwin")
 ]
 
 # To get julia_versions
@@ -31,16 +31,8 @@ include("../../L/libjulia/common.jl")
 script = raw"""
 cd $WORKSPACE/srcdir
 
-# Get binary for powsybl-java, generated with GraalVm
-if [[ "${target}" == *-mingw* ]]; then
-    cp -r powsybl-java-windows/* ${prefix}
-fi
-if [[ "${target}" == *-linux-* ]]; then
-    cp -r powsybl-java-linux/* ${prefix}
-fi
-if [[ "${target}" == *-apple-* ]]; then
-    cp -r powsybl-java-darwin/* ${prefix}
-fi
+# Get binary for powsybl-java, generated with GraalVm, install them in ${prefix} path
+cp -rv powsybl-java-${target}/* ${prefix}
 
 cd $WORKSPACE/srcdir/pypowsybl/cpp
 cmake -B build \

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -10,10 +10,13 @@ sources = [
     GitSource("https://github.com/powsybl/powsybl.jl.git", "0a9e3110c366808e7ac23cfd9e19f51793807392"),
     GitSource("https://github.com/powsybl/pypowsybl.git", "cd5fea41bbfb2897fd71a6e63b2d07a465055699"),
     ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-windows.zip",
+                  "82d3cee44992dcceaee7549f17351155e91c9eb2bdce97b1cf6c0107155991e8",
                   "powsybl-java-windows"),
     ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-linux.zip",
+                  "8832e1ff432e97807dc6dfddb4b001dd2c3c05a7411fc3748c8af3854a3b448c",
                   "powsybl-java-linux"),
     ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-darwin.zip",
+                  "d541eb07a334d9272b167cb30f7d846ff109db49ac61a9776593c1aface18324",
                   "powsybl-java-darwin")
 ]
 

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -3,8 +3,8 @@ using BinaryBuilder, Pkg
 name = "Powsybl"
 version = v"0.1"
 sources = [
-    GitSource("https://github.com/powsybl/powsybl.jl.git", "b1f9ec74fc703d85f5d34c8a5f7148a316852f1d"),
-    GitSource("https://github.com/powsybl/pypowsybl.git", "4b2c40531890760872ee85c1b37dc600d6bbfeae")
+    GitSource("https://github.com/powsybl/powsybl.jl.git", "f019cc3fb0ef19c41812780d068d302b7ef879bd"),
+    GitSource("https://github.com/powsybl/pypowsybl.git", "cd5fea41bbfb2897fd71a6e63b2d07a465055699")
 ]
 
 julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]
@@ -14,13 +14,13 @@ cd $WORKSPACE/srcdir
 
 # Get binary for powsybl-java, generated with GraalVm
 if [[ "${target}" == *-mingw* ]]; then
-    wget https://github.com/powsybl/pypowsybl/releases/download/vBinariesDeployment/binaries-vBinariesDeployment-windows.zip -O powsybl-java.zip
+    wget https://github.com/powsybl/pypowsybl/releases/download/v1.7.0/binaries-v1.7.0-windows.zip -O powsybl-java.zip
 fi
 if [[ "${target}" == *-linux-* ]]; then
-    wget https://github.com/powsybl/pypowsybl/releases/download/vBinariesDeployment/binaries-vBinariesDeployment-linux.zip -O powsybl-java.zip
+    wget https://github.com/powsybl/pypowsybl/releases/download/v1.7.0/binaries-v1.7.0-linux.zip -O powsybl-java.zip
 fi
 if [[ "${target}" == *-apple-* ]]; then
-    wget https://github.com/powsybl/pypowsybl/releases/download/vBinariesDeployment/binaries-vBinariesDeployment-darwin.zip -O powsybl-java.zip
+    wget https://github.com/powsybl/pypowsybl/releases/download/v1.7.0/binaries-v1.7.0-darwin.zip -O powsybl-java.zip
 fi
 unzip powsybl-java.zip -d $prefix
 
@@ -41,8 +41,6 @@ platforms = vcat(libjulia_platforms.(julia_versions)...)
 
 filter!(p -> arch(p) == "x86_64" && os(p) ∈ ("windows", "linux", "macos"), platforms)
 platforms = expand_cxxstring_abis(platforms)
-
-@show platforms
 
 products = [
 LibraryProduct(["math", "libmath"], :libmath)

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -78,5 +78,5 @@ dependencies = [
     Dependency("libjulia_jll")
 ]
 
-#build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-#    preferred_gcc_version=v"10", julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    preferred_gcc_version=v"10", julia_compat="1.6")

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -3,6 +3,11 @@ using BinaryBuilder, Pkg
 name = "Powsybl"
 version = v"0.1.0"
 
+# See https://github.com/JuliaLang/Pkg.jl/issues/2942
+# Once this Pkg issue is resolved, this must be removed
+uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
+delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
+
 pypowsybl_version = v"1.7.0"
 
 

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -1,9 +1,9 @@
 using BinaryBuilder, Pkg
 
 name = "Powsybl"
-version = v"0.1"
+version = v"0.1.0"
 sources = [
-    GitSource("https://github.com/powsybl/powsybl.jl.git", "f019cc3fb0ef19c41812780d068d302b7ef879bd"),
+    GitSource("https://github.com/powsybl/powsybl.jl.git", "0a9e3110c366808e7ac23cfd9e19f51793807392"),
     GitSource("https://github.com/powsybl/pypowsybl.git", "cd5fea41bbfb2897fd71a6e63b2d07a465055699")
 ]
 

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -20,9 +20,12 @@ sources = [
     ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-linux.zip",
                   "8832e1ff432e97807dc6dfddb4b001dd2c3c05a7411fc3748c8af3854a3b448c",
                   "powsybl-java-x86_64-linux-gnu"),
+    ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-linux.zip",
+                  "8832e1ff432e97807dc6dfddb4b001dd2c3c05a7411fc3748c8af3854a3b448c",
+                  "powsybl-java-x86_64-linux-musl"), # linux package for gnu and musl
     ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-darwin.zip",
                   "d541eb07a334d9272b167cb30f7d846ff109db49ac61a9776593c1aface18324",
-                  "powsybl-java-x86_64-apple-darwin")
+                  "powsybl-java-x86_64-apple-darwin14")
 ]
 
 # To get julia_versions

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -25,14 +25,9 @@ if [[ "${target}" == *-apple-* ]]; then
 fi
 unzip powsybl-java.zip -d $prefix
 
-# Build powsybl-cpp API
-cmake ${WORKSPACE}/srcdir/pypowsybl/cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_PYPOWSYBL_JAVA=OFF -DBUILD_PYTHON_BINDINGS=OFF -DPYPOWSYBL_JAVA_LIBRARY_DIR=$prefix/lib -DPYPOWSYBL_JAVA_INCLUDE_DIR=$prefix/include -DCMAKE_INSTALL_PREFIX=$prefix
-cmake --build . --target install --config Release
-
 cd $WORKSPACE/srcdir/pypowsybl/cpp
 cmake -B build \
-    -DCMAKE_BUILD_TYPE=Release \
-    pypowsybl/cpp \
+    ${WORKSPACE}/srcdir/pypowsybl/cpp \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DBUILD_PYPOWSYBL_JAVA=OFF \
     -DBUILD_PYTHON_BINDINGS=OFF \

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -2,9 +2,19 @@ using BinaryBuilder, Pkg
 
 name = "Powsybl"
 version = v"0.1.0"
+
+pypowsybl_version = v"1.7.0"
+
+
 sources = [
     GitSource("https://github.com/powsybl/powsybl.jl.git", "0a9e3110c366808e7ac23cfd9e19f51793807392"),
-    GitSource("https://github.com/powsybl/pypowsybl.git", "cd5fea41bbfb2897fd71a6e63b2d07a465055699")
+    GitSource("https://github.com/powsybl/pypowsybl.git", "cd5fea41bbfb2897fd71a6e63b2d07a465055699"),
+    ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-windows.zip",
+                  "powsybl-java-windows"),
+    ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-linux.zip",
+                  "powsybl-java-linux"),
+    ArchiveSource("https://github.com/powsybl/pypowsybl/releases/download/v$(pypowsybl_version)/binaries-v$(pypowsybl_version)-darwin.zip",
+                  "powsybl-java-darwin")
 ]
 
 # To get julia_versions
@@ -15,15 +25,14 @@ cd $WORKSPACE/srcdir
 
 # Get binary for powsybl-java, generated with GraalVm
 if [[ "${target}" == *-mingw* ]]; then
-    wget https://github.com/powsybl/pypowsybl/releases/download/v1.7.0/binaries-v1.7.0-windows.zip -O powsybl-java.zip
+    mv powsybl-java-windows/* ${prefix}
 fi
 if [[ "${target}" == *-linux-* ]]; then
-    wget https://github.com/powsybl/pypowsybl/releases/download/v1.7.0/binaries-v1.7.0-linux.zip -O powsybl-java.zip
+    mv powsybl-java-linux/* ${prefix}
 fi
 if [[ "${target}" == *-apple-* ]]; then
-    wget https://github.com/powsybl/pypowsybl/releases/download/v1.7.0/binaries-v1.7.0-darwin.zip -O powsybl-java.zip
+    mv powsybl-java-darwin/* ${prefix}
 fi
-unzip powsybl-java.zip -d $prefix
 
 cd $WORKSPACE/srcdir/pypowsybl/cpp
 cmake -B build \

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -7,7 +7,8 @@ sources = [
     GitSource("https://github.com/powsybl/pypowsybl.git", "cd5fea41bbfb2897fd71a6e63b2d07a465055699")
 ]
 
-julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]
+# To get julia_versions
+include("../../L/libjulia/common.jl")
 
 script = raw"""
 cd $WORKSPACE/srcdir
@@ -25,14 +26,37 @@ fi
 unzip powsybl-java.zip -d $prefix
 
 # Build powsybl-cpp API
-cd pypowsybl/cpp && mkdir build && cd build
 cmake ${WORKSPACE}/srcdir/pypowsybl/cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_PYPOWSYBL_JAVA=OFF -DBUILD_PYTHON_BINDINGS=OFF -DPYPOWSYBL_JAVA_LIBRARY_DIR=$prefix/lib -DPYPOWSYBL_JAVA_INCLUDE_DIR=$prefix/include -DCMAKE_INSTALL_PREFIX=$prefix
 cmake --build . --target install --config Release
 
+cd $WORKSPACE/srcdir/pypowsybl/cpp
+cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    pypowsybl/cpp \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DBUILD_PYPOWSYBL_JAVA=OFF \
+    -DBUILD_PYTHON_BINDINGS=OFF \
+    -DPYPOWSYBL_JAVA_LIBRARY_DIR=${prefix}/lib \
+    -DPYPOWSYBL_JAVA_INCLUDE_DIR=${prefix}/include \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+cmake --build build --parallel ${nproc}
+cmake --install build
+
 # Build julia wrapper
-cd $WORKSPACE/srcdir/powsybl.jl && mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ../cpp/powsybljl-cpp -DJulia_PREFIX=$prefix -DJlCxx_DIR=$prefix/lib/cmake/JlCxx -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_PREFIX_PATH=$prefix -DCMAKE_INSTALL_PREFIX=$prefix -DPOWSYBL_INSTALL_DIR=$prefix
-cmake --build . --target install --config Release
+cd $WORKSPACE/srcdir/powsybl.jl
+cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    cpp/powsybljl-cpp \
+    -DJulia_PREFIX=${prefix} \
+    -DJlCxx_DIR=${prefix}/lib/cmake/JlCxx \
+    -DCMAKE_FIND_ROOT_PATH=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_PREFIX_PATH=${prefix} \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DPOWSYBL_INSTALL_DIR=${prefix}
+cmake --build build --parallel ${nproc}
+cmake --install build
+
 install_license $WORKSPACE/srcdir/powsybl.jl/LICENSE.md
 """
 
@@ -43,10 +67,10 @@ filter!(p -> arch(p) == "x86_64" && os(p) ∈ ("windows", "linux", "macos"), pla
 platforms = expand_cxxstring_abis(platforms)
 
 products = [
-LibraryProduct(["math", "libmath"], :libmath)
-LibraryProduct(["pypowsybl-java", "libpypowsybl-java"], :libpypowsybl_java)
-LibraryProduct(["powsybl-cpp", "libpowsybl-cpp"], :libpowsybl_cpp)
-LibraryProduct(["PowsyblJlWrap", "libPowsyblJlWrap"], :libPowsyblJlWrap)
+    LibraryProduct(["math", "libmath"], :libmath)
+    LibraryProduct(["pypowsybl-java", "libpypowsybl-java"], :libpypowsybl_java)
+    LibraryProduct(["powsybl-cpp", "libpowsybl-cpp"], :libpowsybl_cpp)
+    LibraryProduct(["PowsyblJlWrap", "libPowsyblJlWrap"], :libPowsyblJlWrap)
 ]
 
 dependencies = [
@@ -54,5 +78,5 @@ dependencies = [
     Dependency("libjulia_jll")
 ]
 
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    preferred_gcc_version=v"12", julia_compat="1.6")
+#build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+#    preferred_gcc_version=v"10", julia_compat="1.6")

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -28,13 +28,13 @@ cd $WORKSPACE/srcdir
 
 # Get binary for powsybl-java, generated with GraalVm
 if [[ "${target}" == *-mingw* ]]; then
-    mv powsybl-java-windows/* ${prefix}
+    cp -r powsybl-java-windows/* ${prefix}
 fi
 if [[ "${target}" == *-linux-* ]]; then
-    mv powsybl-java-linux/* ${prefix}
+    cp -r powsybl-java-linux/* ${prefix}
 fi
 if [[ "${target}" == *-apple-* ]]; then
-    mv powsybl-java-darwin/* ${prefix}
+    cp -r powsybl-java-darwin/* ${prefix}
 fi
 
 cd $WORKSPACE/srcdir/pypowsybl/cpp

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -1,0 +1,65 @@
+using BinaryBuilder, Pkg
+
+name = "Powsybl"
+version = v"0.1"
+sources = [
+    GitSource("https://github.com/powsybl/powsybl.jl.git", "dc890a91ab706bf6d7fa3a5edf2b8ec7c191aedf")
+]
+
+#julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]
+julia_versions = [v"1.10"]
+
+script = raw"""
+cd $WORKSPACE/srcdir
+
+# Get binary for powsybl-java, generated with GraalVm
+if [[ "${target}" == *-mingw* ]]; then
+    wget https://github.com/powsybl/pypowsybl/releases/download/vBinariesDeployment/binaries-vBinariesDeployment-windows.zip -O powsybl-java.zip
+fi
+if [[ "${target}" == *-linux-* ]]; then
+    wget https://github.com/powsybl/pypowsybl/releases/download/vBinariesDeployment/binaries-vBinariesDeployment-linux.zip -O powsybl-java.zip
+fi
+if [[ "${target}" == *-apple-* ]]; then
+    wget https://github.com/powsybl/pypowsybl/releases/download/vBinariesDeployment/binaries-vBinariesDeployment-darwin.zip -O powsybl-java.zip
+fi
+unzip powsybl-java.zip -d $prefix
+cd powsybl.jl/
+git submodule init
+git submodule update
+mkdir build
+cd cpp/pypowsybl/
+mkdir build
+cd build
+# Build powsybl-cpp API
+cmake ${WORKSPACE}/srcdir/powsybl.jl/cpp/pypowsybl/cpp/powsybl-cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_ONLY_POWSYBL_CPP=ON -DPOWSYBL_JAVA_LIB_INSTALL_DIR=$prefix/lib -DPOWSYBL_INCLUDE_DIR=$prefix/include/powsybl-cpp -DCMAKE_INSTALL_PREFIX=$prefix
+cmake --build . --target install --config Release
+# Build julia wrapper
+cd ../../../build/
+cmake -DCMAKE_BUILD_TYPE=Release ../cpp/powsybljl-cpp -DJulia_PREFIX=$prefix -DJlCxx_DIR=$prefix/lib/cmake/JlCxx -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_PREFIX_PATH=$prefix -DCMAKE_INSTALL_PREFIX=$prefix -DPOWSYBL_INSTALL_DIR=$prefix
+cmake --build . --target install --config Release
+install_license $WORKSPACE/srcdir/powsybl.jl/LICENSE.md
+"""
+
+include("../../L/libjulia/common.jl")
+platforms = vcat(libjulia_platforms.(julia_versions)...)
+
+#filter!(p -> arch(p) == "x86_64" && os(p) ∈ ("windows", "linux", "macos"), platforms)
+filter!(p -> arch(p) == "x86_64" && os(p) ∈ ("linux", "linux"), platforms)
+platforms = expand_cxxstring_abis(platforms)
+
+@show platforms
+
+products = [
+LibraryProduct(["PowsyblJlWrap", "libPowsyblJlWrap"], :libPowsyblJlWrap)
+LibraryProduct(["math", "libmath"], :libmath)
+LibraryProduct(["pypowsybl-java", "libpypowsybl-java"], :libpypowsybl_java)
+LibraryProduct(["powsybl-cpp", "libpowsybl-cpp"], :libpowsybl_cpp)
+]
+
+dependencies = [
+    Dependency("libcxxwrap_julia_jll"),
+    Dependency("libjulia_jll")
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    preferred_gcc_version=v"12", julia_compat="1.6")

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -9,6 +9,7 @@ sources = [
 julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]
 
 script = raw"""
+
 cd $WORKSPACE/srcdir
 
 # Get binary for powsybl-java, generated with GraalVm

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -3,13 +3,13 @@ using BinaryBuilder, Pkg
 name = "Powsybl"
 version = v"0.1"
 sources = [
-    GitSource("https://github.com/powsybl/powsybl.jl.git", "554ae1c7804af8a32a8480c779fb1b0505d112a5")
+    GitSource("https://github.com/powsybl/powsybl.jl.git", "554ae1c7804af8a32a8480c779fb1b0505d112a5"),
+    GitSource("https://github.com/powsybl/pypowsybl.git", "vBinariesDeployment")
 ]
 
 julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]
 
 script = raw"""
-
 cd $WORKSPACE/srcdir
 
 # Get binary for powsybl-java, generated with GraalVm
@@ -23,18 +23,14 @@ if [[ "${target}" == *-apple-* ]]; then
     wget https://github.com/powsybl/pypowsybl/releases/download/vBinariesDeployment/binaries-vBinariesDeployment-darwin.zip -O powsybl-java.zip
 fi
 unzip powsybl-java.zip -d $prefix
-cd powsybl.jl/
-git submodule init
-git submodule update
-mkdir build
-cd cpp/pypowsybl/
-mkdir build
-cd build
+
 # Build powsybl-cpp API
-cmake ${WORKSPACE}/srcdir/powsybl.jl/cpp/pypowsybl/cpp/powsybl-cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_PYPOWSYBL_JAVA=OFF -DPYPOWSYBL_JAVA_LIBRARY_DIR=$prefix/lib -DPYPOWSYBL_JAVA_INCLUDE_DIR=$prefix/include -DCMAKE_INSTALL_PREFIX=$prefix
+cd pypowsybl/cpp && mkdir build && cd build
+cmake ${WORKSPACE}/srcdir/pypowsybl/cpp/powsybl-cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_PYPOWSYBL_JAVA=OFF -DPYPOWSYBL_JAVA_LIBRARY_DIR=$prefix/lib -DPYPOWSYBL_JAVA_INCLUDE_DIR=$prefix/include -DCMAKE_INSTALL_PREFIX=$prefix
 cmake --build . --target install --config Release
+
 # Build julia wrapper
-cd ../../../build/
+cd $WORKSPACE/srcdir/powsybl.jl && mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ../cpp/powsybljl-cpp -DJulia_PREFIX=$prefix -DJlCxx_DIR=$prefix/lib/cmake/JlCxx -DCMAKE_FIND_ROOT_PATH=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_PREFIX_PATH=$prefix -DCMAKE_INSTALL_PREFIX=$prefix -DPOWSYBL_INSTALL_DIR=$prefix
 cmake --build . --target install --config Release
 install_license $WORKSPACE/srcdir/powsybl.jl/LICENSE.md

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -3,8 +3,8 @@ using BinaryBuilder, Pkg
 name = "Powsybl"
 version = v"0.1"
 sources = [
-    GitSource("https://github.com/powsybl/powsybl.jl.git", "554ae1c7804af8a32a8480c779fb1b0505d112a5"),
-    GitSource("https://github.com/powsybl/pypowsybl.git", "eafe449f246343b5d9aedb9eb2e2757cd9dd76e1")
+    GitSource("https://github.com/powsybl/powsybl.jl.git", "b1f9ec74fc703d85f5d34c8a5f7148a316852f1d"),
+    GitSource("https://github.com/powsybl/pypowsybl.git", "4b2c40531890760872ee85c1b37dc600d6bbfeae")
 ]
 
 julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]
@@ -26,7 +26,7 @@ unzip powsybl-java.zip -d $prefix
 
 # Build powsybl-cpp API
 cd pypowsybl/cpp && mkdir build && cd build
-cmake ${WORKSPACE}/srcdir/pypowsybl/cpp/powsybl-cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_PYPOWSYBL_JAVA=OFF -DPYPOWSYBL_JAVA_LIBRARY_DIR=$prefix/lib -DPYPOWSYBL_JAVA_INCLUDE_DIR=$prefix/include -DCMAKE_INSTALL_PREFIX=$prefix
+cmake ${WORKSPACE}/srcdir/pypowsybl/cpp/powsybl-cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_PYPOWSYBL_JAVA=OFF -DBUILD_PYTHON_BINDINGS=OFF -DPYPOWSYBL_JAVA_LIBRARY_DIR=$prefix/lib -DPYPOWSYBL_JAVA_INCLUDE_DIR=$prefix/include -DCMAKE_INSTALL_PREFIX=$prefix
 cmake --build . --target install --config Release
 
 # Build julia wrapper

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -6,8 +6,7 @@ sources = [
     GitSource("https://github.com/powsybl/powsybl.jl.git", "dc890a91ab706bf6d7fa3a5edf2b8ec7c191aedf")
 ]
 
-#julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]
-julia_versions = [v"1.10"]
+julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]
 
 script = raw"""
 cd $WORKSPACE/srcdir
@@ -43,8 +42,7 @@ install_license $WORKSPACE/srcdir/powsybl.jl/LICENSE.md
 include("../../L/libjulia/common.jl")
 platforms = vcat(libjulia_platforms.(julia_versions)...)
 
-#filter!(p -> arch(p) == "x86_64" && os(p) ∈ ("windows", "linux", "macos"), platforms)
-filter!(p -> arch(p) == "x86_64" && os(p) ∈ ("linux", "linux"), platforms)
+filter!(p -> arch(p) == "x86_64" && os(p) ∈ ("windows", "linux", "macos"), platforms)
 platforms = expand_cxxstring_abis(platforms)
 
 @show platforms

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -26,7 +26,7 @@ unzip powsybl-java.zip -d $prefix
 
 # Build powsybl-cpp API
 cd pypowsybl/cpp && mkdir build && cd build
-cmake ${WORKSPACE}/srcdir/pypowsybl/cpp/powsybl-cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_PYPOWSYBL_JAVA=OFF -DBUILD_PYTHON_BINDINGS=OFF -DPYPOWSYBL_JAVA_LIBRARY_DIR=$prefix/lib -DPYPOWSYBL_JAVA_INCLUDE_DIR=$prefix/include -DCMAKE_INSTALL_PREFIX=$prefix
+cmake ${WORKSPACE}/srcdir/pypowsybl/cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_PYPOWSYBL_JAVA=OFF -DBUILD_PYTHON_BINDINGS=OFF -DPYPOWSYBL_JAVA_LIBRARY_DIR=$prefix/lib -DPYPOWSYBL_JAVA_INCLUDE_DIR=$prefix/include -DCMAKE_INSTALL_PREFIX=$prefix
 cmake --build . --target install --config Release
 
 # Build julia wrapper

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -4,7 +4,7 @@ name = "Powsybl"
 version = v"0.1"
 sources = [
     GitSource("https://github.com/powsybl/powsybl.jl.git", "554ae1c7804af8a32a8480c779fb1b0505d112a5"),
-    GitSource("https://github.com/powsybl/pypowsybl.git", "vBinariesDeployment")
+    GitSource("https://github.com/powsybl/pypowsybl.git", "eafe449f246343b5d9aedb9eb2e2757cd9dd76e1")
 ]
 
 julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]

--- a/P/Powsybl/build_tarballs.jl
+++ b/P/Powsybl/build_tarballs.jl
@@ -3,7 +3,7 @@ using BinaryBuilder, Pkg
 name = "Powsybl"
 version = v"0.1"
 sources = [
-    GitSource("https://github.com/powsybl/powsybl.jl.git", "dc890a91ab706bf6d7fa3a5edf2b8ec7c191aedf")
+    GitSource("https://github.com/powsybl/powsybl.jl.git", "554ae1c7804af8a32a8480c779fb1b0505d112a5")
 ]
 
 julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10"]
@@ -30,7 +30,7 @@ cd cpp/pypowsybl/
 mkdir build
 cd build
 # Build powsybl-cpp API
-cmake ${WORKSPACE}/srcdir/powsybl.jl/cpp/pypowsybl/cpp/powsybl-cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_ONLY_POWSYBL_CPP=ON -DPOWSYBL_JAVA_LIB_INSTALL_DIR=$prefix/lib -DPOWSYBL_INCLUDE_DIR=$prefix/include/powsybl-cpp -DCMAKE_INSTALL_PREFIX=$prefix
+cmake ${WORKSPACE}/srcdir/powsybl.jl/cpp/pypowsybl/cpp/powsybl-cpp -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DBUILD_PYPOWSYBL_JAVA=OFF -DPYPOWSYBL_JAVA_LIBRARY_DIR=$prefix/lib -DPYPOWSYBL_JAVA_INCLUDE_DIR=$prefix/include -DCMAKE_INSTALL_PREFIX=$prefix
 cmake --build . --target install --config Release
 # Build julia wrapper
 cd ../../../build/
@@ -48,10 +48,10 @@ platforms = expand_cxxstring_abis(platforms)
 @show platforms
 
 products = [
-LibraryProduct(["PowsyblJlWrap", "libPowsyblJlWrap"], :libPowsyblJlWrap)
 LibraryProduct(["math", "libmath"], :libmath)
 LibraryProduct(["pypowsybl-java", "libpypowsybl-java"], :libpypowsybl_java)
 LibraryProduct(["powsybl-cpp", "libpowsybl-cpp"], :libpowsybl_cpp)
+LibraryProduct(["PowsyblJlWrap", "libPowsyblJlWrap"], :libPowsyblJlWrap)
 ]
 
 dependencies = [


### PR DESCRIPTION
Hello,

This pull request is adding the build script build_tarballs.jl to build the binary part of powsybl julia bindings.

[PowSyBl ](https://www.powsybl.org/)(Power System Blocks) is an open source framework written in Java, dedicated to electrical grid modelling and simulation.

One thing that is a bit specific to the building process here is that we have a dependency to pre built binaries generated by GraalVM native image. it is used by [pypowsybl ](https://github.com/powsybl/pypowsybl) (powsybl python bindings) to provide a C++ interface to the java framework. Those binaries are also used by the julia bindings and need to be pre built elsewhere because native image does not support cross compilation yet.

This is a work in progress, feel free to comment if something seems off.