### PR TITLE
MAGEMin v1.7.5

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 name = "MAGEMin"
-version = v"1.7.4"
+version = v"1.7.5"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "5fae0eba319656b19e601ba0cb4a88e2caa6f57e")                 ]
+                    "26a6712bbcdd5d8f45fdac696941606d89d2132a")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Corrected wrong memory access for ume database (leading to crash during memory deallocation)
- Added test for ume database to avoid such problem in the future
