### PR TITLE
upgrade to latest LTS v2.5.19 and set OpenSSL to v3.0.15

### DIFF
--- a/O/OpenLDAPClient/build_tarballs.jl
+++ b/O/OpenLDAPClient/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "OpenLDAPClient"
-version = v"2.5.14"
+version = v"2.5.19"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$(version).tgz",
-                  "577d0ef7b7b2334b5d537318e4369c8dc6b066ebec0cee5cc3ecd8931e1ea76d"),
+                  "56e2936c7169aa7547cfc93d5c87db46aa05e98dee6321590c3ada92e1fbb66c"),
 ]
 
 # Bash recipe for building across all platforms
@@ -83,7 +83,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="1.1.10"),
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15"),
     Dependency(PackageSpec(name="PCRE_jll",  uuid="2f80f16e-611a-54ab-bc61-aa92de5b98fc"); platforms=filter(Sys.iswindows, platforms)),
 ]
 


### PR DESCRIPTION
Hi! Here’s a small update for OpenLDAPClient:

1. The package version has been updated to the current LTS 2.5.19, based on the information from the [OpenLDAP download page](https://www.openldap.org/software/download/)
2. The OpenSSL dependency version has been updated to 3.0.15, which is more compatible with other packages and allowed starting from 2.5.14. Relevant references - [bug tracker](https://bugs.openldap.org/show_bug.cgi?id=10030#c1) and 
[implementation](https://git.openldap.org/openldap/openldap/-/merge_requests/489#ee3f73f86d0c13e4ac673288bb586615f8ef66c2)