### PR TITLE
[mmtk_julia] Set the recipe to do a non-moving build of mmtk-julia

### DIFF
--- a/M/mmtk_julia/build_tarballs.jl
+++ b/M/mmtk_julia/build_tarballs.jl
@@ -13,7 +13,8 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/mmtk-julia/
-make release
+# do a non-moving build until we support moving Immix
+MMTK_MOVING=0 make release 
 
 # Install
 install -Dvm 755 "mmtk/target/${rust_target}/release/libmmtk_julia.${dlext}" -t "${libdir}"


### PR DESCRIPTION
By default, the binding does a moving build, but we currently do not support moving objects in Julia. This change makes sure we build and use non-moving Immix instead.