### PR TITLE
PoCL: Regenerate wrapper with more `__init__` improvements

### DIFF
--- a/P/pocl/pocl@6/build_tarballs.jl
+++ b/P/pocl/pocl@6/build_tarballs.jl
@@ -300,3 +300,4 @@ for (i,build) in enumerate(builds)
                    julia_compat="1.6", augment_platform_block, init_block)
 end
 
+# bump

--- a/P/pocl/pocl@7/build_tarballs.jl
+++ b/P/pocl/pocl@7/build_tarballs.jl
@@ -106,3 +106,5 @@ for (i,build) in enumerate(builds)
                    build.preferred_gcc_version, preferred_llvm_version=v"20",
                    julia_compat="1.6", init_block=init_block())
 end
+
+# bump


### PR DESCRIPTION
Wrapper scripts are generated atomically now, and I've switched from `-L$path` to `-L`, `$path` since that *somehow* fixes what looks like a memory corruption in those arguments getting forwarded from Clang to lld:

```
# PoCL invoking clang invoking lld

## from clang -v
clang version 16.0.6 (/cache/yggdrasil/downloads/clones/llvm-project.git-5a9787eb535c2edc5dea030cc221c1d60f38c9f42344f410e425ea2139e233aa 499f87882a4ba1837ec12a280478cf4cb0d2753d)
 "/home/tim/.julia/scratchspaces/627d6b7a-bbe6-5189-83e7-98cc0a5aeadd/bin/lld" 
 --hash-style=gnu --eh-frame-hdr -m elf_x86_64 -shared 
 -o /home/tim/.cache/pocl/kcache/tempfile_7XQfLW.so 
 # these forwarded from us adding `-L` to clang
 -L/home/tim/.julia/artifacts/40ea4a5d103adb6fd627ddadb63ebfcda952387c/share/lib 
 -L/home/tim/.julia/scratchspaces/627d6b7a-bbe6-5189-83e7-98cc0a5aeadd/lib 
 # end
 -L/usr/lib64/gcc/x86_64-pc-linux-gnu/15.1.1 
 -L/usr/lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../lib64 
 -L/lib/../lib64 -L/usr/lib/../lib64 -L/lib -L/usr/lib 
 /home/tim/.cache/pocl/kcache/tempfile_oghVwp.so.o -lm 
 -lgcc --as-needed -lgcc_s --no-as-needed -lc -lgcc 
 --as-needed -lgcc_s --no-as-needed

## so clang invokes lld correctly

## now tracing lld (it's a wrapper script so we can add `set -x`)
+ ...
+ exec /home/tim/.julia/artifacts/09801ff9241d2be6ad9d17004b1cd03ffb7c9911/tools/ld.lld --hash-style=gnu --eh-frame-hdr -m elf_x86_64 -shared -o /home/tim/.cache/pocl/kcache/tempfile_7XQfLW.so $'\322=r' Y=r -L/usr/lib64/gcc/x86_64-pc-linux-gnu/15.1.1 -L/usr/lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../lib64 -L/lib/../lib64 -L/usr/lib/../lib64 -L/lib -L/usr/lib /home/tim/.cache/pocl/kcache/tempfile_oghVwp.so.o -lm -lgcc --as-needed -lgcc_s --no-as-needed -lc -lgcc --as-needed -lgcc_s --no-as-needed

## our -L args somehow turned into rubbish?
ld.lld: error: cannot open �=r: No such file or directory
ld.lld: error: cannot open Y=r: No such file or directory
```