### PR TITLE
[openfhe_julia] update to version v0.3.6

### DIFF
--- a/O/openfhe_julia/build_tarballs.jl
+++ b/O/openfhe_julia/build_tarballs.jl
@@ -62,9 +62,10 @@ platforms = vcat(libjulia_platforms.(julia_versions)...)
 # We cannot build with musl since OpenFHE requires the `execinfo.h` header for `backtrace`
 platforms = filter(p -> libc(p) != "musl", platforms)
 
-# PowerPC and 32-bit x86 platforms are not supported by OpenFHE
+# PowerPC and 32-bit x86 and 64-bit FreeBSD on ARM 64 platforms are not supported by OpenFHE
 platforms = filter(p -> arch(p) != "i686", platforms)
 platforms = filter(p -> arch(p) != "powerpc64le", platforms)
+platforms = filter(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
 
 # Expand C++ string ABIs since we use std::string
 platforms = expand_cxxstring_abis(platforms)

--- a/O/openfhe_julia/build_tarballs.jl
+++ b/O/openfhe_julia/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder, Pkg
 
 # See https://github.com/JuliaLang/Pkg.jl/issues/2942
 # Once this Pkg issue is resolved, this must be removed
-uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f") 
+uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "openfhe_julia"

--- a/O/openfhe_julia/build_tarballs.jl
+++ b/O/openfhe_julia/build_tarballs.jl
@@ -8,12 +8,12 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "openfhe_julia"
-version = v"0.3.5"
+version = v"0.3.6"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/hpsc-lab/openfhe-julia.git",
-              "03927c4c396c76a3c22e7f15f849217698c93d2e"),
+              "4939f1dd11ae2640b5bb397f731df8ef94307e74"),
 ]
 
 # Bash recipe for building across all platforms
@@ -79,7 +79,7 @@ products = [
 dependencies = [
     BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.9")),
     Dependency(PackageSpec(name="libcxxwrap_julia_jll", uuid="3eaa8342-bff7-56a5-9981-c04077f7cee7"); compat="0.13.0"),
-    Dependency(PackageSpec(name="OpenFHE_jll", uuid="a2687184-f17b-54bc-b2bb-b849352af807"); compat="1.2.1"),
+    Dependency(PackageSpec(name="OpenFHE_jll", uuid="a2687184-f17b-54bc-b2bb-b849352af807"); compat="1.2.3"),
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");

--- a/O/openfhe_julia/build_tarballs.jl
+++ b/O/openfhe_julia/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder, Pkg
 
 # See https://github.com/JuliaLang/Pkg.jl/issues/2942
 # Once this Pkg issue is resolved, this must be removed
-uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
+uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f") 
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "openfhe_julia"


### PR DESCRIPTION
@sloede,
I have updated openfhe-julia to new version also setting new compats for openfhe-development v1.2.3.
This PR should be merged after #9725 
Close https://github.com/hpsc-lab/openfhe-julia/issues/71