### PR TITLE
oneAPI: Fix unversioned library link

### DIFF
--- a/N/NEO/build_tarballs.jl
+++ b/N/NEO/build_tarballs.jl
@@ -24,6 +24,8 @@ function get_script(; debug::Bool)
         # a script around ocloc that detects when the build is reported
         # successful and ignores the segfault.
         atomic_patch -p0 ./patches/ocloc.patch
+        # Fix OpenCL ICD installation to use prefix instead of /etc
+        atomic_patch -p0 ./patches/install_to_prefix.patch
         cp ocloc_wrapper.sh compute-runtime/shared/source/built_ins/kernels/ocloc_wrapper.sh
         mkdir -p tmpdir
         export TMPDIR=$(pwd)/tmpdir

--- a/N/NEO/bundled/patches/install_to_prefix.patch
+++ b/N/NEO/bundled/patches/install_to_prefix.patch
@@ -1,0 +1,14 @@
+--- compute-runtime/package.cmake.original	2025-08-14 21:19:17.045175056 -0500
++++ compute-runtime/package.cmake	2025-08-14 21:20:49.708282078 -0500
+@@ -46,9 +46,9 @@
+   if(NOT DEFINED OCL_ICD_VENDORDIR)
+     if("${os_name}" STREQUAL "clear-linux-os")
+       # clear-linux-os distribution avoids /etc for distribution defaults.
+-      set(OCL_ICD_VENDORDIR "/usr/share/defaults/etc/OpenCL/vendors")
++      set(OCL_ICD_VENDORDIR "${CMAKE_INSTALL_PREFIX}/share/defaults/etc/OpenCL/vendors")
+     else()
+-      set(OCL_ICD_VENDORDIR "/etc/OpenCL/vendors")
++      set(OCL_ICD_VENDORDIR "${CMAKE_INSTALL_PREFIX}/etc/OpenCL/vendors")
+     endif()
+   endif()
+


### PR DESCRIPTION
For some reason I forgot, I added the unversioned link. In that case NEO_jll picks that one up, which is not good.