### PR TITLE
[Modflow6] New version 6.6.1

### DIFF
--- a/M/Modflow6/build_tarballs.jl
+++ b/M/Modflow6/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/modflow6*
 
-meson -Dnetcdf=true --cross-file=${MESON_TARGET_TOOLCHAIN} builddir
+meson -Ddebug=false -Doptimization=2 -Dnetcdf=true --cross-file=${MESON_TARGET_TOOLCHAIN} builddir
 meson compile -C builddir -j${nproc}
 meson install -C builddir
 """


### PR DESCRIPTION
Adding netcdf-fortran dependency to support NetCDF IO. Bumping GCC version for [compatibility](https://modflow6.readthedocs.io/en/stable/_dev/developer.html#compile).