### PR TITLE
SPIRV-Headers: Bump to SDK 1.4.309.

### DIFF
--- a/S/SPIRV_Headers/build_tarballs.jl
+++ b/S/SPIRV_Headers/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "SPIRV_Headers"
-version = v"1.6.0"
+version = v"1.4.309"
 
 # Collection of sources required to build this package
 sources = [
     GitSource("https://github.com/KhronosGroup/SPIRV-Headers.git",
-              "aa331ab0ffcb3a67021caa1a0c1c9017712f2f31"),
+              "09913f088a1197aba4aefd300a876b2ebbaa3391"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
There's a problem with many SPIR-V JLLs though: Upstream versioning has recently been revamped, now tracking the SDK version for each component (like SPIRV-Headers). That means that for some JLLs, the version will go backwards, as is the case here...

@giordano Any suggestion on how to tackle this? Yank every version > 1.4.309 so that this one is the only one which should get installed?