### PR TITLE
[Reactant] Try building Reactant with a more up-to-date clang

### DIFF
--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -9,7 +9,7 @@ repo = "https://github.com/EnzymeAD/Reactant.jl.git"
 version = v"0.0.19"
 
 sources = [
-   GitSource(repo, "3c95fc51d4ad7f8e380cb495b985aaac991729a4"),
+  GitSource(repo, "ffcfb29e0f5bbf5170973936ecca83502b2c50c1"),
   ArchiveSource("https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-dist.zip",
                 "fc89da919415289f29e4ff18a5e01270ece9a6fe83cb60967218bac4a3bb3ed2"; unpack_target="bazel-dist"),
 ]
@@ -141,11 +141,11 @@ if [[ "${bb_full_target}" == *darwin* ]]; then
 	export LLD2=`pwd`/bin/ld64.lld
 	popd
 
-	if [[ "${bb_full_target}" == *86* ]]; then
+    if [[ "${bb_full_target}" == *86* ]]; then
         BAZEL_BUILD_FLAGS+=(--platforms=@//:darwin_x86_64)
         BAZEL_BUILD_FLAGS+=(--linkopt=-fuse-ld=lld)
     else
-        BAZEL_BUILD_FLAGS+=(--platforms=@//:darwin_aarch64)
+        BAZEL_BUILD_FLAGS+=(--platforms=@//:darwin_arm64)
         sed -i '/gcc-install-dir/d'  "/opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-clang"
         sed -i '/gcc-install-dir/d'  "/opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-clang++"
         BAZEL_BUILD_FLAGS+=(--copt=-D__ARM_FEATURE_AES=1)
@@ -295,6 +295,7 @@ platforms = filter(p -> !(Sys.isfreebsd(p)), platforms)
 # platforms = filter(p -> (Sys.isapple(p)), platforms)
 
 # platforms = filter(p -> !(Sys.isapple(p)), platforms)
+# platforms = filter(p -> arch(p) == "x86_64", platforms)
 # platforms = filter(p -> cxxstring_abi(p) == "cxx11", platforms)
 
 augment_platform_block="""

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -9,7 +9,7 @@ repo = "https://github.com/EnzymeAD/Reactant.jl.git"
 version = v"0.0.19"
 
 sources = [
-  GitSource(repo, "ffcfb29e0f5bbf5170973936ecca83502b2c50c1"),
+  GitSource(repo, "df6316384f420f889dcdff5d1489e272a6d0add3"),
   ArchiveSource("https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-dist.zip",
                 "fc89da919415289f29e4ff18a5e01270ece9a6fe83cb60967218bac4a3bb3ed2"; unpack_target="bazel-dist"),
 ]

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -9,7 +9,7 @@ repo = "https://github.com/EnzymeAD/Reactant.jl.git"
 version = v"0.0.19"
 
 sources = [
-  GitSource(repo, "4f4cb40af080a6f60a63fa3e747b95788804205c"),
+   GitSource(repo, "3c95fc51d4ad7f8e380cb495b985aaac991729a4"),
   ArchiveSource("https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-dist.zip",
                 "fc89da919415289f29e4ff18a5e01270ece9a6fe83cb60967218bac4a3bb3ed2"; unpack_target="bazel-dist"),
 ]

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -209,6 +209,7 @@ sed -i "s/^cc_library(/cc_library(linkstatic=True,/g" /workspace/bazel_root/*/ex
 if [[ "${bb_full_target}" == *darwin* ]]; then
     $BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so || echo stage1
 	sed -i.bak1 "/whole-archive/d" bazel-bin/libReactantExtra.so-2.params
+	sed -i.bak1 "/lrt/d" bazel-bin/libReactantExtra.so-2.params
     sed -i.bak0 "/lld/d" bazel-bin/libReactantExtra.so-2.params
 	echo "-fuse-ld=lld" >> bazel-bin/libReactantExtra.so-2.params
 	echo "--ld-path=$LLD2" >> bazel-bin/libReactantExtra.so-2.params

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -9,7 +9,7 @@ repo = "https://github.com/EnzymeAD/Reactant.jl.git"
 version = v"0.0.19"
 
 sources = [
-  GitSource(repo, "feb322ba407941f65049711b1425d7380a3f09fb"),
+  GitSource(repo, "55ce2cdf40545ba9ac41836ccce2e5b787cf9ea0"),
   ArchiveSource("https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-dist.zip",
                 "fc89da919415289f29e4ff18a5e01270ece9a6fe83cb60967218bac4a3bb3ed2"; unpack_target="bazel-dist"),
 ]

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -18,6 +18,9 @@ sources = [
 script = raw"""
 cd Reactant.jl/deps/ReactantExtra
 
+echo Clang version: $(clang --version)
+echo GCC version: $(gcc --version)
+
 if [[ "${bb_full_target}" == x86_64-apple-darwin* ]]; then
     # LLVM requires macOS SDK 10.14.
     pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
@@ -450,7 +453,7 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, build.script,
                    build.platforms, build.products, build.dependencies;
-                   preferred_gcc_version=v"10", julia_compat="1.6",
+                   preferred_gcc_version=v"10", preferred_llvm_version=v"18", julia_compat="1.6",
                    augment_platform_block, lazy_artifacts=true)
 end
 

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -133,13 +133,13 @@ if [[ "${bb_full_target}" == *darwin* ]]; then
     BAZEL_BUILD_FLAGS+=(--define=build_with_mkl=false --define=enable_mkl=false --define=build_with_mkl_aarch64=false)
     BAZEL_BUILD_FLAGS+=(--@xla//xla/tsl/framework/contraction:disable_onednn_contraction_kernel=True)
     
-#    pushd $WORKSPACE/srcdir/llvm*
-#	mkdir build
-#	cd build
-#	cmake ../llvm -DLLVM_ENABLE_PROJECTS="lld" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CROSSCOMPILING=False -DLLVM_TARGETS_TO_BUILD="X86;AArch64" -DCMAKE_TOOLCHAIN_FILE=${CMAKE_HOST_TOOLCHAIN} -GNinja -DCMAKE_EXE_LINKER_FLAGS="-static"
-#	ninja lld
-#	export LLD2=`pwd`/bin/ld64.lld
-#	popd
+    pushd $WORKSPACE/srcdir/llvm*
+	mkdir build
+	cd build
+	cmake ../llvm -DLLVM_ENABLE_PROJECTS="lld" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CROSSCOMPILING=False -DLLVM_TARGETS_TO_BUILD="X86;AArch64" -DCMAKE_TOOLCHAIN_FILE=${CMAKE_HOST_TOOLCHAIN} -GNinja -DCMAKE_EXE_LINKER_FLAGS="-static"
+	ninja lld
+	export LLD2=`pwd`/bin/ld64.lld
+	popd
 
     if [[ "${bb_full_target}" == *86* ]]; then
         BAZEL_BUILD_FLAGS+=(--platforms=@//:darwin_x86_64)
@@ -221,7 +221,7 @@ if [[ "${bb_full_target}" == *darwin* ]]; then
 	sed -i.bak1 "/lrt/d" bazel-bin/libReactantExtra.so-2.params
     sed -i.bak0 "/lld/d" bazel-bin/libReactantExtra.so-2.params
 	echo "-fuse-ld=lld" >> bazel-bin/libReactantExtra.so-2.params
-	#echo "--ld-path=$LLD2" >> bazel-bin/libReactantExtra.so-2.params
+	echo "--ld-path=$LLD2" >> bazel-bin/libReactantExtra.so-2.params
 	cat bazel-bin/libReactantExtra.so-2.params
     cc @bazel-bin/libReactantExtra.so-2.params
 else
@@ -409,6 +409,9 @@ for gpu in ("none", "cuda"), mode in ("opt", "dbg"), platform in platforms
         push!(platform_sources,
               ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz",
                             "0f03869f72df8705b832910517b47dd5b79eb4e160512602f593ed243b28715f"))
+	push!(platform_sources,
+                  ArchiveSource("https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.4/llvm-project-18.1.4.src.tar.xz",
+                                "2c01b2fbb06819a12a92056a7fd4edcdc385837942b5e5260b9c2c0baff5116b"))
     end
 
     if !Sys.isapple(platform)

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -9,7 +9,7 @@ repo = "https://github.com/EnzymeAD/Reactant.jl.git"
 version = v"0.0.19"
 
 sources = [
-  GitSource(repo, "362841e6d37d8adfa4d9f3b446acaf8e09893014"),
+  GitSource(repo, "fd7b5e23fe73bb6296e829b7cb868889331c97da"),
   ArchiveSource("https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-dist.zip",
                 "fc89da919415289f29e4ff18a5e01270ece9a6fe83cb60967218bac4a3bb3ed2"; unpack_target="bazel-dist"),
 ]

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -30,7 +30,7 @@ if [[ "${bb_full_target}" == x86_64-apple-darwin* ]]; then
     popd
 fi
 
-apk add py3-numpy py3-numpy-dev zlib
+apk add py3-numpy py3-numpy-dev
 
 apk add openjdk11-jdk
 apk add bazel --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -212,8 +212,9 @@ if [[ "${bb_full_target}" == *darwin* ]]; then
     if [[ "${bb_full_target}" == *86* ]]; then
     	echo "x86"
     else
-    	sed -i.bak1 "s/\"k8|/\"darwin_arm64\": \":cc-compiler-k8\", \"k8|/g" /workspace/bazel_root/*/external/local_config_cc/BUILD
-    	sed -i.bak1 "s/cpu = \"k8\"/cpu = \"darwin_arm64\"/g" /workspace/bazel_root/*/external/local_config_cc/BUILD
+    	sed -i.bak1 "s/\\"k8|/\\"darwin_arm64\\": \\":cc-compiler-k8\\", \\"k8|/g" /workspace/bazel_root/*/external/local_config_cc/BUILD
+    	sed -i.bak1 "s/cpu = \\"k8\\"/cpu = \\"darwin_arm64\\"/g" /workspace/bazel_root/*/external/local_config_cc/BUILD
+    	cat /workspace/bazel_root/*/external/local_config_cc/BUILD
 	$BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so || echo stage2
     fi
 	sed -i.bak1 "/whole-archive/d" bazel-bin/libReactantExtra.so-2.params

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -9,7 +9,7 @@ repo = "https://github.com/EnzymeAD/Reactant.jl.git"
 version = v"0.0.19"
 
 sources = [
-  GitSource(repo, "fd7b5e23fe73bb6296e829b7cb868889331c97da"),
+  GitSource(repo, "feb322ba407941f65049711b1425d7380a3f09fb"),
   ArchiveSource("https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-dist.zip",
                 "fc89da919415289f29e4ff18a5e01270ece9a6fe83cb60967218bac4a3bb3ed2"; unpack_target="bazel-dist"),
 ]

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -143,7 +143,6 @@ if [[ "${bb_full_target}" == *darwin* ]]; then
 
     if [[ "${bb_full_target}" == *86* ]]; then
         BAZEL_BUILD_FLAGS+=(--platforms=@//:darwin_x86_64)
-        BAZEL_BUILD_FLAGS+=(--linkopt=-fuse-ld=lld)
     else
         BAZEL_BUILD_FLAGS+=(--platforms=@//:darwin_arm64)
         sed -i '/gcc-install-dir/d'  "/opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-clang"
@@ -152,8 +151,9 @@ if [[ "${bb_full_target}" == *darwin* ]]; then
         BAZEL_BUILD_FLAGS+=(--copt=-D__ARM_NEON=1)
         BAZEL_BUILD_FLAGS+=(--copt=-D__ARM_FEATURE_SHA2=1)
         BAZEL_BUILD_FLAGS+=(--copt=-DDNNL_ARCH_GENERIC=1)
-        BAZEL_BUILD_FLAGS+=(--linkopt=-fuse-ld=lld)
+	BAZEL_BUILD_FLAGS+=(--define=@xla//build_with_mkl_aarch64=true)
     fi
+    BAZEL_BUILD_FLAGS+=(--linkopt=-fuse-ld=lld)
     BAZEL_BUILD_FLAGS+=(--linkopt=-twolevel_namespace)
     # BAZEL_BUILD_FLAGS+=(--crosstool_top=@xla//tools/toolchains/cross_compile/cc:cross_compile_toolchain_suite)
     BAZEL_BUILD_FLAGS+=(--define=clang_macos_x86_64=true)

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -9,7 +9,7 @@ repo = "https://github.com/EnzymeAD/Reactant.jl.git"
 version = v"0.0.19"
 
 sources = [
-  GitSource(repo, "55ce2cdf40545ba9ac41836ccce2e5b787cf9ea0"),
+  GitSource(repo, "4f4cb40af080a6f60a63fa3e747b95788804205c"),
   ArchiveSource("https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-dist.zip",
                 "fc89da919415289f29e4ff18a5e01270ece9a6fe83cb60967218bac4a3bb3ed2"; unpack_target="bazel-dist"),
 ]

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -6,7 +6,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "Reactant"
 repo = "https://github.com/EnzymeAD/Reactant.jl.git"
-version = v"0.0.19+1"
+version = v"0.0.19"
 
 sources = [
   GitSource(repo, "362841e6d37d8adfa4d9f3b446acaf8e09893014"),

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -151,6 +151,7 @@ if [[ "${bb_full_target}" == *darwin* ]]; then
         BAZEL_BUILD_FLAGS+=(--copt=-D__ARM_FEATURE_AES=1)
         BAZEL_BUILD_FLAGS+=(--copt=-D__ARM_NEON=1)
         BAZEL_BUILD_FLAGS+=(--copt=-D__ARM_FEATURE_SHA2=1)
+        BAZEL_BUILD_FLAGS+=(--copt=-DDNNL_ARCH_GENERIC=1)
         BAZEL_BUILD_FLAGS+=(--linkopt=-fuse-ld=lld)
     fi
     BAZEL_BUILD_FLAGS+=(--linkopt=-twolevel_namespace)

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -6,10 +6,10 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "Reactant"
 repo = "https://github.com/EnzymeAD/Reactant.jl.git"
-version = v"0.0.19"
+version = v"0.0.19+1"
 
 sources = [
-  GitSource(repo, "f8bbcb842cfb7dfc2179314e8166896d1b56b850"),
+  GitSource(repo, "362841e6d37d8adfa4d9f3b446acaf8e09893014"),
   ArchiveSource("https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-dist.zip",
                 "fc89da919415289f29e4ff18a5e01270ece9a6fe83cb60967218bac4a3bb3ed2"; unpack_target="bazel-dist"),
 ]


### PR DESCRIPTION
There is a very weird bug in Reactant which only appears on Yggdrasil-built aarch64 macOS artifact. If we build it with LLVM 19 on local, it works fine.

We are trying to check if it's due to the LLVM version used for compilation.

Do not merge yet please.