### PR TITLE
[oneAPI] Add oneAPI_Level_Zero_Loader_jll as a dependency of NEO_jll

### DIFF
--- a/N/NEO/build_tarballs.jl
+++ b/N/NEO/build_tarballs.jl
@@ -112,6 +112,7 @@ dependencies = [
     Dependency("gmmlib_jll"; compat="=22.8.1"),
     Dependency("libigc_jll"; compat="=2.18.5"),
     Dependency("oneAPI_Level_Zero_Headers_jll"; compat="=1.13"),
+    Dependency("oneAPI_Level_Zero_Loader_jll"; compat="=1.24.3"),
 ]
 
 augment_platform_block = raw"""


### PR DESCRIPTION
There are missing symbols in `libze_intel_gpu.so.1` that are in `libze_loader.so`.