### PR TITLE
[SuiteSparse] Update to 7.8.0 and use common build script

### DIFF
--- a/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
@@ -1,93 +1,14 @@
 include("../common.jl")
 
 name = "SuiteSparse"
-version = v"7.7.0"
+version = v"7.8.0"
 
 sources = suitesparse_sources(version)
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/SuiteSparse
-
-# Needs cmake >= 3.22 provided by jll
-apk del cmake
-
-# Disable OpenMP as it will probably interfere with blas threads and Julia threads
-FLAGS+=(INSTALL="${prefix}" INSTALL_LIB="${libdir}" INSTALL_INCLUDE="${prefix}/include" CFOPENMP=)
-
-BLAS_NAME=blastrampoline
-if [[ "${target}" == *-mingw* ]]; then
-    BLAS_LIB=${BLAS_NAME}-5
-else
-    BLAS_LIB=${BLAS_NAME}
-fi
-
-if [[ ${bb_full_target} == *-sanitize+memory* ]]; then
-    # Install msan runtime (for clang)
-    cp -rL ${libdir}/linux/* /opt/x86_64-linux-musl/lib/clang/*/lib/linux/
-fi
-
-if [[ ${nbits} == 64 ]]; then
-    CMAKE_OPTIONS=(
-        -DBLAS64_SUFFIX="_64"
-        -DSUITESPARSE_USE_64BIT_BLAS=YES
-    )
-else
-    CMAKE_OPTIONS=(
-        -DSUITESPARSE_USE_64BIT_BLAS=NO
-    )
-fi
-
 PROJECTS_TO_BUILD="suitesparse_config;amd;btf;camd;ccolamd;colamd;cholmod;klu;ldl;umfpack;rbio;spqr"
-
-cmake -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=${prefix} \
-      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-      -DBUILD_STATIC_LIBS=OFF \
-      -DBUILD_TESTING=OFF \
-      -DSUITESPARSE_ENABLE_PROJECTS=${PROJECTS_TO_BUILD} \
-      -DSUITESPARSE_DEMOS=OFF \
-      -DSUITESPARSE_USE_STRICT=ON \
-      -DSUITESPARSE_USE_CUDA=OFF \
-      -DSUITESPARSE_USE_FORTRAN=OFF \
-      -DSUITESPARSE_USE_OPENMP=OFF \
-      -DCHOLMOD_PARTITION=ON \
-      -DBLAS_FOUND=1 \
-      -DBLAS_LIBRARIES="${libdir}/lib${BLAS_LIB}.${dlext}" \
-      -DBLAS_LINKER_FLAGS="${BLAS_LIB}" \
-      -DBLA_VENDOR="${BLAS_NAME}" \
-      -DLAPACK_LIBRARIES="${libdir}/lib${BLAS_LIB}.${dlext}" \
-      -DLAPACK_LINKER_FLAGS="${BLAS_LIB}" \
-      "${CMAKE_OPTIONS[@]}" \
-      .
-make -j${nproc}
-make install
-
-# For now, we'll have to adjust the name of the Lbt library on macOS and FreeBSD.
-# Eventually, this should be fixed upstream
-if [[ ${target} == *-apple-* ]] || [[ ${target} == *freebsd* ]]; then
-    echo "-- Modifying library name for libblastrampoline"
-
-    for nm in libcholmod libspqr libumfpack; do
-        # Figure out what version it probably latched on to:
-        if [[ ${target} == *-apple-* ]]; then
-            LBT_LINK=$(otool -L ${libdir}/${nm}.dylib | grep lib${BLAS_NAME} | awk '{ print $1 }')
-            install_name_tool -change ${LBT_LINK} @rpath/lib${BLAS_NAME}.dylib ${libdir}/${nm}.dylib
-        elif [[ ${target} == *freebsd* ]]; then
-            LBT_LINK=$(readelf -d ${libdir}/${nm}.so | grep lib${BLAS_NAME} | sed -e 's/.*\[\(.*\)\].*/\1/')
-            patchelf --replace-needed ${LBT_LINK} lib${BLAS_NAME}.so ${libdir}/${nm}.so
-        fi
-    done
-fi
-
-# Delete the extra soversion libraries built. https://github.com/JuliaPackaging/Yggdrasil/issues/7
-if [[ "${target}" == *-mingw* ]]; then
-    rm -f ${libdir}/lib*.*.${dlext}
-    rm -f ${libdir}/lib*.*.*.${dlext}
-fi
-
-install_license LICENSE.txt
-"""
+""" * build_script(use_omp = false, use_cuda = false)
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.11")

