### PR TITLE
Cap compatibility of all packages depending on XML2_jll

### DIFF
--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -206,7 +206,7 @@ function llvm_dependencies(; kwargs...)
         # We had to restrict compat with XML2 because of ABI breakage:
         # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
         # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-        Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+        Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
 	# transitive dependency libiconv
     ]
 end

--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -203,10 +203,7 @@ end
 function llvm_dependencies(; kwargs...)
     return [
         Dependency("Zlib_jll"),
-        # We had to restrict compat with XML2 because of ABI breakage:
-        # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
-        # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-        Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+        Dependency("XML2_jll"),
 	# transitive dependency libiconv
     ]
 end

--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -203,7 +203,10 @@ end
 function llvm_dependencies(; kwargs...)
     return [
         Dependency("Zlib_jll"),
-        Dependency("XML2_jll"),
+        # We had to restrict compat with XML2 because of ABI breakage:
+        # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+        # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+        Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
 	# transitive dependency libiconv
     ]
 end

--- a/A/Aravis/build_tarballs.jl
+++ b/A/Aravis/build_tarballs.jl
@@ -41,7 +41,10 @@ products = [
 dependencies = [
     Dependency("Glib_jll"; compat="2.82.2"),
     Dependency("libusb_jll"),
-    Dependency("XML2_jll")
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13")
     ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/Aravis/build_tarballs.jl
+++ b/A/Aravis/build_tarballs.jl
@@ -44,7 +44,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13")
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13")
     ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/Aravis/build_tarballs.jl
+++ b/A/Aravis/build_tarballs.jl
@@ -44,7 +44,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13")
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13")
     ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/Aravis/build_tarballs.jl
+++ b/A/Aravis/build_tarballs.jl
@@ -44,7 +44,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13")
     ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -46,7 +46,10 @@ dependencies = [
     Dependency(PackageSpec(name="Cares_jll")),
     Dependency(PackageSpec(name="LibSSH2_jll")),
     Dependency(PackageSpec(name="OpenSSL_jll"); compat="3.0.8"),
-    Dependency(PackageSpec(name="XML2_jll")),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll"); compat="2.0.0 - 2.13"),
     Dependency(PackageSpec(name="Zlib_jll")),
 ]
 

--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -49,7 +49,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll"); compat="2.9.9 - 2.13"),
+    Dependency(PackageSpec(name="XML2_jll"), v"2.13.6"; compat="2.9.9 - 2.13"),
     Dependency(PackageSpec(name="Zlib_jll")),
 ]
 

--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -49,7 +49,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll"); compat="2.0.0 - 2.13"),
+    Dependency(PackageSpec(name="XML2_jll"); compat="2.9.9 - 2.13"),
     Dependency(PackageSpec(name="Zlib_jll")),
 ]
 

--- a/A/Aria2/build_tarballs.jl
+++ b/A/Aria2/build_tarballs.jl
@@ -49,7 +49,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll"), v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency(PackageSpec(name="XML2_jll"); compat="2.0.0 - 2.13"),
     Dependency(PackageSpec(name="Zlib_jll")),
 ]
 

--- a/A/at_spi2_atk/build_tarballs.jl
+++ b/A/at_spi2_atk/build_tarballs.jl
@@ -39,7 +39,10 @@ dependencies = [
     Dependency("at_spi2_core_jll"),
     Dependency("ATK_jll"),
     Dependency("Xorg_libX11_jll"),
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/at_spi2_atk/build_tarballs.jl
+++ b/A/at_spi2_atk/build_tarballs.jl
@@ -42,7 +42,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/at_spi2_atk/build_tarballs.jl
+++ b/A/at_spi2_atk/build_tarballs.jl
@@ -42,7 +42,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/A/at_spi2_atk/build_tarballs.jl
+++ b/A/at_spi2_atk/build_tarballs.jl
@@ -39,10 +39,7 @@ dependencies = [
     Dependency("at_spi2_core_jll"),
     Dependency("ATK_jll"),
     Dependency("Xorg_libX11_jll"),
-    # We had to restrict compat with XML2 because of ABI breakage:
-    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
-    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -138,7 +138,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.12.0 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.12.0 - 2.13"),
     RuntimeDependency("CUDA_Runtime_jll"; platforms=cuda_platforms),
 ]
 

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -138,7 +138,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.12.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.12.0 - 2.13"),
     RuntimeDependency("CUDA_Runtime_jll"; platforms=cuda_platforms),
 ]
 

