### PR TITLE
[Singular] Revert "update to 4.4.1p1 (#11851)"

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -29,7 +29,7 @@ import Pkg.Types: VersionSpec
 name = "Singular"
 
 upstream_version = v"4.4.1-3" # 4.4.1
-version_offset = v"0.0.0"
+version_offset = v"0.0.1"
 
 version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + version_offset.major,
                         upstream_version.patch * 100 + version_offset.minor,
@@ -37,7 +37,7 @@ version = VersionNumber(upstream_version.major * 100 + upstream_version.minor + 
 
 # Collection of sources required to build Singular
 sources = [
-    GitSource("https://github.com/Singular/Singular.git", "2bb69e4d59e9a3e99ece691ee53178d6391e758f"),
+    GitSource("https://github.com/Singular/Singular.git", "595d7167e6e019d45d9a4f1e18ae741df1f3c41d"),
     #ArchiveSource("https://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/$(upstream_version.major)-$(upstream_version.minor)-$(upstream_version.patch)/singular-$(upstream_version).tar.gz",
     #              "5b0f6c036b4a6f58bf620204b004ec6ca3a5007acc8352fec55eade2fc9d63f6"),
     #DirectorySource("./bundled")


### PR DESCRIPTION
#11851 seems to cause a lot of trouble downstream (see https://github.com/oscar-system/Oscar.jl/issues/5201 and the further failures of the form
```
      From worker 3:	  wrong range[1] in ideal/module _(0)
      From worker 3:	  error occurred in or before primdec.lib::primdecGTZ_i line 5743: `   return(convList(decomp_i(patchPrimaryDecomposition,i,#)));`
      From worker 3:	  leaving primdec.lib::primdecGTZ_i (5685)
``` in https://github.com/oscar-system/Oscar.jl/actions/runs/16991011239/job/48170353920?pr=5202#step:10:4645.

Thus, I would suggest that we immediately revert that change (but still bump the version number), so that Oscar users get basically the previous version. We can then re-land #11851 with a minor version change instead, so that we don't get this to Oscar users immediately but only via a manual SIngular.jl release.
