### PR TITLE
[Gap_pkg_*] Update to gap 4.15.0 and new versioning scheme

### DIFF
--- a/G/GAP_pkg/GAP_pkg_ace/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_ace/build_tarballs.jl
@@ -3,8 +3,8 @@
 include("../common.jl")
 
 name = "ace"
-upstream_version = "5.6.2" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version
+upstream_version = "5.7.0" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # This package only produces an executable and does not need GAP for this at all.
@@ -12,7 +12,7 @@ version = offset_version(upstream_version, offset)
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/ace/releases/download/v$(upstream_version)/ace-$(upstream_version).tar.gz",
-                  "9cc94cd6327147b8b538341ba7594e4252a80ca7c960ac6749224efa437c9b66"),
+                  "7123e4100f1340a791d20bca1a8d9e6d9f09fe74a1c5fb15f1723899a1bb4553"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_anupq/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_anupq/build_tarballs.jl
@@ -3,8 +3,8 @@
 include("../common.jl")
 
 name = "anupq"
-upstream_version = "3.3.1" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version
+upstream_version = "3.3.2" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # This package only produces an executable and does not need GAP for this at all.
@@ -13,7 +13,7 @@ version = offset_version(upstream_version, offset)
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/anupq/releases/download/v$(upstream_version)/anupq-$(upstream_version).tar.gz",
-                  "fba1526f9e904e13ee7a9b980c795fbf27a8276c6734d684c1f91ebb3a1926b6"),
+                  "2ee92fc2314ad139cc6800a8a21e5dfbde04a6182f4867dc32c20024b2ac3bca"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_browse/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "Browse"
 upstream_version = "1.8.21" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.3" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_caratinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_caratinterface/build_tarballs.jl
@@ -4,7 +4,7 @@ include("../common.jl")
 
 name = "caratinterface"
 upstream_version = "2.3.7" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version
 version = offset_version(upstream_version, offset)
 
 # This package only produces an executable and does not need GAP for this at all.
@@ -140,3 +140,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.10", preferred_gcc_version=v"7")
 
+# rebuild trigger: 1

--- a/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cddinterface/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "cddinterface"
-upstream_version = "2024.09.02" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.3" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "2025.06.24" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/homalg-project/CddInterface/releases/download/v$(upstream_version)/CddInterface-$(upstream_version).tar.gz",
-                  "5a59b6306c2b4e75d499cf1465c0b38a22cc275aa76defcfe62aaa365e1b69d1"),
+                  "fc3f4ae2b4cb27152bf82d3a64a3aec63be283c83090e586204540a12b0d4883"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_cohomolo/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cohomolo/build_tarballs.jl
@@ -4,7 +4,7 @@ include("../common.jl")
 
 name = "cohomolo"
 upstream_version = "1.6.11" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # This package only produces an executable and does not need GAP for this at all.
@@ -69,3 +69,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.10", preferred_gcc_version=v"7")
 
+# rebuild trigger: 1

