### PR TITLE
[Qt6Positioning] [Qt6WebChannel] [Qt6WebSockets] drop custom mingw SDK

### DIFF
--- a/Q/Qt6Positioning/build_tarballs.jl
+++ b/Q/Qt6Positioning/build_tarballs.jl
@@ -14,8 +14,6 @@ sources = [
                   "5c2b0d46b8d35126e97c8efe22264b2de7ac1273a5ec38a0314731bb02804f53"),
     ArchiveSource("https://github.com/roblabla/MacOSX-SDKs/releases/download/13.3/MacOSX13.3.sdk.tar.xz",
                   "e5d0f958a079106234b3a840f93653308a76d3dcea02d3aa8f2841f8df33050c"),
-    ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v10.0.0.tar.bz2",
-                  "ba6b430aed72c63a3768531f6a3ffc2b0fde2c57a3b251450dcf489a894f0894")
 ]
 
 script = raw"""
@@ -32,26 +30,6 @@ case "$bb_full_target" in
     ;;
 
     *mingw*)        
-        cd $WORKSPACE/srcdir/mingw*/mingw-w64-headers
-        ./configure --prefix=/opt/$target/$target/sys-root --enable-sdk=all --host=$target
-        make install
-        
-        cd ../mingw-w64-crt/
-        if [ ${target} == "i686-w64-mingw32" ]; then
-            _crt_configure_args="--disable-lib64 --enable-lib32"
-        elif [ ${target} == "x86_64-w64-mingw32" ]; then
-            _crt_configure_args="--disable-lib32 --enable-lib64"
-        fi
-        ./configure --prefix=/opt/$target/$target/sys-root --enable-sdk=all --host=$target --enable-wildcard ${_crt_configure_args}
-        make -j${nproc}
-        make install
-        
-        cd ../mingw-w64-libraries/winpthreads
-        ./configure --prefix=/opt/$target/$target/sys-root --host=$target --enable-static --enable-shared
-        make -j${nproc}
-        make install
-
-        cd $WORKSPACE/srcdir/build
         cmake -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/Q/Qt6WebChannel/build_tarballs.jl
+++ b/Q/Qt6WebChannel/build_tarballs.jl
@@ -14,8 +14,6 @@ sources = [
                   "c188d9fa6e535b850b574fa9e47c6089555b8df1fe041dcb13aeeca336b78e63"),
     ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.0-11.1/MacOSX11.1.sdk.tar.xz",
                   "9b86eab03176c56bb526de30daa50fa819937c54b280364784ce431885341bf6"),
-    ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v10.0.0.tar.bz2",
-                  "ba6b430aed72c63a3768531f6a3ffc2b0fde2c57a3b251450dcf489a894f0894")
 ]
 
 script = raw"""
@@ -32,26 +30,6 @@ case "$bb_full_target" in
     ;;
 
     *mingw*)        
-        cd $WORKSPACE/srcdir/mingw*/mingw-w64-headers
-        ./configure --prefix=/opt/$target/$target/sys-root --enable-sdk=all --host=$target
-        make install
-        
-        cd ../mingw-w64-crt/
-        if [ ${target} == "i686-w64-mingw32" ]; then
-            _crt_configure_args="--disable-lib64 --enable-lib32"
-        elif [ ${target} == "x86_64-w64-mingw32" ]; then
-            _crt_configure_args="--disable-lib32 --enable-lib64"
-        fi
-        ./configure --prefix=/opt/$target/$target/sys-root --enable-sdk=all --host=$target --enable-wildcard ${_crt_configure_args}
-        make -j${nproc}
-        make install
-        
-        cd ../mingw-w64-libraries/winpthreads
-        ./configure --prefix=/opt/$target/$target/sys-root --host=$target --enable-static --enable-shared
-        make -j${nproc}
-        make install
-
-        cd $WORKSPACE/srcdir/build
         cmake -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/Q/Qt6WebSockets/build_tarballs.jl
+++ b/Q/Qt6WebSockets/build_tarballs.jl
@@ -14,8 +14,6 @@ sources = [
                   "204bd7b0dffb54c934abc6cf0eb5e3016f11b3c9721a67b4875a6b21bb8b5c76"),
     ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.0-11.1/MacOSX11.1.sdk.tar.xz",
                   "9b86eab03176c56bb526de30daa50fa819937c54b280364784ce431885341bf6"),
-    ArchiveSource("https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v10.0.0.tar.bz2",
-                  "ba6b430aed72c63a3768531f6a3ffc2b0fde2c57a3b251450dcf489a894f0894")
 ]
 
 script = raw"""
@@ -32,26 +30,6 @@ case "$bb_full_target" in
     ;;
 
     *mingw*)        
-        cd $WORKSPACE/srcdir/mingw*/mingw-w64-headers
-        ./configure --prefix=/opt/$target/$target/sys-root --enable-sdk=all --host=$target
-        make install
-        
-        cd ../mingw-w64-crt/
-        if [ ${target} == "i686-w64-mingw32" ]; then
-            _crt_configure_args="--disable-lib64 --enable-lib32"
-        elif [ ${target} == "x86_64-w64-mingw32" ]; then
-            _crt_configure_args="--disable-lib32 --enable-lib64"
-        fi
-        ./configure --prefix=/opt/$target/$target/sys-root --enable-sdk=all --host=$target --enable-wildcard ${_crt_configure_args}
-        make -j${nproc}
-        make install
-        
-        cd ../mingw-w64-libraries/winpthreads
-        ./configure --prefix=/opt/$target/$target/sys-root --host=$target --enable-static --enable-shared
-        make -j${nproc}
-        make install
-
-        cd $WORKSPACE/srcdir/build
         cmake -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \


### PR DESCRIPTION
This has a hack to not build all variants, to more quickly see if the Windows builds (still) work right.

For this one I had problems with testing because Qt headers for 6.7 are apparently no longer hosted on the official server, and while 6.5 headers are there, it still did run into build issues.

<s>So perhaps 6.8.3 versions will work better (I notice the other Qt6 packages are still at 6.8.2 -- no idea if that'd be a problem? Also, by now there is also Qt 6.10)</s>

UPDATE: OK apparently these all need to be in lockstep, so I changed the three to use 6.8.2. Someone else can think about switching it all to 6.8.3 or 6.10.1 or so.