### PR TITLE
[Aravis] update to 0.8.35

### DIFF
--- a/A/Aravis/build_tarballs.jl
+++ b/A/Aravis/build_tarballs.jl
@@ -39,7 +39,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Glib_jll"; compat="2.82.2"),
+    Dependency("Glib_jll"; compat="2.84.3"),
     Dependency("libusb_jll"),
     # We had to restrict compat with XML2 because of ABI breakage:
     # https://github.com/JuliaPackaging/Yggdrasil/pull/10965#issuecomment-2798501268

--- a/A/Aravis/build_tarballs.jl
+++ b/A/Aravis/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "Aravis"
-version = v"0.8.33"
+version = v"0.8.35"
 
 sources = [
     GitSource("https://github.com/AravisProject/aravis.git",
-              "99081fbda9e820a171d2aaccea0bc95ba5f8c37b")
+              "ea4f3c47cb387d81b63444887f3e0efda7918d50")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
On riscv64-linux-gnu, the following error occurs using the old recipe:
```
[00:45:36] ninja: subcommand failed
[00:45:36] /opt/riscv64-linux-gnu/bin/../lib/gcc/riscv64-linux-gnu/14.2.0/../../../../riscv64-linux-gnu/bin/ld.bfd: /usr/lib/libglib-2.0.so: error adding symbols: file in wrong format
[00:45:36] collect2: error: ld returned 1 exit status
```

Setting a more recent Glib_jll compat version fixes it.