### PR TITLE
[Libffi] Temporary revert to 3.2.2 to build for aarch64-freebsd

### DIFF
--- a/L/Libffi/build_tarballs.jl
+++ b/L/Libffi/build_tarballs.jl
@@ -16,7 +16,16 @@ version = v"3.2.2" # <-- this is a lie, we need to bump the version to require j
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libffi-*/
-atomic_patch -p1 ../patches/*
+atomic_patch -p1 ../patches/0001-libdir-no-touchy.patch
+
+# Required on aarch64-apple-darwin to build with newer versions of LLVM. See:
+# - https://github.com/llvm/llvm-project/issues/72802
+# - Similar issue: https://github.com/libffi/libffi/issues/807
+# - In Julia: https://github.com/JuliaLang/julia/pull/54634
+if [[ ${target} == aarch64-apple-* ]]; then
+    atomic_patch -p1 ../patches/0002-aarch64-llvm18.patch
+fi
+
 update_configure_scripts
 autoreconf -f -i
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static --enable-shared

--- a/L/Libffi/build_tarballs.jl
+++ b/L/Libffi/build_tarballs.jl
@@ -1,32 +1,32 @@
 using BinaryBuilder
 
 name = "Libffi"
-upstream_version = "3.4.6"
-version = VersionNumber(upstream_version)
+version = v"3.2.1"
+
 
 # Collection of sources required to build libffi
 sources = [
-    ArchiveSource("https://github.com/libffi/libffi/releases/download/v$(upstream_version)/libffi-$(upstream_version).tar.gz",
-                  "b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e"),
+    ArchiveSource("https://sourceware.org/pub/libffi/libffi-$(version).tar.gz",
+                  "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37"),
+    DirectorySource("./bundled"),
 ]
+
+version = v"3.2.2" # <-- this is a lie, we need to bump the version to require julia v1.6
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libffi-*/
+atomic_patch -p1 ../patches/*
 update_configure_scripts
-./configure --prefix=${prefix} \
-    --build=${MACHTYPE} \
-    --host=${target} \
-    --disable-static \
-    --enable-shared \
-    --disable-multi-os-directory
+autoreconf -f -i
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static --enable-shared
 make -j${nproc}
 make install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(; experimental=true)
 
 # The products that we will ensure are always built
 products = [
@@ -38,6 +38,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"6")
-
-# Build trigger: 2
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/Libffi/bundled/patches/0001-libdir-no-touchy.patch
+++ b/L/Libffi/bundled/patches/0001-libdir-no-touchy.patch
@@ -1,0 +1,31 @@
+--- libffi-3.2.1-orig/configure.ac	2021-11-18 00:13:42.753131022 -0500
++++ libffi-3.2.1/configure.ac	2021-11-18 00:14:43.014058771 -0500
+@@ -590,26 +590,7 @@
+     AC_DEFINE(USING_PURIFY, 1, [Define this if you are using Purify and want to suppress spurious messages.])
+   fi)
+ 
+-# These variables are only ever used when we cross-build to X86_WIN32.
+-# And we only support this with GCC, so...
+-if test "x$GCC" = "xyes"; then
+-  if test -n "$with_cross_host" &&
+-     test x"$with_cross_host" != x"no"; then
+-    toolexecdir="${exec_prefix}"/'$(target_alias)'
+-    toolexeclibdir="${toolexecdir}"/lib
+-  else
+-    toolexecdir="${libdir}"/gcc-lib/'$(target_alias)'
+-    toolexeclibdir="${libdir}"
+-  fi
+-  multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
+-  case $multi_os_directory in
+-    .) ;; # Avoid trailing /.
+-    ../*) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
+-  esac
+-  AC_SUBST(toolexecdir)
+-else
+-  toolexeclibdir="${libdir}"
+-fi
++toolexeclibdir="${libdir}"
+ AC_SUBST(toolexeclibdir)
+ 
+ AC_CONFIG_COMMANDS(include, [test -d include || mkdir include])
+

--- a/L/Libffi/bundled/patches/0002-aarch64-llvm18.patch
+++ b/L/Libffi/bundled/patches/0002-aarch64-llvm18.patch
@@ -1,0 +1,22 @@
+--- libffi-clean/src/aarch64/sysv.S     2014-11-08 13:47:24.000000000 +0100
++++ libffi-3.2.1/src/aarch64/sysv.S     2024-12-14 13:17:42.329889690 +0100
+@@ -100,8 +100,8 @@
+ 
+ #define ffi_call_SYSV_FS (8 * 4)
+ 
+-        .cfi_startproc
+ CNAME(ffi_call_SYSV):
++        .cfi_startproc
+         stp     x29, x30, [sp, #-16]!
+        cfi_adjust_cfa_offset (16)
+         cfi_rel_offset (x29, 0)
+@@ -247,8 +247,8 @@
+ #ifdef __APPLE__
+         .align 2
+ #endif
+-        .cfi_startproc
+ CNAME(ffi_closure_SYSV):
++    .cfi_startproc
+         stp     x29, x30, [sp, #-16]!
+        cfi_adjust_cfa_offset (16)
+         cfi_rel_offset (x29, 0)


### PR DESCRIPTION
As discussed here: https://github.com/JuliaPackaging/Yggdrasil/pull/10006#discussion_r1885031567

This reverts the following commits:
- "[Libffi] Rebuild for freebsd-aarch64 (#9909)":           670483cc247dba8d14365ff8c001253ca550988d
- "Libffi: Build for aarch64-freebsd (#9782)":              f66e34e1a1469b79237ede7ec283b4460b9e08b3
- "Libffi: New version 3.4.6 (#8275)":                      ff6c5543a8362e0f64c1e215df971d068ca56512
- "[Libffi] Upgrade to v3.4.4 (#5834)":                     cca8463eb26fd4acc357c6cd9f06a7cb1105224d
- ~~"libffi: Stop messing with the install diretory (#3906)": 7629d04b17d885309dd15bcb96e7bc990695a7dd~~

Libffi has a more interesting commit history than Expat so I opted to revert all the commits newer than the change to 3.2.2 to be on the safe side. Interestingly, turns out that the JLL version 3.2.2 is actually building the library version 3.2.1.

EDIT: oops, https://github.com/JuliaPackaging/Yggdrasil/pull/3906 wasn't a version change so that shouldn't have been reverted.