### PR TITLE
LLVM: dlopen libraries in unified JLLs.

### DIFF
--- a/L/LLVM/Clang_unified/build_tarballs.jl
+++ b/L/LLVM/Clang_unified/build_tarballs.jl
@@ -30,7 +30,8 @@ for llvm_assertions in (false, true), llvm_full_version in llvm_full_versions
     libllvm_version = llvm_full_version
     _, _, sources, script, platforms, products, dependencies =
         configure_extraction(ARGS, llvm_full_version, "Clang", libllvm_version;
-                             assert=llvm_assertions, augmentation=true)
+                             assert=llvm_assertions, augmentation=true,
+                             dont_dlopen=false)
     # ignore the output version, as we want a unified JLL
     dependencies = map(dependencies) do dep
         # ignore the version of any LLVM dependency, as we'll automatically load
@@ -55,7 +56,7 @@ non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
 for (i, build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    build...;
-                   skip_audit=true, julia_compat="1.10",
+                   skip_audit=true, dont_dlopen=true, julia_compat="1.10",
                    augment_platform_block)
 end
 

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -673,7 +673,9 @@ function configure_build(ARGS, version; experimental_platforms=false, assert=fal
     return name, custom_version, sources, config * buildscript, platforms, products, dependencies
 end
 
-function configure_extraction(ARGS, LLVM_full_version, name, libLLVM_version=nothing; experimental_platforms=false, assert=false, augmentation=false)
+function configure_extraction(ARGS, LLVM_full_version, name, libLLVM_version=nothing;
+                              experimental_platforms=false, assert=false,
+                              augmentation=false, dont_dlopen=true)
     if isempty(LLVM_full_version.build)
         error("You must lock an extracted LLVM build to a particular LLVM_full build number!")
     end
@@ -685,14 +687,14 @@ function configure_extraction(ARGS, LLVM_full_version, name, libLLVM_version=not
     if name == "libLLVM"
         script = libllvmscript
         products = [
-            LibraryProduct(["LLVM", "libLLVM", "libLLVM-$(version.major)jl"], :libllvm, dont_dlopen=true),
+            LibraryProduct(["LLVM", "libLLVM", "libLLVM-$(version.major)jl"], :libllvm; dont_dlopen),
             ExecutableProduct("llvm-config", :llvm_config, "tools"),
         ]
     elseif name == "Clang"
         script = clangscript
         products = [
-            LibraryProduct("libclang", :libclang, dont_dlopen=true),
-            LibraryProduct("libclang-cpp", :libclang_cpp, dont_dlopen=true),
+            LibraryProduct("libclang", :libclang; dont_dlopen),
+            LibraryProduct("libclang-cpp", :libclang_cpp; dont_dlopen),
             ExecutableProduct(["clang", "clang-$(version.major)"], :clang, "tools"),
         ]
     elseif name == "MLIR"
@@ -706,13 +708,13 @@ function configure_extraction(ARGS, LLVM_full_version, name, libLLVM_version=not
             mlirscript_v16
         end
         products = [
-            LibraryProduct("libMLIR", :libMLIR, dont_dlopen=true),
+            LibraryProduct("libMLIR", :libMLIR; dont_dlopen),
         ]
         if v"12" <= version < v"13"
-            push!(products, LibraryProduct("libMLIRPublicAPI", :libMLIRPublicAPI, dont_dlopen=true))
+            push!(products, LibraryProduct("libMLIRPublicAPI", :libMLIRPublicAPI; dont_dlopen))
         end
         if version >= v"14"
-            push!(products, LibraryProduct(["MLIR-C", "libMLIR-C"], :mlir_c, dont_dlopen=true))
+            push!(products, LibraryProduct(["MLIR-C", "libMLIR-C"], :mlir_c; dont_dlopen))
         end
     elseif name == "LLD"
         script = lldscript
@@ -724,7 +726,7 @@ function configure_extraction(ARGS, LLVM_full_version, name, libLLVM_version=not
     elseif name == "LLVM"
         script = version < v"14" ? llvmscript_v13 : llvmscript_v14
         products = [
-            LibraryProduct(["LTO", "libLTO"], :liblto, dont_dlopen=true),
+            LibraryProduct(["LTO", "libLTO"], :liblto; dont_dlopen),
             ExecutableProduct("opt", :opt, "tools"),
             ExecutableProduct("llc", :llc, "tools"),
         ]


### PR DESCRIPTION
Our LLVM JLLs are a bit of a mess, IMO. Clang_jll and friends are seemingly only to be used as build tools, since they have `dont_dlopen` set on all LibraryProducts (essentially breaking downstream JLLs that would depend on, e.g.,`libclang`). Yet they have `compat` bounds and artifact selection hooks that only allow use on matching Julia versions...

Meanwhile, the newly introduced Clang_unified_jll _is_ strictly intended to be used as a runtime dependency, so here I'm adding the ability to toggle the `dont_dlopen` setting on LibraryProducts that are produced by the LLVM helper scripts.

All this isn't particularly great, and I may have to revisit it because of OpenCL's annoying property that driver libraries are discovered through env vars instead of normal library semantics, but I'm taking things one step at a time here.