### PR TITLE
[OpenBLASConsistentFPCSR] Set version to 0.3.22 and add support for aarch64

### DIFF
--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.21/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.21/build_tarballs.jl
@@ -4,14 +4,11 @@ include("../common.jl")
 
 # Collection of sources required to build OpenBLAS
 name = "OpenBLASConsistentFPCSR"
-version = v"0.3.21"
+version = v"0.3.22"
 
 sources = openblas_sources(version)
 script = openblas_script(;aarch64_ilp64=true, num_64bit_threads=512, consistent_fpcsr=true)
-# CONSISTENT_FPCSR = 1 works only for for x86/x86_64
-# It should work for aarch64 but we have no aarch64 machine for debugging,
-# so we exclude it for the moment
-platforms = expand_gfortran_versions(supported_platforms(; exclude=p -> arch(p) != "x86_64"))
+platforms = expand_gfortran_versions(supported_platforms(; exclude=p -> (arch(p) != "x86_64" && arch(p) != "aarch64")))
 # push!(platforms, Platform("x86_64", "linux"; sanitize="memory"))
 products = openblas_products()
 dependencies = openblas_dependencies(platforms)

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.21/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.21/build_tarballs.jl
@@ -4,11 +4,14 @@ include("../common.jl")
 
 # Collection of sources required to build OpenBLAS
 name = "OpenBLASConsistentFPCSR"
-version = v"0.3.22"
+version = v"0.3.21"
 
 sources = openblas_sources(version)
 script = openblas_script(;aarch64_ilp64=true, num_64bit_threads=512, consistent_fpcsr=true)
-platforms = expand_gfortran_versions(supported_platforms(; exclude=p -> (arch(p) != "x86_64" && arch(p) != "aarch64")))
+# CONSISTENT_FPCSR = 1 works only for for x86/x86_64
+# It should work for aarch64 but we have no aarch64 machine for debugging,
+# so we exclude it for the moment
+platforms = expand_gfortran_versions(supported_platforms(; exclude=p -> arch(p) != "x86_64"))
 # push!(platforms, Platform("x86_64", "linux"; sanitize="memory"))
 products = openblas_products()
 dependencies = openblas_dependencies(platforms)

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"0.3.29"
 
 sources = openblas_sources(version)
 script = openblas_script(;aarch64_ilp64=true, num_64bit_threads=512, bfloat16=true, consistent_fpcsr=true)
-platforms = openblas_platforms(; version)
+platforms = expand_gfortran_versions(supported_platforms(; exclude=p -> (arch(p) != "x86_64" && arch(p) != "aarch64")))
 push!(platforms, Platform("x86_64", "linux"; sanitize="memory"))
 products = openblas_products()
 preferred_llvm_version = v"13.0.1"

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
@@ -17,6 +17,6 @@ dependencies = openblas_dependencies(platforms; llvm_compilerrt_version=preferre
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"11", lock_microarchitecture=false,
-               julia_compat="1.11", preferred_llvm_version=preferred_llvm_version)
+               julia_compat="1.6", preferred_llvm_version=preferred_llvm_version)
 
 # Build trigger: 1

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
@@ -9,7 +9,6 @@ version = v"0.3.29"
 sources = openblas_sources(version)
 script = openblas_script(;aarch64_ilp64=true, num_64bit_threads=512, bfloat16=true, consistent_fpcsr=true)
 platforms = expand_gfortran_versions(supported_platforms(; exclude=p -> !(arch(p) in ("x86_64", "aarch64"))))
-push!(platforms, Platform("x86_64", "linux"; sanitize="memory"))
 products = openblas_products()
 dependencies = openblas_dependencies(platforms)
 

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
@@ -11,8 +11,7 @@ script = openblas_script(;aarch64_ilp64=true, num_64bit_threads=512, bfloat16=tr
 platforms = expand_gfortran_versions(supported_platforms(; exclude=p -> (arch(p) != "x86_64" && arch(p) != "aarch64")))
 push!(platforms, Platform("x86_64", "linux"; sanitize="memory"))
 products = openblas_products()
-preferred_llvm_version = v"13.0.1"
-dependencies = openblas_dependencies(platforms; llvm_compilerrt_version=preferred_llvm_version)
+dependencies = openblas_dependencies(platforms)
 
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
@@ -1,0 +1,22 @@
+using BinaryBuilder
+
+include("../common.jl")
+
+# Collection of sources required to build OpenBLAS
+name = "OpenBLASConsistentFPCSR"
+version = v"0.3.29"
+
+sources = openblas_sources(version)
+script = openblas_script(;aarch64_ilp64=true, num_64bit_threads=512, bfloat16=true, consistent_fpcsr=true)
+platforms = openblas_platforms(; version)
+push!(platforms, Platform("x86_64", "linux"; sanitize="memory"))
+products = openblas_products()
+preferred_llvm_version = v"13.0.1"
+dependencies = openblas_dependencies(platforms; llvm_compilerrt_version=preferred_llvm_version)
+
+# Build the tarballs
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version=v"11", lock_microarchitecture=false,
+               julia_compat="1.11", preferred_llvm_version=preferred_llvm_version)
+
+# Build trigger: 1

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
@@ -16,6 +16,6 @@ dependencies = openblas_dependencies(platforms)
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"11", lock_microarchitecture=false,
-               julia_compat="1.6", preferred_llvm_version=preferred_llvm_version)
+               julia_compat="1.6")
 
 # Build trigger: 1

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"0.3.29"
 
 sources = openblas_sources(version)
 script = openblas_script(;aarch64_ilp64=true, num_64bit_threads=512, bfloat16=true, consistent_fpcsr=true)
