### PR TITLE
[fts] bump version to remove Pkg dependency

### DIFF
--- a/F/fts/build_tarballs.jl
+++ b/F/fts/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "fts"
-version = v"1.2.8"  # XXX: upstream is 1.2.7, but we needed a version bump
+version = v"1.2.9"  # XXX: upstream is 1.2.7, but we needed a version bump
 
 # Collection of sources required to build fts
 sources = [


### PR DESCRIPTION
This is one of many packages whose JLL depends explicitly on `Pkg`. To remove it, we need to bump the version and rebuild the JLL. 