### PR TITLE
Wizard recipe: Epsteinlib-v0.1.0

### DIFF
--- a/E/Epsteinlib/build_tarballs.jl
+++ b/E/Epsteinlib/build_tarballs.jl
@@ -17,6 +17,7 @@ cd $WORKSPACE/srcdir/epsteinlib
 meson setup build --cross-file=${MESON_TARGET_TOOLCHAIN} --buildtype=release -Dbuild_python=false
 ninja -C build -j${nproc}
 ninja -C build install
+install_license LICENSES/*
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
This pull request contains a new build recipe I built using the BinaryBuilder.jl wizard:

* Package name: Epsteinlib
* Version: v0.1.0

@staticfloat please review and merge.

This package implements the Epstein zeta function, a generalization of the Riemann zeta function to higher dimensions.

Build fails for aarch64 macOS. I use the meson toolchain that works in the rest of architectures, but for aarch64 there is a missing linker: 
```
Build started at 2025-10-16T05:35:55.090258
Main binary: /usr/bin/python3
Build Options: -Dbuildtype=release --cross-file=/opt/toolchains/aarch64-apple-darwin20-libgfortran5-cxx11/target_aarch64-apple-darwin20.meson
Python system: Linux
The Meson build system
Version: 1.4.0
Source dir: /workspace/srcdir/epsteinlib
Build dir: /workspace/srcdir/epsteinlib/build
Build type: cross build
Project name: epsteinlib
Project version: 0.5.0
-----------
Detecting compiler via: `/opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang --version` -> 0
stdout:
clang version 18.1.7 (/home/tim/.cache/BinaryBuilder/downloads/clones/llvm-project.git-1df819a03ecf6890e3787b27bfd4f160aeeeeacd50a98d003be8b0893f11a9be 768118d1ad38bf13c545828f67bd6b474d61fc55)
Target: arm64-apple-darwin20
Thread model: posix
InstalledDir: /opt/x86_64-linux-musl/bin
-----------
Running command: /opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang -E -dM -
-----
-----------
Detecting linker via: `/opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang -Wl,--version -L/workspace/destdir/lib -fuse-ld=/opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-ld` -> 1
stderr:
ld: warning: directory not found for option '-L/workspace/destdir/lib'
ld: unknown option: --version
clang: error: linker command failed with exit code 1 (use -v to see invocation)
-----------
-----------
Detecting Apple linker via: `/opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang -Wl,-v -L/workspace/destdir/lib` -> 1
stderr:
ld64.lld: warning: directory not found for option -L/workspace/destdir/lib
LLD 18.1.7
Library search paths:
	/opt/aarch64-apple-darwin20/aarch64-apple-darwin20/lib
	/opt/aarch64-apple-darwin20/aarch64-apple-darwin20/sys-root/usr/lib
Framework search paths:
	/opt/aarch64-apple-darwin20/aarch64-apple-darwin20/sys-root/System/Library/Frameworks
ld64.lld: error: undefined symbol: main
>>> referenced by the entry point
clang: error: linker command failed with exit code 1 (use -v to see invocation)
-----------

meson.build:6:0: ERROR: Unable to detect linker for compiler `/opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang -Wl,--version -L/workspace/destdir/lib -fuse-ld=/opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-ld`
stdout: 
stderr: ld: warning: directory not found for option '-L/workspace/destdir/lib'
ld: unknown option: --version
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
