### PR TITLE
Add llamacppoutlines v1.1.0

### DIFF
--- a/L/LlamaCppOutlines/build_tarballs.jl
+++ b/L/LlamaCppOutlines/build_tarballs.jl
@@ -71,12 +71,7 @@ elif [[ "${target}" == "aarch64-apple-darwin"* ]]; then
     SOURCE_DIR="macos-arm"
 fi
 
-echo "Target: ${target}"
-echo "Using source directory: ${SOURCE_DIR}"
 cd ${SOURCE_DIR}
-
-echo "Contents of source directory:"
-ls -la
 
 # Create destination directories
 mkdir -p ${libdir}
@@ -97,14 +92,10 @@ if [[ "${target}" == *"mingw"* ]]; then
 else
     # Linux and macOS: Standard layout
     if [ -d lib ]; then
-        echo "Copying libraries from lib/:"
-        ls -la lib/
-        # Copy .so and .dylib files individually to avoid subdirectories
         find lib -maxdepth 1 -name "*.so*" -exec cp {} ${libdir}/ \;
         find lib -maxdepth 1 -name "*.dylib" -exec cp {} ${libdir}/ \;
     fi
     if [ -d bin ]; then
-        echo "Copying binaries from bin/:"
         cp bin/* ${bindir}/
     fi
 fi
@@ -117,11 +108,6 @@ fi
 # Set permissions
 chmod +x ${libdir}/* 2>/dev/null || true
 chmod +x ${bindir}/* 2>/dev/null || true
-
-echo "Final libdir contents:"
-ls -la ${libdir}
-echo "Final bindir contents:"
-ls -la ${bindir}
 """
 
 platforms = [
@@ -145,9 +131,9 @@ products = [
     ExecutableProduct("llama-gguf", :llama_gguf),
     ExecutableProduct("llama-tokenize", :llama_tokenize),
     ExecutableProduct("llama-imatrix", :llama_imatrix),
-    LibraryProduct(["libggml", "ggml"], :libggml),
-    LibraryProduct(["libllama", "llama"], :libllama),
-    LibraryProduct(["liboutlines_core", "outlines_core"], :liboutlines_core),
+    LibraryProduct(["libggml", "ggml"], :libggml; dont_dlopen=true),
+    LibraryProduct(["libllama", "llama"], :libllama; dont_dlopen=true),
+    LibraryProduct(["liboutlines_core", "outlines_core"], :liboutlines_core; dont_dlopen=true),
 ]
 
 dependencies = Dependency[]


### PR DESCRIPTION
Provides pre-built binaries for llama.cpp with outlines-core integration for structured text generation.

## Features
- llama.cpp executables (cli, server, quantize, etc.)
- outlines-core library for JSON schema validation
- Support for CPU and CUDA on Linux and Windows
- Support for Metal on macOS (Intel and Apple Silicon)

## Platforms
- x86_64-linux-gnu (CPU)
- x86_64-linux-gnu-cuda+12 (CUDA)
- x86_64-w64-mingw32 (CPU)
- x86_64-w64-mingw32-cuda+12 (CUDA)
- x86_64-apple-darwin (Metal)
- aarch64-apple-darwin (Metal)
