### PR TITLE
[libjulia] Upstream function for proper compat strings

### DIFF
--- a/A/AlphaMolWrapper/build_tarballs.jl
+++ b/A/AlphaMolWrapper/build_tarballs.jl
@@ -3,8 +3,6 @@ using BinaryBuilder, Pkg
 name = "AlphaMolWrapper"
 version = v"0.5.0"
 julia_versions = [v"1.7", v"1.8", v"1.9", v"1.10", v"1.11"]
-julia_compat = join("~" .* string.(getfield.(julia_versions, :major)) .* "." .* string.(getfield.(julia_versions, :minor)), ", ")
-
 
 sources = [
     GitSource("https://github.com/IvanSpirandelli/AlphaMolWrapper", "e3e0dd706b6bad98d5c58b96e0a9fc6b5fb7a2a3"),    
@@ -20,6 +18,7 @@ cmake .. \
 VERBOSE=ON cmake --build . --config Release --target install -- -j${nproc}
 """
 include("../../L/libjulia/common.jl")
+julia_compat = libjulia_julia_compat(julia_versions)
 platforms = expand_cxxstring_abis(vcat(libjulia_platforms.(julia_versions)...))
 
 products = [

--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -137,6 +137,6 @@ dependencies = [
 
 # Build the tarballs.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version=v"7", julia_compat=string(libjulia_min_julia_version))
+               preferred_gcc_version=v"7", julia_compat=libjulia_julia_compat(julia_versions))
 
 # rebuild trigger: 1

--- a/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_juliainterface/build_tarballs.jl
@@ -67,6 +67,6 @@ products = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version=v"7", julia_compat=string(libjulia_min_julia_version))
+               preferred_gcc_version=v"7", julia_compat=libjulia_julia_compat(julia_versions))
 
 # rebuild trigger: 1

--- a/J/JSBSim/build_tarballs.jl
+++ b/J/JSBSim/build_tarballs.jl
@@ -4,7 +4,6 @@ name = "JSBSim"
 version = v"1.1.12"
 
 julia_versions = [v"1.6.3", v"1.7", v"1.8", v"1.9", v"1.10"]
-julia_compat = join("~" .* string.(getfield.(julia_versions, :major)) .* "." .* string.(getfield.(julia_versions, :minor)), ", ")
 
 # Collection of sources required to build JSBSim
 sources = [
@@ -43,6 +42,7 @@ cp julia/*JSBSimJL*.$dlext $libdir/.
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 include("../../L/libjulia/common.jl")
+julia_compat = libjulia_julia_compat(julia_versions)
 platforms = vcat(libjulia_platforms.(julia_versions)...)
 platforms = expand_cxxstring_abis(platforms)
 

--- a/L/libcxxwrap_julia/build_tarballs.jl
+++ b/L/libcxxwrap_julia/build_tarballs.jl
@@ -58,4 +58,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    preferred_gcc_version = v"10", julia_compat = string(libjulia_min_julia_version))
+    preferred_gcc_version = v"10", julia_compat = libjulia_julia_compat(julia_versions))

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -59,6 +59,10 @@ function libjulia_platforms(julia_version)
     return platforms
 end
 
+function libjulia_julia_compat(julia_versions=julia_versions)
+    return join("~" .* string.(getfield.(julia_versions, :major)) .* "." .* string.(getfield.(julia_versions, :minor)), ", ")
+end
+
 # Collection of sources required to build Julia
 function build_julia(ARGS, version::VersionNumber; jllversion=version)
     name = "libjulia"
@@ -433,6 +437,6 @@ function build_julia(ARGS, version::VersionNumber; jllversion=version)
     if any(should_build_platform.(triplet.(platforms)))
         build_tarballs(ARGS, name, jllversion, sources, script, platforms, products, dependencies;
                    preferred_gcc_version=gcc_ver, preferred_llvm_version=v"17",
-                   lock_microarchitecture=false, julia_compat=string(libjulia_min_julia_version))
+                   lock_microarchitecture=false, julia_compat=libjulia_julia_compat(julia_versions))
     end
 end

--- a/L/libpolymake_julia/build_tarballs.jl
+++ b/L/libpolymake_julia/build_tarballs.jl
@@ -23,7 +23,7 @@ version = v"0.14.3"
 
 # reminder: change the above version when changing the supported julia versions
 # julia_versions is now taken from libjulia/common.jl and filtered
-julia_compat = join("~" .* string.(getfield.(julia_versions, :major)) .* "." .* string.(getfield.(julia_versions, :minor)), ", ")
+julia_compat = libjulia_julia_compat(julia_versions)
 
 # Collection of sources required to build libpolymake_julia
 sources = [

--- a/L/libsingular_julia/build_tarballs.jl
+++ b/L/libsingular_julia/build_tarballs.jl
@@ -67,6 +67,6 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    preferred_gcc_version=v"8", julia_compat=string(libjulia_min_julia_version))
+    preferred_gcc_version=v"8", julia_compat=libjulia_julia_compat(julia_versions))
 
 # rebuild trigger: 0

--- a/P/polymake_oscarnumber/build_tarballs.jl
+++ b/P/polymake_oscarnumber/build_tarballs.jl
@@ -23,7 +23,7 @@ version = v"0.3.12"
 
 # reminder: change the above version when changing the supported julia versions
 # julia_versions is now taken from libjulia/common.jl and filtered
-julia_compat = join("~" .* string.(getfield.(julia_versions, :major)) .* "." .* string.(getfield.(julia_versions, :minor)), ", ")
+julia_compat = libjulia_julia_compat(julia_versions)
 
 # Collection of sources required to build polymake
 sources = [

--- a/R/RichDEM/build_tarballs.jl
+++ b/R/RichDEM/build_tarballs.jl
@@ -57,13 +57,9 @@ VERBOSE=ON cmake --build . --config Release --target install -- -j${nproc}
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 julia_versions = [v"1.6.3", v"1.7", v"1.8", v"1.9", v"1.10"]
-julia_compat = join(
-    "~" .* string.(getfield.(julia_versions, :major)) .* "." .*
-    string.(getfield.(julia_versions, :minor)),
-    ", ",
-)
 
 include("../../L/libjulia/common.jl")
+julia_compat = libjulia_julia_compat(julia_versions)
 platforms = vcat(libjulia_platforms.(julia_versions)...)
 platformfilter(p) = (arch(p) != "armv6l" && !Sys.isbsd(p))
 platforms = filter(platformfilter, platforms)


### PR DESCRIPTION
and use them in dependent packages. (At least in the ones that recently started using the libjulia variable, and the ones that have identical code in their recipe.)

This is motivated by https://github.com/JuliaPackaging/Yggdrasil/pull/12459#issuecomment-3480099532. Something like `1.10` is not a valid compat string for libjulia_jll and everything that uses it as a BuildDependency, as e.g. there is no support for julia 1.15. It is better to have a compat string like `~1.10, ~1.11, ~1.12, ~1.13, ~1.14`, as in this case one notices unsupported julia versions already during resolving and not only way later during precompilation.

[skip build] [skip ci]