### PR TITLE
ZeroMQ: Build with libgfortran5 platform tag

### DIFF
--- a/Z/ZeroMQ/build_tarballs.jl
+++ b/Z/ZeroMQ/build_tarballs.jl
@@ -52,4 +52,4 @@ dependencies = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                clang_use_lld=false, julia_compat="1.6")
 
-# Build trigger: 1
+# Build trigger: 2


### PR DESCRIPTION
#10641 failed to build on RISC-V due to not finding a version with the libgfortran5 tag... guessing it is just a matter of rebuilding the dependency again so the re-built package has the additional tag?