### PR TITLE
[LAPACK/BLAS] Remove stop command from error handler

### DIFF
--- a/L/LAPACK/LAPACK/build_tarballs.jl
+++ b/L/LAPACK/LAPACK/build_tarballs.jl
@@ -16,4 +16,4 @@ filter!(p -> !(arch(p) == "aarch64" && Sys.islinux(p) && libgfortran_version(p) 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                clang_use_lld=false, julia_compat="1.12", preferred_gcc_version=v"6")
 
-# Build Trigger: 11
+# Build Trigger: 12

--- a/L/LAPACK/LAPACK32/build_tarballs.jl
+++ b/L/LAPACK/LAPACK32/build_tarballs.jl
@@ -12,4 +12,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                clang_use_lld=false, julia_compat="1.12", preferred_gcc_version=v"6")
 
-# Build Trigger: 8
+# Build Trigger: 9

--- a/L/LAPACK/common.jl
+++ b/L/LAPACK/common.jl
@@ -20,6 +20,10 @@ function lapack_script(;lapack32::Bool=false)
     script *= raw"""
     cd $WORKSPACE/srcdir/lapack*
 
+    # Remove the stop command from the xerbla function to prevent
+    # us from exiting Julia on bad arguments
+    sed -i '/^[ \t]*STOP/d' SRC/xerbla.f
+
     if [[ "${target}" == *-mingw* ]]; then
         BLAS="blastrampoline-5"
     else

--- a/R/ReferenceBLAS/ReferenceBLAS/build_tarballs.jl
+++ b/R/ReferenceBLAS/ReferenceBLAS/build_tarballs.jl
@@ -12,4 +12,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.6", preferred_gcc_version=v"6")
 
-# Build Trigger: 5
+# Build Trigger: 6

--- a/R/ReferenceBLAS/ReferenceBLAS32/build_tarballs.jl
+++ b/R/ReferenceBLAS/ReferenceBLAS32/build_tarballs.jl
@@ -12,4 +12,4 @@ products = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.6", preferred_gcc_version=v"6")
 
-# Build Trigger: 4
+# Build Trigger: 5

--- a/R/ReferenceBLAS/common.jl
+++ b/R/ReferenceBLAS/common.jl
@@ -23,6 +23,10 @@ function blas_script(;blas32::Bool=false)
       INDEX64="OFF"
     fi
 
+    # Remove the stop command from the xerbla function to prevent
+    # us from exiting Julia on bad arguments
+    sed -i '/^[ \t]*STOP/d' SRC/xerbla.f
+
     # FortranCInterface_VERIFY fails on macOS, but it's not actually needed for the current build
     sed -i 's/FortranCInterface_VERIFY/# FortranCInterface_VERIFY/g' ./CBLAS/CMakeLists.txt
     sed -i 's/FortranCInterface_VERIFY/# FortranCInterface_VERIFY/g' ./LAPACKE/include/CMakeLists.txt


### PR DESCRIPTION
The reference LAPACK version of `xerbla` includes a call to `STOP` that will terminate the program when it is reached. On some systems, this seems to actually terminate Julia as well, e.g., https://github.com/JuliaLinearAlgebra/BLISBLAS.jl/issues/24, and that happens during the LBT initialization phase.

OpenBLAS and BLIS seem to have removed the stop from their implementations, so the program doesn't terminate. So let's do that for our build of the reference versions as well.