### PR TITLE
oneAPI: Bump to v2025.0.0

### DIFF
--- a/O/oneAPI_Support/build_tarballs.jl
+++ b/O/oneAPI_Support/build_tarballs.jl
@@ -178,6 +178,7 @@ dependencies = [
     BuildDependency("oneAPI_Level_Zero_Headers_jll"),
     Dependency("oneAPI_Level_Zero_Loader_jll"),
     Dependency("OpenCL_jll"),
+    Dependency("Hwloc_jll"),
 ]
 
 non_reg_ARGS = filter(arg -> arg != "--register", ARGS)

--- a/O/oneAPI_Support/build_tarballs.jl
+++ b/O/oneAPI_Support/build_tarballs.jl
@@ -148,6 +148,9 @@ done
 cd oneAPI.jl/deps
 
 CMAKE_FLAGS=()
+# Tell CMake we're cross-compiling
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
 # Release build for best performance
 CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=RelWithDebInfo)
 # Install things into $prefix
@@ -157,10 +160,6 @@ CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
 CMAKE_FLAGS+=(-DCMAKE_SHARED_LINKER_FLAGS="-L${libdir}")
 # BUG: intel/llvm#5932
 CMAKE_FLAGS+=(-DCMAKE_CXX_FLAGS="-I${includedir}/sycl")
-# Explicitly use our cmake toolchain file and tell CMake we're cross-compiling
-# XXX: we use the Clang version to work around an issue with the SYCL headers
-CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake)
-CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
 cmake -B build -S . -GNinja ${CMAKE_FLAGS[@]}
 
 ninja -C build -j ${nproc} install

--- a/O/oneAPI_Support/build_tarballs.jl
+++ b/O/oneAPI_Support/build_tarballs.jl
@@ -1,13 +1,13 @@
 using BinaryBuilder, Pkg
 
 name = "oneAPI_Support"
