### PR TITLE
[MongoC] update to 1.28.1, update openssl version

### DIFF
--- a/M/MongoC/build_tarballs.jl
+++ b/M/MongoC/build_tarballs.jl
@@ -3,20 +3,20 @@
 using BinaryBuilder, Pkg
 
 name = "MongoC"
-version = v"1.25.1"
+version = v"1.28.1"
 
 # Collection of sources required to complete build
 sources = [
     GitSource(
         "https://github.com/mongodb/mongo-c-driver.git",
-        "e9c77e4753a80535d027734823e6c144fcb25cf4";
+        "97f166d8d784d6096d48ba288f98b48028cdfe8b";
     )
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd mongo-c-driver
+cd $WORKSPACE/srcdir/mongo-c-driver
+
 sed -i "s/Windows.h/windows.h/" src/libmongoc/src/mongoc/mongoc-client.c
 sed -i "s/WinDNS.h/windns.h/" src/libmongoc/src/mongoc/mongoc-client.c
 sed -i "s/Mstcpip.h/mstcpip.h/" src/libmongoc/src/mongoc/mongoc-client.c
@@ -25,13 +25,8 @@ sed -i "s/Dnsapi/dnsapi/" build/cmake/ResSearch.cmake
 mkdir cmake-build
 cd cmake-build
 
-if [[ "${nbits}" == 32 ]]; then
-    export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib"
-elif [[ "${target}" != *-apple-* ]]; then
-    export CFLAGS="-Wl,-rpath-link,/opt/${target}/${target}/lib64"
-fi
-if [[ "${target}" == *-mingw* ]]; then
-    export CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO=1"
+if [[ "${target}" == *-mingw* ]] || [[ "${target}" == *-linux-* ]]; then
+    export CFLAGS="$CFLAGS -Wno-maybe-uninitialized"
 fi
 
 cmake \
@@ -63,7 +58,7 @@ fi
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
@@ -73,10 +68,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10")
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4"))
-    Dependency(PackageSpec(name="snappy_jll", uuid="fe1e1685-f7be-5f59-ac9f-4ca204017dfd"), v"1.1.9")
+    Dependency(PackageSpec(name="snappy_jll", uuid="fe1e1685-f7be-5f59-ac9f-4ca204017dfd"), v"1.2.1")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/MongoC/build_tarballs.jl
+++ b/M/MongoC/build_tarballs.jl
@@ -71,7 +71,7 @@ dependencies = [
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4"))
-    Dependency(PackageSpec(name="snappy_jll", uuid="fe1e1685-f7be-5f59-ac9f-4ca204017dfd"), v"1.2.1")
+    Dependency(PackageSpec(name="snappy_jll", uuid="fe1e1685-f7be-5f59-ac9f-4ca204017dfd"); compat="1.2.1")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
fixes #9666, updates to openssl 3 and should build for aarch64-freebsd now.

Note that this seems to break the tests for Mongoc.jl, see https://github.com/felipenoris/Mongoc.jl/pull/123, the code does work fine though.