### PR TITLE
[DuckDB] Explicitly set compatible platform targets

### DIFF
--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -24,8 +24,7 @@ cmake -B build \
       -DENABLE_EXTENSION_AUTOLOADING=1 \
       -DENABLE_EXTENSION_AUTOINSTALL=1 \
       -DBUILD_UNITTESTS=FALSE \
-      -DBUILD_SHELL=TRUE \
-      -DDUCKDB_EXPLICIT_PLATFORM="${target}"
+      -DBUILD_SHELL=TRUE
 cmake --build build --parallel ${nproc}
 cmake --install build
 

--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -15,11 +15,11 @@ script = raw"""
 cd $WORKSPACE/srcdir/duckdb/
 
 export DUCKDB_TARGET="${target}"
-if [[ "${target}" == *86*-linux-gnu ]]; then
+if [[ "${target}" == "x86_64-linux-gnu" ]]; then
     export DUCKDB_TARGET="linux_amd64"
 elif [[ "${target}" == aarch64-linux-gnu ]]; then
     export DUCKDB_TARGET="linux_arm64"
-elif [[ "${target}" == *86*-linux-musl* ]]; then
+elif [[ "${target}" == "x86_64-linux-musl" ]]; then
     export DUCKDB_TARGET="linux_amd64_musl"
 elif [[ "${target}" == "x86_64-w64-mingw32" ]]; then
     export DUCKDB_TARGET="windows_amd64_mingw"
@@ -29,7 +29,18 @@ elif [[ "${target}" == "aarch64-apple-darwin" ]]; then
     export DUCKDB_TARGET="osx_arm64"
 fi
 
+if [[ "${COMPILER_TARGET}" == *-cxx03 ]]; then
+    export DUCKDB_TARGET="${DUCKDB_TARGET}_gcc4"
+fi
+
 echo "Compiling for DuckDB Target - $DUCKDB_TARGET"
+echo "COMPILER_TARGET ${COMPILER_TARGET}"
+echo "CMAKE_TARGET_TOOLCHAIN ${CMAKE_TARGET_TOOLCHAIN}"
+echo "prefix ${prefix}"
+echo "libdir ${libdir}"
+echo "WORKSPACE ${WORKSPACE}"
+echo "MACHTYPE ${MACHTYPE}"
+echo "HOST_TARGET ${HOST_TARGET}"
 
 cmake -B build \
       -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -29,7 +29,7 @@ elif [[ "${target}" == "aarch64-apple-darwin" ]]; then
     export DUCKDB_TARGET="osx_arm64"
 fi
 
-if [[ "${CMAKE_TARGET_TOOLCHAIN}" == *-cxx03* ]]; then
+if [[ "${bb_full_target}" == *-cxx03* ]]; then
     export DUCKDB_TARGET="${DUCKDB_TARGET}_gcc4"
 fi
 

--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -29,18 +29,11 @@ elif [[ "${target}" == "aarch64-apple-darwin" ]]; then
     export DUCKDB_TARGET="osx_arm64"
 fi
 
-if [[ "${COMPILER_TARGET}" == *-cxx03 ]]; then
+if [[ "${CMAKE_TARGET_TOOLCHAIN}" == *-cxx03* ]]; then
     export DUCKDB_TARGET="${DUCKDB_TARGET}_gcc4"
 fi
 
 echo "Compiling for DuckDB Target - $DUCKDB_TARGET"
-echo "COMPILER_TARGET ${COMPILER_TARGET}"
-echo "CMAKE_TARGET_TOOLCHAIN ${CMAKE_TARGET_TOOLCHAIN}"
-echo "prefix ${prefix}"
-echo "libdir ${libdir}"
-echo "WORKSPACE ${WORKSPACE}"
-echo "MACHTYPE ${MACHTYPE}"
-echo "HOST_TARGET ${HOST_TARGET}"
 
 cmake -B build \
       -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -14,6 +14,23 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/duckdb/
 
+export DUCKDB_TARGET="${target}"
+if [[ "${target}" == *86*-linux-gnu ]]; then
+    export DUCKDB_TARGET="linux_amd64"
+elif [[ "${target}" == aarch64-linux-gnu ]]; then
+    export DUCKDB_TARGET="linux_arm64"
+elif [[ "${target}" == *86*-linux-musl* ]]; then
+    export DUCKDB_TARGET="linux_amd64_musl"
+elif [[ "${target}" == "x86_64-w64-mingw32" ]]; then
+    export DUCKDB_TARGET="windows_amd64_mingw"
+elif [[ "${target}" == "x86_64-apple-darwin" ]]; then
+    export DUCKDB_TARGET="osx_amd64"
+elif [[ "${target}" == "aarch64-apple-darwin" ]]; then
+    export DUCKDB_TARGET="osx_arm64"
+fi
+
+echo "Compiling for DuckDB Target - $DUCKDB_TARGET"
+
 cmake -B build \
       -DCMAKE_INSTALL_PREFIX=${prefix} \
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
@@ -24,7 +41,8 @@ cmake -B build \
       -DENABLE_EXTENSION_AUTOLOADING=1 \
       -DENABLE_EXTENSION_AUTOINSTALL=1 \
       -DBUILD_UNITTESTS=FALSE \
-      -DBUILD_SHELL=TRUE
+      -DBUILD_SHELL=TRUE \
+      -DDUCKDB_EXPLICIT_PLATFORM=${DUCKDB_TARGET}
 cmake --build build --parallel ${nproc}
 cmake --install build
 


### PR DESCRIPTION
Should fix issues where extensions can no longer be found in DuckDB.jl