### PR TITLE
[PRIMA] Recompile to avoid the use of executable stack

### DIFF
--- a/P/PRIMA/build_tarballs.jl
+++ b/P/PRIMA/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "PRIMA"
-version = v"0.7.1"
+version = v"0.7.2"  # <-- Release 0.7.1 recompiled with "-Wl,-z,noexecstack"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
Related issue: https://github.com/libprima/PRIMA.jl/issues/46