### PR TITLE
CUDA: Split compiler bits out in separate JLL.

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_11.jl
+++ b/C/CUDA/CUDA_Compiler/build_11.jl
@@ -1,0 +1,7 @@
+products = [
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+]

--- a/C/CUDA/CUDA_Compiler/build_12.jl
+++ b/C/CUDA/CUDA_Compiler/build_12.jl
@@ -1,0 +1,7 @@
+products = [
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+]

--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -1,0 +1,100 @@
+using BinaryBuilder, Pkg
+
+include("../common.jl")
+
+const YGGDRASIL_DIR = "../../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+
+name = "CUDA_Compiler"
+version = v"0.1"
+
+augment_platform_block = read(joinpath(@__DIR__, "platform_augmentation.jl"), String)
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("aarch64", "linux"; cuda_platform="jetson"),
+             Platform("aarch64", "linux"; cuda_platform="sbsa"),
+             Platform("x86_64", "windows")]
+
+script = raw"""
+# rename directories, stripping the architecture and version suffix
+for dir in *-archive; do
+    base=$(echo $dir | cut -d '-' -f 1)
+    mv $dir $base
+done
+
+# license
+install_license cuda_nvcc/LICENSE
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
+if [[ ${target} == *-linux-gnu ]]; then
+    mv cuda_cudart/lib/libcudadevrt.a ${libdir}
+
+    mkdir ${prefix}/share/libdevice
+    mv cuda_nvcc/bin/ptxas ${bindir}
+    mv cuda_nvcc/bin/nvlink ${bindir}
+    mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    mv cuda_nvdisasm/bin/nvdisasm ${bindir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    if [[ -d cuda_cudart/lib/x64 ]]; then
+        mv cuda_cudart/lib/x64/cudadevrt.lib ${prefix}/lib
+    else
+        mv cuda_cudart/lib/cudadevrt.lib ${prefix}/lib
+    fi
+
+    mkdir ${prefix}/share/libdevice
+    mv cuda_nvcc/bin/ptxas.exe ${bindir}
+    mv cuda_nvcc/bin/nvlink.exe ${bindir}
+    mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
+
+    mv cuda_nvdisasm/bin/nvdisasm.exe ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.exe
+fi
+"""
+
+dependencies = [
+    Dependency("CUDA_Driver_jll", v"12.9"; compat="12")
+]
+
+# determine exactly which tarballs we should build
+builds = []
+for version in [ v"11.8", v"12.9"]
+    include("build_$(version.major).jl")
+
+    # CUDA_Compiler uses the following components
+    components = [
+        "cuda_cudart",
+        "cuda_nvcc",
+        "cuda_nvdisasm"
+    ]
+
+    for platform in platforms
+        augmented_platform = deepcopy(platform)
+        augmented_platform["cuda"] = "$(version.major)"
+        should_build_platform(triplet(augmented_platform)) || continue
+
+        push!(builds,
+            (; script, platforms=[augmented_platform], products,
+               sources=get_sources("cuda", components; version, platform)
+        ))
+    end
+end
+
+# don't allow `build_tarballs` to override platform selection based on ARGS.
+# we handle that ourselves by calling `should_build_platform`
+non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
+
+# `--register` and `--deploy` should only be passed to the final `build_tarballs` invocation
+non_reg_ARGS = filter(non_platform_ARGS) do arg
+    arg != "--register" && !startswith(arg, "--deploy")
+end
+
+for (i,build) in enumerate(builds)
+    build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
+                   name, version, build.sources, build.script,
+                   build.platforms, build.products, dependencies;
+                   julia_compat="1.6", lazy_artifacts=true, augment_platform_block)
+end

