### PR TITLE
[FFLAS_FFPACK] Fixed return types for cblas_dsyrk and cblas_ssyrk

### DIFF
--- a/F/FFLAS_FFPACK/bundled/patches/fflas-ffpack-typo-in-config-blas.patch
+++ b/F/FFLAS_FFPACK/bundled/patches/fflas-ffpack-typo-in-config-blas.patch
@@ -1,7 +1,13 @@
-diff -ur fflas-ffpack-2.5.0.orig/fflas-ffpack/config-blas.h fflas-ffpack-2.5.0/fflas-ffpack/config-blas.h
+diff -ru fflas-ffpack-2.5.0.orig/fflas-ffpack/config-blas.h fflas-ffpack-2.5.0/fflas-ffpack/config-blas.h
 --- fflas-ffpack-2.5.0.orig/fflas-ffpack/config-blas.h	2020-06-10 08:00:45.000000000 +0000
-+++ fflas-ffpack-2.5.0/fflas-ffpack/config-blas.h	2024-10-29 20:32:26.046983457 +0000
-@@ -293,18 +295,18 @@
++++ fflas-ffpack-2.5.0/fflas-ffpack/config-blas.h	2024-10-30 13:16:37.002589168 +0000
+@@ -288,23 +290,23 @@
+             sgemm_ ( EXT_BLAS_TRANSPOSE(TransA), EXT_BLAS_TRANSPOSE(TransB), &M, &N, &K, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
+     }
+ 
+-    static inline cblas_ssyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
++    static inline void cblas_ssyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                               const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
                                const float alpha, const float *A, const int lda,
                                const float beta, float *C, const int ldc){
         if (Order == CblasRowMajor)
@@ -11,7 +17,8 @@ diff -ur fflas-ffpack-2.5.0.orig/fflas-ffpack/config-blas.h fflas-ffpack-2.5.0/f
 -           ssryk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); 
 +           ssyrk_ (EXT_BLAS_UPLO (Uplo), EXT_BLAS_TRANSPOSE(Trans), N, K, alpha, A, lda, beta, C, ldc); 
      }
-     void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+-    void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
++    static inline void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
                   const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
                   const double alpha, const double *A, const int lda,
                       const double beta, double *C, const int ldc){


### PR DESCRIPTION
Another small error in the original library, which breaks some compilers.