### PR TITLE
[libssh] Update version to 0.11.3

### DIFF
--- a/L/libssh/build_tarballs.jl
+++ b/L/libssh/build_tarballs.jl
@@ -60,7 +60,7 @@ products = [
 dependencies = [
     HostBuildDependency("Doxygen_jll"),
     Dependency("Kerberos_krb5_jll"; compat="1.19.3"),
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.8"),
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.16"),
     Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"); compat="1.2.12")
 ]
 


### PR DESCRIPTION
https://www.libssh.org/2025/09/09/libssh-0-11-3-security-and-bugfix-release/