--- a/G/GAP_pkg/GAP_pkg_crypting/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_crypting/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "crypting"
-upstream_version = "0.10.5" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "0.10.6" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/crypting/releases/download/v$(upstream_version)/crypting-$(upstream_version).tar.gz",
-                  "bbb8d321bc1e616a975960a7ecdddb8478f70e9ccc3d6e77c7c30283153aafc5"),
+                  "946b05c75e877de8aea71b5bf0af74f79b392064793fda7322e4895073e7cf6a"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_curlinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_curlinterface/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "curlinterface"
-upstream_version = "2.4.0" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "2.4.2" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/curlInterface/releases/download/v$(upstream_version)/curlInterface-$(upstream_version).tar.gz",
-                  "6f758ad512edf033ba8892875c3216cf111feb5b856909b84889cad89c78a4ff"),
+                  "973d4b518bb25295fa36e367c54fd257adb7af4723634f039f53dae507855756"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_cvec/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "cvec"
-upstream_version = "2.8.2" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "2.8.4" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/cvec/releases/download/v$(upstream_version)/cvec-$(upstream_version).tar.gz",
-                  "6232ed29003713263ec95b0c562d710cf3fd18015266dc34a4b51581c2a1461b"),
+                  "0df5c9d9b5e55002f596e79a4a799d09554d4964683fbd8f813ed2f9d2f5635f"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_datastructures/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "datastructures"
-upstream_version = "0.3.1" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "0.3.3" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/datastructures/releases/download/v$(upstream_version)/datastructures-$(upstream_version).tar.gz",
-                  "0d4fba02f80e7c5eada63fae0402effbbe2ccbeb4d204c1d826cc85e67a582b0"),
+                  "c0231ad18ae23a4da6c62373df5032c3bd284dae922e05362551fe55a6a14c0d"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_deepthought/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_deepthought/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "deepthought"
-upstream_version = "1.0.7" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "1.0.9" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/DeepThought/releases/download/v$(upstream_version)/DeepThought-$(upstream_version).tar.gz",
-                  "01d89babd2f62307bb0c4fe42303c6c645192ca6141ce02299c1c240e92ea93a"),
+                  "4eda8cddaa8987473b963c740d6f1f647099a92112a1e7c8bba4fff7515fb5e4"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
@@ -4,14 +4,14 @@ include("../common.jl")
 
 gap_version = v"400.1500.0"
 name = "digraphs"
-upstream_version = "1.12.1" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.12.2" # when you increment this, reset offset to v"0.0.0"
 offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/digraphs/Digraphs/releases/download/v$(upstream_version)/digraphs-$(upstream_version).tar.gz",
-                  "d565360b528c468686086d15294a58edc9c50fa99d982645efd42de2742b7da5"),
+                  "7dfbc15618282e40bddafd3524d3fcf48a7a80ce5725069a1e3f34e5f44cec2c"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "digraphs"
-upstream_version = "1.9.0" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "1.11.0" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/digraphs/Digraphs/releases/download/v$(upstream_version)/digraphs-$(upstream_version).tar.gz",
-                  "08dcc08be73a042f85ec1694111f91b1026b3241483f74f7100b308bbf9c4f11"),
+                  "e1968f3bc2ffccd99fb407836e9f67c8916aa8e3362ffec9e0d9c653efbfb1e8"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
@@ -4,14 +4,14 @@ include("../common.jl")
 
 gap_version = v"400.1500.0"
 name = "digraphs"
-upstream_version = "1.12.2" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.13.1" # when you increment this, reset offset to v"0.0.0"
 offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/digraphs/Digraphs/releases/download/v$(upstream_version)/digraphs-$(upstream_version).tar.gz",
-                  "7dfbc15618282e40bddafd3524d3fcf48a7a80ce5725069a1e3f34e5f44cec2c"),
+                  "b965094b187b448c36edac9eb8400809adcd3045df7067aea47ba3dd5fec7396"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
@@ -4,14 +4,14 @@ include("../common.jl")
 
 gap_version = v"400.1500.0"
 name = "digraphs"
-upstream_version = "1.11.0" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.12.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/digraphs/Digraphs/releases/download/v$(upstream_version)/digraphs-$(upstream_version).tar.gz",
-                  "e1968f3bc2ffccd99fb407836e9f67c8916aa8e3362ffec9e0d9c653efbfb1e8"),
+                  "c6a16647437a17d6cfe76cd53f33e6e35e118f57e1e732f4fc147167657eabc4"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_digraphs/build_tarballs.jl
@@ -4,14 +4,14 @@ include("../common.jl")
 
 gap_version = v"400.1500.0"
 name = "digraphs"
-upstream_version = "1.12.0" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.12.1" # when you increment this, reset offset to v"0.0.0"
 offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/digraphs/Digraphs/releases/download/v$(upstream_version)/digraphs-$(upstream_version).tar.gz",
