### PR TITLE
[coveralls] Add recipe

### DIFF
--- a/C/coveralls/build_tarballs.jl
+++ b/C/coveralls/build_tarballs.jl
@@ -34,8 +34,7 @@ apk add --no-cache \
     libevent-dev \
     libevent-static \
     gc-dev \
-    libxml2-dev \
-    libxml2-static
+    libxml2-dev
 
 # Set environment variables for static linking
 export CRYSTAL_CACHE_DIR=${WORKSPACE}/crystal_cache


### PR DESCRIPTION
A recipe for https://github.com/coverallsapp/coverage-reporter which we need a macOS binary for, and they only serve it via homebrew.