### PR TITLE
[OpenBLAS] Backport patch to 0.3.23 to fix ASUM error

### DIFF
--- a/O/OpenBLAS/OpenBLAS32@0.3.23/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS32@0.3.23/build_tarballs.jl
@@ -17,4 +17,4 @@ build_tarballs(ARGS, name, version, sources, script, platforms, products, depend
                preferred_gcc_version=v"6", preferred_llvm_version=v"13.0.1", lock_microarchitecture=false, julia_compat="1.10")
 
 
-# Build trigger: 1
+# Build trigger: 2

--- a/O/OpenBLAS/OpenBLAS32@0.3.23/bundled/patches/openblas-asum-fix.patch
+++ b/O/OpenBLAS/OpenBLAS32@0.3.23/bundled/patches/openblas-asum-fix.patch
@@ -1,0 +1,68 @@
+From 9019bc494514a74c2042152cdca0a36adea7b42f Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Sat, 4 Nov 2023 22:10:06 +0100
+Subject: [PATCH] Use SkylakeX ?ASUM microkernel for Cooperlake/Sapphirerapids
+ as well
+
+---
+ kernel/x86_64/casum.c | 2 +-
+ kernel/x86_64/dasum.c | 2 +-
+ kernel/x86_64/sasum.c | 2 +-
+ kernel/x86_64/zasum.c | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/kernel/x86_64/casum.c b/kernel/x86_64/casum.c
+index 60feec0ce..e4d054311 100644
+--- a/kernel/x86_64/casum.c
++++ b/kernel/x86_64/casum.c
+@@ -4,7 +4,7 @@
+ #define ABS_K(a) ((a) > 0 ? (a) : (-(a)))
+ #endif
+ 
+-#if defined(SKYLAKEX)
++#if defined(SKYLAKEX) || defined(COOPERLAKE) || defined(SAPPHIRERAPIDS)
+ #include "casum_microk_skylakex-2.c"
+ #endif
+ 
+diff --git a/kernel/x86_64/dasum.c b/kernel/x86_64/dasum.c
+index a9c40f38f..0147c6978 100644
+--- a/kernel/x86_64/dasum.c
++++ b/kernel/x86_64/dasum.c
+@@ -4,7 +4,7 @@
+ #define ABS_K(a) ((a) > 0 ? (a) : (-(a)))
+ #endif
+ 
+-#if defined(SKYLAKEX)
++#if defined(SKYLAKEX) || defined(COOPERLAKE) || defined(SAPPHIRERAPIDS)
+ #include "dasum_microk_skylakex-2.c"
+ #elif defined(HASWELL) || defined(ZEN)
+ #include "dasum_microk_haswell-2.c"
+diff --git a/kernel/x86_64/sasum.c b/kernel/x86_64/sasum.c
+index 37a92468f..3f22cb97a 100644
+--- a/kernel/x86_64/sasum.c
++++ b/kernel/x86_64/sasum.c
+@@ -9,7 +9,7 @@
+ 
+ #endif
+ 
+-#if defined(SKYLAKEX)
++#if defined(SKYLAKEX) || defined(COOPERLAKE) || defined(SAPPHIRERAPIDS)
+ #include "sasum_microk_skylakex-2.c"
+ #elif defined(HASWELL) || defined(ZEN)
+ #include "sasum_microk_haswell-2.c"
+diff --git a/kernel/x86_64/zasum.c b/kernel/x86_64/zasum.c
+index 80e95a2c8..3f17ab1cf 100644
+--- a/kernel/x86_64/zasum.c
++++ b/kernel/x86_64/zasum.c
+@@ -4,7 +4,7 @@
+ #define ABS_K(a) ((a) > 0 ? (a) : (-(a)))
+ #endif
+ 
+-#if defined(SKYLAKEX)
++#if defined(SKYLAKEX) || defined(COOPERLAKE) || defined(SAPPHIRERAPIDS)
+ #include "zasum_microk_skylakex-2.c"
+ #endif
+ 
+-- 
+2.50.1
+

