### PR TITLE
[libdmg-hfsplus] new package

### DIFF
--- a/L/libdmg_hfsplus/build_tarballs.jl
+++ b/L/libdmg_hfsplus/build_tarballs.jl
@@ -1,0 +1,45 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "libdmg_hfsplus"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/mozilla/libdmg-hfsplus.git", "d6287b5afc2406b398de42f74eba432f2123b937")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+mkdir -p /tmp/libdmg-build
+cd /tmp/libdmg-build
+cmake /workspace/srcdir/libdmg-hfsplus   -DZLIB_INCLUDE_DIR=$WORKSPACE/destdir/include   -DZLIB_LIBRARY=$WORKSPACE/destdir/lib/libz.so   -DBZIP2_INCLUDE_DIR=$WORKSPACE/destdir/include   -DBZIP2_LIBRARIES=$WORKSPACE/destdir/lib/libbz2.so   -DLIBLZMA_INCLUDE_DIR=$WORKSPACE/destdir/include   -DLIBLZMA_LIBRARY=$WORKSPACE/destdir/lib/liblzma.so   -DOPENSSL_INCLUDE_DIR=$WORKSPACE/destdir/include   -DOPENSSL_CRYPTO_LIBRARY=$WORKSPACE/destdir/lib/libcrypto.so   -DWITH_LZFSE=OFF
+make
+install -Dvm 755 "/tmp/libdmg-build/dmg/dmg${exeext}" "${bindir}/dmg${exeext}"
+cd /workspace/srcdir/libdmg-hfsplus/
+install_license LICENSE 
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "linux"; libc = "glibc")
+]
+
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("dmg", :dmg)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
+    Dependency(PackageSpec(name="Bzip2_jll", uuid="6e34b625-4abd-537c-b88f-471c36dfa7a0"))
+    Dependency(PackageSpec(name="XZ_jll", uuid="ffd25f8a-64ca-5728-b0f7-c24cf3aae800"))
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/L/libdmg_hfsplus/build_tarballs.jl
+++ b/L/libdmg_hfsplus/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "libdmg_hfsplus"
-version = v"0.0.0"
+version = v"0.5.0"
 
 # Collection of sources required to complete build
 sources = [

--- a/L/libdmg_hfsplus/build_tarballs.jl
+++ b/L/libdmg_hfsplus/build_tarballs.jl
@@ -39,7 +39,7 @@ script = raw"""
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-filter!(p -> !(Sys.iswindows(p) && arch(p) == "i686"), platforms)
+filter!(!Sys.iswindows, platforms)
 filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
 filter!(p -> arch(p) != "riscv64", platforms)
 

--- a/L/libdmg_hfsplus/build_tarballs.jl
+++ b/L/libdmg_hfsplus/build_tarballs.jl
@@ -38,17 +38,10 @@ script = raw"""
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("aarch64", "linux"; libc = "glibc"),
-    Platform("x86_64", "linux"; libc = "musl"),
-    Platform("aarch64", "linux"; libc = "musl"),
-    Platform("x86_64", "macos"),
-    Platform("aarch64", "macos"),
-    Platform("x86_64", "freebsd"), 
-    Platform("aarch64", "freebsd"),
-]
-
+platforms = supported_platforms()
+filter!(p -> !(Sys.iswindows(p) && arch(p) == "i686"), platforms)
+filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
+filter!(p -> arch(p) != "riscv64", platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/L/libdmg_hfsplus/build_tarballs.jl
+++ b/L/libdmg_hfsplus/build_tarballs.jl
@@ -12,7 +12,6 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-
     cd $WORKSPACE/srcdir/libdmg-hfsplus
 
     cmake -B build \
@@ -26,8 +25,10 @@ script = raw"""
         -DLIBLZMA_INCLUDE_DIR=$WORKSPACE/destdir/include \
         -DLIBLZMA_LIBRARY="$WORKSPACE/destdir/lib/liblzma.${dlext}" \
         -DOPENSSL_INCLUDE_DIR=$WORKSPACE/destdir/include \
-        -DOPENSSL_CRYPTO_LIBRARY="$WORKSPACE/destdir/lib/libcrypto.${dlext}"  
-
+        -DOPENSSL_CRYPTO_LIBRARY="$WORKSPACE/destdir/lib/libcrypto.${dlext}" \
+        -DLZFSE_INCLUDE_DIR=$WORKSPACE/destdir/include \
+        -DLZFSE_LIBRARY="$WORKSPACE/destdir/lib/liblzfse.${dlext}"
+ 
     cmake --build build --parallel ${nproc}
 
     install -Dvm 755 "build/dmg/dmg${exeext}" "${bindir}/dmg${exeext}"
@@ -41,7 +42,7 @@ script = raw"""
 platforms = supported_platforms()
 filter!(!Sys.iswindows, platforms)
 filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
-filter!(p -> arch(p) != "riscv64", platforms)
+filter!(p -> arch(p) == "riscv64", platforms)
 
 # The products that we will ensure are always built
 products = [
@@ -52,9 +53,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
-    Dependency(PackageSpec(name="Bzip2_jll", uuid="6e34b625-4abd-537c-b88f-471c36dfa7a0"); compat="1.0.9")
-    Dependency(PackageSpec(name="XZ_jll", uuid="ffd25f8a-64ca-5728-b0f7-c24cf3aae800"))
+    Dependency(PackageSpec(name="LZFSE_jll")),
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a")),
+    Dependency(PackageSpec(name="Bzip2_jll", uuid="6e34b625-4abd-537c-b88f-471c36dfa7a0"); compat="1.0.9"),
+    Dependency(PackageSpec(name="XZ_jll", uuid="ffd25f8a-64ca-5728-b0f7-c24cf3aae800")),
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.16")
 ]
 

--- a/L/libdmg_hfsplus/build_tarballs.jl
+++ b/L/libdmg_hfsplus/build_tarballs.jl
@@ -41,8 +41,6 @@ script = raw"""
 # platforms are passed in on the command line
 platforms = supported_platforms()
 filter!(!Sys.iswindows, platforms)
-filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
-filter!(p -> arch(p) == "riscv64", platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/L/libdmg_hfsplus/build_tarballs.jl
+++ b/L/libdmg_hfsplus/build_tarballs.jl
@@ -45,6 +45,8 @@ platforms = [
     Platform("aarch64", "linux"; libc = "musl"),
     Platform("x86_64", "macos"),
     Platform("aarch64", "macos"),
+    Platform("x86_64", "freebsd"), 
+    Platform("aarch64", "freebsd"),
 ]
 
 

--- a/L/libdmg_hfsplus/build_tarballs.jl
+++ b/L/libdmg_hfsplus/build_tarballs.jl
@@ -18,16 +18,16 @@ script = raw"""
         -DCMAKE_INSTALL_PREFIX=${prefix} \
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
         -DCMAKE_BUILD_TYPE=Release \
-        -DZLIB_INCLUDE_DIR=$WORKSPACE/destdir/include \
-        -DZLIB_LIBRARY="$WORKSPACE/destdir/lib/libz.${dlext}" \
-        -DBZIP2_INCLUDE_DIR=$WORKSPACE/destdir/include  \
-        -DBZIP2_LIBRARIES="$WORKSPACE/destdir/lib/libbz2.${dlext}" \
-        -DLIBLZMA_INCLUDE_DIR=$WORKSPACE/destdir/include \
-        -DLIBLZMA_LIBRARY="$WORKSPACE/destdir/lib/liblzma.${dlext}" \
-        -DOPENSSL_INCLUDE_DIR=$WORKSPACE/destdir/include \
-        -DOPENSSL_CRYPTO_LIBRARY="$WORKSPACE/destdir/lib/libcrypto.${dlext}" \
-        -DLZFSE_INCLUDE_DIR=$WORKSPACE/destdir/include \
-        -DLZFSE_LIBRARY="$WORKSPACE/destdir/lib/liblzfse.${dlext}"
+        -DZLIB_INCLUDE_DIR=${includedir} \
+        -DZLIB_LIBRARY="${libdir}/libz.${dlext}" \
+        -DBZIP2_INCLUDE_DIR=${includedir}  \
+        -DBZIP2_LIBRARIES="${libdir}/libbz2.${dlext}" \
+        -DLIBLZMA_INCLUDE_DIR=${includedir} \
+        -DLIBLZMA_LIBRARY="${libdir}/liblzma.${dlext}" \
+        -DOPENSSL_INCLUDE_DIR=${includedir} \
+        -DOPENSSL_CRYPTO_LIBRARY="${libdir}/libcrypto.${dlext}" \
+        -DLZFSE_INCLUDE_DIR=${includedir} \
+        -DLZFSE_LIBRARY="${libdir}/liblzfse.${dlext}"
  
     cmake --build build --parallel ${nproc}
 

--- a/L/libdmg_hfsplus/build_tarballs.jl
+++ b/L/libdmg_hfsplus/build_tarballs.jl
@@ -60,9 +60,9 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
-    Dependency(PackageSpec(name="Bzip2_jll", uuid="6e34b625-4abd-537c-b88f-471c36dfa7a0"))
+    Dependency(PackageSpec(name="Bzip2_jll", uuid="6e34b625-4abd-537c-b88f-471c36dfa7a0"); compat="1.0.9")
     Dependency(PackageSpec(name="XZ_jll", uuid="ffd25f8a-64ca-5728-b0f7-c24cf3aae800"))
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"))
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.16")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Libdmg-hfsplus offers open-source utilities for creating compressed dmg files, a de facto standard for MacOS application distribution. It can be used as a cross-platform alternative to `hdiutil`, which, to my understanding, [according to the thread](https://bugzilla.mozilla.org/show_bug.cgi?id=935237), is used by Mozilla to package Firefox in a Linux build environment something like:
```
mkisofs -D -V "Firefox test" -no-pad -r -apple -o firefox-uncompressed.dmg /tmp/bundle/
dmg dmg /build/obj-firefox-darwin/dist/firefox-uncompressed.dmg /build/obj-firefox-darwin/dist/firefox.dmg
```
Alternatively, one can preallocate a disk image and add files to it:
```
   dd if=/dev/zero of=uncompressed.dmg bs=1M count=256
    mkfs.hfsplus -v "Firefox 40.x" uncompressed.dmg
    hfsplus attract.dmg addall stagedir
    dmg dmg uncompressed.dmg compressed.dmg
```

Although the software is used in the wild, it has never been released. Hence, I had to set its version to `0.0.0`. 
