### PR TITLE
FlowCutterPACE17: Apple silicon support

### DIFF
--- a/F/FlowCutterPACE17/build_tarballs.jl
+++ b/F/FlowCutterPACE17/build_tarballs.jl
@@ -19,8 +19,7 @@ c++ -o "${bindir}/flow_cutter_pace17${exeext}" -Wall -std=c++11 -O3 -DNDEBUG src
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = filter(p -> arch(p) != "riscv64", supported_platforms())
-platforms = expand_cxxstring_abis(platforms)
+platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [
@@ -32,4 +31,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/F/FlowCutterPACE17/build_tarballs.jl
+++ b/F/FlowCutterPACE17/build_tarballs.jl
@@ -19,7 +19,7 @@ c++ -o "${bindir}/flow_cutter_pace17${exeext}" -Wall -std=c++11 -O3 -DNDEBUG src
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = filter(p -> arch(p) != "riscv64", supported_platforms())
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/F/FlowCutterPACE17/build_tarballs.jl
+++ b/F/FlowCutterPACE17/build_tarballs.jl
@@ -32,4 +32,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.6")

--- a/F/FlowCutterPACE17/build_tarballs.jl
+++ b/F/FlowCutterPACE17/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "FlowCutterPACE17"
-version = v"0.0.1"
+version = v"0.0.2"
 
 # Collection of sources required to complete build
 sources = [

--- a/F/FlowCutterPACE17/build_tarballs.jl
+++ b/F/FlowCutterPACE17/build_tarballs.jl
@@ -11,8 +11,10 @@ sources = [
 ]
 
 # Bash recipe for building across all platforms
+# The second line fixes a missing `include` needed for newer GCC versions.
 script = raw"""
 cd $WORKSPACE/srcdir/flow-cutter-pace17/
+sed -i '/#include <tuple>/a #include <string>' src/list_graph.h
 mkdir -p "${bindir}"
 c++ -o "${bindir}/flow_cutter_pace17${exeext}" -Wall -std=c++11 -O3 -DNDEBUG src/*.cpp
 """


### PR DESCRIPTION
Set `julia_compat = 1.6` so that binaries will be built for Apple silicon.