### PR TITLE
[TensorRT] Changed to package v10.7.0

### DIFF
--- a/T/TensorRT/build_cuda+11.jl
+++ b/T/TensorRT/build_cuda+11.jl
@@ -1,8 +1,8 @@
 platforms_and_sources = Dict(
     Platform("x86_64", "linux") => [
-        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.5.0/tars/TensorRT-10.5.0.18.Linux.x86_64-gnu.cuda-11.8.tar.gz",
-                      "ca37e6752e8182173aa18051a21c3082f8fdcb9995951e0ed0a8c2395f6f77b3")],
+        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/tars/TensorRT-10.7.0.23.Linux.x86_64-gnu.cuda-11.8.tar.gz",
+                      "958e1c32b48e41d1c48bdc94363450e14f996ca9de0e205ccee65af319eea2c0")],
     Platform("x86_64", "windows") => [
-        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.5.0/zip/TensorRT-10.5.0.18.Windows.win10.cuda-11.8.zip",
-                      "9e83c1c877ee9b36e916adaaf8af009c6bddc05529b7f8ad0e8a39f582d92f93")],
+        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/zip/TensorRT-10.7.0.23.Windows.win10.cuda-11.8.zip",
+                      "fd6ec60f8fc48cdd050fbcc632473b42c28a217f0ec44e0177c4cc9a18c77af8")],
 )

--- a/T/TensorRT/build_cuda+12.jl
+++ b/T/TensorRT/build_cuda+12.jl
@@ -1,14 +1,14 @@
 platforms_and_sources = Dict(
     Platform("aarch64", "linux"; cuda_platform="jetson") => [
-        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.5.0/tars/TensorRT-10.5.0.18.l4t.aarch64-gnu.cuda-12.6.tar.gz",
-                      "9f039b38db99dc0ff8994dab3b71653faca6a1a4f42bbe13140c679072d7b5cb")],
+        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/tars/TensorRT-10.7.0.23.l4t.aarch64-gnu.cuda-12.6.tar.gz",
+                      "b3028a82818a9daf6296f43d0cdecfa51eaea4552ffb6fe6fad5e6e1aea44da6")],
     Platform("aarch64", "linux"; cuda_platform="sbsa") => [
-        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.5.0/tars/TensorRT-10.5.0.18.Ubuntu-24.04.aarch64-gnu.cuda-12.6.tar.gz",
-                      "c306bb5d01e496fc20728d3a1a30731f6f1a7c33f92a2726ff2cc8e110906683")],
+        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/tars/TensorRT-10.7.0.23.Ubuntu-24.04.aarch64-gnu.cuda-12.6.tar.gz",
+                      "6b304cf014f2977e845bd44fdb343f0e7af2d9cded997bc9cfea3949d9e84dcb")],
     Platform("x86_64", "linux") => [
-        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.5.0/tars/TensorRT-10.5.0.18.Linux.x86_64-gnu.cuda-12.6.tar.gz",
-                      "f404d379d639552a3e026cd5267213bd6df18a4eb899d6e47815bbdb34854958")],
+        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/tars/TensorRT-10.7.0.23.Linux.x86_64-gnu.cuda-12.6.tar.gz",
+                      "d7f16520457caaf97ad8a7e94d802f89d77aedf9f361a255f2c216e2a3a40a11")],
     Platform("x86_64", "windows") => [
-        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.5.0/zip/TensorRT-10.5.0.18.Windows.win10.cuda-12.6.zip",
-                      "e6436f4164db4e44d727354dccf7d93755efb70d6fbfd6fa95bdfeb2e7331b24")],
+        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/zip/TensorRT-10.7.0.23.Windows.win10.cuda-12.6.zip",
+                      "fbdef004578e7ccd5ee51fe7f846b57422364a743372fd8f9f1d7dbd33f62879")],
 )

--- a/T/TensorRT/build_cuda+12.jl
+++ b/T/TensorRT/build_cuda+12.jl
@@ -3,7 +3,7 @@ platforms_and_sources = Dict(
         ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/tars/TensorRT-10.7.0.23.l4t.aarch64-gnu.cuda-12.6.tar.gz",
                       "b3028a82818a9daf6296f43d0cdecfa51eaea4552ffb6fe6fad5e6e1aea44da6")],
     Platform("aarch64", "linux"; cuda_platform="sbsa") => [
-        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/tars/TensorRT-10.7.0.23.Ubuntu-24.04.aarch64-gnu.cuda-12.6.tar.gz",
+        ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/tars/TensorRT-10.7.0.23.Linux.aarch64-gnu.cuda-12.6.tar.gz",
                       "6b304cf014f2977e845bd44fdb343f0e7af2d9cded997bc9cfea3949d9e84dcb")],
     Platform("x86_64", "linux") => [
         ArchiveSource("https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.7.0/tars/TensorRT-10.7.0.23.Linux.x86_64-gnu.cuda-12.6.tar.gz",

--- a/T/TensorRT/build_tarballs.jl
+++ b/T/TensorRT/build_tarballs.jl
@@ -6,7 +6,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "TensorRT"
-version = v"10.5.0"
+version = v"10.7.0"
 
 cuda_versions = [
     v"11",


### PR DESCRIPTION
v10.8.0 bumps the minium glibc version for Linux x86_64 from 2.17 to 2.28: https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-1070/release-notes/index.html#rel-10-7-0