### PR TITLE
[MbedTLS@2.28.6] Rebuild for FreeBSD AArch64 support

### DIFF
--- a/M/MbedTLS/MbedTLS@2.28.6/build_tarballs.jl
+++ b/M/MbedTLS/MbedTLS@2.28.6/build_tarballs.jl
@@ -3,3 +3,5 @@ include("../common.jl")
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.9", preferred_llvm_version=llvm_version)
+
+# Build trigger: 1


### PR DESCRIPTION
Given that Julia is moving toward replacing MbedTLS with OpenSSL and relevant builders for Julia's dependencies have been updated to use OpenSSL instead of MbedTLS, this rebuild may not end up getting used, at least for Julia itself. Might as well rebuild just in case though.