### PR TITLE
Bump rr to 5.8

### DIFF
--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"5.8"
 # Collection of sources required to build rr
 sources = [
     GitSource("https://github.com/JuliaLang/rr.git",
-              "14ccee90bf59b9eead214a2b4d30d41328cea8f0")
+              "994b70fd32e39c9bb8a14bed84810676c7f477d0")
 ]
 
 # Bash recipe for building across all platforms

--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "rr"
-version = v"5.7"
+version = v"5.8"
 
 # Collection of sources required to build rr
 sources = [
     GitSource("https://github.com/JuliaLang/rr.git",
-              "39f8a2923be89e2df2997d85f8ea2574ea1bc203")
+              "2a922abed97a02d006629d924366a7a9103d3248")
 ]
 
 # Bash recipe for building across all platforms

--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"5.8"
 # Collection of sources required to build rr
 sources = [
     GitSource("https://github.com/JuliaLang/rr.git",
-              "2a922abed97a02d006629d924366a7a9103d3248")
+              "14ccee90bf59b9eead214a2b4d30d41328cea8f0")
 ]
 
 # Bash recipe for building across all platforms

--- a/R/rr/build_tarballs.jl
+++ b/R/rr/build_tarballs.jl
@@ -54,6 +54,7 @@ dependencies = [
     # For the capnp static support library
     BuildDependency("capnproto_jll"),
     Dependency("Zlib_jll"),
+    Dependency("Zstd_jll"),
     Dependency("CompilerSupportLibraries_jll"),
 ]
 


### PR DESCRIPTION
Updates rr to current master, which in particular has https://github.com/rr-debugger/rr/commit/07415f58c423053ad024c69918a014275ef6f73f which fixes rr asserts seen on CI. Also picks up https://github.com/rr-debugger/rr/commit/c1ca64585a923f75b12df2eba259ab64bc5646a1, which was a patch we'd been carrying locally.