### PR TITLE
Update Qt6Base_jll for GR

### DIFF
--- a/G/GR/build_tarballs.jl
+++ b/G/GR/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "GR"
-version = v"0.73.15"
+version = v"0.73.14"
 
 # Collection of sources required to complete build
 sources = [
@@ -88,15 +88,15 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Bzip2_jll"; compat="1.0.9"),
-    Dependency("Cairo_jll"; compat="1.18.5"),
+    Dependency("Bzip2_jll"),
+    Dependency("Cairo_jll"),
     Dependency("FFMPEG_jll"),
     Dependency("Fontconfig_jll"),
     Dependency("FreeType2_jll"; compat="2.13.4"),
     Dependency("GLFW_jll"),
     Dependency("JpegTurbo_jll"),
     Dependency("libpng_jll"),
-    Dependency("Libtiff_jll"; compat="4.7.1"),
+    Dependency("Libtiff_jll"),
     Dependency("Pixman_jll"),
     HostBuildDependency("Qt6Base_jll"),
     Dependency("Qt6Base_jll"; compat="~6.8.2"), # Never allow upgrading more than the minor version without recompilation

--- a/G/GR/build_tarballs.jl
+++ b/G/GR/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "GR"
-version = v"0.73.14"
+version = v"0.73.15"
 
 # Collection of sources required to complete build
 sources = [
@@ -78,28 +78,28 @@ platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libGR", :libGR, dont_dlopen=true),
-    LibraryProduct("libGR3", :libGR3, dont_dlopen=true),
-    LibraryProduct("libGRM", :libGRM, dont_dlopen=true),
-    LibraryProduct("libGKS", :libGKS, dont_dlopen=true),
+    LibraryProduct("libGR", :libGR; dont_dlopen=true),
+    LibraryProduct("libGR3", :libGR3; dont_dlopen=true),
+    LibraryProduct("libGRM", :libGRM; dont_dlopen=true),
+    LibraryProduct("libGKS", :libGKS; dont_dlopen=true),
     ExecutableProduct("gksqt", :gksqt),
     ExecutableProduct("grplot", :grplot),
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Bzip2_jll"; compat="1.0.8"),
-    Dependency("Cairo_jll"; compat="1.16.1"),
+    Dependency("Bzip2_jll"; compat="1.0.9"),
+    Dependency("Cairo_jll"; compat="1.18.5"),
     Dependency("FFMPEG_jll"),
     Dependency("Fontconfig_jll"),
-    Dependency("FreeType2_jll"; compat="2.10.4"),
+    Dependency("FreeType2_jll"; compat="2.13.4"),
     Dependency("GLFW_jll"),
     Dependency("JpegTurbo_jll"),
     Dependency("libpng_jll"),
     Dependency("Libtiff_jll"; compat="4.7.1"),
     Dependency("Pixman_jll"),
     HostBuildDependency("Qt6Base_jll"),
-    Dependency("Qt6Base_jll"; compat="~6.7.1"), # Never allow upgrading more than the minor version without recompilation
+    Dependency("Qt6Base_jll"; compat="~6.8.2"), # Never allow upgrading more than the minor version without recompilation
     BuildDependency("Xorg_libX11_jll"),
     BuildDependency("Xorg_xproto_jll"),
     Dependency("Zlib_jll"),


### PR DESCRIPTION
In https://github.com/JuliaPlots/Plots.jl/actions/runs/14569694494/job/40864550200#step:9:1032, this was the reason for the `ImageXXX` stack being left behind latest versions.

Cc @jheinen, since changing compat bounds are always risky in `Yggdrasil`.

**before PR**
```
⌃ [35d6a980] ColorSchemes v3.26.0 (<v3.29.0)
⌅ [3da002f7] ColorTypes v0.11.5 (<v0.12.1): ColorSchemes, ColorVectorSpace, Colors, TiffImages
⌅ [c3611d14] ColorVectorSpace v0.9.10 (<v0.11.0): ColorSchemes, ImageCore
⌅ [5ae59095] Colors v0.12.11 (<v0.13.0): ColorSchemes, ImageCore
⌃ [2803e5a7] ImageAxes v0.6.11 (<v0.6.12)
⌃ [c817782e] ImageBase v0.1.5 (<v0.1.7)
⌅ [a09fc81d] ImageCore v0.9.4 (<v0.10.5): ImageBase, ImageMagick, ImageSegmentation, QuartzImageIO
⌃ [6a3955dd] ImageFiltering v0.7.6 (<v0.7.9)
⌃ [82e4d734] ImageIO v0.6.8 (<v0.6.9)
⌃ [6218d12a] ImageMagick v1.2.1 (<v1.4.1)
⌃ [bc367c6b] ImageMetadata v0.9.9 (<v0.9.10)
⌃ [80713f31] ImageSegmentation v1.8.1 (<v1.8.4)
⌃ [916415d5] Images v0.26.1 (<v0.26.2)
⌅ [033835bb] JLD2 v0.4.54 (<v0.5.13): MetaGraphs
⌅ [626554b9] MetaGraphs v0.7.2 (<v0.8.0): ImageSegmentation
⌅ [aea7be01] PrecompileTools v1.2.1 (<v1.3.2): julia
⌃ [dca85d43] QuartzImageIO v0.7.4 (<v0.7.5)
⌅ [df47a6cb] RData v0.8.3 (<v1.0.0): RDatasets
⌅ [731e570b] TiffImages v0.10.2 (<v0.11.3): ImageIO
⌃ [7b86fcea] ATK_jll v2.38.0+0 (<v2.38.1+0)
⌃ [83423d85] Cairo_jll v1.18.4+0 (<v1.18.5+0)
⌅ [b22a6f82] FFMPEG_jll v4.4.4+1 (<v7.1.0+0): FFMPEG
⌃ [7746bdde] Glib_jll v2.82.4+0 (<v2.84.0+0)
⌅ [c73af94c] ImageMagick_jll v6.9.13+0 (<v7.1.1+1): ImageMagick
⌅ [e9f186c6] Libffi_jll v3.2.2+2 (<v3.4.7+0): Glib_jll, HarfBuzz_jll, Wayland_jll
⌅ [c0090381] Qt6Base_jll v6.7.1+1 (<v6.8.2+1): GR_jll, Qt6Declarative_jll, Qt6ShaderTools_jll, Qt6Wayland_jll
⌅ [629bc702] Qt6Declarative_jll v6.7.1+2 (<v6.8.2+1): Qt6Wayland_jll
⌅ [ce943373] Qt6ShaderTools_jll v6.7.1+1 (<v6.8.2+1): Qt6Declarative_jll
⌃ [e99dba38] Qt6Wayland_jll v6.7.1+1 (<v6.8.2+0)
⌃ [a2964d1f] Wayland_jll v1.21.0+2 (<v1.23.1+0)
⌅ [02c8fc9c] XML2_jll v2.13.6+1 (<v2.14.1+0): Gettext_jll, Wayland_jll, at_spi2_atk_jll
⌅ [b437f822] adwaita_icon_theme_jll v3.33.93+0 (<v43.0.1+0): Gtk
⌅ [1270edf5] x264_jll v2021.5.5+0 (<v10164.0.1+0): FFMPEG_jll
⌅ [dfaa095f] x265_jll v3.5.0+0 (<v4.1.0+0): FFMPEG_jll
```

**after PR**
```
⌅ [aea7be01] PrecompileTools v1.2.1 (<v1.3.2): julia
⌅ [df47a6cb] RData v0.8.3 (<v1.0.0): RDatasets
⌃ [7b86fcea] ATK_jll v2.38.0+0 (<v2.38.1+0)
⌃ [83423d85] Cairo_jll v1.18.4+0 (<v1.18.5+0)
⌅ [b22a6f82] FFMPEG_jll v4.4.4+1 (<v7.1.0+0): FFMPEG
⌃ [7746bdde] Glib_jll v2.82.4+0 (<v2.84.0+0)
⌅ [88015f11] LERC_jll v3.0.0+1 (<v4.0.1+0): Libtiff_jll
⌅ [e9f186c6] Libffi_jll v3.2.2+2 (<v3.4.7+0): Glib_jll, HarfBuzz_jll, Wayland_jll
⌅ [89763e89] Libtiff_jll v4.4.0+0 (<v4.7.1+0): ImageMagick_jll, LittleCMS_jll, OpenJpeg_jll, gdk_pixbuf_jll
⌃ [d3a379c0] LittleCMS_jll v2.12.0+0 (<v2.16.0+0)
⌃ [643b3616] OpenJpeg_jll v2.4.0+0 (<v2.5.4+0)
⌃ [a2964d1f] Wayland_jll v1.21.0+2 (<v1.23.1+0)
⌅ [02c8fc9c] XML2_jll v2.13.6+1 (<v2.14.1+0): Gettext_jll, Wayland_jll, at_spi2_atk_jll
⌅ [b437f822] adwaita_icon_theme_jll v3.33.93+0 (<v43.0.1+0): Gtk
⌃ [da03df04] gdk_pixbuf_jll v2.42.8+0 (<v2.42.12+0)
⌃ [c5f90fcd] libwebp_jll v1.4.0+0 (<v1.5.0+0)
⌅ [1270edf5] x264_jll v2021.5.5+0 (<v10164.0.1+0): FFMPEG_jll
⌅ [dfaa095f] x265_jll v3.5.0+0 (<v4.1.0+0): FFMPEG_jll
```