### PR TITLE
Python: Declare LibMPDec compat bound

### DIFF
--- a/P/Python/build_tarballs.jl
+++ b/P/Python/build_tarballs.jl
@@ -106,7 +106,7 @@ dependencies = [
     Dependency("Bzip2_jll"; compat="1.0.9"),
     Dependency("Libffi_jll"; compat="~3.4.6"),
     Dependency("SQLite_jll"),
-    Dependency("LibMPDec_jll"),
+    Dependency("LibMPDec_jll"; compat="2.5.1"),
     Dependency("Zlib_jll"),
     Dependency("XZ_jll"),
     Dependency("OpenSSL_jll"; compat="3.0.16"),


### PR DESCRIPTION
See https://github.com/JuliaPackaging/Yggdrasil/pull/10579: There is a new, incompatible version of `LibMPDec` (with a new major version number).