### PR TITLE
[RootFS] Do not link to libquadmath in RISC-V Fortran tests

### DIFF
--- a/0_RootFS/Rootfs/bundled/testsuite/fortran/hello_world/Makefile
+++ b/0_RootFS/Rootfs/bundled/testsuite/fortran/hello_world/Makefile
@@ -6,9 +6,9 @@ include ../../common.mk
 # ppc64le sometimes requires -lm because it's bugged.  It doesn't hurt us to include it, so we do it everywhere
 CFLDFLAGS = -lgfortran -lm
 
-# On armv7l, aarch64 and powerpc64le, libquadmath doesn't exist!
+# On armv7l, aarch64, powerpc64le, and risc-v libquadmath doesn't exist!
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85440
-ifeq (,$(findstring arm-,$(target))$(findstring aarch64,$(target))$(findstring powerpc64le,$(target)))
+ifeq (,$(findstring arm-,$(target))$(findstring aarch64,$(target))$(findstring powerpc64le,$(target))$(findstring riscv,$(target)))
 CFLDFLAGS += -lquadmath
 endif
 


### PR DESCRIPTION
Ref: https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1357#issuecomment-2561141450.