### PR TITLE
libcxxwrap_julia: Build for riscv64

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -59,5 +59,3 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
     preferred_gcc_version = v"10", julia_compat = "1.6")
-
-# rebuild trigger: 1


### PR DESCRIPTION
I am rebuilding the package which will automatically build for `riscv64` as well because the build will pick up a new set of build dependencies.

I do not bump the version number. Please let me know if this is a problem, either for this package or for downstream packages.
