### PR TITLE
[GAP_lib] Backport extraperfect fix (again)

### DIFF
--- a/G/GAP_lib/build_tarballs.jl
+++ b/G/GAP_lib/build_tarballs.jl
@@ -78,3 +78,5 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+
+# Build trigger: 1


### PR DESCRIPTION
https://github.com/JuliaPackaging/Yggdrasil/pull/10611 again, with the hope that registration works now with https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1370 available.

cc @fingolfin @giordano 