### PR TITLE
[aws_c_auth] Update to version 0.7.24

### DIFF
--- a/A/aws_c_auth/build_tarballs.jl
+++ b/A/aws_c_auth/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_auth"
-version = v"0.7.23"
+version = v"0.7.24"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-auth.git", "300ae823aa0d5cacfabe901f55096f0452c4ca89"),
+    GitSource("https://github.com/awslabs/aws-c-auth.git", "d7895252915259d037f10be223369eb99e837471"),
 ]
 
 # Bash recipe for building


### PR DESCRIPTION
This PR updates aws_c_auth to version 0.7.24. cc: @quinnj @Octogonapus