### PR TITLE
[CXSparse 4.4.0] Build for SuiteSparse 7.7.0 for Julia 1.11

### DIFF
--- a/S/SuiteSparse/CXSparse/build_tarballs.jl
+++ b/S/SuiteSparse/CXSparse/build_tarballs.jl
@@ -1,8 +1,8 @@
 include("../common.jl")
 
 name = "CXSparse"
-version = v"4.4.0"
-SS_version_str = "7.7.0"
+version = v"4.2.1"
+SS_version_str = "7.2.1"
 SS_version = VersionNumber(SS_version_str)
 sources = suitesparse_sources(SS_version)
 

--- a/S/SuiteSparse/CXSparse/build_tarballs.jl
+++ b/S/SuiteSparse/CXSparse/build_tarballs.jl
@@ -1,8 +1,8 @@
 include("../common.jl")
 
 name = "CXSparse"
-version = v"4.4.1"
-SS_version_str = "7.8.0"
+version = v"4.4.0"
+SS_version_str = "7.7.0"
 SS_version = VersionNumber(SS_version_str)
 LLVM_version = v"16.0.6"
 sources = suitesparse_sources(SS_version)

--- a/S/SuiteSparse/CXSparse/build_tarballs.jl
+++ b/S/SuiteSparse/CXSparse/build_tarballs.jl
@@ -1,10 +1,9 @@
 include("../common.jl")
 
 name = "CXSparse"
-version = v"4.4.1"
-SS_version_str = "7.8.0"
+version = v"4.2.1"
+SS_version_str = "7.2.1"
 SS_version = VersionNumber(SS_version_str)
-LLVM_version = v"16.0.6"
 sources = suitesparse_sources(SS_version)
 
 # Bash recipe for building across all platforms
@@ -24,10 +23,6 @@ fi
 
 # Add dependency on SuiteSparse_jll
 dependencies = append!(dependencies, [
-    BuildDependency(PackageSpec(name="LLVMCompilerRT_jll",
-                                uuid="4e17d02c-6bf5-513e-be62-445f41c75a11",
-                                version=LLVM_version);
-                    platforms=[Platform("aarch64", "macos")]),
     Dependency("SuiteSparse_jll"; compat = "=$SS_version_str"),
     Dependency("CompilerSupportLibraries_jll")
 ])
@@ -36,5 +31,4 @@ products = [
     LibraryProduct("libcxsparse", :libcxsparse)
 ]
 build_tarballs(ARGS, name, version, sources, script, platforms,
-               products, dependencies; julia_compat="1.11",
-               preferred_llvm_version=LLVM_version)
+               products, dependencies; julia_compat="1.10")

--- a/S/SuiteSparse/CXSparse/build_tarballs.jl
+++ b/S/SuiteSparse/CXSparse/build_tarballs.jl
@@ -1,9 +1,10 @@
 include("../common.jl")
 
 name = "CXSparse"
-version = v"4.2.1"
-SS_version_str = "7.2.1"
+version = v"4.4.1"
+SS_version_str = "7.8.0"
 SS_version = VersionNumber(SS_version_str)
+LLVM_version = v"16.0.6"
 sources = suitesparse_sources(SS_version)
 
 # Bash recipe for building across all platforms
@@ -23,6 +24,10 @@ fi
 
 # Add dependency on SuiteSparse_jll
 dependencies = append!(dependencies, [
+    BuildDependency(PackageSpec(name="LLVMCompilerRT_jll",
+                                uuid="4e17d02c-6bf5-513e-be62-445f41c75a11",
+                                version=LLVM_version);
+                    platforms=[Platform("aarch64", "macos")]),
     Dependency("SuiteSparse_jll"; compat = "=$SS_version_str"),
     Dependency("CompilerSupportLibraries_jll")
 ])
@@ -31,4 +36,5 @@ products = [
     LibraryProduct("libcxsparse", :libcxsparse)
 ]
 build_tarballs(ARGS, name, version, sources, script, platforms,
-               products, dependencies; julia_compat="1.10")
+               products, dependencies; julia_compat="1.11",
+               preferred_llvm_version=LLVM_version)

--- a/S/SuiteSparse/CXSparse/build_tarballs.jl
+++ b/S/SuiteSparse/CXSparse/build_tarballs.jl
@@ -1,8 +1,8 @@
 include("../common.jl")
 
 name = "CXSparse"
-version = v"4.2.1"
-SS_version_str = "7.2.1"
+version = v"4.4.0"
+SS_version_str = "7.7.0"
 SS_version = VersionNumber(SS_version_str)
 sources = suitesparse_sources(SS_version)
 


### PR DESCRIPTION
We need to build CXSparse for every release SuiteSparse that is in Julia. Julia 1.10 is not straightforward because it uses SuiteSparse 7.2 which had the old build system.