### PR TITLE
[GoogleCodeSearch] update to force Go toolchain update

### DIFF
--- a/G/GoogleCodeSearch/build_tarballs.jl
+++ b/G/GoogleCodeSearch/build_tarballs.jl
@@ -3,11 +3,14 @@
 using BinaryBuilder, Pkg
 
 name = "GoogleCodeSearch"
-version = v"1.2.0"
+# This version is different than the source version as we need to rebuild this with an updated Go version
+# and update compat bounds
+# The original version is v1.2.0 which hasn't been updated since 2020
+version = v"1.2.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/google/codesearch.git", "8ba29bd255b740aee4eb4e4ddb5d7ec0b4d9f23e")
+    GitSource("https://github.com/google/codesearch.git", "8ba29bd255b740aee4eb4e4ddb5d7ec0b4d9f23e") # v1.2.0
 ]
 
 # Bash recipe for building across all platforms
@@ -38,4 +41,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers = [:go, :c])
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", compilers = [:go, :c], preferred_go_version = v"1.23")


### PR DESCRIPTION
The go version and stdlib this was compiled with 5 years ago has several reported vulnerabilties. Since JuliaHub uses this jll, we get pinged on this in our docker image scans all the time.

I'm not sure of the best way to force a rebuild, but it doesn't build as it was.  I have to set julia_compat to 1.6 to have it build for the experimental platforms.

Is this the best way to do force a rebuild? Will this cause a released jll as `1.2.0+1` when it's merged?