### PR TITLE
Fix formatting of component-owners action reference

### DIFF
--- a/.github/workflows/component_owners.yml
+++ b/.github/workflows/component_owners.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Auto Assign Owners
     steps:
-      - uses: dyladan/component-owners@ 58bd86e9814d23f1525d0a970682cead459fa783 # v0.1.0
+      - uses: dyladan/component-owners@58bd86e9814d23f1525d0a970682cead459fa783 # v0.1.0
         with:
           config-file: .github/component_owners.yml
           repo-token: ${{ github.token }} 


### PR DESCRIPTION
A pesky space slipped into #11917 