### PR TITLE
Add compiler shards for LLVM 14, 15 and 17.

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -45,11 +45,11 @@ version = "0.5.8"
 
 [[deps.BinaryBuilderBase]]
 deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll", "unzip_jll"]
-git-tree-sha1 = "8489219d5487499ff5e068bbe9bfbac28d926833"
+git-tree-sha1 = "6493c0c0530c38c21723c30c965fc5e6c94e3fea"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "1.30.0"
+version = "1.30.1"
 
 [[deps.BitFlags]]
 git-tree-sha1 = "0691e34b3bb8be9307330f88d1a3c3f25466c24d"
@@ -64,9 +64,9 @@ version = "1.0.8+1"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "59939d8a997469ee05c4b4944560a820f9ba0d73"
+git-tree-sha1 = "b8fe8546d52ca154ac556809e10c75e6e7430ac8"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.4"
+version = "0.7.5"
 
 [[deps.Compat]]
 deps = ["Dates", "LinearAlgebra", "TOML", "UUIDs"]
@@ -80,9 +80,9 @@ uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [[deps.ConcurrentUtilities]]
 deps = ["Serialization", "Sockets"]
-git-tree-sha1 = "6cbbd4d241d7e6579ab354737f4dd95ca43946e1"
+git-tree-sha1 = "ea32b83ca4fefa1768dc84e504cc0a94fb1ab8d1"
 uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
-version = "2.4.1"
+version = "2.4.2"
 
 [[deps.DataAPI]]
 git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
@@ -157,15 +157,16 @@ uuid = "9fb69e20-1954-56bb-a84f-559cc56a8ff7"
 version = "0.2.2"
 
 [[deps.HistoricalStdlibVersions]]
-git-tree-sha1 = "acd79eca861af7d6413c61fbdf81e060ed787309"
+deps = ["Pkg"]
+git-tree-sha1 = "d50c73e4abd8f7c58eb76a8884dfd531fa8dac81"
 uuid = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"
-version = "1.2.4"
+version = "2.0.0"
 
 [[deps.InlineStrings]]
 deps = ["Parsers"]
-git-tree-sha1 = "86356004f30f8e737eff143d57d41bd580e437aa"
+git-tree-sha1 = "45521d31238e87ee9f9732561bfee12d4eebd52d"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
-version = "1.4.1"
+version = "1.4.2"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -177,10 +178,10 @@ uuid = "82899510-4779-5014-852e-03e436cf321d"
 version = "1.0.0"
 
 [[deps.JLD2]]
-deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "PrecompileTools", "Reexport", "Requires", "TranscodingStreams", "UUIDs", "Unicode"]
-git-tree-sha1 = "bdbe8222d2f5703ad6a7019277d149ec6d78c301"
+deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "PrecompileTools", "Reexport", "Requires", "TranscodingStreams", "UUIDs", "Unicode"]
+git-tree-sha1 = "67d4690d32c22e28818a434b293a374cc78473d3"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.48"
+version = "0.4.51"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
@@ -254,9 +255,9 @@ version = "1.0.3"
 
 [[deps.Lz4_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "6c26c5e8a4203d43b5497be3ec5d4e0c3cde240a"
+git-tree-sha1 = "7f26c8fc5229e68484e0b3447312c98e16207d11"
 uuid = "5ced341a-0733-55b8-9ab6-a4889d929147"
-version = "1.9.4+0"
+version = "1.10.0+0"
 
 [[deps.MacroTools]]
 deps = ["Markdown", "Random"]
@@ -283,9 +284,9 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.Mocking]]
 deps = ["Compat", "ExprTools"]
-git-tree-sha1 = "bf17d9cb4f0d2882351dfad030598f64286e5936"
+git-tree-sha1 = "c74e5e7c5f83ccb0bca0377d316d966d296106d4"
 uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
-version = "0.7.8"
+version = "0.7.9"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
@@ -377,9 +378,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[deps.ProgressMeter]]
 deps = ["Distributed", "Printf"]
-git-tree-sha1 = "763a8ceb07833dd51bb9e3bbca372de32c0605ad"
+git-tree-sha1 = "8f6bc219586aef8baf0ff9a5fe16ee9c70cb65e4"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "1.10.0"
+version = "1.10.2"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
@@ -467,10 +468,10 @@ uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 version = "1.0.1"
 
 [[deps.Tables]]
-deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "OrderedCollections", "TableTraits"]
-git-tree-sha1 = "cb76cf677714c095e535e3501ac7954732aeea2d"
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
+git-tree-sha1 = "598cd7c1f68d1e205689b1c2fe65a9f85846f297"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.11.1"
+version = "1.12.0"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
@@ -505,9 +506,9 @@ version = "1.11.0"
 
 [[deps.TranscodingStreams]]
 deps = ["Random", "Test"]
-git-tree-sha1 = "d73336d81cafdc277ff45558bb7eaa2b04a8e472"
+git-tree-sha1 = "96612ac5365777520c3c5396314c8cf7408f436a"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.10.10"
+version = "0.11.1"
 
 [[deps.URIs]]
 git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"

--- a/0_RootFS/LLVMBootstrap@14/build_tarballs.jl
+++ b/0_RootFS/LLVMBootstrap@14/build_tarballs.jl
@@ -1,0 +1,16 @@
+# Include everything common between our LLVM versions (That's a lot)
+include("../llvm_common.jl")
+
+# Build the tarballs, then upload to Yggdrasil releases
+
+name = "LLVMBootstrap"
+version = v"14.0.6"
+sources, script, products, dependencies = llvm_build_args(;version=version)
+ndARGS, deploy_target = find_deploy_arg(ARGS)
+# Earlier versions of GCC can cause Clang to fail with `error: unknown target CPU 'x86-64'`
+# https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/112#issuecomment-776940748
+build_info = build_tarballs(ndARGS, name, version, sources, script, [host_platform], products, dependencies;
+                            skip_audit=true, preferred_gcc_version=v"7.1")
+if deploy_target !== nothing
+    upload_and_insert_shards(deploy_target, name, version, build_info)
+end

--- a/0_RootFS/LLVMBootstrap@14/bundled/patches/0002-llvm8_libcxx_musl.patch
+++ b/0_RootFS/LLVMBootstrap@14/bundled/patches/0002-llvm8_libcxx_musl.patch
@@ -1,0 +1,1 @@
+../../../LLVMBootstrap@8/bundled/patches/0002-llvm8_libcxx_musl.patch

--- a/0_RootFS/LLVMBootstrap@14/bundled/patches/0010-add-musl-triples.patch
+++ b/0_RootFS/LLVMBootstrap@14/bundled/patches/0010-add-musl-triples.patch
@@ -1,0 +1,57 @@
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 4f2340316654..e2e835243e74 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2218,7 +2218,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
+   static const char *const AArch64Triples[] = {
+       "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
+-      "aarch64-suse-linux"};
++      "aarch64-suse-linux", "aarch64-linux-musl"};
+   static const char *const AArch64beLibDirs[] = {"/lib"};
+   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
+                                                  "aarch64_be-linux-gnu"};
+@@ -2229,6 +2229,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+                                              "armv7hl-redhat-linux-gnueabi",
+                                              "armv6hl-suse-linux-gnueabi",
+                                              "armv7hl-suse-linux-gnueabi"};
++  static const char *const ARMHFMuslTriples[] = {"arm-linux-musleabihf", "armv7l-linux-musleabihf",
++                                            "armv6l-linux-musleabihf"};
+   static const char *const ARMebLibDirs[] = {"/lib"};
+   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi"};
+   static const char *const ARMebHFTriples[] = {
+@@ -2248,7 +2250,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "x86_64-redhat-linux",    "x86_64-suse-linux",
+       "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
+       "x86_64-slackware-linux", "x86_64-unknown-linux",
+-      "x86_64-amazon-linux"};
++      "x86_64-amazon-linux",  "x86_64-linux-musl"};
+   static const char *const X32Triples[] = {"x86_64-linux-gnux32",
+                                            "x86_64-pc-linux-gnux32"};
+   static const char *const X32LibDirs[] = {"/libx32", "/lib"};
+@@ -2257,6 +2259,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "i586-linux-gnu",      "i686-linux-gnu",        "i686-pc-linux-gnu",
+       "i386-redhat-linux6E", "i686-redhat-linux",     "i386-redhat-linux",
+       "i586-suse-linux",     "i686-montavista-linux", "i686-gnu",
++      "i686-linux-musl"
+   };
+
+   static const char *const LoongArch64LibDirs[] = {"/lib64", "/lib"};
+@@ -2462,6 +2465,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     LibDirs.append(begin(ARMLibDirs), end(ARMLibDirs));
+     if (TargetTriple.getEnvironment() == llvm::Triple::GNUEABIHF) {
+       TripleAliases.append(begin(ARMHFTriples), end(ARMHFTriples));
++    } else if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++      TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
+     } else {
+       TripleAliases.append(begin(ARMTriples), end(ARMTriples));
+     }
+@@ -2471,6 +2476,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     LibDirs.append(begin(ARMebLibDirs), end(ARMebLibDirs));
+     if (TargetTriple.getEnvironment() == llvm::Triple::GNUEABIHF) {
+       TripleAliases.append(begin(ARMebHFTriples), end(ARMebHFTriples));
++    } else if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++      TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
+     } else {
+       TripleAliases.append(begin(ARMebTriples), end(ARMebTriples));
+     }

