### PR TITLE
[aws_checksums] Update to version 0.2.6

### DIFF
--- a/A/aws_checksums/build_tarballs.jl
+++ b/A/aws_checksums/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder, Pkg
 
 name = "aws_checksums"
 
-version = v"0.2.5"
+version = v"0.2.6"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-checksums.git", "66b447c0765a2caff2d806111e6ec1db2383e4d2"),
+    GitSource("https://github.com/awslabs/aws-checksums.git", "9978ba2c33a7a259c1a6bd0f62abe26827d03b85"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_checksums to version 0.2.6. cc: @quinnj @Octogonapus