### PR TITLE
Add recipe for juliaup

### DIFF
--- a/J/juliaup/build_tarballs.jl
+++ b/J/juliaup/build_tarballs.jl
@@ -1,0 +1,50 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "juliaup"
+version = v"1.17.19"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/JuliaLang/juliaup.git", "c4c4659d09938a6472a44f45246eb2d69deb6a9b")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/juliaup
+cargo build --release
+install -Dm 755 "target/${rust_target}/release/juliaup${exeext}" "${bindir}/juliaup${exeext}"
+install -Dm 755 "target/${rust_target}/release/julia${exeext}" "${bindir}/julia${exeext}"
+"""
+
+include("../../L/libjulia/common.jl")
+platforms = julia_supported_platforms(v"1.11.1")
+
+# We don't have rust for these platforms
+filter!(p -> !(arch(p) == "aarch64" && Sys.isfreebsd(p)), platforms)
+filter!(p -> !(arch(p) == "riscv64"), platforms)
+
+# Rust cross compile is broken for this platform (https://github.com/rust-lang/rust/issues/79609)
+filter!(p-> p != Platform("i686", "windows"), platforms)
+
+# Juliaup doesn't currently have these platforms
+filter!(p -> !(arch(p) == "powerpc64le"), platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("juliaup", :juliaup) 
+    ExecutableProduct("julia", :julia)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+    Dependency("Libiconv_jll"),
+    # Links to libgcc_s on linux for something
+    Dependency("CompilerSupportLibraries_jll"; platforms=filter(p -> Sys.islinux(p),  platforms))
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+	       compilers=[:rust, :c], julia_compat="1.6", preferred_rust_version=v"1.87",
+	       lock_microarchitecture=false) # cargo inserts -march


### PR DESCRIPTION
Of course, it's a bit backwards to have this, because if you can install julia packages, you probably already have julia, but in https://github.com/Keno/ClaudeBox.jl I'm using JLLs for the non-standard purpose of putting together a container image in which I'd like to have juliaup available.