### PR TITLE
Add recipe for the LLVM SPIR-V back-end.

### DIFF
--- a/S/SPIRV_LLVM_Backend/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Backend/build_tarballs.jl
@@ -1,0 +1,93 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "SPIRV_LLVM_Backend"
+version = v"19"
+
+# Collection of sources required to build SPIRV_LLVM_Backend
+sources = [
+    # LLVM v19.1.7
+    GitSource("https://github.com/llvm/llvm-project",
+              "cd708029e0b2869e80abe31ddb175f7c35361f90"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd llvm-project/llvm
+LLVM_SRCDIR=$(pwd)
+
+install_license LICENSE.TXT
+
+# The very first thing we need to do is to build llvm-tblgen for x86_64-linux-muslc
+# This is because LLVM's cross-compile setup is kind of borked, so we just
+# build the tools natively ourselves, directly.  :/
+
+# Build llvm-tblgen and llvm-config
+mkdir ${WORKSPACE}/bootstrap
+pushd ${WORKSPACE}/bootstrap
+CMAKE_FLAGS=()
+CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD:STRING=host)
+CMAKE_FLAGS+=(-DLLVM_HOST_TRIPLE=${MACHTYPE})
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='llvm')
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING=False)
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_HOST_TOOLCHAIN})
+cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]}
+ninja -j${nproc} llvm-tblgen llvm-config
+popd
+
+# Let's do the actual build within the `build` subdirectory
+mkdir ${WORKSPACE}/build && cd ${WORKSPACE}/build
+CMAKE_FLAGS=()
+
+# Tell LLVM where our pre-built tblgen tools are
+CMAKE_FLAGS+=(-DLLVM_TABLEGEN=${WORKSPACE}/bootstrap/bin/llvm-tblgen)
+CMAKE_FLAGS+=(-DLLVM_CONFIG_PATH=${WORKSPACE}/bootstrap/bin/llvm-config)
+
+# Install things into $prefix
+CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+
+# Explicitly use our cmake toolchain file and tell CMake we're cross-compiling
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
+
+# Release build for best performance
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+
+# Only build the SPIR-V back-end
+CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD=)
+CMAKE_FLAGS+=(-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV)
+
+# Turn on ZLIB
+CMAKE_FLAGS+=(-DLLVM_ENABLE_ZLIB=ON)
+# Turn off XML2
+CMAKE_FLAGS+=(-DLLVM_ENABLE_LIBXML2=OFF)
+
+# Disable useless things like docs, terminfo, etc....
+CMAKE_FLAGS+=(-DLLVM_INCLUDE_DOCS=Off)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_TERMINFO=Off)
+CMAKE_FLAGS+=(-DHAVE_HISTEDIT_H=Off)
+CMAKE_FLAGS+=(-DHAVE_LIBEDIT=Off)
+
+cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]}
+ninja -j${nproc} tools/llc/install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = Product[
+    ExecutableProduct("llc", :llc),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Zlib_jll")
+]
+
+build_tarballs(ARGS, name, version, sources, script,
+               platforms, products, dependencies;
+               preferred_gcc_version=v"10", julia_compat="1.6")

--- a/S/SPIRV_LLVM_Backend/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Backend/build_tarballs.jl
@@ -9,12 +9,15 @@ version = v"20"
 sources = [
     ArchiveSource("https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.0-rc1/llvm-project-20.1.0-rc1.src.tar.xz",
                   "5f8653a2ffb59febd07d816778efe0dfc7a3d55f65b4213399608535d7bdc9a2"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd llvm-project-*/llvm
 LLVM_SRCDIR=$(pwd)
+
+atomic_patch -p1 $WORKSPACE/srcdir/patches/avoid_builtin_available.patch
 
 install_license LICENSE.TXT
 

--- a/S/SPIRV_LLVM_Backend/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Backend/build_tarballs.jl
@@ -7,14 +7,13 @@ version = v"19"
 
 # Collection of sources required to build SPIRV_LLVM_Backend
 sources = [
-    # LLVM v19.1.7
-    GitSource("https://github.com/llvm/llvm-project",
-              "cd708029e0b2869e80abe31ddb175f7c35361f90"),
+    ArchiveSource("https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/llvm-project-19.1.7.src.tar.xz",
+                  "82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd llvm-project/llvm
+cd llvm-project-*/llvm
 LLVM_SRCDIR=$(pwd)
 
 install_license LICENSE.TXT

--- a/S/SPIRV_LLVM_Backend/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Backend/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "SPIRV_LLVM_Backend"
-version = v"19"
+version = v"20"
 
 # Collection of sources required to build SPIRV_LLVM_Backend
 sources = [
-    ArchiveSource("https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/llvm-project-19.1.7.src.tar.xz",
-                  "82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501"),
+    ArchiveSource("https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.0-rc1/llvm-project-20.1.0-rc1.src.tar.xz",
+                  "5f8653a2ffb59febd07d816778efe0dfc7a3d55f65b4213399608535d7bdc9a2"),
 ]
 
 # Bash recipe for building across all platforms
@@ -55,8 +55,7 @@ CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
 CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
 
 # Only build the SPIR-V back-end
-CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD=)
-CMAKE_FLAGS+=(-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV)
+CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD=SPIRV)
 
 # Turn on ZLIB
 CMAKE_FLAGS+=(-DLLVM_ENABLE_ZLIB=ON)

--- a/S/SPIRV_LLVM_Backend/bundled/patches/avoid_builtin_available.patch
+++ b/S/SPIRV_LLVM_Backend/bundled/patches/avoid_builtin_available.patch
@@ -1,0 +1,11 @@
+--- a/lib/Support/Unix/Path.inc
++++ b/lib/Support/Unix/Path.inc
+@@ -1487,7 +1487,7 @@
+   std::string FromS = From.str();
+   std::string ToS = To.str();
+ #if __has_builtin(__builtin_available)
+-  if (__builtin_available(macos 10.12, *)) {
++  {
+     // Optimistically try to use clonefile() and handle errors, rather than
+     // calling stat() to see if it'll work.
+     //


### PR DESCRIPTION
To check if it's possible to move from https://github.com/KhronosGroup/SPIRV-LLVM-Translator to LLVM proper.

Doesn't need platform augmentations, because I'd like to simply use the latest version of the back-end possible. This works as long as we statically link `libLLVM`, but may still pose problems when there's IR incompatibilities that can't get auto-upgraded.

cc @vchuravy 