### PR TITLE
[LibTracyClient] Update to v0.10

### DIFF
--- a/L/LibTracyClient/LibTracyClient@0.10.0/build_tarballs.jl
+++ b/L/LibTracyClient/LibTracyClient@0.10.0/build_tarballs.jl
@@ -1,0 +1,50 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "LibTracyClient"
+version = v"0.10.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/wolfpld/tracy.git",
+              "37aff70dfa50cf6307b3fee6074d627dc2929143"), # v0.10
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/tracy*/
+if [[ "${target}" != *-mingw* ]]; then
+    echo "target_compile_definitions(TracyClient PUBLIC __STDC_FORMAT_MACROS)" >> CMakeLists.txt
+else
+    echo "target_compile_definitions(TracyClient PUBLIC WINVER=0x0602 _WIN32_WINNT=0x0602)" >> CMakeLists.txt
+fi
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/libTracyClient-freebsd-elfw.patch
+cmake -B static -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DTRACY_FIBERS=ON -DTRACY_ONLY_LOCALHOST=ON -DTRACY_NO_CODE_TRANSFER=ON -DTRACY_NO_FRAME_IMAGE=ON -DTRACY_NO_CRASH_HANDLER=ON -DTRACY_ON_DEMAND=ON -DTRACY_NO_SAMPLING=ON -DTRACY_TIMER_FALLBACK=ON -DTRACY_PATCHABLE_NOPSLEDS=ON .
+cd static
+make -j${nproc}
+make install
+cd ..
+cmake -B shared -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DTRACY_FIBERS=ON -DTRACY_ONLY_LOCALHOST=ON -DTRACY_NO_CODE_TRANSFER=ON -DTRACY_NO_FRAME_IMAGE=ON -DTRACY_NO_CRASH_HANDLER=ON -DTRACY_ON_DEMAND=ON -DTRACY_NO_SAMPLING=ON -DTRACY_TIMER_FALLBACK=ON -DTRACY_PATCHABLE_NOPSLEDS=ON .
+cd shared
+make -j${nproc}
+make install
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libTracyClient", :libTracyClient),
+    FileProduct(["lib/libTracyClient.a", "lib/libTracyClient.lib"], :libTracyClient_static)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[]
+
+# Build the tarballs, and possibly a `build.jl` as well
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version=v"7")

--- a/L/LibTracyClient/LibTracyClient@0.10.0/bundled/patches/libTracyClient-freebsd-elfw.patch
+++ b/L/LibTracyClient/LibTracyClient@0.10.0/bundled/patches/libTracyClient-freebsd-elfw.patch
@@ -1,0 +1,33 @@
+diff --git a/public/TracyClient.cpp b/public/TracyClient.cpp
+index 77f81a4a..ebeb65c9 100644
+--- a/public/TracyClient.cpp
++++ b/public/TracyClient.cpp
+@@ -19,6 +19,28 @@
+ #  pragma warning(push, 0)
+ #endif
+
++#ifndef ElfW
++#  if defined(FREEBSD)
++#    if __ELF_WORD_SIZE == 32
++#      define ElfW(type) Elf32_##type
++#    else
++#      define ElfW(type) Elf64_##type
++#    endif
++#  elif defined(NETBSD) || defined(OPENBSD)
++#    if ELFSIZE == 32
++#      define ElfW(type) Elf32_##type
++#    else
++#      define ElfW(type) Elf64_##type
++#    endif
++#  else
++#    if !defined(ELF_CLASS) || ELF_CLASS == ELFCLASS32
++#      define ElfW(type) Elf32_##type
++#    else
++#      define ElfW(type) Elf64_##type
++#    endif
++#  endif
++#endif
++
+ #include "common/tracy_lz4.cpp"
+ #include "client/TracyProfiler.cpp"
+ #include "client/TracyCallstack.cpp"


### PR DESCRIPTION
To be merged at the same time as https://github.com/JuliaPackaging/Yggdrasil/pull/8437 to avoid breakage.
Among the 4 patches needed for v0.9.1, I could remove three patches who are part of v0.10

* libTracyClient-no-sampling.patch : https://github.com/wolfpld/tracy/pull/545
* libTracyClient-plot-config.patch : https://github.com/wolfpld/tracy/commit/7151c6afd9cc40877325c64bd19bcff7211fbd59
* libTracyClient-rr-nopl-seq.patch : https://github.com/wolfpld/tracy/pull/597