-                  "c6a16647437a17d6cfe76cd53f33e6e35e118f57e1e732f4fc147167657eabc4"),
+                  "d565360b528c468686086d15294a58edc9c50fa99d982645efd42de2742b7da5"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_edim/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_edim/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "EDIM"
 upstream_version = "1.3.8" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.3" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_ferret/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_ferret/build_tarballs.jl
@@ -4,14 +4,14 @@ include("../common.jl")
 
 gap_version = v"400.1500.0"
 name = "ferret"
-upstream_version = "1.0.14" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "1.0.15" # when you increment this, reset offset to v"0.0.0"
 offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/ferret/releases/download/v$(upstream_version)/ferret-$(upstream_version).tar.gz",
-                  "6e9b7e5aa98dbcafaf5630560b53d42c53dd97d4c7137c2bcf80045c4710d995"),
+                  "2850f3c13114cb4c05f8da16104d63db94452fe2c7fb642caa7a7ad863e802a0"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_ferret/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_ferret/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "ferret"
 upstream_version = "1.0.14" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_float/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_float/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "float"
-upstream_version = "1.0.5" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "1.0.9" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/float/releases/download/v$(upstream_version)/float-$(upstream_version).tar.gz",
-                  "d7c07cc3fe892c2fd8a808624ee3e24d5412e44e38325a7e946bab821d3b75a0"),
+                  "cf4e87714ef774d5d760ef252f81bcfe6d0b3bb726ae263c602c68cd5d3a495b"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_fplsa/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_fplsa/build_tarballs.jl
@@ -3,8 +3,8 @@
 include("../common.jl")
 
 name = "fplsa"
-upstream_version = "1.2.6" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version
+upstream_version = "1.2.7" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version
 version = offset_version(upstream_version, offset)
 
 # This package only produces an executable and does not need GAP for this at all.
@@ -12,7 +12,7 @@ version = offset_version(upstream_version, offset)
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/FPLSA/releases/download/v$(upstream_version)/FPLSA-$(upstream_version).tar.gz",
-                  "cd9fb93eb4198955070d836575e15f6e156c7fee417fef9c42c8fc3502ba422f"),
+                  "eb3400869479a547c80f7b461ce0dceec5d480fa7042f2abffc2fd8d3df05fc3"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_gauss/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_gauss/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "gauss"
 upstream_version = "2024.11-01" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL

--- a/G/GAP_pkg/GAP_pkg_guava/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_guava/build_tarballs.jl
@@ -3,8 +3,8 @@
 include("../common.jl")
 
 name = "guava"
-upstream_version = "3.19" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version
+upstream_version = "3.20" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version
 version = offset_version(upstream_version, offset)
 
 # This package only produces an executable and does not need GAP for this at all.
@@ -12,7 +12,7 @@ version = offset_version(upstream_version, offset)
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/guava/releases/download/v$(upstream_version)/guava-$(upstream_version).tar.gz",
-                  "653fa83dfb97702eab0936c2e8db6d293a4d55fd73f8e5e6f3847ee19da3fe3d"),
+                  "a6a19aae3dc8d32569d2c98715c3de84df88e65819ce70bdb7595850de5cbe56"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_io/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_io/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "io"
-upstream_version = "4.9.1" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "4.9.3" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/io/releases/download/v$(upstream_version)/io-$(upstream_version).tar.gz",
-                  "edb0a8ab61ad36664e2ddaab38af052ad3e063479dfdb7985a10ebb8b1c7795b"),
+                  "842926c02ecdfcc16ff31468c376dcf4fbb7faa5094e637c83d7b00a503900c3"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_json/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_json/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "json"
-upstream_version = "2.2.2" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "2.2.3" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/json/releases/download/v$(upstream_version)/json-$(upstream_version).tar.gz",
-                  "4991f1f1fadba4b2369ba808a5976b722261ea1dbe11d15339260983684c953b"),
+                  "a504a50d662c3d1167e25aba9be2f528a2f907c832a4dd452e7e915a3ebc5f39"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -17,7 +17,7 @@ version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
-    GitSource("https://github.com/oscar-system/GAP.jl", "26e001ad3de107eec866090e59916ec46abdcda1"), # DO NOT MERGE, this commit is on a temporary branch
+    GitSource("https://github.com/oscar-system/GAP.jl", "00b09a25508495a60e53c65de6aaf2f16ec4fb5c"), # DO NOT MERGE, this commit is on a temporary branch
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -9,9 +9,9 @@ using Pkg
 uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
 delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "JuliaInterface"
