### PR TITLE
[GAP_pkg_*] Rebuild with extended platforms (part 1)

### DIFF
--- a/G/GAP/common.jl
+++ b/G/GAP/common.jl
@@ -5,11 +5,6 @@ function gap_platforms(; expand_julia_versions::Bool=false)
         platforms = vcat(libjulia_platforms.(julia_versions)...)
     else
         platforms = union(julia_supported_platforms.(julia_versions)...)
-        
-        filter!(p -> arch(p) != "riscv64", platforms) # riscv64 is not supported atm
-
-        # TODO: re-enable FreeBSD aarch64 support once GAP_jll supports it
-        filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
     end
 
     # we only care about 64bit builds

--- a/G/GAP/common.jl
+++ b/G/GAP/common.jl
@@ -3,25 +3,20 @@ include("../../L/libjulia/common.jl")
 function gap_platforms(; expand_julia_versions::Bool=false)
     if expand_julia_versions
         platforms = vcat(libjulia_platforms.(julia_versions)...)
-
-        # we only care about 64bit builds
-        filter!(p -> nbits(p) == 64, platforms)
-
-        # Windows is not supported
-        filter!(!Sys.iswindows, platforms)
-
-        return platforms
     else
         platforms = union(julia_supported_platforms.(julia_versions)...)
         
-        filter!(p -> nbits(p) == 64, platforms) # we only care about 64bit builds
-        filter!(!Sys.iswindows, platforms)      # Windows is not supported
-
         filter!(p -> arch(p) != "riscv64", platforms) # riscv64 is not supported atm
 
         # TODO: re-enable FreeBSD aarch64 support once GAP_jll supports it
         filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
-
-        return platforms
     end
+
+    # we only care about 64bit builds
+    filter!(p -> nbits(p) == 64, platforms)
+
+    # Windows is not supported
+    filter!(!Sys.iswindows, platforms)
+
+    return platforms
 end

--- a/G/GAP/common.jl
+++ b/G/GAP/common.jl
@@ -12,10 +12,8 @@ function gap_platforms(; expand_julia_versions::Bool=false)
 
         return platforms
     else
-        # TODO: create the platforms from the above list coming from libjulia
-        # by removing the julia_version tag
+        platforms = union(julia_supported_platforms.(julia_versions)...)
         
-        platforms = supported_platforms()
         filter!(p -> nbits(p) == 64, platforms) # we only care about 64bit builds
         filter!(!Sys.iswindows, platforms)      # Windows is not supported
 

--- a/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "Browse"
 upstream_version = "1.8.21" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "cddinterface"
 upstream_version = "2024.09.02" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
@@ -32,6 +32,10 @@ name = gap_pkg_name(name)
 dependencies = gap_pkg_dependencies(gap_version)
 platforms = gap_platforms()
 
+# TODO: re-enable the below platforms once cddlib_jll supports them
+filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
+filter!(p -> arch(p) != "riscv64", platforms)
+
 append!(dependencies, [
     Dependency("GMP_jll", v"6.2.0"),
     Dependency("cddlib_jll"),

--- a/G/GAP_pkg/GAP_pkg_crypting/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_crypting/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "crypting"
 upstream_version = "0.10.5" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_curlinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_curlinterface/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "curlinterface"
 upstream_version = "2.4.0" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "cvec"
 upstream_version = "2.8.2" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/Project.toml
+++ b/G/GAP_pkg/Project.toml
@@ -1,3 +1,5 @@
 [deps]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -1,4 +1,6 @@
 # Update the GAP_pkg_* recipes to match GAP / GAP_lib
+# Execute from the G/GAP_pkg/ directory, e.g.:
+# julia --project=. update.jl
 
 using JSON
 import Downloads

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -93,7 +93,15 @@ function update_gap_pkg_recipe(dir)
         @info "skipping $pkgname"
         return
     elseif old_upstream_version != upstream_version
-        offset = v"0.0.0"
+        _old_upstream_version = VersionNumber(replace(old_upstream_version, "-" => "."))
+        _upstream_version = VersionNumber(replace(upstream_version, "-" => "."))
+        if old_upstream_version.major != upstream_version.major
+            offset = v"0.0.0"
+        elseif old_upstream_version.minor != upstream_version.minor
+            offset = VersionNumber(offset.major, 0, 0)
+        else
+            offset = VersionNumber(offset.major, offset.minor, 0)
+        end
     else
         offset = VersionNumber(offset.major, offset.minor, offset.patch + 1)
     end

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -6,7 +6,7 @@ using SHA
 using GZip
 
 upstream_version = v"4.14.0"
-gap_version = v"400.1400.000"
+gap_version = v"400.1400.005"
 gap_lib_version = v"400.1400.000"
 
 function download_with_sha256(url)


### PR DESCRIPTION
Changes:
- Resolves the other TODO from https://github.com/JuliaPackaging/Yggdrasil/pull/11412.
- Applies some comments from https://github.com/JuliaPackaging/Yggdrasil/pull/11412.
- Extends the platform list for gap package jlls to include aarch64-freebsd and riscv (each that fails will have them filtered again in the respective recipe)
- Small changes to `update.jl`:
  - Adapt the Project.toml to include all deps that are loaded, fixed executing it for me
  - Fix the setting of `offset` when the upstream version changes. This is not relevant for anything in this PR, but I noticed that the current code is just wrong. Consider `upstream_version = v"1.2.3"; offset = v"1.0.0"` (so `version = v"101.200.300") and there is now a patch release of upstream. Resetting offset to `v"0.0.0"` would result in losing the API-incompatibility, so only the offset parts strictly left of the change in the upstream version should better be kept.
- Run `update.jl` for a handful packages. Once this is merged, I'll make some more PRs with updates for small-ish groups of the other gap package jlls.  

cc @fingolfin 