### PR TITLE
LLVM: Allow installation of LLVM_full on all Julia versions.

### DIFF
--- a/L/LLVM/LLVM_full@12.0.0/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@12.0.0/build_tarballs.jl
@@ -3,4 +3,4 @@ version = v"12.0.0"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.7")
+                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@12.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@12.0.1/build_tarballs.jl
@@ -3,4 +3,4 @@ version = v"12.0.1"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.7")
+               preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@13.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@13.0.1/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.8")
+               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@14.0.5/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@14.0.5/build_tarballs.jl
@@ -3,4 +3,4 @@ version = v"14.0.5"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.9")
+               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@14/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@14/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.9")
+               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@15/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@15/build_tarballs.jl
@@ -3,8 +3,4 @@ version = v"15.0.7"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.10")
-
-               
-# rebuild please
-
+               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@16/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@16/build_tarballs.jl
@@ -3,5 +3,4 @@ version = v"16.0.6"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.10")
-#Let's build!! 3
+               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@17/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@17/build_tarballs.jl
@@ -3,5 +3,4 @@ version = v"17.0.6"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.12")
-# Build trigger: 7
+               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")

--- a/L/LLVM/LLVM_full@18/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@18/build_tarballs.jl
@@ -3,5 +3,4 @@ version = v"18.1.7"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"17", julia_compat="1.12")
-# Build trigger: 2
+               preferred_gcc_version=v"10", preferred_llvm_version=v"17", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@11.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@11.0.1/build_tarballs.jl
@@ -2,6 +2,5 @@ version = v"11.0.1"
 
 include("../common.jl")
 
-
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true, assert=true)...;
                      preferred_gcc_version=v"7", preferred_llvm_version=v"8", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@12.0.0/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@12.0.0/build_tarballs.jl
@@ -3,4 +3,4 @@ version = v"12.0.0"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true, assert=true)...;
-                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.7")
+                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@12.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@12.0.1/build_tarballs.jl
@@ -3,5 +3,5 @@ version = v"12.0.1"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true, assert=true)...;
-                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.7")
+                     preferred_gcc_version=v"7", preferred_llvm_version=v"9", julia_compat="1.6")
 

--- a/L/LLVM/LLVM_full_assert@13.0.1/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@13.0.1/build_tarballs.jl
@@ -2,7 +2,6 @@ version = v"13.0.1"
 
 include("../common.jl")
 
-
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true, assert=true)...;
-                     preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.8")
+                     preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.6")
 

--- a/L/LLVM/LLVM_full_assert@14.0.5/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@14.0.5/build_tarballs.jl
@@ -3,4 +3,4 @@ version = v"14.0.5"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.9")
+               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@14/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@14/build_tarballs.jl
@@ -2,6 +2,5 @@ version = v"14.0.6"
 
 include("../common.jl")
 
-
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.9")
+               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@15/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@15/build_tarballs.jl
@@ -3,8 +3,4 @@ version = v"15.0.7"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
-               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.10")
-
-               
-# rebuild please
-
+               preferred_gcc_version=v"7", preferred_llvm_version=v"12", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@16/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@16/build_tarballs.jl
@@ -3,5 +3,4 @@ version = v"16.0.6"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.10")
-# It's building time!! 3
+               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@17/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@17/build_tarballs.jl
@@ -3,5 +3,4 @@ version = v"17.0.6"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.12")
-# Build trigger: 7
+               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")

--- a/L/LLVM/LLVM_full_assert@18/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@18/build_tarballs.jl
@@ -3,5 +3,5 @@ version = v"18.1.7"
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"17", julia_compat="1.12")
+               preferred_gcc_version=v"10", preferred_llvm_version=v"17", julia_compat="1.6")
 # Build trigger: 3

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -14,6 +14,7 @@ const llvm_tags = Dict(
     v"12.0.0" => "d28af7c654d8db0b68c175db5ce212d74fb5e9bc",
     v"12.0.1" => "980d2f60a8524c5546397db9e8bbb7d6ea56c1b7", # julia-12.0.1-4
     v"13.0.1" => "8a2ae8c8064a0544814c6fac7dd0c4a9aa29a7e6", # julia-13.0.1-3
+    v"14.0.5" => "73db33ead13c3596f53408ad6d1de4d0f2270adb", # julia-14.0.5-3
     v"14.0.6" => "5c82f5309b10fab0adf6a94969e0dddffdb3dbce", # julia-14.0.6-3
     v"15.0.7" => "2593167b92dd2d27849e8bc331db2072a9b4bd7f", # julia-15.0.7-10
     v"16.0.6" => "499f87882a4ba1837ec12a280478cf4cb0d2753d", # julia-16.0.6-2


### PR DESCRIPTION
LLVM_full is a build tool, and should be installable on all LLVM versions. I don't think there's a reason the compat restriction is there; it seems to have been added as `julia_version=1.6` for `experimental_platforms=true` (older versions of LLVM-related JLLs don't have any compat restriction), and got unnecessarily updated with newer releases of LLVM.

Re-land of https://github.com/JuliaPackaging/Yggdrasil/pull/3943. This version of the PR has `[ci skip]`; if landed I'll create a PR on General to update existing JLLs.

I also considered relaxing the compat bounds on packages like LLD_jll or LLVM_jll, since the LibraryProducts have `dont_dlopen=true` anyway, but IIUC these all end up depending on libLLVM_jll which would retain its compat bounds, so the situation wouldn't change in practice.
