### PR TITLE
NetCDF: Bump major version due to ABI change

### DIFF
--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -14,7 +14,7 @@ name = "NetCDF"
 upstream_version = v"4.9.3"
 
 # Offset to add to the version number.  Remember to always bump this.
-version_offset = v"0.2.0"
+version_offset = v"1.0.0"
 
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
@@ -131,6 +131,7 @@ dependencies = [
     Dependency("XML2_jll"; compat="2.13.6"),
     Dependency("Zlib_jll"; compat="1.2.12"),
     Dependency("Zstd_jll"; compat="1.5.7"),
+    Dependency("libaec_jll"; compat="1.1.3"), # This is the successor of szlib
     Dependency("libzip_jll"; compat="1.11.3"),
 ]
 append!(dependencies, platform_dependencies)


### PR DESCRIPTION
NetCFD 4.9.3 is API and ABI incompatible with 4.9.2. Bump the major version number.

See https://github.com/JuliaPackaging/Yggdrasil/pull/10636, https://github.com/JuliaRegistries/General/pull/126541, https://github.com/JuliaBinaryWrappers/NetCDF_jll.jl/commit/09ffe880302aea634969e39a965c5aab5f845ab9, https://github.com/Unidata/netcdf-c/pull/2743/files .
