### PR TITLE
[nauty] Patch invalid C++ code in header

### DIFF
--- a/N/nauty/build_tarballs.jl
+++ b/N/nauty/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder
 
 name = "nauty"
 upstream_version = v"2.8.9"
-version = v"2.8.10"
+version = v"2.8.11"
 
 # Collection of sources required to build nauty
 sources = [
@@ -17,6 +17,10 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/nauty*
 
+for f in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 ${f}
+done
+
 # Remove misleading libtool files
 rm -f ${prefix}/lib/*.la
 
@@ -27,7 +31,6 @@ export LDFLAGS="${LDFLAGS} -L${prefix}/lib"
 # `popcnt` CPU instruction is available. This check is not possible during cross-compilation,
 # which causes the entire configure script to fail. We patch `configure.ac` to simply disable
 # `popcnt` while cross-compiling, and generate a new, working configure script with `autoreconf`.
-atomic_patch -p1 ../patches/autotools.patch
 autoreconf -v
 
 # We use --enable-generic to ensure maximum hardware compatibility and we

--- a/N/nauty/bundled/patches/NORET_ATTR.patch
+++ b/N/nauty/bundled/patches/NORET_ATTR.patch
@@ -1,0 +1,55 @@
+From 05d4308e49341b5acbb9d0953f77d50ce8a91a27 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lars=20G=C3=B6ttgens?= <lars.goettgens@rwth-aachen.de>
+Date: Mon, 17 Mar 2025 12:32:40 +0100
+Subject: [PATCH] Try to fix building with C++
+
+Proposed in https://mailman.anu.edu.au/pipermail/nauty/2025-February/000992.html
+---
+ gtools.h   | 2 +-
+ nauty-h.in | 8 +++-----
+ 2 files changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/gtools.h b/gtools.h
+index 193fc87..aee97b8 100644
+--- a/gtools.h
++++ b/gtools.h
+@@ -302,7 +302,7 @@ extern void arg_sequence(char**,char*,long*,int,int*,char*);
+ extern void arg_sequence_min(char**,char*,long*,int,int,int*,char*);
+ 
+ extern void writerange(FILE*,int,long,long);
+-extern void NORET_ATTR gt_abort(const char*);
++NORET_ATTR extern void gt_abort(const char*);
+ extern char *stringcopy(char*);
+ extern boolean strhaschar(char*,int);
+ 
+diff --git a/nauty-h.in b/nauty-h.in
+index 289831d..9e25d6d 100644
+--- a/nauty-h.in
++++ b/nauty-h.in
+@@ -53,12 +53,10 @@ it is necessary to check they are correct.
+ #endif
+ 
+ /* Function noreturn attribute, if any */
+-#define C_NORET_ATTR @ac_cv_noret@   /* Only for C */
+-#if (defined(__cplusplus) && __cplusplus >= 202302L) \
++#define C_NORET_ATTR _Noreturn   /* Only for C */
++#if (defined(__cplusplus) && __cplusplus >= 201102L) \
+         || (!defined(__cplusplus) && __STDC_VERSION__ >= 202311L)
+ #define NORET_ATTR [[noreturn]]
+-#elif defined(__cplusplus) && __cplusplus >= 201103L
+-#define NORET_ATTR [[_Noreturn]]
+ #elif !defined(__cplusplus) && __STDC_VERSION__ >= 201112L
+ #define NORET_ATTR _Noreturn
+ #elif defined(__GNUC__)
+@@ -1464,7 +1462,7 @@ int leftbit[] =   {8,7,6,6,5,5,5,5,4,4,4,4,4,4,4,4,
+ extern "C" {
+ #endif
+ 
+-extern void NORET_ATTR alloc_error(const char*);
++NORET_ATTR extern void alloc_error(const char*);
+ extern void breakout(int*,int*,int,int,int,set*,int);
+ extern boolean cheapautom(int*,int,boolean,int);
+ extern void doref(graph*,int*,int*,int,int*,int*,int*,set*,int*,
+-- 
+2.48.1
+

--- a/N/nauty/bundled/patches/autotools.patch
+++ b/N/nauty/bundled/patches/autotools.patch
@@ -1,3 +1,10 @@
+Subject: [PATCH] Fix popcnt detection during cross-compilation
+
+Nauty's configure script performs a runtime check to find out whether the
+`popcnt` CPU instruction is available. This check is not possible during cross-compilation,
+which causes the entire configure script to fail. We patch `configure.ac` to simply disable
+`popcnt` while cross-compiling, and generate a new, working configure script with `autoreconf`.
+
 --- a/configure.ac	2024-09-06 16:08:24
 +++ b/configure.ac	2024-09-06 16:08:41
 @@ -352,7 +352,7 @@


### PR DESCRIPTION
This adds the patch discussed on the nauty mailing list (https://mailman.anu.edu.au/pipermail/nauty/2025-February/000992.html).
I verified locally that with this patch normaliz_jll builds successfully on `x86_64-linux-musl-cxx03,x86_64-linux-musl-cxx11,x86_64-unknown-freebsd` (cf. https://github.com/JuliaPackaging/Yggdrasil/pull/10746#issuecomment-2728870068).


cc @benlorenz @fingolfin 