### PR TITLE
[eccodes] Use macOS SDK helpers

### DIFF
--- a/platforms/macos_sdks.jl
+++ b/platforms/macos_sdks.jl
@@ -113,12 +113,7 @@ function get_macos_sdk_script(version::String; deployment_target::String = versi
             --strip-components=1 \
             MacOSX${macos_sdk_version}.sdk/System \
             MacOSX${macos_sdk_version}.sdk/usr
-        if [[ "${target}" == aarch64-apple-darwin* ]] &&
-           [[ "${macosx_deployment_target}" == 10.* ]]; then
-            export MACOSX_DEPLOYMENT_TARGET=11.0
-        else
-            export MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
-        fi
+        export MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
     fi
     """
 end


### PR DESCRIPTION
Follow up to PR #12557

I am still not quite sure how to deal with the `MACOSX_DEPLOYMENT_TARGET` issue. Since I see some build recipes that do support `MACOSX_DEPLOYMENT_TARGET` beyond 10, and since [this comment](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/blob/30feb2624dae7f79a0821bf29142bb004cff5b53/src/Runner.jl#L913-L917) indicates it may be related to  the tool versions, I'll experiment a bit with this.

Should be merged with `[skip ci]`