--- a/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
@@ -1,3 +1,4 @@
+# Build counter: 1
 include("../common.jl")
 
 name = "SuiteSparse"

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -95,17 +95,10 @@ function build_script(; use_omp::Bool = false, use_cuda::Bool = false)
     return "USEOMP=$(use_omp)\nUSECUDA=$(use_cuda)\n" * raw"""
 cd $WORKSPACE/srcdir/SuiteSparse
 
-# Needs cmake >= 3.24 provided by jll
+# Needs cmake >= 3.29 provided by jll
 apk del cmake
 
 FLAGS+=(INSTALL="${prefix}" INSTALL_LIB="${libdir}" INSTALL_INCLUDE="${prefix}/include")
-
-BLAS_NAME=blastrampoline
-if [[ "${target}" == *-mingw* ]]; then
-    BLAS_LIB=${BLAS_NAME}-5
-else
-    BLAS_LIB=${BLAS_NAME}
-fi
 
 if [[ ${bb_full_target} == *-sanitize+memory* ]]; then
     # Install msan runtime (for clang)
@@ -133,6 +126,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
       -DBUILD_STATIC_LIBS=OFF \
       -DBUILD_TESTING=OFF \
+      -DBLA_VENDOR=libblastrampoline \
       -DSUITESPARSE_ENABLE_PROJECTS=${PROJECTS_TO_BUILD} \
       -DSUITESPARSE_DEMOS=OFF \
       -DSUITESPARSE_USE_STRICT=ON \
@@ -140,12 +134,6 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DSUITESPARSE_USE_OPENMP=${USEOMP} \
       -DSUITESPARSE_USE_CUDA=${USECUDA} \
       -DCHOLMOD_PARTITION=ON \
-      -DBLAS_FOUND=1 \
-      -DBLAS_LIBRARIES="${libdir}/lib${BLAS_LIB}.${dlext}" \
-      -DBLAS_LINKER_FLAGS="${BLAS_LIB}" \
-      -DBLA_VENDOR="${BLAS_NAME}" \
-      -DLAPACK_LIBRARIES="${libdir}/lib${BLAS_LIB}.${dlext}" \
-      -DLAPACK_LINKER_FLAGS="${BLAS_LIB}" \
       "${CMAKE_OPTIONS[@]}" \
       ..
 
@@ -157,6 +145,7 @@ cmake --install .
 if [[ ${target} == *-apple-* ]] || [[ ${target} == *freebsd* ]]; then
     echo "-- Modifying library name for libblastrampoline"
 
+    BLAS_NAME=blastrampoline
     for nm in libcholmod libspqr libumfpack; do
         if [[ *"${nm}"* == PROJECTS_TO_BUILD ]]; then
             # Figure out what version it probably latched on to:

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -43,6 +43,10 @@ function suitesparse_sources(version::VersionNumber; kwargs...)
             GitSource("https://github.com/DrTimothyAldenDavis/SuiteSparse.git",
                       "13806726cbf470914d012d132a85aea1aff9ee77")
         ],
+        v"7.8.0" => [
+            GitSource("https://github.com/DrTimothyAldenDavis/SuiteSparse.git",
+                      "58e6558408f6a51c08e35a5557d5e68cae32147e")
+        ],
     )
     return Any[
         suitesparse_version_sources[version]...,
@@ -75,7 +79,8 @@ products = [
 dependencies = [
     Dependency("libblastrampoline_jll"; compat="5.8.0"),
     BuildDependency("LLVMCompilerRT_jll",platforms=[Platform("x86_64", "linux"; sanitize="memory")]),
-    HostBuildDependency(PackageSpec(; name="CMake_jll", version = v"3.24.3"))
+    # Need the most recent 3.29.3+1 version (or later) to get libblastrampoline support
+    HostBuildDependency(PackageSpec(; name="CMake_jll", version = v"3.29.3"))
 ]
 
 # Generate a common build script for most SuiteSparse packages.
@@ -86,7 +91,7 @@ dependencies = [
 # for instance -DSUITESPARSE_USE_SYSTEM_*=ON to use pre-existing JLLs for
 # certain packages.
 # Use PROJECTS_TO_BUILD to specify which projects to build.
-function build_script(use_omp::Bool = false, use_cuda::Bool = false)
+function build_script(; use_omp::Bool = false, use_cuda::Bool = false)
     return "USEOMP=$(use_omp)\nUSECUDA=$(use_cuda)\n" * raw"""
 cd $WORKSPACE/srcdir/SuiteSparse
 


### PR DESCRIPTION
New SuiteSparse release 7.8.0: https://github.com/DrTimothyAldenDavis/SuiteSparse/releases/tag/v7.8.0.

I don't think there are major changes to anything in the core parts we build here, but there might need to be some tweaks to the wrappers (it looks like cholmod at least gained a new function).