### PR TITLE
[nghttp2] Bump to 1.65.0

### DIFF
--- a/N/nghttp2/common.jl
+++ b/N/nghttp2/common.jl
@@ -9,6 +9,7 @@ function configure_nghttp2_build(version; kwargs...)
     versions_tags = Dict(
         v"1.41.0" => "8f7b008b158e12de0e58247afd170f127dbb6456",
         v"1.64.0" => "526ff38e0249acbcc4d0e8958c12cdeae9960cfe",
+        v"1.65.0" => "319bf015de8fa38e21ac271ce2f7d61aa77d90cb",
     )
 
     sources = [

--- a/N/nghttp2/nghttp2@1.65/build_tarballs.jl
+++ b/N/nghttp2/nghttp2@1.65/build_tarballs.jl
@@ -1,0 +1,8 @@
+version = v"1.65.0"
+
+include("../common.jl")
+
+build_tarballs(ARGS, configure_nghttp2_build(version)...;
+               julia_compat="1.6", preferred_llvm_version=llvm_version)
+
+# Build trigger: 1


### PR DESCRIPTION
New version: https://github.com/nghttp2/nghttp2/releases/tag/v1.65.0