### PR TITLE
Heptagon: Bump version.

### DIFF
--- a/H/Heptagon/build_tarballs.jl
+++ b/H/Heptagon/build_tarballs.jl
@@ -15,7 +15,7 @@ sources = [
     GitSource("https://gitlab.inria.fr/fpottier/menhir",
               "d71051f500c4f34c9faf93192a593cdf4903b0c0"),  # 20240715
 
-    GitSource("https://gitlab.inria.fr/synchrone/heptagon",
+    GitSource("https://github.com/JuliaComputing/heptagon",
               "43cfe7ebd78bab246b5e8206eb8a3741c3f1b5c9")
 ]
 


### PR DESCRIPTION
Includes a patch for better compatibility with Julia (supporting sized integers and using a compatible bool representation): https://github.com/JuliaComputing/heptagon/commit/43cfe7ebd78bab246b5e8206eb8a3741c3f1b5c9