### PR TITLE
Bump SPIRV-LLVM Translator.

### DIFF
--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@16/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@16/build_tarballs.jl
@@ -2,8 +2,8 @@ version = v"16.0"
 llvm_version = v"16.0.6"
 include("../common.jl")
 
-# Collection of sources required to build attr
-sources = [GitSource(repo, "1f9e0e36d8917cece7593771304d8db0bcd9f614")]
+# Collection of sources required to build the package
+sources = [GitSource(repo, "b786f8c31eead5788ac8ca33ccedf29a4a7faedf")]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [

--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@17/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@17/build_tarballs.jl
@@ -2,8 +2,8 @@ version = v"17.0"
 llvm_version = v"17.0.6"
 include("../common.jl")
 
-# Collection of sources required to build attr
-sources = [GitSource(repo, "3aa5bcd0c60a2c05b3a045339b2ef001465961ec")]
+# Collection of sources required to build the package
+sources = [GitSource(repo, "27bbf0fa898b6945dbd097dfd1e87b4f4becb19a")]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [

--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@18/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@18/build_tarballs.jl
@@ -2,8 +2,8 @@ version = v"18.0"
 llvm_version = v"18.1.7"
 include("../common.jl")
 
-# Collection of sources required to build attr
-sources = [GitSource(repo, "242df2cb83e2322b456990fb0ca3e30bd9209ed0")]
+# Collection of sources required to build the package
+sources = [GitSource(repo, "7515735e387c65cbb7821a78f122cfd89115a779")]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [

--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@19/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@19/build_tarballs.jl
@@ -1,9 +1,9 @@
-version = v"15.0"
-llvm_version = v"15.0.7"
+version = v"19.0"
+llvm_version = v"19.1.1"
 include("../common.jl")
 
 # Collection of sources required to build the package
-sources = [GitSource(repo, "4b96335944e70032f4dfa4807d9c5683eaabdae5")]
+sources = [GitSource(repo, "90a976491d3847657396456e0e94d7dc48d35996")]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [

--- a/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator_unified/build_tarballs.jl
@@ -7,16 +7,17 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
 
 name = "SPIRV_LLVM_Translator_unified"
 repo = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git"
-version = v"0.6"
+version = v"0.7"
 
-llvm_versions = [v"15.0.7", v"16.0.6", v"17.0.6", v"18.1.7"]
+llvm_versions = [v"15.0.7", v"16.0.6", v"17.0.6", v"18.1.7", v"19.1.1"]
 
 # Collection of sources required to build SPIRV_LLVM_Translator
 sources = Dict(
-    v"15.0.7" => [GitSource(repo, "1e170e22f65d6bf01e6c592f8ed845dcceb69bea")],
-    v"16.0.6" => [GitSource(repo, "1f9e0e36d8917cece7593771304d8db0bcd9f614")],
-    v"17.0.6" => [GitSource(repo, "3aa5bcd0c60a2c05b3a045339b2ef001465961ec")],
-    v"18.1.7" => [GitSource(repo, "242df2cb83e2322b456990fb0ca3e30bd9209ed0")],
+    v"15.0.7" => [GitSource(repo, "4b96335944e70032f4dfa4807d9c5683eaabdae5")],
+    v"16.0.6" => [GitSource(repo, "b786f8c31eead5788ac8ca33ccedf29a4a7faedf")],
+    v"17.0.6" => [GitSource(repo, "27bbf0fa898b6945dbd097dfd1e87b4f4becb19a")],
+    v"18.1.7" => [GitSource(repo, "7515735e387c65cbb7821a78f122cfd89115a779")],
+    v"19.1.1" => [GitSource(repo, "90a976491d3847657396456e0e94d7dc48d35996")],
 )
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
This is also a build to prime the worker caches, as we'll be using the new version of `julia-buildkite-plugin` now which performs some cleanup that's expected to take a significant time the first time it executes. (If it keeps being problematic we'll move away from ZFS again.)