### PR TITLE
Restrict compat with `HDF5_jll` for packages using v1.14

### DIFF
--- a/A/ADIOS2/build_tarballs.jl
+++ b/A/ADIOS2/build_tarballs.jl
@@ -164,7 +164,10 @@ dependencies = [
     Dependency(PackageSpec(name="Blosc2_jll"); compat="201.1500.101"),
     Dependency(PackageSpec(name="Bzip2_jll"); compat="1.0.8"),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"), v"0.5.2"),
-    Dependency(PackageSpec(name="HDF5_jll"); compat="~1.14.3", platforms=hdf5_platforms),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="HDF5_jll"); compat="=1.14.3", platforms=hdf5_platforms),
     # Dependency(PackageSpec(name="MGARD_jll"); compat="1.5.2"),
     Dependency(PackageSpec(name="ZeroMQ_jll")),
     # Dependency(PackageSpec(name="Zstd_jll")),

--- a/A/AMReX/build_tarballs.jl
+++ b/A/AMReX/build_tarballs.jl
@@ -149,7 +149,10 @@ dependencies = [
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else. 
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
                platforms=filter(!Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="HDF5_jll"); compat="~1.14", platforms=hdf5_platforms),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="HDF5_jll"); compat="1.14.0 - 1.14.3", platforms=hdf5_platforms),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
                platforms=filter(Sys.isbsd, platforms)),
 ]

--- a/C/CGNS/build_tarballs.jl
+++ b/C/CGNS/build_tarballs.jl
@@ -47,7 +47,10 @@ products = [
 ]
 
 dependencies = [
-    Dependency("HDF5_jll"; compat="~1.14"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency("HDF5_jll"; compat="1.14.0 - 1.14.3"),
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/C/Compose/build_tarballs.jl
+++ b/C/Compose/build_tarballs.jl
@@ -63,7 +63,10 @@ dependencies = [
                platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
                platforms=filter(Sys.isbsd, platforms)),
-    Dependency(PackageSpec(name="HDF5_jll"); compat="~1.14"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="HDF5_jll"); compat="1.14.0 - 1.14.3"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -101,8 +101,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="Fmt_jll", uuid="5dc1e892-f187-50dd-85f3-7dff85c47fc5"))
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
     # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="HDF5_jll", uuid="0234f1f7-429e-5d53-9886-15a909be8d59"); compat="~1.14")
