### PR TITLE
[XZ] Use default GCC version instead of v7

### DIFF
--- a/X/XZ/build_tarballs.jl
+++ b/X/XZ/build_tarballs.jl
@@ -86,6 +86,6 @@ products = [
 dependencies = Dependency[
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well
+# Build the tarballs, and possibly a `build.jl` as well!
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.6")

--- a/X/XZ/build_tarballs.jl
+++ b/X/XZ/build_tarballs.jl
@@ -88,4 +88,4 @@ dependencies = Dependency[
 
 # Build the tarballs, and possibly a `build.jl` as well
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"7")
+               julia_compat="1.6")


### PR DESCRIPTION
The `preferred_gcc_version` was set to v7 in #8166 due to issues with the assembler emitting instructions not supported by the version of binutils bundled with the default GCC. This was in service of updating XZ to v5.6.0, but as of #8396, we build XZ v5.2.5. When v2.5.2 was initially added in #2057, we used the default GCC, so it should no longer be necessary to require v7.