### PR TITLE
[libcint] Add windows platform

### DIFF
--- a/L/libcint/build_tarballs.jl
+++ b/L/libcint/build_tarballs.jl
@@ -30,7 +30,8 @@ platforms = [
     Platform("aarch64", "macos"; ),
     Platform("aarch64", "linux"; libc = "glibc"),
     Platform("x86_64", "macos"; ),
-    Platform("x86_64", "linux"; libc = "glibc")
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("x86_64", "windows")
 ]
 
 # The products that we will ensure are always built


### PR DESCRIPTION
The current new version of libcint (6.1.2) seems to be compatible with windows.