### PR TITLE
[GAP] Rebuild with latest libjulia

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -27,7 +27,7 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "GAP"
 upstream_version = v"4.14.0"
-version = v"400.1400.003"
+version = v"400.1400.004"
 
 # Collection of sources required to complete build
 sources = [
@@ -141,7 +141,7 @@ dependencies = [
     Dependency("GMP_jll"),
     Dependency("Readline_jll"; compat="8.2.1"),
     Dependency("Zlib_jll"),
-    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.15")),
+    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.16")),
 ]
 
 # Build the tarballs.


### PR DESCRIPTION
Our nightly testsuite currently fails with segfaults like the following one:
```julia
[10949] signal 11 (2): Segmentation fault: 11
in expression starting at /Users/goettgen/julia/GAP.jl/test/runtests.jl:3
_platform_strlen at /usr/lib/system/libsystem_platform.dylib (unknown line)
Allocations: 3302178 (Pool: 3292810; Big: 9368); GC: 7
ERROR: Package GAP errored during testing (received signal: 11)
```

I hope that this gets fixed by rebuilding GAP_jll and GAP_pkg_juliainterfact_jll with the new libjulia. This PR does the first part for that.

cc @fingolfin 