### PR TITLE
LLVM: Bump downgrader to v0.4.

### DIFF
--- a/L/LLVMDowngrader/build_tarballs.jl
+++ b/L/LLVMDowngrader/build_tarballs.jl
@@ -7,17 +7,17 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
 
 name = "LLVMDowngrader"
 repo = "https://github.com/JuliaGPU/llvm-downgrade"
-version = v"0.3"
+version = v"0.4"
 
 llvm_versions = [v"13.0.1", v"14.0.6", v"15.0.7", v"16.0.6", v"17.0.6"]
 
 # Collection of sources required to build LLVMDowngrader
 sources = Dict(
-    v"13.0.1" => [GitSource(repo, "5538d5106dd4779c9aa475a78cfbe9f70053f44c")],
-    v"14.0.6" => [GitSource(repo, "07810b82a167176a9e81f59435a6ac551dfd52e9")],
-    v"15.0.7" => [GitSource(repo, "50983362d3083909d606fe02eb758d4788f832a0")],
-    v"16.0.6" => [GitSource(repo, "3d9f87e0d55e1f6d64d4d5b3f373523c735c49a2")],
-    v"17.0.6" => [GitSource(repo, "4ebc423a3c9760fbb8dd58724966e75e0a66f8a2")],
+    v"13.0.1" => [GitSource(repo, "c697ae3f3e236383d1aec2b3174827e2279a4c9f")],
+    v"14.0.6" => [GitSource(repo, "5865d775feed861a59ebb0fda19dc2fd5295a26c")],
+    v"15.0.7" => [GitSource(repo, "b559a5918bbd73afbe8a37b92bcf5d8a2436f09d")],
+    v"16.0.6" => [GitSource(repo, "e73ad19a4570a97e010053858d99b03abe206430")],
+    v"17.0.6" => [GitSource(repo, "cd4d00ba0f294ff7e7385f85c6142d0490386eef")],
 )
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
v0.4 supports `atomicrmw` and `cmpxchg` for https://github.com/JuliaConcurrent/Atomix.jl/pull/39