### PR TITLE
[GAP_pkg_juliainterface] Rebuild with GAP 4.15.0

### DIFF
--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -53,7 +53,7 @@ platforms = gap_platforms(expand_julia_versions=true)
 # that's a small risk, usually immediately detected in CI test, and fixing it
 # is easy as it only requires a change to GAP.jl, not to any JLLs.
 dependencies = [
-    Dependency("GAP_jll", gap_version),
+    Dependency(PackageSpec(; name="GAP_jll", url="http://github.com/lgoettgens/GAP_jll.jl")), # DO NOT MERGE, this line has to be reverted
     BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.20")),
 ]
 


### PR DESCRIPTION
Companion to https://github.com/JuliaPackaging/Yggdrasil/pull/11987.

I am getting the following build failure locally:
```julia
[16:32:07]  ---> cd GAP.jl/pkg/JuliaInterface
[16:32:07]  ---> ./configure --with-gaproot=${prefix}/lib/gap
[16:32:07]  ---> make CFLAGS="-I${includedir} -I${includedir}/julia" LDFLAGS="-ljulia -lgap" V=1
[16:32:07] src/JuliaInterface.c:19:10: fatal error: julia_gc.h: No such file or directory
[16:32:07]  #include <julia_gc.h>    // GAP header
[16:32:07]           ^~~~~~~~~~~~
[16:32:07] compilation terminated.
[16:32:07] make: *** [Makefile.gappkg:119: gen/src/JuliaInterface.o] Error 1
[16:32:07]  ---> make CFLAGS="-I${includedir} -I${includedir}/julia" LDFLAGS="-ljulia -lgap" V=1
[16:32:07]  ---> make CFLAGS="-I${includedir} -I${includedir}/julia" LDFLAGS="-ljulia -lgap" V=1
[16:32:07] Previous command exited with 2
[16:32:07] Child Process exited, exit code 2
```

I remebember seeing discussions about gap headers somewhere, but I don't find it anymore nor is there something in the release notes. This could also be related to https://github.com/JuliaPackaging/Yggdrasil/pull/11987#discussion_r2313918603. @fingolfin do you have an idea what's going on here?