### PR TITLE
qpOASES: version 3.2.2 and MUMPS as sparse solver

### DIFF
--- a/Q/qpOASES/build_tarballs.jl
+++ b/Q/qpOASES/build_tarballs.jl
@@ -1,44 +1,91 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
-
 name = "qpOASES"
-version = v"3.2.1"
+version = v"3.2.2"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/coin-or/qpOASES.git",
-    "51d3fbea30142d3acbf40cf7a1c519efc27ea67b"),
+    "680f18c8ef0018a120e1604b769f056e8368df97"),
     DirectorySource("./bundled")
 ]
 
+include("../../L/libjulia/common.jl")
+
+
 # Bash recipe for building across all platforms
 script = raw"""
+apk del cmake
 cd $WORKSPACE/srcdir
-for f in ${WORKSPACE}/srcdir/patches/*.patch; do
-    atomic_patch -p1 ${f}
+cd qpOASES
+
+atomic_patch -p1  ${WORKSPACE}/srcdir/patches/mypatch.patch
+
+rm Makefile
+rm *.mk
+mkdir build && cd build
+if [[ "$nbits" == "64" ]]; then
+    LOB="${libdir}/libopenblas64_.${dlext}";
+else
+    LOB="$libdir/libopenblas.$dlext"
+fi
+
+for sym in  sgemm dgemm spotrf dpotrf strcon dtrcon strtrs dtrtrs ; do
+    SYMB_DEFS+=("-D${sym}_=${sym}_64_")
 done
-cd qpOASES/
-cmake -B build \
-    -DCMAKE_INSTALL_PREFIX=$prefix \
+
+export CXXFLAGS="${SYMB_DEFS[@]}"
+export LDFLAGS="-L${libdir}"
+cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_PREFIX_PATH=${libdir} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-    -DCMAKE_BUILD_TYPE=Release
-cmake --build build --parallel ${nproc}
-cmake --install build
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_MODULE_PATH=$WORKSPACE/srcdir \
+    -DMUMPS_INCLUDE_DIR=${includedir} \
+    -DMUMPS_LIBRARIES="${libdir}/libdmumps.${dlext}" \
+    -DMUMPS_COMMON_LIBRARY="${libdir}/libmumps_common.${dlext}" \
+    -DMUMPS_PORD_LIBRARY="${libdir}/libpord.${dlext}" \
+    -DMUMPS_MPISEQ_LIBRARY="${libdir}/libmpiseq.${dlext}" \
+    -DBLAS_LIBRARIES=${LOB} \
+    -DLAPACK_LIBRARIES=${LOB} \
+    ..
+
+make
+make install
+install_license ../LICENSE
 """
+
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
+platforms = expand_cxxstring_abis(platforms)
+#platforms = expand_gfortran_versions(platforms)
+filter!(p -> !(os(p) == "freebsd"), platforms)
+filter!(p -> !(arch(p) == "i686"), platforms)
+filter!(p -> !(libc(p) == "musl"), platforms)
+filter!(p -> !(arch(p) == "riscv64"), platforms)
+filter!(p -> !(arch(p) == "powerpc64le"), platforms)
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libqpOASES", :libqpOASES)
+    LibraryProduct("libqpOASES", :libqpOASES),
+    LibraryProduct("libqpOASES_MUMPS", :libqpOASES_MUMPS),
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
-]
+dependencies = [
+    Dependency(PackageSpec(name="MUMPS_seq_jll",
+                uuid="d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"),
+                compat="500.700.301"),
+    Dependency("OpenBLAS_jll"; compat="0.3.23"),
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll",
+                uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+    HostBuildDependency(PackageSpec(; name="CMake_jll"))
+    ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    preferred_gcc_version=v"9",
+    julia_compat="1.9")

