### PR TITLE
CUDA: Consider device capabilities when loading a newer driver.

### DIFF
--- a/C/CUDA/CUDA_Driver/init.jl
+++ b/C/CUDA/CUDA_Driver/init.jl
@@ -28,21 +28,23 @@ end
 
 libcuda_deps = [libcuda_debugger, libnvidia_nvvm, libnvidia_ptxjitcompiler]
 libcuda_system = Sys.iswindows() ? "nvcuda" : "libcuda.so.1"
-can_use_compat = true
+
+# if anything goes wrong, we'll use the system driver
+global libcuda = libcuda_system
 
 # check if we even have an artifact
 if @isdefined(libcuda_compat)
     @debug "Forward-compatible driver found at $libcuda_compat"
 else
     @debug "No forward-compatible driver available for your platform."
-    can_use_compat = false
+    return
 end
 
 # check the user preference
 if compat_preference !== missing
     if !compat_preference
         @debug "User disallows using forward-compatible driver."
-        can_use_compat = false
+        return
     end
 end
 
@@ -50,60 +52,136 @@ end
 # the code that loaded it in the first place might have made assumptions based on it.
 if Libdl.dlopen(libcuda_system, Libdl.RTLD_NOLOAD; throw_error=false) !== nothing
     @debug "System CUDA driver already loaded, continuing using it."
-    can_use_compat = false
+    return
 end
 
