### PR TITLE
[Singular] restore 4.4.0p7 but with minor version +1

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -28,8 +28,8 @@ import Pkg.Types: VersionSpec
 #
 name = "Singular"
 
-upstream_version = v"4.4.0-7" # 4.4.0p6 (the difference here is due to a retroactive re-release of 404.0.606 as 404.0.711)
-version_offset = v"0.0.11"
+upstream_version = v"4.4.0-7" # 4.4.0p7
+version_offset = v"0.1.0"
 
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,
                         upstream_version.patch * 100 + version_offset.minor,
@@ -37,7 +37,7 @@ version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + 
 
 # Collection of sources required to build normaliz
 sources = [
-    GitSource("https://github.com/Singular/Singular.git", "e16b3cb440c0dced4852258c179628b7223bf2cf"),
+    GitSource("https://github.com/Singular/Singular.git", "9633130e253337be890bc62b1537bebd2bd4f2c4"),
     #ArchiveSource("https://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/$(upstream_version.major)-$(upstream_version.minor)-$(upstream_version.patch)/singular-$(upstream_version).tar.gz",
     #              "5b0f6c036b4a6f58bf620204b004ec6ca3a5007acc8352fec55eade2fc9d63f6"),
     #DirectorySource("./bundled")


### PR DESCRIPTION
For reference, `Singular.jl` currently has this compat entry `Singular_jll = "~404.000.606"` which this PR should produce version `404.001.700`.

This way the current Singular.jl release will not pick it up giving us time to adjust and release libsingular_julia_jll and then Singular.jl and then finally Oscar.jl (via  PR that changes the compat entry in Project.toml also adjusts the doctests).

ping @hannes14 @thofma @benlorenz @lgoettgens 

Let's wait with merging this until *at least* https://github.com/JuliaRegistries/General/pull/120134 is merged. And it'd be great if someone double checks my logic above so we don't run into a brick wall right again.