### PR TITLE
[Libxc] version 6.2.2 + CUDA binaries for aarch64

### DIFF
--- a/L/Libxc/Libxc/build_tarballs.jl
+++ b/L/Libxc/Libxc/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder, Pkg
 
 name = "Libxc"
-version = v"6.1.0"
+version = v"6.2.2"
 include("../sources.jl")
 
 
@@ -37,4 +37,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version=v"5", julia_compat="1.6")
+               preferred_gcc_version=v"7", julia_compat="1.8")

--- a/L/Libxc/Libxc_GPU/build_tarballs.jl
+++ b/L/Libxc/Libxc_GPU/build_tarballs.jl
@@ -5,42 +5,58 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "Libxc_GPU"
-version = v"6.1.0"
+version = v"6.2.2"
 include("../sources.jl")
 
 sources = [
     sources;
-    DirectorySource("./bundled")
+    DirectorySource("./bundled");
+    # aarch64 binaries precompiled and hosted on GitHub
+    GitSource("https://github.com/abussy/libxc_aarch64_gpu_binaries.git",
+              "9ec834896f04f8e8de6427352b0b1a6e61d4ba7b")
 ]
 
 # Bash recipe for building GPU version
 # Notes:
 #   - 3rd and 4th derivatives (KXC, LXC) not built since gives a binary size of ~200MB
 script = raw"""
-cd $WORKSPACE/srcdir/libxc-*/
 
-# Needed for Libxc 6.1.0 as these backport some fixes on libxc master
-# On Libxc > 6.1.0 we can also remove the -DBUILD_TESTING=OFF
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/cmake-cuda.patch
-atomic_patch -p1 ${WORKSPACE}/srcdir/patches/source-fixes.patch
+if [[ "${target}" == *aarch64* ]]; then
+   cuda_ver=$(echo "$bb_full_target" | sed -n 's/.*cuda+\([0-9]\+\.[0-9]\+\).*/\1/p')
+   cd $WORKSPACE/srcdir/libxc_aarch64_gpu_binaries/binaries
+   unzip cuda-${cuda_ver}.zip
 
-mkdir libxc_build
-cd libxc_build
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-    -DCMAKE_BUILD_TYPE=Release -DENABLE_XHOST=OFF -DBUILD_SHARED_LIBS=ON \
-    -DENABLE_CUDA=ON -DCMAKE_CUDA_COMPILER=$prefix/cuda/bin/nvcc -DBUILD_TESTING=OFF \
-    -DENABLE_FORTRAN=OFF -DDISABLE_KXC=ON ..
+   cp -r products/lib/libxc.so* $prefix/lib
+   chmod 555 $prefix/lib/libxc.so*
+   cp -r products/include $prefix/include
+   cp -r products/bin $prefix/bin
 
-make -j${nproc}
-make install
+else
+   cd $WORKSPACE/srcdir/libxc-*/
+
+   # Needed for Libxc 6.2.2 as these backport some fixes on libxc master
+   atomic_patch -p1 ${WORKSPACE}/srcdir/patches/cmake-cuda.patch
+   atomic_patch -p1 ${WORKSPACE}/srcdir/patches/source-fixes.patch
+
+   mkdir libxc_build
+   cd libxc_build
+
+   mv ${WORKSPACE}/destdir/cuda/lib ${WORKSPACE}/destdir/cuda/lib64
+
+   cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}\
+       -DCMAKE_BUILD_TYPE=Release -DENABLE_XHOST=OFF -DBUILD_SHARED_LIBS=ON \
+       -DENABLE_CUDA=ON -DCMAKE_CUDA_COMPILER=$prefix/cuda/bin/nvcc \
+       -DBUILD_TESTING=OFF -DENABLE_FORTRAN=OFF \
+       -DDISABLE_KXC=ON ..
+
+   make -j${nproc}
+   make install
+fi
 """
 
-augment_platform_block = CUDA.augment
-
 # Override the default platforms
