### PR TITLE
MAGEMin v1.8.1

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 name = "MAGEMin"
-version = v"1.8.0"
+version = v"1.8.1"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "0179e8fb81104d595e81bd421a5146e773d53b97")                 ]
+                    "b32a3d91665e51226e08de69986390ab0f4b8643")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Added hematite (hem) pure phase to ultramafic and ultramafic extended database
- Added simplified structure types for MAGEMin_C: out_struct, out_TE_struct. Can be used to allocate output structures using Julia wrapper e.g., out = Vector{out_struct}
- Added calculation of melt viscosity in MAGEMin_C (after Giordano et al., 2008)
- Added assemblage differentiation for entropy and enthalpy