### PR TITLE
Add builder for whereami

### DIFF
--- a/W/WhereAmI/build_tarballs.jl
+++ b/W/WhereAmI/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "WhereAmI"
-version = v"2024.8.6"  # no proper versions/releases, this is the date of the commit used
+version = v"1.0.0"  # no proper versions/releases, this is made up
 
 sources = [
     GitSource("https://github.com/gpakosz/whereami",

--- a/W/WhereAmI/build_tarballs.jl
+++ b/W/WhereAmI/build_tarballs.jl
@@ -11,7 +11,11 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/whereami/
 mkdir -p "${libdir}"
-cc -Isrc -O2 -std=c99 -fPIC -ldl -shared -o "${libdir}/libwai.${dlext}"
+FLAGS=(-Isrc -O2 -std=c99 -fPIC)
+if [[ "${target}" != *-mingw* ]]; then
+    FLAGS+=(-ldl)
+fi
+cc ${FLAGS[@]} -shared -o "${libdir}/libwai.${dlext}"
 install -Dvm 644 src/whereami.h "${includedir}/whereami.h"
 install_license LICENSE.MIT
 """

--- a/W/WhereAmI/build_tarballs.jl
+++ b/W/WhereAmI/build_tarballs.jl
@@ -1,0 +1,27 @@
+using BinaryBuilder
+
+name = "WhereAmI"
+version = v"2024.8.6"  # no proper versions/releases, this is the date of the commit used
+
+sources = [
+    GitSource("https://github.com/gpakosz/whereami",
+              "dcb52a058dc14530ba9ae05e4339bd3ddfae0e0e"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/whereami/
+cc -Isrc -O2 -std=c99 -fPIC -ldl -shared -o "${libdir}/libwai.${dlext}"
+install -Dvm 644 src/whereami.h "${includedir}/whereami.h"
+install_license LICENSE.MIT
+"""
+
+platforms = supported_platforms()
+
+products = [
+    LibraryProduct("libwai", :libwai),
+]
+
+dependencies = Dependency[]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")

--- a/W/WhereAmI/build_tarballs.jl
+++ b/W/WhereAmI/build_tarballs.jl
@@ -12,10 +12,10 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/whereami/
 mkdir -p "${libdir}"
 FLAGS=(-Isrc -O2 -std=c99 -fPIC)
-if [[ "${target}" != *-mingw* ]]; then
+if [[ "${target}" == *-gnu* ]]; then
     FLAGS+=(-ldl)
 fi
-cc ${FLAGS[@]} -shared -o "${libdir}/libwai.${dlext}"
+cc src/whereami.c ${FLAGS[@]} -shared -o "${libdir}/libwai.${dlext}"
 install -Dvm 644 src/whereami.h "${includedir}/whereami.h"
 install_license LICENSE.MIT
 """

--- a/W/WhereAmI/build_tarballs.jl
+++ b/W/WhereAmI/build_tarballs.jl
@@ -10,6 +10,7 @@ sources = [
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/whereami/
+mkdir -p "${libdir}"
 cc -Isrc -O2 -std=c99 -fPIC -ldl -shared -o "${libdir}/libwai.${dlext}"
 install -Dvm 644 src/whereami.h "${includedir}/whereami.h"
 install_license LICENSE.MIT


### PR DESCRIPTION
Cross-platform library for identifying where on the filesystem the current executable lives.