### PR TITLE
[GAP_pkg_*] Rebuild with extended platforms (part 2)

### DIFF
--- a/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "datastructures"
 upstream_version = "0.3.1" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_deepthought/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_deepthought/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "deepthought"
 upstream_version = "1.0.7" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "digraphs"
 upstream_version = "1.9.0" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_edim/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_edim/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "EDIM"
 upstream_version = "1.3.8" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL


### PR DESCRIPTION
Touches some recipes to rebuild with the changes from https://github.com/JuliaPackaging/Yggdrasil/pull/11455.

> Extends the platform list for gap package jlls to include aarch64-freebsd and riscv (each that fails will have them filtered again in the respective recipe)

cc @fingolfin 