--- a/E/Extrae/build_tarballs.jl
+++ b/E/Extrae/build_tarballs.jl
@@ -135,7 +135,10 @@ dependencies = [
     Dependency("Binutils_jll"; compat="~2.41"),
     Dependency("LibUnwind_jll"),
     Dependency("PAPI_jll"; compat="~7.1"),
-    Dependency("XML2_jll"; compat="2.12.0"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.12.0 - 2.13"),
     RuntimeDependency("CUDA_Runtime_jll"; platforms=cuda_platforms),
 ]
 

--- a/G/GDAL/build_tarballs.jl
+++ b/G/GDAL/build_tarballs.jl
@@ -201,7 +201,10 @@ dependencies = [
     Dependency("PROJ_jll"; compat="902.500.100"),
     Dependency("Qhull_jll"; compat="10008.0.1004"),
     Dependency("SQLite_jll"; compat="3.48.0"),
-    Dependency("XML2_jll"; compat="2.13.6"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.13.6 - 2.13"),
     Dependency("XZ_jll"; compat="5.6.4"),
     Dependency("Zlib_jll"; compat="1.2.12"),
     Dependency("Zstd_jll"; compat="1.5.7"),

--- a/G/Gettext/build_tarballs.jl
+++ b/G/Gettext/build_tarballs.jl
@@ -53,7 +53,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/Gettext/build_tarballs.jl
+++ b/G/Gettext/build_tarballs.jl
@@ -53,7 +53,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/Gettext/build_tarballs.jl
+++ b/G/Gettext/build_tarballs.jl
@@ -53,7 +53,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/Gettext/build_tarballs.jl
+++ b/G/Gettext/build_tarballs.jl
@@ -50,7 +50,10 @@ products = [
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
     Dependency("Libiconv_jll"),
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GraphicsMagick/build_tarballs.jl
+++ b/G/GraphicsMagick/build_tarballs.jl
@@ -86,7 +86,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
     Dependency("XZ_jll"),
     Dependency("Zlib_jll"),
     Dependency("Zstd_jll"),

--- a/G/GraphicsMagick/build_tarballs.jl
+++ b/G/GraphicsMagick/build_tarballs.jl
@@ -83,7 +83,10 @@ dependencies = [
     Dependency("JasPer_jll"),
     Dependency("JpegTurbo_jll"),
     Dependency("Libtiff_jll"; compat="~4.5.1"),
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("XZ_jll"),
     Dependency("Zlib_jll"),
     Dependency("Zstd_jll"),

--- a/G/GraphicsMagick/build_tarballs.jl
+++ b/G/GraphicsMagick/build_tarballs.jl
@@ -86,7 +86,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("XZ_jll"),
     Dependency("Zlib_jll"),
     Dependency("Zstd_jll"),

--- a/G/GraphicsMagick/build_tarballs.jl
+++ b/G/GraphicsMagick/build_tarballs.jl
@@ -86,7 +86,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
     Dependency("XZ_jll"),
     Dependency("Zlib_jll"),
     Dependency("Zstd_jll"),

--- a/H/hsa_rocr/common.jl
+++ b/H/hsa_rocr/common.jl
@@ -69,7 +69,7 @@ function configure_build(version)
         # We had to restrict compat with XML2 because of ABI breakage:
         # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
         # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-        Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+        Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
         Dependency("Elfutils_jll"),
     ]
     if version < v"5"

--- a/H/hsa_rocr/common.jl
+++ b/H/hsa_rocr/common.jl
@@ -66,10 +66,7 @@ function configure_build(version)
         Dependency("hsakmt_roct_jll", version),
         Dependency("ROCmDeviceLibs_jll", version),
         Dependency("NUMA_jll"),
-        # We had to restrict compat with XML2 because of ABI breakage:
-        # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
-        # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-        Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+        Dependency("XML2_jll"),
         Dependency("Elfutils_jll"),
     ]
     if version < v"5"

--- a/H/hsa_rocr/common.jl
+++ b/H/hsa_rocr/common.jl
@@ -66,7 +66,10 @@ function configure_build(version)
         Dependency("hsakmt_roct_jll", version),
         Dependency("ROCmDeviceLibs_jll", version),
         Dependency("NUMA_jll"),
-        Dependency("XML2_jll"),
+        # We had to restrict compat with XML2 because of ABI breakage:
+        # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+        # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+        Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
         Dependency("Elfutils_jll"),
     ]
     if version < v"5"

--- a/I/igraph/build_tarballs.jl
+++ b/I/igraph/build_tarballs.jl
@@ -65,7 +65,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms))

