### PR TITLE
Sync Tk version with Tcl version

### DIFF
--- a/T/Tk/build_tarballs.jl
+++ b/T/Tk/build_tarballs.jl
@@ -64,7 +64,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     BuildDependency("Xorg_xorgproto_jll"; platforms=x11_platforms),
-    Dependency("Tcl_jll"),
+    Dependency("Tcl_jll"; compat=string(version)),
     Dependency("Xorg_libXft_jll"; platforms=x11_platforms)
 ]
 


### PR DESCRIPTION
Need to wait for Tcl 8.6.12 to propagate all the way into the pkg servers and then restart this build.