### PR TITLE
[LibCURL] Build with zstd support

### DIFF
--- a/L/LibCURL/LibCURL@8/build_tarballs.jl
+++ b/L/LibCURL/LibCURL@8/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_libcurl(ARGS, "LibCURL", v"8.15.0")
+build_libcurl(ARGS, "LibCURL", v"8.15.0"; with_zstd=true)
 
 # Build trigger: 2


### PR DESCRIPTION
Since Zstd_jll is now a julia standard lib, there is no reason not to enable it in CURL (and in fact a source build currently enables it automatically). Ref https://github.com/JuliaLang/julia/issues/59171.