### PR TITLE
[XSLT] Update dependency for freebsd-aarch64 support

### DIFF
--- a/X/XSLT/build_tarballs.jl
+++ b/X/XSLT/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder
 
 name = "XSLT"
-version = v"1.1.41"
+version = v"1.1.42"
 
 # Collection of sources required to build XSLT
 sources = [
     ArchiveSource("https://download.gnome.org/sources/libxslt/$(version.major).$(version.minor)/libxslt-$(version).tar.xz",
-                  "3ad392af91115b7740f7b50d228cc1c5fc13afc1da7f16cb0213917a37f71bda"),
+                  "85ca62cac0d41fc77d3f6033da9df6fd73d20ea2fc18b0a3609ffb4110e1baeb"),
 ]
 
 # Bash recipe for building across all platforms

--- a/X/XSLT/build_tarballs.jl
+++ b/X/XSLT/build_tarballs.jl
@@ -44,4 +44,4 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 # XML2_jll builds with GCC 8 and we need to do the same to avoid linker errors
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"8", )
+               julia_compat="1.6", preferred_gcc_version=v"11")

--- a/X/XSLT/build_tarballs.jl
+++ b/X/XSLT/build_tarballs.jl
@@ -33,15 +33,11 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-# - Build against XML2_jll v2.12.7 as it bundles the string-handling trio library,
-#   and the i686-w64-mingw32 build implicitly needs it.
-#   Removed in v2.13.0:
-#   https://gitlab.gnome.org/GNOME/libxml2/-/blob/fe1ee0f25f43e33a9981fd6fe7b0483a8c8b5e8d/NEWS#L173
 dependencies = [
     Dependency("Libgpg_error_jll"; compat="1.50"),
     Dependency("Libgcrypt_jll"),
     Dependency("Libiconv_jll"),
-    Dependency("XML2_jll", v"2.12.7"),
+    Dependency("XML2_jll"),
     Dependency("Zlib_jll"),
 ]
 

--- a/X/XSLT/build_tarballs.jl
+++ b/X/XSLT/build_tarballs.jl
@@ -34,7 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Libgpg_error_jll", v"1.42.0"; compat="1.42.0"),
+    Dependency("Libgpg_error_jll"; compat="1.50"),
     Dependency("Libgcrypt_jll"),
     Dependency("Libiconv_jll"),
     Dependency("XML2_jll"),

--- a/X/XSLT/build_tarballs.jl
+++ b/X/XSLT/build_tarballs.jl
@@ -33,11 +33,15 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
+# - Build against XML2_jll v2.12.7 as it bundles the string-handling trio library,
+#   and the i686-w64-mingw32 build implicitly needs it.
+#   Removed in v2.13.0:
+#   https://gitlab.gnome.org/GNOME/libxml2/-/blob/fe1ee0f25f43e33a9981fd6fe7b0483a8c8b5e8d/NEWS#L173
 dependencies = [
     Dependency("Libgpg_error_jll"; compat="1.50"),
     Dependency("Libgcrypt_jll"),
     Dependency("Libiconv_jll"),
-    Dependency("XML2_jll"),
+    Dependency("XML2_jll", v"2.12.7"),
     Dependency("Zlib_jll"),
 ]
 


### PR DESCRIPTION
This takes inspiration from #9680 to raise the compatibility bound of the Libgpg_error_jll dependency to include a version that has the necessary FreeBSD support