### PR TITLE
[libpolymake_julia] Switch to libcxxwrap 0.14

### DIFF
--- a/L/libpolymake_julia/build_tarballs.jl
+++ b/L/libpolymake_julia/build_tarballs.jl
@@ -16,7 +16,7 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.13.0"), uuidopenssl)
 include("../../L/libjulia/common.jl")
 
 name = "libpolymake_julia"
-version = v"0.14.0"
+version = v"0.13.3"
 
 # reminder: change the above version when changing the supported julia versions
 # julia_versions is now taken from libjulia/common.jl


### PR DESCRIPTION
This is needed to get the libcxxwrap that was build against the new libjula in our dependency tree.

This libcxxwrap version corresponds to CxxWrap 0.17.x.

cc @fingolfin @benlorenz  