### PR TITLE
[GAP_pkg_*] change GAP_lib_jll to a BuildDependency

### DIFF
--- a/G/GAP_pkg/common.jl
+++ b/G/GAP_pkg/common.jl
@@ -42,7 +42,7 @@ function setup_gap_package(gap_version::VersionNumber, gap_lib_version::VersionN
 
     dependencies = BinaryBuilder.AbstractDependency[
         Dependency("GAP_jll", gap_version; compat="~$(gap_version)"),
-        Dependency("GAP_lib_jll", gap_lib_version; compat="~$(gap_lib_version)"),
+        BuildDependency(PackageSpec(name="GAP_lib_jll", version=gap_lib_version)),
     ]
 
     return platforms, dependencies


### PR DESCRIPTION
Logically the code in these packages only depends on the GAP kernel ABI, and hence GAP_jll, but not on the library code in GAP_lib_jll. Decoupling these make it easier to perform various upgrades. See also #10309 for some background.

This changes has no effect yet, but the next time we update any of the GAP_pkg_* JLLs we will see the benefit.

CC @lgoettgens @ThomasBreuer