### PR TITLE
[OpenBLAS] Backport new threading buffer patch

### DIFF
--- a/O/OpenBLAS/OpenBLAS32@0.3.28/bundled/patches/81-memory-buffer-multi-threading.patch
+++ b/O/OpenBLAS/OpenBLAS32@0.3.28/bundled/patches/81-memory-buffer-multi-threading.patch
@@ -1,0 +1,26 @@
+From d24b3cf39392a99e81ed47a5f093fbd074d4b39b Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Thu, 15 Aug 2024 15:32:58 +0200
+Subject: [PATCH] properly fix buffer allocation and assignment
+
+---
+ driver/others/blas_server.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/driver/others/blas_server.c b/driver/others/blas_server.c
+index b9a7674c17..29f8a5e646 100644
+--- a/driver/others/blas_server.c
++++ b/driver/others/blas_server.c
+@@ -1076,7 +1076,11 @@ fprintf(STDERR, "Server[%2ld] Calculation started.  Mode = 0x%03x M = %3ld N=%3l
+       main_status[cpu] = MAIN_RUNNING1;
+ #endif
+ 
+-if (buffer == NULL) blas_thread_buffer[cpu] = blas_memory_alloc(2);
++if (buffer == NULL) {
++	blas_thread_buffer[cpu] = blas_memory_alloc(2);
++	buffer = blas_thread_buffer[cpu];
++}      
++
+ 	
+ //For target LOONGSON3R5, applying an offset to the buffer is essential
+ //for minimizing cache conflicts and optimizing performance.

--- a/O/OpenBLAS/OpenBLAS@0.3.28/bundled/patches/81-memory-buffer-multi-threading.patch
+++ b/O/OpenBLAS/OpenBLAS@0.3.28/bundled/patches/81-memory-buffer-multi-threading.patch
@@ -1,0 +1,26 @@
+From d24b3cf39392a99e81ed47a5f093fbd074d4b39b Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Thu, 15 Aug 2024 15:32:58 +0200
+Subject: [PATCH] properly fix buffer allocation and assignment
+
+---
+ driver/others/blas_server.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/driver/others/blas_server.c b/driver/others/blas_server.c
+index b9a7674c17..29f8a5e646 100644
+--- a/driver/others/blas_server.c
++++ b/driver/others/blas_server.c
+@@ -1076,7 +1076,11 @@ fprintf(STDERR, "Server[%2ld] Calculation started.  Mode = 0x%03x M = %3ld N=%3l
+       main_status[cpu] = MAIN_RUNNING1;
+ #endif
+ 
+-if (buffer == NULL) blas_thread_buffer[cpu] = blas_memory_alloc(2);
++if (buffer == NULL) {
++	blas_thread_buffer[cpu] = blas_memory_alloc(2);
++	buffer = blas_thread_buffer[cpu];
++}      
++
+ 	
+ //For target LOONGSON3R5, applying an offset to the buffer is essential
+ //for minimizing cache conflicts and optimizing performance.


### PR DESCRIPTION
Follow up to #9262, backport https://github.com/OpenMathLib/OpenBLAS/pull/4879.