### PR TITLE
neper: Set NLopt compat bounds

### DIFF
--- a/N/neper/build_tarballs.jl
+++ b/N/neper/build_tarballs.jl
@@ -45,7 +45,7 @@ dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="GSL_jll", uuid="1b77fbbe-d8ee-58f0-85f9-836ddc23a7a4"); compat="~2.7.2"),
-    Dependency(PackageSpec(name="NLopt_jll", uuid="079eb43e-fd8e-5478-9966-2cf3e3edb778"); compat="2 - 2.10"),
+    Dependency(PackageSpec(name="NLopt_jll", uuid="079eb43e-fd8e-5478-9966-2cf3e3edb778"); compat="2.6.2 - 2.9"),
     Dependency(PackageSpec(name="SCOTCH_jll", uuid="a8d0f55d-b80e-548d-aff6-1a04c175f0f9"); compat="6.1.3"),
     RuntimeDependency(PackageSpec(name="gmsh_jll", uuid="630162c2-fc9b-58b3-9910-8442a8a132e6")),
 ]

--- a/N/neper/build_tarballs.jl
+++ b/N/neper/build_tarballs.jl
@@ -45,7 +45,7 @@ dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="GSL_jll", uuid="1b77fbbe-d8ee-58f0-85f9-836ddc23a7a4"); compat="~2.7.2"),
-    Dependency(PackageSpec(name="NLopt_jll", uuid="079eb43e-fd8e-5478-9966-2cf3e3edb778")),
+    Dependency(PackageSpec(name="NLopt_jll", uuid="079eb43e-fd8e-5478-9966-2cf3e3edb778"); compat="2 - 2.10"),
     Dependency(PackageSpec(name="SCOTCH_jll", uuid="a8d0f55d-b80e-548d-aff6-1a04c175f0f9"); compat="6.1.3"),
     RuntimeDependency(PackageSpec(name="gmsh_jll", uuid="630162c2-fc9b-58b3-9910-8442a8a132e6")),
 ]


### PR DESCRIPTION
Running ``run(`$(neper()) -T -n 10`)`` fails with 
`dyld[7307]: Library not loaded: @rpath/libnlopt.0.dylib` using default installation, but solved by `add NLopt_jll@2.9` before loading `neper_jll`.

I'm not sure if this is the correct way to fix it, but from what I could find, 
the update from NLopt_jll from v2.9 to v2.10 renames, e.g., `libnlopt.so.0` to `libnlopt.so.1`: https://github.com/JuliaBinaryWrappers/NLopt_jll.jl/commit/28cc85df871ea6eaa5a8de90dfb7ee9858b322a5

Since I'm not sure how I should verify that this change is the correct, this PR needs to be verified by someone who knows - tagging those who have worked on this file: @fredrikekre @amontoison @kimauth

Also not sure why the compat bounds says no versions left, shouldn't this correspond to `[2, 2.10)`? 