### PR TITLE
[open62541] update to v 1.4.6

### DIFF
--- a/O/open62541/open62541@1.4/build_tarballs.jl
+++ b/O/open62541/open62541@1.4/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "open62541"
-version = v"1.4.4"
+version = v"1.4.6"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/open62541/open62541.git",
-              "f3e334c9ec36cf7a22ba73a25021867dccd393a8")
+              "50ae40d3c98a5ff0458ee2b5ae92bea53e11af4e")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Updates open62541 recipe to version 1.4.6
https://github.com/open62541/open62541/releases/tag/v1.4.6