### PR TITLE
[CUDA_Compiler_jll] Add a runtime dependency on CUDA_Runtime_jll

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -59,7 +59,8 @@ fi
 """
 
 dependencies = [
-    Dependency("CUDA_Driver_jll", v"13.0"; compat="13")
+    Dependency("CUDA_Driver_jll", v"13.0"; compat="13"),
+    RuntimeDependency("CUDA_Runtime_jll"),
 ]
 
 products = [

--- a/C/CUDA/CUDA_Compiler/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Compiler/platform_augmentation.jl
@@ -5,7 +5,6 @@ using Libdl
 # re-use the CUDA_Runtime_jll preference to select the appropriate compiler
 const CUDA_Runtime_jll_uuid = Base.UUID("76a88914-d11a-5bdc-97e0-2f5a05c973a2")
 const preferences = Base.get_preferences(CUDA_Runtime_jll_uuid)
-Base.record_compiletime_preference(CUDA_Runtime_jll_uuid, "version")
 function parse_version_preference(key)
     if haskey(preferences, key)
         if isa(preferences[key], String)


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/julia/issues/59257 we can't declare compile time preferences on preferences not owned by the package.
We must therefore declare a RuntimeDependency (like we do on MPIPreference) on CUDA_Runtime_jll so that CUDA_Compiler_jll get's invalidated on preference changes.