--- a/I/igraph/build_tarballs.jl
+++ b/I/igraph/build_tarballs.jl
@@ -65,7 +65,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms))

--- a/I/igraph/build_tarballs.jl
+++ b/I/igraph/build_tarballs.jl
@@ -65,7 +65,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms))

--- a/I/igraph/build_tarballs.jl
+++ b/I/igraph/build_tarballs.jl
@@ -62,7 +62,10 @@ dependencies = [
     Dependency(PackageSpec(name="GLPK_jll", uuid="e8aa6df9-e6ca-548a-97ff-1f85fc5b8b98"))
     Dependency(PackageSpec(name="GMP_jll", uuid="781609d7-10c4-51f6-84f2-b8444358ff6d"); compat="6.2.1")
     Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"); compat="5.4")
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
     # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms))

--- a/L/LFortran/build_tarballs.jl
+++ b/L/LFortran/build_tarballs.jl
@@ -40,7 +40,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 

--- a/L/LFortran/build_tarballs.jl
+++ b/L/LFortran/build_tarballs.jl
@@ -37,7 +37,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 

--- a/L/LFortran/build_tarballs.jl
+++ b/L/LFortran/build_tarballs.jl
@@ -40,7 +40,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 

--- a/L/LFortran/build_tarballs.jl
+++ b/L/LFortran/build_tarballs.jl
@@ -40,7 +40,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 

--- a/L/LLVMCompilerRT/build_tarballs.jl
+++ b/L/LLVMCompilerRT/build_tarballs.jl
@@ -108,7 +108,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("Zlib_jll"),
     BuildDependency(PackageSpec(name="LLVM_full_jll"; version)),
 ]

--- a/L/LLVMCompilerRT/build_tarballs.jl
+++ b/L/LLVMCompilerRT/build_tarballs.jl
@@ -108,7 +108,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
     Dependency("Zlib_jll"),
     BuildDependency(PackageSpec(name="LLVM_full_jll"; version)),
 ]

--- a/L/LLVMCompilerRT/build_tarballs.jl
+++ b/L/LLVMCompilerRT/build_tarballs.jl
@@ -105,7 +105,10 @@ products = LibraryProduct[
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("Zlib_jll"),
     BuildDependency(PackageSpec(name="LLVM_full_jll"; version)),
 ]

--- a/L/LLVMCompilerRT/build_tarballs.jl
+++ b/L/LLVMCompilerRT/build_tarballs.jl
@@ -108,7 +108,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
     Dependency("Zlib_jll"),
     BuildDependency(PackageSpec(name="LLVM_full_jll"; version)),
 ]

