### PR TITLE
[GAP_pkg_juliainterface] Rebuild with latest master

### DIFF
--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -11,13 +11,13 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 gap_version = v"400.1401.5"
 name = "JuliaInterface"
-upstream_version = "0.15.0" # when you increment this, reset offset to v"0.0.0"
+upstream_version = "0.15.3" # when you increment this, reset offset to v"0.0.0"
 offset = v"0.0.0" # increment this when rebuilding with unchanged upstream_version, e.g. gap_version changes
 version = offset_version(upstream_version, offset)
 
 # Collection of sources required to build this JLL
 sources = [
-    GitSource("https://github.com/oscar-system/GAP.jl", "364a42d7cec574b7b67269879c4dcbb9c5c2c9fc"),
+    GitSource("https://github.com/oscar-system/GAP.jl", "43ec515a9c5e8f087e32c87e5412c600b8329a85"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Having this makes our treehash job green again, and allows us to release a 0.15.3 patch release of GAP.jl before we flip the switch to gap 4.15.0.