### PR TITLE
MGARD: trigger rebuild

### DIFF
--- a/M/MGARD/build_tarballs.jl
+++ b/M/MGARD/build_tarballs.jl
@@ -70,3 +70,5 @@ dependencies = [
 # We need at least GCC 8 for C++17
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.6", preferred_gcc_version=v"8")
+
+# Build trigger: 1


### PR DESCRIPTION
`MGARD_jll` wasn't packaged because its dependency `protoc_jll` had an error. Trigger a rebuild to fix this.