### PR TITLE
[Makemsix] fix makemsix runtime error on windows

### DIFF
--- a/M/Makemsix/build_tarballs.jl
+++ b/M/Makemsix/build_tarballs.jl
@@ -74,6 +74,7 @@ script = raw"""
 
         # Windows-specific compiler flags
         export LDFLAGS="-L${libdir}"
+        export CXXFLAGS="$CXXFLAGS -include windows.h"
 
         PLATFORM_OPTIONS="-DWIN32=on"
     fi


### PR DESCRIPTION
The `makemsix -pack` command fails on Windows with the following error:
```
Microsoft (R) makemsix version 1.7.241
Copyright (C) 2017 Microsoft.  All rights reserved.
Error: 0x80070057
LOG:

Invalid file name
Call failed in /workspace/srcdir/msix-packaging/src/msix/pack/AppxPackageWriter.cpp on line 159
```
This regression was introduced during a refactoring that removed a forced include. The missing `windows.h` header causes runtime issues when using the tool.

To resolve the error, I added the missing header by setting:
```bash
export CXXFLAGS="$CXXFLAGS -include windows.h"
```
This ensures the necessary Windows API definitions are available during compilation and resolves the runtime error. 
