### PR TITLE
[gmsh] update to 4.13.1, compat for OCCT_jll

### DIFF
--- a/G/gmsh/build_tarballs.jl
+++ b/G/gmsh/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "gmsh"
-version = v"4.13.0"
+version = v"4.13.1"
 
 # Collection of sources required to build Gmsh
 sources = [
     ArchiveSource("https://gmsh.info/src/gmsh-$(version)-source.tgz",
-                  "2a286195e27fe11ee48ce3c98a07c6a4b9961f1e03878e0e3681cf2cfc08db11"),
+                  "77972145f431726026d50596a6a44fb3c1c95c21255218d66955806b86edbe8d"),
 ]
 
 # Bash recipe for building across all platforms
@@ -76,7 +76,7 @@ dependencies = [
     Dependency("LLVMOpenMP_jll"; platforms=filter(Sys.isbsd, platforms)),
     Dependency("METIS_jll"),
     Dependency("MMG_jll"),
-    Dependency("OCCT_jll"),
+    Dependency("OCCT_jll"; compat="~7.7.2"),
     Dependency("Xorg_libX11_jll"; platforms=x11_platforms),
     Dependency("Xorg_libXext_jll"; platforms=x11_platforms),
     Dependency("Xorg_libXfixes_jll"; platforms=x11_platforms),


### PR DESCRIPTION
Update gmsh to latest 4.13.1.

Add compat for OCCT_jll `~7.7.2`.  Registration is still open https://github.com/JuliaRegistries/General/pull/113891.

Weirdly, for the previous version `https://gmsh.info/src/gmsh-4.13.0-source.tgz` I get `sha256sum` `c85f056ee549a433e814a61c385c97952bbfe514b442b999f6149fffb1e54f64` that does not match `2a286195e27fe11ee48ce3c98a07c6a4b9961f1e03878e0e3681cf2cfc08db11`.