### PR TITLE
[Uno] bump gitsha without updating version

### DIFF
--- a/U/Uno/build_tarballs.jl
+++ b/U/Uno/build_tarballs.jl
@@ -9,7 +9,7 @@ version = v"1.1.0"
 sources = [
     GitSource(
         "https://github.com/cvanaret/Uno.git",
-        "0ccd578d7c0b3ee9e3efd7c04aa1918e49867f77",
+        "934f17ba2ed5e7c1bc25ca42a1ab9045eab0b85a",
     ),
 ]
 


### PR DESCRIPTION
We're nearly at a point where Uno is usable: https://github.com/jump-dev/AmplNLWriter.jl/pull/190

This PR pulls in a couple of new commits to simplify option handling.