### PR TITLE
rsync: New version 3.4.0

### DIFF
--- a/R/rsync/build_tarballs.jl
+++ b/R/rsync/build_tarballs.jl
@@ -41,8 +41,9 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-# xxHash is not available for riscv64
+# xxHash is not yet available for riscv64 or aarch64-*-freebsd
 filter!(p -> arch(p) != "riscv64", platforms)
+filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
 # We don't know how to link against OpenSSL (this should be fixable)
 filter!(!Sys.iswindows, platforms)
 

--- a/R/rsync/build_tarballs.jl
+++ b/R/rsync/build_tarballs.jl
@@ -1,14 +1,15 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
+using BinaryBuilderBase: get_addable_spec
 
 name = "rsync"
-version = v"3.3.0"
+version = v"3.4.0"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://download.samba.org/pub/rsync/src/rsync-$(version).tar.gz",
-                  "7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90")
+                  "8e942f95a44226a012fe822faffa6c7fc38c34047add3a0c941e9bc8b8b93aa4")
 ]
 
 # Bash recipe for building across all platforms
@@ -40,6 +41,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
+# xxHash is not available for riscv64
+filter!(p -> arch(p) != "riscv64", platforms)
 # We don't know how to link against OpenSSL (this should be fixable)
 filter!(!Sys.iswindows, platforms)
 
@@ -51,7 +54,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="Lz4_jll", uuid="5ced341a-0733-55b8-9ab6-a4889d929147")),
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.13"),
+    # Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.13"),
+    # Until we have a new version of OpenSSL built for riscv64 we need to use the
+    # `get_addable_spec` hack.  From v3.0.16 we should be able to remove it here.
+    Dependency(get_addable_spec("OpenSSL_jll", v"3.0.15+2"); compat="3.0.15", platforms=filter(p -> !(Sys.iswindows(p) || Sys.isapple(p)), platforms)),
     Dependency(PackageSpec(name="Popt_jll", uuid="e80236cf-ab1d-5f5d-8534-1d1285fe49e8")),
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4")),

--- a/R/rsync/build_tarballs.jl
+++ b/R/rsync/build_tarballs.jl
@@ -41,9 +41,8 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-# xxHash is not yet available for riscv64 or aarch64-*-freebsd
+# Popt_jll is not yet available for riscv64
 filter!(p -> arch(p) != "riscv64", platforms)
-filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
 # We don't know how to link against OpenSSL (this should be fixable)
 filter!(!Sys.iswindows, platforms)
 

--- a/R/rsync/build_tarballs.jl
+++ b/R/rsync/build_tarballs.jl
@@ -57,7 +57,7 @@ dependencies = [
     # Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.13"),
     # Until we have a new version of OpenSSL built for riscv64 we need to use the
     # `get_addable_spec` hack.  From v3.0.16 we should be able to remove it here.
-    Dependency(get_addable_spec("OpenSSL_jll", v"3.0.15+2"); compat="3.0.15", platforms=filter(p -> !(Sys.iswindows(p) || Sys.isapple(p)), platforms)),
+    Dependency(get_addable_spec("OpenSSL_jll", v"3.0.15+2"); compat="3.0.15"),
     Dependency(PackageSpec(name="Popt_jll", uuid="e80236cf-ab1d-5f5d-8534-1d1285fe49e8")),
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4")),


### PR DESCRIPTION
This is a security update https://kb.cert.org/vuls/id/952657.