### PR TITLE
[libtakum] Update to v0.5.1

### DIFF
--- a/L/libtakum/build_tarballs.jl
+++ b/L/libtakum/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "libtakum"
-version = v"0.5.0"
+version = v"0.5.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/takum-arithmetic/libtakum.git", "913b8e653b837864f8480cab9e0d480a0a22df8d")
+    GitSource("https://github.com/takum-arithmetic/libtakum.git", "e7f9abe94bfa865711af17a0dbb6a0e5bf5a915e")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This release makes the *_pi_times() functions more precise, fixes a bug for 0^a with a<0, overhauls the unit tests to use random sampling and fixes a problem with the tie-rounding.

There is also some code refactoring and removal of internal data structures in takum.h. Some inlined header functions are properly implemented such that they can be used by non-C/C++ FFI library consumers.