### PR TITLE
UCX 1.18.1 + Expand CUDA Vers + Updaet ROCM Ver

### DIFF
--- a/U/UCX/build_tarballs.jl
+++ b/U/UCX/build_tarballs.jl
@@ -4,6 +4,7 @@ using BinaryBuilder, Pkg
 
 const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "UCX"
 version = v"1.18.1"

--- a/U/UCX/build_tarballs.jl
+++ b/U/UCX/build_tarballs.jl
@@ -6,12 +6,17 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "UCX"
-version = v"1.18.0"
+version = v"1.18.1"
+
+MIN_CUDA_VERSION = v"11.8"
+MAX_CUDA_VERSION = v"12.9.999"
+ROCM_VERSION = v"5.4.4"
+
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/openucx/ucx.git",
-                  "693d02837894b9c346c9f91b105e4aff6f259c09"),
+                  "d9aa5650d4cbcbb00d61af980614dbe9dd27a1f2"),
     ]
 
 # Bash recipe for building across all platforms
@@ -25,6 +30,7 @@ for f in $WORKSPACE/srcdir/patches/*.patch; do
     atomic_patch -p1 ${f}
 done
 fi
+
 ./autogen.sh
 update_configure_scripts --reconf
 
@@ -42,10 +48,7 @@ FLAGS+=(--enable-mt)
 FLAGS+=(--enable-frame-pointer)
 FLAGS+=(--enable-cma)
 FLAGS+=(--with-rdmacm=${prefix})
-
-if [[ "${target}" != *aarch64* ]]; then
-    FLAGS+=(--with-cuda=${prefix}/cuda)
-fi
+FLAGS+=(--with-cuda=${prefix}/cuda)
 
 if [[ "${target}" == *x86_64* ]]; then
     FLAGS+=(--with-rocm=${prefix})
@@ -59,16 +62,10 @@ make -j${nproc} V=1
 make install
 
 install_license LICENSE
+
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = [
-    Platform("x86_64", "linux"; libc="glibc"),
-    Platform("aarch64", "linux"; libc="glibc"),
-    Platform("powerpc64le", "linux"; libc="glibc"),
-]
-
+platforms = CUDA.supported_platforms(; min_version = MIN_CUDA_VERSION, max_version = MAX_CUDA_VERSION)
 
 # The products that we will ensure are always built
 products = [
@@ -90,17 +87,23 @@ products = [
 #   - gdrcopy -> kernel module
 # - ROCM -> TODO
 
-cuda_version = v"11.4"
-rocm_version = v"4.2.0"
-
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency(PackageSpec(name="NUMA_jll", uuid="7f51dc2b-bb24-59f8-b771-bb1490e4195d")),
     Dependency(PackageSpec(name="rdma_core_jll", uuid="69dc3629-5c98-505f-8bcd-225213cebe70")),
-    BuildDependency(PackageSpec(name="CUDA_full_jll", version=CUDA.full_version(cuda_version))),
-    BuildDependency(PackageSpec(name="hsa_rocr_jll", version=rocm_version))
+    BuildDependency(PackageSpec(name="hsa_rocr_jll", version=ROCM_VERSION))
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version=v"5")
+
+for platform in platforms
+
+    should_build_platform(triplet(platform)) || continue
+
+    cuda_deps = CUDA.required_dependencies(platform, static_sdk=true)
+
+    build_tarballs(ARGS, name, version, sources, script, [platform],
+                    products, [dependencies; cuda_deps];
+                    julia_compat = "1.10", preferred_gcc_version = v"5",
+                    augment_platform_block=CUDA.augment, 
+                )
+end

--- a/U/UCX/build_tarballs.jl
+++ b/U/UCX/build_tarballs.jl
@@ -102,6 +102,9 @@ for platform in platforms
 
     cuda_deps = CUDA.required_dependencies(platform, static_sdk=true)
 
+    # Remvoe CUDA_Runtime_JLL dependency
+    cuda_deps = filter!(d -> typeof(d) != RuntimeDependency, cuda_deps)
+
     build_tarballs(ARGS, name, version, sources, script, [platform],
                     products, [dependencies; cuda_deps];
                     julia_compat = "1.10", preferred_gcc_version = v"5",

--- a/U/UCX/build_tarballs.jl
+++ b/U/UCX/build_tarballs.jl
@@ -10,7 +10,7 @@ name = "UCX"
 version = v"1.18.1"
 
 MIN_CUDA_VERSION = v"11.8"
-MAX_CUDA_VERSION = v"12.9.999"
+MAX_CUDA_VERSION = v"12.8.999"
 ROCM_VERSION = v"5.4.4"
 
 


### PR DESCRIPTION
This PR updates the UCX version to latest, and adds the augment platform block for CUDA. ROCM has also been updated to the latest version, but there is no augment_platform block for that.

Prior build did not have CUDA_Runtime_JLL, but I believe this is added as a RuntimeDependency by the CUDA.required_dependencies. Could probably remove that from the `cuda_deps`??