### PR TITLE
Update OpenSSH and add `sftp` as a product

### DIFF
--- a/O/OpenSSH/build_tarballs.jl
+++ b/O/OpenSSH/build_tarballs.jl
@@ -18,7 +18,7 @@ script = raw"""
 cd $WORKSPACE/srcdir
 
 install_license openssh-*/LICENCE
-PRODUCTS=(ssh${exeext} ssh-add${exeext} ssh-keygen${exeext} ssh-keyscan${exeext} ssh-agent${exeext} scp${exeext})
+PRODUCTS=(ssh${exeext} ssh-add${exeext} ssh-keygen${exeext} ssh-keyscan${exeext} ssh-agent${exeext} scp${exeext} sftp${exeext})
 
 if [[ "${target}" == *-mingw* ]]; then
     cd "${target}/OpenSSH-Win${nbits}"
@@ -58,6 +58,7 @@ platforms = supported_platforms()
 products = [
     ExecutableProduct("ssh", :ssh),
     ExecutableProduct("scp", :scp),
+    ExecutableProduct("sftp", :sftp),
     ExecutableProduct("ssh-agent", :ssh_agent),
     ExecutableProduct("ssh-add", :ssh_add),
     ExecutableProduct("ssh-keygen", :ssh_keygen),

--- a/O/OpenSSH/build_tarballs.jl
+++ b/O/OpenSSH/build_tarballs.jl
@@ -68,7 +68,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Zlib_jll"),
-    Dependency("OpenSSL_jll"; compat="3.0.8"),
+    Dependency("OpenSSL_jll"; compat="3.0.15"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/O/OpenSSH/build_tarballs.jl
+++ b/O/OpenSSH/build_tarballs.jl
@@ -1,16 +1,16 @@
 using BinaryBuilder
 
 name = "OpenSSH"
-version = v"9.3.2"
+version = v"9.9.1"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.3p2.tar.gz",
-                  "200ebe147f6cb3f101fd0cdf9e02442af7ddca298dffd9f456878e7ccac676e8"),
-    ArchiveSource("https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.2.2.0p1-Beta/OpenSSH-Win32.zip",
-                  "7b132aad088eae3ac67d85751e88d884e80631607cab9b1da52c838655bb5ae6"; unpack_target = "i686-w64-mingw32"),
-    ArchiveSource("https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.2.2.0p1-Beta/OpenSSH-Win64.zip",
-                  "ec8144a107014740ec3ce16ec51710398fc390fca5344931c1506e7cc2e181f3"; unpack_target = "x86_64-w64-mingw32"),
+    ArchiveSource("https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.9p1.tar.gz",
+                  "b343fbcdbff87f15b1986e6e15d6d4fc9a7d36066be6b7fb507087ba8f966c02"),
+    ArchiveSource("https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win32.zip",
+                  "9245c9ff62d6d11708cb3125097f8cd5627e995c225d0469cf2c3c6be4014952"; unpack_target = "i686-w64-mingw32"),
+    ArchiveSource("https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64.zip",
+                  "bd48fe985d400402c278c485db20e6a82bc4c7f7d8e0ef5a81128f523096530c"; unpack_target = "x86_64-w64-mingw32"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Updated to 9.5.0 on Windows, which seems to be the latest available.