### PR TITLE
Update to libglvnd v1.7

### DIFF
--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -30,8 +30,8 @@ meson setup . .. \
     --cross-file="${MESON_TARGET_TOOLCHAIN}" \
     --buildtype=release \
     --prefix=$sysprefix \
-    --libdir=$prefix/lib \
-    --includedir=$prefix/include \
+    --libdir=${libdir} \
+    --includedir=${includedir} \
     "${FLAGS[@]}"
 ninja -j${nproc}
 ninja install

--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -42,8 +42,8 @@ install_license ../README.md
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = filter!(p ->Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
-# Remove when X11 stack will support armv6l
-filter!(p -> arch(p) != "armv6l", platforms)
+# Remove when X11 stack will support armv6l and aarch64-freebsd
+filter!(p -> (arch(p) != "armv6l") || (Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
 
 # The products that we will ensure are always built
 products = Product[

--- a/L/Libglvnd/build_tarballs.jl
+++ b/L/Libglvnd/build_tarballs.jl
@@ -43,7 +43,7 @@ install_license ../README.md
 # platforms are passed in on the command line
 platforms = filter!(p ->Sys.islinux(p) || Sys.isfreebsd(p), supported_platforms())
 # Remove when X11 stack will support armv6l and aarch64-freebsd
-filter!(p -> (arch(p) != "armv6l") || (Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
+filter!(p -> (arch(p) != "armv6l") && !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
 
 # The products that we will ensure are always built
 products = Product[


### PR DESCRIPTION
~~More importantly, setup the `__EGL_VENDOR_LIBRARY_DIRS` environment variable on load to point to locations of system-installed descriptors of the available EGL providers. Without this environment variable, compile-time paths (e.g. `/workspace/destdir/share/glvnd/egl_vendor.d`) appropriate for the Yggdrasil build environment will be used instead, which generally won't work when used by a user.~~

See also https://github.com/NVIDIA/libglvnd/blob/v1.7.0/src/EGL/icd_enumeration.md

More importantly, patch the loader to not look for the `egl_vendors.d` directory inside the BinaryBuilders path environment, which otherwise prevents the EGL library from finding the user's system EGL configuration.