### PR TITLE
[XGBoost] Builds for Apple Systems and more CUDA platforms

### DIFF
--- a/X/XGBoost/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/XGBoost/build_tarballs.jl
@@ -8,23 +8,13 @@ sources = get_sources()
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd ${WORKSPACE}/srcdir/
-
-# we can't seem to build from source for Apple, so install the pre-built binaries directly instead
-# see https://github.com/dmlc/xgboost/issues/11676 for details
-if [[ "${target}" == *apple-darwin* ]]; then
-    unzip -d xgboost-${target} xgboost-${target}.whl
-    cd xgboost-${target}/xgboost
-    cp ../../xgboost/LICENSE .
-else
-    cd xgboost
-    git submodule update --init
-    mkdir build && cd build
-    cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
-            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
-    make -j${nproc}
-    cd ..
-fi
+cd ${WORKSPACE}/srcdir/xgboost
+git submodule update --init
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
+make -j${nproc}
+cd ..
 """ * install_script
 
 # The products that we will ensure are always built

--- a/X/XGBoost/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/XGBoost/build_tarballs.jl
@@ -8,12 +8,28 @@ sources = get_sources()
 
 # Bash recipe for building across all platforms
 script = raw"""
+# apple builds require a newer SDK (at least v12 to cover both x86_64 and aarch64) based on build info here:
+# https://github.com/dmlc/xgboost/blob/910c34b971b06861e66d3850714540b0697001e1/ops/pipeline/build-python-wheels-macos.sh#L14-L24
+if [[ $target == *"apple-darwin"* ]]; then
+    apple_sdk_root=$WORKSPACE/srcdir/MacOSX14.0.sdk
+    sed -i "s!/opt/$bb_target/$bb_target/sys-root!$apple_sdk_root!" $CMAKE_TARGET_TOOLCHAIN
+    sed -i "s!/opt/$bb_target/$bb_target/sys-root!$apple_sdk_root!" /opt/bin/$bb_full_target/$target-clang++
+    export MACOSX_DEPLOYMENT_TARGET=12
+fi
+
+# remove default cmake to use newer version from build dependency
+apk del cmake
+
+# now build library
 cd ${WORKSPACE}/srcdir/xgboost
 git submodule update --init
+
 mkdir build && cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
 make -j${nproc}
+
+# move out of the build folder - the install script runs at the level of the xgboost directory
 cd ..
 """ * install_script
 

--- a/X/XGBoost/XGBoost/build_tarballs.jl
+++ b/X/XGBoost/XGBoost/build_tarballs.jl
@@ -1,7 +1,7 @@
 include("../common.jl")
 
 name = "XGBoost"
-version = v"2.1.4+0"
+version = v"2.1.5"
 
 # Collection of sources required to build XGBoost
 sources = get_sources()

--- a/X/XGBoost/XGBoost_GPU/build_tarballs.jl
+++ b/X/XGBoost/XGBoost_GPU/build_tarballs.jl
@@ -45,12 +45,20 @@ augment_platform_block = CUDA.augment
 products = get_products()
 
 # XGBoost v2.1 doesn't support only has CUDA support for linux builds
-# we also rely on CUDA_full_jll so can only build up to CUDA v12.2.1 for now
+# note also builds don't work for CUDA v12.5 and v12.6 due to a bug in CCCL (the patch fix for this is 
+# not available in the shipped CUDA SDK)
+# see the following issues: https://github.com/dmlc/xgboost/issues/10555, https://github.com/dmlc/xgboost/issues/11640
 platforms = expand_cxxstring_abis(
-    filter!(p -> arch(p) == "x86_64" && os(p) == "linux", 
+    filter!(p -> all([
+            arch(p) == "x86_64", 
+            os(p) == "linux",
+            platforms[1].tags["cuda"] ∉ ["12.5", "12.6"]
+        ]),
         CUDA.supported_platforms(; min_version = v"11.8", max_version = v"12.9.1")
     )
 )
+
+platforms = [Platform("x86_64", "linux"; cxxstring_abi="cxx11", cuda = "12.5")]
 
 
 for platform ∈ platforms

--- a/X/XGBoost/XGBoost_GPU/build_tarballs.jl
+++ b/X/XGBoost/XGBoost_GPU/build_tarballs.jl
@@ -52,7 +52,7 @@ platforms = expand_cxxstring_abis(
     filter!(p -> all([
             arch(p) == "x86_64", 
             os(p) == "linux",
-            platforms[1].tags["cuda"] ∉ ["12.5", "12.6"]
+            p.tags["cuda"] ∉ ["12.5", "12.6"]
         ]),
         CUDA.supported_platforms(; min_version = v"11.8", max_version = v"12.9.1")
     )

--- a/X/XGBoost/XGBoost_GPU/build_tarballs.jl
+++ b/X/XGBoost/XGBoost_GPU/build_tarballs.jl
@@ -1,6 +1,6 @@
 include("../common.jl")
 name = "XGBoost_GPU"
-version = v"2.1.4+0"
+version = v"2.1.5"
 
 include(normpath(joinpath(YGGDRASIL_DIR, "..", "platforms", "cuda.jl")))
 

--- a/X/XGBoost/XGBoost_GPU/build_tarballs.jl
+++ b/X/XGBoost/XGBoost_GPU/build_tarballs.jl
@@ -27,7 +27,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
         -DUSE_CUDA=ON \
         -DBUILD_WITH_CUDA_CUB=ON
 make -j${nproc}
-
+cd ..
 """ * install_script
 
 augment_platform_block = CUDA.augment

