### PR TITLE
[MicrosoftMPI] Use GCC5 for ligbfortran3 architectures

### DIFF
--- a/M/MicrosoftMPI/build_tarballs.jl
+++ b/M/MicrosoftMPI/build_tarballs.jl
@@ -114,4 +114,5 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+# We use GCC 5 to ensure Fortran module files are readable by all `libgfortran3` architectures. GCC 4 would use an older format.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, preferred_gcc_version=v"5")


### PR DESCRIPTION
Because MPICH is now compiled with GCC5, we also need to regenerate the `*.mod` files for Fortran with `MicrosoftMPI`.
Otherwise we have this error:
```shell
[16:57:41]    use mpi
[16:57:41]       1
[16:57:41] Fatal Error: Cannot read module file ‘mpi.mod’ opened at (1), because it was created by a different version of GNU Fortran
```
when we compile a Fortran that relies on MPICH / MicrosoftMPI + `libgfortran3`.

Related PR: https://github.com/JuliaPackaging/Yggdrasil/pull/8609