### PR TITLE
[SIRIUS] New package SIRIUS v7.6.0

### DIFF
--- a/S/SIRIUS/build_tarballs.jl
+++ b/S/SIRIUS/build_tarballs.jl
@@ -6,11 +6,11 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SIRIUS"
-version = v"7.6.0"
+version = v"7.6.1"
 
 sources = [
    GitSource("https://github.com/electronic-structure/SIRIUS.git",
-             "21c8fd5019d85ca3181d895e3bc209cb8bba55bb")
+             "63202622b85f0c5ac5d7a6d66ab21adb6dd573cd")
 ]
 
 

--- a/S/SIRIUS/build_tarballs.jl
+++ b/S/SIRIUS/build_tarballs.jl
@@ -1,0 +1,117 @@
+# Note that this script can accept some limited command-line arguments, run                          
+# `julia build_tarballs.jl --help` to see a usage message.                                           
+using BinaryBuilder, Pkg                                                                             
+using Base.BinaryPlatforms                                                                           
+const YGGDRASIL_DIR = "../.."                                                                        
+include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
+
+name = "SIRIUS"
+version = v"7.6.0"
+
+sources = [
+   GitSource("https://github.com/electronic-structure/SIRIUS/", "21c8fd5019d85ca3181d895e3bc209cb8bba55bb")
+]
+
+
+script = raw"""
+apk del cmake
+
+cd $WORKSPACE/srcdir
+
+mkdir build
+cd build
+
+#For GSL to be correctly linked to cblas
+export LDFLAGS="-lgsl -lgslcblas -lblastrampoline"
+
+CMAKE_ARGS="-DSIRIUS_CREATE_FORTRAN_BINDINGS=ON \
+            -DSIRIUS_USE_OPENMP=ON \
+            -DSIRIUS_USE_PUGIXML=ON \
+            -DSIRIUS_USE_MEMORY_POOL=OFF \
+            -DSIRIUS_BUILD_APPS=OFF \
+            -DSIRIUS_USE_PROFILER=OFF \
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+            -DCMAKE_FIND_ROOT_PATH='${prefix}/lib/mpich;${prefix}' \
+            -DCMAKE_INSTALL_PREFIX=$prefix \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DMPI_C_COMPILER=$bindir/mpicc \
+            -DMPI_CXX_COMPILER=$bindir/mpicxx"
+
+if [[ "${target}" == *-apple-mpich ]]; then
+  CMAKE_ARGS="${CMAKE_ARGS} \
+               -DMPI_C_LIB_NAMES='mpi;pmpi;hwloc' \
+               -DMPI_CXX_LIB_NAMES='mpicxx;mpi;pmpi;hwloc' \
+               -DMPI_mpicxx_LIBRARY=${libdir}/libmpicxx.dylib \
+               -DMPI_mpi_LIBRARY=${libdir}/libmpi.dylib \
+               -DMPI_pmpi_LIBRARY=${libdir}/libpmpi.dylib \
+               -DMPI_hwloc_LIBRARY=${libdir}/libhwloc.dylib"
+fi
+
+if [[ "${target}" == *-apple-mpitrampoline ]]; then
+  CMAKE_ARGS="${CMAKE_ARGS} \
+               -DMPI_C_LIB_NAMES='mpi;pmpi;hwloc' \
+               -DMPI_CXX_LIB_NAMES='mpicxx;mpi;pmpi;hwloc' \
+               -DMPI_mpicxx_LIBRARY=${libdir}/mpich/lib.libmpicxx.a \
+               -DMPI_mpi_LIBRARY=${libdir}/mpich/lib/libmpi.a \
+               -DMPI_pmpi_LIBRARY=${libdir}/mpich/lib/libpmpi.a \
+               -DMPI_hwloc_LIBRARY=${libdir}/libhwloc.dylib"
+fi
+
+#On MacOS, need to explicitly remove the -fallow-argument-mismatch flag, because not recognized by Clang
+if [[ "${target}" == *-apple* ]]; then
+  CMAKE_ARGS="${CMAKE_ARGS} -DMPI_Fortran_COMPILE_OPTIONS:STRING=''"
+fi
+
+#somehow need to run cmake twice for MPI Fortran to work
+cmake .. ${CMAKE_ARGS} || cmake .. ${CMAKE_ARGS}
+
+make -j${nproc} install
+"""
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+    $(MPI.augment)
+    augment_platform!(platform::Platform) = augment_mpi!(platform)
+"""
+platforms = [Platform("x86_64", "linux"), Platform("aarch64", "linux"), Platform("aarch64", "macos")]
+filter!(p -> !(libc(p) == "musl"), platforms)
+platforms = expand_cxxstring_abis(platforms)
+
+platforms = expand_gfortran_versions(platforms)
+filter!(p -> !(libgfortran_version(p) < v"5"), platforms)
+
+products = [
+   LibraryProduct("libsirius", :libsirius)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("GSL_jll"), 
+    Dependency("pugixml_jll"), 
+    #Using either MKL or OPENBLAS32
+    Dependency("libblastrampoline_jll"),
+    Dependency("Libxc_jll"), 
+    Dependency("HDF5_jll"),
+    Dependency("spglib_jll"), 
+    Dependency("spla_jll"), 
+    Dependency("SpFFT_jll"), 
+    Dependency("COSTA_jll"), 
+    Dependency("CompilerSupportLibraries_jll"), 
+    Dependency("LLVMOpenMP_jll", platforms=filter(Sys.isapple, platforms)),
+    HostBuildDependency(PackageSpec(; name="CMake_jll", version = v"3.28.1"))
+]
+
+platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.2.1", OpenMPI_compat="4.1.6, 5")
+# Avoid platforms where the MPI implementation isn't supported
+# OpenMPI
+platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)
+# MPItrampoline
+platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && (Sys.iswindows(p) || libc(p) == "musl")), platforms)
+platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
+
+append!(dependencies, platform_dependencies)
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               augment_platform_block, julia_compat="1.6", preferred_gcc_version = v"10")

--- a/S/SIRIUS/build_tarballs.jl
+++ b/S/SIRIUS/build_tarballs.jl
@@ -80,7 +80,7 @@ dependencies = [
     #Using either MKL or OPENBLAS32
     Dependency("libblastrampoline_jll"; compat="5.4.0"),
     Dependency("Libxc_jll"),
-    Dependency("HDF5_jll"),
+    Dependency("HDF5_jll"; compat="~1.14.3"),
     Dependency("spglib_jll"),
     Dependency("spla_jll"),
     Dependency("SpFFT_jll"),
@@ -90,13 +90,12 @@ dependencies = [
     HostBuildDependency(PackageSpec(; name="CMake_jll", version = v"3.28.1"))
 ]
 
-platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.2.1", OpenMPI_compat="4.1.6, 5")
+platforms, platform_dependencies = MPI.augment_platforms(platforms; MPItrampoline_compat="5.3.1", OpenMPI_compat="4.1.6, 5")
 # Avoid platforms where the MPI implementation isn't supported
 # OpenMPI
 platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "armv6l" && libc(p) == "glibc"), platforms)
 # MPItrampoline
-platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && (Sys.iswindows(p) || libc(p) == "musl")), platforms)
-platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
+platforms = filter(p -> !(p["mpi"] == "mpitrampoline"), platforms) #HDF5 incompatibility with v5.3.1
 
 append!(dependencies, platform_dependencies)
 

--- a/S/SIRIUS/build_tarballs.jl
+++ b/S/SIRIUS/build_tarballs.jl
@@ -58,13 +58,22 @@ if [[ "${target}" == *-apple-mpitrampoline ]]; then
                -DMPI_hwloc_LIBRARY=${libdir}/libhwloc.dylib"
 fi
 
+#need to pass various results of CMake's try_run() for MPI compilers for succesful build
+CMAKE_ARGS="${CMAKE_ARGS} -DMPI_RUN_RESULT_C_libver_mpi_normal=0 \
+                          -DMPI_RUN_RESULT_C_libver_mpi_normal__TRYRUN_OUTPUT='' \
+                          -DMPI_RUN_RESULT_CXX_libver_mpi_normal=0 \
+                          -DMPI_RUN_RESULT_CXX_libver_mpi_normal__TRYRUN_OUTPUT='' \
+                          -DMPI_RUN_RESULT_Fortran_libver_mpi_F90_MODULE=0 \
+                          -DMPI_RUN_RESULT_Fortran_libver_mpi_F90_MODULE__TRYRUN_OUTPUT='' \
+                          -DMPI_RUN_RESULT_Fortran_libver_mpi_F08_MODULE=0 \
+                          -DMPI_RUN_RESULT_Fortran_libver_mpi_F08_MODULE__TRYRUN_OUTPUT=''"
+
+cmake .. ${CMAKE_ARGS}
+
 #On MacOS, need to explicitly remove the -fallow-argument-mismatch flag, because not recognized by Clang
 if [[ "${target}" == *-apple* ]]; then
-  CMAKE_ARGS="${CMAKE_ARGS} -DMPI_Fortran_COMPILE_OPTIONS:STRING=''"
+   cmake .. "-DMPI_Fortran_COMPILE_OPTIONS=''"
 fi
-
-#somehow need to run cmake twice for MPI Fortran to work
-cmake .. ${CMAKE_ARGS} || cmake .. ${CMAKE_ARGS}
 
 make -j${nproc} install
 """


### PR DESCRIPTION
New build recipe for the SIRIUS library, a C/C++ library for electronic structure calculations (density functional theory).

Note that the `cmake` command is run twice in a row. If not, a cryptic error message appears:

> CMake Error: try_run() invoked in cross-compiling mode, please set the following cache variables appropriately:
   MPI_RUN_RESULT_C_libver_mpi_normal (advanced)
   MPI_RUN_RESULT_C_libver_mpi_normal__TRYRUN_OUTPUT (advanced)

I am happy to hear suggestions on how to tackle this. 

The jll package is only built for linux-x86_64, linux-aarch64 and macos-aarch64. This is a conscious decision.