### PR TITLE
[GASNet] Add GASNet smp conduit recipe

### DIFF
--- a/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
+++ b/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
@@ -1,0 +1,69 @@
+using BinaryBuilder, Pkg
+
+include(joinpath(@__DIR__, "../common.jl"))
+
+name = gasnet_name("smp")
+version = v"2024.5.0"
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/GASNet-2024.5.0/
+
+# TODO this needs platform-dependent optimization!
+export CROSS_HAVE_MMAP='1'
+export CROSS_PAGESIZE=4096
+export CROSS_STACK_GROWS_UP='0'
+export CROSS_HAVE_X86_CMPXCHG16B='0'
+export CROSS_HAVE_SHM_OPEN='1'
+
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${MACHTYPE} --target=${target} \
+    --enable-cross-compile \
+    --with-cflags=-fPIC --with-cxxflags=-fPIC --with-mpi-cflags=-fPIC \
+    --enable-smp \
+    --disable-udp \
+    --disable-mpi
+
+make -j${nproc}
+
+# build for smp conduit
+pushd smp-conduit
+for file in libgasnet-smp-*.a; do
+    # extract the object files from the static library
+    ar -x $file
+
+    # extract the suffix from the filename
+    mode=${file#libgasnet-smp-}
+    mode=${mode%.a}
+
+    ${CC} -shared *.o -o libgasnet-smp-$mode.${dlext}
+    install -Dvm 0755 libgasnet-smp-$mode.${dlext} ${libdir}/libgasnet-smp-$mode.${dlext}
+
+    rm *.o
+done
+popd
+
+install_license license.txt
+"""
+
+platforms = [
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="gnu"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("aarch64", "macos"),
+]
+
+# The products that we will ensure are always built
+products = Product[
+    LibraryProduct("libgasnet-smp-seq", :libgasnet_smp_seq),
+    LibraryProduct("libgasnet-smp-par", :libgasnet_smp_par),
+    LibraryProduct("libgasnet-smp-parsync", :libgasnet_smp_parsync),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    preferred_gcc_version=v"7", julia_compat="1.6")

--- a/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
+++ b/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
@@ -66,6 +66,7 @@ platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
     Platform("aarch64", "linux"; libc="gnu"),
     Platform("aarch64", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
     Platform("aarch64", "macos"),
 ]
 

--- a/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
+++ b/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
@@ -16,6 +16,11 @@ export CROSS_STACK_GROWS_UP='0'
 export CROSS_HAVE_X86_CMPXCHG16B='0'
 export CROSS_HAVE_SHM_OPEN='1'
 
+# if target contains apple-darwin, set RANLIB to ar (llvm-ranlib fails)
+if [[ ${target} == *apple-darwin* ]]; then
+    export RANLIB=ar
+fi
+
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${MACHTYPE} --target=${target} \
     --enable-cross-compile \
     --with-cflags=-fPIC --with-cxxflags=-fPIC --with-mpi-cflags=-fPIC \

--- a/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
+++ b/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
@@ -56,6 +56,8 @@ for file in libgasnet-smp-*.a; do
 done
 popd
 
+make install-includeHEADERS
+
 install_license license.txt
 """
 
@@ -72,6 +74,7 @@ products = Product[
     LibraryProduct("libgasnet-smp-seq", :libgasnet_smp_seq),
     LibraryProduct("libgasnet-smp-par", :libgasnet_smp_par),
     LibraryProduct("libgasnet-smp-parsync", :libgasnet_smp_parsync),
+    FileProduct("include/gasnet.h", :gasnet_h),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
+++ b/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
@@ -9,11 +9,20 @@ version = v"2024.5.0"
 script = raw"""
 cd ${WORKSPACE}/srcdir/GASNet-2024.5.0/
 
-# TODO this needs platform-dependent optimization!
+# TODO this needs platform-dependent optimization! should be automatically detected on target platforms
+## Whether the system has a working version of anonymous mmap
 export CROSS_HAVE_MMAP='1'
+
+## The system VM page size (ie mmap granularity, even if swapping is not supported)
 export CROSS_PAGESIZE=4096
+
+## Does the system stack grow up?
 export CROSS_STACK_GROWS_UP='0'
+
+## MIC doesn't have cmpxchg16b instruction!
 export CROSS_HAVE_X86_CMPXCHG16B='0'
+
+## Enable Posix shared memory
 export CROSS_HAVE_SHM_OPEN='1'
 
 # if target contains apple-darwin, set RANLIB to ar (llvm-ranlib fails)

--- a/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
+++ b/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
@@ -2,8 +2,7 @@ using BinaryBuilder, Pkg
 
 include(joinpath(@__DIR__, "../common.jl"))
 
-name = gasnet_name("smp")
-version = v"2024.5.0"
+name = gasnet_conduit_name("smp")
 
 # Bash recipe for building across all platforms
 script = raw"""
@@ -60,15 +59,6 @@ make install-includeHEADERS
 
 install_license license.txt
 """
-
-platforms = [
-    Platform("x86_64", "linux"; libc="musl"),
-    Platform("x86_64", "linux"; libc="glibc"),
-    Platform("aarch64", "linux"; libc="gnu"),
-    Platform("aarch64", "linux"; libc="musl"),
-    Platform("x86_64", "macos"),
-    Platform("aarch64", "macos"),
-]
 
 # The products that we will ensure are always built
 products = Product[

--- a/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
+++ b/G/GASNet/GASNet_conduit_smp/build_tarballs.jl
@@ -80,4 +80,4 @@ dependencies = Dependency[
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    preferred_gcc_version=v"7", julia_compat="1.6")
+    preferred_gcc_version=v"7", julia_compat="1.6", lazy_artifacts=true)

--- a/G/GASNet/common.jl
+++ b/G/GASNet/common.jl
@@ -1,0 +1,52 @@
+gasnet_name(x) = "GASNet_conduit_$x"
+
+version = v"2024.5.0"
+
+sources = [
+    ArchiveSource("https://gasnet.lbl.gov/EX/GASNet-2024.5.0.tar.gz", "f945e80f71d340664766b66290496d230e021df5e5cd88f404d101258446daa9"),
+]
+
+platforms = [
+    Platform("x86_64", "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="gnu"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("aarch64", "macos"),
+]
+
+# TODO checkout
+# --enable-debug - build GASNet in a debugging mode. This turns on C-level
+#   debugger options and also enables extensive error and sanity checking 
+#   system-wide, which is highly recommended for developing and debugging 
+#   GASNet clients (but should NEVER be used for performance testing). 
+#   --enable-debug also implies --enable-{trace,stats,debug-malloc},
+#   but these can still be selectively --disable'd.
+# --enable-trace - turn on GASNet tracing (see usage info below)
+# --enable-stats - turn on GASNet statistical collection (see usage info below)
+# --enable-debug-malloc - use GASNet debugging malloc (see usage info below)
+# --enable-segment-{fast,large,everything} - select a GASNet segment 
+#   configuration (see the GASNet spec for more info)
+# --enable-pshm - Build GASNet with inter-Process SHared Memory (PSHM) support.
+#   This feature uses shared memory communication among the processes (aka
+#   GASNet nodes) within a single compute node (where the other alternatives
+#   are multi-threading via a PAR or PARSYNC build; or use of the conduit's
+#   API to perform the communication).
+#   Note that not all conduits and operating systems support this feature.
+#   For more information, see the section below entitled "GASNet inter-Process
+#   SHared Memory (PSHM)".
+
+
+# recommendations for systems:
+# On HPE Cray EX (aka "Shasta") systems, we recommend the following configure
+#   arguments to use the vendor's compiler wrappers:
+#     --with-cc=cc --with-cxx=CC --with-mpi-cc=cc
+#   Additionally, exactly one of the following is recommended to ensure that
+#   ofi-conduit is built for the appropriate libfabric provider:
+#     * HPE Cray EX with Slingshot-10 (100Gbps) NICs: --with-ofi-provider=verbs
+#     * HPE Cray EX with Slingshot-11 (200Gbps) NICs: --with-ofi-provider=cxi
+#     * HPE Cray EX with BOTH NIC types: --with-ofi-provider=generic
+# On Linux clusters with Omni-Path networks from Intel or Cornelis Networks, we
+#   recommend the following configure arguments to avoid using ibv-conduit over
+#   an emulated libibverbs:
+#     --disable-ibv --enable-ofi --with-ofi-provider=psm2
+# for linux-infiniband: --enable-mpi --disable-ibv --disable-ofi

--- a/G/GASNet/common.jl
+++ b/G/GASNet/common.jl
@@ -1,4 +1,4 @@
-gasnet_name(x) = "GASNet_conduit_$x"
+gasnet_conduit_name(x) = "GASNet_conduit_$x"
 
 version = v"2024.5.0"
 
@@ -11,6 +11,7 @@ platforms = [
     Platform("x86_64", "linux"; libc="glibc"),
     Platform("aarch64", "linux"; libc="gnu"),
     Platform("aarch64", "linux"; libc="musl"),
+    Platform("x86_64", "macos"),
     Platform("aarch64", "macos"),
 ]
 


### PR DESCRIPTION
there are still some things to properly configure, like:

- ~the `CROSS_HAVE_MMAP`, `CROSS_PAGESIZE`, `CROSS_STACK_GROWS_UP`, `CROSS_HAVE_X86_CMPXCHG16B`, `CROSS_HAVE_SHM_OPEN` env vars~ (needs better tuning but can be done later)
- ~~flags for debug mode~~ (not a priority)
- ~~fix for macOS~~ (fixed)

if this works correctly, i will add more conduits like the mpi and the ucx ones