### PR TITLE
PoCL: Regenerate v7 wrappers.

### DIFF
--- a/P/pocl/pocl@7/build_tarballs.jl
+++ b/P/pocl/pocl@7/build_tarballs.jl
@@ -106,3 +106,5 @@ for (i,build) in enumerate(builds)
                    build.preferred_gcc_version, preferred_llvm_version=v"20",
                    julia_compat="1.6", init_block=init_block())
 end
+
+# bump


### PR DESCRIPTION
The `.pkg` dir reappeared because we rebuilt PoCL v6.

x-ref https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1383