### PR TITLE
[PETSc] version 3.21.4

### DIFF
--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -86,7 +86,7 @@ else
 fi
 
 atomic_patch -p1 $WORKSPACE/srcdir/patches/mingw-version.patch
-atomic_patch -p1 $WORKSPACE/srcdir/patches/mpi-constants.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/mpi-constants.patch     
 atomic_patch -p1 $WORKSPACE/srcdir/patches/sosuffix.patch   
 
 mkdir $libdir/petsc

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -4,8 +4,12 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "PETSc"
-version = v"3.20.5"
-petsc_version = v"3.20.5"
+version = v"3.19.0"
+petsc_version = v"3.19.0"
+MUMPS_COMPAT_VERSION = "5.5.1"
+SUITESPARSE_COMPAT_VERSION = "5.10.1"
+SUPERLUDIST_COMPAT_VERSION = "8.1.2"   
+MPItrampoline_compat_version="5.2.1"    
 
 MPItrampoline_compat_version="5.2.1"
 MicrosoftMPI_compat_version="~10.1.4" 
@@ -13,8 +17,8 @@ MPICH_compat_version="~4.1.2"
 
 # Collection of sources required to build PETSc.
 sources = [
-    ArchiveSource("https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-$(petsc_version).tar.gz",
-    "fb4e637758737af910b05f30a785245633916cd0a929b7b6447ad1028da4ea5a"),
+    ArchiveSource("https://www.mcs.anl.gov/petsc/mirror/release-snapshots/petsc-$(petsc_version).tar.gz",
+    "8ced753e4d2fb6565662b2b1fbba75a426cbf8438203f82717ce270f0591322c"),
     DirectorySource("./bundled"),
 ]
 

--- a/P/PETSc/build_tarballs.jl
+++ b/P/PETSc/build_tarballs.jl
@@ -18,8 +18,8 @@ MPICH_compat_version="~4.1.2"
 
 # Collection of sources required to build PETSc.
 sources = [
-    ArchiveSource("https://www.mcs.anl.gov/petsc/mirror/release-snapshots/petsc-$(petsc_version).tar.gz",
-    "8ced753e4d2fb6565662b2b1fbba75a426cbf8438203f82717ce270f0591322c"),
+    ArchiveSource("https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-$(petsc_version).tar.gz",
+    "a9ae076d4617c7d84ce2bed37194022319c19f19b3930edf148b2bc8ecf2248d"),
     DirectorySource("./bundled"),
 ]
 

--- a/P/PETSc/bundled/patches/mpi-constants.patch
+++ b/P/PETSc/bundled/patches/mpi-constants.patch
@@ -1,38 +1,20 @@
 diff --git a/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c b/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c
-index dd3ec73de3d..b70bacb2858 100644
+diff --git a/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c b/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c
+index 7b5e24b..b0edf7d 100644
 --- a/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c
 +++ b/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c
