### PR TITLE
LibCURL: Build without MacOSX SDK

### DIFF
--- a/L/LibCURL/LibCURL@8/build_tarballs.jl
+++ b/L/LibCURL/LibCURL@8/build_tarballs.jl
@@ -1,3 +1,5 @@
 include("../common.jl")
 
 build_libcurl(ARGS, "LibCURL", v"8.14.1")
+
+# Build trigger: 1

--- a/L/LibCURL/common.jl
+++ b/L/LibCURL/common.jl
@@ -38,7 +38,7 @@ function build_libcurl(ARGS, name::String, version::VersionNumber)
         ArchiveSource("https://curl.se/download/curl-$(version).tar.gz", hash),
         DirectorySource("../patches"),
     ]
-    if version >= v"8.13"
+    if version == v"8.13"
         append!(sources, [
             ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz",
                           "a3a077385205039a7c6f9e2c98ecdf2a720b2a819da715e03e0630c75782c1e4")


### PR DESCRIPTION
Re-build LibCURL 8.14.1 without using a MacOSX SDK. It appears that using the SDK was necessary only for version 8.13. As a long shot, this might solve the MacOSX build failure seen in https://github.com/JuliaLang/julia/pull/58708.