### PR TITLE
New Recipe: libharu v2.4.4

### DIFF
--- a/L/libharu/build_tarballs.jl
+++ b/L/libharu/build_tarballs.jl
@@ -21,10 +21,7 @@ cmake --build build --target install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("x86_64", "linux"; libc = "glibc")
-]
-
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/L/libharu/build_tarballs.jl
+++ b/L/libharu/build_tarballs.jl
@@ -17,7 +17,7 @@ cmake -B build \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_C_STANDARD="c99"
+    -DCMAKE_C_STANDARD="99"
 cmake --build build --parallel ${nproc}
 cmake --build build --target install
 """

--- a/L/libharu/build_tarballs.jl
+++ b/L/libharu/build_tarballs.jl
@@ -12,8 +12,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd libharu
+cd $WORKSPACE/srcdir/libharu
 mkdir build
 cmake -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-std=c99"
 cmake --build build --parallel ${nproc}

--- a/L/libharu/build_tarballs.jl
+++ b/L/libharu/build_tarballs.jl
@@ -13,7 +13,6 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libharu
-mkdir build
 cmake -B build \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/L/libharu/build_tarballs.jl
+++ b/L/libharu/build_tarballs.jl
@@ -1,0 +1,42 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libharu"
+version = v"2.4.4"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/libharu/libharu.git", "0c598becaadaef8e3d12b883f9fc2864a118c12d")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+cd libharu
+mkdir build
+cmake -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-std=c99"
+cmake --build build --parallel ${nproc}
+cmake --build build --target install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc = "glibc")
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libhpdf", :libhpdf)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
+    Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/libharu/build_tarballs.jl
+++ b/L/libharu/build_tarballs.jl
@@ -14,7 +14,11 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/libharu
 mkdir build
-cmake -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-std=c99"
+cmake -B build \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_STANDARD="c99"
 cmake --build build --parallel ${nproc}
 cmake --build build --target install
 """

--- a/L/libharu/build_tarballs.jl
+++ b/L/libharu/build_tarballs.jl
@@ -25,6 +25,8 @@ cmake --build build --target install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
+#  Cannot find required math library
+filter!(p -> arch(p) != "riscv64", platforms)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
add a pdf-generating library libharu to the julia JLL.

Linux x86_64 glibc only.