### PR TITLE
[unzip] Drop support for Windows

### DIFF
--- a/U/unzip/build_tarballs.jl
+++ b/U/unzip/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "unzip"
-version = v"6.0.3"
+version = v"6.0.4"
 
 # Collection of sources required to complete build
 sources = [
@@ -49,7 +49,11 @@ install_license WHERE
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+# Unicode support is broken on Windows.
+# Ref https://github.com/JuliaPackaging/Yggdrasil/issues/7679
+# Upstream is uninterested in fixing this: https://github.com/madler/unzip/issues/5
+# Windows users will have a better time using `p7zip_jll`.
+platforms = supported_platforms(; exclude=Sys.iswindows)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
`unzip` is currently broken on Windows.

Ref: https://github.com/JuliaPackaging/Yggdrasil/issues/7679#issuecomment-3419079074 https://github.com/JuliaIO/ZipArchives.jl/pull/36#issuecomment-3404300240

`unzip_jll` is being used by:

Reactant.jl in https://github.com/EnzymeAD/Reactant.jl/blob/c3255d4e49fc12c2804d6a72d1b2e99129dbbfea/src/accelerators/TPU.jl#L49-L50

BinaryBuilderBase.jl in 
https://github.com/JuliaPackaging/BinaryBuilderBase.jl/blob/bb1d736c160de8c5f1bde41e814d8d82d972fc00/src/Prefix.jl#L379-L381

MORWiki.jl in 
https://github.com/mpimd-csc/MORWiki.jl/blob/a71d59c250ce0a4b1b4cd854db8b2377f97ceedc/src/oberwolfach/steelProfile.jl#L17

These usages should be replaced with the `p7zip_jll` standard library to avoid downloading extra dependencies and to correctly follow the ZIP spec on Windows.

```
run(`$(unzip_jll.unzip()) -qq $(zip_file_path) -d $(target_dir)`)
```

```
run(pipeline(`$(p7zip_jll.p7zip()) x -tzip -y -o$(target_dir) $(zip_file_path)`, devnull))
```

CC: @jonas-schulze @giordano 