--- a/C/CUDA/CUDA_Compiler/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Compiler/platform_augmentation.jl
@@ -1,0 +1,129 @@
+using Base.BinaryPlatforms
+
+using Libdl
+
+# before loading CUDA_Driver_jll, try to find out where the system driver is located.
+let
+    name = if Sys.iswindows()
+        Libdl.find_library("nvcuda")
+    else
+        Libdl.find_library(["libcuda.so.1", "libcuda.so"])
+    end
+
+    # if we've found a system driver, put a dependency on it,
+    # so that we get recompiled if the driver changes.
+    if name != ""
+        handle = Libdl.dlopen(name)
+        path = Libdl.dlpath(handle)
+        Libdl.dlclose(handle)
+
+        @debug "Adding include dependency on $path"
+        Base.include_dependency(path)
+    end
+end
+
+# platform augmentation hooks run in an ill-defined environment, where:
+# - CUDA_Driver_jll may not be available
+# - the wrong version of CUDA_Driver_jll may be available
+#
+# because of that, we need to be very careful about using that dependency.
+# currently, we support all existing versions of CUDA_Driver_jll, but if we
+# ever need to introduce a breaking change, we'll need some way to identify
+# the version of CUDA_Driver_jll from its module (e.g. a global constant).
+#
+# ref: https://github.com/JuliaLang/Pkg.jl/issues/3225
+# can't use Preferences for the same reason
+try
+    using CUDA_Driver_jll
+catch err
+    # we'll handle this below
+end
+
+# get the version of the available CUDA driver by querying either CUDA_Driver_jll's
+# driver, or the system driver if CUDA_Driver_jll is not available
+function get_driver_version()
+    if !@isdefined(CUDA_Driver_jll)
+        # driver JLL not available because we're in the middle of installing packages
+        @debug "CUDA_Driver_jll not available; not selecting an artifact"
+        return nothing
+    end
+
+    cuda_driver = if CUDA_Driver_jll.is_available()
+        @debug "Using CUDA_Driver_jll for driver discovery"
+
+        if !isdefined(CUDA_Driver_jll, :libcuda) || # CUDA_Driver_jll@0.4-compat
+            isnothing(CUDA_Driver_jll.libcuda)      # https://github.com/JuliaLang/julia/issues/48999
+            # no driver found
+            @debug "CUDA_Driver_jll reports no driver found"
+            return nothing
+        end
+        CUDA_Driver_jll.libcuda
+    else
+        # CUDA_Driver_jll only kicks in for supported platforms, so fall back to
+        # a system search if the artifact isn't available (JLLWrappers.jl#50)
+        @debug "CUDA_Driver_jll unavailable, falling back to system search"
+
+        driver_name = if Sys.iswindows()
+            Libdl.find_library("nvcuda")
+        else
+            Libdl.find_library(["libcuda.so.1", "libcuda.so"])
+        end
+        if driver_name == ""
+            # no driver found
+            @debug "CUDA_Driver_jll unavailable, and no system CUDA driver found"
+            return nothing
+        end
+
+        driver_name
+    end
+    @debug "Found CUDA driver at '$cuda_driver'"
+
+    # minimal API call wrappers we need
+    function cuDriverGetVersion(library_handle)
+        function_handle = Libdl.dlsym(library_handle, "cuDriverGetVersion"; throw_error=false)
+        if function_handle === nothing
+            @debug "Driver library seems invalid (does not contain 'cuDriverGetVersion')"
+            return nothing
+        end
+        version_ref = Ref{Cint}()
+        status = ccall(function_handle, Cint, (Ptr{Cint},), version_ref)
+        if status != 0
+            @debug "Call to 'cuDriverGetVersion' failed with status $status"
+            return nothing
+        end
+        major, ver = divrem(version_ref[], 1000)
+        minor, patch = divrem(ver, 10)
+        return VersionNumber(major, minor, patch)
+    end
+
+    driver_handle = Libdl.dlopen(cuda_driver; throw_error=false)
+    if driver_handle === nothing
+        @debug "Failed to load CUDA driver"
+        return nothing
+    end
+
+    cuDriverGetVersion(driver_handle)
+end
+
+# returns the value for the "cuda" tag we should use in the platform ("$MAJOR")
+# or nothing if no CUDA driver was found.
+function cuda_driver_tag()
+    cuda_driver = get_driver_version()
+    if cuda_driver === nothing
+        @debug "Failed to query CUDA driver version"
+        return nothing
+    end
+    @debug "CUDA driver version: $cuda_driver"
+
+    "$(cuda_driver.major)"
+end
+
+function augment_platform!(platform::Platform)
+    if !haskey(platform, "cuda")
+        platform["cuda"] = something(cuda_driver_tag(), "none")
+        # XXX: use "none" when we couldn't find a compatible toolkit.
+        #      we can't just leave off the platform tag or Pkg would select *any* artifact.
+    end
+
+    return platform
+end

--- a/C/CUDA/CUDA_Runtime/build_10.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_10.2.jl
@@ -18,7 +18,7 @@ rm -rf ${prefix}/include/thrust
 mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
 if [[ ${target} == *-linux-gnu ]]; then
     # CUDA Runtime
-    mv lib64/libcudart.so* lib64/libcudadevrt.a ${libdir}
+    mv lib64/libcudart.so* ${libdir}
 
     # CUDA FFT Library
     mv lib64/libcufft.so* lib64/libcufftw.so* ${libdir}
@@ -40,10 +40,6 @@ if [[ ${target} == *-linux-gnu ]]; then
     # CUDA Random Number Generation Library
     mv lib64/libcurand.so* ${libdir}
 
