### PR TITLE
[ITKIOWrapper-v1.0.0] fixed  @wrapmodule error

### DIFF
--- a/I/ITKIOWrapper/src/CMakeLists.txt
+++ b/I/ITKIOWrapper/src/CMakeLists.txt
@@ -14,7 +14,21 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${JlCxx_location}")
 
 message(STATUS "Found JlCxx at ${JlCxx_location}")
 
-find_package(ITK REQUIRED)
+# Update the ITK components list
+set(ITK_COMPONENTS
+    ITKCommon
+    ITKIOImageBase
+    ITKIOGDCM
+    ITKIONIFTI
+    ITKIONRRD
+    ITKIOHDF5
+    ITKIOMeta
+    ITKIOPNG
+    ITKIOTIFF
+    ITKImageIO
+)
+
+find_package(ITK REQUIRED COMPONENTS ${ITK_COMPONENTS})
 include(${ITK_USE_FILE})
 
 message(STATUS "Found ITK at ${ITK_USE_FILE}")

--- a/I/ITKIOWrapper/src/itklib.cpp
+++ b/I/ITKIOWrapper/src/itklib.cpp
@@ -1,24 +1,76 @@
+
+// #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/jlcxx.hpp"
+#include "jlcxx/array.hpp"
+#include "jlcxx/tuple.hpp"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkImage.h"
+#include <vector>
+#include <memory>
+#include <stdexcept>
 
 using ImageType = itk::Image<float, 3>;
 
-ImageType::Pointer loadImage(const std::string& filename) {
-    auto reader = itk::ImageFileReader<ImageType>::New();
-    reader->SetFileName(filename);
-    reader->Update();
-    return reader->GetOutput();
-}
+class ITKImageWrapper {
+private:
+    ImageType::Pointer m_Image;
 
-void writeImage(ImageType::Pointer image, const std::string& filename) {
-    auto writer = itk::ImageFileWriter<ImageType>::New();
-    writer->SetFileName(filename);
-    writer->SetInput(image);
-    writer->Update();
-}
+public:
+    ITKImageWrapper(const std::string& filename) {
+        auto reader = itk::ImageFileReader<ImageType>::New();
+        reader->SetFileName(filename);
+        reader->Update();
+        m_Image = reader->GetOutput();
+    }
 
-JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
-    mod.method("loadImage", loadImage);
-    mod.method("writeImage", writeImage);
+    std::vector<double> getOrigin() const {
+        auto origin = m_Image->GetOrigin();
+        return {origin[0], origin[1], origin[2]};
+    }
+
+    std::vector<double> getSpacing() const {
+        auto spacing = m_Image->GetSpacing();
+        return {spacing[0], spacing[1], spacing[2]};
+    }
+
+    std::vector<std::size_t> getSize() const {
+        auto size = m_Image->GetLargestPossibleRegion().GetSize();
+        return {size[0], size[1], size[2]};
+    }
+
+    std::vector<float> getPixelData() const {
+        std::vector<float> data;
+        itk::ImageRegionConstIterator<ImageType> it(m_Image, m_Image->GetLargestPossibleRegion());
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            data.push_back(it.Get());
+        }
+        return data;
+    }
+
+    void writeImage(const std::string& filename) const {
+        auto writer = itk::ImageFileWriter<ImageType>::New();
+        writer->SetFileName(filename);
+        writer->SetInput(m_Image);
+        writer->Update();
+    }
+};
+
+
+JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
+{
+    mod.add_type<ITKImageWrapper>("ITKImageWrapper")
+        .constructor<std::string>()
+        .method("getOrigin", &ITKImageWrapper::getOrigin)
+        .method("getSpacing", &ITKImageWrapper::getSpacing)
+        .method("getSize", &ITKImageWrapper::getSize)
+        .method("getPixelData", &ITKImageWrapper::getPixelData)
+        .method("writeImage", &ITKImageWrapper::writeImage);
+
+    // Explicitly map methods to the allocated type
+    mod.method("getOrigin", [](ITKImageWrapper& w) { return w.getOrigin(); });
+    mod.method("getSpacing", [](ITKImageWrapper& w) { return w.getSpacing(); });
+    mod.method("getSize", [](ITKImageWrapper& w) { return w.getSize(); });
+    mod.method("getPixelData", [](ITKImageWrapper& w) { return w.getPixelData(); });
+    mod.method("writeImage", [](ITKImageWrapper& w, const std::string& filename) { w.writeImage(filename); });
 }


### PR DESCRIPTION
The package was basically unusable due to c++ pointer errors,
resolved with the addition of functions for loading spatial metadata from images.
