### PR TITLE
[ITK-v5.3.2] Finally fixed windows minc error

### DIFF
--- a/I/ITK/build_tarballs.jl
+++ b/I/ITK/build_tarballs.jl
@@ -1,6 +1,6 @@
 using BinaryBuilder, Pkg
 name = "ITK"
-version = v"5.3.1"
+version = v"5.3.2"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/InsightSoftwareConsortium/ITK.git", "1fc47c7bec4ee133318c1892b7b745763a17d411")
@@ -49,8 +49,8 @@ cmake --install build
 install_license ${WORKSPACE}/srcdir/ITK/LICENSE
 
 if [[ "${target}" == *x86_64-w64-mingw32* ]]; then
-mkdir -pv ${libdir}
-find "${prefix}/lib" -name "*.${dlext}" -exec mv -v {} ${libdir} \;
+    cp $prefix/lib/libitkminc2-5.3.dll $prefix/bin
+    cp $prefix/lib/libitkminc2-5.3.dll.a $prefix/bin
 fi
 """
 # These are the platforms we will build for by default, unless further

--- a/I/ITK/build_tarballs.jl
+++ b/I/ITK/build_tarballs.jl
@@ -5,7 +5,12 @@ version = v"5.3.2"
 sources = [
     GitSource("https://github.com/InsightSoftwareConsortium/ITK.git", "1fc47c7bec4ee133318c1892b7b745763a17d411")
 ]
-# Bash recipe for building across all Platforms
+# Bash recipe for building across all platforms
+
+# [windows] The libitkminc2-5.3.dll and libitkminc2-5.3.dll.a results in CMAKE configuration errors upstream unless they are copied to $prefix/bin
+# [windows] Specifically CMAKe produces the following error which is eliminated by copying: 
+#  the imported target itkminc2 references the file 
+#  "/opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/usr/local/lib/libitkminc2-5.3.dll" but this file does not exist
 script = raw"""
 if [[ "${target}" == *x86_64-w64-mingw32* ]]; then
     CONFIG=msys2-64
@@ -53,6 +58,8 @@ if [[ "${target}" == *x86_64-w64-mingw32* ]]; then
     cp $prefix/lib/libitkminc2-5.3.dll.a $prefix/bin
 fi
 """
+# Fixing itkminc2 reference error on windows platforms with above
+
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()


### PR DESCRIPTION
Hello, So after weeks of head butting, I finally realised the minc error is only and only resolved if we standalone copy the libitkminc2 dll files in the bin directory for windows platforms.

Hoping to get this merged, this is the last time , since i tested it and it works like a charm with the upstream package.

Also, changed the package version to ensure compat bounds.

I tried everything but the only solution for libitkminc2 error in Cmake configuration on windows was copying both the dll files within the 
$prefix/bin directory.