### PR TITLE
[SPIRV_LLVM_TRANSLATOR] add patch for addrspacecast of null

### DIFF
--- a/S/SPIRV_LLVM_Translator/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/build_tarballs.jl
@@ -14,12 +14,14 @@ llvm_version = v"20.1.2"
 sources = [
     GitSource(
         "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",
-        "dee371987a59ed8654083c09c5f1d5c54f5db318")
+        "dee371987a59ed8654083c09c5f1d5c54f5db318"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 get_script(llvm_version) = raw"""
 cd SPIRV-LLVM-Translator
+atomic_patch -p1 ../addrspacecast_null.patch
 install_license LICENSE.TXT
 
 if [[ ("${target}" == x86_64-apple-darwin*) ]]; then

--- a/S/SPIRV_LLVM_Translator/bundled/addrspacecast_null.patch
+++ b/S/SPIRV_LLVM_Translator/bundled/addrspacecast_null.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/SPIRV/SPIRVWriter.cpp b/lib/SPIRV/SPIRVWriter.cpp
+index d668ee89..4ae4f7ca 100644
+--- a/lib/SPIRV/SPIRVWriter.cpp
++++ b/lib/SPIRV/SPIRVWriter.cpp
+@@ -1628,6 +1628,9 @@ SPIRVValue *LLVMToSPIRVBase::transUnaryInst(UnaryInstruction *U,
+       } else {
+         BOC = OpCrossWorkgroupCastToPtrINTEL;
+       }
++    } else if (isa<ConstantPointerNull>(Cast->getPointerOperand())) {
++      SPIRVType *TransTy = transScavengedType(U);
++      return BM->addNullConstant(bcast<SPIRVTypePointer>(TransTy));
+     } else {
+       getErrorLog().checkError(
+           SrcAddrSpace == SPIRAS_Generic, SPIRVEC_InvalidModule, U,


### PR DESCRIPTION
Required after the codegen changes in JuliaLang/julia#58837

Upstream PR opened at KhronosGroup/SPIRV-LLVM-Translator#3305
