### PR TITLE
x265: New version 4.1

### DIFF
--- a/X/x265/build_tarballs.jl
+++ b/X/x265/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "x265"
-version = v"4.0"
+version = v"4.1"
 
 # NOTE: The release notes for version 4.0 do not mention any
 # incompatibility with version 3.6. Packages currently using 3.6 might
@@ -12,25 +12,32 @@ version = v"4.0"
 # Collection of sources required to build x265
 sources = [
     GitSource("https://bitbucket.org/multicoreware/x265_git.git",
-              "4ecee600df03bc5c7679d2caf702be9169f41aec"),
+              "32e25ffcf810c5fe284901859b369270824c4596"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/*x265*/
-# Remove `-march` and `-mcpu` flags
-SED_SCRIPTS=(-e  -e -- 's/-mcpu=native //g')
-for CMAKE_FILE in source/CMakeLists.txt source/dynamicHDR10/CMakeLists.txt; do
-    sed -i 's/add_definitions(-march=i686)//g' "${CMAKE_FILE}"
-    sed -i 's/-mcpu=native //g' "${CMAKE_FILE}"
-done
-FLAGS=()
+cd $WORKSPACE/srcdir/*x265*
+
+# x265 builds for multiple architectures, using `-march` and `-mcpu`
+# options, and then dispatches at run time. To support that, we need to
+# (1) Disable the checks for `-march` and `-mcpu` in the compiler wrappers
+# (2) Don't set `-march` or `-mcpu` in the compiler wrappers
+# We still can't have `-march=native` or `-mpcu=native`.
+
+# Disable `-march` checks in our compiler wrappers
+sed -i 's/"-march="/this_will_never_match/g' $(dirname $(which gcc))/*
+# Don't set a default architecture or cpu in our compiler wrappers, x265 wants to do that
+sed -i 's/-m\(arch\|cpu\)=[-+.0-9A-Za-z_]*//g' $(dirname $(which gcc))/*
+
+# Remove `-march=native` and `-mcpu=native` flags in x265
+sed -i 's/-m\(arch\|cpu\)=native//g' source/CMakeLists.txt source/dynamicHDR10/CMakeLists.txt
+
 cmake -S source -B build \
     -DCMAKE_INSTALL_PREFIX="${prefix}" \
     -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
     -DENABLE_PIC=ON \
-    -DENABLE_SHARED=ON \
-    ${FLAGS[@]}
+    -DENABLE_SHARED=ON
 cmake --build build --parallel ${nproc}
 cmake --install build
 # Remove the large static archive
@@ -54,6 +61,6 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-# We need GCC 10 to support the aarch64 assembler intrinsics.
+# We need GCC 12 to support the aarch64 assembler intrinsics.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"10")
+               julia_compat="1.6", preferred_gcc_version=v"12")

--- a/X/x265/build_tarballs.jl
+++ b/X/x265/build_tarballs.jl
@@ -11,13 +11,13 @@ version = v"4.1"
 
 # Collection of sources required to build x265
 sources = [
-    GitSource("https://bitbucket.org/multicoreware/x265_git.git",
-              "32e25ffcf810c5fe284901859b369270824c4596"),
+    GitSource("https://bitbucket.org/multicoreware/x265_git.git", "32e25ffcf810c5fe284901859b369270824c4596"),
+    DirectorySource("bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/*x265*
+cd ${WORKSPACE}/srcdir/x265_git
 
 # x265 builds for multiple architectures, using `-march` and `-mcpu`
 # options, and then dispatches at run time. To support that, we need to
@@ -32,6 +32,8 @@ sed -i 's/-m\(arch\|cpu\)=[-+.0-9A-Za-z_]*//g' $(dirname $(which gcc))/*
 
 # Remove `-march=native` and `-mcpu=native` flags in x265
 sed -i 's/-m\(arch\|cpu\)=native//g' source/CMakeLists.txt source/dynamicHDR10/CMakeLists.txt
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/neon.patch
 
 cmake -S source -B build \
     -DCMAKE_INSTALL_PREFIX="${prefix}" \

--- a/X/x265/bundled/patches/neon.patch
+++ b/X/x265/bundled/patches/neon.patch
@@ -1,0 +1,13 @@
+diff --git a/source/common/cpu.cpp b/source/common/cpu.cpp
+index ae0907890..99095d63e 100644
+--- a/source/common/cpu.cpp
++++ b/source/common/cpu.cpp
+@@ -352,7 +352,7 @@ uint32_t cpu_detect(bool benableavx512)
+ {
+     int flags = 0;
+ 
+-#if HAVE_ARMV6
++#if HAVE_ARMV6 && HAVE_ASSEMBLY
+     flags |= X265_CPU_ARMV6;
+ 
+     // don't do this hack if compiled with -mfpu=neon


### PR DESCRIPTION
x265 builds for multiple architectures, using `-march` and `-mcpu` options, and then dispatches at run time. To support that, we need to
- Disable the checks for `-march` and `-mcpu` in the compiler wrappers
- Don't set `-march` or `-mcpu` in the compiler wrappers

We still disable `-march=native` and `-mpcu=native`.
