### PR TITLE
MAGEMin v1.6.1

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.6.0"
+version = v"1.6.1"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "e2ec98af90e2a6fd418222acf5de0964960b1e35")                 ]
+                    "c60b621879c68caaea84f7cd99ed4c3c8cf0cd42")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Added frac_M_vol, frac_F_vol and frac_S_vol output for MAGEMin_C
- Corrected wrong set of W's for spinel in the metapelite and metapelite extended database
- Added molar mass of CO2 for MAGEMin_C (which was leading to failed mpe bulk loading in the App)