### PR TITLE
Git: Update last Windows 32-bit version

### DIFF
--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "Git"
-version = v"2.51.0"
+version = v"2.51.1"
 
 # <https://github.com/git-for-windows/git/releases> says:
 # "Git for Windows v2.48.1 was the last version to ship with the i686 ("32-bit") variant of the installer, portable Git and archive."

--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -4,6 +4,7 @@ using BinaryBuilder
 
 name = "Git"
 version = v"2.51.1"
+upstream_version = v"2.51.0"
 
 # <https://github.com/git-for-windows/git/releases> says:
 # "Git for Windows v2.48.1 was the last version to ship with the i686 ("32-bit") variant of the installer, portable Git and archive."
@@ -12,11 +13,11 @@ last_windows_32_bit_version = v"2.50.1"
 
 # Collection of sources required to build Git
 sources = [
-    ArchiveSource("https://mirrors.edge.kernel.org/pub/software/scm/git/git-$(version).tar.xz",
+    ArchiveSource("https://mirrors.edge.kernel.org/pub/software/scm/git/git-$(upstream_version).tar.xz",
                   "60a7c2251cc2e588d5cd87bae567260617c6de0c22dca9cdbfc4c7d2b8990b62"),
     ArchiveSource("https://github.com/git-for-windows/git/releases/download/v$(last_windows_32_bit_version).windows.1/Git-$(last_windows_32_bit_version)-32-bit.tar.bz2",
                   "796d8f4fdd19c668e348d04390a3528df61cfc9864d1f276d9dc585a8a0ac82c"; unpack_target = "i686-w64-mingw32"),
-    ArchiveSource("https://github.com/git-for-windows/git/releases/download/v$(version).windows.1/Git-$(version)-64-bit.tar.bz2",
+    ArchiveSource("https://github.com/git-for-windows/git/releases/download/v$(upstream_version).windows.1/Git-$(upstream_version)-64-bit.tar.bz2",
                   "151bddf70e1115631e62bb05535b5e6726b3813e1f363953ad6b4e6697d96933"; unpack_target = "x86_64-w64-mingw32"),
 ]
 

--- a/G/Git/build_tarballs.jl
+++ b/G/Git/build_tarballs.jl
@@ -7,14 +7,15 @@ version = v"2.51.0"
 
 # <https://github.com/git-for-windows/git/releases> says:
 # "Git for Windows v2.48.1 was the last version to ship with the i686 ("32-bit") variant of the installer, portable Git and archive."
-last_windows_32_bit_version = v"2.48.1"
+# But v2.50.1 was made available "after warranty" to address critical vulnerabilities: https://github.com/git-for-windows/git/releases/tag/v2.50.1.windows.1
+last_windows_32_bit_version = v"2.50.1"
 
 # Collection of sources required to build Git
 sources = [
     ArchiveSource("https://mirrors.edge.kernel.org/pub/software/scm/git/git-$(version).tar.xz",
                   "60a7c2251cc2e588d5cd87bae567260617c6de0c22dca9cdbfc4c7d2b8990b62"),
     ArchiveSource("https://github.com/git-for-windows/git/releases/download/v$(last_windows_32_bit_version).windows.1/Git-$(last_windows_32_bit_version)-32-bit.tar.bz2",
-                  "41af3c80fd618855ad20b441f5f47763cece1ed07f6849ecbdb43066d0aa1dfd"; unpack_target = "i686-w64-mingw32"),
+                  "796d8f4fdd19c668e348d04390a3528df61cfc9864d1f276d9dc585a8a0ac82c"; unpack_target = "i686-w64-mingw32"),
     ArchiveSource("https://github.com/git-for-windows/git/releases/download/v$(version).windows.1/Git-$(version)-64-bit.tar.bz2",
                   "151bddf70e1115631e62bb05535b5e6726b3813e1f363953ad6b4e6697d96933"; unpack_target = "x86_64-w64-mingw32"),
 ]


### PR DESCRIPTION
This installer was made available "after warranty" to address a number of vulnerability advisories.

https://github.com/git-for-windows/git/releases/tag/v2.50.1.windows.1

Should this bump the patch version of the JLL itself?