### PR TITLE
MAGEMin v1.7.1

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -6,13 +6,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MAGEMin"
-version = v"1.7.0"
+version = v"1.7.1"
 
 MPItrampoline_compat_version="5.2.1"  
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "d1bbc90386a1b4bd6fdc5e2f9eba7a8671267a93")                 ]
+                    "47e6680889862c63f36d054a2f774c9487405b06")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Corrected trace-elements output
- Corrected legacy solver that was leading to unsatisfied bulk-rock composition in some cases
- Largely improved use of initial guess to compute phase diagrams