### PR TITLE
[GAP] Patch CLOSE_PTY_IOSTREAM

### DIFF
--- a/G/GAP/bundled/patches/kill-then-wait.patch
+++ b/G/GAP/bundled/patches/kill-then-wait.patch
@@ -1,0 +1,43 @@
+From 2253127bd7648a4f2dba3e2e800a0cbcb818c918 Mon Sep 17 00:00:00 2001
+From: Max Horn <max@quendi.de>
+Date: Tue, 24 Sep 2024 22:27:09 +0200
+Subject: [PATCH] kernel: wait for child process to die before closing pty
+
+---
+ src/iostream.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/iostream.c b/src/iostream.c
+index 18db09901..68bdf6a4d 100644
+--- a/src/iostream.c
++++ b/src/iostream.c
+@@ -1007,13 +1007,11 @@ static Obj FuncSIGNAL_CHILD_IOSTREAM(Obj self, Obj stream, Obj sig)
+ static Obj FuncCLOSE_PTY_IOSTREAM(Obj self, Obj stream)
+ {
+     UInt pty = HashLockStreamIfAvailable(stream);
++    int status, retcode;
+ 
+     // Close down the child
+-    int status;
+     kill(PtyIOStreams[pty].childPID, SIGTERM);
+-    int retcode = close(PtyIOStreams[pty].ptyFD);
+-    if (retcode)
+-        Pr("Strange close return code %d\n", retcode, 0);
++
+     // GAP (or another library) might wait on this PID before
+     // we handle it. If that happens, waitpid will return -1.
+     retcode = waitpid(PtyIOStreams[pty].childPID, &status, WNOHANG);
+@@ -1028,6 +1026,10 @@ static Obj FuncCLOSE_PTY_IOSTREAM(Obj self, Obj stream)
+         retcode = waitpid(PtyIOStreams[pty].childPID, &status, 0);
+     }
+ 
++    retcode = close(PtyIOStreams[pty].ptyFD);
++    if (retcode)
++        Pr("Strange close return code %d\n", retcode, 0);
++
+     PtyIOStreams[pty].inuse = 0;
+ 
+     FreeStream(pty);
+-- 
+2.46.0
+


### PR DESCRIPTION
... to avoid hang when calling StopSingular(). See also <https://github.com/oscar-system/Oscar.jl/issues/4136> and https://github.com/gap-system/gap/pull/5804