### PR TITLE
Update to catch22-v0.5.0

### DIFF
--- a/C/catch22/build_tarballs.jl
+++ b/C/catch22/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "catch22"
-version = v"0.5.0"
+version = v"0.4.1"
 
 # Collection of sources required to complete build
 sources = [

--- a/C/catch22/build_tarballs.jl
+++ b/C/catch22/build_tarballs.jl
@@ -3,35 +3,60 @@
 using BinaryBuilder, Pkg
 
 name = "catch22"
-version = v"0.4.0"
+version = v"0.5.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/chlubba/catch22.git", "2e1a271c6a7437b6a4a754e1adc7e34d7a224c01")
+    GitSource("https://github.com/DynamicsAndNeuralSystems/catch22.git",
+              "2e1a271c6a7437b6a4a754e1adc7e34d7a224c01")
 ]
 
 # Bash recipe for building across all platforms
-script = raw"""
-cd $WORKSPACE/srcdir
-cd catch22/C/
-echo -e 'CFLAGS = -fPIC\nLDFLAGS = -shared\nRM = rm -f\nTARGET_LIB = "lib${SRC_NAME}.${dlext}"\nSRCS = main.c CO_AutoCorr.c DN_Mean.c DN_Spread_Std.c DN_HistogramMode_10.c DN_HistogramMode_5.c DN_OutlierInclude.c FC_LocalSimple.c IN_AutoMutualInfoStats.c MD_hrv.c PD_PeriodicityWang.c SB_BinaryStats.c SB_CoarseGrain.c SB_MotifThree.c SB_TransitionMatrix.c SC_FluctAnal.c SP_Summaries.c butterworth.c fft.c helper_functions.c histcounts.c splinefit.c stats.c\nOBJS = $(SRCS:.c=.o)\n.PHONY: all\nall: ${TARGET_LIB}\n$(TARGET_LIB): $(OBJS);    $(CC) ${LDFLAGS} -o $@ $^\n$(SRCS:.c=.d):%.d:%.c;$(CC) $(CFLAGS) -MM $< >$@\ninclude $(SRCS:.c=.d)\n.PHONY: clean\nclean:-${RM} ${TARGET_LIB} ${OBJS} $(SRCS:.c=.d)' >> Makefile
-make
-mkdir "${libdir}"
-cp "./lib${SRC_NAME}.${dlext}" "${libdir}/lib${SRC_NAME}.${dlext}"
+makefile = raw"""
+CC = cc
+CFLAGS = -std=c11 -fPIC -Wall -Wextra -g -O2 -lm
+LDFLAGS = -shared -lm
+RM = rm -f
+TARGET_LIB = "lib$(SRC_NAME).$(dlext)"
+
+SRCS := $(shell find ./ -name "*.c" ! -name "main.c")
+
+OBJS = $(SRCS:.c=.o)
+.PHONY: all;
+all: ${TARGET_LIB}
+$(TARGET_LIB): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS) $(FLAGS)
+$(SRCS:.c=.d):%.d:%.c
+	$(CC) $(CFLAGS) $(FLAGS) -MM $< >$@
+	include $(SRCbS:.c=.d)
+.PHONY: clean
+clean:
+	$(RM) $(TARGET_LIB) $(OBJS) $(SRCS:.c=.d)
+.PHONY: install
+install:
+	install -Dvm 755 "./lib${SRC_NAME}.$(dlext)" "$(libdir)/lib$(SRC_NAME).$(dlext)"
 """
+script = raw"""
+cd ${WORKSPACE}/srcdir
+cd catch22/C/
+echo -e '""" * makefile * raw"""' >> Makefile
+    make -j${nproc} FLAGS="${FLAGS}"
+    make install
+    """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
+# platforms = supported_platforms(; exclude=Sys.iswindows)
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libcatch22", :ccatch22)
+    LibraryProduct("libcatch22", :libcatch22)
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
-]
+dependencies = []
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"9.1.0", julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version = v"9.1.0", julia_compat = "1.6")

--- a/C/catch22/build_tarballs.jl
+++ b/C/catch22/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "catch22"
-version = v"0.4.1"
+version = v"0.5.0"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
Adds optimization flags, and generally cleans up the makefile, to resolve [this bug](https://discourse.julialang.org/t/julia-vs-python-performance-on-package-catch22-why-is-julia-slower-in-this-case-and-how-can-i-improve-it/117936/11)