### PR TITLE
Improve contributing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ This repository contains recipes for building binaries for Julia packages using 
 
 ## Contributing
 
-To contribute a new recipe, you can either
+For detailed information and step-by-step instructions about contributing, go to ["CONTRIBUTING.md"](https://github.com/JuliaPackaging/Yggdrasil/blob/master/CONTRIBUTING.md). For a quick overview, continue reading.
 
+To contribute a new recipe, you can either
 * use `BinaryBuilder.run_wizard()`, which will automatically open a pull request to this repository after a successfull build for all requested platforms
 * Copy another build recipe using it as a template, and then open a manual pull request to this repository
 
-Yggdrasil builds the tarballs using `master` version of BinaryBuilder.jl, which requires Julia 1.3.0 or later versions.  Note that this BinaryBuilder.jl version has some differences compared to v0.1.4 and the builders generated are slightly different.  You are welcome to contribute builders written for  BinaryBuilder.jl v0.1.4, but they will likely need minor adjustements.
+Yggdrasil builds the tarballs using `master` version of BinaryBuilder.jl, which requires Julia 1.3.0 or later versions. Note that this BinaryBuilder.jl version has some differences compared to v0.1.4 and the builders generated are slightly different. You are welcome to contribute builders written for  BinaryBuilder.jl v0.1.4, but they will likely need minor adjustements.
 
 [Buildkite CI](https://buildkite.com/julialang/yggdrasil) is used to test that the builders can successfully produce the tarballs.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repository contains recipes for building binaries for Julia packages using 
 
 For detailed information and step-by-step instructions about contributing, go to ["CONTRIBUTING.md"](https://github.com/JuliaPackaging/Yggdrasil/blob/master/CONTRIBUTING.md). For a quick overview, continue reading.
 
+To update the version to build for an existing recipe, simply open a PR to this repository making the required tweaks. This usually boils down to only updating the version number and the source (e.g., URL and hash for an archive, or the revision for a git repository) of the relevant `build_tarballs.jl` file, but in some cases more changes may be needed. For an example, see [this PR](https://github.com/JuliaPackaging/Yggdrasil/pull/8833). The version number should be easy to find, and the URL + hash can be found by clicking the release, clicking the final commit in the release, and copying the information from the URL bar.
+
 To contribute a new recipe, you can either
 * use `BinaryBuilder.run_wizard()`, which will automatically open a pull request to this repository after a successfull build for all requested platforms
 * Copy another build recipe using it as a template, and then open a manual pull request to this repository
@@ -18,11 +20,7 @@ Yggdrasil builds the tarballs using `master` version of BinaryBuilder.jl, which 
 
 [Buildkite CI](https://buildkite.com/julialang/yggdrasil) is used to test that the builders can successfully produce the tarballs.
 
-If you prefer to test your manual buildscript before opening the pull request, we suggest installing `BinaryBuilder.jl` on Julia 1.3 or any following release and running `julia --color=yes build_tarballs.jl --verbose --debug` locally.  On MacOS, you will need to have `docker` installed for this to work.
-
-### Updating the version of an existing builder
-
-To trigger the build of a new version of the upstream package simply open a pull request to update the builder as necessary.  This usually boils down to only updating the version number and the source (e.g., URL and hash for an archive, or the revision for a git repository), but in some cases more changes may be needed.
+If you prefer to test your manual buildscript before opening the pull request, we suggest installing `BinaryBuilder.jl` on Julia 1.3 or any following release and running `julia --color=yes build_tarballs.jl --verbose --debug` locally.  On MacOS, you will need to have `docker` installed for this to work.  
 
 ## Using the generated tarballs
 


### PR DESCRIPTION
This PR adds a link to the CONTRIBUTING file in the readme.

It also moves the information on updating an existing release to the top. This is because it was really easy to do, and putting the easy stuff first help ensuring that people who want to do the easy stuff do not stop/quit at the hard stuff.

This PR also and removes the separate section for it, as the slightly smaller heading in markdown is usually not sufficient to signal that it is a subsection. Also, there is just a single paragraph of instructions, so a new heading was overkill.