### PR TITLE
MAGEMin v1.6.0

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.5.9"
+version = v"1.6.0"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "e04e9394be5c384e17b26fe0a8f473181e1642cf")                 ]
+                    "e2ec98af90e2a6fd418222acf5de0964960b1e35")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Added extended metapelite database to account for CO2 and S
- Added option to select combination of solution phase for metapelite and metabasite database
- Added “light” option to save minimum output from MAGEMin_C calculations
- Added several pseudocompounds for metapelite to improve phase diagrams quality 
- Corrected mistake when saving endmember wt fraction and end member wt composition
