### PR TITLE
Add a builder for the AWS command line interface v2

### DIFF
--- a/A/AWSCLI/build_tarballs.jl
+++ b/A/AWSCLI/build_tarballs.jl
@@ -1,0 +1,31 @@
+using BinaryBuilder
+
+name = "AWSCLI"
+version = v"2.17.22"
+
+sources = [
+    GitSource("https://github.com/aws/aws-cli.git",
+              "18d64caf588186c396dd58ff2346a8ca9657fdcb"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/aws-cli
+
+export CMAKE_INSTALL_PREFIX="${prefix}"
+export CMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}"
+
+./scripts/install -i "${bindir}"
+
+install_license ./LICENSE.txt
+"""
+
+platforms = supported_platforms()
+
+products = [
+    ExecutableProduct("aws", :awscli),
+]
+
+dependencies = Dependency[]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               compilers=[:c, :rust], julia_compat="1.6")


### PR DESCRIPTION
This is based in part on https://github.com/aws/aws-cli/discussions/7168, which is for FreeBSD but should apply to any other platform as well (or so I would assume). It differs from the process described in the discussion in that it uses a provided installation script rather than the development build instructions in the README, which is all the process in the discussion is, except with some particular requisite system package installs. Notable among the installed packages are CMake and Rust, which is why I've added Rust to the `compilers` list and defined some CMake environment variables.