-    # NVIDIA Common Device Math Functions Library
-    mkdir ${prefix}/share/libdevice
-    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
-
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/libcupti.so* ${libdir}
 
@@ -52,15 +48,9 @@ if [[ ${target} == *-linux-gnu ]]; then
 
     mv lib64/libnvrtc.so* ${libdir}
     mv lib64/libnvrtc-builtins.so* ${libdir}
-
-    # Additional binaries
-    mv bin/ptxas ${bindir}
-    mv bin/nvdisasm ${bindir}
-    mv bin/nvlink ${bindir}
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Runtime
     mv bin/cudart64_*.dll ${bindir}
-    mv lib/x64/cudadevrt.lib ${prefix}/lib
 
     # CUDA FFT Library
     mv bin/cufft64_*.dll bin/cufftw64_*.dll ${bindir}
@@ -80,10 +70,6 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # CUDA Random Number Generation Library
     mv bin/curand64_*.dll ${bindir}
 
-    # NVIDIA Common Device Math Functions Library
-    mkdir ${prefix}/share/libdevice
-    mv nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
-
     # CUDA Profiling Tools Interface (CUPTI) Library
     mv extras/CUPTI/lib64/cupti64_*.dll ${bindir}
 
@@ -93,13 +79,8 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv bin/nvrtc64_* ${bindir}
     mv bin/nvrtc-builtins64_* ${bindir}
 
-    # Additional binaries
-    mv bin/ptxas.exe ${bindir}
-    mv bin/nvdisasm.exe ${bindir}
-    mv bin/nvlink.exe ${bindir}
-
     # Fix permissions
