### PR TITLE
Trigger a build of LLVM 18/19/20 with an ORC fix.

### DIFF
--- a/L/LLVM/LLVM_full@18/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@18/build_tarballs.jl
@@ -5,3 +5,4 @@ include("../common.jl")
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"17",
                julia_compat="1.6")
+# Build trigger: #11152

--- a/L/LLVM/LLVM_full@19/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@19/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 9
+# Build trigger: #11152

--- a/L/LLVM/LLVM_full@20/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@20/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 9
+# Build trigger: #11152

--- a/L/LLVM/LLVM_full_assert@18/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@18/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"17", julia_compat="1.6")
-# Build trigger: 4
+# Build trigger: #11152

--- a/L/LLVM/LLVM_full_assert@19/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@19/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 10
+# Build trigger: #11152

--- a/L/LLVM/LLVM_full_assert@20/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@20/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 10
+# Build trigger: #11152

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -19,9 +19,9 @@ const llvm_tags = Dict(
     v"15.0.7" => "2593167b92dd2d27849e8bc331db2072a9b4bd7f", # julia-15.0.7-10
     v"16.0.6" => "4a5c1da0d268d2858def6c1aa206ac4b31956208", # julia-16.0.6-4
     v"17.0.6" => "0007e48608221f440dce2ea0d3e4f561fc10d3c6", # julia-17.0.6-5
-    v"18.1.7" => "ed30d043a240d06bb6e010a41086e75713156f4f", # julia-18.1.7-2
-    v"19.1.7" => "a9df916357c2fd0851df026a84f83d87efd6e212", # julia-19.1.7-1
-    v"20.1.2" => "4f020e6d4d37d271d46befedb896ea3df95fdc49", # julia-20.1.2-0
+    v"18.1.7" => "907734ec3579c6b031b8c129fc4512d6197ebb7a", # julia-18.1.7-3
+    v"19.1.7" => "ccda9ec62497d9de88ca7090a749e52a89f62132", # julia-19.1.7-2
+    v"20.1.2" => "6fe525631430a9cca35e564f90752ac6b7d9d951", # julia-20.1.2-1
 )
 
 const buildscript = raw"""


### PR DESCRIPTION
This backports https://github.com/llvm/llvm-project/pull/139259 to the LLVM versions that are currently being used by Julia: 18 for Julia 1.12, 19 for nightly, and 20 for https://github.com/JuliaLang/julia/pull/58142. I didn't bother bumping LLVM 17, even though it's also affected, because it's not being used by any Julia release right now.