### PR TITLE
OpenMPI 5: Declare Fortran libraries

### DIFF
--- a/O/OpenMPI/OpenMPI@5/build_tarballs.jl
+++ b/O/OpenMPI/OpenMPI@5/build_tarballs.jl
@@ -94,6 +94,9 @@ foreach(p -> (p["mpi"] = "OpenMPI"), platforms)
 products = [
     # OpenMPI
     LibraryProduct("libmpi", :libmpi),
+    LibraryProduct("libmpi_mpifh", :libmpi_mpifh),
+    LibraryProduct("libmpi_usempi_ignore_tkr", :libmpi_usempi_ignore_tkr),
+    LibraryProduct("libmpi_usempif08", :libmpi_usempif08),
     ExecutableProduct("mpiexec", :mpiexec),
 ]
 


### PR DESCRIPTION
This should address https://github.com/JuliaIO/HDF5.jl/issues/1191.