### PR TITLE
[MPFR] Trigger a rebuild for updated PlatformSupport

### DIFF
--- a/M/MPFR/build_tarballs.jl
+++ b/M/MPFR/build_tarballs.jl
@@ -55,4 +55,4 @@ build_tarballs(ARGS, name, version, sources, script, platforms, products, depend
                preferred_gcc_version=v"5", preferred_llvm_version=llvm_version,
                julia_compat="1.6")
 
-# Build trigger: 1
+# Build trigger: 2


### PR DESCRIPTION
I've observed odd behavior with GMP and MPFR (the latter more recently) on FreeBSD 14.1 AArch64 with binaries built for 13.2. Now that the FreeBSD version for AArch64 has been updated to 14.1 and GMP 6.3.0 has been rebuilt atop that, let's rebuild MPFR to see whether oddities are resolved.