### PR TITLE
[LAPACK32] Build against OpenBLAS32

### DIFF
--- a/L/LAPACK/LAPACK/build_tarballs.jl
+++ b/L/LAPACK/LAPACK/build_tarballs.jl
@@ -10,13 +10,13 @@ products = [
 
 # Building ILP64 LAPACK on aarch64 linux runs into internal compiler errors with
 # GCC ≤ 7 (=> libgfortran ≤ 4).
-#filter!(p -> !(arch(p) == "aarch64" && Sys.islinux(p) && libgfortran_version(p) ≤ v"4"), platforms)
+filter!(p -> !(arch(p) == "aarch64" && Sys.islinux(p) && libgfortran_version(p) ≤ v"4"), platforms)
 
 append!(dependencies,
         [Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), compat="5.4.0")])
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               clang_use_lld=false, julia_compat="1.9", preferred_gcc_version=v"8")
+               clang_use_lld=false, julia_compat="1.9", preferred_gcc_version=v"6")
 
 # Build Trigger: 3

--- a/L/LAPACK/LAPACK/build_tarballs.jl
+++ b/L/LAPACK/LAPACK/build_tarballs.jl
@@ -10,10 +10,13 @@ products = [
 
 # Building ILP64 LAPACK on aarch64 linux runs into internal compiler errors with
 # GCC ≤ 7 (=> libgfortran ≤ 4).
-filter!(p -> !(arch(p) == "aarch64" && Sys.islinux(p) && libgfortran_version(p) ≤ v"4"), platforms)
+#filter!(p -> !(arch(p) == "aarch64" && Sys.islinux(p) && libgfortran_version(p) ≤ v"4"), platforms)
+
+append!(dependencies,
+        [Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), compat="5.4.0")])
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               clang_use_lld=false, julia_compat="1.9", preferred_gcc_version=v"6")
+               clang_use_lld=false, julia_compat="1.9", preferred_gcc_version=v"8")
 
 # Build Trigger: 3

--- a/L/LAPACK/LAPACK32/build_tarballs.jl
+++ b/L/LAPACK/LAPACK32/build_tarballs.jl
@@ -8,6 +8,8 @@ products = [
     LibraryProduct("liblapack32", :liblapack32),
 ]
 
+append!(dependencies, [Dependency("OpenBLAS32_jll")]);
+
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                clang_use_lld=false, julia_compat="1.9", preferred_gcc_version=v"6")

--- a/L/LAPACK/common.jl
+++ b/L/LAPACK/common.jl
@@ -23,8 +23,14 @@ function lapack_script(;lapack32::Bool=false)
 
     atomic_patch -p1 $WORKSPACE/srcdir/patches/cmake.patch
 
-    BLAS=openblas
-    
+    if [[ ${LAPACK32} ]]; then
+        BLAS=openblas
+    elif [[ "${target}" == *-mingw* ]]; then
+        BLAS="blastrampoline-5"
+    else
+        BLAS="blastrampoline"
+    fi
+
     FFLAGS=-ffixed-line-length-none
     if [[ ${nbits} == 64 ]] && [[ "${LAPACK32}" != "true" ]]; then
       FFLAGS="${FFLAGS} -cpp -DUSE_ISNAN -fdefault-integer-8"

--- a/L/LAPACK/common.jl
+++ b/L/LAPACK/common.jl
@@ -23,8 +23,8 @@ function lapack_script(;lapack32::Bool=false)
 
     atomic_patch -p1 $WORKSPACE/srcdir/patches/cmake.patch
 
-    if [[ ${LAPACK32} ]]; then
-        BLAS=openblas
+    if [[ ${LAPACK32} == true ]]; then
+        BLAS="openblas"
     elif [[ "${target}" == *-mingw* ]]; then
         BLAS="blastrampoline-5"
     else

--- a/L/LAPACK/common.jl
+++ b/L/LAPACK/common.jl
@@ -23,12 +23,8 @@ function lapack_script(;lapack32::Bool=false)
 
     atomic_patch -p1 $WORKSPACE/srcdir/patches/cmake.patch
 
-    if [[ "${target}" == *-mingw* ]]; then
-        BLAS="blastrampoline-5"
-    else
-        BLAS="blastrampoline"
-    fi
-
+    BLAS=openblas
+    
     FFLAGS=-ffixed-line-length-none
     if [[ ${nbits} == 64 ]] && [[ "${LAPACK32}" != "true" ]]; then
       FFLAGS="${FFLAGS} -cpp -DUSE_ISNAN -fdefault-integer-8"
@@ -372,6 +368,6 @@ platforms = expand_gfortran_versions(supported_platforms())
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
-    Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), compat="5.4.0"),
+    Dependency("CompilerSupportLibraries_jll"),
+    Dependency("OpenBLAS32_jll"),
 ]

--- a/L/LAPACK/common.jl
+++ b/L/LAPACK/common.jl
@@ -375,5 +375,4 @@ platforms = expand_gfortran_versions(supported_platforms())
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
-    Dependency("OpenBLAS32_jll"),
 ]


### PR DESCRIPTION
Build LAPACK32 directly against OpenBLAS32. 

@amontoison This is a bit of a step backwards from LBT. The reason is that when I build other executables, like Octave, where one would like to run the JLL binaries directly, it is unclear where the LBT forwarding should be done. Unless of course, we require having an Octave.jl that does all the forwarding and such before binaries using LBT for 32-bit BLAS forwarding can be used.

Any thoughts?