### PR TITLE
[slope] lower libcxxwrap_julia_jll compat to 0.13.4

### DIFF
--- a/S/slope/build_tarballs.jl
+++ b/S/slope/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder, Pkg
 
 name = "slope"
-version = v"1.0.0"
+version = v"1.0.1"
 
 # See https://github.com/JuliaLang/Pkg.jl/issues/2942
 # Once this Pkg issue is resolved, this must be removed

--- a/S/slope/build_tarballs.jl
+++ b/S/slope/build_tarballs.jl
@@ -66,7 +66,7 @@ dependencies = [
     BuildDependency("libjulia_jll"),
     Dependency("CompilerSupportLibraries_jll"),
     Dependency("LLVMOpenMP_jll", platforms=filter(Sys.isapple, platforms)),
-    Dependency("libcxxwrap_julia_jll"; compat="0.14.1"),
+    Dependency("libcxxwrap_julia_jll"; compat="0.13.4"),
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;


### PR DESCRIPTION
I am running into unsatisfiable dependency issues when trying to use `slope_jll` together with `CxxWrap` when I am trying to build a Julia package around it:

```
ERROR: Unsatisfiable requirements detected for package libcxxwrap_julia_jll [3eaa8342]:
 libcxxwrap_julia_jll [3eaa8342] log:
 ├─possible versions are: 0.6.5 - 0.14.1 or uninstalled
 ├─restricted by julia compatibility requirements to versions: [0.6.5 - 0.8.0, 0.8.5 - 0.14.1] or uninstal
led
 ├─restricted by compatibility requirements with CxxWrap [1f15a43c] to versions: 0.13.0 - 0.13.4
 │ └─CxxWrap [1f15a43c] log:
 │   ├─possible versions are: 0.7.0 - 0.16.2 or uninstalled
 │   └─restricted to versions 0.16.2 - 0.16 by SLOPE [e3f974f6], leaving only versions: 0.16.2
 │     └─SLOPE [e3f974f6] log:
 │       ├─possible versions are: 1.0.0 or uninstalled
 │       └─SLOPE [e3f974f6] is fixed to version 1.0.0
 └─restricted by compatibility requirements with slope_jll [baac1969] to versions: 0.14.1 — no versions le
ft
   └─slope_jll [baac1969] log:
     ├─possible versions are: 1.0.0 or uninstalled
     └─restricted to versions * by an explicit requirement, leaving only versions: 1.0.0
```

The problem is that the current `CxxWrap` in the registry restricts libcxxwrap to 0.13.0:

https://github.com/JuliaInterop/CxxWrap.jl/blob/71eeee2edfc6b85ff0b2d863f714e1b05c766a05/Project.toml#L14

which is not compatible with `slope_jll`'s requirement of 0.14.1

This PR reduces the requirement to 0.13.4

This can be bumped again, if necessary, when the next version of CxxWrap is released.