### PR TITLE
[SuiteSparse@7] Temporarily set version back to 7.7.0

### DIFF
--- a/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
@@ -1,8 +1,8 @@
-# Build counter: 0
+# Build counter: 1
 include("../common.jl")
 
 name = "SuiteSparse"
-version = v"7.8.2"
+version = v"7.7.0"
 
 sources = suitesparse_sources(version)
 


### PR DESCRIPTION
Julia 1.11 uses SuiteSparse 7.7 and Julia 1.12 uses SuiteSparse 7.8, so separating the builders permits easier per-Julia-version maintenance.

cc @rayegun @giordano 