### PR TITLE
[aws_c_http_jq] Update to version 0.10.3

### DIFF
--- a/A/aws_c_http_jq/build_tarballs.jl
+++ b/A/aws_c_http_jq/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_http_jq"
-version = v"0.10.2"
+version = v"0.10.3"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/quinnj/aws-c-http.git", "26208db7d9158e67a278c76caf23e5c992751455"),
+    GitSource("https://github.com/quinnj/aws-c-http.git", "bfa03928d95771853d3bc952c30cad3ac7fdb361"),
 ]
 
 # Bash recipe for building across all platforms
@@ -37,8 +37,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("aws_c_compression_jll"; compat="0.3.1"),
-    Dependency("aws_c_io_jll"; compat="0.19.0"),
+    Dependency("aws_c_compression_jll"; compat="0.3.2"),
+    Dependency("aws_c_io_jll"; compat="0.21.0"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_http_jq to version 0.10.3. cc: @quinnj @Octogonapus