### PR TITLE
MAGEMin 1.7.3

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -42,7 +42,7 @@ install_license LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms((; exclude=p->Sys.isfreebsd(p) && arch(p) == "aarch64"))
 platforms = expand_gfortran_versions(platforms)
 platforms = filter(p -> !(arch(p)  == "riscv64"), platforms)
 platforms = filter(p -> !( (libgfortran_version(p) == v"3" || libgfortran_version(p) == v"4") && arch(p)=="powerpc64le"), platforms)

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -16,9 +16,7 @@ sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin",
 script = raw"""
 cd MAGEMin*
 
-USE_MPI ?= 0
-
-CCFLAGS="-DUSE_MPI -O3 -g -fPIC -std=c99"
+CCFLAGS="-DUSE_MPI=0 -O3 -g -fPIC -std=c99"
 
 if [[ "${target}" == *-apple* ]]; then 
     # Use Accelerate for Lapack dependencies

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -16,7 +16,9 @@ sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin",
 script = raw"""
 cd MAGEMin*
 
-CCFLAGS="-DUSE_MPI=0 -O3 -g -fPIC -std=c99"
+USE_MPI ?= 0
+
+CCFLAGS="-DUSE_MPI -O3 -g -fPIC -std=c99"
 
 if [[ "${target}" == *-apple* ]]; then 
     # Use Accelerate for Lapack dependencies
@@ -28,10 +30,10 @@ else
 fi
 
 # Compile library:
-make CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" lib
+make USE_MPI=0 CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" lib
 
 # Compile binary
-make EXE_NAME="MAGEMin${exeext}" CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" all
+make USE_MPI=0 EXE_NAME="MAGEMin${exeext}" CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" all
 
 install -Dvm 755 libMAGEMin.dylib "${libdir}/libMAGEMin.${dlext}"
 install -Dvm 755 MAGEMin${exeext} "${bindir}/MAGEMin${exeext}"

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin",
 script = raw"""
 cd MAGEMin*
 
-CCFLAGS="-DUSE_MPI=0 -O3 -g -fPIC -std=c99"
+CCFLAGS="-O3 -g -fPIC -std=c99"
 
 if [[ "${target}" == *-apple* ]]; then 
     # Use Accelerate for Lapack dependencies
@@ -28,10 +28,10 @@ else
 fi
 
 # Compile library:
-make USE_MPI=0 CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" lib
+make CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" lib
 
 # Compile binary
-make USE_MPI=0 EXE_NAME="MAGEMin${exeext}" CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" all
+make EXE_NAME="MAGEMin${exeext}" CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" all
 
 install -Dvm 755 libMAGEMin.dylib "${libdir}/libMAGEMin.${dlext}"
 install -Dvm 755 MAGEMin${exeext} "${bindir}/MAGEMin${exeext}"

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -66,7 +66,7 @@ dependencies = [
     Dependency("OpenBLAS32_jll"; platforms=filter(!Sys.isapple, platforms))
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))
 ]
-append!(dependencies, platform_dependencies)
+append!(dependencies)
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -2,7 +2,6 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
-const YGGDRASIL_DIR = "../.."
 
 name = "MAGEMin"
 version = v"1.7.3"
@@ -27,10 +26,10 @@ else
 fi
 
 # Compile library:
-make CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" lib
+make -j${nproc} CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" lib
 
 # Compile binary
-make EXE_NAME="MAGEMin${exeext}" CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" all
+make -j${nproc} EXE_NAME="MAGEMin${exeext}" CC="${CC}" CCFLAGS="${CCFLAGS}" LIBS="${LIBS}" INC="${INC}" all
 
 install -Dvm 755 libMAGEMin.dylib "${libdir}/libMAGEMin.${dlext}"
 install -Dvm 755 MAGEMin${exeext} "${bindir}/MAGEMin${exeext}"
@@ -39,10 +38,6 @@ install -Dvm 755 MAGEMin${exeext} "${bindir}/MAGEMin${exeext}"
 install -vm 644 src/*.h "${includedir}"
 
 install_license LICENSE
-"""
-
-augment_platform_block = """
-    using Base.BinaryPlatforms
 """
 
 # These are the platforms we will build for by default, unless further
@@ -69,4 +64,4 @@ append!(dependencies)
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.6", preferred_gcc_version=v"6")
+               julia_compat="1.6", preferred_gcc_version=v"6")

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -42,7 +42,7 @@ install_license LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms((; exclude=p->Sys.isfreebsd(p) && arch(p) == "aarch64"))
+platforms = supported_platforms(; exclude=p->Sys.isfreebsd(p) && arch(p) == "aarch64")
 platforms = expand_gfortran_versions(platforms)
 platforms = filter(p -> !(arch(p)  == "riscv64"), platforms)
 platforms = filter(p -> !( (libgfortran_version(p) == v"3" || libgfortran_version(p) == v"4") && arch(p)=="powerpc64le"), platforms)

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -42,7 +42,7 @@ install_license LICENSE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude=p->Sys.isfreebsd(p) && arch(p) == "aarch64")
+platforms = supported_platforms()
 platforms = expand_gfortran_versions(platforms)
 platforms = filter(p -> !( (libgfortran_version(p) == v"3" || libgfortran_version(p) == v"4") && arch(p)=="powerpc64le"), platforms)
 

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -44,7 +44,6 @@ install_license LICENSE
 # platforms are passed in on the command line
 platforms = supported_platforms(; exclude=p->Sys.isfreebsd(p) && arch(p) == "aarch64")
 platforms = expand_gfortran_versions(platforms)
-platforms = filter(p -> !(arch(p)  == "riscv64"), platforms)
 platforms = filter(p -> !( (libgfortran_version(p) == v"3" || libgfortran_version(p) == v"4") && arch(p)=="powerpc64le"), platforms)
 
 

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -3,7 +3,6 @@
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 const YGGDRASIL_DIR = "../.."
-include(joinpath(YGGDRASIL_DIR, "platforms"))
 
 name = "MAGEMin"
 version = v"1.7.3"

--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -44,6 +44,7 @@ install_license LICENSE
 # platforms are passed in on the command line
 platforms = supported_platforms()
 platforms = expand_gfortran_versions(platforms)
+platforms = filter(p -> !(arch(p)  == "riscv64"), platforms)
 platforms = filter(p -> !( (libgfortran_version(p) == v"3" || libgfortran_version(p) == v"4") && arch(p)=="powerpc64le"), platforms)
 
 


### PR DESCRIPTION
- Dropping out support for MPI, which is never used with the Julia wrapper and was creating conflict with LaMEM.
- This new version will allow to easily call LaMEM and MAGEMin_C at the same time to compute stable phase equilibrium from passives tracers