### PR TITLE
[Uno] update to v2.3.0

### DIFF
--- a/U/Uno/build_tarballs.jl
+++ b/U/Uno/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder, Pkg
 
 name = "Uno"
 
-version = v"2.2.2"
+version = v"2.3.0"
 
 sources = [
     GitSource(
         "https://github.com/cvanaret/Uno.git",
-        "5a6bbfdecf3f18072a34ec48ab87f6f3a20a49de",
+        "4764c01247e60426234dc5c309a532fd67d7ed36",
     ),
 ]
 


### PR DESCRIPTION
[Uno v2.3.0](https://github.com/cvanaret/Uno/releases/tag/v2.3.0) was released on Oct 24, 2025.

cc @amontoison 