+    Dependency(PackageSpec(name="HDF5_jll", uuid="0234f1f7-429e-5d53-9886-15a909be8d59"); compat="1.14.0 - 1.14.3")
     Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"))
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -205,7 +205,10 @@ dependencies = [
     Dependency("Expat_jll"; compat="2.2.10"),
     Dependency("GEOS_jll"; compat="3.11.2"),
     # Dependency("HDF4_jll"; compat="4.3.0"),
-    Dependency("HDF5_jll"; compat="~1.14.3", platforms=hdf5_platforms),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency("HDF5_jll"; compat="=1.14.3", platforms=hdf5_platforms),
     Dependency("LERC_jll"; compat="4"),
     Dependency("LibCURL_jll"; compat="7.73,8"),
     Dependency("LibPQ_jll"; compat="16"),

--- a/G/gmsh/build_tarballs.jl
+++ b/G/gmsh/build_tarballs.jl
@@ -68,8 +68,10 @@ dependencies = [
     Dependency("FreeType2_jll", v"2.13.1"; compat="2.10.4"), # TODO: `compat="2.10.4"` is a LIE, in order to be able to rebuild the package without changing the compat bound.  In practice the compat bounds of Cairo_jll shouldn't allow having incompatible versions/.  Next version, change this compat to `"2.13.1"` and remove the build version.
     Dependency("GLU_jll"; platforms=x11_platforms),
     Dependency("GMP_jll"; compat="6.2"),
-    # Updating to a newer HDF5 version requires rebuilding this package
-    Dependency("HDF5_jll"; platforms=hdf5_platforms, compat="~1.14.3"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency("HDF5_jll"; platforms=hdf5_platforms, compat="=1.14.3"),
     Dependency("JpegTurbo_jll"),
     Dependency("Libglvnd_jll"; platforms=x11_platforms),
     Dependency("libpng_jll"),

--- a/H/HighFive/build_tarballs.jl
+++ b/H/HighFive/build_tarballs.jl
@@ -43,7 +43,10 @@ products = Product[
 dependencies = [
     BuildDependency("Eigen_jll"),
     BuildDependency("xtensor_jll"),
-    Dependency("HDF5_jll"; compat="~1.14.0"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency("HDF5_jll"; compat="1.14.0 - 1.14.3"),
     # Dependency("OpenCV_jll"),
     Dependency("boost_jll"; compat="=1.79.0"),
 ]

--- a/M/Matio/build_tarballs.jl
+++ b/M/Matio/build_tarballs.jl
@@ -42,7 +42,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Zlib_jll"),
-    Dependency("HDF5_jll"; compat="1.14.2"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency("HDF5_jll"; compat="1.14.2 - 1.14.3"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -133,7 +133,10 @@ products = [
 dependencies = [
     Dependency("Blosc_jll"),
     Dependency("Bzip2_jll"),
-    Dependency("HDF5_jll"; compat = "~1.14.3"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency("HDF5_jll"; compat = "=1.14.3"),
     Dependency("LibCURL_jll"; compat = "7.73.0,8"),
     Dependency("XML2_jll"),
     Dependency("Zlib_jll"),

--- a/O/openPMD_api/build_tarballs.jl
+++ b/O/openPMD_api/build_tarballs.jl
@@ -118,7 +118,10 @@ dependencies = [
     Dependency(PackageSpec(name="ADIOS2_jll"); platforms=filter(p -> nbits(p) ≠ 32, platforms)),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     # Parallel HDF5 is not available on Windows
-    Dependency(PackageSpec(name="HDF5_jll"); compat="~1.14", platforms=filter(!Sys.iswindows, platforms)),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="HDF5_jll"); compat="1.14.0 - 1.14.3", platforms=filter(!Sys.iswindows, platforms)),
     Dependency(PackageSpec(name="libcxxwrap_julia_jll")),
 ]
 

--- a/S/SIRIUS/build_tarballs.jl
+++ b/S/SIRIUS/build_tarballs.jl
@@ -80,7 +80,10 @@ dependencies = [
     #Using either MKL or OPENBLAS32
     Dependency("libblastrampoline_jll"; compat="5.4.0"),
     Dependency("Libxc_jll"),
-    Dependency("HDF5_jll"; compat="~1.14.3"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency("HDF5_jll"; compat="=1.14.3"),
     Dependency("spglib_jll"),
     Dependency("spla_jll"),
     Dependency("SpFFT_jll"),

--- a/S/SZ/build_tarballs.jl
+++ b/S/SZ/build_tarballs.jl
@@ -69,7 +69,10 @@ dependencies = [
                platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
                platforms=filter(Sys.isbsd, platforms)),
-    Dependency("HDF5_jll"; compat="~1.14"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency("HDF5_jll"; compat="1.14.0 - 1.14.3"),
     Dependency("NetCDF_jll"),
     Dependency("Zlib_jll"),
     Dependency("Zstd_jll"),

--- a/S/SZ3/build_tarballs.jl
+++ b/S/SZ3/build_tarballs.jl
@@ -79,8 +79,10 @@ dependencies = [
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
                platforms=filter(Sys.isbsd, platforms)),
     Dependency("GSL_jll"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
     # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
-    Dependency("HDF5_jll"; compat="~1.14"),
+    Dependency("HDF5_jll"; compat="1.14.0 - 1.14.3"),
     Dependency("Zstd_jll"),
 ]
 

--- a/T/TempestModel/build_tarballs.jl
+++ b/T/TempestModel/build_tarballs.jl
@@ -130,8 +130,10 @@ dependencies = [
     # semver-like.
     Dependency("MKL_jll", v"2023.2.0"),
     Dependency("NetCDF_jll"; compat="400.902.208 - 400.999"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
     # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
-    Dependency("HDF5_jll"; compat="~1.14.3"),
+    Dependency("HDF5_jll"; compat="=1.14.3"),
 ]
 append!(dependencies, platform_dependencies)
 

--- a/T/TempestRemap/build_tarballs.jl
+++ b/T/TempestRemap/build_tarballs.jl
@@ -78,7 +78,10 @@ products = [
 
 dependencies = [
     Dependency("OpenBLAS32_jll"),
-    Dependency("HDF5_jll", v"1.14.2", compat="~1.14"),
+    # We had to restrict compat with HDF5 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
+    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
+    Dependency("HDF5_jll"; compat="1.14.2 - 1.14.3"),
     Dependency("NetCDF_jll", v"400.902.208", compat="~400.902.207"),
 ]
 


### PR DESCRIPTION
Reflect changes in <https://github.com/JuliaRegistries/General/pull/125412>. Ref:
<https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973>.