### PR TITLE
[aws_c_http_jq] Update to version 0.10.6

### DIFF
--- a/A/aws_c_http_jq/build_tarballs.jl
+++ b/A/aws_c_http_jq/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_http_jq"
-version = v"0.10.4"
+version = v"0.10.6"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/quinnj/aws-c-http.git", "ce0d65623bff28f03204756d9d1b3366bd0b387d"),
+    GitSource("https://github.com/quinnj/aws-c-http.git", "e638eb00423029d422aea97fcfadeb68890a2f5c"),
 ]
 
 # Bash recipe for building across all platforms
@@ -38,7 +38,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("aws_c_compression_jll"; compat="0.3.2"),
-    Dependency("aws_c_io_jll"; compat="0.21.2"),
+    Dependency("aws_c_io_jll"; compat="0.23.2"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_http_jq to version 0.10.6. cc: @quinnj @Octogonapus