### PR TITLE
[odrpack] update to 3.0.1; no closures

### DIFF
--- a/O/odrpack/build_tarballs.jl
+++ b/O/odrpack/build_tarballs.jl
@@ -30,4 +30,4 @@ ninja install
 """
 # gcc-14 fails with x86_64-apple
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", clang_use_lld=false, preferred_gcc_version=v"13")
+               julia_compat="1.6", clang_use_lld=false, preferred_gcc_version=v"12")


### PR DESCRIPTION
This library version has no closures, which removes the need for an executable stack (required by GCC), and can be invoked from the Julia REPL with raising a stackoverflow error.