### PR TITLE
MAGEMin v1.8.5

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 name = "MAGEMin"
-version = v"1.8.4"
+version = v"1.8.5"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "442b7b93ed40dcdcc5e05a8a3e005241a88f2047")                 ]
+                    "748d91d9877a98269f570502adfc14262bcb95d4")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Corrected oversight introduced in v1.8.4 when using initial guess. This was leading to MAGEMin failing when using initial guess outside of PT diagram (PX, TX etc.) -> Added a new test to avoid this kind of problems in the future
- Added option to access and modify standard state properties of the end-members through the Julia wrapper.