--- a/0_RootFS/LLVMBootstrap@14/bundled/patches/0100-llvm-13-musl-bb.patch
+++ b/0_RootFS/LLVMBootstrap@14/bundled/patches/0100-llvm-13-musl-bb.patch
@@ -1,0 +1,24 @@
+From f1901de14ff1f1abcc729c4adccfbd5017e30357 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 7 May 2021 13:54:41 -0400
+Subject: [PATCH] [Compiler-RT] Fix compilation on musl
+
+---
+ compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp                    | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+index b87798603fda..452a08aafe0e 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+@@ -26,6 +26,7 @@
+ 
+ #include <cassert>
+ #include <cstdint>
++#include <stddef.h>
+ #include <dlfcn.h> // for dlsym()
+ 
+ static void *getFuncAddr(const char *name, uintptr_t wrapper_addr) {
+-- 
+2.31.1
+

--- a/0_RootFS/LLVMBootstrap@15/build_tarballs.jl
+++ b/0_RootFS/LLVMBootstrap@15/build_tarballs.jl
@@ -1,0 +1,16 @@
+# Include everything common between our LLVM versions (That's a lot)
+include("../llvm_common.jl")
+
+# Build the tarballs, then upload to Yggdrasil releases
+
+name = "LLVMBootstrap"
+version = v"15.0.7"
+sources, script, products, dependencies = llvm_build_args(;version=version)
+ndARGS, deploy_target = find_deploy_arg(ARGS)
+# Earlier versions of GCC can cause Clang to fail with `error: unknown target CPU 'x86-64'`
+# https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/112#issuecomment-776940748
+build_info = build_tarballs(ndARGS, name, version, sources, script, [host_platform], products, dependencies;
+                            skip_audit=true, preferred_gcc_version=v"7.1")
+if deploy_target !== nothing
+    upload_and_insert_shards(deploy_target, name, version, build_info)
+end

--- a/0_RootFS/LLVMBootstrap@15/bundled/0009-compiler-rt-build-crt-in-runtimes-build.patch
+++ b/0_RootFS/LLVMBootstrap@15/bundled/0009-compiler-rt-build-crt-in-runtimes-build.patch
@@ -1,0 +1,774 @@
+diff --git a/compiler-rt/CMakeLists.txt b/compiler-rt/CMakeLists.txt
+index 62737735695f..41552f2da661 100644
+--- a/compiler-rt/CMakeLists.txt
++++ b/compiler-rt/CMakeLists.txt
+@@ -35,10 +35,6 @@ include(CMakeDependentOption)
+ 
+ option(COMPILER_RT_BUILD_BUILTINS "Build builtins" ON)
+ mark_as_advanced(COMPILER_RT_BUILD_BUILTINS)
+-option(COMPILER_RT_BUILD_CRT "Build crtbegin.o/crtend.o" ON)
+-mark_as_advanced(COMPILER_RT_BUILD_CRT)
+-option(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY "Use eh_frame in crtbegin.o/crtend.o" ON)
+-mark_as_advanced(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY)
+ option(COMPILER_RT_BUILD_SANITIZERS "Build sanitizers" ON)
+ mark_as_advanced(COMPILER_RT_BUILD_SANITIZERS)
+ option(COMPILER_RT_BUILD_XRAY "Build xray" ON)
+diff --git a/compiler-rt/cmake/builtin-config-ix.cmake b/compiler-rt/cmake/builtin-config-ix.cmake
+index 439abc713bad..8715220f2be3 100644
+--- a/compiler-rt/cmake/builtin-config-ix.cmake
++++ b/compiler-rt/cmake/builtin-config-ix.cmake
+@@ -13,6 +13,11 @@ builtin_check_c_compiler_flag(-fvisibility=hidden   COMPILER_RT_HAS_VISIBILITY_H
+ builtin_check_c_compiler_flag(-fomit-frame-pointer  COMPILER_RT_HAS_OMIT_FRAME_POINTER_FLAG)
+ builtin_check_c_compiler_flag(-ffreestanding        COMPILER_RT_HAS_FFREESTANDING_FLAG)
+ builtin_check_c_compiler_flag(-fxray-instrument     COMPILER_RT_HAS_XRAY_COMPILER_FLAG)
++builtin_check_c_compiler_flag(-fno-lto              COMPILER_RT_HAS_FNO_LTO_FLAG)
++builtin_check_c_compiler_flag(-fno-profile-generate COMPILER_RT_HAS_FNO_PROFILE_GENERATE_FLAG)
++builtin_check_c_compiler_flag(-fno-profile-instr-generate COMPILER_RT_HAS_FNO_PROFILE_INSTR_GENERATE_FLAG)
++builtin_check_c_compiler_flag(-fno-profile-instr-use COMPILER_RT_HAS_FNO_PROFILE_INSTR_USE_FLAG)
++builtin_check_c_compiler_flag(-Wno-pedantic         COMPILER_RT_HAS_WNO_PEDANTIC)
+ 
+ builtin_check_c_compiler_source(COMPILER_RT_HAS_ATOMIC_KEYWORD
+ "
+@@ -44,6 +49,12 @@ asm(\".arch armv8-a+lse\");
+ asm(\"cas w0, w1, [x2]\");
+ ")
+ 
++if(ANDROID)
++  set(OS_NAME "Android")
++else()
++  set(OS_NAME "${CMAKE_SYSTEM_NAME}")
++endif()
++
+ set(ARM64 aarch64)
+ set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv8m.main armv8.1m.main)
+ set(AVR avr)
+@@ -229,4 +240,10 @@ else()
+     ${ALL_BUILTIN_SUPPORTED_ARCH})
+ endif()
+ 
++if (OS_NAME MATCHES "Linux" AND NOT LLVM_USE_SANITIZER)
++  set(COMPILER_RT_HAS_CRT TRUE)
++else()
++  set(COMPILER_RT_HAS_CRT FALSE)
++endif()
++
+ message(STATUS "Builtin supported architectures: ${BUILTIN_SUPPORTED_ARCH}")
+diff --git a/compiler-rt/lib/CMakeLists.txt b/compiler-rt/lib/CMakeLists.txt
+index 18eed2446dc6..e48a2675a6a3 100644
+--- a/compiler-rt/lib/CMakeLists.txt
++++ b/compiler-rt/lib/CMakeLists.txt
+@@ -17,10 +17,6 @@ if(COMPILER_RT_BUILD_BUILTINS)
+   add_subdirectory(builtins)
+ endif()
+ 
+-if(COMPILER_RT_BUILD_CRT)
+-  add_subdirectory(crt)
+-endif()
+-
+ function(compiler_rt_build_runtime runtime)
+   string(TOUPPER ${runtime} runtime_uppercase)
+   if(COMPILER_RT_HAS_${runtime_uppercase})
+diff --git a/compiler-rt/lib/builtins/CMakeLists.txt b/compiler-rt/lib/builtins/CMakeLists.txt
+index df02682ae00f..2e75f045fb84 100644
+--- a/compiler-rt/lib/builtins/CMakeLists.txt
++++ b/compiler-rt/lib/builtins/CMakeLists.txt
+@@ -49,10 +49,7 @@ if (COMPILER_RT_STANDALONE_BUILD)
+ endif()
+ 
+ include(builtin-config-ix)
+-
+-if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+-  include(CompilerRTAIXUtils)
+-endif()
++include(CMakeDependentOption)
+ 
+ option(COMPILER_RT_BUILTINS_HIDE_SYMBOLS
+   "Do not export any symbols from the static library." ON)
+@@ -646,7 +643,7 @@ set(powerpc64_SOURCES
+   ${GENERIC_SOURCES}
+ )
+ # These routines require __int128, which isn't supported on AIX.
+-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
++if (NOT OS_NAME MATCHES "AIX")
+   set(powerpc64_SOURCES
+     ppc/floattitf.c
+     ppc/fixtfti.c
+@@ -789,6 +786,8 @@ else ()
+   endforeach ()
+ endif ()
+ 
++add_dependencies(compiler-rt builtins)
++
+ option(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC
+   "Build standalone shared atomic library."
+   OFF)
+@@ -797,7 +796,8 @@ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
+   add_custom_target(builtins-standalone-atomic)
+   set(BUILTIN_DEPS "")
+   set(BUILTIN_TYPE SHARED)
+-  if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
++  if(OS_NAME MATCHES "AIX")
++    include(CompilerRTAIXUtils)
+     if(NOT COMPILER_RT_LIBATOMIC_LINK_FLAGS)
+       get_aix_libatomic_default_link_flags(COMPILER_RT_LIBATOMIC_LINK_FLAGS
+         "${CMAKE_CURRENT_SOURCE_DIR}/ppc/atomic.exp")
+@@ -823,7 +823,7 @@ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
+   # FIXME: On AIX, we have to archive built shared libraries into a static
+   # archive, i.e., libatomic.a. Once cmake adds support of such usage for AIX,
+   # this ad-hoc part can be removed.
+-  if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
++  if(OS_NAME MATCHES "AIX")
+     archive_aix_libatomic(clang_rt.atomic libatomic
+                           ARCHS ${BUILTIN_SUPPORTED_ARCH}
+                           PARENT_TARGET builtins-standalone-atomic)
+@@ -831,4 +831,40 @@ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
+   add_dependencies(compiler-rt builtins-standalone-atomic)
+ endif()
+ 
+-add_dependencies(compiler-rt builtins)
++cmake_dependent_option(COMPILER_RT_BUILD_CRT "Build crtbegin.o/crtend.o" ON "COMPILER_RT_HAS_CRT" OFF)
++
++if(COMPILER_RT_BUILD_CRT)
++  add_compiler_rt_component(crt)
++
++  option(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY "Use eh_frame in crtbegin.o/crtend.o" ON)
++
++  include(CheckSectionExists)
++  check_section_exists(".init_array" COMPILER_RT_HAS_INITFINI_ARRAY
++    SOURCE "volatile int x;\n__attribute__((constructor)) void f(void) {x = 0;}\nint main(void) { return 0; }\n")
++
++  append_list_if(COMPILER_RT_HAS_STD_C11_FLAG -std=c11 CRT_CFLAGS)
++  append_list_if(COMPILER_RT_HAS_INITFINI_ARRAY -DCRT_HAS_INITFINI_ARRAY CRT_CFLAGS)
++  append_list_if(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY -DEH_USE_FRAME_REGISTRY CRT_CFLAGS)
++  append_list_if(COMPILER_RT_HAS_FPIC_FLAG -fPIC CRT_CFLAGS)
++  append_list_if(COMPILER_RT_HAS_WNO_PEDANTIC -Wno-pedantic CRT_CFLAGS)
++  if (COMPILER_RT_HAS_FCF_PROTECTION_FLAG)
++    append_list_if(COMPILER_RT_ENABLE_CET -fcf-protection=full CRT_CFLAGS)
++  endif()
++
++  foreach(arch ${BUILTIN_SUPPORTED_ARCH})
++    add_compiler_rt_runtime(clang_rt.crtbegin
++      OBJECT
++      ARCHS ${arch}
++      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtbegin.c
++      CFLAGS ${CRT_CFLAGS}
++      PARENT_TARGET crt)
++    add_compiler_rt_runtime(clang_rt.crtend
++      OBJECT
++      ARCHS ${arch}
++      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtend.c
++      CFLAGS ${CRT_CFLAGS}
++      PARENT_TARGET crt)
++  endforeach()
++
++  add_dependencies(compiler-rt crt)
++endif()
+diff --git a/compiler-rt/lib/crt/CMakeLists.txt b/compiler-rt/lib/crt/CMakeLists.txt
+deleted file mode 100644
+index 60b30566b792..000000000000
+--- a/compiler-rt/lib/crt/CMakeLists.txt
++++ /dev/null
+@@ -1,63 +0,0 @@
+-if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+-  cmake_minimum_required(VERSION 3.13.4)
+-
+-  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+-  project(CompilerRTCRT C)
+-  set(COMPILER_RT_STANDALONE_BUILD TRUE)
+-  set(COMPILER_RT_CRT_STANDALONE_BUILD TRUE)
+-
+-  set(COMPILER_RT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+-
+-  set(LLVM_COMMON_CMAKE_UTILS "${COMPILER_RT_SOURCE_DIR}/../cmake")
+-
+-  # Add path for custom modules
+-  list(INSERT CMAKE_MODULE_PATH 0
+-    "${COMPILER_RT_SOURCE_DIR}/cmake"
+-    "${COMPILER_RT_SOURCE_DIR}/cmake/Modules"
+-    "${LLVM_COMMON_CMAKE_UTILS}"
+-    "${LLVM_COMMON_CMAKE_UTILS}/Modules"
+-    )
+-
+-  include(base-config-ix)
+-  include(CompilerRTUtils)
+-
+-  load_llvm_config()
+-  construct_compiler_rt_default_triple()
+-
+-  include(SetPlatformToolchainTools)
+-  include(AddCompilerRT)
+-endif()
+-
+-include(crt-config-ix)
+-
+-if(COMPILER_RT_HAS_CRT)
+-  add_compiler_rt_component(crt)
+-
+-  include(CheckSectionExists)
+-  check_section_exists(".init_array" COMPILER_RT_HAS_INITFINI_ARRAY
+-    SOURCE "volatile int x;\n__attribute__((constructor)) void f(void) {x = 0;}\nint main(void) { return 0; }\n")
+-
+-  append_list_if(COMPILER_RT_HAS_STD_C11_FLAG -std=c11 CRT_CFLAGS)
+-  append_list_if(COMPILER_RT_HAS_INITFINI_ARRAY -DCRT_HAS_INITFINI_ARRAY CRT_CFLAGS)
+-  append_list_if(COMPILER_RT_CRT_USE_EH_FRAME_REGISTRY -DEH_USE_FRAME_REGISTRY CRT_CFLAGS)
+-  append_list_if(COMPILER_RT_HAS_FPIC_FLAG -fPIC CRT_CFLAGS)
+-  append_list_if(COMPILER_RT_HAS_WNO_PEDANTIC -Wno-pedantic CRT_CFLAGS)
+-  if (COMPILER_RT_HAS_FCF_PROTECTION_FLAG)
+-    append_list_if(COMPILER_RT_ENABLE_CET -fcf-protection=full CRT_CFLAGS)
+-  endif()
+-
+-  foreach(arch ${CRT_SUPPORTED_ARCH})
+-    add_compiler_rt_runtime(clang_rt.crtbegin
+-      OBJECT
+-      ARCHS ${arch}
+-      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtbegin.c
+-      CFLAGS ${CRT_CFLAGS}
+-      PARENT_TARGET crt)
+-    add_compiler_rt_runtime(clang_rt.crtend
+-      OBJECT
+-      ARCHS ${arch}
+-      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtend.c
+-      CFLAGS ${CRT_CFLAGS}
+-      PARENT_TARGET crt)
+-  endforeach()
+-endif()
+diff --git a/compiler-rt/lib/crt/crtbegin.c b/compiler-rt/lib/crt/crtbegin.c
+deleted file mode 100644
+index 7b041ff00b6b..000000000000
+--- a/compiler-rt/lib/crt/crtbegin.c
++++ /dev/null
+@@ -1,127 +0,0 @@
+-//===-- crtbegin.c - Start of constructors and destructors ----------------===//
+-//
+-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+-// See https://llvm.org/LICENSE.txt for license information.
+-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-//
+-//===----------------------------------------------------------------------===//
+-
+-#include <stddef.h>
+-
+-__attribute__((visibility("hidden"))) void *__dso_handle = &__dso_handle;
+-
+-#ifdef EH_USE_FRAME_REGISTRY
+-__extension__ static void *__EH_FRAME_LIST__[]
+-    __attribute__((section(".eh_frame"), aligned(sizeof(void *)))) = {};
+-
+-extern void __register_frame_info(const void *, void *) __attribute__((weak));
+-extern void *__deregister_frame_info(const void *) __attribute__((weak));
+-#endif
+-
+-#ifndef CRT_HAS_INITFINI_ARRAY
+-typedef void (*fp)(void);
+-
+-static fp __CTOR_LIST__[]
+-    __attribute__((section(".ctors"), aligned(sizeof(fp)))) = {(fp)-1};
+-extern fp __CTOR_LIST_END__[];
+-#endif
+-
+-extern void __cxa_finalize(void *) __attribute__((weak));
+-
+-static void __attribute__((used)) __do_init(void) {
+-  static _Bool __initialized;
+-  if (__builtin_expect(__initialized, 0))
+-    return;
+-  __initialized = 1;
+-
+-#ifdef EH_USE_FRAME_REGISTRY
+-  static struct { void *p[8]; } __object;
+-  if (__register_frame_info)
+-    __register_frame_info(__EH_FRAME_LIST__, &__object);
+-#endif
+-#ifndef CRT_HAS_INITFINI_ARRAY
+-  const size_t n = __CTOR_LIST_END__ - __CTOR_LIST__ - 1;
+-  for (size_t i = n; i >= 1; i--) __CTOR_LIST__[i]();
+-#endif
+-}
+-
+-#ifdef CRT_HAS_INITFINI_ARRAY
+-__attribute__((section(".init_array"),
+-               used)) static void (*__init)(void) = __do_init;
+-#elif defined(__i386__) || defined(__x86_64__)
+-__asm__(".pushsection .init,\"ax\",@progbits\n\t"
+-    "call " __USER_LABEL_PREFIX__ "__do_init\n\t"
+-    ".popsection");
+-#elif defined(__riscv)
+-__asm__(".pushsection .init,\"ax\",%progbits\n\t"
+-        "call " __USER_LABEL_PREFIX__ "__do_init\n\t"
+-        ".popsection");
+-#elif defined(__arm__) || defined(__aarch64__)
+-__asm__(".pushsection .init,\"ax\",%progbits\n\t"
+-    "bl " __USER_LABEL_PREFIX__ "__do_init\n\t"
+-    ".popsection");
+-#elif defined(__powerpc__) || defined(__powerpc64__)
+-__asm__(".pushsection .init,\"ax\",@progbits\n\t"
+-    "bl " __USER_LABEL_PREFIX__ "__do_init\n\t"
+-    "nop\n\t"
+-    ".popsection");
+-#elif defined(__sparc__)
+-__asm__(".pushsection .init,\"ax\",@progbits\n\t"
+-    "call " __USER_LABEL_PREFIX__ "__do_init\n\t"
+-    ".popsection");
+-#else
+-#error "crtbegin without .init_fini array unimplemented for this architecture"
+-#endif // CRT_HAS_INITFINI_ARRAY
+-
+-#ifndef CRT_HAS_INITFINI_ARRAY
+-static fp __DTOR_LIST__[]
+-    __attribute__((section(".dtors"), aligned(sizeof(fp)))) = {(fp)-1};
+-extern fp __DTOR_LIST_END__[];
+-#endif
+-
+-static void __attribute__((used)) __do_fini(void) {
+-  static _Bool __finalized;
+-  if (__builtin_expect(__finalized, 0))
+-    return;
+-  __finalized = 1;
+-
+-  if (__cxa_finalize)
+-    __cxa_finalize(__dso_handle);
+-
+-#ifndef CRT_HAS_INITFINI_ARRAY
+-  const size_t n = __DTOR_LIST_END__ - __DTOR_LIST__ - 1;
+-  for (size_t i = 1; i <= n; i++) __DTOR_LIST__[i]();
+-#endif
+-#ifdef EH_USE_FRAME_REGISTRY
+-  if (__deregister_frame_info)
+-    __deregister_frame_info(__EH_FRAME_LIST__);
+-#endif
+-}
+-
+-#ifdef CRT_HAS_INITFINI_ARRAY
+-__attribute__((section(".fini_array"),
+-               used)) static void (*__fini)(void) = __do_fini;
+-#elif defined(__i386__) || defined(__x86_64__)
+-__asm__(".pushsection .fini,\"ax\",@progbits\n\t"
+-    "call " __USER_LABEL_PREFIX__ "__do_fini\n\t"
+-    ".popsection");
+-#elif defined(__arm__) || defined(__aarch64__)
+-__asm__(".pushsection .fini,\"ax\",%progbits\n\t"
+-    "bl " __USER_LABEL_PREFIX__ "__do_fini\n\t"
+-    ".popsection");
+-#elif defined(__powerpc__) || defined(__powerpc64__)
+-__asm__(".pushsection .fini,\"ax\",@progbits\n\t"
+-    "bl " __USER_LABEL_PREFIX__ "__do_fini\n\t"
+-    "nop\n\t"
+-    ".popsection");
+-#elif defined(__riscv)
+-__asm__(".pushsection .fini,\"ax\",@progbits\n\t"
+-        "call " __USER_LABEL_PREFIX__ "__do_fini\n\t"
+-        ".popsection");
+-#elif defined(__sparc__)
+-__asm__(".pushsection .fini,\"ax\",@progbits\n\t"
+-    "call " __USER_LABEL_PREFIX__ "__do_fini\n\t"
+-    ".popsection");
+-#else
+-#error "crtbegin without .init_fini array unimplemented for this architecture"
+-#endif  // CRT_HAS_INIT_FINI_ARRAY
+diff --git a/compiler-rt/lib/crt/crtend.c b/compiler-rt/lib/crt/crtend.c
+deleted file mode 100644
+index ebcc60b89a10..000000000000
+--- a/compiler-rt/lib/crt/crtend.c
++++ /dev/null
+@@ -1,22 +0,0 @@
+-//===-- crtend.c - End of constructors and destructors --------------------===//
+-//
+-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+-// See https://llvm.org/LICENSE.txt for license information.
+-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-//
+-//===----------------------------------------------------------------------===//
+-
+-#include <stdint.h>
+-
+-// Put 4-byte zero which is the length field in FDE at the end as a terminator.
+-const int32_t __EH_FRAME_LIST_END__[]
+-    __attribute__((section(".eh_frame"), aligned(sizeof(int32_t)),
+-                   visibility("hidden"), used)) = {0};
+-
+-#ifndef CRT_HAS_INITFINI_ARRAY
+-typedef void (*fp)(void);
+-fp __CTOR_LIST_END__[]
+-    __attribute__((section(".ctors"), visibility("hidden"), used)) = {0};
+-fp __DTOR_LIST_END__[]
+-    __attribute__((section(".dtors"), visibility("hidden"), used)) = {0};
+-#endif
+diff --git a/compiler-rt/test/CMakeLists.txt b/compiler-rt/test/CMakeLists.txt
+index 3cbfc4b0e544..c28f2c651c0c 100644
+--- a/compiler-rt/test/CMakeLists.txt
++++ b/compiler-rt/test/CMakeLists.txt
+@@ -96,9 +96,6 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
+   if(COMPILER_RT_BUILD_ORC)
+     compiler_rt_Test_runtime(orc)
+   endif()
+-  if(COMPILER_RT_BUILD_CRT)
+-    add_subdirectory(crt)
+-  endif()
+   # ShadowCallStack does not yet provide a runtime with compiler-rt, the tests
+   # include their own minimal runtime
+   add_subdirectory(shadowcallstack)
+diff --git a/compiler-rt/test/builtins/CMakeLists.txt b/compiler-rt/test/builtins/CMakeLists.txt
+index 1579e223e875..d2115501e772 100644
+--- a/compiler-rt/test/builtins/CMakeLists.txt
++++ b/compiler-rt/test/builtins/CMakeLists.txt
+@@ -13,6 +13,10 @@ configure_lit_site_cfg(
+ 
+ include(builtin-config-ix)
+ 
++if (COMPILER_RT_HAS_CRT)
++  list(APPEND BUILTINS_TEST_DEPS crt)
++endif()
++
+ # Indicate if this is an MSVC environment.
+ pythonize_bool(MSVC)
+ 
+diff --git a/compiler-rt/test/builtins/Unit/lit.cfg.py b/compiler-rt/test/builtins/Unit/lit.cfg.py
+index fa6dc86783d3..a531175ba8e9 100644
+--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
++++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
+@@ -2,6 +2,8 @@
+ 
+ import os
+ import platform
++import shlex
++import subprocess
+ 
+ import lit.formats
+ 
+@@ -25,6 +27,40 @@ def get_required_attr(config, attr_name):
+       "to lit.site.cfg.py " % attr_name)
+   return attr_value
+ 
++def get_library_path(file):
++    cmd = subprocess.Popen(
++        [config.clang.strip(), "-print-file-name=%s" % file]
++        + shlex.split(config.target_cflags),
++        stdout=subprocess.PIPE,
++        env=config.environment,
++        universal_newlines=True,
++    )
++    if not cmd.stdout:
++        lit_config.fatal("Couldn't find the library path for '%s'" % file)
++    dir = cmd.stdout.read().strip()
++    if sys.platform in ["win32"] and execute_external:
++        # Don't pass dosish path separator to msys bash.exe.
++        dir = dir.replace("\\", "/")
++    return dir
++
++
++def get_libgcc_file_name():
++    cmd = subprocess.Popen(
++        [config.clang.strip(), "-print-libgcc-file-name"]
++        + shlex.split(config.target_cflags),
++        stdout=subprocess.PIPE,
++        env=config.environment,
++        universal_newlines=True,
++    )
++    if not cmd.stdout:
++        lit_config.fatal("Couldn't find the library path for '%s'" % file)
++    dir = cmd.stdout.read().strip()
++    if sys.platform in ["win32"] and execute_external:
++        # Don't pass dosish path separator to msys bash.exe.
++        dir = dir.replace("\\", "/")
++    return dir
++
++
+ # Setup config name.
+ config.name = 'Builtins' + config.name_suffix
+ 
+@@ -51,6 +87,27 @@ else:
+     base_lib = base_lib.replace('\\', '/')
+   config.substitutions.append( ("%librt ", base_lib + ' -lc -lm ') )
+ 
++  if config.host_os == "Linux":
++      base_obj = os.path.join(
++          config.compiler_rt_libdir, "clang_rt.%%s%s.o" % config.target_suffix
++      )
++      if sys.platform in ["win32"] and execute_external:
++          # Don't pass dosish path separator to msys bash.exe.
++          base_obj = base_obj.replace("\\", "/")
++
++      config.substitutions.append(("%crtbegin", base_obj % "crtbegin"))
++      config.substitutions.append(("%crtend", base_obj % "crtend"))
++
++      config.substitutions.append(("%crt1", get_library_path("crt1.o")))
++      config.substitutions.append(("%crti", get_library_path("crti.o")))
++      config.substitutions.append(("%crtn", get_library_path("crtn.o")))
++
++      config.substitutions.append(("%libgcc", get_libgcc_file_name()))
++
++      config.substitutions.append(
++          ("%libstdcxx", "-l" + config.sanitizer_cxx_lib.lstrip("lib"))
++      )
++
+ builtins_source_dir = os.path.join(
+   get_required_attr(config, "compiler_rt_src_root"), "lib", "builtins")
+ if sys.platform in ['win32'] and execute_external:
+diff --git a/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in b/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in
+index e55dd5d51f3d..920c915feb08 100644
+--- a/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in
++++ b/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in
+@@ -4,6 +4,7 @@ config.name_suffix = "@BUILTINS_TEST_CONFIG_SUFFIX@"
+ config.builtins_lit_source_dir = "@BUILTINS_LIT_SOURCE_DIR@/Unit"
+ config.target_cflags = "@BUILTINS_TEST_TARGET_CFLAGS@"
+ config.target_arch = "@BUILTINS_TEST_TARGET_ARCH@"
++config.sanitizer_cxx_lib = "@SANITIZER_TEST_CXX_LIBNAME@"
+ config.is_msvc = @MSVC_PYBOOL@
+ config.builtins_is_msvc = @BUILTINS_IS_MSVC_PYBOOL@
+ config.builtins_lit_source_features = "@BUILTINS_LIT_SOURCE_FEATURES@"
+diff --git a/compiler-rt/test/crt/CMakeLists.txt b/compiler-rt/test/crt/CMakeLists.txt
+deleted file mode 100644
+index f539be34f6ca..000000000000
+--- a/compiler-rt/test/crt/CMakeLists.txt
++++ /dev/null
+@@ -1,41 +0,0 @@
+-include(crt-config-ix)
+-
+-if (COMPILER_RT_HAS_CRT)
+-  set(CRT_LIT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+-
+-  if(NOT COMPILER_RT_STANDALONE_BUILD)
+-    list(APPEND CRT_TEST_DEPS crt)
+-  endif()
+-  if(NOT COMPILER_RT_STANDALONE_BUILD AND NOT LLVM_RUNTIMES_BUILD)
+-    # Use LLVM utils and Clang from the same build tree.
+-    list(APPEND CRT_TEST_DEPS
+-      clang clang-resource-headers FileCheck not llvm-config)
+-  endif()
+-
+-  set(CRT_TEST_ARCH ${CRT_SUPPORTED_ARCH})
+-  foreach(arch ${CRT_TEST_ARCH})
+-    set(CRT_TEST_TARGET_ARCH ${arch})
+-    string(TOLOWER "-${arch}-${OS_NAME}" CRT_TEST_CONFIG_SUFFIX)
+-    get_test_cc_for_arch(${arch} CRT_TEST_TARGET_CC CRT_TEST_TARGET_CFLAGS)
+-    string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-    set(CONFIG_NAME ${ARCH_UPPER_CASE}${OS_NAME}Config)
+-
+-    if (COMPILER_RT_ENABLE_CET)
+-      if (${arch} MATCHES "i386|x86_64")
+-        list(APPEND CRT_TEST_TARGET_CFLAGS -fcf-protection=full)
+-        string(REPLACE ";" " " CRT_TEST_TARGET_CFLAGS "${CRT_TEST_TARGET_CFLAGS}")
+-      else()
+-        message(FATAL_ERROR "The target arch ${arch} doesn't support CET")
+-      endif()
+-    endif()
+-    configure_lit_site_cfg(
+-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg.py)
+-    list(APPEND CRT_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME})
+-  endforeach()
+-
+-  add_lit_testsuite(check-crt "Running the CRT tests"
+-    ${CRT_TESTSUITES}
+-    DEPENDS ${CRT_TEST_DEPS})
+-  set_target_properties(check-crt PROPERTIES FOLDER "Compiler-RT Misc")
+-endif()
+diff --git a/compiler-rt/test/crt/ctor_dtor.c b/compiler-rt/test/crt/ctor_dtor.c
+deleted file mode 100644
+index 2bea05073b4d..000000000000
+--- a/compiler-rt/test/crt/ctor_dtor.c
++++ /dev/null
+@@ -1,41 +0,0 @@
+-// RUN: %clang -fno-use-init-array -g -c %s -o %t.o
+-// RUN: %clang -o %t -no-pie -nostdlib %crt1 %crti %crtbegin %t.o -lc %libgcc %crtend %crtn
+-// RUN: %run %t 2>&1 | FileCheck %s
+-
+-#include <stdio.h>
+-#include <stdlib.h>
+-
+-// Ensure the various startup functions are called in the proper order.
+-
+-// CHECK: __register_frame_info()
+-/// ctor() is here if ld.so/libc supports DT_INIT/DT_FINI
+-// CHECK:      main()
+-/// dtor() is here if ld.so/libc supports DT_INIT/DT_FINI
+-// CHECK:      __deregister_frame_info()
+-
+-struct object;
+-static int counter;
+-
+-void __register_frame_info(const void *fi, struct object *obj) {
+-  printf("__register_frame_info()\n");
+-}
+-
+-void __deregister_frame_info(const void *fi) {
+-  printf("__deregister_frame_info()\n");
+-}
+-
+-void __attribute__((constructor)) ctor() {
+-  printf("ctor()\n");
+-  ++counter;
+-}
+-
+-void __attribute__((destructor)) dtor() {
+-  printf("dtor()\n");
+-  if (--counter != 0)
+-    abort();
+-}
+-
+-int main() {
+-  printf("main()\n");
+-  return 0;
+-}
+diff --git a/compiler-rt/test/crt/dso_handle.cpp b/compiler-rt/test/crt/dso_handle.cpp
+deleted file mode 100644
+index a32ce4b8d382..000000000000
+--- a/compiler-rt/test/crt/dso_handle.cpp
++++ /dev/null
+@@ -1,35 +0,0 @@
+-// RUN: %clangxx -g -DCRT_SHARED -c %s -fPIC -o %tshared.o
+-// RUN: %clangxx -g -c %s -fPIC -o %t.o
+-// RUN: %clangxx -g -shared -o %t.so -nostdlib %crti %crtbegin %tshared.o %libstdcxx -lc -lm %libgcc %crtend %crtn
+-// RUN: %clangxx -g -o %t -fno-pic -no-pie -nostdlib %crt1 %crti %crtbegin %t.o %libstdcxx -lc -lm %libgcc %t.so %crtend %crtn
+-// RUN: %run %t 2>&1 | FileCheck %s
+-
+-// UNSUPPORTED: arm, aarch64
+-
+-#include <stdio.h>
+-
+-// CHECK: 1
+-// CHECK-NEXT: ~A()
+-
+-#ifdef CRT_SHARED
+-bool G;
+-void C() {
+-  printf("%d\n", G);
+-}
+-
+-struct A {
+-  A() { G = true; }
+-  ~A() {
+-    printf("~A()\n");
+-  }
+-};
+-
+-A a;
+-#else
+-void C();
+-
+-int main() {
+-  C();
+-  return 0;
+-}
+-#endif
+diff --git a/compiler-rt/test/crt/lit.cfg.py b/compiler-rt/test/crt/lit.cfg.py
+deleted file mode 100644
+index d5a6aa9862d9..000000000000
+--- a/compiler-rt/test/crt/lit.cfg.py
++++ /dev/null
+@@ -1,95 +0,0 @@
+-# -*- Python -*-
+-
+-import os
+-import subprocess
+-import shlex
+-
+-# Setup config name.
+-config.name = 'CRT' + config.name_suffix
+-
+-# Setup source root.
+-config.test_source_root = os.path.dirname(__file__)
+-
+-
+-# Choose between lit's internal shell pipeline runner and a real shell.  If
+-# LIT_USE_INTERNAL_SHELL is in the environment, we use that as an override.
+-use_lit_shell = os.environ.get("LIT_USE_INTERNAL_SHELL")
+-if use_lit_shell:
+-    # 0 is external, "" is default, and everything else is internal.
+-    execute_external = (use_lit_shell == "0")
+-else:
+-    # Otherwise we default to internal on Windows and external elsewhere, as
+-    # bash on Windows is usually very slow.
+-    execute_external = (not sys.platform in ['win32'])
+-
+-def get_library_path(file):
+-    cmd = subprocess.Popen([config.clang.strip(),
+-                            '-print-file-name=%s' % file] +
+-                           shlex.split(config.target_cflags),
+-                           stdout=subprocess.PIPE,
+-                           env=config.environment,
+-                           universal_newlines=True)
+-    if not cmd.stdout:
+-      lit_config.fatal("Couldn't find the library path for '%s'" % file)
+-    dir = cmd.stdout.read().strip()
+-    if sys.platform in ['win32'] and execute_external:
+-        # Don't pass dosish path separator to msys bash.exe.
+-        dir = dir.replace('\\', '/')
+-    return dir
+-
+-
+-def get_libgcc_file_name():
+-    cmd = subprocess.Popen([config.clang.strip(),
+-                            '-print-libgcc-file-name'] +
+-                           shlex.split(config.target_cflags),
+-                           stdout=subprocess.PIPE,
+-                           env=config.environment,
+-                           universal_newlines=True)
+-    if not cmd.stdout:
+-      lit_config.fatal("Couldn't find the library path for '%s'" % file)
+-    dir = cmd.stdout.read().strip()
+-    if sys.platform in ['win32'] and execute_external:
+-        # Don't pass dosish path separator to msys bash.exe.
+-        dir = dir.replace('\\', '/')
+-    return dir
+-
+-
+-def build_invocation(compile_flags):
+-    return ' ' + ' '.join([config.clang] + compile_flags) + ' '
+-
+-
+-# Setup substitutions.
+-config.substitutions.append(
+-    ('%clang ', build_invocation([config.target_cflags])))
+-config.substitutions.append(
+-    ('%clangxx ',
+-     build_invocation(config.cxx_mode_flags + [config.target_cflags])))
+-
+-base_lib = os.path.join(
+-    config.compiler_rt_libdir, "clang_rt.%%s%s.o" % config.target_suffix)
+-
+-if sys.platform in ['win32'] and execute_external:
+-    # Don't pass dosish path separator to msys bash.exe.
+-    base_lib = base_lib.replace('\\', '/')
+-
+-config.substitutions.append(('%crtbegin', base_lib % "crtbegin"))
+-config.substitutions.append(('%crtend', base_lib % "crtend"))
+-
+-config.substitutions.append(
+-    ('%crt1', get_library_path('crt1.o')))
+-config.substitutions.append(
+-    ('%crti', get_library_path('crti.o')))
+-config.substitutions.append(
+-    ('%crtn', get_library_path('crtn.o')))
+-
+-config.substitutions.append(
+-    ('%libgcc', get_libgcc_file_name()))
+-
+-config.substitutions.append(
+-    ('%libstdcxx', '-l' + config.sanitizer_cxx_lib.lstrip('lib')))
+-
+-# Default test suffixes.
+-config.suffixes = ['.c', '.cpp']
+-
+-if config.host_os not in ['Linux']:
+-    config.unsupported = True
+diff --git a/compiler-rt/test/crt/lit.site.cfg.py.in b/compiler-rt/test/crt/lit.site.cfg.py.in
+deleted file mode 100644
+index 53eda0c45948..000000000000
+--- a/compiler-rt/test/crt/lit.site.cfg.py.in
++++ /dev/null
+@@ -1,14 +0,0 @@
+-@LIT_SITE_CFG_IN_HEADER@
+-
+-# Tool-specific config options.
+-config.name_suffix = "@CRT_TEST_CONFIG_SUFFIX@"
+-config.crt_lit_source_dir = "@CRT_LIT_SOURCE_DIR@"
+-config.target_cflags = "@CRT_TEST_TARGET_CFLAGS@"
+-config.target_arch = "@CRT_TEST_TARGET_ARCH@"
+-config.sanitizer_cxx_lib = "@SANITIZER_TEST_CXX_LIBNAME@"
+-
+-# Load common config for all compiler-rt lit tests
+-lit_config.load_config(config, "@COMPILER_RT_BINARY_DIR@/test/lit.common.configured")
+-
+-# Load tool-specific config that would do the real work.
+-lit_config.load_config(config, "@CRT_LIT_SOURCE_DIR@/lit.cfg.py")

--- a/0_RootFS/LLVMBootstrap@15/bundled/patches/0002-llvm8_libcxx_musl.patch
+++ b/0_RootFS/LLVMBootstrap@15/bundled/patches/0002-llvm8_libcxx_musl.patch
@@ -1,0 +1,1 @@
+../../../LLVMBootstrap@8/bundled/patches/0002-llvm8_libcxx_musl.patch

--- a/0_RootFS/LLVMBootstrap@15/bundled/patches/0010-add-musl-triples.patch
+++ b/0_RootFS/LLVMBootstrap@15/bundled/patches/0010-add-musl-triples.patch
@@ -1,0 +1,57 @@
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 4f2340316654..e2e835243e74 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2218,7 +2218,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
+   static const char *const AArch64Triples[] = {
+       "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
+-      "aarch64-suse-linux"};
++      "aarch64-suse-linux", "aarch64-linux-musl"};
+   static const char *const AArch64beLibDirs[] = {"/lib"};
+   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
+                                                  "aarch64_be-linux-gnu"};
+@@ -2229,6 +2229,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+                                              "armv7hl-redhat-linux-gnueabi",
+                                              "armv6hl-suse-linux-gnueabi",
+                                              "armv7hl-suse-linux-gnueabi"};
++  static const char *const ARMHFMuslTriples[] = {"arm-linux-musleabihf", "armv7l-linux-musleabihf",
++                                            "armv6l-linux-musleabihf"};
+   static const char *const ARMebLibDirs[] = {"/lib"};
+   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi"};
+   static const char *const ARMebHFTriples[] = {
+@@ -2248,7 +2250,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "x86_64-redhat-linux",    "x86_64-suse-linux",
+       "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
+       "x86_64-slackware-linux", "x86_64-unknown-linux",
+-      "x86_64-amazon-linux"};
++      "x86_64-amazon-linux",  "x86_64-linux-musl"};
+   static const char *const X32Triples[] = {"x86_64-linux-gnux32",
+                                            "x86_64-pc-linux-gnux32"};
+   static const char *const X32LibDirs[] = {"/libx32", "/lib"};
+@@ -2257,6 +2259,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "i586-linux-gnu",      "i686-linux-gnu",        "i686-pc-linux-gnu",
+       "i386-redhat-linux6E", "i686-redhat-linux",     "i386-redhat-linux",
+       "i586-suse-linux",     "i686-montavista-linux", "i686-gnu",
++      "i686-linux-musl"
+   };
+
+   static const char *const LoongArch64LibDirs[] = {"/lib64", "/lib"};
+@@ -2462,6 +2465,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     LibDirs.append(begin(ARMLibDirs), end(ARMLibDirs));
+     if (TargetTriple.getEnvironment() == llvm::Triple::GNUEABIHF) {
+       TripleAliases.append(begin(ARMHFTriples), end(ARMHFTriples));
++    } else if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++      TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
+     } else {
+       TripleAliases.append(begin(ARMTriples), end(ARMTriples));
+     }
+@@ -2471,6 +2476,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     LibDirs.append(begin(ARMebLibDirs), end(ARMebLibDirs));
+     if (TargetTriple.getEnvironment() == llvm::Triple::GNUEABIHF) {
+       TripleAliases.append(begin(ARMebHFTriples), end(ARMebHFTriples));
++    } else if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++      TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
+     } else {
+       TripleAliases.append(begin(ARMebTriples), end(ARMebTriples));
+     }

