### PR TITLE
Tag MPI provider with jll

### DIFF
--- a/O/OpenMPI/OpenMPI@4/build_tarballs.jl
+++ b/O/OpenMPI/OpenMPI@4/build_tarballs.jl
@@ -57,8 +57,8 @@ install_license $WORKSPACE/srcdir/openmpi*/LICENSE
 
 augment_platform_block = """
     using Base.BinaryPlatforms
-    $(MPI.augment)
-    augment_platform!(platform::Platform) = augment_mpi!(platform)
+    $(MPI.augment_provider)
+    augment_platform!(platform::Platform) = augment_mpi_provider!(platform)
 """
 
 # These are the platforms we will build for by default, unless further
@@ -66,8 +66,14 @@ augment_platform_block = """
 platforms = filter(p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc"), supported_platforms())
 platforms = expand_gfortran_versions(platforms)
 
+function tag_platform!(p)
+    p["mpi"] = "OpenMPI"
+    p["mpi_provider"] = "jll"
+    p
+end
+
 # Add `mpi+openmpi` platform tag
-foreach(p -> (p["mpi"] = "OpenMPI"), platforms)
+foreach(tag_platform!, platforms)
 
 products = [
     # OpenMPI

--- a/O/OpenMPI/OpenMPI@5/build_tarballs.jl
+++ b/O/OpenMPI/OpenMPI@5/build_tarballs.jl
@@ -88,8 +88,14 @@ filter!(!Sys.iswindows, platforms)
 
 platforms = expand_gfortran_versions(platforms)
 
+function tag_platform!(p)
+    p["mpi"] = "OpenMPI"
+    p["mpi_provider"] = "jll"
+    p
+end
+
 # Add `mpi+openmpi` platform tag
-foreach(p -> (p["mpi"] = "OpenMPI"), platforms)
+foreach(tag_platform!, platforms)
 
 products = [
     # OpenMPI
@@ -115,8 +121,8 @@ dependencies = [
 
 augment_platform_block = """
     using Base.BinaryPlatforms
-    $(MPI.augment)
-    augment_platform!(platform::Platform) = augment_mpi!(platform)
+    $(MPI.augment_provider)
+    augment_platform!(platform::Platform) = augment_mpi_provider!(platform)
 """
 
 init_block = raw"""

--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -41,6 +41,20 @@ const augment = raw"""
     end
     """
 
+const augment_provider = augment * raw"""
+    function augment_mpi_provider!(platform)
+        platform = augment_mpi!(platform)
+
+        binary = get(preferences, "binary", Sys.iswindows(platform) ? "MicrosoftMPI_jll" : "MPICH_jll")
+        provider = binary == "system" ? "system" : "jll"
+
+        if !haskey(platform, "mpi_provider")
+            platform["mpi_provider"] = provider
+        end
+        return platform
+    end
+"""
+
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 


### PR DESCRIPTION
We run into an interesting issue.

1. Packages like `HDF5_jll` have a dependency on the MPI provider JLLs
2. We tag the MPI provider JLLs such that only one will be loaded given an ABI
3. We allow the user to sytem the provider to "system" which will deduce a ABI.
4. `MPIPreferences.jl` now has the job of loading `libmpi` when we use the system provider, 

The load of `libmpi` inside `OpenMPI_jll` is blocked since `MPIPreferences.jl` already has loaded a library
with the same so name (hopefully...)

In #10884 @eschnett added a set of libraries necessary for Fortran and in https://github.com/trixi-framework/libtrixi/issues/237 
we observe that loading those libraries may fail if we are using a system OpenMPI.

My proposal is to tag the "provider" libraries with an additional tag, which will prevent them from loading anything, if we are using the system libraries.

