### PR TITLE
add `libheif`

### DIFF
--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -2,7 +2,7 @@ using BinaryBuilder, Pkg
 
 name = "libheif"
 version = v"1.20.1"
-ygg_build = 0  # NOTE: increment on rebuild of the same upstream version, reset on new  libheifversion
+ygg_build = 0  # NOTE: increment on rebuild of the same upstream version, reset on new libheifversion
 ygg_version = VersionNumber(version.major, version.minor, 1_000 * version.patch + ygg_build)
 
 # Collection of sources required to complete build

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -23,6 +23,7 @@ args+=(-DCMAKE_BUILD_TYPE=RELEASE)
 
 args+=(-DWITH_HEADER_COMPRESSION=1)
 args+=(-DWITH_EXAMPLES=0)
+args+=(-DBUILD_TESTING=0)  # error: 'uncaught_exceptions' is unavailable: introduced in macOS 10.12
 
 cmake -B build -S . "${args[@]}"
 
@@ -41,8 +42,8 @@ products = [LibraryProduct("libheif", :libheif)]
 dependencies = [
     # Dependency("OpenJpeg_jll"),  # examples
     # Dependency("Libtiff_jll"),  # examples
-    Dependency("libavif_jll"),
     Dependency("libde265_jll"),
+    Dependency("libavif_jll"),
     # Dependency("libpng_jll"),  # examples
     Dependency("brotli_jll"),
     Dependency("LERC_jll"),

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -26,7 +26,7 @@ args+=(-DWITH_EXAMPLES=0)
 
 cmake -B build -S . "${args[@]}"
 
-cmake --build build --parallel $nproc
+cmake -B build -j $nproc
 cmake --install build
 """
 

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -26,7 +26,7 @@ args+=(-DWITH_EXAMPLES=0)
 
 cmake -B build -S . "${args[@]}"
 
-cmake -B build -j $nproc
+cmake -B build --parallel $nproc
 cmake --install build
 """
 

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -1,0 +1,55 @@
+using BinaryBuilder, Pkg
+
+name = "libheif"
+version = v"1.20.1"
+ygg_build = 0  # NOTE: increment on rebuild of the same upstream version, reset on new  libheifversion
+ygg_version = VersionNumber(version.major, version.minor, 1_000 * version.patch + ygg_build)
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/strukturag/libheif/releases/download/v$(version)/libheif-$(version).tar.gz",
+                  "55cc76b77c533151fc78ba58ef5ad18562e84da403ed749c3ae017abaf1e2090"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/libheif-*
+
+mkdir build
+
+args+=(-DCMAKE_INSTALL_PREFIX=$prefix)
+args+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+args+=(-DCMAKE_BUILD_TYPE=RELEASE)
+args+=(-DWITH_HEADER_COMPRESSION=1)
+args+=(-DWITH_EXAMPLES=0)
+
+cmake -B build -S . ${args[@]}
+
+cmake --build build --parallel ${nproc}
+cmake --install build
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# The products that we will ensure are always built
+products = [LibraryProduct("libheif", :libheif)]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    # Dependency("OpenJpeg_jll"),
+    # Dependency("Libtiff_jll"),
+    Dependency("libavif_jll"),
+    Dependency("libde265_jll"),
+    # Dependency("libpng_jll"),
+    Dependency("brotli_jll"),
+    Dependency("LERC_jll"),
+    Dependency("Zlib_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(
+    ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
+    julia_compat="1.6", preferred_gcc_version = v"10"
+)

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -41,7 +41,7 @@ dependencies = [
     # Dependency("OpenJpeg_jll"),
     # Dependency("Libtiff_jll"),
     Dependency("libavif_jll"),
-    Dependency(PackageSpec(; name="libde265_jll", uuid="0a7f2b4d-d03c-5694-960e-196e69ee64e2", path="$JULIA_HOME/dev/libde265_jll")),
+    Dependency("libde265_jll"),
     # Dependency("libpng_jll"),
     Dependency("brotli_jll"),
     Dependency("LERC_jll"),

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -17,13 +17,14 @@ cd $WORKSPACE/srcdir/libheif-*
 
 mkdir build
 
+args+=(-DCMAKE_TOOLCHAIN_FILE=$CMAKE_TARGET_TOOLCHAIN)
 args+=(-DCMAKE_INSTALL_PREFIX=$prefix)
-args+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
 args+=(-DCMAKE_BUILD_TYPE=RELEASE)
+
 args+=(-DWITH_HEADER_COMPRESSION=1)
 args+=(-DWITH_EXAMPLES=0)
 
-cmake -B build -S . ${args[@]}
+cmake -B build -S . "${args[@]}"
 
 cmake --build build --parallel ${nproc}
 cmake --install build
@@ -38,11 +39,11 @@ products = [LibraryProduct("libheif", :libheif)]
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # Dependency("OpenJpeg_jll"),
-    # Dependency("Libtiff_jll"),
+    # Dependency("OpenJpeg_jll"),  # examples
+    # Dependency("Libtiff_jll"),  # examples
     Dependency("libavif_jll"),
     Dependency("libde265_jll"),
-    # Dependency("libpng_jll"),
+    # Dependency("libpng_jll"),  # examples
     Dependency("brotli_jll"),
     Dependency("LERC_jll"),
     Dependency("Zlib_jll"),

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -52,5 +52,5 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(
     ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6", preferred_gcc_version = v"5"
+    julia_compat="1.6", preferred_gcc_version = v"9"  # needs CXX20
 )

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -41,7 +41,7 @@ dependencies = [
     # Dependency("OpenJpeg_jll"),
     # Dependency("Libtiff_jll"),
     Dependency("libavif_jll"),
-    Dependency("libde265_jll"),
+    Dependency(PackageSpec(; name="libde265_jll", uuid="0a7f2b4d-d03c-5694-960e-196e69ee64e2", path="$JULIA_HOME/dev/libde265_jll")),
     # Dependency("libpng_jll"),
     Dependency("brotli_jll"),
     Dependency("LERC_jll"),

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -26,7 +26,7 @@ args+=(-DWITH_EXAMPLES=0)
 
 cmake -B build -S . "${args[@]}"
 
-cmake --build build
+cmake --build build --parallel $nproc
 cmake --install build
 """
 
@@ -52,5 +52,5 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(
     ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6", preferred_gcc_version = v"9"  # needs CXX20
+    julia_compat="1.6", preferred_gcc_version = v"9"  # needs CXX20 - build errors on gcc8
 )

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -26,7 +26,7 @@ args+=(-DWITH_EXAMPLES=0)
 
 cmake -B build -S . "${args[@]}"
 
-cmake -B build --parallel $nproc
+cmake --build build --parallel $nproc
 cmake --install build
 """
 

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -52,5 +52,5 @@ dependencies = [
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(
     ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6", preferred_gcc_version = v"10"
+    julia_compat="1.6", preferred_gcc_version = v"5"
 )

--- a/L/libheif/build_tarballs.jl
+++ b/L/libheif/build_tarballs.jl
@@ -26,7 +26,7 @@ args+=(-DWITH_EXAMPLES=0)
 
 cmake -B build -S . "${args[@]}"
 
-cmake --build build --parallel ${nproc}
+cmake --build build
 cmake --install build
 """
 


### PR DESCRIPTION
Needs https://github.com/JuliaPackaging/Yggdrasil/pull/11605.
Needed for https://github.com/JuliaPackaging/Yggdrasil/pull/11604.

Requires a `c++20` aware compiler, narrowed down to gcc 9 to also fix build errors.

TODO:
- [x] test on all platforms locally.

<details>

Hum, `macos`:
```
[12:33:06] /workspace/srcdir/libheif-1.20.1/tests/catch_amalgamated.cpp:7772:21: error: 'uncaught_exceptions' is unavailable: introduced in macOS 10.12
[12:33:06]  7772 |         return std::uncaught_exceptions() > 0;
[12:33:06]       |                     ^
[12:33:06] /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/exception:131:63: note: 'uncaught_exceptions' has been explicitly marked unavailable here
[12:33:06]   131 | _LIBCPP_FUNC_VIS _LIBCPP_AVAILABILITY_UNCAUGHT_EXCEPTIONS int uncaught_exceptions() _NOEXCEPT;
[12:33:06]       |                                                               ^
[12:33:08] 1 error generated.
```
</details>
