### PR TITLE
[OpenBLAS] Backport patch to fix init of threading memory buffers

### DIFF
--- a/O/OpenBLAS/OpenBLAS32@0.3.28/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS32@0.3.28/build_tarballs.jl
@@ -18,4 +18,4 @@ build_tarballs(ARGS, name, version, sources, script, platforms, products, depend
                preferred_gcc_version=v"11", lock_microarchitecture=false,
                julia_compat="1.11", preferred_llvm_version=preferred_llvm_version)
 
-# Build trigger: 2
+# Build trigger: 3

--- a/O/OpenBLAS/OpenBLAS32@0.3.28/bundled/patches/80-memory-buffer-multi-threading.patch
+++ b/O/OpenBLAS/OpenBLAS32@0.3.28/bundled/patches/80-memory-buffer-multi-threading.patch
@@ -1,0 +1,23 @@
+From 23b5d66a86417a071bba9a96a0573192237981b6 Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Wed, 14 Aug 2024 10:35:44 +0200
+Subject: [PATCH] Ensure a memory buffer has been allocated for each thread
+ before invoking it
+
+---
+ driver/others/blas_server.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/driver/others/blas_server.c b/driver/others/blas_server.c
+index 765511d8c7..b9a7674c17 100644
+--- a/driver/others/blas_server.c
++++ b/driver/others/blas_server.c
+@@ -1076,6 +1076,8 @@ fprintf(STDERR, "Server[%2ld] Calculation started.  Mode = 0x%03x M = %3ld N=%3l
+       main_status[cpu] = MAIN_RUNNING1;
+ #endif
+ 
++if (buffer == NULL) blas_thread_buffer[cpu] = blas_memory_alloc(2);
++	
+ //For target LOONGSON3R5, applying an offset to the buffer is essential
+ //for minimizing cache conflicts and optimizing performance.
+ #if defined(ARCH_LOONGARCH64) && !defined(NO_AFFINITY)

--- a/O/OpenBLAS/OpenBLAS@0.3.28/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS@0.3.28/build_tarballs.jl
@@ -19,4 +19,4 @@ build_tarballs(ARGS, name, version, sources, script, platforms, products, depend
                preferred_gcc_version=v"11", lock_microarchitecture=false,
                julia_compat="1.11", preferred_llvm_version=preferred_llvm_version)
 
-# Build trigger: 2
+# Build trigger: 3

--- a/O/OpenBLAS/OpenBLAS@0.3.28/bundled/patches/80-memory-buffer-multi-threading.patch
+++ b/O/OpenBLAS/OpenBLAS@0.3.28/bundled/patches/80-memory-buffer-multi-threading.patch
@@ -1,0 +1,23 @@
+From 23b5d66a86417a071bba9a96a0573192237981b6 Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Wed, 14 Aug 2024 10:35:44 +0200
+Subject: [PATCH] Ensure a memory buffer has been allocated for each thread
+ before invoking it
+
+---
+ driver/others/blas_server.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/driver/others/blas_server.c b/driver/others/blas_server.c
+index 765511d8c7..b9a7674c17 100644
+--- a/driver/others/blas_server.c
++++ b/driver/others/blas_server.c
+@@ -1076,6 +1076,8 @@ fprintf(STDERR, "Server[%2ld] Calculation started.  Mode = 0x%03x M = %3ld N=%3l
+       main_status[cpu] = MAIN_RUNNING1;
+ #endif
+ 
++if (buffer == NULL) blas_thread_buffer[cpu] = blas_memory_alloc(2);
++	
+ //For target LOONGSON3R5, applying an offset to the buffer is essential
+ //for minimizing cache conflicts and optimizing performance.
+ #if defined(ARCH_LOONGARCH64) && !defined(NO_AFFINITY)


### PR DESCRIPTION
Backports https://github.com/OpenMathLib/OpenBLAS/pull/4871.  Ref: https://github.com/JuliaLang/julia/issues/55471, https://github.com/OpenMathLib/OpenBLAS/issues/4868.