### PR TITLE
[GAP_pkg_juliainterface] Rebuild v0.1300.103 against new libjulia

### DIFF
--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -9,15 +9,15 @@ using Pkg
 uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
-gap_version = v"400.1400.005"
+gap_version = v"400.1400.004"
 name = "JuliaInterface"
-upstream_version = "0.14.1" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "0.13.1" # when you increment this, reset offset to v"0.0.0"
+offset = v"0.0.3" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
-    GitSource("https://github.com/oscar-system/GAP.jl", "93b12dd37e581320232e892c18db9048f8c9ad83"),
+    GitSource("https://github.com/oscar-system/GAP.jl", "c33287b416ca30fcc386a6b192d67c1955fdae8f"),
 ]
 
 # Bash recipe for building across all platforms
@@ -37,8 +37,21 @@ install_license ../../LICENSE
 """
 
 name = gap_pkg_name(name)
-# dependencies = gap_pkg_dependencies(gap_version)
-platforms = gap_platforms(expand_julia_versions=true)
+platforms, dependencies = setup_gap_package(gap_version)
+
+# expand julia platforms
+include("../../../L/libjulia/common.jl")
+julia_platforms = []
+for p in platforms
+    for jv in julia_versions
+        if jv == v"1.6.3" && Sys.isapple(p) && arch(p) == "aarch64"
+            continue
+        end
+        p = deepcopy(p)
+        BinaryPlatforms.add_tag!(p.tags, "julia_version", string(jv))
+        push!(julia_platforms, p)
+    end
+end
 
 # Unlike other GAP_pkg_* JLLs, we do *not* set a compat bound for GAP_jll and
 # GAP_lib_jll here. Instead GAP.jl is expected to make sure that it uses right
@@ -63,7 +76,7 @@ products = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+build_tarballs(ARGS, name, version, sources, script, julia_platforms, products, dependencies;
                julia_compat="1.6", preferred_gcc_version=v"7")
 
 # rebuild trigger: 0

--- a/G/GAP_pkg/common.jl
+++ b/G/GAP_pkg/common.jl
@@ -27,10 +27,20 @@ function gap_pkg_name(name::String)
     return "GAP_pkg_$(lowercase(name))"
 end
 
-include("../GAP/common.jl") # make gap_platforms available
+function setup_gap_package(gap_version::VersionNumber)
 
-function gap_pkg_dependencies(gap_version::VersionNumber)
-    return BinaryBuilder.AbstractDependency[
+    platforms = supported_platforms()
+    filter!(p -> nbits(p) == 64, platforms) # we only care about 64bit builds
+    filter!(!Sys.iswindows, platforms)      # Windows is not supported
+
+    filter!(p -> arch(p) != "riscv64", platforms) # riscv64 is not supported atm
+
+    # TODO: re-enable FreeBSD aarch64 support once GAP_jll supports it
+    filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
+
+    dependencies = BinaryBuilder.AbstractDependency[
         Dependency("GAP_jll", gap_version; compat="~$(gap_version)"),
     ]
+
+    return platforms, dependencies
 end


### PR DESCRIPTION
The above is the version that Oscar v1.4.1 on julia 1.12.0-rc1 resolves to. With this rebuild, Oscar v1.4.1 should load again on julia 1.12 rc.
This PR resets the recipe back to https://github.com/lgoettgens/Yggdrasil/blob/86f0a6ac4aec5c17a88b1e05d13075e7e16d093b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl, with the single change of an updated `libjulia_jll` version number.

Immediately after this is merged, this PR should be reverted with `[skip ci]` and `[skip build]` so that we have the latest recipe on the yggy master again.

cc @fingolfin 