--- a/L/LLVMLibcxx/build_tarballs.jl
+++ b/L/LLVMLibcxx/build_tarballs.jl
@@ -56,7 +56,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/L/LLVMLibcxx/build_tarballs.jl
+++ b/L/LLVMLibcxx/build_tarballs.jl
@@ -56,7 +56,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/L/LLVMLibcxx/build_tarballs.jl
+++ b/L/LLVMLibcxx/build_tarballs.jl
@@ -56,7 +56,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/L/LLVMLibcxx/build_tarballs.jl
+++ b/L/LLVMLibcxx/build_tarballs.jl
@@ -53,7 +53,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/L/Libcroco/build_tarballs.jl
+++ b/L/Libcroco/build_tarballs.jl
@@ -40,7 +40,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Glib_jll", v"2.59.0"; compat="2.59"),
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libcroco/build_tarballs.jl
+++ b/L/Libcroco/build_tarballs.jl
@@ -43,7 +43,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libcroco/build_tarballs.jl
+++ b/L/Libcroco/build_tarballs.jl
@@ -43,7 +43,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libcroco/build_tarballs.jl
+++ b/L/Libcroco/build_tarballs.jl
@@ -40,10 +40,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Glib_jll", v"2.59.0"; compat="2.59"),
-    # We had to restrict compat with XML2 because of ABI breakage:
-    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
-    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libical/build_tarballs.jl
+++ b/L/Libical/build_tarballs.jl
@@ -53,7 +53,10 @@ dependencies = [
     Dependency(PackageSpec(name="BerkeleyDB_jll", uuid="cd00e070-8fe2-570d-8212-aefc8f89bd06"))
     Dependency(PackageSpec(name="Glib_jll", uuid="7746bdde-850d-59dc-9ae8-88ece973131d"), v"2.59.0"; compat="2.59.0")
     Dependency(PackageSpec(name="ICU_jll", uuid="a51ab1cf-af8e-5615-a023-bc2c838bba6b"), v"68.2"; compat = "68.2")
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libical/build_tarballs.jl
+++ b/L/Libical/build_tarballs.jl
@@ -56,7 +56,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libical/build_tarballs.jl
+++ b/L/Libical/build_tarballs.jl
@@ -56,7 +56,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/Libical/build_tarballs.jl
+++ b/L/Libical/build_tarballs.jl
@@ -56,7 +56,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libavif/build_tarballs.jl
+++ b/L/libavif/build_tarballs.jl
@@ -38,7 +38,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("JpegTurbo_jll"),
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("Zlib_jll"),
     Dependency("dav1d_jll"),
     Dependency("libaom_jll"),

--- a/L/libavif/build_tarballs.jl
+++ b/L/libavif/build_tarballs.jl
@@ -41,7 +41,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
     Dependency("Zlib_jll"),
     Dependency("dav1d_jll"),
     Dependency("libaom_jll"),

--- a/L/libavif/build_tarballs.jl
+++ b/L/libavif/build_tarballs.jl
@@ -41,7 +41,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
     Dependency("Zlib_jll"),
     Dependency("dav1d_jll"),
     Dependency("libaom_jll"),

--- a/L/libavif/build_tarballs.jl
+++ b/L/libavif/build_tarballs.jl
@@ -41,7 +41,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("Zlib_jll"),
     Dependency("dav1d_jll"),
     Dependency("libaom_jll"),

--- a/L/libbluray/build_tarballs.jl
+++ b/L/libbluray/build_tarballs.jl
@@ -38,10 +38,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # We had to restrict compat with XML2 because of ABI breakage:
-    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
-    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
     Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"); compat="2.10.4")
     Dependency(PackageSpec(name="Fontconfig_jll", uuid="a3f928ae-7b40-5064-980b-68af3947d34b"))
     Dependency(PackageSpec(name="libudfread_jll", uuid="037e6697-03b9-52b7-b841-7aee0d773eb5"))

--- a/L/libbluray/build_tarballs.jl
+++ b/L/libbluray/build_tarballs.jl
@@ -41,7 +41,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"); compat="2.10.4")
     Dependency(PackageSpec(name="Fontconfig_jll", uuid="a3f928ae-7b40-5064-980b-68af3947d34b"))
     Dependency(PackageSpec(name="libudfread_jll", uuid="037e6697-03b9-52b7-b841-7aee0d773eb5"))

--- a/L/libbluray/build_tarballs.jl
+++ b/L/libbluray/build_tarballs.jl
@@ -41,7 +41,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"); compat="2.10.4")
     Dependency(PackageSpec(name="Fontconfig_jll", uuid="a3f928ae-7b40-5064-980b-68af3947d34b"))
     Dependency(PackageSpec(name="libudfread_jll", uuid="037e6697-03b9-52b7-b841-7aee0d773eb5"))

--- a/L/libbluray/build_tarballs.jl
+++ b/L/libbluray/build_tarballs.jl
@@ -38,7 +38,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="FreeType2_jll", uuid="d7e528f0-a631-5988-bf34-fe36492bcfd7"); compat="2.10.4")
     Dependency(PackageSpec(name="Fontconfig_jll", uuid="a3f928ae-7b40-5064-980b-68af3947d34b"))
     Dependency(PackageSpec(name="libudfread_jll", uuid="037e6697-03b9-52b7-b841-7aee0d773eb5"))

