### PR TITLE
[GAP_lib] Set julia compat bound to 1.10

### DIFF
--- a/G/GAP_lib/build_tarballs.jl
+++ b/G/GAP_lib/build_tarballs.jl
@@ -22,7 +22,7 @@ using BinaryBuilder, Pkg
 
 name = "GAP_lib"
 upstream_version = v"4.14.0"
-version = v"400.1400.004"
+version = v"400.1400.005"
 
 # Collection of sources required to complete build
 sources = [
@@ -77,6 +77,7 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.10")
 
 # Build trigger: 1


### PR DESCRIPTION
Previously, it hadn't had any compat bound. But having support for julia 1.5 in a jll has 30 transitive dependencies, instead of 8 without. And since this jll is only used in GAP.jl which has a compat of 1.10, I think we can increase this here all the way to 1.10 as well. 

cc @fingolfin 