### PR TITLE
[minio] Bump MinIO version

### DIFF
--- a/M/minio/build_tarballs.jl
+++ b/M/minio/build_tarballs.jl
@@ -5,7 +5,8 @@ version = v"1.0.0"
 
 # Collection of sources
 sources = [
-    GitSource("https://github.com/minio/minio", "20c89ebbb30f44bbd0eba4e462846a89ab3a56fa"),
+    # RELEASE.2025-07-23T15-54-02Z
+    GitSource("https://github.com/minio/minio", "7ced9663e6a791fef9dc6be798ff24cda9c730ac"),
     ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
                   "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62"),
 ]


### PR DESCRIPTION
The version in use currently has a flaky segfault that makes CloudTest tests spuriously fail.