--- a/X/XGBoost/XGBoost_GPU/build_tarballs.jl
+++ b/X/XGBoost/XGBoost_GPU/build_tarballs.jl
@@ -1,6 +1,6 @@
 include("../common.jl")
 name = "XGBoost_GPU"
-version = v"2.1.4"
+version = v"2.1.4+0"
 
 include(normpath(joinpath(YGGDRASIL_DIR, "..", "platforms", "cuda.jl")))
 

--- a/X/XGBoost/XGBoost_GPU/build_tarballs.jl
+++ b/X/XGBoost/XGBoost_GPU/build_tarballs.jl
@@ -58,8 +58,6 @@ platforms = expand_cxxstring_abis(
     )
 )
 
-platforms = [Platform("x86_64", "linux"; cxxstring_abi="cxx11", cuda = "12.5")]
-
 
 for platform ∈ platforms
     

--- a/X/XGBoost/XGBoost_GPU/build_tarballs.jl
+++ b/X/XGBoost/XGBoost_GPU/build_tarballs.jl
@@ -44,7 +44,7 @@ augment_platform_block = CUDA.augment
 # The products that we will ensure are always built
 products = get_products()
 
-# XGBoost v2.1 doesn't support only has CUDA support for linux builds
+# XGBoost v2.1 only has CUDA support for linux builds and doesn't support CUDA v13
 # note also builds don't work for CUDA v12.5 and v12.6 due to a bug in CCCL (the patch fix for this is 
 # not available in the shipped CUDA SDK)
 # see the following issues: https://github.com/dmlc/xgboost/issues/10555, https://github.com/dmlc/xgboost/issues/11640

--- a/X/XGBoost/XGBoost_GPU/build_tarballs.jl
+++ b/X/XGBoost/XGBoost_GPU/build_tarballs.jl
@@ -40,7 +40,11 @@ products = get_products()
 
 # XGBoost v2.1 doesn't support only has CUDA support for linux builds
 # we also rely on CUDA_full_jll so can only build up to CUDA v12.2.1 for now
-platforms = expand_cxxstring_abis(filter(Sys.islinux, CUDA.supported_platforms(; min_version = v"11.8", max_version = v"12.2.1")))
+platforms = expand_cxxstring_abis(
+    filter!(p -> arch(p) == "x86_64" && Sys.islinux(p), 
+        CUDA.supported_platforms(; min_version = v"11.8", max_version = v"12.2.1")
+    )
+)
 
 
 for platform ∈ platforms

--- a/X/XGBoost/common.jl
+++ b/X/XGBoost/common.jl
@@ -9,13 +9,8 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 function get_sources()
     return [
         GitSource("https://github.com/dmlc/xgboost.git","62e7923619352c4079b24303b367134486b1c84f"), # v2.1.4
-        # for apple systems, we can't build from source - instead, use pre-built wheels from XGBoost itself
-        FileSource("https://files.pythonhosted.org/packages/b6/fe/7a1d2342c2e93f22b41515e02b73504c7809247b16ae395bd2ee7ef11e19/xgboost-2.1.4-py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64.whl",
-                    "78d88da184562deff25c820d943420342014dd55e0f4c017cc4563c2148df5ee";
-                    filename = "xgboost-x86_64-apple-darwin14.whl"),
-        FileSource("https://files.pythonhosted.org/packages/f5/b6/653a70910739f127adffbefb688ebc22b51139292757de7c22b1e04ce792/xgboost-2.1.4-py3-none-macosx_12_0_arm64.whl",
-                    "523db01d4e74b05c61a985028bde88a4dd380eadc97209310621996d7d5d14a7";
-                    filename = "xgboost-aarch64-apple-darwin20.whl")
+        ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
+                    "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4")
     ]
 end
 

