### PR TITLE
[Deno] Update Deno_jll to 2.0.0

### DIFF
--- a/D/Deno/build_tarballs.jl
+++ b/D/Deno/build_tarballs.jl
@@ -3,18 +3,18 @@
 using BinaryBuilder, Pkg
 
 name = "Deno"
-version = v"1.33.4"
+version = v"2.0.0"
 
 release_url = "https://github.com/denoland/deno/releases/download/v$version"
-release_arm_url = "https://github.com/LukeChannings/deno-arm64/releases/download/v$version"
+
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("$release_url/deno-x86_64-unknown-linux-gnu.zip", "2e62448732a8481cae7af6637ddd37289e5baa6f22cd8e2f8197e25991869257"; unpack_target = "x86_64-linux-gnu"),
-    ArchiveSource("$release_arm_url/deno-linux-arm64.zip", "13aa4b3e5f652be2e436798105e5e4a48dbfd398cfc297384e9708a43c9b3337"; unpack_target = "aarch64-linux-gnu"),
-    ArchiveSource("$release_url/deno-x86_64-apple-darwin.zip", "1e2d79b4a237443e201578fc825052245d2a71c9a17e2a5d1327fa35f9e8fc0e"; unpack_target = "x86_64-apple-darwin14"),
-    ArchiveSource("$release_url/deno-aarch64-apple-darwin.zip", "ea504cac8ba53ef583d0f912d7834f4bff88eb647cfb10cb1dd24962b1dc062d"; unpack_target="aarch64-apple-darwin20"),
-    ArchiveSource("$release_url/deno-x86_64-pc-windows-msvc.zip", "f66842f3ed2b906f0db503b2eebd53c87240ade0dd3045919a7a2ba12962c0e4"; unpack_target = "x86_64-w64-mingw32"),
-    ArchiveSource("$release_url/deno_src.tar.gz", "d7d4d525e4f8973a23754654925b14f2a215baff4d3dd183e75047a3dac957ac"),
+    ArchiveSource("$release_url/deno-x86_64-unknown-linux-gnu.zip", "d201b812bbc6cc2565012e52c2a9cb9965d768afd28bbc2ba29ae667bf7250a6"; unpack_target="x86_64-linux-gnu"),
+    ArchiveSource("$release_url/deno-aarch64-unknown-linux-gnu.zip", "a76ada742b4e7670b1c50783cd01be200a38ae2439be583dd07c8069d387f99e"; unpack_target="aarch64-linux-gnu"),
+    ArchiveSource("$release_url/deno-x86_64-apple-darwin.zip", "b74d019d948e50e3eebde16d9c67d5633f46636af04adbb7fca1b5a37232dd80"; unpack_target="x86_64-apple-darwin14"),
+    ArchiveSource("$release_url/deno-aarch64-apple-darwin.zip", "ad122b1c8c823378469fb4972c0cc6dafc01353dfa5c7303d199bdc1dee9d5e9"; unpack_target="aarch64-apple-darwin20"),
+    ArchiveSource("$release_url/deno-x86_64-pc-windows-msvc.zip", "34ea525eeaae3ef2eb72e5f7c237fbf844fa900e6b8e666c5db2553f56f9d382"; unpack_target="x86_64-w64-mingw32"),
+    ArchiveSource("$release_url/deno_src.tar.gz", "7456e2340d363a50a90cb30695a0c0c930969db0bbd0996eb62fd1dcb9637546"),
 ]
 
 # Bash recipe for building across all platforms
@@ -33,7 +33,7 @@ platforms = [
     Platform("x86_64", "macos"),
     Platform("aarch64", "macos"),
     Platform("x86_64", "windows"),
-] 
+]
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
Also use the official Linux aarch64 build, since the previous URL now lists it as archived and points to the official builds instead.