### PR TITLE
MAGEMin v1.7.7

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 name = "MAGEMin"
-version = v"1.7.6"
+version = v"1.7.7"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "e6999ecb69aec6b03511ce454dd4d33b8f7085cc")                 ]
+                    "e67f4656f8f7820afa76caa7402cc17588408d5e")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Fixes shear modulus calculation for slb database
- Fixes issue introduced in version 1.7.6 that was wrongfully outputting phases in mol% on a 1atom basis instead of mol%.

While double checking the output of MAGEMin with a reference software (Theriak-Domino), I realized that the unit displayed in the reference software were not the one used in the calculation. This discrepancy led to breaking MAGEMin in v1.7.6 and version v1.7.7 rolls back the changes... 

