### PR TITLE
[oneAPI] libigc: add cherry-picks to v2.14.1

### DIFF
--- a/L/libigc/build_tarballs.jl
+++ b/L/libigc/build_tarballs.jl
@@ -65,6 +65,11 @@ function get_script(; debug::Bool)
         cd intel-graphics-compiler
         install_license LICENSE.md
 
+        # Need these device IDs
+        git cherry-pick 4185ee4c7eb49d09119884c63e88241a6715eb48
+        git cherry-pick 09046b0c259e46dfbdbfb1d548f18abc116ae512
+
+
         CMAKE_FLAGS=()
 
         # Select a build type


### PR DESCRIPTION
Added 2 cherry-picks that are not included in v2.14.1 but needed to build NEO.