### PR TITLE
0_RootFS bootstrap: Build libstdc++ to be compatible with both TLS and non-TLS ABI

### DIFF
--- a/0_RootFS/GCCBootstrap@14/bundled/patches/gcc/gcc1420-libstdcpp-tls-abi.patch
+++ b/0_RootFS/GCCBootstrap@14/bundled/patches/gcc/gcc1420-libstdcpp-tls-abi.patch
@@ -1,0 +1,166 @@
+From 648157c34413e7ecbbd9dffe871617042e46e7e9 Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliahub.com>
+Date: Tue, 15 Jul 2025 02:47:01 +0000
+Subject: [PATCH] libstdc++: Provide ABI compatibility when turning on
+ _GLIBCXX_HAVE_TLS
+
+The _GLIBCXX_HAVE_TLS flag is an ABI-breaking flag - setting it removes the
+definitions for `set_lock_ptr` (as well as the comptability symbols for
+even older ABIs). Try to improve this situation by changing the flag to
+retain the old symbols, falling back to the previous behavior if __once_call
+is not set. These symbols are used to forward closure data for the initialization
+from whichever thread ends up winning the pthread_once. The __once_call
+is set immediately before the pthread_once and unset (in a destructor)
+immediately after. To avoid the case where there may be a nested __once_proxy
+call that uses the old ABI, we also unset __once_call in the success path
+after retrieving the pointer.
+---
+ libstdc++-v3/src/c++11/mutex.cc | 111 +++++++++++++++++---------------
+ 1 file changed, 59 insertions(+), 52 deletions(-)
+
+diff --git a/libstdc++-v3/src/c++11/mutex.cc b/libstdc++-v3/src/c++11/mutex.cc
+index d5da5c66ae9..4be64633315 100644
+--- a/libstdc++-v3/src/c++11/mutex.cc
++++ b/libstdc++-v3/src/c++11/mutex.cc
+@@ -23,6 +23,7 @@
+ // <http://www.gnu.org/licenses/>.
+ 
+ #include <mutex>
++#include <bits/std_function.h>  // std::function
+ 
+ #ifdef _GLIBCXX_HAS_GTHREADS
+ 
+@@ -30,30 +31,17 @@ namespace std _GLIBCXX_VISIBILITY(default)
+ {
+ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 
+-#ifdef _GLIBCXX_HAVE_TLS
+-  __thread void* __once_callable;
+-  __thread void (*__once_call)();
++// Explicit instantiation due to -fno-implicit-instantiation.
++template class function<void()>;
+ 
+-  extern "C" void __once_proxy()
+-  {
+-    // The caller stored a function pointer in __once_call. If it requires
+-    // any state, it gets it from __once_callable.
+-    __once_call();
+-  }
++function<void()> __once_functor;
+ 
+-#else // ! TLS
+-
+-  // Explicit instantiation due to -fno-implicit-instantiation.
+-  template class function<void()>;
+-
+-  function<void()> __once_functor;
+-
+-  mutex&
+-  __get_once_mutex()
+-  {
+-    static mutex once_mutex;
+-    return once_mutex;
+-  }
++mutex&
++__get_once_mutex()
++{
++  static mutex once_mutex;
++  return once_mutex;
++}
+ 
+ namespace
+ {
+@@ -66,41 +54,60 @@ namespace
+   }
+ }
+ 
+-  // code linked against ABI 3.4.12 and later uses this
+-  void
+-  __set_once_functor_lock_ptr(unique_lock<mutex>* __ptr)
+-  {
+-    (void) set_lock_ptr(__ptr);
+-  }
++// code linked against ABI 3.4.12 and later uses this
++void
++__set_once_functor_lock_ptr(unique_lock<mutex>* __ptr)
++{
++  (void) set_lock_ptr(__ptr);
++}
+ 
+-  // unsafe - retained for compatibility with ABI 3.4.11
+-  unique_lock<mutex>&
+-  __get_once_functor_lock()
+-  {
+-    static unique_lock<mutex> once_functor_lock(__get_once_mutex(), defer_lock);
+-    return once_functor_lock;
+-  }
++// unsafe - retained for compatibility with ABI 3.4.11
++unique_lock<mutex>&
++__get_once_functor_lock()
++{
++  static unique_lock<mutex> once_functor_lock(__get_once_mutex(), defer_lock);
++  return once_functor_lock;
++}
+ 
+-  // This is called via pthread_once while __get_once_mutex() is locked.
+-  extern "C" void
+-  __once_proxy()
+-  {
+-    // Get the callable out of the global functor.
+-    function<void()> callable = std::move(__once_functor);
+-
+-    // Then unlock the global mutex
+-    if (unique_lock<mutex>* lock = set_lock_ptr(nullptr))
+-    {
+-      // Caller is using the new ABI and provided a pointer to its lock.
+-      lock->unlock();
++#ifdef _GLIBCXX_HAVE_TLS
++  __thread void* __once_callable;
++  __thread void (*__once_call)();
++#endif
++
++extern "C" void
++__once_proxy()
++{
++#ifdef _GLIBCXX_HAVE_TLS
++    if (__once_call) {
++      void (*this_once_call)() = __once_call;
++      // Reset __once_call early in case of a nested call to __once_proxy
++      // with the old ABI.
++      __once_call = NULL;
++      return this_once_call();
+     }
+-    else
+-      __get_once_functor_lock().unlock();  // global lock
+ 
+-    // Finally, invoke the callable.
+-    callable();
++    // For compatibility with callers linked against non-_GLIBCXX_HAVE_TLS ABI,
++    // we fall through here to the old behavior.
++#endif
++
++  // If the caller is not using _GLIBCXX_HAVE_TLS, this was called
++  // via pthread_once while __get_once_mutex() is locked.
++
++  // Get the callable out of the global functor.
++  function<void()> callable = std::move(__once_functor);
++
++  // Then unlock the global mutex
++  if (unique_lock<mutex>* lock = set_lock_ptr(nullptr))
++  {
++    // Caller is using the new ABI and provided a pointer to its lock.
++    lock->unlock();
+   }
+-#endif // ! TLS
++  else
++    __get_once_functor_lock().unlock();  // global lock
++
++  // Finally, invoke the callable.
++  callable();
++}
+ 
+ _GLIBCXX_END_NAMESPACE_VERSION
+ } // namespace std
+-- 
+2.43.0
+

--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -130,8 +130,6 @@ function gcc_script(gcc_version::VersionNumber, compiler_target::Platform)
     elif [[ "${COMPILER_TARGET}" == *-mingw* ]]; then
         # On mingw, we need to explicitly set the windres code page to 1, otherwise windres segfaults
         export CPPFLAGS="${CPPFLAGS} -DCP_ACP=1"
-        # Always disable TLS: https://github.com/JuliaLang/julia/pull/45582#issuecomment-1295697412
-        GCC_CONF_ARGS="${GCC_CONF_ARGS} --disable-tls"
 
     elif [[ "${COMPILER_TARGET}" == *-darwin* ]]; then
         # Use llvm archive tools to dodge binutils bugs


### PR DESCRIPTION
As reported in https://github.com/JuliaLang/julia/issues/57021, our Yggdrasil-built binaries no longer work out-of-the box with the msys2-provided mingw toolchain. This is not a good situation, because it basically means that partial BinaryBuilder-provided builds are off the table. The root cause of the issue is that at some point msys2 started building gcc (and libstdc++) with TLS support. Enabling TLS is an ABI-breaking change, because it removes symbols from libstdc++ that were referenced in the header. That said, I don't believe it is necessary for this to be ABI breaking. In particular, I think the included patch provides a correct ABI-compability implementation that supports applications linked against either the TLS enabled or disabled version. The net effect of this change would be that (after this is bumped on CSL) the new binaries we build would have TLS enabled and work on the new msys64 ABI as well as the new CSL, which any old binaries could continue to work on either the new CSL or the old CSL. Notably, new binaries would not work on the old CSL, so once we bump CSL, we'll have to put in new JLL compats for any newly built JLLs.

Note that this only changes the libstdc++ for GCC@14, which is the one we bundle in CSL. However, it does change the TLS flag for all versions of GCC, so that TLS will become enabled even when the new binaries are built with older GCC.