### PR TITLE
Fix infinite init loop for CUDA_Driver_jll

### DIFF
--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -9,7 +9,7 @@ using BinaryBuilder, Pkg
 include("../../../fancy_toys.jl")
 
 name = "CUDA_Driver"
-version = v"0.10.2"
+version = v"0.10.3"
 
 cuda_version = v"12.6"
 cuda_version_str = "$(cuda_version.major)-$(cuda_version.minor)"

--- a/C/CUDA/CUDA_Driver/init.jl
+++ b/C/CUDA/CUDA_Driver/init.jl
@@ -72,8 +72,15 @@ function try_driver(driver, deps)
 
         exit(0)
     """
-    success(`$(Base.julia_cmd()) --compile=min -t1 --startup-file=no -e $script $driver $deps`)
+    # make sure we don't include any system image flags here since this will cause an infinite loop of __init__()
+    success(`$(julia_cmd_without_sysimage()) --compile=min -t1 --startup-file=no -e $script $driver $deps`)
 end
+
+# removes the system image argument from the Julia command to force the session to use the default
+function julia_cmd_without_sysimage()
+    Cmd(filter(e -> !startswith(e, "-J") && !startswith(e, "--sysimage"), Base.julia_cmd().exec))
+end
+
 if can_use_compat && !try_driver(libcuda_compat, libcuda_deps)
     @debug "Failed to load forwards-compatible driver."
     can_use_compat = false

--- a/C/CUDA/CUDA_Driver/init.jl
+++ b/C/CUDA/CUDA_Driver/init.jl
@@ -73,7 +73,7 @@ function try_driver(driver, deps)
         exit(0)
     """
     # make sure we don't include any system image flags here since this will cause an infinite loop of __init__()
-    success(`$(Cmd(filter(e -> !startswith(r"-J|--sysimage"), Base.julia_cmd().exec))) --compile=min -t1 --startup-file=no -e $script $driver $deps`)
+    success(`$(Cmd(filter(!startswith(r"-J|--sysimage"), Base.julia_cmd().exec))) --compile=min -t1 --startup-file=no -e $script $driver $deps`)
 end
 
 if can_use_compat && !try_driver(libcuda_compat, libcuda_deps)

--- a/C/CUDA/CUDA_Driver/init.jl
+++ b/C/CUDA/CUDA_Driver/init.jl
@@ -73,12 +73,7 @@ function try_driver(driver, deps)
         exit(0)
     """
     # make sure we don't include any system image flags here since this will cause an infinite loop of __init__()
-    success(`$(julia_cmd_without_sysimage()) --compile=min -t1 --startup-file=no -e $script $driver $deps`)
-end
-
-# removes the system image argument from the Julia command to force the session to use the default
-function julia_cmd_without_sysimage()
-    Cmd(filter(e -> !startswith(e, "-J") && !startswith(e, "--sysimage"), Base.julia_cmd().exec))
+    success(`$(Cmd(filter(e -> !startswith(r"-J|--sysimage"), Base.julia_cmd().exec))) --compile=min -t1 --startup-file=no -e $script $driver $deps`)
 end
 
 if can_use_compat && !try_driver(libcuda_compat, libcuda_deps)


### PR DESCRIPTION
This is to fix the issue reported [here](https://github.com/JuliaPackaging/Yggdrasil/issues/9462) where we would hit an infinite loop when using CUDA_Driver_jll on a custom system image. 
I've added a step which removes the system image argument on the subprocesses that check for driver compatibility so we don't encounter this. This has fixed the issue when I built it locally