-upstream_version = "0.15.3" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "0.16.0" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
@@ -54,7 +54,7 @@ platforms = gap_platforms(expand_julia_versions=true)
 # is easy as it only requires a change to GAP.jl, not to any JLLs.
 dependencies = [
     Dependency("GAP_jll", gap_version),
-    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.19")),
+    BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.20")),
 ]
 
 # The products that we will ensure are always built

--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -17,7 +17,7 @@ version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
-    GitSource("https://github.com/oscar-system/GAP.jl", "43ec515a9c5e8f087e32c87e5412c600b8329a85"),
+    GitSource("https://github.com/oscar-system/GAP.jl", "26e001ad3de107eec866090e59916ec46abdcda1"), # DO NOT MERGE, this commit is on a temporary branch
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -53,7 +53,7 @@ platforms = gap_platforms(expand_julia_versions=true)
 # that's a small risk, usually immediately detected in CI test, and fixing it
 # is easy as it only requires a change to GAP.jl, not to any JLLs.
 dependencies = [
-    Dependency("GAP_jll", gap_version),
+    Dependency(PackageSpec(; name="GAP_jll", url="http://github.com/lgoettgens/GAP_jll.jl")), # DO NOT MERGE, this line has to be reverted
     BuildDependency(PackageSpec(;name="libjulia_jll", version=v"1.10.20")),
 ]
 

--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -17,7 +17,7 @@ version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
-    GitSource("https://github.com/oscar-system/GAP.jl", "00b09a25508495a60e53c65de6aaf2f16ec4fb5c"), # DO NOT MERGE, this commit is on a temporary branch
+    GitSource("https://github.com/oscar-system/GAP.jl", "43ec515a9c5e8f087e32c87e5412c600b8329a85"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_kbmag/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_kbmag/build_tarballs.jl
@@ -4,7 +4,7 @@ include("../common.jl")
 
 name = "kbmag"
 upstream_version = "1.5.11" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version
 version = offset_version(upstream_version, offset)
 
 # This package only produces an executable and does not need GAP for this at all.
@@ -101,3 +101,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.10", preferred_gcc_version=v"7")
 
+# rebuild trigger: 1

--- a/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_normalizinterface/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "NormalizInterface"
-upstream_version = "1.3.7" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.4" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "1.4.1" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/NormalizInterface/releases/download/v$(upstream_version)/NormalizInterface-$(upstream_version).tar.gz",
-                  "286700d82a2b5a240ff8474990cecfb22526a80b0f28252a95f4792ccde4cb6b"),
+                  "b186c1719f9110bbf96600283a7ab201851ab46571c00487be004a264063b572"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_nq/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_nq/build_tarballs.jl
@@ -4,7 +4,7 @@ include("../common.jl")
 
 name = "nq"
 upstream_version = "2.5.11" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version
 version = offset_version(upstream_version, offset)
 
 # This package only produces an executable and does not need GAP for this at all.
@@ -52,3 +52,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.10", preferred_gcc_version=v"7")
 
+# rebuild trigger: 1

