### PR TITLE
[Libepoxy] bump version to remove Pkg dependency

### DIFF
--- a/L/Libepoxy/build_tarballs.jl
+++ b/L/Libepoxy/build_tarballs.jl
@@ -38,4 +38,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; clang_use_lld=true, julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; clang_use_lld=false, julia_compat="1.6")


### PR DESCRIPTION
This is one of many packages whose JLL depends explicitly on `Pkg`. To remove it, we need to bump the version and rebuild the JLL. 