### PR TITLE
[Qt6Wayland] Disable freeBSD

### DIFF
--- a/Q/Qt6Wayland/build_tarballs.jl
+++ b/Q/Qt6Wayland/build_tarballs.jl
@@ -49,6 +49,10 @@ include("../Qt6Base/common.jl")
 empty!(platforms_macos)
 empty!(platforms_win)
 
+# It seems Qt 6.8 Wayland doesn't compile out of the box on freeBSD and when forced requires
+# proper support in Qt6Base. To be investigated on version upgrade.
+filter!(!Sys.isfreebsd, platforms)
+
 # The products that we will ensure are always built
 products = [
     FileProduct("plugins", :qt6plugins_dir),


### PR DESCRIPTION
It seems the Qt CMakeLists.txt (mistakenly?) disables the freeBSD build entirely, resulting in a missing FileProduct error at registration time. Forcing the build by adapting the CMakeLists.txt reveals a new error related to missing Wayland support in Qt6Base on freeBSD, so fixing this will have to wait until we bump the Qt version.

I had missed this error on the first build, and in fact no artifacts except for the host musl build have been released for this JLL.