### PR TITLE
[Exodus_jll] update build_tarballs.jl for new libexodus version 9.04

### DIFF
--- a/E/Exodus/build_tarballs.jl
+++ b/E/Exodus/build_tarballs.jl
@@ -3,16 +3,19 @@
 using BinaryBuilder, Pkg
 
 name = "Exodus"
-version = v"8.19.1"
+version = v"9.4.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/gsjaardema/seacas.git", "cfc1edd1e1602fd1edc8da90053b66e92499c8e9"),
+    GitSource("https://github.com/gsjaardema/seacas.git", "2f0c364b145df6fb8ac5cb29f80a72b24732b7f4"),
     DirectorySource("bundled")
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
+# below needed to use CMake_jll
+apk del cmake
+
 cd $WORKSPACE/srcdir/seacas
 
 for p in ../patches/*.patch; do
@@ -92,22 +95,20 @@ platforms = expand_cxxstring_abis(platforms)
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libexodus", :libexodus)
+    ExecutableProduct("epu", :epu_exe)
+    ExecutableProduct("exodiff", :exodiff_exe)
     ExecutableProduct("nem_slice", :nem_slice_exe)
     ExecutableProduct("nem_spread", :nem_spread_exe)
-    ExecutableProduct("exodiff", :exodiff_exe)
-    ExecutableProduct("epu", :epu_exe)
 ]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="Fmt_jll", uuid="5dc1e892-f187-50dd-85f3-7dff85c47fc5"))
-    # We had to restrict compat with HDF5 because of ABI breakage:
-    # https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973
-    # Updating to a newer HDF5 version is likely possible without problems but requires rebuilding this package
-    Dependency(PackageSpec(name="HDF5_jll", uuid="0234f1f7-429e-5d53-9886-15a909be8d59"); compat="1.14.0 - 1.14.3")
+    Dependency(PackageSpec(name="HDF5_jll", uuid="0234f1f7-429e-5d53-9886-15a909be8d59"); compat="1.14.6 - 1.14")
     Dependency(PackageSpec(name="NetCDF_jll", uuid="7243133f-43d8-5620-bbf4-c2c921802cf3"))
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"))
+    HostBuildDependency(PackageSpec(name="CMake_jll", uuid="3f4e10e2-61f2-5801-8945-23b9d642d0e6"))
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"5")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"9")

--- a/E/Exodus/bundled/patches/windows-cmake-error.patch
+++ b/E/Exodus/bundled/patches/windows-cmake-error.patch
@@ -1,22 +1,8 @@
-From 8047cdbe21a53fa91de8614b4bed4a6c013757b3 Mon Sep 17 00:00:00 2001
-From: cmhamel <cmhamel32@gmail.com>
-Date: Sun, 19 Feb 2023 11:15:34 -0500
-Subject: [PATCH] Patch for changes to some library names and NetCDF cmake
- build to accomodate for Windows builds with the BinaryBuilder.jl toolset.
- Four files were changed minimally
-
----
- cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake | 6 +++---
- packages/seacas/applications/epu/EP_Internals.C         | 2 +-
- packages/seacas/applications/epu/EP_ParallelDisks.C     | 2 +-
- packages/seacas/libraries/suplib_cpp/sys_info.C         | 2 +-
- 4 files changed, 6 insertions(+), 6 deletions(-)
-
 diff --git a/cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake b/cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake
-index b3e70fe3cd..2f424bd3f8 100644
+index 92cd46a214..7d3f15ccf5 100644
 --- a/cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake
 +++ b/cmake/tribits/common_tpls/find_modules/FindNetCDF.cmake
-@@ -270,9 +270,9 @@ if ( NetCDF_ROOT OR NetCDF_BIN_DIR )
+@@ -240,9 +240,9 @@ if ( NetCDF_ROOT OR NetCDF_BIN_DIR )
          set(NetCDF_NEEDS_PNetCDF "${netCDF_HAS_PNETCDF}")
      else()
          # Otherwise, try calling the nc-config shell script
@@ -29,21 +15,8 @@ index b3e70fe3cd..2f424bd3f8 100644
          find_program(netcdf_config nc-config
                         PATHS ${NetCDF_ROOT}/bin ${NetCDF_BIN_DIR}
  		           NO_DEFAULT_PATH
-diff --git a/packages/seacas/applications/epu/EP_Internals.C b/packages/seacas/applications/epu/EP_Internals.C
-index 39700e0dcd..0e86f3d7f2 100644
---- a/packages/seacas/applications/epu/EP_Internals.C
-+++ b/packages/seacas/applications/epu/EP_Internals.C
-@@ -23,7 +23,7 @@
- 
- #if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) ||                \
-     defined(__MINGW32__) || defined(_WIN64) || defined(__MINGW64__)
--#include <Shlwapi.h>
-+#include <shlwapi.h>
- #endif
- 
- extern "C" {
 diff --git a/packages/seacas/applications/epu/EP_ParallelDisks.C b/packages/seacas/applications/epu/EP_ParallelDisks.C
-index f5496b983e..e11ca5c47a 100644
+index 6a25543b4b..0d3e0b9166 100644
 --- a/packages/seacas/applications/epu/EP_ParallelDisks.C
 +++ b/packages/seacas/applications/epu/EP_ParallelDisks.C
 @@ -15,7 +15,7 @@
@@ -68,6 +41,3 @@ index cc034e1815..5f36b1f8b1 100644
  #undef IN
  #undef OUT
  #include <fmt/ostream.h>
--- 
-2.37.2
-


### PR DESCRIPTION
This PR does the following

1. Updates the git source to point to a new version of libexodus
2. Updates the version number to 9.4.0
3. Adds cmake as a dependency since this version of libexodus requires cmake >= 3.22
4. Bumps preferred_gcc_version to 9 due to build failures in linux aarch64
5. A small patch to fix issues encountered in windows build.