### PR TITLE
Remove get_addable_spec from fancy_toys.jl

### DIFF
--- a/L/libcgal_julia/build_tarballs.jl
+++ b/L/libcgal_julia/build_tarballs.jl
@@ -1,6 +1,7 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
+using BinaryBuilderBase: get_addable_spec
 
 # reminder: change the above version if restricting the supported julia versions
 julia_versions = [v"1.6.3", v"1.7", v"1.8", v"1.9", v"1.10", v"1.11"]

--- a/L/libjulia/common.jl
+++ b/L/libjulia/common.jl
@@ -1,9 +1,10 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
+using BinaryBuilderBase: get_addable_spec
 
 const YGGDRASIL_DIR = "../.."
-include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl")) # for get_addable_spec and should_build_platform
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 # list of supported Julia versions
 julia_full_versions = [v"1.10.0", v"1.11.1", v"1.12.0", v"1.13.0-DEV", v"1.14.0-DEV"]

--- a/O/ONNXRuntime/ONNXRuntime_CUDA/build_tarballs.jl
+++ b/O/ONNXRuntime/ONNXRuntime_CUDA/build_tarballs.jl
@@ -1,6 +1,7 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
+using BinaryBuilderBase: get_addable_spec
 
 const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))

--- a/fancy_toys.jl
+++ b/fancy_toys.jl
@@ -2,9 +2,6 @@
 # developers.  These utilities can be employed in builder files.
 
 using BinaryBuilder, Pkg, LibGit2
-# Note: if you only need `get_addable_spec`, just add the following line to your recipe
-# instead of including this file.  This is reexported here for backward compatibility.
-using BinaryBuilderBase: get_addable_spec
 
 """
     should_build_platform(platform) -> Bool


### PR DESCRIPTION
It only was offered there for backwards compatibility.

Should be merged with `[skip ci]`.