### PR TITLE
[Pango] update to 1.54.0

### DIFF
--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -71,7 +71,7 @@ dependencies = [
     Dependency("Cairo_jll"; compat="1.18.0"),
     Dependency("Fontconfig_jll"),
     Dependency("FreeType2_jll"; compat="2.13.1"),
-    Dependency("FriBidi_jll"),
+    Dependency("FriBidi_jll"; compat="1.0.10"),
     Dependency("Glib_jll"; compat="2.74.0"),
     Dependency("HarfBuzz_jll"; compat="2.8.1"),
     BuildDependency("Xorg_xorgproto_jll"; platforms=filter(p->Sys.islinux(p)||Sys.isfreebsd(p), platforms)),

--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "Pango"
-version = v"1.52.2"
+version = v"1.54.0"
 
 # Collection of sources required to build Pango: https://download.gnome.org/sources/pango/
 sources = [
     ArchiveSource("http://ftp.gnome.org/pub/GNOME/sources/pango/$(version.major).$(version.minor)/pango-$(version).tar.xz",
-                  "d0076afe01082814b853deec99f9349ece5f2ce83908b8e58ff736b41f78a96b"),
+                  "8a9eed75021ee734d7fc0fdf3a65c3bba51dfefe4ae51a9b414a60c70b2d1ed8"),
     ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v11.0.0.tar.bz2",
                   "bd0ea1633bd830204cc23a696889335e9d4a32b8619439ee17f22188695fcc5f"),
 ]


### PR DESCRIPTION
This will probably be a fix for https://github.com/JuliaGraphics/Cairo.jl/issues/363 , based on discussions in https://gitlab.gnome.org/GNOME/pango/-/merge_requests/720

When building with the latest FriBidi_jll, the following error happens on MacOS:

```
../pango/pango-bidi-type.c:83:10: error: use of undeclared identifier '_FRIBIDI_TYPE_SENTINEL'
[10:08:01]     case _FRIBIDI_TYPE_SENTINEL:
[10:08:01]          ^
[10:08:01] 1 error generated.
```

I think the fix is easy, but using the previous version of FriBidi_jll was easier for me than generating a patch. I'll do that if preferred, and either way I'll create an issue upstream.