### PR TITLE
[Cairo] add important bugfix for PDF output

### DIFF
--- a/C/Cairo/build_tarballs.jl
+++ b/C/Cairo/build_tarballs.jl
@@ -6,7 +6,7 @@ version = v"1.18.2"
 
 sources = [
     GitSource("https://gitlab.freedesktop.org/cairo/cairo.git",
-              "200441e6855854eb4dbf338e44d67b00ababe07f"),
+              "b9eed915f9a67380e7ef9d8746656455c43f67e2"),  # this is a few commits after 1.18.2 but includes an important bugfix
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR corrects the just-pushed update to Cairo_jll. It references a later commit than the official 1.18.2 release.

I had browsed the 1.18.2 release notes but did not look at the commits afterward, one of which fixes a regression in 1.18.2: https://gitlab.freedesktop.org/cairo/cairo/-/issues/870. With Cairo_jll 1.18.2, CairoMakie PDF output is corrupted (which I found out shortly after updating Cairo_jll).

I've verified locally that the version produced by this PR works. There will supposedly be a new libcairo release soon, but replacing this will fix the issue without yanking Cairo_jll 1.18.2 from the registry.