### PR TITLE
libzip: New version 1.11.2

### DIFF
--- a/L/libzip/build_tarballs.jl
+++ b/L/libzip/build_tarballs.jl
@@ -3,17 +3,17 @@
 using BinaryBuilder, Pkg
 
 name = "libzip"
-version = v"1.11.1"
+version = v"1.11.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/nih-at/libzip.git", "956320f8502c59468afd2b43557e1c94bb256eaa")
+    GitSource("https://github.com/nih-at/libzip.git", "64b62d6b1a686a1b0bac1b6b9dcb635be0499afb")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-cd libzip/
+cd libzip
 cmake -B build -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel ${nprocs}
 cmake --install build
@@ -34,8 +34,9 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="Bzip2_jll", uuid="6e34b625-4abd-537c-b88f-471c36dfa7a0"); compat="1.0.8"),
-    Dependency(PackageSpec(name="GnuTLS_jll", uuid="0951126a-58fd-58f1-b5b3-b08c7c4a876d");
-               platforms=filter(p -> Sys.islinux(p) || Sys.isfreebsd(p), platforms)),
+    # We're using "Apple's CommonCrypto" on macOS and "Microsoft Windows Cryptography Framework" on Windows
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15",
+               platforms=filter(p -> !Sys.isapple(p) && !Sys.iswindows(p), platforms)),
     Dependency(PackageSpec(name="XZ_jll", uuid="ffd25f8a-64ca-5728-b0f7-c24cf3aae800")),
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4")),


### PR DESCRIPTION
- New version 1.11.2
- Switch from GnuTLS to OpenSSL (preferred by libzip)