### PR TITLE
[GAP_pkg_*] Rebuild for julia 1.13-DEV (group 1)

### DIFF
--- a/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.3"
 name = "Browse"
 upstream_version = "1.8.21" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.3"
 name = "cddinterface"
 upstream_version = "2024.09.02" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build libsingular-julia

--- a/G/GAP_pkg/GAP_pkg_crypting/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_crypting/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.3"
 name = "crypting"
 upstream_version = "0.10.5" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_curlinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_curlinterface/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.3"
 name = "curlinterface"
 upstream_version = "2.4.0" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build libsingular-julia

--- a/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.3"
 name = "cvec"
 upstream_version = "2.8.2" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.3"
 name = "datastructures"
 upstream_version = "0.3.1" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_deepthought/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_deepthought/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.3"
 name = "deepthought"
 upstream_version = "1.0.7" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -6,8 +6,8 @@ using SHA
 using GZip
 
 upstream_version = v"4.14.0"
-gap_version = v"400.1400.000"
-gap_lib_version = v"400.1400.000"
+gap_version = v"400.1400.003"
+gap_lib_version = v"400.1400.003"
 
 function download_with_sha256(url)
     io = IOBuffer()


### PR DESCRIPTION
I have split all the GAP_pkg_*_jlls up into four groups with approximately the same number of build jobs, with the goal to not have to rebuild everything if there is some random failure in one of the builds.

The groups are:
- `browse` - `deepthought` (alphabetically): here
- `digraphs` - `io`: https://github.com/JuliaPackaging/Yggdrasil/pull/10454
- `juliainterface`: https://github.com/JuliaPackaging/Yggdrasil/pull/10440
- `json` - `zeromqinterface`: https://github.com/JuliaPackaging/Yggdrasil/pull/10455

cc @fingolfin 