### PR TITLE
LLVM: Also build `libclang.a`

### DIFF
--- a/L/LLVM/LLVM_full@20/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@20/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: #11135
+# Build trigger: #11667

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -236,6 +236,9 @@ if [ -z "${LLVM_WANT_STATIC}" ]; then
     CMAKE_FLAGS+=(-DLLVM_SHLIB_SYMBOL_VERSION:STRING="JL_LLVM_${LLVM_MAJ_VER}.${LLVM_MIN_VER}")
 fi
 
+# We want to build the Clang monolithic static library (for Rust's bindgen)
+CMAKE_FLAGS+=(-DLIBCLANG_BUILD_STATIC:BOOL=ON)
+
 # We want to build LLVM with EH and RTTI
 if [ ! -z "${LLVM_WANT_EH_RTTI}" ]; then
     CMAKE_FLAGS+=(-DLLVM_ENABLE_RTTI=ON)


### PR DESCRIPTION
This static library can be used by the Rust `clang-sys` crate, which is used by `bindgen`. I'm hoping to use this to resolve an issue where picking up the default (static) musl results in a nonfunctional `dlopen`, breaking `bindgen`; this can be resolved by linking `libclang` statically such that `dlopen` is not required. See https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#static