### PR TITLE
[Rusticl] rebuild for SPIRV-Tools 2025.4

### DIFF
--- a/R/Rusticl/build_tarballs.jl
+++ b/R/Rusticl/build_tarballs.jl
@@ -124,7 +124,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     BuildDependency("libclc_jll"),
-    Dependency("SPIRV_Tools_jll"),
+    Dependency("SPIRV_Tools_jll"; compat = "~2025.4"),
     Dependency("libdrm_jll"),       # XXX: can we get rid of this?
     Dependency("OpenCL_jll"),
 ]


### PR DESCRIPTION
and add tighter compat bounds.

Should fix JuliaGPU/OpenCL.jl#398
