### PR TITLE
[ImageMagick@7] Revert Libtiff_jll to ~4.5.1

### DIFF
--- a/I/ImageMagick/ImageMagick@7/build_tarballs.jl
+++ b/I/ImageMagick/ImageMagick@7/build_tarballs.jl
@@ -2,11 +2,11 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 name = "ImageMagick"
-upstream_version = v"7.1.1-47"
+upstream_version = v"7.1.1-47" # TODO: re-sync with upstream next release (+ 1 below was to update compat)
 version = VersionNumber(
     upstream_version.major,
     upstream_version.minor,
-    upstream_version.patch * 1000 + upstream_version.prerelease[1]
+    upstream_version.patch * 1000 + upstream_version.prerelease[1] + 1
 )
 
 # Collection of sources required to build imagemagick

--- a/I/ImageMagick/ImageMagick@7/build_tarballs.jl
+++ b/I/ImageMagick/ImageMagick@7/build_tarballs.jl
@@ -54,7 +54,7 @@ products = [
 dependencies = [
     Dependency("Ghostscript_jll"),
     Dependency("JpegTurbo_jll"),
-    Dependency("Libtiff_jll"; compat="4.7.1"),
+    Dependency("Libtiff_jll"; compat="~4.5.1"),
     Dependency("OpenJpeg_jll"),
     Dependency("Zlib_jll"; compat="1.2.12"),
     Dependency("libpng_jll"),


### PR DESCRIPTION
Latest `Libtiff_jll` can still not be used with ImageMagick.jl, CI error message(s):

"The value of field_readcount and field_writecount must be greater than or equal to -3 and not zero.. `TIFFMergeFieldInfo' @ error/tiff.c/TIFFErrors/574"

This stems from [this libtiff issue](https://gitlab.com/libtiff/libtiff/-/issues/532#note_2134433038), which has been resolved [here](https://gitlab.com/libtiff/libtiff/-/merge_requests/668) and should be fixed in the next libtiff release.

Making separate PRs for `ImageMagick@6` & `ImageMagick@7` to avoid registration conflicts.