### PR TITLE
Glib: Build with PCRE2 10.42

### DIFF
--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -1,19 +1,17 @@
 using BinaryBuilder
 
 name = "Glib"
-version = v"2.84.0"
-# We bumped the Yggdrasil version number to add a compat bound for PCRE2
-ygg_version = v"2.84.1"
+version = v"2.84.3"
 
 # Collection of sources required to build Glib
 sources = [
     ArchiveSource("https://ftp.gnome.org/pub/gnome/sources/glib/$(version.major).$(version.minor)/glib-$(version).tar.xz",
-                  "f8823600cb85425e2815cfad82ea20fdaa538482ab74e7293d58b3f64a5aff6a"),
+                  "aa4f87c3225bf57ca85f320888f7484901a17934ca37023c3bd8435a72db863e"),
     FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz",
                "a3a077385205039a7c6f9e2c98ecdf2a720b2a819da715e03e0630c75782c1e4"),
     FileSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v10.0.0.tar.bz2",
                "ba6b430aed72c63a3768531f6a3ffc2b0fde2c57a3b251450dcf489a894f0894"),
-    DirectorySource("./bundled"),
+    DirectorySource("bundled"),
 ]
 
 # Bash recipe for building across all platforms
@@ -115,5 +113,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                clang_use_lld=false, julia_compat="1.6", preferred_gcc_version=v"6")

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -68,7 +68,7 @@ MESON_FLAGS+=(-Dtests=false)
 if [[ "${target}" == *-freebsd* ]]; then
     # Our FreeBSD libc has `environ` as undefined symbol, so the linker will
     # complain if this symbol is used in the built library, even if this won't
-    # be a problem at runtim.  This flag allows having undefined symbols.
+    # be a problem at runtime. This flag allows having undefined symbols.
     MESON_FLAGS+=(-Db_lundef=false)
 fi
 
@@ -107,11 +107,12 @@ products = [
 dependencies = [
     # Host gettext needed for "msgfmt"
     HostBuildDependency("Gettext_jll"),
-    Dependency("Libiconv_jll"),
     Dependency("Libffi_jll"; compat="~3.4.7"),
+    Dependency("Libiconv_jll"),
+    Dependency("Libmount_jll"; platforms=filter(Sys.islinux, platforms)),
     Dependency("PCRE2_jll"; compat="10.42.0"),
     Dependency("Zlib_jll"; compat="1.2.12"),
-    Dependency("Libmount_jll"; platforms=filter(Sys.islinux, platforms)),
+    RuntimeDependency("GettextRuntime_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -2,6 +2,8 @@ using BinaryBuilder
 
 name = "Glib"
 version = v"2.84.0"
+# We bumped the Yggdrasil version number to add a compat bound for PCRE2
+ygg_version = v"2.84.1"
 
 # Collection of sources required to build Glib
 sources = [
@@ -107,14 +109,11 @@ dependencies = [
     HostBuildDependency("Gettext_jll"),
     Dependency("Libiconv_jll"),
     Dependency("Libffi_jll"; compat="~3.4.7"),
-    # Gettext is only needed on macOS, as far as I could see
-    Dependency("Gettext_jll", v"0.21.0"; compat="=0.21.0"),
-    # no compat entry for PCRE2 to make riscv64 work
-    Dependency("PCRE2_jll"),
+    Dependency("PCRE2_jll"; compat="10.42.0"),
     Dependency("Zlib_jll"; compat="1.2.12"),
     Dependency("Libmount_jll"; platforms=filter(Sys.islinux, platforms)),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
                clang_use_lld=false, julia_compat="1.6", preferred_gcc_version=v"6")

--- a/G/Glib/build_tarballs.jl
+++ b/G/Glib/build_tarballs.jl
@@ -9,30 +9,29 @@ ygg_version = v"2.84.1"
 sources = [
     ArchiveSource("https://ftp.gnome.org/pub/gnome/sources/glib/$(version.major).$(version.minor)/glib-$(version).tar.xz",
                   "f8823600cb85425e2815cfad82ea20fdaa538482ab74e7293d58b3f64a5aff6a"),
-    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz",
-                  "a3a077385205039a7c6f9e2c98ecdf2a720b2a819da715e03e0630c75782c1e4"),
-    ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v10.0.0.tar.bz2",
-                  "ba6b430aed72c63a3768531f6a3ffc2b0fde2c57a3b251450dcf489a894f0894"),
+    FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz",
+               "a3a077385205039a7c6f9e2c98ecdf2a720b2a819da715e03e0630c75782c1e4"),
+    FileSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v10.0.0.tar.bz2",
+               "ba6b430aed72c63a3768531f6a3ffc2b0fde2c57a3b251450dcf489a894f0894"),
     DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
-    export MACOSX_DEPLOYMENT_TARGET=10.13
-    pushd ${WORKSPACE}/srcdir/MacOSX10.*.sdk
     rm -rf /opt/${target}/${target}/sys-root/System
-    cp -a usr/* "/opt/${target}/${target}/sys-root/usr/"
-    cp -a System "/opt/${target}/${target}/sys-root/"
-    popd
+    tar --extract --file=${WORKSPACE}/srcdir/MacOSX10.13.sdk.tar.xz --directory="/opt/${target}/${target}/sys-root/." --strip-components=1 MacOSX10.13.sdk/System MacOSX10.13.sdk/usr
+    export MACOSX_DEPLOYMENT_TARGET=10.13
 fi
 
 if [[ "${target}" == *-mingw* ]]; then
-    cd $WORKSPACE/srcdir/mingw*/mingw-w64-headers
+    cd $WORKSPACE/srcdir
+    tar xjf ${WORKSPACE}/srcdir/mingw-w64-v10.0.0.tar.bz2
+    cd mingw*/mingw-w64-headers
     ./configure --prefix=/opt/$target/$target/sys-root --enable-sdk=all --host=$target
     make install
 
-    cd ../mingw-w64-crt/
+    cd ../mingw-w64-crt
     if [ ${target} == "i686-w64-mingw32" ]; then
         _crt_configure_args="--disable-lib64 --enable-lib32"
     elif [ ${target} == "x86_64-w64-mingw32" ]; then
@@ -43,7 +42,7 @@ if [[ "${target}" == *-mingw* ]]; then
     make install
 fi
 
-cd $WORKSPACE/srcdir/glib-*/
+cd $WORKSPACE/srcdir/glib-*
 install_license COPYING
 
 # meson shouldn't be so opinionated (mesonbuild/meson#4542 is incomplete)
@@ -107,12 +106,12 @@ products = [
 dependencies = [
     # Host gettext needed for "msgfmt"
     HostBuildDependency("Gettext_jll"),
+    Dependency("GettextRuntime_jll"; compat="0.22.4"),
     Dependency("Libffi_jll"; compat="~3.4.7"),
     Dependency("Libiconv_jll"),
     Dependency("Libmount_jll"; platforms=filter(Sys.islinux, platforms)),
     Dependency("PCRE2_jll"; compat="10.42.0"),
     Dependency("Zlib_jll"; compat="1.2.12"),
-    RuntimeDependency("GettextRuntime_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
Closes https://github.com/JuliaPackaging/Yggdrasil/issues/11498#issuecomment-2992104107.

I don't think Gettext is necessary at run time. I am building without, and there are no errors nor warnings, and the Gettext library is not referenced in the shared libraries.
