### PR TITLE
Add support for FreeBSD AArch64

### DIFF
--- a/0_RootFS/PlatformSupport/build_tarballs.jl
+++ b/0_RootFS/PlatformSupport/build_tarballs.jl
@@ -51,11 +51,19 @@ sources = [
                   "b5de28fd594a01edacd06e53491ad0890293e5fbf98329346426cf6030ef1ea6"),
     ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v7.0.0.tar.bz2",
                   "aa20dfff3596f08a7f427aab74315a6cb80c2b086b4a107ed35af02f9496b628"),
-    ArchiveSource("http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.2-RELEASE/base.txz",
-                  "3a9250f7afd730bbe274691859756948b3c57a99bcda30d65d46ae30025906f0"),
     ArchiveSource("https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/libcxx-8.0.1.src.tar.xz",
                   "7f0652c86a0307a250b5741ab6e82bb10766fb6f2b5a5602a63f30337e629b78"),
 ]
+
+freebsd_base = if Sys.isfreebsd(compiler_target) && arch(compiler_target) == "aarch64"
+    ArchiveSource("http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/arm64/13.2-RELEASE/base.txz",
+                  "7d1b032a480647a73d6d7331139268a45e628c9f5ae52d22b110db65fdcb30ff")
+else
+    ArchiveSource("http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.2-RELEASE/base.txz",
+                  "3a9250f7afd730bbe274691859756948b3c57a99bcda30d65d46ae30025906f0")
+end
+
+push!(sources, freebsd_base)
 
 macos_sdk = if Sys.isapple(compiler_target) && arch(compiler_target) == "aarch64"
     ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.0-11.1/MacOSX11.1.sdk.tar.xz",

--- a/0_RootFS/Rust/build_tarballs.jl
+++ b/0_RootFS/Rust/build_tarballs.jl
@@ -44,6 +44,7 @@ chmod +x rustup-init
 # Collection of all rust targets we will download toolchains for:
 RUST_TARGETS=(
     aarch64-apple-darwin
+    aarch64-unknown-freebsd
     aarch64-unknown-linux-gnu
     aarch64-unknown-linux-musl
     arm-unknown-linux-gnueabihf

--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -21,7 +21,7 @@
 #   `--deploy` flag to the `build_tarballs.jl` script.  You can either build &
 #   deploy the compilers one by one or run something like
 #
-#      for p in i686-linux-gnu x86_64-linux-gnu aarch64-linux-gnu armv7l-linux-gnueabihf powerpc64le-linux-gnu i686-linux-musl x86_64-linux-musl aarch64-linux-musl armv7l-linux-musleabihf x86_64-apple-darwin14 x86_64-unknown-freebsd13.2 i686-w64-mingw32 x86_64-w64-mingw32; do julia build_tarballs.jl --debug --verbose --deploy "${p}"; done
+#      for p in i686-linux-gnu x86_64-linux-gnu aarch64-linux-gnu armv7l-linux-gnueabihf powerpc64le-linux-gnu i686-linux-musl x86_64-linux-musl aarch64-linux-musl armv7l-linux-musleabihf x86_64-apple-darwin14 x86_64-unknown-freebsd13.2 aarch64-unknown-freebsd13.2 i686-w64-mingw32 x86_64-w64-mingw32; do julia build_tarballs.jl --debug --verbose --deploy "${p}"; done
 
 include("./common.jl")
 include("./gcc_sources.jl")

--- a/0_RootFS/gcc_sources.jl
+++ b/0_RootFS/gcc_sources.jl
@@ -262,10 +262,17 @@ function gcc_sources(gcc_version::VersionNumber, compiler_target::Platform; kwar
             ]
         end
     elseif Sys.isfreebsd(compiler_target)
-        libc_sources = [
-            ArchiveSource("http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.2-RELEASE/base.txz",
-                          "3a9250f7afd730bbe274691859756948b3c57a99bcda30d65d46ae30025906f0"),
-        ]
+        if arch(compiler_target) == "aarch64"
+            libc_sources = [
+                ArchiveSource("http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/arm64/13.2-RELEASE/base.txz",
+                              "7d1b032a480647a73d6d7331139268a45e628c9f5ae52d22b110db65fdcb30ff"),
+            ]
+        else
+            libc_sources = [
+                ArchiveSource("http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.2-RELEASE/base.txz",
+                              "3a9250f7afd730bbe274691859756948b3c57a99bcda30d65d46ae30025906f0"),
+            ]
+        end
     elseif Sys.iswindows(compiler_target)
         libc_sources = [
             ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v11.0.1.tar.bz2",

--- a/RootFS.md
+++ b/RootFS.md
@@ -6,7 +6,7 @@ This document details some of the journey we have embarked upon to create a Linu
 * glibc Linux: `i686-linux-gnu`, `x86_64-linux-gnu`, `aarch64-linux-gnu`, `armv7l-linux-gnueabihf`, `powerpc64le-linux-gnu`, `armv6l-linux-gnueabihf`
 * musl Linux: `i686-linux-musl`, `x86_64-linux-musl`, `aarch64-linux-musl`, `armv7l-linux-musleabihf`, `armv6l-linux-musleabihf`
 * MacOS: `x86_64-apple-darwin`, `aarch64-apple-darwin`
-* FreeBSD: `x86_64-unknown-freebsd13.2`
+* FreeBSD: `x86_64-unknown-freebsd13.2`, `aarch64-unknown-freebsd13.2`
 * Windows: `i686-w64-mingw32`, `x86_64-w64-mingw32`
 
 These target platforms are compiled for by building a suite a cross-compilers (`gcc`, `gfortran`, `clang`, `binutils`, etc...) that run on `x86-64-linux-musl`, but target the specific platform.  Unfortunately, it is not sufficient to simply build these compilers once per target, because of incompatibilities between the generated code and the user's system where this code may eventually be running.


### PR DESCRIPTION
This uses FreeBSD 13.2 to match the setup for x86_64. When adding support for FreeBSD AArch64 to Julia, I was using FreeBSD 14.1, so this may turn out to be a different beast altogether. I guess we'll find out.

Trying to remember what all it is I need to do in order to add a new platform... I think there was something I needed to do that made a tag with release assets for all of the platforms. 🤔