--- a/G/GAP_pkg/GAP_pkg_orb/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_orb/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "orb"
-upstream_version = "4.9.1" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "5.0.1" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/orb/releases/download/v$(upstream_version)/orb-$(upstream_version).tar.gz",
-                  "747b963f1125b51244b279ed090f2a15d480d88beb4782b1ae0307fbc3daed8a"),
+                  "3f8430f5ba49bab1ce69d13894fff30bc1dd04bbf371e4a872740c93c51fd246"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_profiling/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_profiling/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "profiling"
-upstream_version = "2.6.0" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "2.6.2" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/profiling/releases/download/v$(upstream_version)/profiling-$(upstream_version).tar.gz",
-                  "6bdb7e3e908c45d4b683be4fbb60a733ec75a171c242e16251d5ed8602cac43a"),
+                  "bc8bb0839ee400915df1c809ba9ba131c34bd022d194db4d4828115d7dbf8e99"),
 ]
 
 # Bash recipe for building across all platforms
@@ -30,6 +30,7 @@ install_license COPYRIGHT
 name = gap_pkg_name(name)
 dependencies = gap_pkg_dependencies(gap_version)
 platforms = gap_platforms()
+platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "semigroups"
-upstream_version = "5.4.0" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.4" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "5.5.4" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/semigroups/Semigroups/releases/download/v$(upstream_version)/semigroups-$(upstream_version).tar.gz",
-                  "9a22d6c6cd2a99392e286b6a4636258cdf50a308655dc11f444696aa4880d98e"),
+                  "df0488b14af106338009c0ae7dc8b7def9052fb3619a6ba53c31f60cc0731353"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/GAP_pkg_simpcomp/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_simpcomp/build_tarballs.jl
@@ -4,7 +4,7 @@ include("../common.jl")
 
 name = "simpcomp"
 upstream_version = "2.1.14" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.1" # increment this when rebuilding with unchanged upstream_version
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # This package only produces an executable and does not need GAP for this at all.
@@ -45,3 +45,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.10", preferred_gcc_version=v"7")
 
+# rebuild trigger: 1

--- a/G/GAP_pkg/GAP_pkg_simpcomp/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_simpcomp/build_tarballs.jl
@@ -32,6 +32,7 @@ install_license COPYING
 name = gap_pkg_name(name)
 
 platforms = gap_platforms()
+platforms = expand_cxxstring_abis(platforms)
 
 dependencies = Dependency[
 ]

--- a/G/GAP_pkg/GAP_pkg_zeromqinterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_zeromqinterface/build_tarballs.jl
@@ -2,16 +2,16 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
 
-gap_version = v"400.1401.5"
+gap_version = v"400.1500.0"
 name = "zeromqinterface"
-upstream_version = "0.16" # when you increment this, reset offset to v"0.0.0"
-offset = v"0.0.2" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
+upstream_version = "0.17" # when you increment this, reset offset to v"0.0.0"
+offset = v"1.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
     ArchiveSource("https://github.com/gap-packages/ZeroMQInterface/releases/download/v$(upstream_version)/ZeroMQInterface-$(upstream_version).tar.gz",
-                  "da9fc9ee04ba701b224d0809fdf4fc5b9782d9399326982273f77419fb3bd400"),
+                  "d77e979dc3a0b18e95fe2b61f45e5a765cb5661d52507019cf307929f50f65a9"),
 ]
 
 # Bash recipe for building across all platforms

--- a/G/GAP_pkg/common.jl
+++ b/G/GAP_pkg/common.jl
@@ -36,6 +36,6 @@ include("../GAP/common.jl") # make gap_platforms available
 
 function gap_pkg_dependencies(gap_version::VersionNumber)
     return BinaryBuilder.AbstractDependency[
-        Dependency("GAP_jll", gap_version; compat="~$(gap_version)"),
+        Dependency(PackageSpec(; name="GAP_jll", url="http://github.com/lgoettgens/GAP_jll.jl")), # DO NOT MERGE, this line has to be reverted
     ]
 end

--- a/G/GAP_pkg/common.jl
+++ b/G/GAP_pkg/common.jl
@@ -6,6 +6,11 @@ using BinaryBuilder
 Compute a version that allows distinguishing between changes in the upstream
 version and changes to the JLL which retain the same upstream version.
 
