### PR TITLE
[libzenohc] Update to 1.6.2

### DIFF
--- a/L/libzenohc/build_tarballs.jl
+++ b/L/libzenohc/build_tarballs.jl
@@ -7,7 +7,10 @@ version = v"1.6.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/eclipse-zenoh/zenoh-c.git", "f376456ccf75ed837a21a186bdf5191cba50eb3b")
+    GitSource(
+        "https://github.com/eclipse-zenoh/zenoh-c.git",
+        "f376456ccf75ed837a21a186bdf5191cba50eb3b",
+    ),
 ]
 
 # Bash recipe for building across all platforms
@@ -48,15 +51,23 @@ filter!(p -> arch(p) != "riscv64", platforms)
 filter!(p -> os(p) != "freebsd", platforms)
 
 # The products that we will ensure are always built
-products = Product[
-    LibraryProduct("libzenohc", :libzenohc)
-]
+products = Product[LibraryProduct(["libzenohc", "zenohc"], :libzenohc)]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
-]
+dependencies = Dependency[]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6", compilers=[:rust, :c],
-    preferred_gcc_version=v"14.2.0", lock_microarchitecture=false)
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    julia_compat = "1.6",
+    compilers = [:rust, :c],
+    preferred_gcc_version = v"8.1.0",
+    lock_microarchitecture = false,
+)


### PR DESCRIPTION
Update to version 1.6.2.

In the meantime, another build script for this library was posted [here](https://github.com/JuliaPackaging/Yggdrasil/tree/master/Z/ZenohC).
The build script was adapted from there (thanks @BenChung!).

I suppose going forward besides compatibility with existing code there's no need for redundancy, should these versions be merged/unified (in either direction)?