### PR TITLE
[GAP_pkg_juliainterface] Rebuild with latest libjulia

### DIFF
--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -66,4 +66,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.10", preferred_gcc_version=v"7")
 
-# rebuild trigger: 1
+# rebuild trigger: 0


### PR DESCRIPTION
This needs to wait until https://github.com/JuliaPackaging/Yggdrasil/pull/12018 is merged and released. I'll restart the build then.