### PR TITLE
[GettextRuntime] Make gettext-runtime its own package

### DIFF
--- a/G/GettextRuntime/build_tarballs.jl
+++ b/G/GettextRuntime/build_tarballs.jl
@@ -12,8 +12,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/gettext-*/
-cd gettext-runtime
+cd $WORKSPACE/srcdir/gettext-*/gettext-runtime
 
 ./configure --prefix=${prefix} \
     --build=${MACHTYPE} \

--- a/G/GettextRuntime/build_tarballs.jl
+++ b/G/GettextRuntime/build_tarballs.jl
@@ -2,10 +2,11 @@ using BinaryBuilder
 
 # Collection of sources required to build GettextRuntime
 name = "GettextRuntime"
-version = v"0.22.4"
+version_string = "0.22.4"
+version = VersionNumber(version_string)
 
 sources = [
-    ArchiveSource("https://ftp.gnu.org/pub/gnu/gettext/gettext-$(version.major).$(version.minor).$(version.patch).tar.xz",
+    ArchiveSource("https://ftp.gnu.org/pub/gnu/gettext/gettext-$(version_string).tar.xz",
                   "29217f1816ee2e777fa9a01f9956a14139c0c23cc1b20368f06b2888e8a34116"),
 ]
 

--- a/G/GettextRuntime/build_tarballs.jl
+++ b/G/GettextRuntime/build_tarballs.jl
@@ -24,6 +24,11 @@ cd gettext-runtime
 
 make -j${nproc}
 make install
+
+# Multiple licenses are required
+cp ../COPYING toplevel-COPYING
+cp intl/COPYING.LIB intl-COPYING.LIB
+install_license COPYING toplevel-COPYING intl-COPYING.LIB
 """
 
 # These are the platforms we will build for by default, unless further

--- a/G/GettextRuntime/build_tarballs.jl
+++ b/G/GettextRuntime/build_tarballs.jl
@@ -1,0 +1,48 @@
+using BinaryBuilder
+
+# Collection of sources required to build GettextRuntime
+name = "GettextRuntime"
+version = v"0.24.0"
+
+sources = [
+    ArchiveSource("https://ftp.gnu.org/pub/gnu/gettext/gettext-$(version.major).$(version.minor).tar.xz",
+                  "e1620d518b26d7d3b16ac570e5018206e8b0d725fb65c02d048397718b5cf318"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/gettext-*/
+cd gettext-runtime
+
+./configure --prefix=${prefix} \
+    --build=${MACHTYPE} \
+    --host=${target} \
+    --disable-static \
+    --enable-relocatable \
+    --with-libiconv-prefix=${prefix} \
+    --with-included-gettext
+
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libintl", :libintl),
+    LibraryProduct("libasprintf", :libasprintf),
+    ExecutableProduct("gettext", :gettext),
+    ExecutableProduct("ngettext", :ngettext),
+    ExecutableProduct("envsubst", :envsubst),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Libiconv_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/G/GettextRuntime/build_tarballs.jl
+++ b/G/GettextRuntime/build_tarballs.jl
@@ -2,11 +2,11 @@ using BinaryBuilder
 
 # Collection of sources required to build GettextRuntime
 name = "GettextRuntime"
-version = v"0.24.0"
+version = v"0.25.0"
 
 sources = [
     ArchiveSource("https://ftp.gnu.org/pub/gnu/gettext/gettext-$(version.major).$(version.minor).tar.xz",
-                  "e1620d518b26d7d3b16ac570e5018206e8b0d725fb65c02d048397718b5cf318"),
+                  "05240b29f5b0f422e5a4ef8e9b5f76d8fa059cc057693d2723cdb76f36a88ab0"),
 ]
 
 # Bash recipe for building across all platforms
@@ -46,6 +46,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
     Dependency("Libiconv_jll"),
 ]
 

--- a/G/GettextRuntime/build_tarballs.jl
+++ b/G/GettextRuntime/build_tarballs.jl
@@ -2,11 +2,11 @@ using BinaryBuilder
 
 # Collection of sources required to build GettextRuntime
 name = "GettextRuntime"
-version = v"0.25.0"
+version = v"0.22.4"
 
 sources = [
-    ArchiveSource("https://ftp.gnu.org/pub/gnu/gettext/gettext-$(version.major).$(version.minor).tar.xz",
-                  "05240b29f5b0f422e5a4ef8e9b5f76d8fa059cc057693d2723cdb76f36a88ab0"),
+    ArchiveSource("https://ftp.gnu.org/pub/gnu/gettext/gettext-$(version.major).$(version.minor).$(version.patch).tar.xz",
+                  "29217f1816ee2e777fa9a01f9956a14139c0c23cc1b20368f06b2888e8a34116"),
 ]
 
 # Bash recipe for building across all platforms
@@ -21,7 +21,8 @@ cd gettext-runtime
     --enable-relocatable \
     --with-libiconv-prefix=${prefix} \
     --with-included-gettext
-
+    am_cv_lib_iconv=yes \
+    am_cv_func_iconv=yes
 make -j${nproc}
 make install
 


### PR DESCRIPTION
Fixes #11030

These are the parts of gettext that are useful at runtime. Unlike the current `Gettext_jll`, this package doesn't depend on `XML2_jll`.