### PR TITLE
SPIRV LLVM translator: set dont_dlopen=true.

### DIFF
--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@15/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@15/build_tarballs.jl
@@ -13,3 +13,5 @@ dependencies = [
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, get_script(llvm_version), platforms, products,
                dependencies; preferred_gcc_version=v"10", julia_compat="1.6")
+
+# bump

--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@16/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@16/build_tarballs.jl
@@ -13,3 +13,5 @@ dependencies = [
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, get_script(llvm_version), platforms, products,
                dependencies; preferred_gcc_version=v"10", julia_compat="1.6")
+
+# bump

--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@17/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@17/build_tarballs.jl
@@ -13,3 +13,5 @@ dependencies = [
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, get_script(llvm_version), platforms, products,
                dependencies; preferred_gcc_version=v"10", julia_compat="1.6")
+
+# bump

--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@18/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@18/build_tarballs.jl
@@ -13,3 +13,5 @@ dependencies = [
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, get_script(llvm_version), platforms, products,
                dependencies; preferred_gcc_version=v"10", julia_compat="1.6")
+
+# bump

--- a/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@19/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/SPIRV_LLVM_Translator@19/build_tarballs.jl
@@ -13,3 +13,5 @@ dependencies = [
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, get_script(llvm_version), platforms, products,
                dependencies; preferred_gcc_version=v"10", julia_compat="1.6")
+
+# bump

--- a/S/SPIRV_LLVM_Translator/common.jl
+++ b/S/SPIRV_LLVM_Translator/common.jl
@@ -58,6 +58,6 @@ install -Dm755 build/tools/llvm-spirv/llvm-spirv${exeext} -t ${bindir}
 
 # The products that we will ensure are always built
 products = Product[
-    LibraryProduct(["libLLVMSPIRVLib", "LLVMSPIRVLib"], :libLLVMSPIRV),
+    LibraryProduct(["libLLVMSPIRVLib", "LLVMSPIRVLib"], :libLLVMSPIRV; dont_dlopen=true),
     ExecutableProduct("llvm-spirv", :llvm_spirv),
 ]


### PR DESCRIPTION
Simply [relaxing the compat](https://github.com/JuliaRegistries/General/pull/129041) wasn't enough, we also need to make sure we don't `dlopen` the library (which depends on LLVM).

@giordano This should be an ideal case of `[skip build]`; in combination I should do `[ci skip]` when merging, right?