### PR TITLE
[CFITSIO] Use GCC 5

### DIFF
--- a/C/CFITSIO/build_tarballs.jl
+++ b/C/CFITSIO/build_tarballs.jl
@@ -77,4 +77,4 @@ dependencies = [
 # When using lld for AArch64 macOS, linking fails with
 #     ld64.lld: error: -dylib_current_version 10.4.3.1: malformed version
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               clang_use_lld=false, julia_compat="1.6")
+               clang_use_lld=false, julia_compat="1.6", preferred_gcc_version=v"5")


### PR DESCRIPTION
The x86_64-linux-gnu GCC v4.8 toolchain was built with too old glibc.