### PR TITLE
[lib4ti2] Rebuild to drop Pkg dependency

### DIFF
--- a/L/lib4ti2/build_tarballs.jl
+++ b/L/lib4ti2/build_tarballs.jl
@@ -5,7 +5,8 @@ using BinaryBuilder
 # Julia does not allow identifiers starting with a digit, so we can't
 # call this just "4ti2"
 name = "lib4ti2"
-version = v"1.6.10" # <-- This is a lie, we're bumping from 1.6.9 to 1.6.10 to create a Julia v1.6+ release with experimental platforms
+upstream_version = v"1.6.9"
+version = v"1.6.11"
 
 # Collection of sources required to build 4ti2
 sources = [
@@ -59,7 +60,7 @@ fi
 """
 
 # Build for all platforms
-platforms = supported_platforms(;experimental=true)
+platforms = supported_platforms()
 
 # 4ti2 contains std::string values; to avoid incompatibilities across
 # the GCC 4/5 version boundary, we need the following:


### PR DESCRIPTION
I know that there are new releases (up to 1.6.13), but I don't wanna spend any time on cross-building problems, the current patches etc.
Due to this not having a rebuild for a really long time, this still has Pkg in it's dependencies. See https://github.com/JuliaLang/julia/issues/57970 for a motivation to excise Pkg as a transitive dependency of Oscar.

cc @fingolfin @benlorenz 