### PR TITLE
[ROCmDeviceLibs] bump julia compat

### DIFF
--- a/R/ROCmDeviceLibs/ROCmDeviceLibs@6.4.1/build_tarballs.jl
+++ b/R/ROCmDeviceLibs/ROCmDeviceLibs@6.4.1/build_tarballs.jl
@@ -37,4 +37,4 @@ build_tarballs(
     ARGS, configure_build(v"6.4.1")...;
     preferred_gcc_version=v"7",
     preferred_llvm_version=v"9",
-    julia_compat="1.12")
+    julia_compat="1.13")


### PR DESCRIPTION
LLVM 19 is required.
Julia 1.12 uses LLVM 18
Julia master uses LLVM 20