--- a/0_RootFS/LLVMBootstrap@15/bundled/patches/0100-llvm-13-musl-bb.patch
+++ b/0_RootFS/LLVMBootstrap@15/bundled/patches/0100-llvm-13-musl-bb.patch
@@ -1,0 +1,24 @@
+From f1901de14ff1f1abcc729c4adccfbd5017e30357 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 7 May 2021 13:54:41 -0400
+Subject: [PATCH] [Compiler-RT] Fix compilation on musl
+
+---
+ compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp                    | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+index b87798603fda..452a08aafe0e 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+@@ -26,6 +26,7 @@
+ 
+ #include <cassert>
+ #include <cstdint>
++#include <stddef.h>
+ #include <dlfcn.h> // for dlsym()
+ 
+ static void *getFuncAddr(const char *name, uintptr_t wrapper_addr) {
+-- 
+2.31.1
+

--- a/0_RootFS/LLVMBootstrap@15/bundled/patches/install-prefix.patch
+++ b/0_RootFS/LLVMBootstrap@15/bundled/patches/install-prefix.patch
@@ -1,0 +1,31 @@
+starting from llvm14 the install prefix breaks via symlinks;
+/usr/lib/llvm14/lib/cmake/llvm/LLVMConfig.cmake goes up 3 directories to find
+/usr/lib/llvm14/include as LLVM_INCLUDE_DIRS, but to even use this cmake folder
+at all it has to be symlinked to /usr/lib/cmake/llvm .. so the directory it
+instead uses is just /usr/include, which is not where the cmake includes are.
+this hardcodes them to the install prefix we pass via cmake, which should
+always be correct, and what cmake tries to autodetect anyway.
+
+also see: https://reviews.llvm.org/D29969
+
+this is supposedly fixed now, but for some reason it still isn't
+--- a/llvm/cmake/modules/CMakeLists.txt
++++ b/llvm/cmake/modules/CMakeLists.txt
+@@ -41,6 +41,8 @@
+ #
+
+ set(LLVM_CONFIG_CODE "
++# this is wrong when automatically detected
++set(LLVM_INSTALL_PREFIX \"${CMAKE_INSTALL_PREFIX}\")
+ # LLVM_BUILD_* values available only from LLVM build tree.
+ set(LLVM_BUILD_BINARY_DIR \"${LLVM_BINARY_DIR}\")
+ set(LLVM_BUILD_LIBRARY_DIR \"${LLVM_LIBRARY_DIR}\")
+@@ -109,8 +111,6 @@
+ #
+ # Generate LLVMConfig.cmake for the install tree.
+ #
+-
+-find_prefix_from_config(LLVM_CONFIG_CODE LLVM_INSTALL_PREFIX "${LLVM_INSTALL_PACKAGE_DIR}")
+
+ extend_path(LLVM_CONFIG_MAIN_INCLUDE_DIR "\${LLVM_INSTALL_PREFIX}" "${CMAKE_INSTALL_INCLUDEDIR}")
+ # This is the same as the above because the handwritten and generated headers

--- a/0_RootFS/LLVMBootstrap@17/build_tarballs.jl
+++ b/0_RootFS/LLVMBootstrap@17/build_tarballs.jl
@@ -1,0 +1,16 @@
+# Include everything common between our LLVM versions (That's a lot)
+include("../llvm_common.jl")
+
+# Build the tarballs, then upload to Yggdrasil releases
+
+name = "LLVMBootstrap"
+version = v"17.0.6"
+sources, script, products, dependencies = llvm_build_args(;version=version)
+ndARGS, deploy_target = find_deploy_arg(ARGS)
+# Earlier versions of GCC can cause Clang to fail with `error: unknown target CPU 'x86-64'`
+# https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/112#issuecomment-776940748
+build_info = build_tarballs(ndARGS, name, version, sources, script, [host_platform], products, dependencies;
+                            skip_audit=true, preferred_gcc_version=v"8")
+if deploy_target !== nothing
+    upload_and_insert_shards(deploy_target, name, version, build_info)
+end

--- a/0_RootFS/LLVMBootstrap@17/bundled/libcxx_patches/0002-llvm8_libcxx_musl.patch
+++ b/0_RootFS/LLVMBootstrap@17/bundled/libcxx_patches/0002-llvm8_libcxx_musl.patch
@@ -1,0 +1,22 @@
+diff --git a/include/locale b/include/locale
+index 874866f69822..8206013a0719 100644
+--- a/include/locale
++++ b/include/locale
+@@ -758,7 +758,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end,
+         __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        long long __ll = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        long long __ll = strtoll(__a, &__p2, __base);
+         __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;
+@@ -798,7 +798,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end,
+         __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        unsigned long long __ll = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        unsigned long long __ll = strtoull(__a, &__p2, __base);
+         __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;

--- a/0_RootFS/LLVMBootstrap@17/bundled/patches/0004-enable-emutls-for-mingw.patch
+++ b/0_RootFS/LLVMBootstrap@17/bundled/patches/0004-enable-emutls-for-mingw.patch
@@ -1,0 +1,11 @@
+--- a/llvm/include/llvm/TargetParser/Triple.h
++++ b/llvm/include/llvm/TargetParser/Triple.h
+@@ -993,7 +993,7 @@ public:
+   /// Note: Android API level 29 (10) introduced ELF TLS.
+   bool hasDefaultEmulatedTLS() const {
+     return (isAndroid() && isAndroidVersionLT(29)) || isOSOpenBSD() ||
+-           isWindowsCygwinEnvironment() || isOHOSFamily();
++           isOSCygMing() || isOHOSFamily();
+   }
+
+   /// Tests whether the target uses -data-sections as default.

--- a/0_RootFS/LLVMBootstrap@17/bundled/patches/0010-add-musl-triples.patch
+++ b/0_RootFS/LLVMBootstrap@17/bundled/patches/0010-add-musl-triples.patch
@@ -1,0 +1,57 @@
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 4f2340316654..e2e835243e74 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2218,7 +2218,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
+   static const char *const AArch64Triples[] = {
+       "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
+-      "aarch64-suse-linux"};
++      "aarch64-suse-linux", "aarch64-linux-musl"};
+   static const char *const AArch64beLibDirs[] = {"/lib"};
+   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
+                                                  "aarch64_be-linux-gnu"};
+@@ -2229,6 +2229,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+                                              "armv7hl-redhat-linux-gnueabi",
+                                              "armv6hl-suse-linux-gnueabi",
+                                              "armv7hl-suse-linux-gnueabi"};
++  static const char *const ARMHFMuslTriples[] = {"arm-linux-musleabihf", "armv7l-linux-musleabihf",
++                                            "armv6l-linux-musleabihf"};
+   static const char *const ARMebLibDirs[] = {"/lib"};
+   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi"};
+   static const char *const ARMebHFTriples[] = {
+@@ -2248,7 +2250,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "x86_64-redhat-linux",    "x86_64-suse-linux",
+       "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
+       "x86_64-slackware-linux", "x86_64-unknown-linux",
+-      "x86_64-amazon-linux"};
++      "x86_64-amazon-linux",  "x86_64-linux-musl"};
+   static const char *const X32Triples[] = {"x86_64-linux-gnux32",
+                                            "x86_64-pc-linux-gnux32"};
+   static const char *const X32LibDirs[] = {"/libx32", "/lib"};
+@@ -2257,6 +2259,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "i586-linux-gnu",      "i686-linux-gnu",        "i686-pc-linux-gnu",
+       "i386-redhat-linux6E", "i686-redhat-linux",     "i386-redhat-linux",
+       "i586-suse-linux",     "i686-montavista-linux", "i686-gnu",
++      "i686-linux-musl"
+   };
+
+   static const char *const LoongArch64LibDirs[] = {"/lib64", "/lib"};
+@@ -2462,6 +2465,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     LibDirs.append(begin(ARMLibDirs), end(ARMLibDirs));
+     if (TargetTriple.getEnvironment() == llvm::Triple::GNUEABIHF) {
+       TripleAliases.append(begin(ARMHFTriples), end(ARMHFTriples));
++    } else if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++      TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
+     } else {
+       TripleAliases.append(begin(ARMTriples), end(ARMTriples));
+     }
+@@ -2471,6 +2476,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     LibDirs.append(begin(ARMebLibDirs), end(ARMebLibDirs));
+     if (TargetTriple.getEnvironment() == llvm::Triple::GNUEABIHF) {
+       TripleAliases.append(begin(ARMebHFTriples), end(ARMebHFTriples));
++    } else if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++      TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
+     } else {
+       TripleAliases.append(begin(ARMebTriples), end(ARMebTriples));
+     }

