### PR TITLE
[Singular] Revert recent changes due to downstream breakage

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -28,8 +28,8 @@ import Pkg.Types: VersionSpec
 #
 name = "Singular"
 
-upstream_version = v"4.4.0-7" # 4.4.0p7
-version_offset = v"0.0.8"
+upstream_version = v"4.4.0-7" # 4.4.0p6
+version_offset = v"0.0.7"
 
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,
                         upstream_version.patch * 100 + version_offset.minor,
@@ -37,7 +37,7 @@ version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + 
 
 # Collection of sources required to build normaliz
 sources = [
-    GitSource("https://github.com/Singular/Singular.git", "b3ba3db6b5a761767722d2e7bd42b5771924a5ec"),
+    GitSource("https://github.com/Singular/Singular.git", "16cd1da3c7c1d5fd98e996f5deef57addec633d6"),
     #ArchiveSource("https://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/$(upstream_version.major)-$(upstream_version.minor)-$(upstream_version.patch)/singular-$(upstream_version).tar.gz",
     #              "5b0f6c036b4a6f58bf620204b004ec6ca3a5007acc8352fec55eade2fc9d63f6"),
     #DirectorySource("./bundled")

--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -29,7 +29,7 @@ import Pkg.Types: VersionSpec
 name = "Singular"
 
 upstream_version = v"4.4.0-7" # 4.4.0p7
-version_offset = v"0.0.9"
+version_offset = v"0.0.8"
 
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,
                         upstream_version.patch * 100 + version_offset.minor,
@@ -37,7 +37,7 @@ version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + 
 
 # Collection of sources required to build normaliz
 sources = [
-    GitSource("https://github.com/Singular/Singular.git", "9f4b8c87374a5d13d0d7fa743e8f37d5435aa974"),
+    GitSource("https://github.com/Singular/Singular.git", "b3ba3db6b5a761767722d2e7bd42b5771924a5ec"),
     #ArchiveSource("https://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/$(upstream_version.major)-$(upstream_version.minor)-$(upstream_version.patch)/singular-$(upstream_version).tar.gz",
     #              "5b0f6c036b4a6f58bf620204b004ec6ca3a5007acc8352fec55eade2fc9d63f6"),
     #DirectorySource("./bundled")

--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -28,8 +28,8 @@ import Pkg.Types: VersionSpec
 #
 name = "Singular"
 
-upstream_version = v"4.4.0-7" # 4.4.0p6
-version_offset = v"0.0.7"
+upstream_version = v"4.4.0-6" # 4.4.0p6
+version_offset = v"0.0.6"
 
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,
                         upstream_version.patch * 100 + version_offset.minor,
@@ -37,7 +37,7 @@ version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + 
 
 # Collection of sources required to build normaliz
 sources = [
-    GitSource("https://github.com/Singular/Singular.git", "16cd1da3c7c1d5fd98e996f5deef57addec633d6"),
+    GitSource("https://github.com/Singular/Singular.git", "e16b3cb440c0dced4852258c179628b7223bf2cf"),
     #ArchiveSource("https://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/$(upstream_version.major)-$(upstream_version.minor)-$(upstream_version.patch)/singular-$(upstream_version).tar.gz",
     #              "5b0f6c036b4a6f58bf620204b004ec6ca3a5007acc8352fec55eade2fc9d63f6"),
     #DirectorySource("./bundled")

--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -29,7 +29,7 @@ import Pkg.Types: VersionSpec
 name = "Singular"
 
 upstream_version = v"4.4.0-6" # 4.4.0p6
-version_offset = v"0.0.6"
+version_offset = v"0.0.11"
 
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,
                         upstream_version.patch * 100 + version_offset.minor,

--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -28,7 +28,7 @@ import Pkg.Types: VersionSpec
 #
 name = "Singular"
 
-upstream_version = v"4.4.0-6" # 4.4.0p6
+upstream_version = v"4.4.0-7" # 4.4.0p6 (the difference here is due to a retroactive re-release of 404.0.606 as 404.0.711)
 version_offset = v"0.0.11"
 
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,

--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -29,7 +29,7 @@ import Pkg.Types: VersionSpec
 name = "Singular"
 
 upstream_version = v"4.4.0-7" # 4.4.0p7
-version_offset = v"0.0.10"
+version_offset = v"0.0.9"
 
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,
                         upstream_version.patch * 100 + version_offset.minor,
@@ -37,7 +37,7 @@ version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + 
 
 # Collection of sources required to build normaliz
 sources = [
-    GitSource("https://github.com/Singular/Singular.git", "9633130e253337be890bc62b1537bebd2bd4f2c4"),
+    GitSource("https://github.com/Singular/Singular.git", "9f4b8c87374a5d13d0d7fa743e8f37d5435aa974"),
     #ArchiveSource("https://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/$(upstream_version.major)-$(upstream_version.minor)-$(upstream_version.patch)/singular-$(upstream_version).tar.gz",
     #              "5b0f6c036b4a6f58bf620204b004ec6ca3a5007acc8352fec55eade2fc9d63f6"),
     #DirectorySource("./bundled")


### PR DESCRIPTION
This reverts PRs #9811, #9840, #9846, #9851. (i.e. everything since last Friday).

Therefore I expect it to resolve https://github.com/oscar-system/Oscar.jl/issues/4341 that started happening after #9811 (but no idea how to test that locally). This would be the fastest way to get green OSCAR CI again that I can think of. The "real fixes" can be worked on afterwards, maybe in a minor version bump to not have it automatically downstream.

ping @hannes14 @fingolfin 