-version = v"0.6.0"
+version = v"0.7.0"
 
 non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
 
 generic_sources = [
     GitSource("https://github.com/JuliaGPU/oneAPI.jl",
-              "1a4e9fa4bf8283474cad062ba7df3aba02aaa9bf")
+              "fc225b0b0691ab3df0898ef29fe907a7728d52d0")
 ]
 
 platform_sources = Dict(
@@ -15,103 +15,118 @@ platform_sources = Dict(
     # https://conda.anaconda.org/intel/linux-64
     Platform("x86_64", "linux"; libc="glibc") => [
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/dpcpp-cpp-rt-2024.2.0-intel_981.tar.bz2",
-            "bb430763d0ee6029d6befa911605faf514ce83584933f64647c8fff527f5d136"
+            "https://software.repos.intel.com/python/conda/linux-64/compiler_shared-2025.0.0-intel_1169.tar.bz2",
+            "d31c89f3ffcc5b45366f7465b5a3411a3a2c529ecf72eebcc4c3a244f713d3eb"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/dpcpp_impl_linux-64-2024.2.0-intel_981.tar.bz2",
-            "958dc668d49d2ae9dbe0f0e55f8f5025b3e280be0a5b294a3898bc6efbc74627"
+            "https://software.repos.intel.com/python/conda/linux-64/dpcpp-cpp-rt-2025.0.0-intel_1169.tar.bz2",
+            "2e74407b49fbf865462be995806aad4411ed992e1bee8404d2c75616db9c4ac6"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/dpcpp_linux-64-2024.2.0-intel_981.tar.bz2",
-            "7bfef6c455ae87a034e6efef1bbbbd7079875fcb4bdb3d5edbda950d1a1f0ee7"
+            "https://software.repos.intel.com/python/conda/linux-64/dpcpp_impl_linux-64-2025.0.0-intel_1169.tar.bz2",
+            "926f17c28168db9cb110d9803fc6037c0ea0b2bd37074ff4b21a1543f9e37777"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/icc_rt-2024.2.1-intel_1079.tar.bz2",
-            "3f5eb6990d6f804f6af0074f9ac6744a641005ababb22390e288c5b3f593748d"
+            "https://software.repos.intel.com/python/conda/linux-64/dpcpp_linux-64-2025.0.0-intel_1169.tar.bz2",
+            "fc652956fb8315ce23cb677678e788c519c817c1f82d1548a37bc8b90fab4994"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/intel-cmplr-lib-rt-2024.2.0-intel_981.tar.bz2",
-            "a9b1c6fa0547f2c28a5b1b560fd656859af30933259f1c2b3e30f1bec5d9b259"
+            "https://software.repos.intel.com/python/conda/linux-64/intel-cmplr-lib-rt-2025.0.0-intel_1169.tar.bz2",
+            "9a6a149681d2cc87e0e818140c13af04c82fbfc0760a451db70cbbf07c560bde"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/intel-cmplr-lib-ur-2024.2.0-intel_981.tar.bz2",
-            "7b39b7446b875408045a3b578ad467060db66be1c71dbbf25e1310c53a0857ea"
+            "https://software.repos.intel.com/python/conda/linux-64/intel-cmplr-lib-ur-2025.0.0-intel_1169.tar.bz2",
+            "95ec7e7014adfc2dda389008975e63a66338a235dbdef4a694989ed41ee5db75"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/intel-cmplr-lic-rt-2024.2.0-intel_981.tar.bz2",
-            "ab37ae3b142ea2cdd5bfed4389ea3299e66cc6da14e8751d8a609f970ae732ff"
+            "https://software.repos.intel.com/python/conda/linux-64/intel-cmplr-lic-rt-2025.0.0-intel_1169.tar.bz2",
+            "865288f5b133f205692f88e38af5b1928f8e7ce0c99f9068be2a5d247c540067"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/intel-opencl-rt-2024.2.0-intel_981.tar.bz2",
-            "1a33749a1696c0c0f2d572b76a98891c032e8e58354d6969036451f0848dff05"
+            "https://software.repos.intel.com/python/conda/linux-64/intel-opencl-rt-2025.0.0-intel_1169.tar.bz2",
+            "fe38bfd3fcc01068aced409d34d64ee44e39831d2c4f1fcbf93bd0dee63f48ad"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/intel-openmp-2024.2.0-intel_981.tar.bz2",
-            "db46064dbf0dbc096d92d8368ef8172ae335001b81055840c97fcfda3d09d64d"
+            "https://software.repos.intel.com/python/conda/linux-64/intel-openmp-2025.0.0-intel_1169.tar.bz2",
+            "bd2ef2fdac3e013bfdf71921e0c7d3e831b9f498d6303852539b2c447bd42790"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/intel-sycl-rt-2024.2.0-intel_981.tar.bz2",
-            "98a5503a47feb2e72b2fce045d7edc177c333828b5eee3dd337dfd7441c8c11a"
-        ),
-
-
-        ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/mkl-2024.2.0-intel_663.tar.bz2",
-            "f480deb23179471b5f05de50b06ad984702be25e66d58ef614b804b781a3613e"
-        ),
-        ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/mkl-devel-2024.2.0-intel_663.tar.bz2",
-            "e3c37c75aa870aa8daa32e6cbfa6e34639f7e6fe6a67fc4b34fa2a94a497df15"
-        ),
-        ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/mkl-devel-dpcpp-2024.2.0-intel_663.tar.bz2",
-            "82a403a7ae930e9ace33472fa9f0b7652f292f106d2d290668643d57207783d1"
-        ),
-        ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/mkl-dpcpp-2024.2.0-intel_663.tar.bz2",
-            "08426f44ca13ff81030a8ce8d777f167d06b9194df8b5635fd143c0848bac3f2"
-        ),
-        ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/mkl-include-2024.2.0-intel_663.tar.bz2",
-            "2e29ca36f199bafed778230b054256593c2d572aeb050389fd87355ba0466d13"
+            "https://software.repos.intel.com/python/conda/linux-64/intel-sycl-rt-2025.0.0-intel_1169.tar.bz2",
+            "696aeb88832c8836d202bb4a434c5aa7ec145f92d62cc0a2d36fe10e77494a62"
         ),
 