--- a/L/libcellml/build_tarballs.jl
+++ b/L/libcellml/build_tarballs.jl
@@ -52,7 +52,7 @@ dependencies = [
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
     # XML2 apparently had a breaking change, so it's important to specify the compat bound:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/9673#issuecomment-2434514026
-    Dependency("XML2_jll", v"2.13.6"; compat="2.13.4 - 2.13"),
+    Dependency("XML2_jll"; compat="2.13.4 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/L/libcellml/build_tarballs.jl
+++ b/L/libcellml/build_tarballs.jl
@@ -47,9 +47,12 @@ products = [
 ]
 
 dependencies = [
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
     # XML2 apparently had a breaking change, so it's important to specify the compat bound:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/9673#issuecomment-2434514026
-    Dependency("XML2_jll"; compat="2.13.4"),
+    Dependency("XML2_jll"; compat="2.13.4 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/L/libcellml/build_tarballs.jl
+++ b/L/libcellml/build_tarballs.jl
@@ -52,7 +52,7 @@ dependencies = [
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
     # XML2 apparently had a breaking change, so it's important to specify the compat bound:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/9673#issuecomment-2434514026
-    Dependency("XML2_jll"; compat="2.13.4 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.13.4 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/L/libspatialite/build_tarballs.jl
+++ b/L/libspatialite/build_tarballs.jl
@@ -90,7 +90,10 @@ dependencies = [
     Dependency(get_addable_spec("PROJ_jll", v"902.500.100+1"); compat="902.500.100")
     Dependency(PackageSpec(name="Libiconv_jll", uuid="94ce4f54-9a6c-5748-9c1c-f9c7231a4531"))
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(get_addable_spec("OpenSSL_jll", v"3.0.15+2"); compat="3.0.15", platforms=filter(p -> !(Sys.iswindows(p) || Sys.isapple(p)), platforms))
 ]
 

--- a/L/libspatialite/build_tarballs.jl
+++ b/L/libspatialite/build_tarballs.jl
@@ -93,7 +93,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(get_addable_spec("OpenSSL_jll", v"3.0.15+2"); compat="3.0.15", platforms=filter(p -> !(Sys.iswindows(p) || Sys.isapple(p)), platforms))
 ]
 

--- a/L/libspatialite/build_tarballs.jl
+++ b/L/libspatialite/build_tarballs.jl
@@ -93,7 +93,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
     Dependency(get_addable_spec("OpenSSL_jll", v"3.0.15+2"); compat="3.0.15", platforms=filter(p -> !(Sys.iswindows(p) || Sys.isapple(p)), platforms))
 ]
 

--- a/L/libspatialite/build_tarballs.jl
+++ b/L/libspatialite/build_tarballs.jl
@@ -93,7 +93,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
     Dependency(get_addable_spec("OpenSSL_jll", v"3.0.15+2"); compat="3.0.15", platforms=filter(p -> !(Sys.iswindows(p) || Sys.isapple(p)), platforms))
 ]
 

--- a/L/lttng_tools/build_tarballs.jl
+++ b/L/lttng_tools/build_tarballs.jl
@@ -42,7 +42,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="lttng_ust_jll", uuid="a2826780-45ff-53db-9dda-fd961bc58de1"))
 ]
 

