### PR TITLE
Don't request reviews when doing component notifications

### DIFF
--- a/.github/workflows/component_owners.yml
+++ b/.github/workflows/component_owners.yml
@@ -24,4 +24,6 @@ jobs:
           config-file: .github/component_owners.yml
           repo-token: ${{ github.token }} 
           assign-owners: "true"
-          request-owner-reviews: "true"
+          # We only use this system to notify people about the proposed changes,
+          # not as a way of delegating a review.
+          request-owner-reviews: "false"


### PR DESCRIPTION
We are going to be treating this system as just an advisory/notification system for letting relevant people know about changes to packages, they are not expected (or required to) do reviews on them if they don't want to (or have nothing to say).