### PR TITLE
Add Patch to Legate

### DIFF
--- a/L/legate/build_tarballs.jl
+++ b/L/legate/build_tarballs.jl
@@ -13,6 +13,7 @@ name = "legate"
 version = v"25.5" # Year.Month
 sources = [
     GitSource("https://github.com/nv-legate/legate.git","8a619fa468a73f9766f59ac9a614c0ee084ecbdd"),
+    DirectorySource("./bundled"),
     FileSource("https://repo.anaconda.com/miniconda/Miniconda3-py311_24.3.0-0-Linux-x86_64.sh", 
                 "4da8dde69eca0d9bc31420349a204851bfa2a1c87aeb87fe0c05517797edaac4", "miniconda.sh")
 ]
@@ -96,6 +97,13 @@ ln -s ${CUDA_HOME}/lib ${CUDA_HOME}/lib64
     -- "-DCMAKE_TOOLCHAIN_FILE=/opt/toolchains/${bb_full_target}/target_${target}_clang.cmake" \
         "-DCMAKE_CUDA_HOST_COMPILER=$(which clang++)" \
 
+
+# Patch redop header that is installed by configure script
+cd ${WORKSPACE}/srcdir
+atomic_patch -p1 ./legion_redop.patch
+
+# Go back to main dir
+cd ${WORKSPACE}/srcdir/legate
 
 make install -j ${nproc} PREFIX=${prefix}
 install_license ${WORKSPACE}/srcdir/legate/LICENSE