--- a/Q/qpOASES/bundled/patches/mypatch.patch
+++ b/Q/qpOASES/bundled/patches/mypatch.patch
@@ -1,13 +1,382 @@
-diff --git before/qpOASES/CMakeLists.txt after/qpOASES/CMakeLists.txt
-index adb111f..d3c6ce3 100644
---- before/qpOASES/CMakeLists.txt
-+++ after/qpOASES/CMakeLists.txt
-@@ -104,7 +104,7 @@ INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/include)
- FILE(GLOB SRC src/*.cpp)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 24c1a81..6700c49 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -121,80 +121,61 @@ endif("${isSystemDir}" STREQUAL "-1")
+ ############################################################
+ INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/include)
+ # compile qpOASES libraries
+-FILE(GLOB SRC src/*.cpp)
++
++
++# compile qpOASES with standard options
++FILE(GLOB SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
  
  # library
--ADD_LIBRARY(qpOASES STATIC ${SRC})
+-ADD_LIBRARY(qpOASES ${SRC})
 +ADD_LIBRARY(qpOASES SHARED ${SRC})
++
  INSTALL(TARGETS qpOASES
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+ )
++
+ SET_TARGET_PROPERTIES(
+     qpOASES
+     PROPERTIES
+     SOVERSION ${PACKAGE_SO_VERSION}
+     )
+ 
+-# headers
+-INSTALL(FILES include/qpOASES.hpp
+-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ 
+-INSTALL(DIRECTORY include/qpOASES
+-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+-  FILES_MATCHING PATTERN "*.hpp"
+-  PATTERN "*.ipp"
+-  PATTERN ".svn" EXCLUDE)
++INSTALL(TARGETS qpOASES
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    PUBLIC_HEADER
++      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++      )
+ 
+-############################################################
+-######################### Package Config ###################
+-############################################################
+ 
+-include(CMakePackageConfigHelpers)
+-set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+-set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+-configure_package_config_file(qpOASESConfig.cmake.in
+-  ${CMAKE_CURRENT_BINARY_DIR}/qpOASESConfig.cmake
+-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/qpOASES
+-  PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR
+-  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+-
+-write_basic_package_version_file(
+-    ${CMAKE_CURRENT_BINARY_DIR}/qpOASESConfigVersion.cmake
+-    VERSION ${PACKAGE_VERSION}
+-    COMPATIBILITY SameMajorVersion)
+-
+-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/qpOASESConfig.cmake
+-    ${CMAKE_CURRENT_BINARY_DIR}/qpOASESConfigVersion.cmake
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/qpOASES
+-    COMPONENT qpOASES)
++# compile qpOASES with MUMPS
++FILE(GLOB SRC_MUMPS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
++list(REMOVE_ITEM SRC_MUMPS ${CMAKE_CURRENT_SOURCE_DIR}/src/LAPACKReplacement.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/BLASReplacement.cpp)
+ 
+-############################################################
+-######################### examples #########################
+-############################################################
++# library
++ADD_LIBRARY(qpOASES_MUMPS SHARED ${SRC_MUMPS})
+ 
+-if (QPOASES_BUILD_EXAMPLES)
+-    # compile qpOASES examples
+-    SET(EXAMPLE_NAMES
+-        example1
+-        example1a
+-        example1b
+-        example2
+-        example3
+-        example3b
+-        example4
+-        example5
+-        exampleLP
+-        qrecipe
+-        qrecipeSchur
+-    )
++target_include_directories(qpOASES_MUMPS PUBLIC ${MUMPS_INCLUDE_DIR} ${MUMPS_INCLUDE_DIR}/libseq)
++target_compile_options(qpOASES_MUMPS PUBLIC -DSOLVER_MUMPS -DUSE_MPI_H)
++target_link_libraries(qpOASES_MUMPS PUBLIC ${LAPACK_LIBRARIES} ${MUMPS_LIBRARIES} ${MUMPS_COMMON_LIBRARY} ${MUMPS_PORD_LIBRARY} ${MUMPS_MPISEQ_LIBRARY})
+ 
+-    FOREACH(ELEMENT ${EXAMPLE_NAMES})
+-        ADD_EXECUTABLE(${ELEMENT} examples/${ELEMENT}.cpp)
+-        TARGET_LINK_LIBRARIES(${ELEMENT} qpOASES)
+-    ENDFOREACH(ELEMENT ${EXAMPLE_NAMES})
+-endif(QPOASES_BUILD_EXAMPLES)
++INSTALL(TARGETS qpOASES_MUMPS
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  PUBLIC_HEADER
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++)
++SET_TARGET_PROPERTIES(
++    qpOASES_MUMPS
++    PROPERTIES
++    SOVERSION ${PACKAGE_SO_VERSION}
++    )
+ 
+-##
+-##   end of file
+-##
++# headers /usr/lib/gcc/x86_64-linux-gnu/11/
++INSTALL(FILES include/qpOASES.hpp
++  DESTINATION include)
++INSTALL(DIRECTORY include/qpOASES
++  DESTINATION include
++  FILES_MATCHING PATTERN "*.hpp"
++  PATTERN "*.ipp"
++  PATTERN ".svn" EXCLUDE)
+diff --git a/src/SparseSolver.cpp b/src/SparseSolver.cpp
+index c3b996a..59c2311 100644
+--- a/src/SparseSolver.cpp
++++ b/src/SparseSolver.cpp
+@@ -34,6 +34,7 @@
+ 
+ 
+ #include <qpOASES/SparseSolver.hpp>
++#include <iostream>
+ 
+ #ifndef __MATLAB__
+ # include <cstdarg>
+@@ -686,6 +687,7 @@ Ma57SparseSolver::Ma57SparseSolver( ) : SparseSolver()
+ 	icntl_ma57[0] = -1;			/* Suppress error messages */
+ 	icntl_ma57[1] = -1;			/* Suppress warning messages */
+ 	icntl_ma57[2] = -1;			/* Suppress monitoring messages */
++	icntl_ma57[5] = 5;          /* Matrix reordering. Default value 5: Automatic choice between METIS and MC47, 4: METIS*/
+ 	/*icntl_ma57[4] = 4;		// Print everything (for debugging) */
+ 	icntl_ma57[15] = 1;			/* Place small pivots at the end of the factorization (default: 0) */
+ 
+@@ -844,6 +846,7 @@ returnValue Ma57SparseSolver::factorize( )
+ 	ierror = info_ma57[1];  /* Error flag */
+ 	neig = info_ma57[23];   /* Number of negative eigenvalues */
+ 	rank = info_ma57[24];   /* Rank of matrix */
++	
+ 
+ 	/* Read pivot sequence (see MA57UD source code) */
+ 	pivots = new fint_t[dim];
+@@ -861,6 +864,7 @@ returnValue Ma57SparseSolver::factorize( )
+ 
+         iwpos = iwpos+ncols+2;
+     }
++    
+ 
+ 	if (iflag == 4)
+ 	{
+@@ -979,7 +983,7 @@ returnValue Ma57SparseSolver::getZeroPivots( int_t *&zeroPivots )
+ {
+ 	for ( int_t k=0; k<dim-rank; k++ )
+ 		zeroPivots[k] = pivots[rank+k];
+-
++        
+ 	return SUCCESSFUL_RETURN;
+ }
+ 
+@@ -1109,23 +1113,15 @@ returnValue Ma57SparseSolver::copy( 	const Ma57SparseSolver& rhs
+ __attribute__((constructor))
+ static void MPIinit(void)
+ {
+-    int mpi_initialized;
+-    MPI_Initialized(&mpi_initialized);
+-    if( !mpi_initialized )
+-    {
+-        int argc = 1;
+-        char** argv = NULL;
+-        MPI_Init(&argc, &argv);
+-    }
++	int argc = 1;
++	char** argv = NULL;
++	MPI_Init(&argc, &argv);
+ }
+ 
+ __attribute__((destructor))
+ static void MPIfini(void)
+ {
+-    int mpi_finalized;
+-    MPI_Finalize(&mpi_finalized);
+-    if(!mpi_finalized)
+-        MPI_Finalize();
++	MPI_Finalize();
+ }
+ #endif /* !USE_MPI_H */
+ 
+@@ -1159,10 +1155,10 @@ MumpsSparseSolver::MumpsSparseSolver( ) : SparseSolver()
+ // #endif
+ 
+     mumps_c(mumps_);
+-    mumps_->icntl[1] = 0;
+-    mumps_->icntl[2] = 0; //QUIETLY!
+-    mumps_->icntl[3] = 0;
+-
++    mumps_->icntl[1] = -1;
++    mumps_->icntl[2] = -1; //QUIETLY!
++    mumps_->icntl[3] = -1;
++    
+ 
+     // these values are just copied from Ipopt: better values might exist
+     mem_percent_ = 1000;
+@@ -1171,10 +1167,12 @@ MumpsSparseSolver::MumpsSparseSolver( ) : SparseSolver()
+     mumps_scaling_ = 77;
+     mumps_dep_tol_ = 0.0;
+ 
+-    pivtol_ = 0.000001;
++    //pivtol_ = 0.000001;
++    //pivtol_ = 0.1;
+     // pivtol_ = 1.0;
+     // pivtol_ = 0.1;
+     // pivtol_ = 0.0;
++	pivtol_ = 0.01; //default value for general symmetric matrices
+     pivtolmax_ = 0.1; // actually unused atm
+ 
+     // Reset all private data
+@@ -1205,11 +1203,13 @@ MumpsSparseSolver::~MumpsSparseSolver( )
+ // #ifndef IPOPT_MUMPS_NOMUTEX
+ //     const std::lock_guard<std::mutex> lock(mumps_call_mutex);
+ // #endif
++	clear();
+ 
+     MUMPS_STRUC_C* mumps_ = static_cast<MUMPS_STRUC_C*>(mumps_ptr_);
+     mumps_->job = -2; //terminate mumps
+     mumps_c(mumps_);
+-    delete[] mumps_->a;
++    //delete[] mumps_->a;
++    //delete[] a_mumps;
+     free(mumps_);
+ }
+ 
+@@ -1256,14 +1256,15 @@ returnValue MumpsSparseSolver::setMatrixData(	int_t dim_,
+ 		jcn_mumps = new fint_t[numNonzeros_];
+ 
+ 		numNonzeros=0;
+-		for (int_t i=0; i<numNonzeros_; ++i)
++		for (int_t i=0; i<numNonzeros_; ++i){
+ 			if ( isZero(avals[i]) == BT_FALSE )
+-			{
++			{       
+ 				a_mumps[numNonzeros] = avals[i];
+ 				irn_mumps[numNonzeros] = irn[i];
+ 				jcn_mumps[numNonzeros] = jcn[i];
+ 				numNonzeros++;
+ 			}
++		}
+ 	}
+ 	else
+ 	{
+@@ -1296,26 +1297,21 @@ returnValue MumpsSparseSolver::factorize( )
+     MUMPS_STRUC_C* mumps_ = static_cast<MUMPS_STRUC_C*>(mumps_ptr_);
+     mumps_data->n = dim;
+     mumps_data->nz = numNonzeros;
+-    delete[] mumps_data->a;
+-    mumps_data->a = NULL;
++    
+ 
+-    mumps_data->a = new double[numNonzeros];
++	mumps_data->a = const_cast<double*>(a_mumps);
+     mumps_data->irn = const_cast<int*>(irn_mumps);
+     mumps_data->jcn = const_cast<int*>(jcn_mumps);
++    
+ 
+     // make sure we do the symbolic factorization before a real
+     // factorization
+     have_symbolic_factorization_ = false;
+ 
+-// #ifndef IPOPT_MUMPS_NOMUTEX
+-//     const std::lock_guard<std::mutex> lock(mumps_call_mutex);
+-// #endif
++	// #ifndef IPOPT_MUMPS_NOMUTEX
++	//     const std::lock_guard<std::mutex> lock(mumps_call_mutex);
++	// #endif
+ 
+-    mumps_data->job = 1;      //symbolic ordering pass
+-
+-    //mumps_data->icntl[1] = 6;
+-    //mumps_data->icntl[2] = 6;//QUIETLY!
+-    //mumps_data->icntl[3] = 4;
+ 
+     mumps_data->icntl[5] = mumps_permuting_scaling_;
+     mumps_data->icntl[6] = mumps_pivot_order_;
+@@ -1324,12 +1320,21 @@ returnValue MumpsSparseSolver::factorize( )
+ 
+     mumps_data->icntl[12] = 1;   //avoid lapack bug, ensures proper inertia; mentioned to be very expensive in mumps manual
+     mumps_data->icntl[13] = mem_percent_; //% memory to allocate over expected
+-    mumps_data->cntl[0] = pivtol_;  // Set pivot tolerance
++    
++	mumps_data->icntl[24-1] = 1; //enable null pivot detection
++	//mumps_data->icntl[56-1] = 1; //enable rank revealing and returning of indices corresponding to null singular values
++	
++	//TODO good default value. 1e-8 is set above for MA27. MA57 manual suggests 1e-12 as a normal value.
++	mumps_data->cntl[3-1] = 1e-12; //null pivot tolerance
++	
++	mumps_data->cntl[0] = pivtol_;  // Set pivot tolerance
+ 
+     // dump_matrix(mumps_data);
+ 
+-    // MyPrintf("Calling MUMPS-1 for symbolic factorization.\n");
++
++    mumps_data->job = 1;      //symbolic ordering pass
+     mumps_c(mumps_data);
++    
+     // MyPrintf("Done with MUMPS-1 for symbolic factorization.\n");
+     int error = mumps_data->info[0];
+     const int& mumps_permuting_scaling_used = mumps_data->infog[22];
+@@ -1359,7 +1364,7 @@ returnValue MumpsSparseSolver::factorize( )
+     mumps_c(mumps_data);
+     // MyPrintf("Done with MUMPS-2 for numerical factorization.\n");
+     error = mumps_data->info[0];
+-
++    
+     //Check for errors
+     if( error == -8 || error == -9 )  //not enough memory
+     {
+@@ -1391,11 +1396,18 @@ returnValue MumpsSparseSolver::factorize( )
+     // MyPrintf("Number of doubles for MUMPS to hold factorization (INFO(9)) = %i\n", mumps_data->info[8]);
+     // MyPrintf("Number of integers for MUMPS to hold factorization (INFO(10)) = %i\n", mumps_data->info[9]);
+ 
++	//REMOVED: Mumps does not error on singular systems if null pivot detection is enabled. infog[28-1] instead contains number of null pivots
++	/*
+     if( error == -10 )  //system is singular
+     {
+         MyPrintf("MUMPS returned INFO(1) = %i matrix is singular.\n", error);
+         return RET_MATRIX_FACTORISATION_FAILED;
+     }
++	*/
++	if (mumps_data->infog[28-1]){
++		return RET_KKT_MATRIX_SINGULAR;
++	}
++
+ 
+     negevals_ = mumps_data->infog[11];
+ 
+@@ -1490,22 +1502,22 @@ int_t MumpsSparseSolver::getNegativeEigenvalues( )
+ }
+ 
+ 
+-// TODO(andrea: not implemented yet, default behavior)
+ 
+ /*
+  *	g e t R a n k
+  */
+-int_t MumpsSparseSolver::getRank( )
+-{
+-	return -1;
++int_t MumpsSparseSolver::getRank(){
++	return dim - static_cast<MUMPS_STRUC_C*>(mumps_ptr_)->infog[28-1];
+ }
++
+ /*
+  *	g e t Z e r o P i v o t s
+  */
+-returnValue MumpsSparseSolver::getZeroPivots( int_t *&zeroPivots )
+-{
+-	if ( zeroPivots ) delete[] zeroPivots;
+-	zeroPivots = 0;
++returnValue MumpsSparseSolver::getZeroPivots( int_t *&zeroPivots ){
++	MUMPS_STRUC_C* mumps_data = static_cast<MUMPS_STRUC_C*>(mumps_ptr_);
++	for (int i = 0; i < mumps_data->infog[28-1]; i++){
++		zeroPivots[i] = mumps_data->pivnul_list[i] - 1;
++	}
+ 	return SUCCESSFUL_RETURN;
+ }
+ 
+@@ -1606,7 +1618,6 @@ returnValue DummySparseSolver::solve(	int_t dim, /**< Dimension of the linear sy
+ 
+ END_NAMESPACE_QPOASES
+ 
+-
+ /*
+  *	end of file
+  */


### PR DESCRIPTION
I've adapted the build script to the version 3.2.2 of qpOASES and also build a second solver lib in which MUMPS is used as the underlying sparse solver to have the full functionality of QPOASES.