### PR TITLE
[FLINT] Bump to v3.2.1

### DIFF
--- a/F/FLINT/build_tarballs.jl
+++ b/F/FLINT/build_tarballs.jl
@@ -25,7 +25,7 @@ using BinaryBuilder, Pkg
 # coordinated with corresponding changes to Singular_jll.jl, Nemo.jl and polymake_jll.jl
 # and possibly other packages.
 name = "FLINT"
-upstream_version = v"3.2.0"
+upstream_version = v"3.2.1"
 version_offset = v"0.0.0"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
@@ -34,7 +34,7 @@ version = VersionNumber(upstream_version.major * 100 + version_offset.major,
 # Collection of sources required to build FLINT
 sources = [
    ArchiveSource("https://github.com/flintlib/flint/releases/download/v$(upstream_version)/flint-$(upstream_version).tar.gz",
-                 "6d182c4a05d3d6bfc611565d6331d02f94066a3be32df36ed880264afa9c30f4"),
+                 "ca7be46d77972277eb6fe0c4f767548432f56bb534aa17d6dba2d7cce15cd23f"),
    DirectorySource("./bundled"),
 ]
 

--- a/F/FLINT/bundled/patches/Use-__ARM_ACLE-to-guard-inclusion-of-arm_acle.h.patch
+++ b/F/FLINT/bundled/patches/Use-__ARM_ACLE-to-guard-inclusion-of-arm_acle.h.patch
@@ -1,7 +1,7 @@
 From efcd23a2ea0e176ac0c0950c656c466791f4f7b7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Lars=20G=C3=B6ttgens?= <lars.goettgens@rwth-aachen.de>
 Date: Thu, 13 Mar 2025 00:56:32 +0100
-Subject: [PATCH] Use __ARM_ACLE to guard inclusion of arm_acle.h
+Subject: [PATCH] Use __ARM_ACLE to guard inclusion of arm_acle.h (#2264)
 
 ---
  src/ulong_extras/revbin.c | 2 +-
@@ -16,7 +16,7 @@ index 922a123e9..8698f8e18 100644
  #endif
  
 -#if defined(__GNUC__) && FLINT64 && HAVE_RBIT
-+#if defined(__GNUC__) && FLINT64 && defined(__ARM_ACLE) && HAVE_RBIT
++#if FLINT64 && __ARM_ACLE && HAVE_RBIT
  # include <arm_acle.h>
  ulong
  n_revbin(ulong n, ulong b)


### PR DESCRIPTION
This is completely orthogonal to our rebuilding efforts for FLINT's inverse deps for v3.2.0, but shouldn't complicate anything.

cc @fingolfin @thofma @Joel-Dahne 
