### PR TITLE
Libxc: turn ENABLE_FORTRAN back ON

### DIFF
--- a/L/Libxc/Libxc/build_tarballs.jl
+++ b/L/Libxc/Libxc/build_tarballs.jl
@@ -18,7 +18,7 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=ON \
       -DENABLE_XHOST=OFF \
-      -DENABLE_FORTRAN=OFF \
+      -DENABLE_FORTRAN=ON \
       -DDISABLE_KXC=ON ..
 
 make -j${nproc}

--- a/L/Libxc/Libxc_GPU/build_tarballs.jl
+++ b/L/Libxc/Libxc_GPU/build_tarballs.jl
@@ -45,7 +45,7 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DBUILD_TESTING=OFF \
       -DENABLE_CUDA=ON \
       -DENABLE_XHOST=OFF \
-      -DENABLE_FORTRAN=OFF \
+      -DENABLE_FORTRAN=ON \
       -DDISABLE_KXC=ON ..
 
 cmake --build . --parallel $nproc


### PR DESCRIPTION
Hi,

It looks like ENABLE_FORTRAN was inadvertently disabled in https://github.com/JuliaPackaging/Yggdrasil/pull/6019. However, it is required to build and use the Quantum ESPRESSO JLL. So here we go.