### PR TITLE
fix `gnuplot_qt` and `gnuplot_x11`

### DIFF
--- a/G/Gnuplot/build_tarballs.jl
+++ b/G/Gnuplot/build_tarballs.jl
@@ -12,6 +12,8 @@ sources = [
     DirectorySource("./bundled"),
 ]
 
+libexec_path = joinpath("libexec", "gnuplot", "$(version.major).$(version.minor)")
+
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/gnuplot-*
@@ -43,6 +45,10 @@ esac
 
 make -C src -j${nproc}
 make -C src install
+""" * """
+mkdir -p \$prefix/$libexec_path
+touch \$prefix/$libexec_path/gnuplot_fake
+chmod +x \$prefix/$libexec_path/gnuplot_fake
 """
 
 # These are the platforms we will build for by default, unless further
@@ -50,11 +56,11 @@ make -C src install
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
-libexec_path = joinpath("libexec", "gnuplot", "$(version.major).$(version.minor)")
 # @show libexec_path
 products = [
     ExecutableProduct("gnuplot", :gnuplot),
-    ExecutableProduct("gnuplot_x11", :gnuplot_x11, libexec_path),
+    ExecutableProduct("gnuplot_fake", :gnuplot_fake, libexec_path),
+    # ExecutableProduct("gnuplot_x11", :gnuplot_x11, libexec_path),
     # ExecutableProduct("gnuplot_qt", :gnuplot_qt, libexec_path),
 ]
 

--- a/G/Gnuplot/build_tarballs.jl
+++ b/G/Gnuplot/build_tarballs.jl
@@ -47,7 +47,7 @@ make -C src -j${nproc}
 make -C src install
 
 if [[ "${target}" == *-mingw* ]]; then
-    suffix='.exe"
+    suffix='.exe'
 else
     suffix=''
 fi

--- a/G/Gnuplot/build_tarballs.jl
+++ b/G/Gnuplot/build_tarballs.jl
@@ -54,8 +54,8 @@ libexec_path = joinpath("libexec", "gnuplot", "$(version.major).$(version.minor)
 # @show libexec_path
 products = [
     ExecutableProduct("gnuplot", :gnuplot),
-    ExecutableProduct("gnuplot_qt", :gnuplot_qt, libexec_path),
     ExecutableProduct("gnuplot_x11", :gnuplot_x11, libexec_path),
+    # ExecutableProduct("gnuplot_qt", :gnuplot_qt, libexec_path),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/G/Gnuplot/build_tarballs.jl
+++ b/G/Gnuplot/build_tarballs.jl
@@ -45,10 +45,16 @@ esac
 
 make -C src -j${nproc}
 make -C src install
+
+if [[ "${target}" == *-mingw* ]]; then
+    suffix='.exe"
+else
+    suffix=''
+fi
 """ * """
 mkdir -p \$prefix/$libexec_path
-touch \$prefix/$libexec_path/gnuplot_fake
-chmod +x \$prefix/$libexec_path/gnuplot_fake
+touch \$prefix/$libexec_path/gnuplot_fake\$suffix
+chmod +x \$prefix/$libexec_path/gnuplot_fake\$suffix
 """
 
 # These are the platforms we will build for by default, unless further

--- a/G/Gnuplot/build_tarballs.jl
+++ b/G/Gnuplot/build_tarballs.jl
@@ -45,16 +45,10 @@ esac
 
 make -C src -j${nproc}
 make -C src install
-
-if [[ "${target}" == *-mingw* ]]; then
-    suffix='.exe'
-else
-    suffix=''
-fi
 """ * """
 mkdir -p \$prefix/$libexec_path
-touch \$prefix/$libexec_path/gnuplot_fake\$suffix
-chmod +x \$prefix/$libexec_path/gnuplot_fake\$suffix
+touch \$prefix/$libexec_path/gnuplot_fake\$exeext
+chmod +x \$prefix/$libexec_path/gnuplot_fake\$exeext
 """
 
 # These are the platforms we will build for by default, unless further

--- a/G/Gnuplot/build_tarballs.jl
+++ b/G/Gnuplot/build_tarballs.jl
@@ -46,6 +46,7 @@ esac
 make -C src -j${nproc}
 make -C src install
 """ * """
+# add a fake `gnuplot_fake` executable, in order to determine `GNUPLOT_DRIVER_DIR` in `Gaston.jl`
 mkdir -p \$prefix/$libexec_path
 touch \$prefix/$libexec_path/gnuplot_fake\$exeext
 chmod +x \$prefix/$libexec_path/gnuplot_fake\$exeext

--- a/G/Gnuplot/build_tarballs.jl
+++ b/G/Gnuplot/build_tarballs.jl
@@ -2,7 +2,7 @@ using BinaryBuilder, Pkg
 
 name = "Gnuplot"
 version = v"6.0.3"
-build_number_jll = 0  # NOTE: increment on rebuild of the same version, reset on new gnuplot version
+build_number_jll = 1  # NOTE: increment on rebuild of the same version, reset on new gnuplot version
 version_jll = VersionNumber(version.major, version.minor, 1_000 * version.patch + build_number_jll)
 
 # Collection of sources required to complete build
@@ -50,7 +50,13 @@ make -C src install
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
-products = [ExecutableProduct("gnuplot", :gnuplot)]
+libexec_path = joinpath("libexec", "gnuplot", "$(version.major).$(version.minor)")
+# @show libexec_path
+products = [
+    ExecutableProduct("gnuplot", :gnuplot),
+    ExecutableProduct("gnuplot_qt", :gnuplot_qt, libexec_path),
+    ExecutableProduct("gnuplot_x11", :gnuplot_x11, libexec_path),
+]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [

--- a/G/Gnuplot/build_tarballs.jl
+++ b/G/Gnuplot/build_tarballs.jl
@@ -62,7 +62,6 @@ chmod +x \$prefix/$libexec_path/gnuplot_fake\$suffix
 platforms = supported_platforms()
 
 # The products that we will ensure are always built
-# @show libexec_path
 products = [
     ExecutableProduct("gnuplot", :gnuplot),
     ExecutableProduct("gnuplot_fake", :gnuplot_fake, libexec_path),


### PR DESCRIPTION
For https://github.com/mbaz/Gaston.jl/pull/192.

~We need to figure out what to do when the qt terminal is unavailable on some platforms.~
I've added a fake executable in `libexec`, in order to determine `GNUPLOT_DRIVER_DIR` at runtime.