--- a/L/lttng_tools/build_tarballs.jl
+++ b/L/lttng_tools/build_tarballs.jl
@@ -39,7 +39,10 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="URCU_jll", uuid="aa747835-a391-587f-982f-064ff03f7d29"))
     Dependency(PackageSpec(name="Popt_jll", uuid="e80236cf-ab1d-5f5d-8534-1d1285fe49e8"))
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="lttng_ust_jll", uuid="a2826780-45ff-53db-9dda-fd961bc58de1"))
 ]
 

--- a/L/lttng_tools/build_tarballs.jl
+++ b/L/lttng_tools/build_tarballs.jl
@@ -42,7 +42,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="lttng_ust_jll", uuid="a2826780-45ff-53db-9dda-fd961bc58de1"))
 ]
 

--- a/L/lttng_tools/build_tarballs.jl
+++ b/L/lttng_tools/build_tarballs.jl
@@ -42,7 +42,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="lttng_ust_jll", uuid="a2826780-45ff-53db-9dda-fd961bc58de1"))
 ]
 

--- a/M/MDAL/build_tarballs.jl
+++ b/M/MDAL/build_tarballs.jl
@@ -77,7 +77,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
     Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.902.5")
 ]

--- a/M/MDAL/build_tarballs.jl
+++ b/M/MDAL/build_tarballs.jl
@@ -74,7 +74,10 @@ dependencies = [
     Dependency(PackageSpec(name="GDAL_jll", uuid="a7073274-a066-55f0-b90d-d619367d196c"))
     # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
     Dependency(PackageSpec(name="HDF5_jll", uuid="0234f1f7-429e-5d53-9886-15a909be8d59"); compat="~1.12")
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
     Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.902.5")
 ]

--- a/M/MDAL/build_tarballs.jl
+++ b/M/MDAL/build_tarballs.jl
@@ -77,7 +77,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
     Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.902.5")
 ]

--- a/M/MDAL/build_tarballs.jl
+++ b/M/MDAL/build_tarballs.jl
@@ -77,7 +77,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
     Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"); compat="400.902.5")
 ]