+To match the gap code of a package with its kernel extension jll, we need to
+make sure that any change to the upstream version is reflected at least
+as a minor version change. Patch versions are just for changes in jll
+dependencies, updated gap version etc.
+
 When the `upstream` version is changed, `offset` version numbers should be reset
 to `v"0.0.0"` and incremented following semantic versioning.
 """
@@ -13,8 +18,8 @@ function offset_version(upstream_str, offset)
     upstream = VersionNumber(replace(upstream_str, "-" => "."))
     return VersionNumber(
         upstream.major * 100 + offset.major,
-        upstream.minor * 100 + offset.minor,
-        upstream.patch * 100 + offset.patch,
+        upstream.minor * 10000 + upstream.patch * 100 + offset.minor,
+        offset.patch,
     )
 end
 

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -7,9 +7,9 @@ import Downloads
 using SHA
 using GZip
 
-upstream_version = v"4.14.0"
-gap_version = v"400.1401.005"
-gap_lib_version = v"400.1400.000"
+upstream_version = v"4.15.0-beta1"
+gap_version = v"400.1500.000"
+gap_lib_version = v"400.1500.000"
 
 function download_with_sha256(url)
     io = IOBuffer()
@@ -95,12 +95,10 @@ function update_gap_pkg_recipe(dir)
     elseif old_upstream_version != upstream_version
         _old_upstream_version = VersionNumber(replace(old_upstream_version, "-" => "."))
         _upstream_version = VersionNumber(replace(upstream_version, "-" => "."))
-        if old_upstream_version.major != upstream_version.major
+        if _old_upstream_version.major != _upstream_version.major
             offset = v"0.0.0"
-        elseif old_upstream_version.minor != upstream_version.minor
-            offset = VersionNumber(offset.major, 0, 0)
         else
-            offset = VersionNumber(offset.major, offset.minor, 0)
+            offset = VersionNumber(offset.major, 0, 0)
         end
     else
         offset = VersionNumber(offset.major, offset.minor, offset.patch + 1)

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -64,7 +64,7 @@ function update_gap_pkg_recipe(dir)
 
     # new metadata from the GAP package registry
     if pkgname == "juliainterface"
-        upstream_version = "0.15.0"
+        upstream_version = "0.16.0"
         sha256 = "DUMMY"
     else
         meta = pkginfo[pkgname]

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -2,12 +2,12 @@
 # Execute from the G/GAP_pkg/ directory, e.g.:
 # julia --project=. update.jl
 
-using JSON
 import Downloads
-using SHA
 using GZip
+using JSON
+using SHA
 
-upstream_version = v"4.15.0-beta1"
+upstream_version = v"4.15.0-beta2"
 gap_version = v"400.1500.000"
 gap_lib_version = v"400.1500.000"
 

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -7,7 +7,7 @@ using GZip
 using JSON
 using SHA
 
-upstream_version = v"4.15.0-beta3"
+upstream_version = v"4.15.0"
 gap_version = v"400.1500.000"
 gap_lib_version = v"400.1500.000"
 

--- a/G/GAP_pkg/update.jl
+++ b/G/GAP_pkg/update.jl
@@ -7,7 +7,7 @@ using GZip
 using JSON
 using SHA
 
-upstream_version = v"4.15.0-beta2"
+upstream_version = v"4.15.0-beta3"
 gap_version = v"400.1500.000"
 gap_lib_version = v"400.1500.000"
 


### PR DESCRIPTION
Companion to https://github.com/JuliaPackaging/Yggdrasil/pull/11987.

This implements the changed versioning scheme @fingolfin and I discussed about two weeks ago. Furthermore, it updates the package distro to 4.15.0-beta1.
I am currently building all of the packages locally to get a working GAP.jl with gap 4.15.0-beta1.

Once we wanna get this into yggdrasil and built for all platforms (after 4.15.0 is actually released), I am  gonna split this up into a bunch for small PRs.