--- a/L/legate/bundled/legion_redop.patch
+++ b/L/legate/bundled/legion_redop.patch
@@ -1,0 +1,246 @@
+diff --git a/legion_redop.old b/legion_redop.new
+index 75c3733..d647a15 100644
+--- a/legate/arch-linux-release/cmake_build/_deps/legion-src/runtime/legion/legion_redop.inl
++++ b/legate/arch-linux-release/cmake_build/_deps/legion-src/runtime/legion/legion_redop.inl
+@@ -17,7 +17,6 @@
+ #include "legion/legion_redop.h"
+ 
+ #include <array>
+-#include <string.h>
+ 
+ #ifndef __MAX__
+ #define __MAX__(x,y) (((x) > (y)) ? (x) : (y))
+@@ -29,7 +28,7 @@
+ 
+ namespace Legion {
+ 
+-#if !defined(__cpp_lib_atomic_ref) || (__cpp_lib_atomic_ref < 201806L)
++// #if !defined(__cpp_lib_atomic_ref) || (__cpp_lib_atomic_ref < 201806L)
+   // We only need this crap if we're using a version of c++ < 20
+   // Starting with c++20 we can do all this the right way with atomic_ref
+   namespace TypePunning {
+@@ -130,7 +129,7 @@ namespace Legion {
+       uint8_t buffer[sizeof(T1)];
+     };
+   }; // TypePunning
+-#endif
++// #endif
+ 
+ #if defined (__CUDACC__) || defined (__HIPCC__)
+   // We have these functions here because calling memcpy (per the
+@@ -1377,6 +1376,7 @@ namespace Legion {
+             __complex_as_uint(oldval), __complex_as_uint(newval)));
+     } while (oldval != newval);
+ #else
++/*  
+ #if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
+     std::atomic_ref<LHS> atomic(lhs);
+     RHS oldval = atomic.load();
+@@ -1385,6 +1385,7 @@ namespace Legion {
+       newval = oldval + rhs;
+     } while (!atomic.compare_exchange_weak(oldval, newval));
+ #else
++*/    
+     TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
+     TypePunning::Pointer<int32_t> pointer((void*)&lhs);
+     do {
+@@ -1392,7 +1393,7 @@ namespace Legion {
+       newval = oldval.as_two() + rhs;
+     } while (!__sync_bool_compare_and_swap((int32_t*)pointer,
+                       oldval.as_one(), newval.as_one()));
+-#endif
++// #endif
+ #endif
+   }
+ 
+@@ -1417,7 +1418,7 @@ namespace Legion {
+             __complex_as_uint(oldval), __complex_as_uint(newval)));
+     } while (oldval != newval);
+ #else
+-#if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
++/*#if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
+     std::atomic_ref<RHS> atomic(rhs1);
+     RHS oldval = atomic.load();
+     RHS newval;
+@@ -1425,6 +1426,7 @@ namespace Legion {
+       newval = oldval + rhs2;
+     } while (!atomic.compare_exchange_weak(oldval, newval));
+ #else
++*/    
+     TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
+     TypePunning::Pointer<int32_t> pointer((void*)&rhs1);
+     do {
+@@ -1432,7 +1434,7 @@ namespace Legion {
+       newval = oldval.as_two() + rhs2;
+     } while (!__sync_bool_compare_and_swap((int32_t*)pointer,
+                       oldval.as_one(), newval.as_one()));
+-#endif
++// #endif
+ #endif
+   }
+ #endif // LEGION_REDOP_HALF
+@@ -2463,6 +2465,7 @@ namespace Legion {
+             __complex_as_uint(oldval), __complex_as_uint(newval)));
+     } while (oldval != newval);
+ #else
++/*    
+ #if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
+     std::atomic_ref<LHS> atomic(lhs);
+     RHS oldval = atomic.load();
+@@ -2471,6 +2474,7 @@ namespace Legion {
+       newval = oldval - rhs;
+     } while (!atomic.compare_exchange_weak(oldval, newval));
+ #else
++*/
+     TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
+     TypePunning::Pointer<int32_t> pointer((void*)&lhs);
+     do {
+@@ -2478,7 +2482,7 @@ namespace Legion {
+       newval = oldval.as_two() - rhs;
+     } while (!__sync_bool_compare_and_swap((int32_t*)pointer,
+                       oldval.as_one(), newval.as_one()));
+-#endif
++// #endif
+ #endif
+   }
+ 
+@@ -2503,7 +2507,7 @@ namespace Legion {
+             __complex_as_uint(oldval), __complex_as_uint(newval)));
+     } while (oldval != newval);
+ #else
+-#if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
++/* #if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
+     std::atomic_ref<RHS> atomic(rhs1);
+     RHS oldval = atomic.load();
+     RHS newval;
+@@ -2511,14 +2515,15 @@ namespace Legion {
+       newval = oldval - rhs2;
+     } while (!atomic.compare_exchange_weak(oldval, newval));
+ #else
+-    TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
++*/    
++TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
+     TypePunning::Pointer<int32_t> pointer((void*)&rhs1);
+     do {
+       oldval.load(pointer);
+       newval = oldval.as_two() - rhs2;
+     } while (!__sync_bool_compare_and_swap((int32_t*)pointer,
+                       oldval.as_one(), newval.as_one()));
+-#endif
++// #endif
+ #endif
+   }
+ #endif // LEGION_REDOP_HALF
+@@ -3785,7 +3790,7 @@ namespace Legion {
+             __complex_as_uint(oldval), __complex_as_uint(newval)));
+     } while (oldval != newval);
+ #else
+-#if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
++/* #if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
+     std::atomic_ref<LHS> atomic(lhs);
+     RHS oldval = atomic.load();
+     RHS newval;
+@@ -3793,14 +3798,15 @@ namespace Legion {
+       newval = oldval * rhs;
+     } while (!atomic.compare_exchange_weak(oldval, newval));
+ #else
+-    TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
++*/     
++TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
+     TypePunning::Pointer<int32_t> pointer((void*)&lhs);
+     do {
+       oldval.load(pointer);
+       newval = oldval.as_two() * rhs;
+     } while (!__sync_bool_compare_and_swap((int32_t*)pointer,
+                       oldval.as_one(), newval.as_one()));
+-#endif
++// #endif
+ #endif
+   }
+ 
+@@ -3825,7 +3831,7 @@ namespace Legion {
+             __complex_as_uint(oldval), __complex_as_uint(newval)));
+     } while (oldval != newval);
+ #else
+-#if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
++/* #if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
+     std::atomic_ref<RHS> atomic(rhs1);
+     RHS oldval = atomic.load();
+     RHS newval;
+@@ -3833,6 +3839,7 @@ namespace Legion {
+       newval = oldval * rhs2;
+     } while (!atomic.compare_exchange_weak(oldval, newval));
+ #else
++*/
+     TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
+     TypePunning::Pointer<int32_t> pointer((void*)&rhs1);
+     do {
+@@ -3840,7 +3847,7 @@ namespace Legion {
+       newval = oldval.as_two() * rhs2;
+     } while (!__sync_bool_compare_and_swap((int32_t*)pointer,
+                       oldval.as_one(), newval.as_one()));
+-#endif
++//#endif
+ #endif
+   }
+ #endif // LEGION_REDOP_HALF
+@@ -5019,7 +5026,7 @@ namespace Legion {
+             __complex_as_uint(oldval), __complex_as_uint(newval)));
+     } while (oldval != newval);
+ #else
+-#if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
++/* #if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
+     std::atomic_ref<LHS> atomic(lhs);
+     RHS oldval = atomic.load();
+     RHS newval;
+@@ -5027,14 +5034,15 @@ namespace Legion {
+       newval = oldval / rhs;
+     } while (!atomic.compare_exchange_weak(oldval, newval));
+ #else
+-    TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
++*/    
++TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
+     TypePunning::Pointer<int32_t> pointer((void*)&lhs);
+     do {
+       oldval.load(pointer);
+       newval = oldval.as_two() / rhs;
+     } while (!__sync_bool_compare_and_swap((int32_t*)pointer,
+                       oldval.as_one(), newval.as_one()));
+-#endif
++// #endif
+ #endif
+   }
+ 
+@@ -5059,7 +5067,7 @@ namespace Legion {
+             __complex_as_uint(oldval), __complex_as_uint(newval)));
+     } while (oldval != newval);
+ #else
+-#if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
++/* #if defined(__cpp_lib_atomic_ref) && (__cpp_lib_atomic_ref >= 201806L)
+     std::atomic_ref<RHS> atomic(rhs1);
+     RHS oldval = atomic.load();
+     RHS newval;
+@@ -5067,6 +5075,7 @@ namespace Legion {
+       newval = oldval / rhs2;
+     } while (!atomic.compare_exchange_weak(oldval, newval));
+ #else
++*/
+     TypePunning::Alias<int32_t,complex<__half> > oldval, newval;
+     TypePunning::Pointer<int32_t> pointer((void*)&rhs1);
+     do {
+@@ -5074,7 +5083,7 @@ namespace Legion {
+       newval = oldval.as_two() / rhs2;
+     } while (!__sync_bool_compare_and_swap((int32_t*)pointer,
+                       oldval.as_one(), newval.as_one()));
+-#endif
++// #endif
+ #endif
+   }
+ #endif // LEGION_REDOP_HALF
+@@ -9806,4 +9815,4 @@ namespace Legion {
+ }; // namespace Legion
+ 
+-#undef __MAX__
++#undef __MAX__
+-#undef __MIN__
++#undef __MIN__


### PR DESCRIPTION
Adds patch to legate_jll instead of the wrapper code.

The patch is applied to a dependency of legate that we do not wrap and do not have control over. It is applied after configuration which is responsible for cloning the source of the external library we patch. This also ensures the patch is shipped to all dependencies of legate_jll.