### PR TITLE
[GAP_pkg_*] Rebuild with extended platforms (part 4)

### DIFF
--- a/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
@@ -32,6 +32,10 @@ dependencies = gap_pkg_dependencies(gap_version)
 platforms = gap_platforms()
 platforms = expand_cxxstring_abis(platforms)
 
+# TODO: re-enable the below platforms once normaliz_jll supports them
+filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
+filter!(p -> arch(p) != "riscv64", platforms)
+
 push!(dependencies, Dependency("normaliz_jll", compat = "~300.1000.200"))
 
 # The products that we will ensure are always built

--- a/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "NormalizInterface"
 upstream_version = "1.3.7" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_orb/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_orb/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "orb"
 upstream_version = "4.9.1" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_profiling/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_profiling/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "profiling"
 upstream_version = "2.6.0" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
@@ -50,6 +50,9 @@ dependencies = gap_pkg_dependencies(gap_version)
 platforms = gap_platforms()
 platforms = expand_cxxstring_abis(platforms)
 
+# TODO: re-enable the below platforms
+filter!(p -> arch(p) != "riscv64", platforms)
+
 # The products that we will ensure are always built
 products = [
     FileProduct("lib/gap/semigroups.so", :semigroups),

--- a/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "semigroups"
 upstream_version = "5.4.0" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_zeromqinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_zeromqinterface/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1400.0"
+gap_version = v"400.1400.5"
 name = "zeromqinterface"
 upstream_version = "0.16" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL


### PR DESCRIPTION
Touches some recipes to rebuild with the changes from https://github.com/JuliaPackaging/Yggdrasil/pull/11455.

> Extends the platform list for gap package jlls to include aarch64-freebsd and riscv (each that fails will have them filtered again in the respective recipe)

cc @fingolfin 