### PR TITLE
libevent: Build for aarch64-unknown-freebsd

### DIFF
--- a/L/libevent/build_tarballs.jl
+++ b/L/libevent/build_tarballs.jl
@@ -20,6 +20,9 @@ cd $WORKSPACE/srcdir/libevent-*
 if [[ "${target}" == aarch64-apple-* ]]; then
     # Build without `-Wl,--no-undefined`
     atomic_patch -p1 ../patches/build_with_no_undefined.patch
+elif [[ "${target}" == *-mingw* ]]; then
+     # Required to find OpenSSL
+     export LDFLAGS="${LDFLAGS} -L${bindir}"
 fi
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}

--- a/L/libevent/build_tarballs.jl
+++ b/L/libevent/build_tarballs.jl
@@ -42,7 +42,7 @@ products_unix = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("OpenSSL_jll"; compat="3.0.12"),
+    Dependency("OpenSSL_jll"; compat="3.0.15"), # Required for aarch64-unknown-freebsd
 ]
 
 include("../../fancy_toys.jl")

--- a/L/libevent/build_tarballs.jl
+++ b/L/libevent/build_tarballs.jl
@@ -4,8 +4,8 @@ using BinaryBuilder, Pkg
 
 name = "libevent"
 libevent_version =v"2.1.12"
-# We update to 2.1.13 because we updated our dependencies
-version = v"2.1.13"
+# We update to 2.1.14 because we updated our dependencies
+version = v"2.1.14"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
I updated the OpenSSL compat bounds. Not sure whether that's necessary – it builds without that update, claiming to load `OpenSSL_jll 3.0.12`, which doesn't exist for `aarch64-unknown-freebsd`.