### PR TITLE
[Pythia8-cxxwrap] Patched wrapper code

### DIFF
--- a/P/Pythia8_cxxwrap/build_tarballs.jl
+++ b/P/Pythia8_cxxwrap/build_tarballs.jl
@@ -8,12 +8,12 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "Pythia8_cxxwrap"
-version = v"0.2.0"
+version = v"0.2.1"
 
 # Collection of sources required to build Pythia8_cxxwrap  
 sources = [
     GitSource("https://github.com/peremato/Pythia8_cxxwrap.git",
-              "983d2e471276ffb793bed19b923e0769f6b43e06"),
+              "30b9f1e116ee6f73804c7304c1be665aade10f4f"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Fix for a couple of minor issues in wrapper code

- Removed Pythia8::Hist::operator+(double) while waiting for [CxxWrap issue 458](https://github.com/JuliaInterop/CxxWrap.jl/issues/458)
- Do not export `cd` name to avoid warnings