### PR TITLE
odrpack: new package for Odrpack.jl

### DIFF
--- a/O/Odrpack/build_tarballs.jl
+++ b/O/Odrpack/build_tarballs.jl
@@ -1,0 +1,41 @@
+using BinaryBuilder
+
+name = "odrpack95"
+version = v"2.0.1"
+
+# Collection of sources required to build ECOSBuilder
+sources = [
+    GitSource("https://github.com/HugoMVale/odrpack95.git", "54e58ae7f56564e358fb097f2108e4112498fce9")
+]
+
+platforms = [
+    # Platform("x86_64", "windows")
+    Platform("x86_64", "linux"; libc="glibc")
+]
+
+products = [
+    LibraryProduct("libodrpack95", :libodrpack95)
+]
+
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll")
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir/odrpack95
+
+# Set pkg-config path so Meson can find openblas.pc
+export PKG_CONFIG_PATH="${prefix}/lib/pkgconfig"
+
+# Optional: show what pkg-config sees
+pkg-config --list-all | grep blas || true
+
+# Configure Meson, build and install
+mkdir build && cd build
+meson .. --cross-file="${MESON_TARGET_TOOLCHAIN}" -Dbuild_shared=true
+ninja -j${nproc}
+ninja install
+"""
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    julia_compat="1.6", preferred_gcc_version=v"14")

--- a/O/Odrpack/build_tarballs.jl
+++ b/O/Odrpack/build_tarballs.jl
@@ -1,6 +1,6 @@
 using BinaryBuilder
 
-name = "odrpack95"
+name = "Odrpack"
 version = v"2.0.1"
 
 # Collection of sources required to build ECOSBuilder
@@ -13,12 +13,20 @@ platforms = [
     Platform("x86_64", "linux"; libc="glibc")
 ]
 
+# Disable RISC-V
+filter!(p -> arch(p) != "riscv64", platforms)
+
+platforms = expand_gfortran_versions(platforms)
+# Disable old libgfortran builds - only use libgfortran5
+filter!(p -> !(any(libgfortran_version(p) .== (v"4.0.0", v"3.0.0"))), platforms)
+
 products = [
     LibraryProduct("libodrpack95", :libodrpack95)
 ]
 
 dependencies = [
-    Dependency("CompilerSupportLibraries_jll")
+    Dependency("CompilerSupportLibraries_jll"),
+    Dependency("OpenBLAS32_jll")
 ]
 
 script = raw"""

--- a/O/odrpack/build_tarballs.jl
+++ b/O/odrpack/build_tarballs.jl
@@ -1,9 +1,8 @@
 using BinaryBuilder
 
-name = "Odrpack"
+name = "odrpack"
 version = v"2.0.1"
 
-# Collection of sources required to build ECOSBuilder
 sources = [
     GitSource("https://github.com/HugoMVale/odrpack95.git", "54e58ae7f56564e358fb097f2108e4112498fce9")
 ]
@@ -13,9 +12,7 @@ platforms = [
     Platform("x86_64", "linux"; libc="glibc")
 ]
 
-# Disable RISC-V
 filter!(p -> arch(p) != "riscv64", platforms)
-
 platforms = expand_gfortran_versions(platforms)
 # Disable old libgfortran builds - only use libgfortran5
 filter!(p -> !(any(libgfortran_version(p) .== (v"4.0.0", v"3.0.0"))), platforms)


### PR DESCRIPTION
This package will contain the binaries corresponding to the Fortran source code  [odrpack](https://github.com/HugoMVale/odrpack95).
This jll then be called by the companion bindings package [Odrpack.jl](https://github.com/HugoMVale/Odrpack.jl).