--- a/O/OpenBLAS/OpenBLAS@0.3.23/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS@0.3.23/build_tarballs.jl
@@ -17,4 +17,4 @@ dependencies = openblas_dependencies(platforms)
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"6", preferred_llvm_version=v"13.0.1", lock_microarchitecture=false, julia_compat="1.10")
 
-# Build trigger: 4
+# Build trigger: 5

--- a/O/OpenBLAS/OpenBLAS@0.3.23/bundled/patches/openblas-asum-fix.patch
+++ b/O/OpenBLAS/OpenBLAS@0.3.23/bundled/patches/openblas-asum-fix.patch
@@ -1,0 +1,68 @@
+From 9019bc494514a74c2042152cdca0a36adea7b42f Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Sat, 4 Nov 2023 22:10:06 +0100
+Subject: [PATCH] Use SkylakeX ?ASUM microkernel for Cooperlake/Sapphirerapids
+ as well
+
+---
+ kernel/x86_64/casum.c | 2 +-
+ kernel/x86_64/dasum.c | 2 +-
+ kernel/x86_64/sasum.c | 2 +-
+ kernel/x86_64/zasum.c | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/kernel/x86_64/casum.c b/kernel/x86_64/casum.c
+index 60feec0ce..e4d054311 100644
+--- a/kernel/x86_64/casum.c
++++ b/kernel/x86_64/casum.c
+@@ -4,7 +4,7 @@
+ #define ABS_K(a) ((a) > 0 ? (a) : (-(a)))
+ #endif
+ 
+-#if defined(SKYLAKEX)
++#if defined(SKYLAKEX) || defined(COOPERLAKE) || defined(SAPPHIRERAPIDS)
+ #include "casum_microk_skylakex-2.c"
+ #endif
+ 
+diff --git a/kernel/x86_64/dasum.c b/kernel/x86_64/dasum.c
+index a9c40f38f..0147c6978 100644
+--- a/kernel/x86_64/dasum.c
++++ b/kernel/x86_64/dasum.c
+@@ -4,7 +4,7 @@
+ #define ABS_K(a) ((a) > 0 ? (a) : (-(a)))
+ #endif
+ 
+-#if defined(SKYLAKEX)
++#if defined(SKYLAKEX) || defined(COOPERLAKE) || defined(SAPPHIRERAPIDS)
+ #include "dasum_microk_skylakex-2.c"
+ #elif defined(HASWELL) || defined(ZEN)
+ #include "dasum_microk_haswell-2.c"
+diff --git a/kernel/x86_64/sasum.c b/kernel/x86_64/sasum.c
+index 37a92468f..3f22cb97a 100644
+--- a/kernel/x86_64/sasum.c
++++ b/kernel/x86_64/sasum.c
+@@ -9,7 +9,7 @@
+ 
+ #endif
+ 
+-#if defined(SKYLAKEX)
++#if defined(SKYLAKEX) || defined(COOPERLAKE) || defined(SAPPHIRERAPIDS)
+ #include "sasum_microk_skylakex-2.c"
+ #elif defined(HASWELL) || defined(ZEN)
+ #include "sasum_microk_haswell-2.c"
+diff --git a/kernel/x86_64/zasum.c b/kernel/x86_64/zasum.c
+index 80e95a2c8..3f17ab1cf 100644
+--- a/kernel/x86_64/zasum.c
++++ b/kernel/x86_64/zasum.c
+@@ -4,7 +4,7 @@
+ #define ABS_K(a) ((a) > 0 ? (a) : (-(a)))
+ #endif
+ 
+-#if defined(SKYLAKEX)
++#if defined(SKYLAKEX) || defined(COOPERLAKE) || defined(SAPPHIRERAPIDS)
+ #include "zasum_microk_skylakex-2.c"
+ #endif
+ 
+-- 
+2.50.1
+


### PR DESCRIPTION
This backports the upstream commit that fixes the ASUM computation error reported in https://github.com/JuliaLang/LinearAlgebra.jl/issues/1406 to 0.3.23 so it can be included in Julia 1.10.