### PR TITLE
[ITKIOWrapper-win-mac-v3.0.0] The holy grail for MedEye3d

### DIFF
--- a/I/ITKIOWrapper/build_tarballs.jl
+++ b/I/ITKIOWrapper/build_tarballs.jl
@@ -1,7 +1,7 @@
 # Note: this script will require BinaryBuilder.jl v0.3.0 or greater
 using BinaryBuilder, Pkg
 name = "ITKIOWrapper"
-version = v"2.0.0"
+version = v"3.0.0"
 # Collection of sources required to build ITKWrapper
 sources = [
     DirectorySource("./src"),
@@ -18,15 +18,19 @@ julia_versions = filter(v-> v >= v"1.10", julia_versions)
 
 # Bash recipe for building across all platforms
 script = raw"""
-export CXXFLAGS="-I${includedir}/julia $CXXFLAGS"
-export CFLAGS="-I${includedir}/julia $CFLAGS"
+export CXXFLAGS="-I${includedir}/julia -DITK_LEGACY_REMOVE=OFF ${CXXFLAGS}"
+export CFLAGS="-I${includedir}/julia ${CFLAGS}"
 mkdir -p build/
 cmake -B build -S . \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DBUILD_SHARED_LIBS:BOOL=ON \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DITK_LEGACY_REMOVE=OFF \
+    -DITK_BUILD_TESTING=OFF \
+    -DBUILD_TESTING=OFF \
+    -DITK_SKIP_PATH_LENGTH_CHECKS=ON
 
 cmake --build build --parallel ${nproc}
 cmake --install build
@@ -40,7 +44,6 @@ filter!(p -> !(arch(p) == "i686"), platforms)
 filter!(!Sys.isfreebsd, platforms)
 filter!(p -> !(arch(p) == "x86_64" && libc(p) == "musl"), platforms)
 filter!(p -> !(arch(p) == "riscv64"), platforms)
-filter!(!Sys.iswindows, platforms)
 
 # Expand C++ string ABI platforms
 platforms = expand_cxxstring_abis(platforms)
@@ -52,7 +55,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     BuildDependency(PackageSpec(name="Eigen_jll", uuid="bc6bbf8a-a594-5541-9c57-10b0d0312c70")),
-    Dependency(PackageSpec(name="ITK_jll", uuid="3324d3a8-621a-5aaa-97fa-c3bc8dfc0481"); compat="5.3.1"),
+    Dependency(PackageSpec(name="ITK_jll", uuid="3324d3a8-621a-5aaa-97fa-c3bc8dfc0481"); compat="5.3.2"),
     Dependency(PackageSpec(name="libcxxwrap_julia_jll", uuid="3eaa8342-bff7-56a5-9981-c04077f7cee7"); compat = "0.13.4"),
     BuildDependency(PackageSpec(name="libjulia_jll", uuid="5ad3ddd2-0711-543a-b040-befd59781bbf"))
 ]

--- a/I/ITKIOWrapper/src/CMakeLists.txt
+++ b/I/ITKIOWrapper/src/CMakeLists.txt
@@ -7,9 +7,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
-endif()
+  endif()
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DITK_LEGACY_REMOVE=OFF")
+set(ITK_BUILD_TESTING OFF)
+set(BUILD_TESTING OFF)
 
 find_package(JlCxx)
 include_directories(${JlCxx_INCLUDE_DIRS})
@@ -33,7 +36,6 @@ set(ITK_COMPONENTS
     ITKImageIO
 )
 
-# Add HDF5 find package before ITK
 find_package(HDF5 REQUIRED COMPONENTS CXX C HL)
 find_package(ITK REQUIRED COMPONENTS ${ITK_COMPONENTS})
 include(${ITK_USE_FILE})
@@ -43,12 +45,11 @@ message(STATUS "Found ITK at ${ITK_USE_FILE}")
 add_library(ITKIOWrapper SHARED itklib.cpp)
 
 target_link_libraries(ITKIOWrapper
-    PUBLIC
-    JlCxx::cxxwrap_julia
-    ${ITK_LIBRARIES}
+  PUBLIC
+  JlCxx::cxxwrap_julia
+  ${ITK_LIBRARIES}
 )
 
-# Add include directories explicitly
 target_include_directories(ITKIOWrapper
     PUBLIC
     ${JlCxx_INCLUDE_DIRS}


### PR DESCRIPTION
Backend Wrapper library that supports : 

-- Loading of NIfTI file formats
-- Loading of DICOM file formats
-- Provides spatial metadata
-- Provides voxel data 
-- Writes Nifti file formats
-- Writes Dicom file formats
-- Reorients to a default LPS orientation 

Supported on - Windows, Linux and Mac