--- a/0_RootFS/LLVMBootstrap@17/bundled/patches/0100-llvm-13-musl-bb.patch
+++ b/0_RootFS/LLVMBootstrap@17/bundled/patches/0100-llvm-13-musl-bb.patch
@@ -1,0 +1,24 @@
+From f1901de14ff1f1abcc729c4adccfbd5017e30357 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 7 May 2021 13:54:41 -0400
+Subject: [PATCH] [Compiler-RT] Fix compilation on musl
+
+---
+ compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp                    | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+index b87798603fda..452a08aafe0e 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+@@ -26,6 +26,7 @@
+ 
+ #include <cassert>
+ #include <cstdint>
++#include <stddef.h>
+ #include <dlfcn.h> // for dlsym()
+ 
+ static void *getFuncAddr(const char *name, uintptr_t wrapper_addr) {
+-- 
+2.31.1
+

--- a/0_RootFS/LLVMBootstrap@17/bundled/patches/install-prefix.patch
+++ b/0_RootFS/LLVMBootstrap@17/bundled/patches/install-prefix.patch
@@ -1,0 +1,31 @@
+starting from llvm14 the install prefix breaks via symlinks;
+/usr/lib/llvm14/lib/cmake/llvm/LLVMConfig.cmake goes up 3 directories to find
+/usr/lib/llvm14/include as LLVM_INCLUDE_DIRS, but to even use this cmake folder
+at all it has to be symlinked to /usr/lib/cmake/llvm .. so the directory it
+instead uses is just /usr/include, which is not where the cmake includes are.
+this hardcodes them to the install prefix we pass via cmake, which should
+always be correct, and what cmake tries to autodetect anyway.
+
+also see: https://reviews.llvm.org/D29969
+
+this is supposedly fixed now, but for some reason it still isn't
+--- a/llvm/cmake/modules/CMakeLists.txt
++++ b/llvm/cmake/modules/CMakeLists.txt
+@@ -41,6 +41,8 @@
+ #
+
+ set(LLVM_CONFIG_CODE "
++# this is wrong when automatically detected
++set(LLVM_INSTALL_PREFIX \"${CMAKE_INSTALL_PREFIX}\")
+ # LLVM_BUILD_* values available only from LLVM build tree.
+ set(LLVM_BUILD_BINARY_DIR \"${LLVM_BINARY_DIR}\")
+ set(LLVM_BUILD_LIBRARY_DIR \"${LLVM_LIBRARY_DIR}\")
+@@ -109,8 +111,6 @@
+ #
+ # Generate LLVMConfig.cmake for the install tree.
+ #
+-
+-find_prefix_from_config(LLVM_CONFIG_CODE LLVM_INSTALL_PREFIX "${LLVM_INSTALL_PACKAGE_DIR}")
+
+ extend_path(LLVM_CONFIG_MAIN_INCLUDE_DIR "\${LLVM_INSTALL_PREFIX}" "${CMAKE_INSTALL_INCLUDEDIR}")
+ # This is the same as the above because the handwritten and generated headers

--- a/0_RootFS/LLVMBootstrap@17/bundled/patches/normalize-cmake-triple.patch
+++ b/0_RootFS/LLVMBootstrap@17/bundled/patches/normalize-cmake-triple.patch
@@ -1,0 +1,102 @@
+diff --git a/cmake/Modules/HandleOutOfTreeLLVM.cmake b/cmake/Modules/HandleOutOfTreeLLVM.cmake
+index edffe572e091..ea7f3aab7e8a 100644
+--- a/cmake/Modules/HandleOutOfTreeLLVM.cmake
++++ b/cmake/Modules/HandleOutOfTreeLLVM.cmake
+@@ -32,6 +32,21 @@ message(STATUS "Configuring for standalone build.")
+ include(GetHostTriple)
+ get_host_triple(LLVM_INFERRED_HOST_TRIPLE)
+ set(LLVM_HOST_TRIPLE "${LLVM_INFERRED_HOST_TRIPLE}" CACHE STRING "Host on which LLVM binaries will run")
++#NOTE: we must normalize specified target triple to a fully specified triple,
++# including the vendor part. It is necessary to synchronize the runtime library
++# installation path and operable target triple by Clang to get a correct runtime
++# path through `-print-runtime-dir` Clang option.
++string(REPLACE "-" ";" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++list(LENGTH LLVM_HOST_TRIPLE LLVM_HOST_TRIPLE_LEN)
++if (LLVM_HOST_TRIPLE_LEN LESS 3)
++  message(FATAL_ERROR "invalid target triple")
++endif()
++# We suppose missed vendor's part.
++if (LLVM_HOST_TRIPLE_LEN LESS 4)
++  list(INSERT LLVM_HOST_TRIPLE 1 "unknown")
++endif()
++string(REPLACE ";" "-" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++
+ set(LLVM_DEFAULT_TARGET_TRIPLE "${LLVM_HOST_TRIPLE}" CACHE STRING "Target triple used by default.")
+
+ # Add LLVM Functions --------------------------------------------------------
+diff --git a/llvm/cmake/config-ix.cmake b/llvm/cmake/config-ix.cmake
+index b78c1b34ab8b..d3786c3ea611 100644
+--- a/llvm/cmake/config-ix.cmake
++++ b/llvm/cmake/config-ix.cmake
+@@ -446,6 +446,21 @@ get_host_triple(LLVM_INFERRED_HOST_TRIPLE)
+ set(LLVM_HOST_TRIPLE "${LLVM_INFERRED_HOST_TRIPLE}" CACHE STRING
+     "Host on which LLVM binaries will run")
+
++  #NOTE: we must normalize specified target triple to a fully specified triple,
++  # including the vendor part. It is necessary to synchronize the runtime library
++  # installation path and operable target triple by Clang to get a correct runtime
++  # path through `-print-runtime-dir` Clang option.
++string(REPLACE "-" ";" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++list(LENGTH LLVM_HOST_TRIPLE LLVM_HOST_TRIPLE_LEN)
++if (LLVM_HOST_TRIPLE_LEN LESS 3)
++  message(FATAL_ERROR "invalid target triple")
++endif()
++# We suppose missed vendor's part.
++if (LLVM_HOST_TRIPLE_LEN LESS 4)
++  list(INSERT LLVM_HOST_TRIPLE 1 "unknown")
++endif()
++string(REPLACE ";" "-" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++
+ # Determine the native architecture.
+ string(TOLOWER "${LLVM_TARGET_ARCH}" LLVM_NATIVE_ARCH)
+ if( LLVM_NATIVE_ARCH STREQUAL "host" )
+diff --git a/llvm/cmake/modules/SetTargetTriple.cmake b/llvm/cmake/modules/SetTargetTriple.cmake
+index ed0a53ca3ec9..8485c5f1c354 100644
+--- a/llvm/cmake/modules/SetTargetTriple.cmake
++++ b/llvm/cmake/modules/SetTargetTriple.cmake
+@@ -8,6 +8,20 @@ macro(set_llvm_target_triple)
+   else()
+     set(LLVM_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
+   endif()
++  #NOTE: we must normalize specified target triple to a fully specified triple,
++# including the vendor part. It is necessary to synchronize the runtime library
++# installation path and operable target triple by Clang to get a correct runtime
++# path through `-print-runtime-dir` Clang option.
++string(REPLACE "-" ";" LLVM_TARGET_TRIPLE "${LLVM_TARGET_TRIPLE}")
++list(LENGTH LLVM_TARGET_TRIPLE LLVM_TARGET_TRIPLE_LEN)
++if (LLVM_TARGET_TRIPLE_LEN LESS 3)
++  message(FATAL_ERROR "invalid target triple")
++endif()
++# We suppose missed vendor's part.
++if (LLVM_TARGET_TRIPLE_LEN LESS 4)
++  list(INSERT LLVM_TARGET_TRIPLE 1 "unknown")
++endif()
++string(REPLACE ";" "-" LLVM_TARGET_TRIPLE "${LLVM_TARGET_TRIPLE}")
+   message(STATUS "LLVM host triple: ${LLVM_HOST_TRIPLE}")
+   message(STATUS "LLVM default target triple: ${LLVM_DEFAULT_TARGET_TRIPLE}")
+ endmacro()
+diff --git a/runtimes/CMakeLists.txt b/runtimes/CMakeLists.txt
+index 50f782205ab4..7c6006d7946a 100644
+--- a/runtimes/CMakeLists.txt
++++ b/runtimes/CMakeLists.txt
+@@ -161,6 +161,21 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter)
+ # Host triple is used by tests to check if they are running natively.
+ include(GetHostTriple)
+ get_host_triple(LLVM_HOST_TRIPLE)
++#NOTE: we must normalize specified target triple to a fully specified triple,
++# including the vendor part. It is necessary to synchronize the runtime library
++# installation path and operable target triple by Clang to get a correct runtime
++# path through `-print-runtime-dir` Clang option.
++string(REPLACE "-" ";" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++list(LENGTH LLVM_HOST_TRIPLE LLVM_HOST_TRIPLE_LEN)
++if (LLVM_HOST_TRIPLE_LEN LESS 3)
++  message(FATAL_ERROR "invalid target triple")
++endif()
++# We suppose missed vendor's part.
++if (LLVM_HOST_TRIPLE_LEN LESS 4)
++  list(INSERT LLVM_HOST_TRIPLE 1 "unknown")
++endif()
++string(REPLACE ";" "-" LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}")
++
+ set(LLVM_DEFAULT_TARGET_TRIPLE "${LLVM_HOST_TRIPLE}" CACHE STRING
+   "Default target for which the runtimes will be built.")

--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -33,7 +33,10 @@ llvm_tags = Dict(
     v"11.0.1" => "43ff75f2c3feef64f9d73328230d34dac8832a91",
     v"12.0.0" => "d28af7c654d8db0b68c175db5ce212d74fb5e9bc",
     v"13.0.1" => "75e33f71c2dae584b13a7d1186ae0a038ba98838",
+    v"14.0.6" => "f28c006a5895fc0e329fe15fead81e37457cb1d1",
+    v"15.0.7" => "8dfdcc7b7bf66834a761bd8de445840ef68e4d1a",
     v"16.0.6" => "7cbf1a2591520c2491aa35339f227775f4d3adf6",
+    v"17.0.6" => "6009708b4367171ccdbf4b5905cb6a803753fe18",
 )
 
 function llvm_sources(;version = "v8.0.1", kwargs...)
@@ -143,8 +146,9 @@ function llvm_script(;version = v"8.0.1", llvm_build_type = "Release", kwargs...
     CMAKE_FLAGS+=("-DCMAKE_INSTALL_PREFIX=${prefix}")
 
     # Manually set the host triplet, as otherwise on some platforms it tries to guess using
-    # `ld -v`, which is hilariously wrong. We set a bunch of musl-related options here
-    CMAKE_FLAGS+=("-DLLVM_HOST_TRIPLE=${target}")
+    # `ld -v`, which is hilariously wrong. See llvm-project/llvm#49139, and note that setting
+    # the triple to $target does not suffice. We also set a bunch of musl-related options here
+    CMAKE_FLAGS+=("-DLLVM_HOST_TRIPLE=x86_64-alpine-linux-musl")
     CMAKE_FLAGS+=(-DLIBCXX_HAS_MUSL_LIBC=ON -DLIBCXX_HAS_GCC_S_LIB=OFF)
     CMAKE_FLAGS+=(-DCLANG_DEFAULT_CXX_STDLIB=libc++ -DCLANG_DEFAULT_LINKER=lld -DCLANG_DEFAULT_RTLIB=compiler-rt)
     CMAKE_FLAGS+=(-DLLVM_ENABLE_CXX1Y=ON -DLLVM_ENABLE_PIC=ON)


### PR DESCRIPTION
For building POCL, I need a `clang` version that's compatible with the `libLLVM` that will be loaded at run time. I can't use the one from a `HostDependency`, because it doesn't support generating code for the target I'm working with. So instead I think I have to use `preferred_llvm_version`, matching that up with the LLVM version of the build.

However, it looks like we currently only provide:

```
julia> BinaryBuilder.BinaryBuilderBase.available_llvm_builds
8-element Vector{BinaryBuilderBase.LLVMBuild}:
 BinaryBuilderBase.LLVMBuild(v"6.0.1", NamedTuple())
 BinaryBuilderBase.LLVMBuild(v"7.1.0", NamedTuple())
 BinaryBuilderBase.LLVMBuild(v"8.0.1", NamedTuple())
 BinaryBuilderBase.LLVMBuild(v"9.0.1", NamedTuple())
 BinaryBuilderBase.LLVMBuild(v"11.0.1", NamedTuple())
 BinaryBuilderBase.LLVMBuild(v"12.0.0", NamedTuple())
 BinaryBuilderBase.LLVMBuild(v"13.0.1", NamedTuple())
 BinaryBuilderBase.LLVMBuild(v"16.0.6", NamedTuple())
```

This PR is the first step to extending that to cover all LLVM versions encountered in Julia. I just copied the previous version's directories, so this is probably incomplete.