### PR TITLE
[CImGuiPack] Bump to build for Julia 1.13

### DIFF
--- a/C/CImGuiPack/build_tarballs.jl
+++ b/C/CImGuiPack/build_tarballs.jl
@@ -10,7 +10,7 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 include("../../L/libjulia/common.jl")
 
 name = "CImGuiPack"
-version = v"0.8.1"
+version = v"0.8.0"
 
 # Collection of sources required to build CImGuiPack
 sources = [

--- a/C/CImGuiPack/build_tarballs.jl
+++ b/C/CImGuiPack/build_tarballs.jl
@@ -10,7 +10,7 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 include("../../L/libjulia/common.jl")
 
 name = "CImGuiPack"
-version = v"0.8.0"
+version = v"0.8.1"
 
 # Collection of sources required to build CImGuiPack
 sources = [
@@ -75,9 +75,9 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.13")),
+    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.15")),
     Dependency("GLFW_jll"),
-    Dependency("libcxxwrap_julia_jll"; compat="0.13.3")
+    Dependency("libcxxwrap_julia_jll"; compat="0.13.4")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
After #10437 was merged CI failed on Julia 1.13 and that caused registration to be blocked: https://buildkite.com/julialang/yggdrasil/builds/17275#_

But libcxxwrap is now built for 1.13 so the build should succeed: #10441.