### PR TITLE
LLVM: Bump libLLVM for LLVM 18 and 19.

### DIFF
--- a/L/LLVM/libLLVM@18/build_tarballs.jl
+++ b/L/LLVM/libLLVM@18/build_tarballs.jl
@@ -1,5 +1,5 @@
 name = "libLLVM"
-version = v"18.1.7+3"
+version = v"18.1.7+4"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms

--- a/L/LLVM/libLLVM@19/build_tarballs.jl
+++ b/L/LLVM/libLLVM@19/build_tarballs.jl
@@ -1,5 +1,5 @@
 name = "libLLVM"
-version = v"19.1.7+1"
+version = v"19.1.7+2"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms


### PR DESCRIPTION
Not bumping LLVM 20 (Julia 1.13) because that PR hasn't merged yet, and a bump will need to happen soon for https://github.com/JuliaPackaging/Yggdrasil/pull/11135 anyway.

IIUC I also only need to bump `libLLVM`, and not the `LLVM`, `LLD`, `Clang` or `MLIR` JLLs as done in e.g. https://github.com/JuliaPackaging/Yggdrasil/pull/10600, because (1) the patch I backported is entirely nonbreaking, and (2) existing JLLs depend on `libLLVM_jll` and thus will work just fine with the bumped `libLLVM_jll`.