### PR TITLE
New manual recipe: LEMON graphs toolkit

### DIFF
--- a/L/LEMON/build_tarballs.jl
+++ b/L/LEMON/build_tarballs.jl
@@ -1,0 +1,53 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "LEMON"
+version = v"1.3.1"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("http://lemon.cs.elte.hu/pub/sources/lemon-$(version).tar.gz", "71b7c725f4c0b4a8ccb92eb87b208701586cf7a96156ebd821ca3ed855bad3c8")
+    DirectorySource("./bundled") # for the Julia wrapper
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+export CXXFLAGS="-Wno-register" # cland C++17 expects the `register` storage class to be written as `REGISTER`
+
+cd $WORKSPACE/srcdir
+cd lemon-1.3.1/
+cmake -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel ${nproc}
+cmake --install build
+install_license LICENSE
+
+cd ..
+$CXX -shared -std=c++17 -O3 -fPIC -o ${libdir}/liblemoncxxwrap.${dlext} cxxwrap/lemoncxxwrap.cpp -I$includedir/julia -lemon -ljulia -lcxxwrap_julia
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+
+# Because we bundle the Julia-targetting cxxwrapper,
+# we need a build for each supported julia version.
+include("../../L/libjulia/common.jl")
+platforms = vcat(libjulia_platforms.(julia_versions)...)
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("dimacs-to-lgf", :dimacs_to_lgf),
+    ExecutableProduct("lgf-gen", :lgf_gen),
+    ExecutableProduct("dimacs-solver", :dimacs_solver),
+    LibraryProduct("liblemoncxxwrap", :liblemoncxxwrap)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("libcxxwrap_julia_jll"),
+    BuildDependency("libjulia_jll")
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.7.0", preferred_gcc_version = v"7.1.0")

--- a/L/LEMON/bundled/cxxwrap/lemoncxxwrap.cpp
+++ b/L/LEMON/bundled/cxxwrap/lemoncxxwrap.cpp
@@ -1,0 +1,76 @@
+#include "jlcxx/jlcxx.hpp"
+
+#include <lemon/list_graph.h>
+#include <lemon/matching.h>
+
+#include <functional>
+
+using namespace lemon;
+using namespace std;
+
+std::string compiledebug()
+{
+   return "baseline compilation works";
+}
+
+namespace jlcxx
+{
+  template<> struct SuperType<ListGraph::NodeIt> { typedef ListGraph::Node type; };
+  template<> struct SuperType<ListGraph::EdgeIt> { typedef ListGraph::Edge type; };
+  template<> struct SuperType<ListDigraph::NodeIt> { typedef ListDigraph::Node type; };
+  // no appropriate factory error
+  //template<> struct SuperType<ListDigraph::ArcIt> { typedef ListDigraph::Arc type; };
+}
+
+JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
+{
+  mod.method("compiledebug", &compiledebug);
+
+  mod.add_type<ListGraph::Node>("ListGraphNode");
+  mod.add_type<ListDigraph::Node>("ListDigraphNode");
+  mod.add_type<ListGraph::Edge>("ListGraphEdge");
+  mod.add_type<ListDigraph::Arc>("ListDigraphArc");
+
+  mod.method("id", static_cast<int(*)(ListGraph::Node)>(&ListGraph::id));
+  mod.method("id", static_cast<int(*)(ListGraph::Edge)>(&ListGraph::id));
+  mod.method("id", static_cast<int(*)(ListDigraph::Node)>(&ListDigraph::id));
+  mod.method("id", static_cast<int(*)(ListDigraph::Arc)>(&ListDigraph::id));
+
+  mod.add_type<ListGraph>("ListGraph")
+    .method("addNode"  , &ListGraph::addNode)
+    .method("addEdge"  , &ListGraph::addEdge);
+  mod.add_type<ListDigraph>("ListDigraph")
+    .method("addNode"  , &ListDigraph::addNode)
+    .method("addArc"   , &ListDigraph::addArc);
+
+  mod.add_type<ListGraph::NodeIt>("ListGraphNodeIt", jlcxx::julia_base_type<ListGraph::Node>())
+    .constructor<const ListGraph&>()
+    .method("iternext", &ListGraph::NodeIt::operator++);
+  mod.add_type<ListDigraph::NodeIt>("ListDigraphNodeIt", jlcxx::julia_base_type<ListDigraph::Node>())
+    .constructor<const ListDigraph&>()
+    .method("iternext", &ListDigraph::NodeIt::operator++);
+  mod.add_type<ListGraph::EdgeIt>("ListGraphEdgeIt", jlcxx::julia_base_type<ListGraph::Edge>())
+    .constructor<const ListGraph&>()
+    .method("iternext", &ListGraph::EdgeIt::operator++);
+  // no appropriate factory error
+  //mod.add_type<ListDigraph::ArcIt>("ListDigraphArcIt", jlcxx::julia_base_type<ListDigraph::ArcIt>())
+  //  .constructor<const ListDigraph&>()
+  //  .method("iternext", &ListDigraph::ArcIt::operator++);
+
+  mod.add_type<ListGraph::NodeMap<int>>("ListGraphNodeMapInt")
+    .constructor<const ListGraph&>()
+    .method("set", &ListGraph::NodeMap<int>::set);
+  mod.add_type<ListDigraph::NodeMap<int>>("ListDigraphNodeMapInt")
+    .constructor<const ListDigraph&>()
+    .method("set", &ListDigraph::NodeMap<int>::set);
+  mod.add_type<ListGraph::EdgeMap<int>>("ListGraphEdgeMapInt")
+    .constructor<const ListGraph&>()
+    .method("set", &ListGraph::EdgeMap<int>::set);
+
+  mod.add_type<MaxWeightedPerfectMatching<ListGraph, ListGraph::EdgeMap<int>>>("MaxWeightedPerfectMatchingListGraphInt")
+    .constructor<const ListGraph&, const ListGraph::EdgeMap<int>&>()
+    .method("mate", &MaxWeightedPerfectMatching<ListGraph, ListGraph::EdgeMap<int>>::mate)
+    .method("run", &MaxWeightedPerfectMatching<ListGraph, ListGraph::EdgeMap<int>>::run)
+    .method("matchingWeight", &MaxWeightedPerfectMatching<ListGraph, ListGraph::EdgeMap<int>>::matchingWeight);
+
+}


### PR DESCRIPTION
This recipe was built mostly without the wizard.

LEMON is a graph theory package that has stopped being developed around 2014. It is one of the very few OSS packages that include a minimum weight perfect matching (MWPM) algorithm.

A very minimal cxxwrap.jl wrapper is included in the `bundled` folder. My plan is to use this to add a MWPM algorithm to Graphs.jl. Potentially in the future the wrapper here might be improved and expanded.

I do not expect LEMON itself will ever have a new version.