### PR TITLE
[CUDA] Upgrade to 12.6 Update 2

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_12.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.6.jl
@@ -8,7 +8,7 @@ function get_products(platform)
         LibraryProduct(["libcusolver", "cusolver64_11"], :libcusolver),
         LibraryProduct(["libcusolverMg", "cusolverMg64_11"], :libcusolverMg),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
-        LibraryProduct(["libcupti", "cupti64_2024.3.1"], :libcupti),
+        LibraryProduct(["libcupti", "cupti64_2024.3.2"], :libcupti),
         LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.15.2"
+version = v"0.15.3"
 
 augment_platform_block = """
     $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))

--- a/C/CUDA/CUDA_SDK@12.6/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK@12.6/build_tarballs.jl
@@ -15,5 +15,3 @@ platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "windows")]
 
 build_sdk(name, version, platforms; static=false)
-
-# bump

--- a/C/CUDA/CUDA_SDK_static@12.6/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK_static@12.6/build_tarballs.jl
@@ -15,5 +15,3 @@ platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "windows")]
 
 build_sdk(name, version, platforms; static=true)
-
-# bump

--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -125,7 +125,7 @@ const cuda_full_versions = [
     v"12.3.2",
     v"12.4.1",
     v"12.5.1",
-    v"12.6.1",
+    v"12.6.2",
 ]
 
 function full_version(ver::VersionNumber)


### PR DESCRIPTION
NVIDIA didn't released new drivers with this new minor release.
However they added new routines in CUSOLVER, which is unexpected for a minor version.

This is the release note for each updated library:
- [CUBLAS](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cublas-release-12-6-update-2)
- [CUFFT](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cufft-release-12-6-update-2)
- [CUSOLVER](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cusolver-release-12-6-update-2)
- [CUSPARSE](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cusparse-release-12-6-update-2)