+
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-blas-2024.2.0-intel_663.tar.bz2",
-            "1d622d465ed0eaf583e30a0351873437e58952b71553fbb68f28ca4fc92bb9d9"
+            "https://software.repos.intel.com/python/conda/linux-64/mkl-2025.0.0-intel_939.tar.bz2",
+            "08018b7b73b8f1ceb2286d0fbf443bcf22ffd5fdff2010265f3cedbd0c3075d6"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-datafitting-2024.2.0-intel_663.tar.bz2",
-            "d7da0657275e1640b15f8640f321028b1c9576eca42bf59674e1d286f5cba937"
+            "https://software.repos.intel.com/python/conda/linux-64/mkl-devel-2025.0.0-intel_939.tar.bz2",
+            "89fc99f696ee10291b39bd60f6104966ba07f750e4291830d3ed142e651ef0c3"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-dft-2024.2.0-intel_663.tar.bz2",
-            "2dba874c8fd0ebb2f4b005e937241de9706b028ba11a0667abeafa0edfad6956"
+            "https://software.repos.intel.com/python/conda/linux-64/mkl-devel-dpcpp-2025.0.0-intel_939.tar.bz2",
+            "149c3d52dcc7db2d30329e686f721dc3addc017ba19034b7517c9d287f29f7d6"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-lapack-2024.2.0-intel_663.tar.bz2",
-            "4e4eb4b88d0715d8cc2c7b7a937d579da97ea099be7bf7f8b75968a1c32d6aa5"
+            "https://software.repos.intel.com/python/conda/linux-64/mkl-dpcpp-2025.0.0-intel_939.tar.bz2",
+            "dfa829d9de4e7fbefacad3849a95957c020dc628b4ba010107918d62db4516be"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-rng-2024.2.0-intel_663.tar.bz2",
-            "c401d5e830bd3edf70c07fb1dc25067e80979d6aa7d971ec4391541c6dbd7df8"
+            "https://software.repos.intel.com/python/conda/linux-64/mkl-include-2025.0.0-intel_939.tar.bz2",
+            "e3c02344b0405d90c7b992493a081f1f763fa96493626a5da1fe7693040a486f"
+        ),
+
+        ArchiveSource(
+            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-blas-2025.0.0-intel_939.tar.bz2",
+            "89c7455152074e75cb8891ae95445e033f28243ca8ce0e54d7ef2a0890cd03dc"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-sparse-2024.2.0-intel_663.tar.bz2",
-            "2c369bdd91eba6b70bee073ef43fd27730939852d2bf40ed10a7cc16ef44691b"
+            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-datafitting-2025.0.0-intel_939.tar.bz2",
+            "08076e4d6395c68dc6cf125a9362cb2f3da1ec34d207a65bae483f57f3b05547"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-stats-2024.2.0-intel_663.tar.bz2",
-            "7dba88f56711ff66fd4eb188b70e55e79ecb385842a85459d96d4c196304be55"
+            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-dft-2025.0.0-intel_939.tar.bz2",
+            "d982cc495b4a19457c1f0382c312465628e774c627300a0530a3d674241f647b"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-vm-2024.2.0-intel_663.tar.bz2",
-            "43e1e0363dfc22cb9dbea61306324b63f4b1b7a90fc1cf0f5cfb6400698dee33"
+            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-lapack-2025.0.0-intel_939.tar.bz2",
+            "875292b7539b528c027d8c4e78ebe809c3914359decc2fc1c66e7ed03c16feb1"
         ),
         ArchiveSource(
-            "https://software.repos.intel.com/python/conda/linux-64/tbb-2021.13.1-intel_12.tar.bz2",
-            "eacc00ee2442cfaf9efb1cd8ee227f76d24fc5a4a14853e328c0b4780f83dd41"
+            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-rng-2025.0.0-intel_939.tar.bz2",
+            "21911e846fa86f447eb25e251c02a813dc582c17b25ed0a74a934a2f89a5e80d"
+        ),
+        ArchiveSource(
+            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-sparse-2025.0.0-intel_939.tar.bz2",
+            "041968f53a5ae7c74193afb55dd57ffc20ad038cb4aeb33bdd39fe789e077ea8"
+        ),
+        ArchiveSource(
+            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-stats-2025.0.0-intel_939.tar.bz2",
+            "a7f2d5fb02a6999a5f189cd4a493471c6ab3e716d94ef4b9247653db723329d7"
+        ),
+        ArchiveSource(
+            "https://software.repos.intel.com/python/conda/linux-64/onemkl-sycl-vm-2025.0.0-intel_939.tar.bz2",
+            "ee515cc5ad823d6980e519a9dc8c53dbac42e82ec178b33eeddca4eac2b36060"
+        ),
+
+        ArchiveSource(
+            "https://software.repos.intel.com/python/conda/linux-64/tbb-2022.0.0-intel_402.tar.bz2",
+            "3b5abd11a7d2ae0162b8f40bea311e4566e3a6b02a9d4f0928134ae27d76aabd"
+        ),
+        ArchiveSource(
+            "https://software.repos.intel.com/python/conda/linux-64/tbb-devel-2022.0.0-intel_402.tar.bz2",
+            "1b1029a9ceb00ef7116c3ec0c15a1de10a78eb27a2d3591b53a43a5ffd00ea9e"
+        ),
+
+        ArchiveSource(
+            "https://software.repos.intel.com/python/conda/linux-64/tcm-1.2.0-intel_589.tar.bz2",
+            "5806a0b472192a350dc3f9865b980d8f1cc403c94445c77aa8fe4139aa121d99"
+        ),
+
+        ArchiveSource(
+            "https://software.repos.intel.com/python/conda/linux-64/umf-0.9.0-intel_590.tar.bz2",
+            "16a384288a8d2b66320aae06201eeecae2a424a7c6c3e5066ff97fe441cef7f9"
         ),
     ]
 )
