### PR TITLE
[AppBundlerUtils] new recipe

### DIFF
--- a/A/AppBundlerUtils/build_tarballs.jl
+++ b/A/AppBundlerUtils/build_tarballs.jl
@@ -22,10 +22,7 @@ install -Dvm 755 "launcher" "${bindir}/macos_launcher"
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Platform("x86_64", "macos"),
-    Platform("aarch64", "macos"),
-]
+platforms = supported_platforms(; exclude=!Sys.isapple)
 
 # The products that we will ensure are always built
 products = [

--- a/A/AppBundlerUtils/build_tarballs.jl
+++ b/A/AppBundlerUtils/build_tarballs.jl
@@ -1,0 +1,40 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "AppBundlerUtils"
+version = v"0.1.5"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/PeaceFounder/AppBundler.jl.git", "dfddaa473e9e8a11cee95ede5cd351051907f2d3")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/AppBundler.jl/recipes/macos
+
+$CC -o launcher launcher.c
+
+install_license $WORKSPACE/srcdir/AppBundler.jl/LICENSE
+install -Dvm 755 "launcher" "${bindir}/macos_launcher"
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("x86_64", "macos"),
+    Platform("aarch64", "macos"),
+]
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("macos_launcher", :macos_launcher)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/A/AppBundlerUtils/build_tarballs.jl
+++ b/A/AppBundlerUtils/build_tarballs.jl
@@ -30,7 +30,7 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
+dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This is a trivial utility that is only useful in the context of the AppBundler package. The MacOS application bundle format requires that the main launcher is located at
```
Contents/MacOS/appname
```
as it needs to encode the whole application signature and hold corresponding entitlements. 

On MacOS, it is easy to compile it with `Clang_jll`; I wouldn’t need this binary product as I could make it in place. However, on Linux, where all the bundling toolchains are already available, I do have an issue with the MacOS SDK headers not being available. Retrieving them is possible, but that introduces another potential point of failure, which I would like to avoid. 

Hence, my solution is to package the launcher with BinaryBuilder and then retrieve it independently from the host platform as:
```
function retrieve_macos_launcher(platform::AbstractPlatform, destination)

    artifacts_toml = joinpath(dirname(dirname(pathof(AppBundlerUtils_jll))), "Artifacts.toml")
    artifacts = Artifacts.select_downloadable_artifacts(artifacts_toml; platform)["AppBundlerUtils"]
        
    hash = artifacts["git-tree-sha1"]
    Pkg.Artifacts.ensure_artifact_installed("AppBundlerUtils", artifacts, artifacts_toml) 
    cp(joinpath(artifacts_cache(), hash, "bin", "macos_launcher"), destination, force=true)

    return
end
```
The `macos_launcher` itself launches an executable bash script at `../Libraries/main`, where I can set `DEPOT_PATH`, `LOAD_PATH`, etc., to start a Julia session for the application. In the future, another executable product may also launch a CLI in a Terminal window, almost identical to the one used in the Julia DMG installer. 