### PR TITLE
cuQuantum: Bump to 24.11.0

### DIFF
--- a/C/CUDA/cuQuantum/build_tarballs.jl
+++ b/C/CUDA/cuQuantum/build_tarballs.jl
@@ -37,7 +37,8 @@ products = [
 ]
 
 platforms = [Platform("x86_64", "linux"),
-    Platform("aarch64", "linux")]
+    Platform("aarch64", "linux"; cuda_platform="jetson"),
+    Platform("aarch64", "linux"; cuda_platform="sbsa")]
 
 builds = []
 for cuda_version in [v"11", v"12"], platform in platforms

--- a/C/CUDA/cuQuantum/build_tarballs.jl
+++ b/C/CUDA/cuQuantum/build_tarballs.jl
@@ -37,7 +37,6 @@ products = [
 ]
 
 platforms = [Platform("x86_64", "linux"),
-    Platform("aarch64", "linux"; cuda_platform="jetson"),
     Platform("aarch64", "linux"; cuda_platform="sbsa")]
 
 builds = []

--- a/C/CUDA/cuQuantum/build_tarballs.jl
+++ b/C/CUDA/cuQuantum/build_tarballs.jl
@@ -8,7 +8,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "cuQuantum"
-version_str = "24.03.0"
+version_str = "24.11.0"
 version = VersionNumber(version_str)
 
 # Bash recipe for building across all platforms
@@ -33,11 +33,12 @@ dependencies = [
 products = [
     LibraryProduct("libcustatevec", :libcustatevec),
     LibraryProduct("libcutensornet", :libcutensornet),
+    LibraryProduct("libcutensornet", :libcudensitymat),
 ]
 
 platforms = [Platform("x86_64", "linux"),
-             Platform("powerpc64le", "linux"),
-             Platform("aarch64", "linux")]
+    Platform("powerpc64le", "linux"),
+    Platform("aarch64", "linux")]
 
 builds = []
 for cuda_version in [v"11", v"12"], platform in platforms
@@ -46,7 +47,7 @@ for cuda_version in [v"11", v"12"], platform in platforms
     should_build_platform(triplet(augmented_platform)) || continue
 
     sources = get_sources("cuquantum", ["cuquantum"]; version=version_str, platform,
-                          variant="cuda$(cuda_version.major)")
+        variant="cuda$(cuda_version.major)")
 
     push!(builds, (; platforms=[augmented_platform], sources))
 end
@@ -58,9 +59,9 @@ non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
 # `--register` should only be passed to the latest `build_tarballs` invocation
 non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
 
-for (i,build) in enumerate(builds)
+for (i, build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
-                   name, version, build.sources, script,
-                   build.platforms, products, dependencies;
-                   julia_compat="1.6", augment_platform_block, dont_dlopen=true)
+        name, version, build.sources, script,
+        build.platforms, products, dependencies;
+        julia_compat="1.6", augment_platform_block, dont_dlopen=true)
 end

--- a/C/CUDA/cuQuantum/build_tarballs.jl
+++ b/C/CUDA/cuQuantum/build_tarballs.jl
@@ -37,7 +37,6 @@ products = [
 ]
 
 platforms = [Platform("x86_64", "linux"),
-    Platform("powerpc64le", "linux"),
     Platform("aarch64", "linux")]
 
 builds = []

--- a/C/CUDA/cuQuantum/build_tarballs.jl
+++ b/C/CUDA/cuQuantum/build_tarballs.jl
@@ -33,7 +33,7 @@ dependencies = [
 products = [
     LibraryProduct("libcustatevec", :libcustatevec),
     LibraryProduct("libcutensornet", :libcutensornet),
-    LibraryProduct("libcutensornet", :libcudensitymat),
+    LibraryProduct("libcudensitymat", :libcudensitymat),
 ]
 
 platforms = [Platform("x86_64", "linux"),


### PR DESCRIPTION
Update to the latest stable release of cuQuantum. Include new library cuDensityMat.