### PR TITLE
[libcxxwrap-julia] Version 0.14.0

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -49,7 +49,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.10")),
+    BuildDependency("libjulia_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -11,13 +11,13 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 include("../../L/libjulia/common.jl")
 
 name = "libcxxwrap_julia"
-version = v"0.13.2"
+version = v"0.14.0"
 
 git_repo = "https://github.com/JuliaInterop/libcxxwrap-julia.git"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource(git_repo, "20eaeb785dcd18bd19ae3b029e0349f12f88a05a"),
+    GitSource(git_repo, "d4192fe3ea20829bd399d812863abd8303f9bcab"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This fixes some issues with the STL wrappings and allows simplification of the OpenCV patch.

Breaks binary compatibility, hence the bump to 0.14.