### PR TITLE
CUDA: Bump version of compiler JLL

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "CUDA_Compiler"
-version = v"0.1"
+version = v"0.2"
 
 augment_platform_block = read(joinpath(@__DIR__, "platform_augmentation.jl"), String)
 


### PR DESCRIPTION
Without a version bump, the new CUDA_Driver_jll compat doesn't work.