-platforms = expand_gfortran_versions(supported_platforms(; exclude=p -> (arch(p) != "x86_64" && arch(p) != "aarch64")))
+platforms = expand_gfortran_versions(supported_platforms(; exclude=p -> !(arch(p) in ("x86_64", "aarch64"))))
 push!(platforms, Platform("x86_64", "linux"; sanitize="memory"))
 products = openblas_products()
 dependencies = openblas_dependencies(platforms)

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/bundled/patches/10-disable-running-tests.patch
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/bundled/patches/10-disable-running-tests.patch
@@ -1,0 +1,20 @@
+diff --git a/ctest/Makefile b/ctest/Makefile
+index bbaf96f8e..75ba5426a 100644
+--- a/ctest/Makefile
++++ b/ctest/Makefile
+@@ -203,7 +203,6 @@ ifeq ($(BUILD_COMPLEX16),1)
+        OPENBLAS_NUM_THREADS=2 ./xzcblat3 < zin3
+ endif
+ endif
+-endif
+
+ ifeq ($(SUPPORT_GEMM3M),1)
+ ifeq ($(USE_OPENMP), 1)
+@@ -222,6 +221,7 @@ ifeq ($(BUILD_COMPLEX16),1)
+ endif
+ endif
+ endif
++endif
+
+
+

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/bundled/patches/30-openblas-ofast-power.patch
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/bundled/patches/30-openblas-ofast-power.patch
@@ -1,0 +1,43 @@
+diff --git a/Makefile.power b/Makefile.power
+index aa1ca080a..42c417a78 100644
+--- a/Makefile.power
++++ b/Makefile.power
+@@ -13,16 +13,16 @@ ifeq ($(CORE), POWER10)
+ ifneq ($(C_COMPILER), PGI)
+ ifeq ($(C_COMPILER), GCC))
+ ifeq ($(GCCVERSIONGTEQ10), 1)
+-CCOMMON_OPT += -Ofast -mcpu=power10 -mtune=power10 -mvsx -fno-fast-math
++CCOMMON_OPT += -mcpu=power10 -mtune=power10 -mvsx -fno-fast-math
+ else ifneq ($(GCCVERSIONGT4), 1)
+ $(warning your compiler is too old to fully support POWER9, getting a newer version of gcc is recommended)
+-CCOMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx -fno-fast-math
++CCOMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx -fno-fast-math
+ else
+ $(warning your compiler is too old to fully support POWER10, getting a newer version of gcc is recommended)
+-CCOMMON_OPT += -Ofast -mcpu=power9 -mtune=power9 -mvsx -fno-fast-math
++CCOMMON_OPT += -mcpu=power9 -mtune=power9 -mvsx -fno-fast-math
+ endif
+ else
+-CCOMMON_OPT += -Ofast -mcpu=power10 -mtune=power10 -mvsx -fno-fast-math
++CCOMMON_OPT += -mcpu=power10 -mtune=power10 -mvsx -fno-fast-math
+ endif
+ ifeq ($(F_COMPILER), IBM)
+ FCOMMON_OPT += -O2 -qrecur -qnosave -qarch=pwr10 -qtune=pwr10 -qfloat=nomaf -qzerosize
+@@ -34,7 +34,7 @@ endif
+ 
+ ifeq ($(CORE), POWER9)
+ ifneq ($(C_COMPILER), PGI)
+-CCOMMON_OPT += -Ofast -mvsx -fno-fast-math
++CCOMMON_OPT += -mvsx -fno-fast-math
+ ifeq ($(C_COMPILER), GCC)
+ ifneq ($(GCCVERSIONGT4), 1)
+ $(warning your compiler is too old to fully support POWER9, getting a newer version of gcc is recommended)
+@@ -70,7 +70,7 @@ endif
+ 
+ ifeq ($(CORE), POWER8)
+ ifneq ($(C_COMPILER), PGI)
+-CCOMMON_OPT += -Ofast -mcpu=power8 -mtune=power8 -mvsx  -fno-fast-math
++CCOMMON_OPT += -mcpu=power8 -mtune=power8 -mvsx  -fno-fast-math
+ else
+ CCOMMON_OPT += -fast -Mvect=simd -Mcache_align
+ endif

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/bundled/patches/50-openblas-winexit.patch
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/bundled/patches/50-openblas-winexit.patch
@@ -1,0 +1,170 @@
+diff --git a/driver/others/memory.c b/driver/others/memory.c
+index 6e654ccf..1d2f9f12 100644
+--- a/driver/others/memory.c
++++ b/driver/others/memory.c
+@@ -1534,7 +1534,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -1572,75 +1572,11 @@ void DESTRUCTOR gotoblas_quit(void) {
+ }
+ 
+ #if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-#if defined(SMP)
+-      blas_thread_memory_cleanup();
+-#endif
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-  gotoblas_quit();
+-  return 0;
+-}
+ #ifdef _WIN64
+ #pragma comment(linker, "/INCLUDE:_tls_used")
+ #else
+ #pragma comment(linker, "/INCLUDE:__tls_used")
+ #endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-
+-#ifdef _WIN64
+-static const PIMAGE_TLS_CALLBACK dll_callback(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#pragma const_seg()
+-#else
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-
+-#ifdef _WIN64
+-static const int(*p_process_term)(void) = on_process_term;
+-#pragma const_seg()
+-#else
+-static int(*p_process_term)(void) = on_process_term;
+-#pragma data_seg()
+-#endif
+ #endif
+ 
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+@@ -3146,7 +3082,7 @@ void CONSTRUCTOR gotoblas_init(void) {
+ 
+ }
+ 
+-void DESTRUCTOR gotoblas_quit(void) {
++void gotoblas_quit(void) {
+ 
+   if (gotoblas_initialized == 0) return;
+ 
+@@ -3175,71 +3111,6 @@ void DESTRUCTOR gotoblas_quit(void) {
+ #endif
+ }
+ 
+-#if defined(_MSC_VER) && !defined(__clang__)
+-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+-{
+-  switch (ul_reason_for_call)
+-  {
+-    case DLL_PROCESS_ATTACH:
+-      gotoblas_init();
+-      break;
+-    case DLL_THREAD_ATTACH:
+-      break;
+-    case DLL_THREAD_DETACH:
+-      break;
+-    case DLL_PROCESS_DETACH:
+-      gotoblas_quit();
+-      break;
+-    default:
+-      break;
+-  }
+-  return TRUE;
+-}
+-
+-/*
+-  This is to allow static linking.
+-  Code adapted from Google performance tools:
+-  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+-  Reference:
+-  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+-  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
+-*/
+-static int on_process_term(void)
+-{
+-  gotoblas_quit();
+-  return 0;
+-}
+-#ifdef _WIN64
+-#pragma comment(linker, "/INCLUDE:_tls_used")
+-#else
+-#pragma comment(linker, "/INCLUDE:__tls_used")
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XLB")
+-#else
+-#pragma data_seg(".CRT$XLB")
+-#endif
+-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-
+-#ifdef _WIN64
+-#pragma const_seg(".CRT$XTU")
+-#else
+-#pragma data_seg(".CRT$XTU")
+-#endif
+-static int(*p_process_term)(void) = on_process_term;
+-#ifdef _WIN64
+-#pragma const_seg()
+-#else
+-#pragma data_seg()
+-#endif
+-#endif
+-
+ #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ /* Don't call me; this is just work around for PGI / Sun bug */
+ void gotoblas_dummy_for_PGI(void) {

--- a/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/bundled/patches/70-Build-with-proper-aarch64-flags-on-Neoverse-Darwin.patch
+++ b/O/OpenBLAS/OpenBLASConsistentFPCSR@0.3.29/bundled/patches/70-Build-with-proper-aarch64-flags-on-Neoverse-Darwin.patch
@@ -1,0 +1,30 @@
+From df138bb4eb87e4e6770876f167c427cc9ea205a2 Mon Sep 17 00:00:00 2001
+From: Ian McInerney <i.mcinerney17@imperial.ac.uk>
+Date: Tue, 9 Apr 2024 23:09:09 +0100
+Subject: [PATCH 1/1] Build with proper aarch64 flags on Neoverse Darwin
+
+We aren't affected by the problems in AppleClang that prompted this
+fallback to an older architecture.
+---
+ Makefile.arm64 | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/Makefile.arm64 b/Makefile.arm64
+index 4feb54523..564ca7942 100644
+--- a/Makefile.arm64
++++ b/Makefile.arm64
+@@ -142,11 +142,7 @@ ifeq ($(CORE), NEOVERSEN2)
+ ifeq (1, $(filter 1,$(GCCVERSIONGTEQ7) $(ISCLANG)))
+ ifeq (1, $(filter 1,$(GCCVERSIONGTEQ10) $(ISCLANG)))
+ ifeq (1, $(filter 1,$(GCCMINORVERSIONGTEQ4) $(GCCVERSIONGTEQ11) $(ISCLANG)))
+-ifneq ($(OSNAME), Darwin)
+ CCOMMON_OPT += -march=armv8.5-a+sve+sve2+bf16 -mtune=neoverse-n2
+-else
+-CCOMMON_OPT += -march=armv8.2-a+sve+bf16 -mtune=cortex-a72
+-endif
+ ifneq ($(F_COMPILER), NAG)
+ FCOMMON_OPT += -march=armv8.5-a+sve+sve2+bf16 -mtune=neoverse-n2
+ endif
+-- 
+2.31.0
+


### PR DESCRIPTION
Following @orkolorko's advice, see [#131](https://github.com/JuliaIntervals/IntervalLinearAlgebra.jl/issues/131)