### PR TITLE
mpi_abi_stubs: New package

### DIFF
--- a/M/mpi_abi_stubs/build_tarballs.jl
+++ b/M/mpi_abi_stubs/build_tarballs.jl
@@ -20,7 +20,7 @@ cd ${WORKSPACE}/srcdir/mpi-abi-stubs
 cmake_args=(
     -DCMAKE_BUILD_TYPE=Release
     -DCMAKE_INSTALL_PREFIX=${prefix}
-    -DCMAKE_PREFIX_PATH=${prefix}
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
 )
 cmake -Bbuild ${cmake_args[@]}
 cmake --build build --parallel ${nproc}

--- a/M/mpi_abi_stubs/build_tarballs.jl
+++ b/M/mpi_abi_stubs/build_tarballs.jl
@@ -1,0 +1,58 @@
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
+
+# Collection of sources required to build mpi-abi-stubs
+name = "mpi_abi_stubs"
+# There are no released versions. We choose a recent commit.
+# This corresponds to the MPI standard 5.0.
+# Let's keep the major/minor version numbers corresponding to the MPI standard,
+# and use the patch number for minor updates.
+version = v"5.0.0"
+
+sources = [
+    GitSource("https://github.com/mpi-forum/mpi-abi-stubs", "6bc15b268d3c780259294ebea9ebaf11bdf8680a"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/mpi-abi-stubs
+cmake_args=(
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=${prefix}
+    -DCMAKE_PREFIX_PATH=${prefix}
+)
+cmake -Bbuild ${cmake_args[@]}
+cmake --build build --parallel ${nproc}
+cmake --install build
+"""
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+    $(MPI.augment)
+    augment_platform!(platform::Platform) = augment_mpi!(platform)
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# Add `mpi+mpiabi` platform tag
+for p in platforms
+    p["mpi"] = "MPIABI"
+end
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    RuntimeDependency(PackageSpec(name="MPIPreferences", uuid="3da0fdf6-3ccc-4f1b-acd9-58baa6c99267");
+                      compat="0.1", top_level=true),
+]
+
+# The products that we will ensure are always built.
+products = [
+    LibraryProduct("libmpi_abi", :libmpi_abi),
+]
+
+# Build the tarballs.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               augment_platform_block, julia_compat="1.6")

--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -46,8 +46,9 @@ const augment = raw"""
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
+# When building for `MPIABI`, build against `mpi_abi_stubs_jll`
 mpi_abis = (
-    ("MPIABI", PackageSpec(name="MPICH_MPIABI_jll"), "4.3.1 - 4", p -> !Sys.iswindows(p)),
+    ("MPIABI", PackageSpec(name="mpi_abi_stubs_jll"), "5.0.0"),
     ("MPICH", PackageSpec(name="MPICH_jll"), "4.3.0 - 4", p -> !Sys.iswindows(p)),
     ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5.5.3 - 5", p -> !Sys.iswindows(p) && !(libc(p) == "musl")),
     ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),
@@ -55,13 +56,13 @@ mpi_abis = (
 )
 
 """
-    augment_platforms(platforms; MPICH_compat = nothing, MPICH_MPIABI_compat = nothing, OpenMPI_compat = nothing, MicrosoftMPI_compat=nothing, MPItrampoline_compat=nothing)
+    augment_platforms(platforms; MPICH_compat = nothing, MPIABI_compat = nothing, OpenMPI_compat = nothing, MicrosoftMPI_compat=nothing, MPItrampoline_compat=nothing)
 
 This augments the platforms with different MPI versions. Compatibilities with different versions can be specified
 """
 function augment_platforms(platforms;
+                MPIABI_compat = nothing,
                 MPICH_compat = nothing,
-                MPICH_MPIABI_compat = nothing,
                 MPItrampoline_compat=nothing)
                 MicrosoftMPI_compat=nothing,
                 OpenMPI_compat = nothing,
@@ -70,7 +71,7 @@ function augment_platforms(platforms;
     for (abi, pkg, compat, f) in mpi_abis
 
         # set specific versions of MPI packages
-        if (abi=="MPIABI" && !isnothing(MPICH_MPIABI_compat)) compat = MPICH_MPIABI_compat; end
+        if (abi=="MPIABI" && !isnothing(MPIABI_compat)) compat = MPIABI_compat; end
         if (abi=="MPICH" && !isnothing(MPICH_compat)) compat = MPICH_compat; end
         if (abi=="MPItrampoline" && !isnothing(MPItrampoline_compat)) compat = MPItrampoline_compat; end
         if (abi=="MicrosoftMPI" && !isnothing(MicrosoftMPI_compat)) compat = MicrosoftMPI_compat; end


### PR DESCRIPTION
Add the package `mpi_abi_stubs` which is provided by the MPI forum (which defines the MPI standard). This package provides header files and a (non-functional) implementation of the MPI ABI.

Since this package provides a library it needs to be built for all platforms.

Since there will be (so I hope) several packages implementing the MPI ABI, building with this ABI should be against this official package. Running will the use another MPI implementation, e.g. MPICH (claims to already support the ABI) or an MPItrampoline-wrapped genering MPI library.

Also extend the list of platform MPI ABIs to include `MPIABI`.
