### PR TITLE
Add helper for installing macOS SDK when needed

### DIFF
--- a/F/FFMPEG/common.jl
+++ b/F/FFMPEG/common.jl
@@ -13,16 +13,13 @@ sources = [
         "b2751fccb6cc4c77708113cd78b561059b6fa904b24162fa0be2d60273d27b8e",
     ),
     ## FFmpeg 6.1.1 does not work with macos 10.13 or earlier.
-    FileSource(
-        "https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz",
-        "a3a077385205039a7c6f9e2c98ecdf2a720b2a819da715e03e0630c75782c1e4",
-    ),
+    get_macos_sdk_sources("10.13")...
 ]
 
 # Bash recipe for building across all platforms
 # TODO: Theora once it's available
 function script(; ffplay=false)
-    "FFPLAY=$(ffplay)\n" * raw"""
+    "FFPLAY=$(ffplay)\n" * get_macos_sdk_script("10.13") * raw"""
 cd $WORKSPACE/srcdir
 cd ffmpeg-*/
 sed -i 's/-lflite"/-lflite -lasound"/' configure
@@ -56,12 +53,6 @@ elif [[ "${target}" == riscv64-* ]]; then
 else
     export ccARCH="x86_64"
 fi
-
-if [[ "${target}" == x86_64-apple-darwin* ]]; then 
-    rm -rf /opt/${target}/${target}/sys-root/System
-    tar --extract --file=${WORKSPACE}/srcdir/MacOSX10.13.sdk.tar.xz --directory="/opt/${target}/${target}/sys-root/." --strip-components=1 MacOSX10.13.sdk/System MacOSX10.13.sdk/usr
-    export MACOSX_DEPLOYMENT_TARGET=10.13
-fi 
 
 export CUDA_ARGS=""
 

--- a/P/PlutoBook/build_tarballs.jl
+++ b/P/PlutoBook/build_tarballs.jl
@@ -2,26 +2,20 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
 name = "PlutoBook"
 version = v"0.9.0"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/plutoprint/plutobook.git", "d18e317a76da51816240c203253bfabb72208011"),
