### PR TITLE
Libwebsockets builded with SOCKS5 support

### DIFF
--- a/L/libwebsockets/build_tarballs.jl
+++ b/L/libwebsockets/build_tarballs.jl
@@ -21,7 +21,8 @@ cmake -B build \
     -DZLIB_INCLUDE_DIR=${includedir} \
     -DLWS_WITH_ACCESS_LOG=ON \
     -DLWS_WITHOUT_EXTENSIONS=OFF \
-    -DLWS_WITHOUT_TESTAPPS=ON
+    -DLWS_WITHOUT_TESTAPPS=ON \
+    -DLWS_WITH_SOCKS5=ON
 cmake --build build --parallel ${nproc}
 cmake --install build
 """ 


### PR DESCRIPTION
Hello! Added an LWS_WITH_SOCKS5 argument to the jll build to enable Libwebsockets to work with SOCKS5.

LWS docs reference: https://github.com/warmcat/libwebsockets/blob/main/lib/secure-streams/README.md?plain=1#L831