### PR TITLE
[LAPACK] Add the missing suffix _64 on new symbols

### DIFF
--- a/L/LAPACK/LAPACK/build_tarballs.jl
+++ b/L/LAPACK/LAPACK/build_tarballs.jl
@@ -16,4 +16,4 @@ filter!(p -> !(arch(p) == "aarch64" && Sys.islinux(p) && libgfortran_version(p) 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                clang_use_lld=false, julia_compat="1.9", preferred_gcc_version=v"6")
 
-# Build Trigger: 9
+# Build Trigger: 10

--- a/L/LAPACK/LAPACK32/build_tarballs.jl
+++ b/L/LAPACK/LAPACK32/build_tarballs.jl
@@ -12,4 +12,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                clang_use_lld=false, julia_compat="1.9", preferred_gcc_version=v"6")
 
-# Build Trigger: 6
+# Build Trigger: 7

--- a/L/LAPACK/common.jl
+++ b/L/LAPACK/common.jl
@@ -382,9 +382,6 @@ end
 # platforms are passed in on the command line
 platforms = expand_gfortran_versions(supported_platforms())
 
-# Require LBT ≥ 5.12.0
-filter!(p -> arch(p) != "riscv64", platforms)
-
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),


### PR DESCRIPTION
I don't understand the issue on `riscv64` :thinking: 