### PR TITLE
msolve - v0.7.5

### DIFF
--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "msolve"
-upstream_version = v"0.7.4"
+upstream_version = v"0.7.5"
 
 version_offset = v"0.0.0"
 version = VersionNumber(upstream_version.major*100+version_offset.major,
@@ -12,7 +12,7 @@ version = VersionNumber(upstream_version.major*100+version_offset.major,
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/algebraic-solving/msolve.git", "e0c2a31ce7816e186c484c138f9aead4f0ec3747")
+    GitSource("https://github.com/algebraic-solving/msolve.git", "1d0d10971467d83985b2f1197e5fe7e4ed4be24f")
 ]
 
 # Bash recipe for building across all platforms

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -46,7 +46,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GMP_jll", v"6.2.1"),
-    Dependency("FLINT_jll", compat = "~300.200.0"),
+    Dependency("FLINT_jll", compat = "~300.100.301"),
     Dependency("MPFR_jll", v"4.1.1"),
 
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -45,8 +45,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("GMP_jll", v"6.2.0"),
-    Dependency("FLINT_jll", compat = "~300.100.301"),
+    Dependency("GMP_jll", v"6.2.1"),
+    Dependency("FLINT_jll", compat = "~300.200.0"),
     Dependency("MPFR_jll", v"4.1.1"),
 
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -29,6 +29,9 @@ make install
 # platforms are passed in on the command line
 platforms = supported_platforms()
 filter!(!Sys.iswindows, platforms)   # not POSIX
+
+filter!(p -> arch(p) != "riscv64", platforms)  # missing FLINT
+
 # At the moment we cannot add optimized versions for specific architectures
 # since the logic of artifact selection when loading the package is not
 # working well.

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -48,6 +48,7 @@ dependencies = [
     Dependency("GMP_jll", v"6.2.1"),
     Dependency("FLINT_jll", compat = "~300.100.301"),
     Dependency("MPFR_jll", v"4.1.1"),
+    Dependency("OpenBLAS32_jll", v"0.3.28"),
 
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -3,16 +3,16 @@
 using BinaryBuilder, Pkg
 
 name = "msolve"
-upstream_version = v"0.7.3"
+upstream_version = v"0.7.4"
 
-version_offset = v"0.0.1"
+version_offset = v"0.0.0"
 version = VersionNumber(upstream_version.major*100+version_offset.major,
                         upstream_version.minor*100+version_offset.minor,
                         upstream_version.patch*100+version_offset.patch)
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/algebraic-solving/msolve.git", "42b9e3364c797554e4e132ca46c4cf22ff54a932")
+    GitSource("https://github.com/algebraic-solving/msolve.git", "e0c2a31ce7816e186c484c138f9aead4f0ec3747")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bug fix release, esp. for segfaults when running msolve with info level 0 and using elimination orderings.