### PR TITLE
Enabled GMock and exported libraries

### DIFF
--- a/G/GoogleTest/build_tarballs.jl
+++ b/G/GoogleTest/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "GoogleTest"
-version = v"1.11.1"
+version = v"1.11.0"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
Not sure why GMock was disabled in GoogleTest. I just reenabled it and increased the version number.