### PR TITLE
New Recipe: FuzzifiED v0.10.1

### DIFF
--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -13,6 +13,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
+cd FuzzifiED_Fortran/src/
 if [[ ${nbits} == 32 ]]; then
     FFLAGS="-O3 -fPIC -fopenmp"
 else

--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "FuzzifiED"
-version = v"0.10.1"
+version = v"0.10.4"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/mankai-chow/FuzzifiED_Fortran.git", "4aff7e2108707b17496dbb7d2e93d61a89ce33f2")
+    GitSource("https://github.com/mankai-chow/FuzzifiED_Fortran.git", "32970bd69f9cc2a17e840399fb973a01535078c0")
 ]
 
 # Bash recipe for building across all platforms

--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -12,23 +12,20 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd FuzzifiED_Fortran/src/
-if [[ ${nbits} == 32 ]]; then
-    FFLAGS="-O3 -fPIC -fopenmp"
-else
-    FFLAGS="-O3 -fdefault-integer-8 -fPIC -fopenmp"
+cd $WORKSPACE/srcdir/FuzzifiED_Fortran/src/
+FFLAGS=(-O3 -fPIC -fopenmp)
+if [[ ${nbits} == 64 ]]; then
+    FFLAGS+=(-fdefault-integer-8)
 fi
 for src in cfs.f90 bs.f90 op.f90 diag.f90 diag_re.f90 ent.f90; do
-    gfortran ${FFLAGS} -c ./${src}
+    gfortran "${FFLAGS[@]}" -c ./${src}
 done
-gfortran ${FFLAGS} -shared -o ${libdir}/libfuzzified.$dlext ./*.o -L ${libdir} -larpack
+gfortran "${FFLAGS[@]}" -shared -o "${libdir}/libfuzzified.${dlext}" ./*.o -L "${libdir}" -larpack
 cd super
 for src in scfs.f90 sbs.f90 sop.f90; do
-    gfortran ${FFLAGS} -c ./${src}
+    gfortran "${FFLAGS[@]}" -c ./${src}
 done
 gfortran ${FFLAGS} -shared -o ${libdir}/libfuzzifino.$dlext ./*.o
-cd ..
 """
 
 # These are the platforms we will build for by default, unless further
@@ -39,7 +36,7 @@ platforms = expand_gfortran_versions(platforms)
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libfuzzified", :LibpathFuzzifiED),
-    LibraryProduct("libfuzzifino", :LibpathFuzzifino)
+    LibraryProduct("libfuzzifino", :LibpathFuzzifino),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -25,7 +25,7 @@ cd super
 for src in scfs.f90 sbs.f90 sop.f90; do
     gfortran "${FFLAGS[@]}" -c ./${src}
 done
-gfortran ${FFLAGS} -shared -o ${libdir}/libfuzzifino.$dlext ./*.o
+gfortran "${FFLAGS[@]}" -shared -o "${libdir}/libfuzzifino.${dlext}" ./*.o
 """
 
 # These are the platforms we will build for by default, unless further

--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -1,0 +1,44 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "FuzzifiED"
+version = v"0.10.1"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/mankai-chow/FuzzifiED_Fortran.git", "4aff7e2108707b17496dbb7d2e93d61a89ce33f2")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd FuzzifiED_Fortran/src/
+if [[ ${nbits} == 32 ]]; then     FFLAGS="-O3 -fPIC -fopenmp"; else     FFLAGS="-O3 -fdefault-integer-8 -fPIC -fopenmp"; fi
+for src in cfs.f90 bs.f90 op.f90 diag.f90 diag_re.f90 ent.f90; do     gfortran ${FFLAGS} -c ./${src}; done
+gfortran ${FFLAGS} -shared -o ${libdir}/libfuzzified.$dlext ./*.o -L ${libdir} -larpack
+cd super
+for src in scfs.f90 sbs.f90 sop.f90; do     gfortran ${FFLAGS} -c ./${src}; done
+gfortran ${FFLAGS} -shared -o ${libdir}/libfuzzifino.$dlext ./*.o
+cd ..
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libfuzzified", :LibpathFuzzifiED),
+    LibraryProduct("libfuzzifino", :LibpathFuzzifino)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
+    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"))
+    Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -13,12 +13,19 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-cd FuzzifiED_Fortran/src/
-if [[ ${nbits} == 32 ]]; then     FFLAGS="-O3 -fPIC -fopenmp"; else     FFLAGS="-O3 -fdefault-integer-8 -fPIC -fopenmp"; fi
-for src in cfs.f90 bs.f90 op.f90 diag.f90 diag_re.f90 ent.f90; do     gfortran ${FFLAGS} -c ./${src}; done
+if [[ ${nbits} == 32 ]]; then
+    FFLAGS="-O3 -fPIC -fopenmp"
+else
+    FFLAGS="-O3 -fdefault-integer-8 -fPIC -fopenmp"
+fi
+for src in cfs.f90 bs.f90 op.f90 diag.f90 diag_re.f90 ent.f90; do
+    gfortran ${FFLAGS} -c ./${src}
+done
 gfortran ${FFLAGS} -shared -o ${libdir}/libfuzzified.$dlext ./*.o -L ${libdir} -larpack
 cd super
-for src in scfs.f90 sbs.f90 sop.f90; do     gfortran ${FFLAGS} -c ./${src}; done
+for src in scfs.f90 sbs.f90 sop.f90; do
+    gfortran ${FFLAGS} -c ./${src}
+done
 gfortran ${FFLAGS} -shared -o ${libdir}/libfuzzifino.$dlext ./*.o
 cd ..
 """
@@ -26,6 +33,7 @@ cd ..
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
+platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -35,8 +43,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
-    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"))
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
+    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"))
 ]
 


### PR DESCRIPTION
`FuzzifiED_jll` provides the necessary Fortran library for the package `FuzzifiED`, hosted at [https://github.com/mankai-chow/FuzzifiED.jl](https://github.com/mankai-chow/FuzzifiED.jl). 

`FuzzifiED_jll` was originally hosted at [https://github.com/mankai-chow/FuzzifiED_jll.jl.git](https://github.com/mankai-chow/FuzzifiED_jll.jl.git) but it would be preferrable if it could be installed without having to specify the url.

The package `FuzzifiED` is designed to do exact diagonalisation (ED) calculations on the fuzzy sphere, and also facilitates the DMRG calculations by ITensors. It can also be used for generic fermion models. 