### PR TITLE
[SuiteSparse CXSparse] Bump versioning

### DIFF
--- a/S/SuiteSparse/CXSparse/build_tarballs.jl
+++ b/S/SuiteSparse/CXSparse/build_tarballs.jl
@@ -1,7 +1,14 @@
 include("../common.jl")
 
 name = "CXSparse"
-version = v"4.4.1"
+
+upstream_version = v"4.4.1"
+version_offset = v"0.0.0" # reset to 0.0.0 once the upstream version changes
+version = VersionNumber(upstream_version.major * 100 + version_offset.major,
+                        upstream_version.minor * 100 + version_offset.minor,
+                        upstream_version.patch * 100 + version_offset.patch)
+
+
 SS_version_str = "7.8.0"
 SS_version = VersionNumber(SS_version_str)
 LLVM_version = v"16.0.6"


### PR DESCRIPTION
CXSparse used to follow the SuiteSparse version numbering, and as a result had 5.x version numbers originally.

Now, since it is a separate package, we use the upstream version of CXSparse (rather than of SuiteSparse collection itself). As a result those are in the 4.x series.

We are also trying to make the CXSparse build independent of SuiteSparse, and as a result all the version numbers are being multiplied by 100 to bypass all the old versions. Hopefully this will be stable in the long run.