-platforms = CUDA.supported_platforms()
-filter!(p -> arch(p) == "x86_64", platforms)
-
+platforms = CUDA.supported_platforms(; min_version=v"11.4")
+filter!(p -> arch(p) in ["x86_64", "aarch64"], platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -49,17 +65,17 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
 
 # Build Libxc for all supported CUDA toolkits
 for platform in platforms
     should_build_platform(triplet(platform)) || continue
 
-    cuda_deps = CUDA.required_dependencies(platform)
+    cuda_deps = CUDA.required_dependencies(platform; static_sdk=true)
 
     build_tarballs(ARGS, name, version, sources, script, [platform],
                    products, [dependencies; cuda_deps]; lazy_artifacts=true,
-                   julia_compat="1.7", augment_platform_block,
+                   julia_compat="1.8", augment_platform_block=CUDA.augment, preferred_gcc_version=v"7",
                    skip_audit=true, dont_dlopen=true)
 end

--- a/L/Libxc/Libxc_GPU/bundled/patches/cmake-cuda.patch
+++ b/L/Libxc/Libxc_GPU/bundled/patches/cmake-cuda.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a45f2db9e..2ee468621 100644
+index d07d3c4e4..f7f843282 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -11,6 +11,16 @@ cmake_minimum_required(VERSION 3.1)
@@ -19,11 +19,10 @@ index a45f2db9e..2ee468621 100644
  ################################### Options ####################################
  include(psi4OptionsTools)
  option_with_default(CMAKE_BUILD_TYPE "Build type" Release)
-@@ -443,6 +453,11 @@ set(raw_sources_list
+@@ -445,6 +455,10 @@ set(raw_sources_list
  set(src_prefix "src/")
  string(REGEX REPLACE "([^;]+)" "${src_prefix}\\1" sources_list "${raw_sources_list}")
  
-+
 +if(ENABLE_CUDA)
 +  set_source_files_properties(${sources_list} PROPERTIES LANGUAGE CUDA)
 +endif()
@@ -31,15 +30,15 @@ index a45f2db9e..2ee468621 100644
  set(raw_sources_list_f03
    src/libxc_master.F90
    )
-@@ -468,6 +483,7 @@ set(CMAKE_INSTALL_RPATH ${base} ${base}/${relDir})
+@@ -470,6 +484,7 @@ set(CMAKE_INSTALL_RPATH ${base} ${base}/${relDir})
  
  # STATIC/SHARED on below governed by BUILD_SHARED_LIBS
  add_library(xc ${sources_list})
 +set_target_properties(xc PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
- target_link_libraries(xc INTERFACE ${STANDARD_MATH_LIBRARY})
+ target_link_libraries(xc PUBLIC ${STANDARD_MATH_LIBRARY})
  set_target_properties(xc PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
    SOVERSION ${${PROJECT_NAME}_SOMAJOR})
-@@ -493,9 +509,15 @@ if(ENABLE_FORTRAN)
+@@ -495,9 +510,15 @@ if(ENABLE_FORTRAN)
  endif()
  
  add_executable(xc-info "${src_prefix}/xc-info.c")
@@ -53,8 +52,8 @@ index a45f2db9e..2ee468621 100644
 +  set_source_files_properties("${src_prefix}/xc-threshold.c" PROPERTIES LANGUAGE CUDA)
 +endif()
  target_link_libraries(xc-threshold xc)
- 
- 
+
+
 diff --git a/config.h.cmake.in b/config.h.cmake.in
 index 7b151e5bf..816fd600e 100644
 --- a/config.h.cmake.in

--- a/L/Libxc/sources.jl
+++ b/L/Libxc/sources.jl
@@ -1,5 +1,6 @@
 # Sources required for all builds
 sources = [
     ArchiveSource("https://gitlab.com/libxc/libxc/-/archive/$(version)/libxc-$(version).tar.gz",
-                  "f593745fa47ebfb9ddc467aaafdc2fa1275f0d7250c692ce9761389a90dd8eaf"),
+                  "d1b65ef74615a1e539d87a0e6662f04baf3a2316706b4e2e686da3193b26b20f"),
+    #GitSource("https://gitlab.com/libxc/libxc", "b4b126153afb94cbb48f33ff707976c0d018fb4e")
 ]


### PR DESCRIPTION
Update Libxc version from 6.1.0 to 6.2.2.

Additionally, added recipes for the combination of `aarch64` and `CUDA`, for Libxc_GPU_jll. Because BinaryBuilder only runs on `x86_64`, and `nvcc` is not a cross compiler, this is a non-trivial operation.

Pre-compiled binaries are available on a separate GitHub [repository](https://github.com/abussy/libxc_aarch64_gpu_binaries), specifically created for this purpose. The `aarch64` BinaryBuilder recipe downloads the binary  for the given `CUDA` version (from 11.4 to 12.6), and repackages it in the correct format.

The binaries were all generated in Docker images, for total control of the environment and reproducibility. All scripts and recipes are available in https://github.com/abussy/libxc_aarch64_gpu_binaries as well. After a discussion on the Julia [slack](https://julialang.slack.com/archives/C674ELDNX/p1726747412673179), special care was given to the `glibc` version and `RPATH`. All `glibc` symbols used by the `libxc.so` shared library come from version 2.17, as per the BinaryBuilder requirements for `aarch64`.

Both `x86_64` and `aarch64` GPU binaries were succesfully tested using the Libxc.jl and DFTK.jl packages.