### PR TITLE
[libsingular_julia] Rebuild with libcxxwrap 0.14

### DIFF
--- a/L/libsingular_julia/build_tarballs.jl
+++ b/L/libsingular_julia/build_tarballs.jl
@@ -9,7 +9,7 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "libsingular_julia"
-version = v"0.47.2"
+version = v"0.48.0"
 
 # Collection of sources required to build libsingular-julia
 sources = [
@@ -55,10 +55,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.15")),
+    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.16")),
     BuildDependency("GMP_jll"),
     BuildDependency("MPFR_jll"),
-    Dependency("libcxxwrap_julia_jll"; compat = "~0.13.4"),
+    Dependency("libcxxwrap_julia_jll"; compat = "~0.14.3"),
     # we do not set a compat entry for Singular_jll -- instead we leave it to
     # Singular.jl to ensure the right versions of libsingular_julia_jll and
     # Singular_jll are paired. This gives us flexibility in the development

--- a/L/libsingular_julia/build_tarballs.jl
+++ b/L/libsingular_julia/build_tarballs.jl
@@ -9,7 +9,7 @@ uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "libsingular_julia"
-version = v"0.48.0"
+version = v"0.47.3"
 
 # Collection of sources required to build libsingular-julia
 sources = [


### PR DESCRIPTION
This is needed to get the libcxxwrap that was build against the new libjula in our dependency tree.

The PR to Singular.jl that bumps the libsingular_julia compat to `~0.48` should also bump the CxxWrap compat to `~0.17`.

cc @fingolfin 