### PR TITLE
[libgeotiff] Fix Zlib_jll compat

### DIFF
--- a/L/libgeotiff/build_tarballs.jl
+++ b/L/libgeotiff/build_tarballs.jl
@@ -54,7 +54,7 @@ dependencies = [
     Dependency("LibCURL_jll"; compat="7.73,8"),
     Dependency("Libtiff_jll"; compat="4.7"),
     Dependency("PROJ_jll"; compat="902.500"),
-    Dependency("Zlib_jll"; compat="1.3"),
+    Dependency("Zlib_jll"; compat="1.2.12"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
In https://github.com/JuliaPackaging/Yggdrasil/pull/9586 I set compat to 1.3. But the latest version I can load on Julia 1.10 is `v1.2.13+1`. This is why https://github.com/JuliaRegistries/General/pull/116992 got stuck.