### PR TITLE
Blosc2: Bump major version number

### DIFF
--- a/B/Blosc2/build_tarballs.jl
+++ b/B/Blosc2/build_tarballs.jl
@@ -8,7 +8,9 @@ upstream_version = v"2.20.0"
 # We add a version offset because:
 # - Blosc2 2.15 is not ABI-compatible with Blosc2 2.14
 #   (see the release notes <https://github.com/Blosc/c-blosc2/releases/tag/v2.15.0>)
-version_offset = v"1.0.0"
+# - Blosc2 2.20 is not ABI-compatible with Blosc2 2.18
+#   (the shared library SOVERSION was increased)
+version_offset = v"2.0.0"
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
                         upstream_version.patch * 100 + version_offset.patch)


### PR DESCRIPTION
The old build needs to be yanked https://github.com/JuliaRegistries/General/pull/136971.