### PR TITLE
platforms/mpi.jl: Update compat and supported architectures

### DIFF
--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -45,11 +45,10 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 mpi_abis = (
-    # Note: riscv64 is only disabled because BinaryBuilder doesn't support it yet, the respective MPI packages have been built.
-    ("MPICH", PackageSpec(name="MPICH_jll"), "4.3.0 - 4", p -> !Sys.iswindows(p) && !(arch(p) == "riscv64")),
-    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "4.1.8, 5", p -> !Sys.iswindows(p) && !(arch(p) == "riscv64") && !(arch(p) == "armv6l" && libc(p) == "glibc")),
+    ("MPICH", PackageSpec(name="MPICH_jll"), "4.3.0 - 4", p -> !Sys.iswindows(p)),
+    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5.5.2 - 5", p -> !Sys.iswindows(p) && !(libc(p) == "musl")),
     ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),
-    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5.5.0 - 5", p -> !(Sys.iswindows(p) || libc(p) == "musl"))
+    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "4.1.8, 5", p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc")),
 )
 
 """

--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -45,8 +45,9 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 mpi_abis = (
-    ("MPICH", PackageSpec(name="MPICH_jll"), "4.2.3 - 4", !Sys.iswindows) ,
-    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "", p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc")),
+    # Note: riscv64 is only disabled because BinaryBuilder doesn't support it yet, the respective MPI packages have been built.
+    ("MPICH", PackageSpec(name="MPICH_jll"), "4.3.0 - 4", p -> !Sys.iswindows(p) && !(arch(p) == "riscv64")),
+    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "4.1.8, 5", p -> !Sys.iswindows(p) && !(arch(p) == "riscv64") && !(arch(p) == "armv6l" && libc(p) == "glibc")),
     ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),
     ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5.5.0 - 5", p -> !(Sys.iswindows(p) || libc(p) == "musl"))
 )


### PR DESCRIPTION
Update the default MPI compat entries and the architectures supported by each MPI implementation. Also disable riscv64 builds with MPI since they don't work yet with BinaryBuilder.