### PR TITLE
Lingeling: add apple

### DIFF
--- a/L/Lingeling/build_tarballs.jl
+++ b/L/Lingeling/build_tarballs.jl
@@ -26,7 +26,6 @@ install_license COPYING
 # platforms are passed in on the command line
 platforms = supported_platforms()
 filter!(!Sys.iswindows, platforms)
-filter!(!Sys.isapple, platforms)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
Removed the filter for apple. Not sure why I included it in the first place.
Does this need a version update? Upstream is still at 1.0.0 so changing it here would be kind of unfortunate ...