### PR TITLE
[terminfo-db] Add a builder for the terminfo database

### DIFF
--- a/T/TermInfoDB/build_tarballs.jl
+++ b/T/TermInfoDB/build_tarballs.jl
@@ -32,6 +32,7 @@ tic -sx -o "${prefix}/share/terminfo" ./terminfo-*
 pushd "${prefix}/share/terminfo/"
 for dir in *; do
     lcdir="${dir,,}"
+    mkdir -vp "${lcdir}"
     for file in ${dir}/*; do
         lcfile="${file,,}"
         if [ "${dir}/${file}" = "${lcdir}/${lcfile}" ]; then

--- a/T/TermInfoDB/build_tarballs.jl
+++ b/T/TermInfoDB/build_tarballs.jl
@@ -55,7 +55,7 @@ find "${prefix}/share/terminfo/" -type d -empty -delete
 install_license "${WORKSPACE}/srcdir/COPYING"
 """
 
-platforms = supported_platforms()
+platforms = [AnyPlatform()]
 
 # I'd rather not list out >2k individual `FileProduct`s so let's just call the entry
 # for xterm our "product" and hope the rest are there

--- a/T/TermInfoDB/build_tarballs.jl
+++ b/T/TermInfoDB/build_tarballs.jl
@@ -13,6 +13,11 @@ sources = [
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/
+
+# Install `tree` to get an overview of what's going to be included in the JLL
+apk update
+apk add tree
+
 gunzip terminfo-*
 mkdir -p "${prefix}/share/terminfo"
 tic -sx -o "${prefix}/share/terminfo" ./terminfo-*

--- a/T/TermInfoDB/build_tarballs.jl
+++ b/T/TermInfoDB/build_tarballs.jl
@@ -14,6 +14,7 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/
 gunzip terminfo-*
+mkdir -p "${prefix}/share/terminfo"
 tic -sx -o "${prefix}/share/terminfo" ./terminfo-*
 
 # When ignoring case, these files are duplicates of others. We'll remove them to ensure

--- a/T/TermInfoDB/build_tarballs.jl
+++ b/T/TermInfoDB/build_tarballs.jl
@@ -47,10 +47,10 @@ DUPS=(
     p/p9-w
 )
 for file in "${DUPS[@]}"; do
-    rm -f "${prefix}/share/terminfo/${file}"
+    rm -fv "${prefix}/share/terminfo/${file}"
 done
 # Remove empty directories
-find "${prefix}/share/terminfo/" -type d -empty -delete
+find "${prefix}/share/terminfo/" -type d -empty -print -delete
 
 install_license "${WORKSPACE}/srcdir/COPYING"
 """

--- a/T/TermInfoDB/build_tarballs.jl
+++ b/T/TermInfoDB/build_tarballs.jl
@@ -36,6 +36,10 @@ for dir in $(ls); do
             continue
         fi
         mv -fv "${dir}/${file}" "${lcdir}/${lcfile}"
+        if [ -e "${dir}/${file}" ]; then
+            echo "ERROR: '${dir}/${file}' not successfully renamed to lowercase!!!"
+            exit 1
+        fi
     done
     if [ -z "$(ls -A "${dir}")" ]; then
         rm -rfv "${dir}"

--- a/T/TermInfoDB/build_tarballs.jl
+++ b/T/TermInfoDB/build_tarballs.jl
@@ -1,0 +1,70 @@
+using BinaryBuilder
+
+# This is based on https://www.freshports.org/misc/terminfo-db/
+name = "TermInfoDB"
+version = v"2023.12.9"
+
+v = string(version.major, lpad(version.minor, 2, '0'), lpad(version.patch, 2, '0'))
+sources = [
+    FileSource("https://invisible-island.net/archives/ncurses/current/terminfo-$v.src.gz",
+               "2debcf2fd689988d44558bcd8a26a104b96542ffc9540f19e2586b3aeecd1c79"),
+    DirectorySource("./bundled"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/
+gunzip terminfo-*
+tic -sx -o "${prefix}/share/terminfo" ./terminfo-*
+
+# When ignoring case, these files are duplicates of others. We'll remove them to ensure
+# they don't cause trouble on case-insensitive filesystems
+DUPS=(
+    2/2621a
+    e/eterm
+    e/eterm-color
+    h/hp2621a
+    h/hp70092a
+    l/lft-pc850
+    n/ncr260vt300wpp
+    n/ncrvt100wpp
+    p/p12
+    p/p12-m
+    p/p12-m-w
+    p/p12-w
+    p/p14
+    p/p14-m
+    p/p14-m-w
+    p/p14-w
+    p/p4
+    p/p5
+    p/p7
+    p/p8
+    p/p8-w
+    p/p9
+    p/p9-8
+    p/p9-8-w
+    p/p9-w
+)
+for file in "${DUPS[@]}"; do
+    rm -f "${prefix}/share/terminfo/${file}"
+done
+# Remove empty directories
+find "${prefix}/share/terminfo/" -type d -empty -delete
+
+install_license "${WORKSPACE}/srcdir/COPYING"
+"""
+
+platforms = supported_platforms()
+
+# I'd rather not list out >2k individual `FileProduct`s so let's just call the entry
+# for xterm our "product" and hope the rest are there
+products = [
+    FileProduct("share/terminfo/x/xterm", :terminfo_xterm),
+]
+
+dependencies = [
+    HostBuildDependency("Ncurses_jll"),  # for `tic`
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")

--- a/T/TermInfoDB/build_tarballs.jl
+++ b/T/TermInfoDB/build_tarballs.jl
@@ -28,17 +28,17 @@ tic -sx -o "${prefix}/share/terminfo" ./terminfo-*
 # for the best.
 pushd "${prefix}/share/terminfo/"
 for dir in $(ls); do
-    if [[ ${dir} =~ [A-Z]+ ]] && [[ -d ${dir,,} ]]; then
-        for file in $(ls ${dir}); do
-            mv -fv "${dir}/${file}" "${dir,,}/${file,,}"
-        done
-        if [ -z "$(ls -A "${dir}")" ]; then
-            rm -rfv "${dir}"
+    lcdir="${dir,,}"
+    for file in $(ls ${dir}); do
+        lcfile="${file,,}"
+        if [ "${dir}/${file}" = "${lcdir}/${lcfile}" ]; then
+            # Already all lowercase, nothing to do
+            continue
         fi
-    elif [[ ${dir} =~ \d+ ]]; then
-        for file in $(ls ${dir}); do
-            mv -fv "${dir}/${file}" "${dir}/${file,,}"
-        done
+        mv -fv "${dir}/${file}" "${lcdir}/${lcfile}"
+    done
+    if [ -z "$(ls -A "${dir}")" ]; then
+        rm -rfv "${dir}"
     fi
 done
 tree

--- a/T/TermInfoDB/build_tarballs.jl
+++ b/T/TermInfoDB/build_tarballs.jl
@@ -34,6 +34,7 @@ for dir in *; do
     lcdir="${dir,,}"
     mkdir -vp "${lcdir}"
     for file in ${dir}/*; do
+        file=$(basename "${file}")
         lcfile="${file,,}"
         if [ "${dir}/${file}" = "${lcdir}/${lcfile}" ]; then
             # Already all lowercase, nothing to do

--- a/T/TermInfoDB/bundled/COPYING
+++ b/T/TermInfoDB/bundled/COPYING
@@ -1,0 +1,29 @@
+Copyright 2018-2022,2023 Thomas E. Dickey
+Copyright 1998-2017,2018 Free Software Foundation, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, distribute with modifications, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE ABOVE COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name(s) of the above copyright
+holders shall not be used in advertising or otherwise to promote the
+sale, use or other dealings in this Software without prior written
+authorization.
+
+-- vile:txtmode fc=72
+-- $Id: COPYING,v 1.12 2023/01/07 17:55:53 tom Exp $


### PR DESCRIPTION
This uses the directory-based database rather than the single Berkeley database (terminfo.db). The license is from ncurses, which is close enough; see https://invisible-island.net/ncurses/terminfo.src.html.

Ideally this would be shipped as one of Julia's dependencies to ensure that the custom terminfo parser actually works on all platforms, as not all have the terminfo database.