### PR TITLE
[HYPRE] Update to 3.0.0 + build with OpenMP

### DIFF
--- a/H/HYPRE/build_tarballs.jl
+++ b/H/HYPRE/build_tarballs.jl
@@ -82,6 +82,10 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="OpenBLAS_jll", uuid="4536629a-c528-5b80-bd46-f80d51c5b363")),
     Dependency(PackageSpec(name="LAPACK_jll", uuid="51474c39-65e3-53ba-86ba-03b1b862ec14")),
+    # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD
+    # systems), and libgomp from `CompilerSupportLibraries_jll` everywhere else.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
+    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms))
 ]
 append!(dependencies, platform_dependencies)
 


### PR DESCRIPTION
This is an attempt at updating hypre to the latest version, and enable OpenMP support. It should not be merged without a thumbs up from @fredrikekre who maintains HYPRE.jl.

The release is breaking, but as far as I can see, only HYPRE.jl uses this jll and the changes are only to the structured interface.

[hypre changelog](https://github.com/hypre-space/hypre/blob/master/CHANGELOG)