--- a/X/XGBoost/common.jl
+++ b/X/XGBoost/common.jl
@@ -8,7 +8,14 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 # Collection of sources required to build XGBoost
 function get_sources()
     return [
-        GitSource("https://github.com/dmlc/xgboost.git","62e7923619352c4079b24303b367134486b1c84f") # v2.1.4
+        GitSource("https://github.com/dmlc/xgboost.git","62e7923619352c4079b24303b367134486b1c84f"), # v2.1.4
+        # for apple systems, we can't build from source - instead, use pre-built wheels from XGBoost itself
+        FileSource("https://files.pythonhosted.org/packages/b6/fe/7a1d2342c2e93f22b41515e02b73504c7809247b16ae395bd2ee7ef11e19/xgboost-2.1.4-py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64.whl",
+                    "78d88da184562deff25c820d943420342014dd55e0f4c017cc4563c2148df5ee";
+                    filename = "xgboost-x86_64-apple-darwin14.whl"),
+        FileSource("https://files.pythonhosted.org/packages/f5/b6/653a70910739f127adffbefb688ebc22b51139292757de7c22b1e04ce792/xgboost-2.1.4-py3-none-macosx_12_0_arm64.whl",
+                    "523db01d4e74b05c61a985028bde88a4dd380eadc97209310621996d7d5d14a7";
+                    filename = "xgboost-aarch64-apple-darwin20.whl")
     ]
 end
 
@@ -31,7 +38,7 @@ function get_dependencies(platform::Platform; cuda::Bool = false, cuda_version::
         Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); 
             platforms=filter(!Sys.isbsd, [platform])),
         Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); 
-            platforms=filter(Sys.isbsd, [platform])),
+            platforms=filter(Sys.isbsd, [platform]))
     ]
 
     # dependencies necessary to build CUDA support
@@ -46,10 +53,11 @@ end
 # common install component of the script across both CPU and GPU builds
 const install_script = raw"""
 # Manual installation, to avoid installing dmlc
-cd ..
-for header in include/xgboost/*.h; do
-    install -Dv "${header}" "${includedir}/xgboost/$(basename ${header})"
-done
+if [[ "${target}" != *apple-darwin* ]]; then
+    for header in include/xgboost/*.h; do
+        install -Dv "${header}" "${includedir}/xgboost/$(basename ${header})"
+    done
+fi
 
 if [[ ${target} == *mingw* ]]; then
     install -Dvm 0755 lib/xgboost.dll ${libdir}/xgboost.dll

--- a/X/XGBoost/common.jl
+++ b/X/XGBoost/common.jl
@@ -26,7 +26,7 @@ function get_platforms()
     return expand_cxxstring_abis(supported_platforms())
 end
 
-function get_dependencies(platform::Platform; cuda::Bool = false, cuda_version::VersionNumber = v"12.0")
+function get_dependencies(platform::Platform)
     dependencies = AbstractDependency[
         # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
         # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
@@ -37,13 +37,6 @@ function get_dependencies(platform::Platform; cuda::Bool = false, cuda_version::
         # builds are done in XGBoost using cmake v3.31 - this turns out to be necessary to include libomp via CompilerSupportLibraries_jll with the newer SDK
         HostBuildDependency(PackageSpec(name="CMake_jll"))
     ]
-
-    # dependencies necessary to build CUDA support
-    if cuda
-        push!(dependencies, BuildDependency(PackageSpec(name="CUDA_full_jll", version=CUDA.full_version(cuda_version))))
-        append!(dependencies, CUDA.required_dependencies(platform))
-    end
-
     return dependencies
 end
 

--- a/X/XGBoost/common.jl
+++ b/X/XGBoost/common.jl
@@ -8,7 +8,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 # Collection of sources required to build XGBoost
 function get_sources()
     return [
-        GitSource("https://github.com/dmlc/xgboost.git","62e7923619352c4079b24303b367134486b1c84f"), # v2.1.4
+        GitSource("https://github.com/dmlc/xgboost.git","62e7923619352c4079b24303b367134486b1c84f"),
         ArchiveSource("https://github.com/roblabla/MacOSX-SDKs/releases/download/macosx14.0/MacOSX14.0.sdk.tar.xz",
                   "4a31565fd2644d1aec23da3829977f83632a20985561a2038e198681e7e7bf49")
     ]


### PR DESCRIPTION
This is a patch fix for #12048. For some reason, building from source on Mac OS systems doesn't seem to work with AppleClang, so instead I've set these systems to exclusively use the pre-built binaries from XGBoost itself. Any thoughts/suggestions welcome :slightly_smiling_face: 