### PR TITLE
[GAP_pkg_*] omit gap_lib_version

### DIFF
--- a/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "Browse"
 upstream_version = "1.8.21" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -38,7 +37,7 @@ install_license /usr/share/licenses/GPL-3.0+
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "cddinterface"
 upstream_version = "2024.09.02" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -30,7 +29,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 append!(dependencies, [
     Dependency("GMP_jll", v"6.2.0"),

--- a/G/GAP_pkg/GAP_pkg_crypting/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_crypting/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "crypting"
 upstream_version = "0.10.5" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_curlinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_curlinterface/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "curlinterface"
 upstream_version = "2.4.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -30,7 +29,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 append!(dependencies, [
     Dependency("LibCURL_jll"; compat="7.73,8"),

--- a/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "cvec"
 upstream_version = "2.8.2" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "datastructures"
 upstream_version = "0.3.1" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_deepthought/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_deepthought/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "deepthought"
 upstream_version = "1.0.7" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "digraphs"
 upstream_version = "1.9.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_edim/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_edim/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "EDIM"
 upstream_version = "1.3.8" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -40,7 +39,7 @@ install_license GPL
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_ferret/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_ferret/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "ferret"
 upstream_version = "1.0.14" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/G/GAP_pkg/GAP_pkg_float/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_float/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "float"
 upstream_version = "1.0.5" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -30,7 +29,7 @@ install_license COPYING
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 platforms = expand_cxxstring_abis(platforms)
 
 append!(dependencies, [

--- a/G/GAP_pkg/GAP_pkg_gauss/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_gauss/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "gauss"
 upstream_version = "2024.11-01" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_io/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_io/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "io"
 upstream_version = "4.9.1" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_json/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_json/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "json"
 upstream_version = "2.2.2" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -10,7 +10,6 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "JuliaInterface"
 upstream_version = "0.13.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -38,7 +37,7 @@ install_license ../../LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # expand julia platforms
 include("../../../L/libjulia/common.jl")
@@ -68,7 +67,6 @@ end
 # is easy as it only requires a change to GAP.jl, not to any JLLs.
 dependencies = [
     Dependency("GAP_jll", gap_version),
-    Dependency("GAP_lib_jll", gap_lib_version),
     BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.13")),
 ]
 

--- a/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "NormalizInterface"
 upstream_version = "1.3.7" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 platforms = expand_cxxstring_abis(platforms)
 
 push!(dependencies, Dependency("normaliz_jll", compat = "~300.1000.200"))

--- a/G/GAP_pkg/GAP_pkg_orb/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_orb/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "orb"
 upstream_version = "4.9.1" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_profiling/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_profiling/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "profiling"
 upstream_version = "2.6.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -29,7 +28,7 @@ install_license COPYRIGHT
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "semigroups"
 upstream_version = "5.4.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -47,7 +46,7 @@ install_license LICENSE
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built

--- a/G/GAP_pkg/GAP_pkg_zeromqinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_zeromqinterface/build_tarballs.jl
@@ -3,7 +3,6 @@
 include("../common.jl")
 
 gap_version = v"400.1400.0"
-gap_lib_version = v"400.1400.0"
 name = "zeromqinterface"
 upstream_version = "0.16" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
@@ -31,7 +30,7 @@ cp bin/*/*.so ${prefix}/lib/gap/
 """
 
 name = gap_pkg_name(name)
-platforms, dependencies = setup_gap_package(gap_version, gap_lib_version)
+platforms, dependencies = setup_gap_package(gap_version)
 
 append!(dependencies, [
     Dependency("ZeroMQ_jll"),

--- a/G/GAP_pkg/common.jl
+++ b/G/GAP_pkg/common.jl
@@ -29,7 +29,7 @@ function gap_pkg_name(name::String)
     return "GAP_pkg_$(lowercase(name))"
 end
 
-function setup_gap_package(gap_version::VersionNumber, gap_lib_version::VersionNumber = gap_version)
+function setup_gap_package(gap_version::VersionNumber)
 
     platforms = supported_platforms()
     filter!(p -> nbits(p) == 64, platforms) # we only care about 64bit builds
@@ -42,7 +42,6 @@ function setup_gap_package(gap_version::VersionNumber, gap_lib_version::VersionN
 
     dependencies = BinaryBuilder.AbstractDependency[
         Dependency("GAP_jll", gap_version; compat="~$(gap_version)"),
-        BuildDependency(PackageSpec(name="GAP_lib_jll", version=gap_lib_version)),
     ]
 
     return platforms, dependencies


### PR DESCRIPTION
... it is not actually needed for building the C/C++ code
of these packages.

No need to rebuild anything just now but good to have this
in place for the next update.

[skip build] [skip ci]
