### PR TITLE
blockSQP: adapt towards sparse version of qpOASES

### DIFF
--- a/B/blockSQP/build_tarballs.jl
+++ b/B/blockSQP/build_tarballs.jl
@@ -4,7 +4,7 @@ name = "blockSQP"
 version = v"0.0.1"
 sources = [
     GitSource("https://github.com/djanka2/blockSQP.git", "da05d3957b93bd55b9a7f08c859d302851056a6d"),
-    GitSource("https://github.com/mathopt/blockSQPWrapper.git", "8d796eda6ceb986c2e04888176c6cb292b94011e"),
+    GitSource("https://github.com/mathopt/blockSQPWrapper.git", "df33d191f1eec687d9efb0116ab515bb7b354dcc"),
     DirectorySource("./bundled")
 ]
 
@@ -27,7 +27,7 @@ cmake \
     -DCMAKE_FIND_ROOT_PATH=$prefix \
     -DBUILD_SHARED_LIBS=ON \
     -DCMAKE_PREFIX_PATH=$prefix \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     ..
 
@@ -42,18 +42,21 @@ filter!(p -> !(arch(p) == "i686"), platforms)
 filter!(p -> !(libc(p) == "musl"), platforms)
 filter!(p -> !(arch(p) == "riscv64"), platforms)
 filter!(p -> !(os(p) == "freebsd"), platforms)
+filter!(p -> !(arch(p) == "powerpc64le"), platforms)
 
 
 dependencies = [
-    Dependency("qpOASES_jll"; compat="3.2.1"),
     Dependency("libcxxwrap_julia_jll"; compat="0.13.4"),
     HostBuildDependency(PackageSpec(; name = "CMake_jll")),
-    BuildDependency("libjulia_jll")
+    BuildDependency(PackageSpec(;name="libjulia_jll")),
+    Dependency("qpOASES_jll"; compat="3.2.2")
 ]
 
 products = [
     LibraryProduct("libblockSQP", :libblockSQP)
     LibraryProduct("libblockSQP_wrapper", :libblockSQP_wrapper)
+    LibraryProduct("libblockSQP_MUMPS", :libblockSQP_MUMPS)
+    LibraryProduct("libblockSQP_MUMPS_wrapper", :libblockSQP_MUMPS_wrapper)
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;


### PR DESCRIPTION
I recently adapted the build script of qpOASES_jll #10843  such that the full functionality of the solver could be used with the sparse LP solver MUMPS.
This PR now takes the change in qpOASES_jll into account and builds the blockSQP library linking against the sparse version of qpOASES.

However, there is still an error that we already encountered in #10433, namely that there are dependency errors for OpenBLAS_jll, perhaps stemming from the fact that we are running the build script with Julia version 1.7 but with compat bounds on OpenBLAS_jll for intended use with newer Julia versions.

I was wondering if we could somehow fix this issue? If it would be better I can also open an issue over at BinaryBuilder.