### PR TITLE
[BLIS] Mangle CBLAS symbols for 64_  suffixes

### DIFF
--- a/B/blis/blis/build_tarballs.jl
+++ b/B/blis/blis/build_tarballs.jl
@@ -11,4 +11,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"11", lock_microarchitecture=false, julia_compat="1.6")
 
-# Build trigger: 3
+# Build trigger: 4

--- a/B/blis/blis32/build_tarballs.jl
+++ b/B/blis/blis32/build_tarballs.jl
@@ -11,4 +11,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                preferred_gcc_version=v"11", lock_microarchitecture=false, julia_compat="1.6")
 
-# Build trigger: 3
+# Build trigger: 4

--- a/B/blis/common.jl
+++ b/B/blis/common.jl
@@ -90,13 +90,13 @@ function blis_script(;blis32::Bool=false)
     # Replace cblas function names to have _64 suffixes
     if [[ "${BLIS32}" != "true" ]]; then
        cd frame/compat/cblas/src
-       sed -i -E "s/cblas_([a-zA-Z0-9_]+)/cblas_\1_64/g" cblas.h
+       sed -i -E "s/cblas_([a-zA-Z0-9_]+)/cblas_\164_/g" cblas.h
        for fname in *.c extra/*.c; do
-           sed -i -E "/^#/!s/cblas_([a-zA-Z0-9_]+)\(/cblas_\1_64\(/g" $fname
+           sed -i -E "/^#/!s/cblas_([a-zA-Z0-9_]+)\(/cblas_\164_\(/g" $fname
        done
        for fname in extra/*.c; do
-           sed -i -E "/^#s/cblas_([a-zA-Z0-9_]+)\"/cblas_\1_64\"/g" $fname
-           sed -i -E "/attribute/s/cblas_([a-zA-Z0-9_]+)/cblas_\1_64/g" $fname
+           sed -i -E "/^#s/cblas_([a-zA-Z0-9_]+)\"/cblas_\164_\"/g" $fname
+           sed -i -E "/attribute/s/cblas_([a-zA-Z0-9_]+)/cblas_\164_/g" $fname
        done
        cd ../../../..
     fi   


### PR DESCRIPTION
This fixes the `dot` test failures in BLISBLAS.jl by providing cblas with 64_ suffixes. Hopefully this will serve us well for a while.