### PR TITLE
[snappy] Remove unused dependencies

### DIFF
--- a/S/snappy/build_tarballs.jl
+++ b/S/snappy/build_tarballs.jl
@@ -36,7 +36,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/snappy/build_tarballs.jl
+++ b/S/snappy/build_tarballs.jl
@@ -37,9 +37,6 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="LZO_jll", uuid="dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac")),
-    Dependency(PackageSpec(name="Lz4_jll", uuid="5ced341a-0733-55b8-9ab6-a4889d929147")),
-    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
libsnappy does not need any dependencies. The dependencies are only used for the `snappy_test_tool` binary to compare performance with other compression libraries, but this binary is not being built.