### PR TITLE
[OpenFHE] and [OpenFHE_int128] set additional compiler flag

### DIFF
--- a/O/OpenFHE/common.jl
+++ b/O/OpenFHE/common.jl
@@ -36,7 +36,7 @@ function prepare_openfhe_build(name::String, git_hash::String)
       -DWITH_BE4=ON \
       -DBUILD_UNITTESTS=OFF \
       -DBUILD_BENCHMARKS=OFF \
-      -DCMAKE_CXX_FLAGS=$(CMAKE_CXX_FLAGS) \
+      -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} \
       -DNATIVE_SIZE=""" * "$native_size" *
     raw"""
     

--- a/O/OpenFHE/common.jl
+++ b/O/OpenFHE/common.jl
@@ -20,6 +20,12 @@ function prepare_openfhe_build(name::String, git_hash::String)
       atomic_patch -p1 "${WORKSPACE}/srcdir/patches/windows-fix-cmake-libdir.patch"
     fi
 
+    # Set additional linker flag to link with typeid(__int128) in macOS
+    CMAKE_CXX_FLAGS=""
+    if [[ "$target" == *-apple-darwin* ]]; then
+        CMAKE_CXX_FLAGS="-lc++abi"
+    fi
+
     mkdir build && cd build
 
     cmake .. \
@@ -30,6 +36,7 @@ function prepare_openfhe_build(name::String, git_hash::String)
       -DWITH_BE4=ON \
       -DBUILD_UNITTESTS=OFF \
       -DBUILD_BENCHMARKS=OFF \
+      -DCMAKE_CXX_FLAGS=$(CMAKE_CXX_FLAGS) \
       -DNATIVE_SIZE=""" * "$native_size" *
     raw"""
     

--- a/O/OpenFHE_int128/build_tarballs.jl
+++ b/O/OpenFHE_int128/build_tarballs.jl
@@ -13,3 +13,4 @@ sources, script, platforms, products, dependencies = prepare_openfhe_build(name,
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"10.2.0")
+

--- a/O/OpenFHE_int128/build_tarballs.jl
+++ b/O/OpenFHE_int128/build_tarballs.jl
@@ -13,4 +13,3 @@ sources, script, platforms, products, dependencies = prepare_openfhe_build(name,
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"10.2.0")
-

--- a/O/OpenFHE_int128/build_tarballs.jl
+++ b/O/OpenFHE_int128/build_tarballs.jl
@@ -1,6 +1,6 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
-include(joinpath(pwd(), "..", "OpenFHE", "common.jl"))
+include(joinpath(@__DIR__, "..", "OpenFHE", "common.jl"))
 
 # If you make changes in this file, e.g., to release a new version,
 # be sure to also release a new version of `OpenFHE` as well (see `../OpenFHE/build_tarballs.jl`)


### PR DESCRIPTION
As was disscused in #9961, we need to recompile OpenFHE_int128 with additional compiler flag to link with `typeid(__int128)`.