--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -128,7 +128,10 @@ dependencies = [
     Dependency("Bzip2_jll"; compat="1.0.9"),
     Dependency("HDF5_jll"; compat="~1.14.6"),
     Dependency("LibCURL_jll"; compat="7.73.0,8"),
-    Dependency("XML2_jll"; compat="2.13.6"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.13.6 - 2.13"),
     Dependency("Zlib_jll"; compat="1.2.12"),
     Dependency("Zstd_jll"; compat="1.5.7"),
     Dependency("libaec_jll"; compat="1.1.3"), # This is the successor of szlib

--- a/N/Netpbm/build_tarballs.jl
+++ b/N/Netpbm/build_tarballs.jl
@@ -446,7 +446,10 @@ dependencies = [
     BuildDependency("Xorg_xproto_jll"),  # compat="7.0.31"
     Dependency("JpegTurbo_jll"; compat="3.1.1"),
     Dependency("Libtiff_jll"; compat="4.7.1"),
-    Dependency("XML2_jll"; compat="2.13.6"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.13.6 - 2.13"),
     # Need at least Xorg_libX11 v1.8.6 for armv6l support
     Dependency("Xorg_libX11_jll"; compat="1.8.6"),
     Dependency("Zlib_jll"; compat="1.2.12"),

--- a/O/OpenSlide/build_tarballs.jl
+++ b/O/OpenSlide/build_tarballs.jl
@@ -41,7 +41,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
     Dependency(PackageSpec(name="Cairo_jll", uuid="83423d85-b0ee-5818-9007-b63ccbeb887a"))
     Dependency("Glib_jll"; compat="2.59")

--- a/O/OpenSlide/build_tarballs.jl
+++ b/O/OpenSlide/build_tarballs.jl
@@ -38,7 +38,10 @@ dependencies = [
     Dependency("Libtiff_jll"; compat="4.1.0")
     Dependency(PackageSpec(name="OpenJpeg_jll", uuid="643b3616-a352-519d-856d-80112ee9badc"))
     Dependency(PackageSpec(name="gdk_pixbuf_jll", uuid="da03df04-f53b-5353-a52f-6a8b0620ced0"))
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
     Dependency(PackageSpec(name="Cairo_jll", uuid="83423d85-b0ee-5818-9007-b63ccbeb887a"))
     Dependency("Glib_jll"; compat="2.59")

--- a/O/OpenSlide/build_tarballs.jl
+++ b/O/OpenSlide/build_tarballs.jl
@@ -38,10 +38,7 @@ dependencies = [
     Dependency("Libtiff_jll"; compat="4.1.0")
     Dependency(PackageSpec(name="OpenJpeg_jll", uuid="643b3616-a352-519d-856d-80112ee9badc"))
     Dependency(PackageSpec(name="gdk_pixbuf_jll", uuid="da03df04-f53b-5353-a52f-6a8b0620ced0"))
-    # We had to restrict compat with XML2 because of ABI breakage:
-    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
-    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
     Dependency(PackageSpec(name="Cairo_jll", uuid="83423d85-b0ee-5818-9007-b63ccbeb887a"))
     Dependency("Glib_jll"; compat="2.59")

--- a/O/OpenSlide/build_tarballs.jl
+++ b/O/OpenSlide/build_tarballs.jl
@@ -41,7 +41,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="SQLite_jll", uuid="76ed43ae-9a5d-5a62-8c75-30186b810ce8"))
     Dependency(PackageSpec(name="Cairo_jll", uuid="83423d85-b0ee-5818-9007-b63ccbeb887a"))
     Dependency("Glib_jll"; compat="2.59")

--- a/O/openbabel/build_tarballs.jl
+++ b/O/openbabel/build_tarballs.jl
@@ -56,7 +56,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 

--- a/O/openbabel/build_tarballs.jl
+++ b/O/openbabel/build_tarballs.jl
@@ -56,7 +56,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 

--- a/O/openbabel/build_tarballs.jl
+++ b/O/openbabel/build_tarballs.jl
@@ -53,7 +53,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     BuildDependency(PackageSpec(name="Eigen_jll", uuid="bc6bbf8a-a594-5541-9c57-10b0d0312c70"))
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 

--- a/O/openbabel/build_tarballs.jl
+++ b/O/openbabel/build_tarballs.jl
@@ -56,7 +56,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
 ]
 

--- a/S/SBML/build_tarballs.jl
+++ b/S/SBML/build_tarballs.jl
@@ -50,7 +50,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/S/SBML/build_tarballs.jl
+++ b/S/SBML/build_tarballs.jl
@@ -50,7 +50,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/S/SBML/build_tarballs.jl
+++ b/S/SBML/build_tarballs.jl
@@ -47,7 +47,10 @@ products = [
 ]
 
 dependencies = [
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/S/SBML/build_tarballs.jl
+++ b/S/SBML/build_tarballs.jl
@@ -50,7 +50,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
     Dependency("Zlib_jll"),
 ]
 

--- a/S/SharedMimeInfo/build_tarballs.jl
+++ b/S/SharedMimeInfo/build_tarballs.jl
@@ -37,7 +37,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.  We use GCC 8 because it is the only GCC version that links

--- a/S/SharedMimeInfo/build_tarballs.jl
+++ b/S/SharedMimeInfo/build_tarballs.jl
@@ -34,7 +34,10 @@ products = [
 # Based on http://www.linuxfromscratch.org/blfs/view/8.3/general/shared-mime-info.html
 dependencies = [
     Dependency("Glib_jll", v"2.59.0"; compat="2.59.0"),
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.  We use GCC 8 because it is the only GCC version that links

--- a/S/SharedMimeInfo/build_tarballs.jl
+++ b/S/SharedMimeInfo/build_tarballs.jl
@@ -34,10 +34,7 @@ products = [
 # Based on http://www.linuxfromscratch.org/blfs/view/8.3/general/shared-mime-info.html
 dependencies = [
     Dependency("Glib_jll", v"2.59.0"; compat="2.59.0"),
-    # We had to restrict compat with XML2 because of ABI breakage:
-    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
-    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.  We use GCC 8 because it is the only GCC version that links

--- a/S/SharedMimeInfo/build_tarballs.jl
+++ b/S/SharedMimeInfo/build_tarballs.jl
@@ -37,7 +37,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.  We use GCC 8 because it is the only GCC version that links

--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -61,7 +61,10 @@ products = [
 dependencies = [
     Dependency("Expat_jll"; compat="2.6.5"),
     Dependency("Libffi_jll"; compat="~3.4.7"),
-    Dependency("XML2_jll"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("EpollShim_jll"),
     HostBuildDependency(PackageSpec("Expat_jll", v"2.6.5")),
     HostBuildDependency(PackageSpec("Libffi_jll", v"3.4.7")),

--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -64,7 +64,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
     Dependency("EpollShim_jll"),
     HostBuildDependency(PackageSpec("Expat_jll", v"2.6.5")),
     HostBuildDependency(PackageSpec("Libffi_jll", v"3.4.7")),

--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -64,7 +64,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
+    Dependency("XML2_jll", v"2.13.6"; compat="2.9.9 - 2.13"),
     Dependency("EpollShim_jll"),
     HostBuildDependency(PackageSpec("Expat_jll", v"2.6.5")),
     HostBuildDependency(PackageSpec("Libffi_jll", v"3.4.7")),

--- a/W/Wayland/build_tarballs.jl
+++ b/W/Wayland/build_tarballs.jl
@@ -64,7 +64,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency("XML2_jll"; compat="2.0.0 - 2.13"),
+    Dependency("XML2_jll"; compat="2.9.9 - 2.13"),
     Dependency("EpollShim_jll"),
     HostBuildDependency(PackageSpec("Expat_jll", v"2.6.5")),
     HostBuildDependency(PackageSpec("Libffi_jll", v"3.4.7")),

--- a/X/XRootD/build_tarballs.jl
+++ b/X/XRootD/build_tarballs.jl
@@ -97,7 +97,10 @@ dependencies = [
     Dependency(PackageSpec(name="Libuuid_jll", uuid="38a345b3-de98-5d2b-a5d3-14cd9215e700"))
     Dependency(PackageSpec(name="libxcrypt_legacy_jll", uuid="5ef642bb-a58b-5208-ae37-583168b2c491"))
     Dependency(PackageSpec(name="JSON_C_jll", uuid="9cdfc4e7-e793-5089-b6f7-569a57a60f0a"))
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"))
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))

--- a/X/XRootD/build_tarballs.jl
+++ b/X/XRootD/build_tarballs.jl
@@ -100,7 +100,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))

--- a/X/XRootD/build_tarballs.jl
+++ b/X/XRootD/build_tarballs.jl
@@ -100,7 +100,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"), v"2.13.6"; compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))

--- a/X/XRootD/build_tarballs.jl
+++ b/X/XRootD/build_tarballs.jl
@@ -100,7 +100,7 @@ dependencies = [
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
     # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.0.0 - 2.13")
+    Dependency(PackageSpec(name="XML2_jll", uuid="02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"); compat="2.9.9 - 2.13")
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15")
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"))

--- a/X/XSLT/build_tarballs.jl
+++ b/X/XSLT/build_tarballs.jl
@@ -37,7 +37,10 @@ dependencies = [
     Dependency("Libgpg_error_jll"; compat="1.51.1"),
     Dependency("Libgcrypt_jll"; compat="1.11.1"),
     Dependency("Libiconv_jll"; compat="1.18"),
-    Dependency("XML2_jll"; compat="2.13.6"),
+    # We had to restrict compat with XML2 because of ABI breakage:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268
+    # Updating to a newer XML2 version is likely possible without problems but requires rebuilding this package
+    Dependency("XML2_jll"; compat="2.13.6 - 2.13"),
     Dependency("Zlib_jll"; compat="1.2.12"),
 ]
 


### PR DESCRIPTION
Reflect changes in https://github.com/JuliaRegistries/General/pull/128943 and https://github.com/JuliaRegistries/General/pull/128961

v2.9.9 is the oldest version of XML2_jll in https://github.com/JuliaRegistries/General/blob/master/jll/X/XML2_jll/Versions.toml

xref: https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268