@@ -124,9 +139,9 @@ install_license "info/licenses/license.txt"
 #       but that's just a lot of work and not worth it for this single build.
 mkdir -p ${libdir} ${includedir}
 cp -r include/* ${includedir}
-for lib in sycl svml irng imf intlc pi_level_zero pi_opencl \
+for lib in sycl svml irng imf intlc ur_loader ur_adapter \
            mkl_core mkl_intel_ilp64 mkl_sequential mkl_sycl \
-           mkl_avx mkl_def; do
+           mkl_avx mkl_def umf tcm; do
     cp -a lib/lib${lib}*.so* ${libdir}
 done
 
@@ -152,14 +167,6 @@ ninja -C build -j ${nproc} install
 
 # remove build-time dependencies we don't need
 rm -rf ${includedir}
-
-# XXX: MKL loads libOpenCL.so dynamically, and not by SONAME,
-#      which isn't covered by our OpenCL_jll dependency.
-#      to work around that, provide the actual library.
-#      this does result in two copies of libOpenCL.so loaded,
-#      but that seems to work fine...
-# XXX: have upstream fix this by dlopen'ing by SONAME first
-cp -f $(realpath ${libdir}/libOpenCL.so) ${libdir}/libOpenCL.so
 """
 
 # The products that we will ensure are always built


### PR DESCRIPTION
Binary counterpart of https://github.com/JuliaGPU/oneAPI.jl/pull/480. Removes the libOpenCL workaround we had in place, and also switches back to GCC now that the SYCL headers seem patched, and to avoid what looks like a Clang bug.

Specifically, with Clang we run into the same issue we had the previous time around:

```
ERROR: could not load library "/home/tim/Julia/src/Yggdrasil/O/oneAPI_Support/build/x86_64-linux-gnu/1wcmn0N3/x86_64-linux-gnu-libgfortran5-cxx11/destdir/lib/liboneapi_support.so"
/home/tim/Julia/src/Yggdrasil/O/oneAPI_Support/build/x86_64-linux-gnu/1wcmn0N3/x86_64-linux-gnu-libgfortran5-cxx11/destdir/lib/liboneapi_support.so: undefined symbol: _ZN6oneapi3mkl6lapack21gebrd_scratchpad_sizeIfTnPNS1_8internal9enable_ifIXsr5is_fpIT_EE5valueEvE4typeELPv0EEElRN4sycl3_V15queueElll
```

Taking a closer look, this symbol is provided by `libmkl_lapack`, but slightly differently mangled:

```
_ZN6oneapi3mkl6lapack21gebrd_scratchpad_sizeIfTnPNS1_8internal9enable_ifIXsr5is_fpIT_EE5valueEvE4typeELPv0EEElRN4sycl3_V15queueElll
```

Both however demangle to the same signature: `long oneapi::mkl::lapack::gebrd_scratchpad_size<float, (void*)0>(sycl::_V1::queue&, long, long, long)`. I'm not sure who or what's to blame here; `icpx` is also Clang based, and generates the correct mangled string... Switching back to GCC works around the issue.