-@@ -130,8 +130,9 @@ typedef struct {
-   gridinfo3d_t grid3d;
+@@ -144,7 +144,8 @@ typedef struct {
  #endif
  } PetscSuperLU_DIST;
  
 -static PetscMPIInt Petsc_Superlu_dist_keyval = MPI_KEYVAL_INVALID;
--
 +static PetscMPIInt Petsc_Superlu_dist_keyval;
 +__attribute__((__constructor__)) static void init_Petsc_Superlu_dist_keyval() { Petsc_Superlu_dist_keyval = MPI_KEYVAL_INVALID; }
-+ 
- PETSC_EXTERN PetscMPIInt MPIAPI Petsc_Superlu_dist_keyval_Delete_Fn(MPI_Comm comm, PetscMPIInt keyval, void *attr_val, void *extra_state)
- {
-   PetscSuperLU_DIST *context = (PetscSuperLU_DIST *)attr_val;
-diff --git a/src/mat/impls/scalapack/matscalapack.c b/src/mat/impls/scalapack/matscalapack.c
-index d105cdd0a57..9cb7352c281 100644
---- a/src/mat/impls/scalapack/matscalapack.c
-+++ b/src/mat/impls/scalapack/matscalapack.c
-@@ -17,7 +17,9 @@ static PetscBool ScaLAPACKCite       = PETSC_FALSE;
-     The variable Petsc_ScaLAPACK_keyval is used to indicate an MPI attribute that
-   is attached to a communicator, in this case the attribute is a Mat_ScaLAPACK_Grid
- */
--static PetscMPIInt Petsc_ScaLAPACK_keyval = MPI_KEYVAL_INVALID;
-+PetscMPIInt Petsc_ScaLAPACK_keyval;
-+__attribute__((__constructor__)) static void init_Petsc_ScaLAPACK_keyval() { Petsc_ScaLAPACK_keyval = MPI_KEYVAL_INVALID; }
-+
  
- static PetscErrorCode Petsc_ScaLAPACK_keyval_free(void)
+ PETSC_EXTERN PetscMPIInt MPIAPI Petsc_Superlu_dist_keyval_DeleteFn(MPI_Comm comm, PetscMPIInt keyval, void *attr_val, void *extra_state)
  {
-   PetscSuperLU_DIST *context = (PetscSuperLU_DIST *)attr_val;
 diff --git a/src/sys/classes/viewer/impls/ascii/vcreatea.c b/src/sys/classes/viewer/impls/ascii/vcreatea.c
-index bc0dac30c9b..04a3dee9d6d 100644
+index cb3c3d5..c128a74 100644
 --- a/src/sys/classes/viewer/impls/ascii/vcreatea.c
 +++ b/src/sys/classes/viewer/impls/ascii/vcreatea.c
 @@ -5,7 +5,8 @@
@@ -44,9 +26,10 @@ index bc0dac30c9b..04a3dee9d6d 100644
 +PetscMPIInt Petsc_Viewer_Stdout_keyval;
 +__attribute__((__constructor__)) static void init_Petsc_Viewer_Stdout_keyval() { Petsc_Viewer_Stdout_keyval = MPI_KEYVAL_INVALID; }
 + 
- /*@
-    PetscViewerASCIIGetStdout - Creates a `PETSCVIEWERASCII` `PetscViewer` shared by all processors
-@@ -81,7 +82,8 @@ PetscViewer PETSC_VIEWER_STDOUT_(MPI_Comm comm)
+ /*@C
+    PETSC_VIEWER_STDOUT_ - Creates a `PETSCVIEWERASCII` `PetscViewer` shared by all MPI processes
+                     in a communicator.
+@@ -45,8 +46,9 @@ PetscViewer PETSC_VIEWER_STDOUT_(MPI_Comm comm)
      The variable Petsc_Viewer_Stderr_keyval is used to indicate an MPI attribute that
    is attached to a communicator, in this case the attribute is a PetscViewer.
  */
@@ -56,8 +39,9 @@ index bc0dac30c9b..04a3dee9d6d 100644
 +__attribute__((__constructor__)) static void init_Petsc_Viewer_Stderr_keyval() { Petsc_Viewer_Stderr_keyval = MPI_KEYVAL_INVALID; }
 + 
  /*@
-    PetscViewerASCIIGetStderr - Creates a `PETSCVIEWERASCII` `PetscViewer` shared by all processors
-@@ -155,7 +157,8 @@ PetscViewer PETSC_VIEWER_STDERR_(MPI_Comm comm)
+   PetscViewerASCIIGetStderr - Creates a `PETSCVIEWERASCII` `PetscViewer` shared by all MPI processes
+   in a communicator. Error returning version of `PETSC_VIEWER_STDERR_()`
+@@ -128,7 +130,8 @@ PetscViewer PETSC_VIEWER_STDERR_(MPI_Comm comm)
    PetscFunctionReturn(viewer);
  }
  
@@ -122,22 +106,7 @@ index 1385b4232ae..9617bd06087 100644
 +__attribute__((__constructor__)) static void init_Petsc_Viewer_Socket_keyval() { Petsc_Viewer_Socket_keyval = MPI_KEYVAL_INVALID; }
  
  /*@C
-      PETSC_VIEWER_SOCKET_ - Creates a socket viewer shared by all processors in a communicator.
-diff --git a/src/sys/objects/optionsyaml.c b/src/sys/objects/optionsyaml.c
-index 254dbf0d352..18b402469da 100644
---- a/src/sys/objects/optionsyaml.c
-+++ b/src/sys/objects/optionsyaml.c
-@@ -10,7 +10,9 @@
- PETSC_INTERN PetscErrorCode PetscOptionsSetValue_Private(PetscOptions, const char[], const char[], int *, PetscOptionSource);
- PETSC_INTERN PetscErrorCode PetscOptionsInsertStringYAML_Private(PetscOptions, const char[], PetscOptionSource);
- 
--static MPI_Comm petsc_yaml_comm = MPI_COMM_NULL; /* only used for parallel error handling */
-+static MPI_Comm petsc_yaml_comm; /* only used for parallel error handling */
-+__attribute__((__constructor__)) static void init_petsc_yaml_comm() { petsc_yaml_comm = MPI_COMM_NULL; }
-+
- 
- static inline MPI_Comm PetscYAMLGetComm(void)
- {
+    PETSC_VIEWER_SOCKET_ - Creates a socket viewer shared by all processors in a communicator.
 diff --git a/src/sys/objects/pinit.c b/src/sys/objects/pinit.c
 index f0b0b569fa4..02357127622 100644
 --- a/src/sys/objects/pinit.c
@@ -224,7 +193,7 @@ index 5da075d555d..812ff10bc78 100644
 +
  
  /*@
-    PetscSequentialPhaseBegin - Begins a sequential section of code.
+   PetscSequentialPhaseBegin - Begins a sequential section of code.
 diff --git a/src/vec/vec/utils/comb.c b/src/vec/vec/utils/comb.c
 index 38ce9beb2b9..7e63236adf0 100644
 --- a/src/vec/vec/utils/comb.c

--- a/P/PETSc/bundled/patches/mpi-constants.patch
+++ b/P/PETSc/bundled/patches/mpi-constants.patch
@@ -1,8 +1,9 @@
 diff --git a/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c b/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c
-index 1361d41..415825e 100644
+index dd3ec73de3d..b70bacb2858 100644
 --- a/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c
 +++ b/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c
-@@ -144,8 +144,9 @@ typedef struct {
+@@ -130,8 +130,9 @@ typedef struct {
+   gridinfo3d_t grid3d;
  #endif
  } PetscSuperLU_DIST;
  
@@ -14,11 +15,27 @@ index 1361d41..415825e 100644
  PETSC_EXTERN PetscMPIInt MPIAPI Petsc_Superlu_dist_keyval_Delete_Fn(MPI_Comm comm, PetscMPIInt keyval, void *attr_val, void *extra_state)
  {
    PetscSuperLU_DIST *context = (PetscSuperLU_DIST *)attr_val;
+diff --git a/src/mat/impls/scalapack/matscalapack.c b/src/mat/impls/scalapack/matscalapack.c
+index d105cdd0a57..9cb7352c281 100644
+--- a/src/mat/impls/scalapack/matscalapack.c
++++ b/src/mat/impls/scalapack/matscalapack.c
+@@ -17,7 +17,9 @@ static PetscBool ScaLAPACKCite       = PETSC_FALSE;
+     The variable Petsc_ScaLAPACK_keyval is used to indicate an MPI attribute that
+   is attached to a communicator, in this case the attribute is a Mat_ScaLAPACK_Grid
+ */
+-static PetscMPIInt Petsc_ScaLAPACK_keyval = MPI_KEYVAL_INVALID;
++PetscMPIInt Petsc_ScaLAPACK_keyval;
++__attribute__((__constructor__)) static void init_Petsc_ScaLAPACK_keyval() { Petsc_ScaLAPACK_keyval = MPI_KEYVAL_INVALID; }
++
+ 
+ static PetscErrorCode Petsc_ScaLAPACK_keyval_free(void)
+ {
+   PetscSuperLU_DIST *context = (PetscSuperLU_DIST *)attr_val;
 diff --git a/src/sys/classes/viewer/impls/ascii/vcreatea.c b/src/sys/classes/viewer/impls/ascii/vcreatea.c
-index 2ce92a6..ebe7461 100644
+index bc0dac30c9b..04a3dee9d6d 100644
 --- a/src/sys/classes/viewer/impls/ascii/vcreatea.c
 +++ b/src/sys/classes/viewer/impls/ascii/vcreatea.c
-@@ -4,8 +4,9 @@
+@@ -5,7 +5,8 @@
      The variable Petsc_Viewer_Stdout_keyval is used to indicate an MPI attribute that
    is attached to a communicator, in this case the attribute is a PetscViewer.
  */
@@ -28,9 +45,8 @@ index 2ce92a6..ebe7461 100644
 +__attribute__((__constructor__)) static void init_Petsc_Viewer_Stdout_keyval() { Petsc_Viewer_Stdout_keyval = MPI_KEYVAL_INVALID; }
 + 
  /*@
-   PetscViewerASCIIGetStdout - Creates a `PETSCVIEWERASCII` `PetscViewer` shared by all processors
-   in a communicator. Error returning version of `PETSC_VIEWER_STDOUT_()`
-@@ -89,8 +90,9 @@ PetscViewer PETSC_VIEWER_STDOUT_(MPI_Comm comm)
+    PetscViewerASCIIGetStdout - Creates a `PETSCVIEWERASCII` `PetscViewer` shared by all processors
+@@ -81,7 +82,8 @@ PetscViewer PETSC_VIEWER_STDOUT_(MPI_Comm comm)
      The variable Petsc_Viewer_Stderr_keyval is used to indicate an MPI attribute that
    is attached to a communicator, in this case the attribute is a PetscViewer.
  */
@@ -40,9 +56,8 @@ index 2ce92a6..ebe7461 100644
 +__attribute__((__constructor__)) static void init_Petsc_Viewer_Stderr_keyval() { Petsc_Viewer_Stderr_keyval = MPI_KEYVAL_INVALID; }
 + 
  /*@
-   PetscViewerASCIIGetStderr - Creates a `PETSCVIEWERASCII` `PetscViewer` shared by all MPI processes
-   in a communicator. Error returning version of `PETSC_VIEWER_STDERR_()`
-@@ -172,7 +174,8 @@ PetscViewer PETSC_VIEWER_STDERR_(MPI_Comm comm)
+    PetscViewerASCIIGetStderr - Creates a `PETSCVIEWERASCII` `PetscViewer` shared by all processors
+@@ -155,7 +157,8 @@ PetscViewer PETSC_VIEWER_STDERR_(MPI_Comm comm)
    PetscFunctionReturn(viewer);
  }
  
@@ -52,19 +67,93 @@ index 2ce92a6..ebe7461 100644
  /*
     Called with MPI_Comm_free() is called on a communicator that has a viewer as an attribute. The viewer is not actually destroyed
     because that is managed by PetscObjectDestroyRegisterAll(). PetscViewerASCIIGetStdout() registers the viewer with PetscObjectDestroyRegister() to be destroyed when PetscFinalize() is called.
+diff --git a/src/sys/classes/viewer/impls/binary/binv.c b/src/sys/classes/viewer/impls/binary/binv.c
+index 132fb1a5497..881614e2576 100644
+--- a/src/sys/classes/viewer/impls/binary/binv.c
++++ b/src/sys/classes/viewer/impls/binary/binv.c
+@@ -1562,7 +1562,8 @@ PETSC_EXTERN PetscErrorCode PetscViewerCreate_Binary(PetscViewer v)
+     The variable Petsc_Viewer_Binary_keyval is used to indicate an MPI attribute that
+   is attached to a communicator, in this case the attribute is a PetscViewer.
+ */
+-PetscMPIInt Petsc_Viewer_Binary_keyval = MPI_KEYVAL_INVALID;
++PetscMPIInt Petsc_Viewer_Binary_keyval;
++__attribute__((__constructor__)) static void init_Petsc_Viewer_Binary_keyval() { Petsc_Viewer_Binary_keyval = MPI_KEYVAL_INVALID; }
+ 
+ /*@C
+      PETSC_VIEWER_BINARY_ - Creates a `PETSCVIEWERBINARY` `PetscViewer` shared by all processors
+diff --git a/src/sys/classes/viewer/impls/draw/drawv.c b/src/sys/classes/viewer/impls/draw/drawv.c
+index 60ef77c612a..8afdd112ae7 100644
+--- a/src/sys/classes/viewer/impls/draw/drawv.c
++++ b/src/sys/classes/viewer/impls/draw/drawv.c
+@@ -720,7 +720,8 @@ PetscErrorCode PetscViewerDrawGetHold(PetscViewer viewer, PetscBool *hold)
+     The variable Petsc_Viewer_Draw_keyval is used to indicate an MPI attribute that
+   is attached to a communicator, in this case the attribute is a PetscViewer.
+ */
+-PetscMPIInt Petsc_Viewer_Draw_keyval = MPI_KEYVAL_INVALID;
++PetscMPIInt Petsc_Viewer_Draw_keyval;
++__attribute__((__constructor__)) static void init_Petsc_Viewer_Draw_keyval() { Petsc_Viewer_Draw_keyval = MPI_KEYVAL_INVALID; }
+ 
+ /*@C
+     PETSC_VIEWER_DRAW_ - Creates a window `PETSCVIEWERDRAW` `PetscViewer` shared by all processors
+diff --git a/src/sys/classes/viewer/impls/hdf5/hdf5v.c b/src/sys/classes/viewer/impls/hdf5/hdf5v.c
+index 1895a16e340..291244814d8 100644
+--- a/src/sys/classes/viewer/impls/hdf5/hdf5v.c
++++ b/src/sys/classes/viewer/impls/hdf5/hdf5v.c
+@@ -1578,7 +1578,8 @@ static PetscErrorCode PetscViewerHDF5HasAttribute_Internal(PetscViewer viewer, c
+   The variable Petsc_Viewer_HDF5_keyval is used to indicate an MPI attribute that
+   is attached to a communicator, in this case the attribute is a PetscViewer.
+ */
+-PetscMPIInt Petsc_Viewer_HDF5_keyval = MPI_KEYVAL_INVALID;
++PetscMPIInt Petsc_Viewer_HDF5_keyval;
++__attribute__((__constructor__)) static void init_Petsc_Viewer_HDF5_keyval() { Petsc_Viewer_HDF5_keyval = MPI_KEYVAL_INVALID; }
+ 
+ /*@C
+   PETSC_VIEWER_HDF5_ - Creates an `PETSCVIEWERHDF5` `PetscViewer` shared by all processors in a communicator.
+diff --git a/src/sys/classes/viewer/impls/socket/send.c b/src/sys/classes/viewer/impls/socket/send.c
+index 1385b4232ae..9617bd06087 100644
+--- a/src/sys/classes/viewer/impls/socket/send.c
++++ b/src/sys/classes/viewer/impls/socket/send.c
+@@ -462,7 +462,8 @@ PetscErrorCode PetscViewerSocketSetConnection(PetscViewer v, const char machine[
+     The variable Petsc_Viewer_Socket_keyval is used to indicate an MPI attribute that
+   is attached to a communicator, in this case the attribute is a PetscViewer.
+ */
+-PetscMPIInt Petsc_Viewer_Socket_keyval = MPI_KEYVAL_INVALID;
++PetscMPIInt Petsc_Viewer_Socket_keyval;
++__attribute__((__constructor__)) static void init_Petsc_Viewer_Socket_keyval() { Petsc_Viewer_Socket_keyval = MPI_KEYVAL_INVALID; }
+ 
+ /*@C
+      PETSC_VIEWER_SOCKET_ - Creates a socket viewer shared by all processors in a communicator.
+diff --git a/src/sys/objects/optionsyaml.c b/src/sys/objects/optionsyaml.c
+index 254dbf0d352..18b402469da 100644
+--- a/src/sys/objects/optionsyaml.c
++++ b/src/sys/objects/optionsyaml.c
+@@ -10,7 +10,9 @@
+ PETSC_INTERN PetscErrorCode PetscOptionsSetValue_Private(PetscOptions, const char[], const char[], int *, PetscOptionSource);
+ PETSC_INTERN PetscErrorCode PetscOptionsInsertStringYAML_Private(PetscOptions, const char[], PetscOptionSource);
+ 
+-static MPI_Comm petsc_yaml_comm = MPI_COMM_NULL; /* only used for parallel error handling */
++static MPI_Comm petsc_yaml_comm; /* only used for parallel error handling */
++__attribute__((__constructor__)) static void init_petsc_yaml_comm() { petsc_yaml_comm = MPI_COMM_NULL; }
++
+ 
+ static inline MPI_Comm PetscYAMLGetComm(void)
+ {
 diff --git a/src/sys/objects/pinit.c b/src/sys/objects/pinit.c
-index 6bbeb4d..03037fa 100644
+index f0b0b569fa4..02357127622 100644
 --- a/src/sys/objects/pinit.c
 +++ b/src/sys/objects/pinit.c
-@@ -42,22 +42,36 @@ PETSC_INTERN PetscErrorCode PetscSequentialPhaseEnd_Private(MPI_Comm, int);
+@@ -41,24 +41,38 @@ PETSC_INTERN PetscErrorCode PetscFinalize_DynamicLibraries(void);
+ PETSC_INTERN PetscErrorCode PetscSequentialPhaseBegin_Private(MPI_Comm, int);
+ PETSC_INTERN PetscErrorCode PetscSequentialPhaseEnd_Private(MPI_Comm, int);
  PETSC_INTERN PetscErrorCode PetscCloseHistoryFile(FILE **);
- 
+-
++ 
  /* user may set these BEFORE calling PetscInitialize() */
 -MPI_Comm PETSC_COMM_WORLD = MPI_COMM_NULL;
 -#if PetscDefined(HAVE_MPI_INIT_THREAD)
--PetscMPIInt PETSC_MPI_THREAD_REQUIRED = PETSC_DECIDE;
+-PetscMPIInt PETSC_MPI_THREAD_REQUIRED = MPI_THREAD_FUNNELED;
 -#else
--PetscMPIInt PETSC_MPI_THREAD_REQUIRED = MPI_THREAD_SINGLE;
+-PetscMPIInt PETSC_MPI_THREAD_REQUIRED = 0;
 -#endif
 -
 -PetscMPIInt Petsc_Counter_keyval      = MPI_KEYVAL_INVALID;
@@ -109,115 +198,45 @@ index 6bbeb4d..03037fa 100644
  
  /*
       Declare and set all the string names of the PETSc enums
-@@ -424,8 +438,9 @@ PETSC_EXTERN PetscMPIInt PetscDataRep_read_conv_fn(void *, MPI_Datatype, PetscMP
+@@ -423,7 +437,10 @@ PETSC_EXTERN PetscMPIInt PetscDataRep_read_conv_fn(void *, MPI_Datatype, PetscMP
  PETSC_EXTERN PetscMPIInt PetscDataRep_write_conv_fn(void *, MPI_Datatype, PetscMPIInt, void *, MPI_Offset, void *);
  #endif
  
 -PetscMPIInt PETSC_MPI_ERROR_CLASS = MPI_ERR_LASTCODE, PETSC_MPI_ERROR_CODE;
--
 +PetscMPIInt PETSC_MPI_ERROR_CLASS,PETSC_MPI_ERROR_CODE;
 +__attribute__((__constructor__)) static void init_PETSC_MPI_ERROR_CLASS() { PETSC_MPI_ERROR_CLASS=MPI_ERR_LASTCODE; }
 + 
++
+ 
  PETSC_INTERN int    PetscGlobalArgc;
  PETSC_INTERN char **PetscGlobalArgs;
- int                 PetscGlobalArgc = 0;
-diff --git a/src/vec/vec/utils/comb.c b/src/vec/vec/utils/comb.c
-index 745a0c0..7484a99 100644
---- a/src/vec/vec/utils/comb.c
-+++ b/src/vec/vec/utils/comb.c
-@@ -271,8 +271,9 @@ static PetscErrorCode PetscSplitReductionDestroy(PetscSplitReduction *sr)
-   PetscFunctionReturn(PETSC_SUCCESS);
- }
- 
--PetscMPIInt Petsc_Reduction_keyval = MPI_KEYVAL_INVALID;
--
-+PetscMPIInt Petsc_Reduction_keyval;
-+__attribute__((__constructor__)) static void init_Petsc_Reduction_keyval() { Petsc_Reduction_keyval = MPI_KEYVAL_INVALID; }
-+ 
- /*
-    Private routine to delete internal storage when a communicator is freed.
-   This is called by MPI, not by users.
-diff --git a/src/sys/objects/optionsyaml.c b/src/sys/objects/optionsyaml.c
-index 28ba6f0df9..617c20aeaf 100644
---- a/src/sys/objects/optionsyaml.c
-+++ b/src/sys/objects/optionsyaml.c
-@@ -7,7 +7,8 @@
- #include <../src/sys/yaml/include/yaml.h>
- #endif
- 
--static MPI_Comm petsc_yaml_comm = MPI_COMM_NULL; /* only used for parallel error handling */
-+static MPI_Comm petsc_yaml_comm; /* only used for parallel error handling */
-+__attribute__((__constructor__)) static void init_petsc_yaml_comm() { petsc_yaml_comm = MPI_COMM_NULL; }
- 
- PETSC_STATIC_INLINE MPI_Comm PetscYAMLGetComm(void)
- {
-diff --git a/src/sys/classes/viewer/impls/binary/binv.c b/src/sys/classes/viewer/impls/binary/binv.c
-index 842cc0750e..a4dee6a96d 100644
---- a/src/sys/classes/viewer/impls/binary/binv.c
-+++ b/src/sys/classes/viewer/impls/binary/binv.c
-@@ -1625,7 +1625,8 @@ PETSC_EXTERN PetscErrorCode PetscViewerCreate_Binary(PetscViewer v)
-     The variable Petsc_Viewer_Binary_keyval is used to indicate an MPI attribute that
-   is attached to a communicator, in this case the attribute is a PetscViewer.
- */
--PetscMPIInt Petsc_Viewer_Binary_keyval = MPI_KEYVAL_INVALID;
-+PetscMPIInt Petsc_Viewer_Binary_keyval;
-+__attribute__((__constructor__)) static void init_Petsc_Viewer_Binary_keyval() { Petsc_Viewer_Binary_keyval = MPI_KEYVAL_INVALID; }
- 
- /*@C
-      PETSC_VIEWER_BINARY_ - Creates a binary PetscViewer shared by all processors
-diff --git a/src/sys/classes/viewer/impls/draw/drawv.c b/src/sys/classes/viewer/impls/draw/drawv.c
-index e98ade22ff..8d27934c3e 100644
---- a/src/sys/classes/viewer/impls/draw/drawv.c
-+++ b/src/sys/classes/viewer/impls/draw/drawv.c
-@@ -752,7 +752,8 @@ PetscErrorCode  PetscViewerDrawGetHold(PetscViewer viewer,PetscBool *hold)
-     The variable Petsc_Viewer_Draw_keyval is used to indicate an MPI attribute that
-   is attached to a communicator, in this case the attribute is a PetscViewer.
- */
--PetscMPIInt Petsc_Viewer_Draw_keyval = MPI_KEYVAL_INVALID;
-+PetscMPIInt Petsc_Viewer_Draw_keyval;
-+__attribute__((__constructor__)) static void init_Petsc_Viewer_Draw_keyval() { Petsc_Viewer_Draw_keyval = MPI_KEYVAL_INVALID; }
- 
- /*@C
-     PETSC_VIEWER_DRAW_ - Creates a window PetscViewer shared by all processors
-diff --git a/src/sys/classes/viewer/impls/socket/send.c b/src/sys/classes/viewer/impls/socket/send.c
-index 3f34bb5e10..5a752fdc24 100644
---- a/src/sys/classes/viewer/impls/socket/send.c
-+++ b/src/sys/classes/viewer/impls/socket/send.c
-@@ -464,7 +464,8 @@ PetscErrorCode  PetscViewerSocketSetConnection(PetscViewer v,const char machine[
-     The variable Petsc_Viewer_Socket_keyval is used to indicate an MPI attribute that
-   is attached to a communicator, in this case the attribute is a PetscViewer.
- */
--PetscMPIInt Petsc_Viewer_Socket_keyval = MPI_KEYVAL_INVALID;
-+PetscMPIInt Petsc_Viewer_Socket_keyval;
-+__attribute__((__constructor__)) static void init_Petsc_Viewer_Socket_keyval() { Petsc_Viewer_Socket_keyval = MPI_KEYVAL_INVALID; }
- 
- /*@C
-      PETSC_VIEWER_SOCKET_ - Creates a socket viewer shared by all processors in a communicator.
 diff --git a/src/sys/utils/mpiu.c b/src/sys/utils/mpiu.c
-index a28ea3dc51..15247372d9 100644
+index 5da075d555d..812ff10bc78 100644
 --- a/src/sys/utils/mpiu.c
 +++ b/src/sys/utils/mpiu.c
-@@ -52,7 +52,8 @@ PETSC_INTERN PetscErrorCode PetscSequentialPhaseEnd_Private(MPI_Comm comm,int ng
+@@ -42,7 +42,9 @@ PETSC_INTERN PetscErrorCode PetscSequentialPhaseEnd_Private(MPI_Comm comm, int n
      The variable Petsc_Seq_keyval is used to indicate an MPI attribute that
    is attached to a communicator that manages the sequential phase code below.
  */
 -PetscMPIInt Petsc_Seq_keyval = MPI_KEYVAL_INVALID;
 +PetscMPIInt Petsc_Seq_keyval;
 +__attribute__((__constructor__)) static void init_Petsc_Seq_keyval() { Petsc_Seq_keyval = MPI_KEYVAL_INVALID; }
++
  
  /*@
     PetscSequentialPhaseBegin - Begins a sequential section of code.
-diff --git a/src/mat/impls/scalapack/matscalapack.c b/src/mat/impls/scalapack/matscalapack.c
-index 9422402d2e..e15cea0ba6 100644
---- a/src/mat/impls/scalapack/matscalapack.c
-+++ b/src/mat/impls/scalapack/matscalapack.c
-@@ -17,7 +17,8 @@
-     The variable Petsc_ScaLAPACK_keyval is used to indicate an MPI attribute that
-   is attached to a communicator, in this case the attribute is a Mat_ScaLAPACK_Grid
- */
--static PetscMPIInt Petsc_ScaLAPACK_keyval = MPI_KEYVAL_INVALID;
-+PetscMPIInt Petsc_ScaLAPACK_keyval;
-+__attribute__((__constructor__)) static void init_Petsc_ScaLAPACK_keyval() { Petsc_ScaLAPACK_keyval = MPI_KEYVAL_INVALID; }
+diff --git a/src/vec/vec/utils/comb.c b/src/vec/vec/utils/comb.c
+index 38ce9beb2b9..7e63236adf0 100644
+--- a/src/vec/vec/utils/comb.c
++++ b/src/vec/vec/utils/comb.c
+@@ -271,7 +271,9 @@ PetscErrorCode PetscSplitReductionDestroy(PetscSplitReduction *sr)
+   PetscFunctionReturn(PETSC_SUCCESS);
+ }
  
- static PetscErrorCode Petsc_ScaLAPACK_keyval_free(void)
- { 
+-PetscMPIInt Petsc_Reduction_keyval = MPI_KEYVAL_INVALID;
++PetscMPIInt Petsc_Reduction_keyval;
++__attribute__((__constructor__)) static void init_Petsc_Reduction_keyval() { Petsc_Reduction_keyval = MPI_KEYVAL_INVALID; }
++
+ 
+ /*
+    Private routine to delete internal storage when a communicator is freed.


### PR DESCRIPTION
PETSc version 3.21.4, our most complete compilation so far with:
- `SuperLU_Dist`
- `MUMPS`
- `SuiteSparse`
- `HDF5`
- `Triangle`
- `TetGen`
Note that `MPI` on windows remains broken and is deactivated.