### PR TITLE
iso_codes: New version 4.17

### DIFF
--- a/I/iso_codes/build_tarballs.jl
+++ b/I/iso_codes/build_tarballs.jl
@@ -22,14 +22,10 @@ make install
 """
 
 # The files are identical for all platforms, and in principle we could
-# use `AnyPlatform()` instead. However:
-#
-# @staticfloat says: Sadly, if you have a platformless binding in an
-# Artifacts.toml file, you can't also have other platform-specific
-# bindings in that same Artifacts.toml file. So the best we can do
-# here is to just have the same tarball listed for a bunch of
-# different platforms, then a different tarball for the windows
-# platforms.
+# use `AnyPlatform()` instead. However this artifact contains symlinks
+# which have to be replaced with copies on Windows, and for that to
+# happen we need to build it for Windows specifically (and hence for
+# all other platforms as well)
 platforms = supported_platforms()
 
 # The products that we will ensure are always built

--- a/I/iso_codes/build_tarballs.jl
+++ b/I/iso_codes/build_tarballs.jl
@@ -3,40 +3,27 @@
 using BinaryBuilder
 
 name = "iso_codes"
-version = v"4.15.1"
-
-# the git tag used for versioning has changed format
-if version < v"4.8"
-    if version < v"4.5" && version.patch == 0
-        tag = "iso-codes-$(version.major).$(version.minor)"
-    else
-        tag = "iso-codes-$version"
-    end
-elseif version == v"4.15.1" # for fake patch version to fix windows install.
-    tag = "v4.15.0"
-else
-    tag = "v$version"
-end
+version = v"4.17.0"
 
 # Collection of sources required to build iso-codes
 sources = [
-    ArchiveSource("https://salsa.debian.org/iso-codes-team/iso-codes/-/archive/$tag/iso-codes-$tag.tar.bz2",
-                  "ca2cadca98ad50af6e0ee4e139ec838695f75729d7a2c6353d31d9dfc6d3f027"),
+    ArchiveSource("https://salsa.debian.org/iso-codes-team/iso-codes/-/archive/v$(version)/iso-codes-v$(version).tar.bz2",
+                  "6d178ef4cea44e55f02eb546b29dcf68d88e9f7a68e0dd7913f5465dbaf8fc14"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/iso-codes-*/
+cd $WORKSPACE/srcdir/iso-codes-*
 apk update
 apk add gettext
-./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+./configure --prefix=${prefix}
 make -j${nproc}
 make install
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = [AnyPlatform()]
 
 # The products that we will ensure are always built
 products = Product[

--- a/I/iso_codes/build_tarballs.jl
+++ b/I/iso_codes/build_tarballs.jl
@@ -16,14 +16,21 @@ script = raw"""
 cd $WORKSPACE/srcdir/iso-codes-*
 apk update
 apk add gettext
-./configure --prefix=${prefix}
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
 make -j${nproc}
 make install
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = [AnyPlatform()]
+# The files are identical for all platforms, and in principle we could
+# use `AnyPlatform()` instead. However:
+#
+# @staticfloat says: Sadly, if you have a platformless binding in an
+# Artifacts.toml file, you can't also have other platform-specific
+# bindings in that same Artifacts.toml file. So the best we can do
+# here is to just have the same tarball listed for a bunch of
+# different platforms, then a different tarball for the windows
+# platforms.
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = Product[


### PR DESCRIPTION
- Update the package to 4.17.
- Convert to a platform-independent package. The only content is JSON files.
