### PR TITLE
[Torch] Updated recipe

### DIFF
--- a/T/Torch/build_tarballs.jl
+++ b/T/Torch/build_tarballs.jl
@@ -243,6 +243,11 @@ dependencies = [
     Dependency("LAPACK_jll"; platforms = openblas_platforms),
     # Dependency("MKL_jll"; platforms = mkl_platforms), # MKL is avoided for all platforms
     # BuildDependency("MKL_Headers_jll"; platforms = mkl_platforms), # MKL is avoided for all platforms
+
+    # libtorch, libtorch_cuda, and libtorch_global_deps all link with `libnvToolsExt`
+    # maleadt: `libnvToolsExt is not shipped by CUDA anymore, so the best solution is definitely static linking. CUDA 10.2 shipped it, later it became a header-only library which we do compile into a dynamic one for use with NVTX.jl, but there's no guarantees that the library we build has the same symbols as the "old" libnvToolsExt shipped by CUDA 10.2
+    RuntimeDependency("NVTX_jll"), # TODO: Replace RuntimeDependency with static linking.
+
     Dependency("OpenBLAS32_jll"; platforms = openblas_platforms),
     Dependency("PThreadPool_jll"; compat = "0.0.20210414"),
     Dependency("SLEEF_jll", v"3.5.2"; compat = "3"),

--- a/T/Torch/build_tarballs.jl
+++ b/T/Torch/build_tarballs.jl
@@ -202,8 +202,8 @@ let cuda_platforms = CUDA.supported_platforms(min_version=v"10.2", max_version=v
     push!(cuda_platforms, Platform("x86_64", "Linux"; cuda = "11.3"))
 
      # Tag non-CUDA platforms matching CUDA platforms with cuda="none"
-    for platform in platforms, cuda_platform in cuda_platforms
-        if platforms_match(platform, cuda_platform)
+    for platform in platforms
+        if CUDA.is_supported(platform) && arch(platform) != "aarch64"
             platform["cuda"] = "none"
         end
     end

--- a/fancy_toys.jl
+++ b/fancy_toys.jl
@@ -14,6 +14,9 @@ Return whether the tarballs for the given `platform` should be built.
 This is useful when the builder has different platform-dependent elements
 (sources, script, products, etc...) that make it hard to have a single
 `build_tarballs` call.
+
+Note that the platform must be augmented, e.g. wrt. CUDA, if the platform
+supplied in ARGS is augmented.
 """
 function should_build_platform(platform)
     # If you need inspiration for how to use this function, look at the builder


### PR DESCRIPTION
Updated Torch recipe

* Changed to provide lazy artifacts.
* Replaced CUDA_full sources with CUDA module dependencies (and similar for CUDA 11.3).
* Updated cuda-part of script accordingly.
* Added xcrun executable for macOS which can handle `--show-sdk-path`.
* Using LLVM v13 (on macOS, v17 has issues).
* Adding cuda="none" tag to non-CUDA platforms with matching CUDA platforms.


Added comment to fancy_toys.jl `should_build_platform`

`should_build_platform` returns true, e.g. for `"x86_64-linux-gnu-cxx11"` when `ARGS = ["x86_64-linux-gnu-cxx11-cuda+10.2"]`.

Added NVTX RuntimeDependency