### PR TITLE
PoCL: Rebuild wrapper for v6.

### DIFF
--- a/P/pocl/pocl@6/build_tarballs.jl
+++ b/P/pocl/pocl@6/build_tarballs.jl
@@ -299,5 +299,3 @@ for (i,build) in enumerate(builds)
                    preferred_gcc_version=v"10", build.preferred_llvm_version,
                    julia_compat="1.6", augment_platform_block, init_block)
 end
-
-# bump


### PR DESCRIPTION
I did this in https://github.com/JuliaPackaging/Yggdrasil/pull/11193, but apparently one can't do a single wrapper regeneration for multiple packages or BB will get confused about the artifacts to download: https://buildkite.com/julialang/yggdrasil/builds/20261#0196ce95-011f-4246-89f8-64d405c9dff9

```
ERROR: LoadError: Incomplete JLL release!  Could not find tarball for i686-linux-gnu-cxx03-llvm_version+14
```

I think this is because PoCL 7 doesn't have an augmented platform anymore, but v6 has? Let's try bumping both separately.