### PR TITLE
[aws_c_http_jq] Update to version 0.10.1

### DIFF
--- a/A/aws_c_http_jq/build_tarballs.jl
+++ b/A/aws_c_http_jq/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_http_jq"
-version = v"0.9.8"
+version = v"0.10.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/quinnj/aws-c-http.git", "3c4527eb051602e9b760286241d71e9327e7a695"),
+    GitSource("https://github.com/quinnj/aws-c-http.git", "3eedf1ef8c6874cd941dbde794a6ab3bd979e181"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_c_http_jq to version 0.10.1. cc: @quinnj @Octogonapus