### PR TITLE
[GMP] Rebuild 6.2.0 to build for all current architectures

### DIFF
--- a/G/GMP/GMP@6.2.0/build_tarballs.jl
+++ b/G/GMP/GMP@6.2.0/build_tarballs.jl
@@ -1,8 +1,10 @@
 version = v"6.2.0"
 
+llvm_version = v"13.0.1"
+
 include("../common.jl")
 
 # Build the tarballs!
-build_tarballs(ARGS, configure(version)...;
-               preferred_gcc_version=v"6", julia_compat="1.6")
-
+build_tarballs(ARGS, configure(version, llvm_version)...;
+               clang_use_lld=false, julia_compat="1.6", preferred_gcc_version=v"6",
+               preferred_llvm_version=llvm_version)


### PR DESCRIPTION
GMP 6.2.0 ships with Julia 1.6.