### PR TITLE
[CUDA] Add missing headers for CUDA 13

### DIFF
--- a/C/CUDA/CUDA_SDK@13.0/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK@13.0/build_tarballs.jl
@@ -20,4 +20,5 @@ for platform in platforms
     push!(full_platforms, augmented_platform)
 end
 
+# bump
 build_sdk(name, version, full_platforms; static=false)

--- a/C/CUDA/CUDA_SDK_static@13.0/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK_static@13.0/build_tarballs.jl
@@ -20,4 +20,5 @@ for platform in platforms
     push!(full_platforms, augmented_platform)
 end
 
+# bump
 build_sdk(name, version, full_platforms; static=true)

--- a/C/CUDA/common.jl
+++ b/C/CUDA/common.jl
@@ -143,6 +143,9 @@ fi"""
         # available earlier, but not for aarch64
         push!(components, "libnvjpeg")
     end
+    if version >= v"13"
+        push!(components, "cuda_crt")
+    end
     for platform in platforms
         should_build_platform(triplet(platform)) || continue
 


### PR DESCRIPTION
With CUDA 13, we need new headers from the package `cuda_crt` to generate the Julia wrappers for `CUDA.jl` or `CUDSS.jl`.