### PR TITLE
[libcxxwrap_julia] Build with libjulia 1.11.0 (and thus for julia 1.14-DEV)

### DIFF
--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -17,7 +17,7 @@ git_repo = "https://github.com/JuliaInterop/libcxxwrap-julia.git"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource(git_repo, "007ef98595326833706404518ed13af780ec113b"),
+    GitSource(git_repo, "0419ca72fd1c5a133bc2ca3e6b90cb29acb08d26"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
I am not quite sure what to do about the version number, as this will restricts the julia compat from 1.6 to 1.10. @barche what is your preferred way here?