### PR TITLE
[GLFW] Require libdecor_jll for Wayland compatibility

### DIFF
--- a/G/GLFW/build_tarballs.jl
+++ b/G/GLFW/build_tarballs.jl
@@ -66,6 +66,7 @@ wayland_platforms = filter(Sys.islinux, platforms)
 dependencies = [
     HostBuildDependency("Wayland_jll"; platforms=wayland_platforms),
     BuildDependency("Xorg_xorgproto_jll"; platforms=x11_platforms),
+    Dependency("libdecor_jll"; platforms=wayland_platforms),
     Dependency("xkbcommon_jll"; platforms=wayland_platforms),
     Dependency("Libglvnd_jll"; platforms=x11_platforms),
     Dependency("Xorg_libXcursor_jll"; platforms=x11_platforms),


### PR DESCRIPTION
GLFW 3.4 uses libdecor to draw client-side decorations when interacting with a Wayland display.