### PR TITLE
New recipe: git-lfs v3.7.0

### DIFF
--- a/G/Git_LFS/build_tarballs.jl
+++ b/G/Git_LFS/build_tarballs.jl
@@ -1,0 +1,39 @@
+using BinaryBuilder
+
+name    = "GitLFS"
+version = v"3.7.0"
+
+sources = [
+    GitSource("https://github.com/git-lfs/git-lfs.git", "92dddf560e62ef7dd25877d87ce072f7595aa52d")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+# echo $GOPATH # /workspace/.gopath
+cd $WORKSPACE/srcdir/git-lfs/
+mkdir -p ${bindir}
+
+# Install goversioninfo if host is Windows
+case "$MACHTYPE" in
+  *mingw*|*cygwin*) go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo ;;
+esac
+export PATH="$GOPATH/bin:$PATH"
+
+go build -o ${bindir}
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms(;experimental=true)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("git-lfs", :git_lfs),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; compilers=[:c, :go], julia_compat="1.6")

--- a/G/Git_LFS/build_tarballs.jl
+++ b/G/Git_LFS/build_tarballs.jl
@@ -23,7 +23,7 @@ go build -o ${bindir}
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [

--- a/G/Git_LFS/build_tarballs.jl
+++ b/G/Git_LFS/build_tarballs.jl
@@ -9,7 +9,6 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-# echo $GOPATH # /workspace/.gopath
 cd $WORKSPACE/srcdir/git-lfs/
 mkdir -p ${bindir}
 

--- a/G/Git_LFS/build_tarballs.jl
+++ b/G/Git_LFS/build_tarballs.jl
@@ -1,6 +1,6 @@
 using BinaryBuilder
 
-name    = "GitLFS"
+name    = "Git_LFS"
 version = v"3.7.0"
 
 sources = [


### PR DESCRIPTION
Would like to hook this up with Git.jl so the git executable provided there calls the git-lfs we build here when we issue commands like ```run(`$(Git.git()) lfs ...`)``` -- not sure how to accomplish that yet ...