### PR TITLE
[GAP] Rebuild against latest libjulia

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -129,7 +129,7 @@ dependencies = [
     Dependency("GMP_jll"),
     Dependency("Readline_jll"; compat="8.2.13"),
     Dependency("Zlib_jll"),
-    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.17")),
+    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.19")),
 ]
 
 # Build the tarballs.


### PR DESCRIPTION
cc @fingolfin 

I am deliberately not bumping the version as I think it should also work this way. If rebuilding both this and GAP_pkg_juliainterface_jll indeed work and fix the 1.12 tests, I'll update our new `README.maintainer.md`.