### PR TITLE
HDF4: Build without NetCDF support

### DIFF
--- a/H/HDF4/build_tarballs.jl
+++ b/H/HDF4/build_tarballs.jl
@@ -3,11 +3,15 @@
 using BinaryBuilder, Pkg
 
 name = "HDF4"
-version = v"4.3.0"
+# We bumped the version number to build without NetCDF support. This
+# is necessary to avoid a name clash when using HDF4_jll and
+# NetCDF_jll together.
+hdf4_version = v"4.3.0"
+version = v"4.3.1"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource("https://github.com/HDFGroup/hdf4/releases/download/hdf$(version)/hdf$(version).tar.gz",
+    ArchiveSource("https://github.com/HDFGroup/hdf4/releases/download/hdf$(hdf4_version)/hdf$(hdf4_version).tar.gz",
                   "282b244a819790590950f772095abcaeef405b0f17d2ee1eb5039da698cf938b"),
 ]
 
@@ -20,7 +24,10 @@ cmake -B build -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DTEST_LFS_WORKS_RUN=0 \
     -DH4_PRINTF_LL_TEST_RUN=0 \
-    -DH4_PRINTF_LL_TEST_RUN__TRYRUN_OUTPUT=
+    -DH4_PRINTF_LL_TEST_RUN__TRYRUN_OUTPUT= \
+    -DHDF4_BUILD_NETCDF_TOOLS=0 \
+    -DHDF4_ENABLE_NETCDF=0 \
+    -DHDF4_ENABLE_SZIP_SUPPORT=1
 cmake --build build --parallel ${nproc}
 cmake --install build
 """
@@ -38,16 +45,17 @@ products = [
     ExecutableProduct("hdiff", :hdiff),
     ExecutableProduct("hdp", :hdp),
     ExecutableProduct("hrepack", :hrepack),
-    ExecutableProduct("ncdump", :ncdump),
-    ExecutableProduct("ncgen", :ncgen),
+    # ExecutableProduct("ncdump", :ncdump),
+    # ExecutableProduct("ncgen", :ncgen),
     LibraryProduct("libhdf", :libhdf),
     LibraryProduct("libmfhdf", :libmfhdf),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    Dependency(PackageSpec(name="JpegTurbo_jll", uuid="aacddb02-875f-59d6-b918-886e6ef4fbf8"); compat="3.1.1"),
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"); compat="1.2.12"),
-    Dependency(PackageSpec(name="JpegTurbo_jll", uuid="aacddb02-875f-59d6-b918-886e6ef4fbf8"); compat="3.0.2"),
+    Dependency(PackageSpec(name="libaec_jll", uuid="477f73a3-ac25-53e9-8cc3-50b2fa2566f0"); compat="1.1.3"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
The current HDF4 setup provides an include file `netcdf.h` which conflicts with the package `NetCDF_jll`. This PR
- configures HDF4 without NetCDF support to avoid this conflict
- we can in the future configure NetCDF to support HDF4 as container format (I think that's the right approach, HDF4 is more low-level in this case)
- add support for `sz` compression
- build for riscv64 architecture
