### PR TITLE
[CUDA_Runtime] Added omitted libraries for CUDA 10.2

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_10.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_10.2.jl
@@ -47,6 +47,12 @@ if [[ ${target} == *-linux-gnu ]]; then
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
 
+    mv extras/CUPTI/lib64/libnvperf_host.so* ${libdir}
+    mv extras/CUPTI/lib64/libnvperf_target.so* ${libdir}
+
+    mv lib64/libnvrtc.so* ${libdir}
+    mv lib64/libnvrtc-builtins.so* ${libdir}
+
     # Additional binaries
     mv bin/ptxas ${bindir}
     mv bin/nvdisasm ${bindir}
@@ -81,6 +87,12 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
 
+    mv extras/CUPTI/lib64/nvperf_host.dll* ${libdir}
+    mv extras/CUPTI/lib64/nvperf_target.dll* ${libdir}
+
+    mv bin/nvrtc64_* ${bindir}
+    mv bin/nvrtc-builtins64_* ${bindir}
+
     # Additional binaries
     mv bin/ptxas.exe ${bindir}
     mv bin/nvdisasm.exe ${bindir}
@@ -100,6 +112,10 @@ function get_products(platform)
         LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),
         LibraryProduct(["libcupti", "cupti64_102"], :libcupti),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_102_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_102"], :libnvrtc_builtins),
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
         ExecutableProduct("ptxas", :ptxas),

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.15.3"
+version = v"0.15.4"
 
 augment_platform_block = """
     $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))


### PR DESCRIPTION
Notably, `libnvrtc`.

This brings CUDA_Runtime for CUDA 10.2 in sync with CUDA 11.4 wrt. products included in the JLL.

As before:
* `libcublasLt` is available for the Linux platforms.
* `libcusolverMg` is only available for `x86_64-linux-gnu`.
