### PR TITLE
[CUDNN] Changed CUDNN to package v8.9.7

### DIFF
--- a/C/CUDA/CUDNN@8/build_tarballs.jl
+++ b/C/CUDA/CUDNN@8/build_tarballs.jl
@@ -8,7 +8,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDNN"
-version = v"8.9.6"
+version = v"8.9.7"
 
 script = raw"""
 mkdir -p ${libdir} ${prefix}/include


### PR DESCRIPTION
The diff from the most recent commit to package CUDNN v8, 8af09247b430da171d9a2096a150d980d7196db8, is minimal.

Required for #10418.