### PR TITLE
[cuPDLPx] Update to 0.1.4

### DIFF
--- a/C/cuPDLPx/build_tarballs.jl
+++ b/C/cuPDLPx/build_tarballs.jl
@@ -5,13 +5,13 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "cuPDLPx"
-version = v"0.1.301"
+version = v"0.1.4"
 
 
 sources = [
     GitSource(
         "https://github.com/MIT-Lu-Lab/cuPDLPx.git",
-        "d45b339cf72c52612cc3df30c4e79fc11e1537de",
+        "31fedcd2f46dfb2723721b02ebd17426a22c5db1",
     ),
 ]
 


### PR DESCRIPTION
## Changes
- Fix: name anonymous unions in the headers so that `Clang.jl` can generate correct Julia bindings, instead of `var"##Ctag#274"`.