### PR TITLE
[OCaml] Fix interpreter shebang for pre-built binaries

### DIFF
--- a/O/OCaml/OCaml@5.3.0/build_tarballs.jl
+++ b/O/OCaml/OCaml@5.3.0/build_tarballs.jl
@@ -41,10 +41,11 @@ else
     make install
 fi
 
-for bin in $(file ${bindir}/* | grep "a ${bindir}/ocamlrun script" | cut -d: -f1); do
+for bin in $(file ${bindir}/* | grep "a \S*/ocamlrun script" | cut -d: -f1); do
     # Fix shebang of ocamlrun scripts to not hardcode
     # a path of the build environment
-    sed -i "s?${bindir}/ocamlrun?/usr/bin/env ocamlrun?" "${bin}"
+    abspath=$(file ${bin} | grep -oh "a \S*/ocamlrun script" | cut -d' ' -f2)
+    sed -i "s?${abspath}?/usr/bin/env ocamlrun?" "${bin}"
 done
 """
 


### PR DESCRIPTION
The pattern matching that I had here assumed that the absolute paths were from BinaryBuilder, but that's no longer true.