-# check if we can load the forward-compatible driver in a separate process
-function try_driver(driver, deps)
+# helper function to load a driver, query its version, and optionally query device
+# capabilities. needs to happen in a separate process because dlclose is unreliable.
+function inspect_driver(driver, deps=String[]; inspect_devices=false)
     script = raw"""
         using Libdl
-        driver, deps... = ARGS
 
-        for dep in deps
-            Libdl.dlopen(dep; throw_error=false) === nothing && exit(-1)
+        const DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR = 75
+        const DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR = 76
+
+        function main(driver, inspect_devices, deps...)
+            inspect_devices = parse(Bool, inspect_devices)
+
+            for dep in deps
+                Libdl.dlopen(dep; throw_error=false) === nothing && exit(-1)
+            end
+
+            library_handle = Libdl.dlopen(driver; throw_error=false)
+            library_handle === nothing && return -1
+
+            cuInit = Libdl.dlsym(library_handle, "cuInit")
+            status = ccall(cuInit, Cint, (UInt32,), 0)
+            status == 0 || return -2
+
+            cuDriverGetVersion = Libdl.dlsym(library_handle, "cuDriverGetVersion")
+            version = Ref{Cint}()
+            status = ccall(cuDriverGetVersion, Cint, (Ptr{Cint},), version)
+            status == 0 || return -3
+            major, ver = divrem(version[], 1000)
+            minor, patch = divrem(ver, 10)
+            println(major, ".", minor, ".", patch)
+
+            if inspect_devices
+                cuDeviceGetCount = Libdl.dlsym(library_handle, "cuDeviceGetCount")
+                device_count = Ref{Cint}()
+                status = ccall(cuDeviceGetCount, Cint, (Ptr{Cint},), device_count)
+                status == 0 || return -4
+
+                cuDeviceGet = Libdl.dlsym(library_handle, "cuDeviceGet")
+                cuDeviceGetAttribute = Libdl.dlsym(library_handle, "cuDeviceGetAttribute")
+                for i in 1:device_count[]
+                    device = Ref{Cint}()
+                    status = ccall(cuDeviceGet, Cint, (Ptr{Cint}, Cint), device, i-1)
+                    status == 0 || return -5
+
+                    major = Ref{Cint}()
+                    status = ccall(cuDeviceGetAttribute, Cint, (Ptr{Cint}, UInt32, Cint), major, DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device[])
+                    status == 0 || return -6
+                    minor = Ref{Cint}()
+                    status = ccall(cuDeviceGetAttribute, Cint, (Ptr{Cint}, UInt32, Cint), minor, DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device[])
+                    status == 0 || return -7
+                    println(major[], ".", minor[])
+                end
+            end
+
+            return 0
         end
 
-        library_handle = Libdl.dlopen(driver; throw_error=false)
-        library_handle === nothing && exit(-1)
-
-        function_handle = Libdl.dlsym(library_handle, "cuInit")
-        status = ccall(function_handle, Cint, (UInt32,), 0)
-        status == 0 || exit(-2)
-
-        exit(0)
+        exit(main(ARGS...))
     """
 
     # make sure we don't include any system image flags here since this will cause an infinite loop of __init__()
     cmd = ```$(Cmd(filter(!startswith(r"-J|--sysimage"), Base.julia_cmd().exec)))
-             --compile=min -t1 --startup-file=no
-             -e $script $driver $deps```
-    proc = withenv("JULIA_LOAD_PATH"=> nothing, "JULIA_DEPOT_PATH"=> nothing) do
-        # make sure we use a fresh environment we can load Libdl in
-        run(ignorestatus(cmd))
+             -O0 --compile=min -t1 --startup-file=no
+             -e $script $driver $inspect_devices $deps```
+
+    # make sure we use a fresh environment we can load Libdl in
+    cmd = addenv(cmd, "JULIA_LOAD_PATH" => nothing, "JULIA_DEPOT_PATH" => nothing)
+
+    # run the command
+    out = Pipe()
+    proc = run(pipeline(cmd, stdout=out, stderr=stdout), wait=false)
+    close(out.in)
+    t = wait(proc)
+    success(proc) || return nothing
+
+    # parse the versions
+    version_strings = readlines(out)
+    driver_version = parse(VersionNumber, version_strings[1])
+    if inspect_devices
+        device_capabilities = map(str -> parse(VersionNumber, str), version_strings[2:end])
+        return driver_version, device_capabilities
+    else
+        return driver_version
     end
-    success(proc)
 end
 
-if can_use_compat && !try_driver(libcuda_compat, libcuda_deps)
+# fetch driver details
+compat_driver_task = Threads.@spawn inspect_driver(libcuda_compat, libcuda_deps)
+system_driver_task = Threads.@spawn inspect_driver(libcuda_system; inspect_devices=true)
+compat_driver_details = fetch(compat_driver_task)
+if compat_driver_details === nothing
     @debug "Failed to load forwards-compatible driver."
-    can_use_compat = false
+    return
 end
+compat_driver_version = compat_driver_details::VersionNumber
+@debug "Forwards compatible driver version: $compat_driver_version"
+system_driver_details = fetch(system_driver_task)
+if system_driver_details === nothing
+    @debug "Failed to load system driver."
+    return
+end
+system_driver_version = system_driver_details[1]::VersionNumber
+device_capabilities = system_driver_details[2]::Vector{VersionNumber}
+@debug "System driver version: $system_driver_version"
 
-# finally, load the appropriate driver
-if can_use_compat
-    @debug "Using forwards-compatible CUDA driver."
-    global libcuda = libcuda_compat
-
-    # load the driver and its dependencies; this should now always succeed
-    # as we've already verified that we can load it in a separate process.
-    for dep in libcuda_deps
-        Libdl.dlopen(dep; throw_error=true)
+# determine if loading the forwards-compatible driver would exclude devices
+for (dev, cap) in enumerate(device_capabilities)
+    # CUDA 12 deprecated Kepler
+    if compat_driver_version >= v"12" && system_driver_version < v"12" && v"3.0" <= cap <= v"3.5"
+        @debug "Loading forwards-compatible driver would exclude device $dev with capability $cap"
+        return
     end
-    Libdl.dlopen(libcuda_compat; throw_error=true)
-elseif Libdl.dlopen(libcuda_system; throw_error=false) !== nothing
-    @debug "Using system CUDA driver."
-    global libcuda = libcuda_system
-else
-    @debug "Could not load system CUDA driver."
-    global libcuda = nothing
+
+    # CUDA 13 deprecated Maxwell, Pascal, and Volta
+    if compat_driver_version >= v"13" && system_driver_version < v"13" && v"5.0" <= cap <= v"7.2"
+        @debug "Loading forwards-compatible driver would exclude device $dev with capability $cap"
+        return
+    end
 end
+
+# finally, load the forwards-compatible driver
+@debug "Using forwards-compatible CUDA driver."
+global libcuda = libcuda_compat
+
+# load the driver and its dependencies; this should now always succeed
+# as we've already verified that we can load it in a separate process.
+for dep in libcuda_deps
+    Libdl.dlopen(dep; throw_error=true)
+end
+Libdl.dlopen(libcuda_compat; throw_error=true)


### PR DESCRIPTION
As it turns out, the forwards compatible driver can now be loaded across major versions. This is great! However, it also exposes us to inadvertently breaking older devices, as noticed in https://github.com/JuliaGPU/CUDA.jl/issues/2844. To prevent this, make CUDA_Driver_jll.jl's `__init__` even more complicated, by inspecting available devices (in a separate process, of course) and using that information to decide whether or not to load the forwards-compatible driver.

Regresses load time of CUDA_Driver_jll by about 30%. On some respectable systems I tested on, it's about 700ms now.

Closes https://github.com/JuliaGPU/CUDA.jl/issues/2844