### PR TITLE
update utf8proc to 2.10

### DIFF
--- a/U/utf8proc/build_tarballs.jl
+++ b/U/utf8proc/build_tarballs.jl
@@ -1,12 +1,12 @@
 using BinaryBuilder
 
 name = "utf8proc"
-version = v"2.9.0"
+version = v"2.10.0"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/JuliaStrings/utf8proc.git",
-              "34db3f7954e9298e89f42641ac78e0450f80a70d"),
+              "a1b99daa2a3393884220264c927a48ba1251a9c6"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Updates utf8proc to 2.10, which adds support for Unicode 16.

See also https://github.com/JuliaLang/julia/pull/56925

cc @eschnett 