### PR TITLE
PoCL 7: Add Zstd_jll dependency.

### DIFF
--- a/P/pocl/pocl@7/build_tarballs.jl
+++ b/P/pocl/pocl@7/build_tarballs.jl
@@ -58,6 +58,7 @@ dependencies = [
     Dependency("OpenCL_jll"),
     Dependency("OpenCL_Headers_jll"),
     Dependency("Hwloc_jll"),
+    Dependency("Zstd_jll"), # our LLVM 20 build has LLVM_ENABLE_ZSTD=ON
     # only used at run time, but also detected by the build
     Dependency("SPIRV_LLVM_Translator_jll", compat="20.1"),
     Dependency("SPIRV_Tools_jll"),


### PR DESCRIPTION
Use of zstd was recently added to our LLVM build, so the PoCL library (which links statically against LLVM) needs to have Zstd_jll as a dependency.