### PR TITLE
MAGEMin v1.5.4

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.5.3"
+version = v"1.5.4"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "727961614ff97ca383801ed34e63b5f8efdf265a")                 ]
+                    "67387fa07ddb6bbdc1cc8dba89074afa46d48139")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Added anhydrous alkaline-silicate melt model (Weller et al., 2024)
- Added upper mantle to uppermost mantle database (Holland et al., 2013)
- corrected computation of apfu for pure phases
- changed simplex threshold from 1e10 to 0 -> fixes issues when dealing with highly reduced systems
- corrected mistake in handling pseudocompounds for the metabasite database
- added several pseudocompounds to improve quality of phase equilibrium for igneous and alkaline database