### PR TITLE
[Uno] Update to Uno v2.2.1

### DIFF
--- a/U/Uno/build_tarballs.jl
+++ b/U/Uno/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder, Pkg
 
 name = "Uno"
 
-version = v"2.2.0"
+version = v"2.2.1"
 
 sources = [
     GitSource(
         "https://github.com/cvanaret/Uno.git",
-        "94768b83d63b8a87c2a2e9530cee98d964095edf",
+        "af68e63bfc77a2f6be032f8aab589a41a82bd2ea",
     ),
 ]
 


### PR DESCRIPTION
[Uno v2.2.1](https://github.com/cvanaret/Uno/releases/tag/v2.2.1) was released on Oct 8, 2025.

cc @amontoison @giordano 