### PR TITLE
[libsingular_julia] Bump version number

### DIFF
--- a/L/libsingular_julia/build_tarballs.jl
+++ b/L/libsingular_julia/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 name = "libsingular_julia"
-version = v"0.47.7"
+version = v"0.47.8"
 
 # Collection of sources required to build libsingular-julia
 sources = [


### PR DESCRIPTION
The previous build in https://github.com/JuliaPackaging/Yggdrasil/pull/12458 violates the registry consistency checks in general, see https://github.com/JuliaRegistries/General/pull/141728.