### PR TITLE
`AcousticsToolbox`: add license information

### DIFF
--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -26,7 +26,7 @@ cd $WORKSPACE/srcdir/ORCA_Mode_modelling_gfortran/src
 perl -p -i -e 's/\r\n/\n/g;' cw_modes.f
 atomic_patch -p1 $WORKSPACE/srcdir/patches/cw_modes.patch
 rm -f *.o *.mod ../bin/*
-make
+make -j${nproc}
 install -Dvm 755 "../bin/orca90${exeext}" "${bindir}/orca90.exe"
 install_license $WORKSPACE/srcdir/at/LICENSE
 install_license $WORKSPACE/srcdir/licenses/LICENSE-orca.txt

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -28,6 +28,8 @@ atomic_patch -p1 $WORKSPACE/srcdir/patches/cw_modes.patch
 rm -f *.o *.mod ../bin/*
 make
 cp ../bin/orca90* $bindir/orca90.exe
+install_license $WORKSPACE/srcdir/at/LICENSE
+install_license $WORKSPACE/srcdir/bundled/licenses/LICENSE-orca.txt
 """
 
 # These are the platforms we will build for by default, unless further

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -28,7 +28,9 @@ atomic_patch -p1 $WORKSPACE/srcdir/patches/cw_modes.patch
 rm -f *.o *.mod ../bin/*
 # don't add -j as it fails
 make
-install -Dvm 755 "../bin/orca90${exeext}" "${bindir}/orca90.exe"
+# install script fails on libfortran3 and libfortran4 on w64 where .exe is not added during compilation
+# install -Dvm 755 "../bin/orca90${exeext}" "${bindir}/orca90.exe"
+cp ../bin/orca90* $bindir/orca90.exe
 install_license $WORKSPACE/srcdir/at/LICENSE
 install_license $WORKSPACE/srcdir/licenses/LICENSE-orca.txt
 """

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -4,7 +4,7 @@
 using BinaryBuilder, Pkg
 
 name = "AcousticsToolbox"
-version = VersionNumber("2025.09.05")
+version = VersionNumber("2025.9.6")
 
 # Collection of sources required to complete build
 sources = [

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -27,7 +27,7 @@ perl -p -i -e 's/\r\n/\n/g;' cw_modes.f
 atomic_patch -p1 $WORKSPACE/srcdir/patches/cw_modes.patch
 rm -f *.o *.mod ../bin/*
 make
-cp ../bin/orca90* $bindir/orca90.exe
+install -Dvm 755 "../bin/orca90${exeext}" "${bindir}/orca90.exe"
 install_license $WORKSPACE/srcdir/at/LICENSE
 install_license $WORKSPACE/srcdir/licenses/LICENSE-orca.txt
 """

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -26,7 +26,8 @@ cd $WORKSPACE/srcdir/ORCA_Mode_modelling_gfortran/src
 perl -p -i -e 's/\r\n/\n/g;' cw_modes.f
 atomic_patch -p1 $WORKSPACE/srcdir/patches/cw_modes.patch
 rm -f *.o *.mod ../bin/*
-make -j${nproc}
+# don't add -j as it fails
+make
 install -Dvm 755 "../bin/orca90${exeext}" "${bindir}/orca90.exe"
 install_license $WORKSPACE/srcdir/at/LICENSE
 install_license $WORKSPACE/srcdir/licenses/LICENSE-orca.txt

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -29,7 +29,7 @@ rm -f *.o *.mod ../bin/*
 make
 cp ../bin/orca90* $bindir/orca90.exe
 install_license $WORKSPACE/srcdir/at/LICENSE
-install_license $WORKSPACE/srcdir/bundled/licenses/LICENSE-orca.txt
+install_license $WORKSPACE/srcdir/licenses/LICENSE-orca.txt
 """
 
 # These are the platforms we will build for by default, unless further

--- a/A/AcousticsToolbox/build_tarballs.jl
+++ b/A/AcousticsToolbox/build_tarballs.jl
@@ -30,7 +30,7 @@ rm -f *.o *.mod ../bin/*
 make
 # install script fails on libfortran3 and libfortran4 on w64 where .exe is not added during compilation
 # install -Dvm 755 "../bin/orca90${exeext}" "${bindir}/orca90.exe"
-cp ../bin/orca90* $bindir/orca90.exe
+install -Dvm 755 ../bin/orca90* "${bindir}/orca90.exe"
 install_license $WORKSPACE/srcdir/at/LICENSE
 install_license $WORKSPACE/srcdir/licenses/LICENSE-orca.txt
 """

--- a/A/AcousticsToolbox/bundled/licenses/LICENSE-orca.txt
+++ b/A/AcousticsToolbox/bundled/licenses/LICENSE-orca.txt
@@ -1,0 +1,21 @@
+
+ COPYRIGHT (c) 2008
+ 
+ Applied Research Laboratories, The University of Texas at Austin
+ (ARL:UT)
+ All rights reserved.
+ 
+ This material may be reproduced by or for the U.S. Government
+ only. This notice must appear in all copies of this file and its
+ derivatives. Further distribution outside the U.S. Government is
+ prohibited without the explicit written authorization from the
+ Director of the Environmental Sciences Laboratory, ARL:UT.
+ 
+ THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ PURPOSE, OR NONINFRINGEMENT.
+ 
+ IN NO EVENT WILL ARL:UT BE LIABLE FOR ANY DAMAGES WHATSOEVER ARISING
+ OUT OF THE USE OR INABILITY TO USE THIS SOFTWARE, EVEN IF ARL:UT HAS
+ BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.


### PR DESCRIPTION
The last PR (https://github.com/JuliaPackaging/Yggdrasil/pull/12013) was missing installation of LICENSE file into the tarball. This PR fixes that.