-    chmod +x ${bindir}/*.{exe,dll}
+    chmod +x ${bindir}/*.dll
 fi
 """
 
@@ -116,10 +97,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvrtc", "nvrtc64_102_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_102"], :libnvrtc_builtins),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.4.jl
@@ -13,10 +13,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_114"], :libnvrtc_builtins),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.5.jl
@@ -13,10 +13,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_115"], :libnvrtc_builtins),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.6.jl
@@ -13,10 +13,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_116"], :libnvrtc_builtins),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.7.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.7.jl
@@ -13,10 +13,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_117"], :libnvrtc_builtins),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_11.8.jl
+++ b/C/CUDA/CUDA_Runtime/build_11.8.jl
@@ -13,10 +13,5 @@ function get_products(platform)
         LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
         LibraryProduct(["libnvrtc", "nvrtc64_112_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_118"], :libnvrtc_builtins),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.0.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.0.jl
@@ -14,10 +14,5 @@ function get_products(platform)
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_120"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.1.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.1.jl
@@ -14,10 +14,5 @@ function get_products(platform)
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_121"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.2.jl
@@ -14,10 +14,5 @@ function get_products(platform)
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_122"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.3.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.3.jl
@@ -14,10 +14,5 @@ function get_products(platform)
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_123"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.4.jl
@@ -14,10 +14,5 @@ function get_products(platform)
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_124"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.5.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.5.jl
@@ -14,10 +14,5 @@ function get_products(platform)
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_125"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.6.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.6.jl
@@ -14,10 +14,5 @@ function get_products(platform)
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_126"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.8.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.8.jl
@@ -14,10 +14,5 @@ function get_products(platform)
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_128"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_12.9.jl
+++ b/C/CUDA/CUDA_Runtime/build_12.9.jl
@@ -14,10 +14,5 @@ function get_products(platform)
         LibraryProduct(["libnvrtc", "nvrtc64_120_0"], :libnvrtc),
         LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_129"], :libnvrtc_builtins),
         LibraryProduct(["libnvJitLink", "nvJitLink_120_0"], :libnvJitLink),
-        FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
-        FileProduct("share/libdevice/libdevice.10.bc", :libdevice),
-        ExecutableProduct("ptxas", :ptxas),
-        ExecutableProduct("nvdisasm", :nvdisasm),
-        ExecutableProduct("nvlink", :nvlink),
     ]
 end

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.17.1"
+version = v"0.18.0"
 
 augment_platform_block = """
     $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))
@@ -31,22 +31,16 @@ install_license cuda_cudart/LICENSE
 # binaries
 mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share
 if [[ ${target} == *-linux-gnu ]]; then
-    mv cuda_cudart/lib/libcudart.so* cuda_cudart/lib/libcudadevrt.a ${libdir}
+    mv cuda_cudart/lib/libcudart.so* ${libdir}
 
     mv cuda_cupti/lib/libcupti.so* ${libdir}
     mv cuda_cupti/lib/libnvperf_host.so* ${libdir}
     mv cuda_cupti/lib/libnvperf_target.so* ${libdir}
 
-    mkdir ${prefix}/share/libdevice
     mv cuda_nvcc/nvvm/lib64/libnvvm.so* ${libdir}
-    mv cuda_nvcc/bin/ptxas ${bindir}
-    mv cuda_nvcc/bin/nvlink ${bindir}
-    mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
 
     mv cuda_nvrtc/lib/libnvrtc.so* ${libdir}
     mv cuda_nvrtc/lib/libnvrtc-builtins.so* ${libdir}
-
-    mv cuda_nvdisasm/bin/nvdisasm ${bindir}
 
     if [[ -d libnvjitlink ]]; then
         mv libnvjitlink/lib/libnvJitLink.so* ${libdir}
@@ -69,26 +63,15 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     done
 
     mv cuda_cudart/bin/cudart64_*.dll ${bindir}
-    if [[ -d cuda_cudart/lib/x64 ]]; then
-        mv cuda_cudart/lib/x64/cudadevrt.lib ${prefix}/lib
-    else
-        mv cuda_cudart/lib/cudadevrt.lib ${prefix}/lib
-    fi
 
     mv cuda_cupti/bin/cupti64_*.dll ${bindir}
     mv cuda_cupti/bin/nvperf_host.dll* ${libdir}
     mv cuda_cupti/bin/nvperf_target.dll* ${libdir}
 
-    mkdir ${prefix}/share/libdevice
     mv cuda_nvcc/nvvm/bin/nvvm64_*.dll ${bindir}
-    mv cuda_nvcc/bin/ptxas.exe ${bindir}
-    mv cuda_nvcc/bin/nvlink.exe ${bindir}
-    mv cuda_nvcc/nvvm/libdevice/libdevice.10.bc ${prefix}/share/libdevice
 
     mv cuda_nvrtc/bin/nvrtc64_* ${bindir}
     mv cuda_nvrtc/bin/nvrtc-builtins64_* ${bindir}
-
-    mv cuda_nvdisasm/bin/nvdisasm.exe ${bindir}
 
     if [[ -d libnvjitlink ]]; then
         mv libnvjitlink/bin/nvJitLink_*.dll ${bindir}
@@ -105,7 +88,7 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv libcurand/bin/curand64_*.dll ${bindir}
 
     # Fix permissions
-    chmod +x ${bindir}/*.{exe,dll}
+    chmod +x ${bindir}/*.dll
 fi
 """
 
@@ -121,7 +104,6 @@ for version in CUDA.cuda_full_versions
         "cuda_cupti",
         "cuda_nvcc",
         "cuda_nvrtc",
-        "cuda_nvdisasm",
 
         "libcublas",
         "libcufft",
@@ -158,14 +140,14 @@ for version in CUDA.cuda_full_versions
 
         if Base.thisminor(version) == v"10.2"
             push!(builds,
-                (; dependencies=[Dependency("CUDA_Driver_jll"; compat="0.13"),
+                (; dependencies=[Dependency("CUDA_Driver_jll", v"12.9"; compat="12"),
                                  BuildDependency(PackageSpec(name="CUDA_SDK_jll", version=v"10.2.89"))],
                    script=get_script(), platforms=[augmented_platform], products=get_products(platform),
                    sources=[]
             ))
         else
             push!(builds,
-                (; dependencies=[Dependency("CUDA_Driver_jll"; compat="0.13")],
+                (; dependencies=[Dependency("CUDA_Driver_jll", v"12.9"; compat="12")],
                    script, platforms=[augmented_platform], products=get_products(platform),
                    sources=get_sources("cuda", components; version, platform)
             ))


### PR DESCRIPTION
Another attempt at separating out the executable compiler bits from the CUDA runtime JLL, only keeping the libraries in there. This makes it possible to keep using the most recent compiler even if the user wants/needs to use an older or local runtime.

Previously attempted in https://github.com/JuliaPackaging/Yggdrasil/pull/8616, reverted in https://github.com/JuliaPackaging/Yggdrasil/pull/8670 because it turned out that `ptxas` from CUDA 12 generates code incompatible with an NVIDIA driver for CUDA 11. Fixed here by using a platform augmentation that inspects the driver version and selects an appropriate artifact.

Note that I only moved out the executable, and kept compiler libraries like `nvrtc` and `nvjitlink` in the runtime JLL. Ideally I wanted to move those out too, in order to use them instead of shelling out to `ptxas` or `nvlink`. However, as it turns out, some of NVIDIA's libraries nowadays actively link against those compiler libraries (doing run-time compilation), so we can't version those separately.