### PR TITLE
[osslsigncode] add builder

### DIFF
--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -12,6 +12,11 @@ sources = [
 ]
 
 script = raw"""
+    if [[ "${target}" == *-mingw32 ]]; then
+        cd /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/lib/
+        ln -s libws2_32.a libWs2_32.a
+    fi
+
     cd $WORKSPACE/srcdir/osslsigncode
 
     cmake -B build \
@@ -27,15 +32,7 @@ script = raw"""
     install -Dvm 755 "build/osslsigncode${exeext}" "${bindir}/osslsigncode${exeext}"
 """
 
-platforms = [
-    Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("aarch64", "linux"; libc = "glibc"),
-    Platform("x86_64", "linux"; libc = "musl"),
-    Platform("aarch64", "linux"; libc = "musl"),
-    Platform("x86_64", "macos"),
-    Platform("aarch64", "macos"),
-    Platform("x86_64", "windows"),
-]
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [
@@ -44,7 +41,7 @@ products = [
 
 dependencies = [
     Dependency("OpenSSL_jll", compat="3.0.16"),
-    Dependency("Zlib_jll", compat="1.3.0"),
+    Dependency("Zlib_jll", compat="1.3.1"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -21,7 +21,7 @@ script = raw"""
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
         -DCMAKE_BUILD_TYPE=Release \
         -DZLIB_INCLUDE_DIR=${includedir} \
-        -DZLIB_LIBRARY=/workspace/destdir/lib/libz.${dlext}
+        -DZLIB_LIBRARY="${libdir}/libz.${dlext}"
 
     cmake --build build --parallel ${nproc}
     

--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -39,7 +39,7 @@ products = [
 
 dependencies = [
     Dependency("OpenSSL_jll", compat="3.0.16"),
-    Dependency("Zlib_jll", compat="1.3.1"),
+    Dependency("Zlib_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -33,6 +33,7 @@ script = raw"""
 """
 
 platforms = supported_platforms()
+filter(!(==)(Platform("i686", "windows")), platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -21,7 +21,7 @@ script = raw"""
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
         -DCMAKE_BUILD_TYPE=Release \
         -DZLIB_INCLUDE_DIR=${includedir} \
-        -DZLIB_LIBRARY=/workspace/destdir/lib/libz.${libext}
+        -DZLIB_LIBRARY=/workspace/destdir/lib/libz.${dlext}
 
     cmake --build build --parallel ${nproc}
     

--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "osslsigncode"
+version = v"2.10.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/mtrojnar/osslsigncode",
+                  "4568c890cc1538ca80be3ee36775ba42223dea04"),
+]
+
+script = raw"""
+    cd $WORKSPACE/srcdir/osslsigncode
+
+    cmake -B build \
+        -DCMAKE_INSTALL_PREFIX=${prefix} \
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DZLIB_INCLUDE_DIR=/workspace/destdir/include \
+        -DZLIB_LIBRARY=/workspace/destdir/lib/libz.a
+
+    cmake --build build --parallel ${nproc}
+    
+    install_license LICENSE.txt
+    install -Dvm 755 "build/osslsigncode${exeext}" "${bindir}/osslsigncode${exeext}"
+"""
+
+platforms = [
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "musl"),
+    Platform("aarch64", "linux"; libc = "musl"),
+    Platform("x86_64", "macos"),
+    Platform("aarch64", "macos"),
+    Platform("x86_64", "windows"),
+]
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("osslsigncode", :osslsigncode)
+]
+
+dependencies = [
+    Dependency("OpenSSL_jll", compat="3.0.16"),
+    Dependency("Zlib_jll", compat="1.3.0"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"8.1.0")

--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -12,12 +12,9 @@ sources = [
 ]
 
 script = raw"""
-    if [[ "${target}" == *-mingw32 ]]; then
-        cd /opt/x86_64-w64-mingw32/x86_64-w64-mingw32/lib/
-        ln -s libws2_32.a libWs2_32.a
-    fi
-
     cd $WORKSPACE/srcdir/osslsigncode
+
+    sed -i 's/Ws2_32/ws2_32/g' CMakeLists.txt
 
     cmake -B build \
         -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "osslsigncode"
-version = v"2.10.0"
+version = v"2.9.0"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/mtrojnar/osslsigncode",
-                  "4568c890cc1538ca80be3ee36775ba42223dea04"),
+                  "76ee550c9d3b9f0e559f044e18136b74c167fef2"),
 ]
 
 script = raw"""

--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -21,7 +21,7 @@ script = raw"""
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
         -DCMAKE_BUILD_TYPE=Release \
         -DZLIB_INCLUDE_DIR=${includedir} \
-        -DZLIB_LIBRARY=/workspace/destdir/lib/libz.a
+        -DZLIB_LIBRARY=/workspace/destdir/lib/libz.${libext}
 
     cmake --build build --parallel ${nproc}
     
@@ -30,7 +30,6 @@ script = raw"""
 """
 
 platforms = supported_platforms()
-filter(!(==)(Platform("i686", "windows")), platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/O/osslsigncode/build_tarballs.jl
+++ b/O/osslsigncode/build_tarballs.jl
@@ -20,7 +20,7 @@ script = raw"""
         -DCMAKE_INSTALL_PREFIX=${prefix} \
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
         -DCMAKE_BUILD_TYPE=Release \
-        -DZLIB_INCLUDE_DIR=/workspace/destdir/include \
+        -DZLIB_INCLUDE_DIR=${includedir} \
         -DZLIB_LIBRARY=/workspace/destdir/lib/libz.a
 
     cmake --build build --parallel ${nproc}


### PR DESCRIPTION
Osslsigncode allows one to sign Windows binaries like `.exe` and `.dll`. It also contains functionality for signing MSI installers, and according to https://github.com/mtrojnar/osslsigncode/pull/277#issue-1771451905, it can also sign MSIX installers, which is relevant for the AppBundler project. 