### PR TITLE
[GAP_pkg_juliainterface] Try to fix build

### DIFF
--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -66,4 +66,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.6", preferred_gcc_version=v"7")
 
-# rebuild trigger: 0
+# rebuild trigger: 1


### PR DESCRIPTION
The CI in https://github.com/JuliaPackaging/Yggdrasil/pull/11812 succeeded, but in the merge commit https://github.com/JuliaPackaging/Yggdrasil/commit/17f85c03318b23ad8e0af1c1abea69916a843d82 then failed, resulting in no registration of the changes in https://github.com/JuliaPackaging/Yggdrasil/pull/11812.
This PR tries to track down why this failed and re-register the version from https://github.com/JuliaPackaging/Yggdrasil/pull/11812.

cc @fingolfin 