### PR TITLE
PoCL: use -hidden-l on macOS to avoid re-exporting all of LLVM.

### DIFF
--- a/P/pocl/pocl@7/bundled/patches/hidden_link.patch
+++ b/P/pocl/pocl@7/bundled/patches/hidden_link.patch
@@ -1,0 +1,96 @@
+diff --git a/lib/CL/CMakeLists.txt b/lib/CL/CMakeLists.txt
+index db98363cb..700f2f50d 100644
+--- a/lib/CL/CMakeLists.txt
++++ b/lib/CL/CMakeLists.txt
+@@ -323,46 +323,68 @@ harden("libpocl_unlinked_objs")
+
+ #################################################################
+
+-set(POCL_PRIVATE_LINK_LIST)
++set(POCL_PRIVATE_LINK_LIBRARIES)
++set(POCL_PRIVATE_LINK_DIRECTORIES)
+
+ # this must come 1st
+ if(SANITIZER_OPTIONS)
+-  set(POCL_PRIVATE_LINK_LIST ${SANITIZER_LIBS})
++  set(POCL_PRIVATE_LINK_LIBRARIES ${SANITIZER_LIBS})
+ endif()
+
+ if(POCL_DEVICES_LINK_LIST)
+-  list(APPEND POCL_PRIVATE_LINK_LIST ${POCL_DEVICES_LINK_LIST})
++  list(APPEND POCL_PRIVATE_LINK_LIBRARIES ${POCL_DEVICES_LINK_LIST})
+ endif()
+
+ if(ENABLE_LLVM)
+-   list(APPEND POCL_PRIVATE_LINK_LIST ${CLANG_LIBFILES} ${POCL_LLVM_LIBS} ${LLVM_SYSLIBS})
+-   if (HAVE_LLVM_SPIRV_LIB)
+-     list(PREPEND POCL_PRIVATE_LINK_LIST ${LLVM_SPIRV_LIB})
+-   endif()
++  if(APPLE AND STATIC_LLVM AND VISIBILITY_HIDDEN)
++    message(STATUS "Linking static LLVM libraries with limited visibility")
++
++    foreach(LIB ${CLANG_LIBFILES})
++      get_filename_component(LIB_NAME ${LIB} NAME_WE)
++      string(REPLACE "lib" "" LIB_BASE ${LIB_NAME})
++      list(APPEND POCL_PRIVATE_LINK_LIBRARIES "-Wl,-hidden-l${LIB_BASE}")
++      get_filename_component(LIB_DIR ${LIB} DIRECTORY)
++    endforeach()
++
++    foreach(LIB ${POCL_LLVM_LIBS})
++      get_filename_component(LIB_NAME ${LIB} NAME_WE)
++      string(REPLACE "lib" "" LIB_BASE ${LIB_NAME})
++      list(APPEND POCL_PRIVATE_LINK_LIBRARIES "-Wl,-hidden-l${LIB_BASE}")
++      get_filename_component(LIB_DIR ${LIB} DIRECTORY)
++    endforeach()
++  else()
++    list(APPEND POCL_PRIVATE_LINK_LIBRARIES ${CLANG_LIBFILES} ${POCL_LLVM_LIBS})
++  endif()
++
++  list(APPEND POCL_PRIVATE_LINK_LIBRARIES ${LLVM_SYSLIBS})
++
++  if (HAVE_LLVM_SPIRV_LIB)
++    list(APPEND POCL_PRIVATE_LINK_LIBRARIES ${LLVM_SPIRV_LIB})
++  endif()
+ endif()
+
+ if(HAVE_LTTNG_UST)
+-  list(APPEND POCL_PRIVATE_LINK_LIST ${LTTNG_UST_LDFLAGS})
++  list(APPEND POCL_PRIVATE_LINK_LIBRARIES ${LTTNG_UST_LDFLAGS})
+ endif()
+
+ # -lrt is required for glibc < 2.17
+ if(HAVE_CLOCK_GETTIME AND CMAKE_SYSTEM_NAME MATCHES "Linux")
+-  list(APPEND POCL_PRIVATE_LINK_LIST "rt")
++  list(APPEND POCL_PRIVATE_LINK_LIBRARIES "rt")
+ endif()
+
+ if(HAVE_64BIT_ATOMICS_WITH_LIB)
+-  list(APPEND POCL_PRIVATE_LINK_LIST "atomic")
++  list(APPEND POCL_PRIVATE_LINK_LIBRARIES "atomic")
+ endif()
+
+ if(ANDROID)
+   find_library(ANDROID_LOG_LIB log)
+-  list(APPEND POCL_PRIVATE_LINK_LIST ${ANDROID_LOG_LIB})
++  list(APPEND POCL_PRIVATE_LINK_LIBRARIES ${ANDROID_LOG_LIB})
+ endif()
+
+-list(APPEND POCL_PRIVATE_LINK_LIST ${LIBMATH} ${CMAKE_DL_LIBS} ${PTHREAD_LIBRARY})
++list(APPEND POCL_PRIVATE_LINK_LIBRARIES ${LIBMATH} ${CMAKE_DL_LIBS} ${PTHREAD_LIBRARY})
+
+ # see lib/CMakeLists.txt
+-set(POCL_TRANSITIVE_LIBS ${POCL_PRIVATE_LINK_LIST} PARENT_SCOPE)
++set(POCL_TRANSITIVE_LIBS ${POCL_PRIVATE_LINK_LIBRARIES} PARENT_SCOPE)
+
+ #################################################################
+
+@@ -386,7 +408,8 @@ set_target_properties("${POCL_LIBRARY_NAME}" PROPERTIES SOVERSION "${LIB_API_VER
+   VERSION "${LIB_BUILD_VERSION}"
+   LINK_FLAGS "${LLVM_LDFLAGS}  ${ICD_LD_FLAGS}")
+
+-target_link_libraries("${POCL_LIBRARY_NAME}" PRIVATE ${POCL_PRIVATE_LINK_LIST})
++target_link_libraries("${POCL_LIBRARY_NAME}" PRIVATE ${POCL_PRIVATE_LINK_LIBRARIES})
++target_link_directories("${POCL_LIBRARY_NAME}" PRIVATE ${POCL_PRIVATE_LINK_DIRECTORIES})
+ install(TARGETS "${POCL_LIBRARY_NAME}"
+         ARCHIVE DESTINATION ${POCL_INSTALL_STATIC_LIBDIR_REL}
+         COMPONENT "dev"

--- a/P/pocl/pocl@7/common.jl
+++ b/P/pocl/pocl@7/common.jl
@@ -8,6 +8,8 @@ function build_script(standalone=false)
     cd $WORKSPACE/srcdir/pocl/
     install_license LICENSE
 
+    atomic_patch -p1 ../patches/hidden_link.patch
+
     if [[ ("${target}" == x86_64-apple-darwin*) ]]; then
         # LLVM 15+ requires macOS SDK 10.14
         pushd $WORKSPACE/srcdir/MacOSX10.*.sdk


### PR DESCRIPTION
Similar to https://github.com/JuliaPackaging/Yggdrasil/pull/11268, but ironically easier since PoCL doesn't use `AddLLVM.cmake`.

Upstreamed as https://github.com/pocl/pocl/pull/1933