### PR TITLE
[SPIRV_LLVM_BACKEND] carry patch for atomic_cmpxchg issue

### DIFF
--- a/S/SPIRV_LLVM_Backend/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Backend/build_tarballs.jl
@@ -18,7 +18,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-mv llvm-* llvm
+mv llvm-*.src llvm
 mv cmake-* cmake
 mv third-party-* third-party
 
@@ -27,6 +27,7 @@ LLVM_SRCDIR=$(pwd)
 
 atomic_patch -p1 $WORKSPACE/srcdir/patches/avoid_builtin_available.patch
 atomic_patch -p1 $WORKSPACE/srcdir/patches/fix_insertvalue.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/atomic_cmpxchg_64bit.patch
 
 install_license LICENSE.TXT
 

--- a/S/SPIRV_LLVM_Backend/bundled/patches/atomic_cmpxchg_64bit.patch
+++ b/S/SPIRV_LLVM_Backend/bundled/patches/atomic_cmpxchg_64bit.patch
@@ -1,0 +1,74 @@
+From 2ffa8bb80d2806aaa913dcd2a35a8f298d511458 Mon Sep 17 00:00:00 2001
+From: Simeon David Schaub <simeon@schaub.rocks>
+Date: Tue, 19 Aug 2025 11:14:53 +0200
+Subject: [PATCH] [SPIR-V] fix return type for OpAtomicCompareExchange
+
+fixes #152863
+
+Tests were written with some help from Copilot
+---
+ lib/Target/SPIRV/SPIRVBuiltins.cpp            |  3 +-
+ .../AtomicCompareExchange64BitPhiNode.ll      | 35 +++++++++++++++++++
+ 2 files changed, 36 insertions(+), 2 deletions(-)
+ create mode 100644 llvm/test/CodeGen/SPIRV/AtomicCompareExchange64BitPhiNode.ll
+
+diff --git a/lib/Target/SPIRV/SPIRVBuiltins.cpp b/lib/Target/SPIRV/SPIRVBuiltins.cpp
+index 95fa7bc3894f..4bc5c4ab377b 100644
+--- a/lib/Target/SPIRV/SPIRVBuiltins.cpp
++++ b/lib/Target/SPIRV/SPIRVBuiltins.cpp
+@@ -791,10 +791,9 @@ static bool buildAtomicCompareExchangeInst(
+     MRI->setRegClass(Tmp, GR->getRegClass(SpvDesiredTy));
+   GR->assignSPIRVTypeToVReg(SpvDesiredTy, Tmp, MIRBuilder.getMF());
+ 
+-  SPIRVType *IntTy = GR->getOrCreateSPIRVIntegerType(32, MIRBuilder);
+   MIRBuilder.buildInstr(Opcode)
+       .addDef(Tmp)
+-      .addUse(GR->getSPIRVTypeID(IntTy))
++      .addUse(GR->getSPIRVTypeID(SpvDesiredTy))
+       .addUse(ObjectPtr)
+       .addUse(ScopeReg)
+       .addUse(MemSemEqualReg)
+diff --git a/test/CodeGen/SPIRV/AtomicCompareExchange64BitPhiNode.ll b/test/CodeGen/SPIRV/AtomicCompareExchange64BitPhiNode.ll
+new file mode 100644
+index 000000000000..63023c63958d
+--- /dev/null
++++ b/test/CodeGen/SPIRV/AtomicCompareExchange64BitPhiNode.ll
+@@ -0,0 +1,35 @@
++; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
++; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o %t.spv -filetype=obj
++; RUN: spirv-val %t.spv
++
++; Regression test for issue https://github.com/llvm/llvm-project/issues/152863
++; Ensure OpAtomicCompareExchange returns the correct i64 type when used in phi nodes.
++; Previously, this would generate invalid SPIR-V where the atomic operation returned
++; uint (32-bit) but the phi node expected ulong (64-bit), causing validation errors.
++
++; CHECK-SPIRV-DAG: %[[#Long:]] = OpTypeInt 64 0
++; CHECK-SPIRV-DAG: %[[#Ptr:]] = OpTypePointer CrossWorkgroup %[[#Long]]
++; CHECK-SPIRV-DAG: %[[#Void:]] = OpTypeVoid
++; CHECK-SPIRV-DAG: %[[#Int:]] = OpTypeInt 32 0
++; CHECK-SPIRV-DAG: %[[#Zero64:]] = OpConstantNull %[[#Long]]
++; CHECK-SPIRV-DAG: %[[#Scope:]] = OpConstant %[[#Int]] 2
++; CHECK-SPIRV-DAG: %[[#MemSem:]] = OpConstant %[[#Int]] 0
++
++; Verify that both the phi node and atomic operation use the same i64 type
++; CHECK-SPIRV: %[[#ValuePhi:]] = OpPhi %[[#Long]] %[[#Zero64]] %[[#]] %[[#AtomicResult:]] %[[#]]
++; CHECK-SPIRV: %[[#AtomicResult]] = OpAtomicCompareExchange %[[#Long]] %[[#]] %[[#Scope]] %[[#MemSem]] %[[#MemSem]] %[[#Zero64]] %[[#ValuePhi]]
++
++target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
++target triple = "spirv64-unknown-unknown"
++
++declare i64 @_Z14atomic_cmpxchgPU8CLglobalVlll(ptr addrspace(1), i64, i64)
++
++define spir_kernel void @test_atomic_cmpxchg_phi(ptr addrspace(1) %ptr) {
++conversion:
++  br label %L6
++
++L6:                                               ; preds = %L6, %conversion
++  %value_phi = phi i64 [ 0, %conversion ], [ %1, %L6 ]
++  %1 = call i64 @_Z14atomic_cmpxchgPU8CLglobalVlll(ptr addrspace(1) %ptr, i64 %value_phi, i64 0)
++  br label %L6
++}
+-- 
+2.50.1
+


### PR DESCRIPTION
fixes JuliaGPU/OpenCL.jl#353

upstream PR opened at llvm/llvm-project#154297
