### PR TITLE
[liblsl] Bump build

### DIFF
--- a/L/liblsl/build_tarballs.jl
+++ b/L/liblsl/build_tarballs.jl
@@ -71,3 +71,4 @@ dependencies = Dependency[
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+# Build number: 1


### PR DESCRIPTION
Bump liblsl build number to build for new platforms.

AFAIK as ARM MacOS is now a supported Platform this should rebuild the 5y old liblsl jll to be used with ARM based MacOS.