### PR TITLE
[aws_c_http_jq] Update to version 0.9.6

### DIFF
--- a/A/aws_c_http_jq/build_tarballs.jl
+++ b/A/aws_c_http_jq/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_http_jq"
-version = v"0.9.5"
+version = v"0.9.6"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
This PR updates aws_c_http_jq to version 0.9.6. cc: @quinnj @Octogonapus