### PR TITLE
[ImageMagick@6] Revert Libtiff_jll to ~4.5.1

### DIFF
--- a/I/ImageMagick/ImageMagick@6/build_tarballs.jl
+++ b/I/ImageMagick/ImageMagick@6/build_tarballs.jl
@@ -2,11 +2,11 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 name = "ImageMagick"
-upstream_version = v"6.9.13-25"
+upstream_version = v"6.9.13-25" # TODO: re-sync with upstream next release (+ 1 below was to update compat)
 version = VersionNumber(
     upstream_version.major,
     upstream_version.minor,
-    upstream_version.patch * 1000 + upstream_version.prerelease[1]
+    upstream_version.patch * 1000 + upstream_version.prerelease[1] + 1
 )
 
 # Collection of sources required to build imagemagick


### PR DESCRIPTION
Latest `Libtiff_jll` can still not be used with ImageMagick.jl, CI error message(s):

"The value of field_readcount and field_writecount must be greater than or equal to -3 and not zero.. `TIFFMergeFieldInfo' @ error/tiff.c/TIFFErrors/574"

This stems from [this libtiff issue](https://gitlab.com/libtiff/libtiff/-/issues/532#note_2134433038), which has been resolved [here](https://gitlab.com/libtiff/libtiff/-/merge_requests/668) and should be fixed in the next libtiff release.

Making separate PRs for `ImageMagick@6` & `ImageMagick@7` to avoid registration conflicts.