### PR TITLE
CUDA: Fix platform passed to 'parse_sources' by compiler JLL recipe.

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -104,7 +104,7 @@ for version in [ v"11.8", v"12.9", v"13.0"]
 
         push!(builds,
             (; script, platforms=[augmented_platform], products, init_block,
-               sources=get_sources("cuda", components; version, platform),
+               sources=get_sources("cuda", components; version, platform=augmented_platform),
         ))
     end
 end

--- a/C/CUDA/common.jl
+++ b/C/CUDA/common.jl
@@ -18,6 +18,9 @@ function parse_sources(json::String, product::String, components::Vector{String}
     root = "https://developer.download.nvidia.com/compute/$product/redist"
 
     redist = JSON3.read(json)
+    if !haskey(platform, "cuda")
+        error("Please provide a platform that has the 'cuda' tag set, indicating which CUDA toolkit version this product is to be used with.")
+    end
     cuda_version = platform["cuda"]
     architecture = if Sys.islinux(platform)
         libc(platform) == "glibc" || error("Only glibc is supported on Linux")


### PR DESCRIPTION
Addresses https://github.com/JuliaPackaging/Yggdrasil/commit/7befe851c92cdf29501ed92149d835755e3422c4#commitcomment-165076454
Closes https://github.com/JuliaGPU/CUDA.jl/issues/2851

cc @kshyatt 