### PR TITLE
[FFLAS_FFPACK] Patched package's config-blas.h to fix silly typo

### DIFF
--- a/F/FFLAS_FFPACK/bundled/patches/fflas-ffpack-typo-in-config-blas.patch
+++ b/F/FFLAS_FFPACK/bundled/patches/fflas-ffpack-typo-in-config-blas.patch
@@ -1,0 +1,26 @@
+diff -ur fflas-ffpack-2.5.0.orig/fflas-ffpack/config-blas.h fflas-ffpack-2.5.0/fflas-ffpack/config-blas.h
+--- fflas-ffpack-2.5.0.orig/fflas-ffpack/config-blas.h	2020-06-10 08:00:45.000000000 +0000
++++ fflas-ffpack-2.5.0/fflas-ffpack/config-blas.h	2024-10-29 20:32:26.046983457 +0000
+@@ -293,18 +295,18 @@
+                               const float alpha, const float *A, const int lda,
+                               const float beta, float *C, const int ldc){
+        if (Order == CblasRowMajor)
+-           ssryk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
++           ssyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
+        else
+-           ssryk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); 
++           ssyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); 
+     }
+     void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const double alpha, const double *A, const int lda,
+                      const double beta, double *C, const int ldc){
+         if (Order == CblasRowMajor)
+-            dsryk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
++            dsyrk_ (EXT_BLAS_UPLO_tr(Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); // @TODO check this
+         else
+-            dsryk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); 
++            dsyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); 
+     }
+ 
+ }


### PR DESCRIPTION
This fixes a silly typo in a header file of the FFLAS_FFPACK library (BLAS call ssryk_ instead of ssyrk_). I should and will upstream it, but meanwhile this fixes compilation problems for libraries using FFLAS_FFPACK_jll