### PR TITLE
[Xorg_libxcb] Rebuild for freebsd-aarch64

### DIFF
--- a/X/Xorg_libxcb/build_tarballs.jl
+++ b/X/Xorg_libxcb/build_tarballs.jl
@@ -59,7 +59,6 @@ dependencies = [
     BuildDependency("Xorg_util_macros_jll"),
     BuildDependency("Xorg_xproto_jll"),
     BuildDependency("Xorg_xcb_proto_jll"),
-    Dependency("XSLT_jll"),
     Dependency("Xorg_libXau_jll"),
     Dependency("Xorg_libXdmcp_jll"),
     Dependency("Xorg_libpthread_stubs_jll"),


### PR DESCRIPTION
In checking that the dependencies were properly built, it seems that the dependecy on XSLT_jll is unnecessary. The in-source `ChangeLog` file (which has more detail than the git-repo NEWS [1]) says that XSLT has been made optional since v1.10 in 2013, and the Arch Linux package [2] agrees in making it a build-only dependecy. See also [3] where it is mentioned that it's only used for generating HTML checks results.

[1] https://gitlab.freedesktop.org/xorg/lib/libxcb/-/blob/master/NEWS
[2] https://archlinux.org/packages/extra/x86_64/libxcb/
[3] https://bugs.freedesktop.org/show_bug.cgi?id=23863