### PR TITLE
PoCL: Include the PID in wrapper script filenames.

### DIFF
--- a/P/pocl/pocl@7/common.jl
+++ b/P/pocl/pocl@7/common.jl
@@ -247,7 +247,8 @@ function init_block(standalone=false)
 
             println(io, "call \\"$path\\" %*")
 
-            joinpath(bindir, name * ".bat")
+            # XXX: on Windows, the Base.rename below often throws EBUSY, so include the PID
+            joinpath(bindir, "$(name).$(getpid()).bat")
         else
             error("Unsupported platform")
         end


### PR DESCRIPTION
Otherwise loading the JLLs often fails:

```
ERROR: LoadError: TaskFailedException

    nested task error: On worker 12:
    LoadError: InitError: IOError: unlink("C:\\Users\\runneradmin\\.julia\\scratchspaces\\627d6b7a-bbe6-5189-83e7-98cc0a5aeadd\\bin\\llvm-spirv.bat"): resource busy or locked (EBUSY)
    Stacktrace:
      [1] uv_error
        @ .\libuv.jl:106 [inlined]
      [2] unlink
        @ .\file.jl:1105
      [3] #rm#10
        @ .\file.jl:283
      [4] rm
        @ .\file.jl:273 [inlined]
      [5] #checkfor_mv_cp_cptree#11
        @ .\file.jl:332
      [6] checkfor_mv_cp_cptree
        @ .\file.jl:318 [inlined]
      [7] #cp#14
        @ .\file.jl:380
      [8] cp
        @ .\file.jl:378 [inlined]
      [9] #rename#38
        @ .\file.jl:1114
     [10] generate_wrapper_script
        @ C:\Users\runneradmin\.julia\packages\pocl_jll\OgsTd\src\wrappers\x86_64-w64-mingw32-cxx11.jl:111
     [11] __init__
        @ C:\Users\runneradmin\.julia\packages\pocl_jll\OgsTd\src\wrappers\x86_64-w64-mingw32-cxx11.jl:122
```

I guess on Windows this isn't really atomic after all?