### PR TITLE
MAGEMin v0.5.7

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.5.6"
+version = v"1.5.7"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "41b7861a26efda070ea1b7b453781d100f34e5f6")                 ]
+                    "8a3110318570b44fd5ca6f66bf394401490c1084")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Added 1atom basis to output structure
- Added buffer and buffer_n to output structure
- Re-added consideration of pure-end member to the minimization, improves performance and accuracy 