### PR TITLE
[ITK-v5.3.1] ommision of itk minc lib copying resulted in upstream errors

### DIFF
--- a/I/ITK/build_tarballs.jl
+++ b/I/ITK/build_tarballs.jl
@@ -5,7 +5,7 @@ version = v"5.3.1"
 sources = [
     GitSource("https://github.com/InsightSoftwareConsortium/ITK.git", "1fc47c7bec4ee133318c1892b7b745763a17d411")
 ]
-# Bash recipe for building across all platforms
+# Bash recipe for building across all Platforms
 script = raw"""
 if [[ "${target}" == *x86_64-w64-mingw32* ]]; then
     CONFIG=msys2-64

--- a/I/ITK/build_tarballs.jl
+++ b/I/ITK/build_tarballs.jl
@@ -55,6 +55,8 @@ install_license ${WORKSPACE}/srcdir/ITK/LICENSE
 if [[ "${target}" == *x86_64-w64-mingw32* ]]; then
 mkdir -pv ${libdir}
 find "${prefix}/lib" -name "*.${dlext}" -exec mv -v {} ${libdir} \;
+cp $prefix/lib/libitkminc2-5.3.dll $prefix/bin
+cp $prefix/lib/libitkminc2-5.3.dll.a $prefix/bin
 fi
 """
 # These are the platforms we will build for by default, unless further

--- a/I/ITK/build_tarballs.jl
+++ b/I/ITK/build_tarballs.jl
@@ -53,7 +53,6 @@ cmake --install build
 install_license ${WORKSPACE}/srcdir/ITK/LICENSE
 
 if [[ "${target}" == *x86_64-w64-mingw32* ]]; then
-mkdir -p ${prefix}/bin
 cp $prefix/lib/libitkminc2-5.3.dll $prefix/bin
 cp $prefix/lib/libitkminc2-5.3.dll.a $prefix/bin
 mkdir -pv ${libdir}

--- a/I/ITK/build_tarballs.jl
+++ b/I/ITK/build_tarballs.jl
@@ -53,11 +53,11 @@ cmake --install build
 install_license ${WORKSPACE}/srcdir/ITK/LICENSE
 
 if [[ "${target}" == *x86_64-w64-mingw32* ]]; then
-mkdir -pv ${libdir}
-find "${prefix}/lib" -name "*.${dlext}" -exec mv -v {} ${libdir} \;
 mkdir -p ${prefix}/bin
 cp $prefix/lib/libitkminc2-5.3.dll $prefix/bin
 cp $prefix/lib/libitkminc2-5.3.dll.a $prefix/bin
+mkdir -pv ${libdir}
+find "${prefix}/lib" -name "*.${dlext}" -exec mv -v {} ${libdir} \;
 fi
 """
 # These are the platforms we will build for by default, unless further

--- a/I/ITK/build_tarballs.jl
+++ b/I/ITK/build_tarballs.jl
@@ -55,6 +55,7 @@ install_license ${WORKSPACE}/srcdir/ITK/LICENSE
 if [[ "${target}" == *x86_64-w64-mingw32* ]]; then
 mkdir -pv ${libdir}
 find "${prefix}/lib" -name "*.${dlext}" -exec mv -v {} ${libdir} \;
+mkdir -p ${prefix}/bin
 cp $prefix/lib/libitkminc2-5.3.dll $prefix/bin
 cp $prefix/lib/libitkminc2-5.3.dll.a $prefix/bin
 fi


### PR DESCRIPTION
While working on the upstream packages, specifically for the windows platforms, 
I carefully anaylsed the successful PR from last year, and realised the following lines were ommitted for a crucial library : 
```
    cp $prefix/lib/libitkminc2-5.3.dll $prefix/bin
    cp $prefix/lib/libitkminc2-5.3.dll.a $prefix/bin
```

Which are hereby added in this PR .