### PR TITLE
0_RootFS: Update MinGW sources to 14.0.0

### DIFF
--- a/0_RootFS/gcc_sources.jl
+++ b/0_RootFS/gcc_sources.jl
@@ -312,8 +312,8 @@ function gcc_sources(gcc_version::VersionNumber, compiler_target::Platform; kwar
         end
     elseif Sys.iswindows(compiler_target)
         libc_sources = [
-            ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v11.0.1.tar.bz2",
-                          "3f66bce069ee8bed7439a1a13da7cb91a5e67ea6170f21317ac7f5794625ee10"),
+            ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v13.0.0.tar.bz2",
+                          "5afe822af5c4edbf67daaf45eec61d538f49eef6b19524de64897c6b95828caf"),
         ]
     else
         error("Unknown libc mapping for platform $(compiler_target)")


### PR DESCRIPTION
As noted in https://github.com/JuliaLang/julia/issues/56840, our CSL-distributed msvcrt is no longer compatible with mingw as distributed in msys2. This is because https://github.com/mingw-w64/mingw-w64/commit/d0cad4c27090246be25ecd4fddaefd71ba8c27af added a call to _initterm_e but the corresponding msvcrt.a emulation was added in https://github.com/mingw-w64/mingw-w64/commit/6c89679ccc51ea4f218683e61943881a7038a1c9 which is newer than what we ship in CSL.

That said, it is not clear to me why we ship msvcrt.a from mingw in CSL at all. It makes sense to ship gnd dlls, but if we're not shipping a toolchain it's odd to ship msvcrt.a. After all, we're not shipping glibc either.