-    # We need C++20
-    FileSource("https://github.com/alexey-lysiuk/macos-sdk/releases/download/14.5/MacOSX14.5.tar.xz",
-               "f6acc6209db9d56b67fcaf91ec1defe48722e9eb13dc21fb91cfeceb1489e57e"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/plutobook/
-
-if [[ "${target}" == *-apple-darwin* ]]; then
-    rm -rf /opt/${target}/${target}/sys-root/System /opt/${target}/${target}/sys-root/usr/include/libxml2
-    tar --extract --file=${WORKSPACE}/srcdir/MacOSX14.5.tar.xz --directory="/opt/${target}/${target}/sys-root/." --strip-components=1 MacOSX14.5.sdk/System MacOSX14.5.sdk/usr
-    export MACOSX_DEPLOYMENT_TARGET=14.5
-fi
 
 mkdir build
 cd build/
@@ -31,6 +25,9 @@ ninja install
 
 install_license ${WORKSPACE}/srcdir/plutobook/LICENSE
 """
+
+# We need C++20
+sources, script = require_macos_sdk("14.5", sources, script)
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line

--- a/R/rcodesign/build_tarballs.jl
+++ b/R/rcodesign/build_tarballs.jl
@@ -2,14 +2,15 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
 name = "rcodesign"
 version = v"0.29.0"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://github.com/indygreg/apple-platform-rs/archive/refs/tags/apple-codesign/$(version).tar.gz", "e92e27c2d0738523b5f0bfc2da5dbab33601568cfeff3e1d40eadd0ffb8e5a98"),
-    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz",
-                  "d3feee3ef9c6016b526e1901013f264467bb927865a03422a9cb925991cc9783"),
 ]
 
 # Bash recipe for building across all platforms
@@ -19,22 +20,15 @@ script = raw"""
         export CFLAGS="${CFLAGS} -D_XOPEN_SOURCE=700"
     fi
 
-    if [[ "${target}" == x86_64-apple-darwin* ]]; then
-        #install a newer SDK which supports `kSecKeyAlgorithmRSASignatureMessagePSSSHA256`
-        pushd $WORKSPACE/srcdir/MacOSX11.*.sdk
-        rm -rf /opt/${target}/${target}/sys-root/System
-        rm -rf /opt/${target}/${target}/sys-root/usr/*
-        cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
-        cp -ra System "/opt/${target}/${target}/sys-root/."
-        popd
-    fi
-
     cd $WORKSPACE/srcdir/apple-platform-rs-apple-codesign-*/
     cargo build --release --package apple-codesign --target-dir ${WORKSPACE}/tmp
 
     install_license apple-codesign/LICENSE
     install -Dvm 755 "${WORKSPACE}/tmp/${rust_target}/release/rcodesign${exeext}" "${bindir}/rcodesign${exeext}"
 """
+
+# install a newer SDK which supports `kSecKeyAlgorithmRSASignatureMessagePSSSHA256`
+sources, script = require_macos_sdk("11.0", sources, script)
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line

--- a/platforms/macos_sdks.jl
+++ b/platforms/macos_sdks.jl
@@ -1,0 +1,115 @@
+"""
+    require_macos_sdk(version::String, sources::Vector, script::String)
+
+Augment `sources` and `script` to ensure the macOS SDK with the indicated
+`version` is available when building for macOS. Returns a new `sources` and
+script value.
+
+Currently this only has an effect when building for macOS on Intel hardware,
+as the ARM builder already uses a recent SDK. In the future this may also gain
+support for installing newer SDK versions on ARM as well.
+"""
+function require_macos_sdk(version::String, sources::Vector, script::String)
+    return vcat(sources, get_macos_sdk_sources(version)), get_macos_sdk_script(version) * script
+end
+
+"""
+    get_macos_sdk_sources(version::String)
+
+Return a vector of sources to be appended to the `sources` list of a build recipe,
+and `sdk_script` is a string to be inserted (usually at the start) of
+the build script.
+
+If used together with `get_macos_sdk_script` this ensures that the macOS SDK
+with the indicated `version` is available when building for macOS.
+
+Normally using `require_macos_sdk` should be preferred over this, so that the
+SDK version is specified in a single place. But when necessary it is useful to
+have this low-level alternative.
+"""
+function get_macos_sdk_sources(version::String)
+    # The natural way to handle installation of a new macOS SDK would be to
+    # add an ArchiveSource for the SDK and then moving it to the right place
+    # for the later build steps to find it.
+    #
+    # But this has the drawback of always extracting this (big) SDK, even on
+    # platforms that don't need it, which of course is most of them. Moreover,
+    # it floods the logs with the gargantuan list of files in these SDKs.
+    #
+    # Thus instead we use a FileSource. This way, the SDK is still always
+    # downloaded, but at least we can choose to only unpack it when we really
+    # need it. Plus we can directly unpack it in its final location; and
+    # suppress the full list of files being unpackaged
+    sdk_source =
+        if version == "10.13"
+            FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz",
+                       "a3a077385205039a7c6f9e2c98ecdf2a720b2a819da715e03e0630c75782c1e4")
+        elseif version == "10.14"
+            FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz",
+                       "0f03869f72df8705b832910517b47dd5b79eb4e160512602f593ed243b28715f")
+        elseif version == "10.15"
+            FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz",
+                       "2408d07df7f324d3beea818585a6d990ba99587c218a3969f924dfcc4de93b62")
+        elseif version == "11.0"
+            FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.0-11.1/MacOSX11.0.sdk.tar.xz",
+                        "d3feee3ef9c6016b526e1901013f264467bb927865a03422a9cb925991cc9783")
+        elseif version == "11.1"
+            FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.0-11.1/MacOSX11.1.sdk.tar.xz",
+                        "9b86eab03176c56bb526de30daa50fa819937c54b280364784ce431885341bf6")
+        elseif version == "11.3"
+            FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
+                       "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4")
+        elseif version == "12.3"
+            FileSource("https://github.com/realjf/MacOSX-SDKs/releases/download/v0.0.1/MacOSX12.3.sdk.tar.xz",
+                        "a511c1cf1ebfe6fe3b8ec005374b9c05e89ac28b3d4eb468873f59800c02b030")
+        elseif version == "14.0"
+            FileSource("https://github.com/roblabla/MacOSX-SDKs/releases/download/macosx14.0/MacOSX14.0.sdk.tar.xz",
+                       "4a31565fd2644d1aec23da3829977f83632a20985561a2038e198681e7e7bf49")
+        elseif version == "14.5"
+            FileSource("https://github.com/alexey-lysiuk/macos-sdk/releases/download/14.5/MacOSX14.5.tar.xz",
+                       "f6acc6209db9d56b67fcaf91ec1defe48722e9eb13dc21fb91cfeceb1489e57e")
+        elseif version == "15.0"
+            FileSource("https://github.com/joseluisq/MacOSX-SDKs/releases/download/15.0/MacOSX15.0.sdk.tar.xz",
+                        "9df0293776fdc8a2060281faef929bf2fe1874c1f9368993e7a4ef87b1207f98")
+        else
+            error("unsupported macOS SDK version $version")
+        end
+
+    # we return a vector just in case in the future we might need more than one source
+    return [sdk_source]
+end
+
+"""
+    get_macos_sdk_script(version::String)
+
+Return a a string to be inserted (usually at the start) of the build script
+of a build recipe.
+
+If used together with `get_macos_sdk_sources` this ensures that the macOS SDK
+with the indicated `version` is available when building for macOS.
+
+Normally using `require_macos_sdk` should be preferred over this, so that the
+SDK version is specified in a single place. But when necessary it is useful to
+have this low-level alternative.
+"""
+function get_macos_sdk_script(version::String)
+    # on ARM, the default macOS SDK we use is 11.1; so if the requested SDK
+    # version is older or equal to that, we can restrict to intel
+    arch = VersionNumber(version) <= v"11.1" ? "x86_64" : "*"
+    return raw"""
+    if [[ "${target}" == """*arch*raw"""-apple-darwin* ]]; then
+        macos_sdk="""*version*"\n"*
+        raw"""
+        echo "Extracting MacOSX${macos_sdk}.sdk.tar.xz (this may take a while)"
+        rm -rf /opt/${target}/${target}/sys-root/System
+        rm -rf /opt/${target}/${target}/sys-root/usr/include/libxml2/libxml
+        tar --extract \
+            --file=${WORKSPACE}/srcdir/MacOSX${macos_sdk}.sdk.tar.xz \
+            --directory="/opt/${target}/${target}/sys-root/." \
+            --strip-components=1 \
+            MacOSX${macos_sdk}.sdk/System \
+            MacOSX${macos_sdk}.sdk/usr
+        export MACOSX_DEPLOYMENT_TARGET=${macos_sdk}
+    fi
+    """
+end


### PR DESCRIPTION
Note: should be squash merged with `[skip ci] [skip build]`


----

For more uniform and better documented access to macOS SDKs.
Also, if we decide that accessing `https://github.com/phracker/MacOSX-SDKs` is not optimal (e.g. perhaps we want our own mirror), or we come up with a better method to handle this entire issue, then there is only one place to change, not dozens.

---

This is still a draft, to solicit feedback and also test that it actually works. The final PR would be made with `skip build` and `skip ci` set.

Things to discuss / to do:
- any objections to the general concept
- the name `require_macos_sdk` is perhaps not ideal, better suggestions welcome
- should this be in `platforms/macos_sdks.jl`? the `platforms` dir is used for "platform augmenting" code so far. Let me know if you think I should move or rename it (and where / to what!)
- more SDK versions could of course be added
- and of course there are about ~70 additional recipes that could / should be changed to use this if we go this route (but that could also happen gradually)
  - setting `YGGDRASIL_DIR` correctly in each of them will be a bit tedious, hence see also issue #12555