### PR TITLE
[Clp] Rebuild with latest LLVM toolchain

### DIFF
--- a/C/Coin-OR/Clp/build_tarballs.jl
+++ b/C/Coin-OR/Clp/build_tarballs.jl
@@ -96,6 +96,6 @@ build_tarballs(
     products,
     dependencies;
     preferred_gcc_version = gcc_version,
-    preferred_llvm_version = llvm_version,
+    clang_use_lld = false,
     julia_compat = "1.9",
 )


### PR DESCRIPTION
We previously restricted compiling this package with LLVM 13 to work around an issue with the `lld` linker, but a better approach is to use the latest LLVM toolchain available but not use `lld` as linker with `clang_use_lld=false`.