### PR TITLE
LLVM: Add unified LLD JLL, and add driver entrypoints.

### DIFF
--- a/L/LLVM/LLD@14/build_tarballs.jl
+++ b/L/LLVM/LLD@14/build_tarballs.jl
@@ -38,4 +38,4 @@ for (i, build) in enumerate(builds)
                    augment_platform_block)
 end
 
-#let's build!
+# bump

--- a/L/LLVM/LLD@15/build_tarballs.jl
+++ b/L/LLVM/LLD@15/build_tarballs.jl
@@ -37,3 +37,5 @@ for (i, build) in enumerate(builds)
                    skip_audit=true, julia_compat="1.9",
                    augment_platform_block)
 end
+
+# bump

--- a/L/LLVM/LLD@16/build_tarballs.jl
+++ b/L/LLVM/LLD@16/build_tarballs.jl
@@ -37,3 +37,5 @@ for (i, build) in enumerate(builds)
                    skip_audit=true, julia_compat="1.11",
                    augment_platform_block)
 end
+
+# bump

--- a/L/LLVM/LLD@17/build_tarballs.jl
+++ b/L/LLVM/LLD@17/build_tarballs.jl
@@ -37,3 +37,5 @@ for (i, build) in enumerate(builds)
                    skip_audit=true, julia_compat="1.11",
                    augment_platform_block)
 end
+
+# bump

--- a/L/LLVM/LLD@18/build_tarballs.jl
+++ b/L/LLVM/LLD@18/build_tarballs.jl
@@ -37,4 +37,5 @@ for (i, build) in enumerate(builds)
                    skip_audit=true, julia_compat="1.12",
                    augment_platform_block)
 end
-#!
+
+# bump

--- a/L/LLVM/LLD@19/build_tarballs.jl
+++ b/L/LLVM/LLD@19/build_tarballs.jl
@@ -37,4 +37,5 @@ for (i, build) in enumerate(builds)
                    skip_audit=true, julia_compat="1.12",
                    augment_platform_block)
 end
-#!
+
+# bump

--- a/L/LLVM/LLD_unified/build_tarballs.jl
+++ b/L/LLVM/LLD_unified/build_tarballs.jl
@@ -6,7 +6,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
 include("../common.jl")
 
-name = "Clang_unified"
+name = "LLD_unified"
 version = v"0.1"
 llvm_full_versions = [
     v"15.0.7+10",
@@ -31,13 +31,13 @@ for llvm_assertions in (false, true), llvm_full_version in llvm_full_versions
     llvm_full_version >= v"15" || continue
     libllvm_version = llvm_full_version
     _, _, sources, script, platforms, products, dependencies =
-        configure_extraction(ARGS, llvm_full_version, "Clang", libllvm_version;
+        configure_extraction(ARGS, llvm_full_version, "LLD", libllvm_version;
                              assert=llvm_assertions, augmentation=true,
                              dont_dlopen=false)
     # ignore the output version, as we want a unified JLL
     dependencies = map(dependencies) do dep
         # ignore the version of any LLVM dependency, as we'll automatically load
-        # an appropriate version of Clang via platform augmentations
+        # an appropriate version of LLD via platform augmentations
         # TODO: make this an argument to `configure_extraction`?
         if isa(dep, Dependency) && contains(dep.pkg.name, "LLVM")
             Dependency(dep.pkg.name; dep.platforms)

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -728,6 +728,11 @@ function configure_extraction(ARGS, LLVM_full_version, name, libLLVM_version=not
         script = lldscript
         products = [
             ExecutableProduct("lld", :lld, "tools"),
+            ExecutableProduct("ld.lld", :ld_lld, "tools"),      # Unix
+            ExecutableProduct("ld64.lld", :ld64_lld, "tools"),  # macOS
+            ExecutableProduct("lld-link", :lld_link, "tools"),  # Windows
+            ExecutableProduct("wasm-ld", :wasm_ld, "tools"),    # WebAssembly
+
             ExecutableProduct("dsymutil", :dsymutil, "tools"),
         ]
 
@@ -755,6 +760,10 @@ function configure_extraction(ARGS, LLVM_full_version, name, libLLVM_version=not
     if version >= v"15"
         # We don't build LLVM 15 for i686-linux-musl.
         filter!(p -> !(arch(p) == "i686" && libc(p) == "musl"), platforms)
+    end
+    if version < v"18"
+        # We only have LLVM builds for AArch64 BSD starting from LLVM 18
+        filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
     end
     platforms = expand_cxxstring_abis(platforms)
 


### PR DESCRIPTION
Currently the JLL only exposes `lld`, which isn't always usable, e.g., when using with Clang and `--ld-path`:

```
lld is a generic driver.
Invoke ld.lld (Unix), ld64.lld (macOS), lld-link (Windows), wasm-ld (WebAssembly) instead
error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR also exposes the platform-specific drivers (which are always built, it seems), and also adds a unified LLD JLL since the library is linked against `libLLVM`.

All this is needed to make Clang_jll portable, as it otherwise relies on a system-wide `ld`.