### PR TITLE
[LLVM] Bump to v19.1.7+0

### DIFF
--- a/L/LLVM/LLVM_full@19/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@19/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 7
+# Build trigger: 8

--- a/L/LLVM/LLVM_full@19/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@19/build_tarballs.jl
@@ -1,7 +1,7 @@
-version = v"19.1.1"
+version = v"19.1.7"
 
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"18", julia_compat="1.6")
+               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
 # Build trigger: 7

--- a/L/LLVM/LLVM_full_assert@19/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@19/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 8
+# Build trigger: 9

--- a/L/LLVM/LLVM_full_assert@19/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@19/build_tarballs.jl
@@ -1,7 +1,7 @@
-version = v"19.1.1"
+version = v"19.1.7"
 
 include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"18", julia_compat="1.6")
+               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
 # Build trigger: 8

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -20,7 +20,7 @@ const llvm_tags = Dict(
     v"16.0.6" => "499f87882a4ba1837ec12a280478cf4cb0d2753d", # julia-16.0.6-2
     v"17.0.6" => "0007e48608221f440dce2ea0d3e4f561fc10d3c6", # julia-17.0.6-5
     v"18.1.7" => "ed30d043a240d06bb6e010a41086e75713156f4f", # julia-18.1.7-2
-    v"19.1.1" => "6e8ff5767e9466d73be85f1eaa760e2c94cdbd86", # julia-19.1.7-0
+    v"19.1.7" => "6e8ff5767e9466d73be85f1eaa760e2c94cdbd86", # julia-19.1.7-0
 )
 
 const buildscript = raw"""

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -20,7 +20,7 @@ const llvm_tags = Dict(
     v"16.0.6" => "499f87882a4ba1837ec12a280478cf4cb0d2753d", # julia-16.0.6-2
     v"17.0.6" => "0007e48608221f440dce2ea0d3e4f561fc10d3c6", # julia-17.0.6-5
     v"18.1.7" => "ed30d043a240d06bb6e010a41086e75713156f4f", # julia-18.1.7-2
-    v"19.1.7" => "6e8ff5767e9466d73be85f1eaa760e2c94cdbd86", # julia-19.1.7-0
+    v"19.1.7" => "3cb75bacf7f61380a4ef45fef519c2fb5940dd4a", # julia-19.1.7-0
 )
 
 const buildscript = raw"""

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -20,7 +20,7 @@ const llvm_tags = Dict(
     v"16.0.6" => "499f87882a4ba1837ec12a280478cf4cb0d2753d", # julia-16.0.6-2
     v"17.0.6" => "0007e48608221f440dce2ea0d3e4f561fc10d3c6", # julia-17.0.6-5
     v"18.1.7" => "ed30d043a240d06bb6e010a41086e75713156f4f", # julia-18.1.7-2
-    v"19.1.1" => "49c6812e2c4624a7f0cee34859a0511209f44b67", # julia-19.1.1-1
+    v"19.1.1" => "6e8ff5767e9466d73be85f1eaa760e2c94cdbd86", # julia-19.1.7-0
 )
 
 const buildscript = raw"""


### PR DESCRIPTION
Also switch clang back to v16 for compilation as that seems to be faster.
