### PR TITLE
[SCALAPACK] Upgrade to v2.2.2

### DIFF
--- a/S/SCALAPACK/build_tarballs.jl
+++ b/S/SCALAPACK/build_tarballs.jl
@@ -15,8 +15,6 @@ script = raw"""
 mkdir -p ${libdir}
 cd $WORKSPACE/srcdir/scalapack
 
-#TODO For BLAS and LAPACK, it would be great to start linking to -lblastrampoline.
-
 CPPFLAGS=()
 CFLAGS=(-Wno-error=implicit-function-declaration)
 FFLAGS=(-cpp -ffixed-line-length-none)


### PR DESCRIPTION
@eschnett The build on `master` for `SCALAPACK` failed:
https://buildkite.com/julialang/yggdrasil/builds/24021/steps/canvas

It is not a bad news because I forgot to update the compat entry of Julia.
We need at least Julia 1.9 to ensure LBT to work on all platforms.

The version 2.2.2 of `SCALAPACK_jll` never landed in the general registry or its GitHub repository (https://github.com/JuliaBinaryWrappers/SCALAPACK_jll.jl) so it is all good.
