### PR TITLE
New Version: FuzzifiED v0.10.5

### DIFF
--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -43,7 +43,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"); compat="~3.8")
+    Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"); compat="~3.5.1")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -30,8 +30,7 @@ gfortran "${FFLAGS[@]}" -shared -o "${libdir}/libfuzzifino.${dlext}" ./*.o
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
-platforms = expand_gfortran_versions(platforms)
+platforms = expand_gfortran_versions(supported_platforms(exclude = p -> arch(p) == "aarch64" && os(p) == "freebsd"))
 
 # The products that we will ensure are always built
 products = [

--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -43,7 +43,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"); compat="< 3.9")
+    Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"); compat="~3.5")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "FuzzifiED"
-version = v"0.10.4"
+version = v"0.10.5"
 
 # Collection of sources required to complete build
 sources = [
@@ -43,7 +43,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"))
+    Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"); compat="< 3.9")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/F/FuzzifiED/build_tarballs.jl
+++ b/F/FuzzifiED/build_tarballs.jl
@@ -43,7 +43,7 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"); compat="~3.5")
+    Dependency(PackageSpec(name="Arpack_jll", uuid="68821587-b530-5797-8361-c406ea357684"); compat="~3.8")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
I notice that there are some issue with Arpack_jll v3.9 --- it cannot find link to the BLAS library, so I am forcing compatibility with only the lower versions. 