### PR TITLE
[libzenohc] Update to 1.2.0

### DIFF
--- a/L/libzenohc/build_tarballs.jl
+++ b/L/libzenohc/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "libzenohc"
-version = v"1.1.1"
+version = v"1.2.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/eclipse-zenoh/zenoh-c.git", "1c9f89bfe3b3f2ddb55231659179c333b2b4a63f")
+    GitSource("https://github.com/eclipse-zenoh/zenoh-c.git", "3e8b75279b4943653d95a4f4a302abe8cf8d9eed")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Simple update to version 1.2.0, no build script changes required.