### PR TITLE
Qt6: Use cmake with ninja

### DIFF
--- a/Q/Qt65Compat/build_tarballs.jl
+++ b/Q/Qt65Compat/build_tarballs.jl
@@ -25,7 +25,7 @@ sed -i "s/WrapIconv::WrapIconv/WrapIconv::WrapIconv iconv/" $qtsrcdir/src/core5/
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -56,7 +56,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/Q/Qt6Charts/build_tarballs.jl
+++ b/Q/Qt6Charts/build_tarballs.jl
@@ -23,7 +23,7 @@ qtsrcdir=`ls -d ../qtcharts-*`
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -54,7 +54,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \

--- a/Q/Qt6Declarative/build_tarballs.jl
+++ b/Q/Qt6Declarative/build_tarballs.jl
@@ -28,7 +28,7 @@ qtsrcdir=`ls -d ../qtdeclarative-*`
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -59,7 +59,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/Q/Qt6Graphs/build_tarballs.jl
+++ b/Q/Qt6Graphs/build_tarballs.jl
@@ -23,7 +23,7 @@ qtsrcdir=`ls -d ../qtgraphs-*`
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -54,7 +54,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \

--- a/Q/Qt6Positioning/build_tarballs.jl
+++ b/Q/Qt6Positioning/build_tarballs.jl
@@ -26,7 +26,7 @@ qtsrcdir=`ls -d ../qtpositioning-*`
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release $qtsrcdir
@@ -53,7 +53,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/Q/Qt6Quick3D/build_tarballs.jl
+++ b/Q/Qt6Quick3D/build_tarballs.jl
@@ -30,7 +30,7 @@ fi
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -61,7 +61,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \

--- a/Q/Qt6QuickTimeline/build_tarballs.jl
+++ b/Q/Qt6QuickTimeline/build_tarballs.jl
@@ -23,7 +23,7 @@ qtsrcdir=`ls -d ../qtquicktimeline-*`
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -54,7 +54,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \

--- a/Q/Qt6ShaderTools/build_tarballs.jl
+++ b/Q/Qt6ShaderTools/build_tarballs.jl
@@ -35,7 +35,7 @@ fi
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -43,7 +43,7 @@ case "$bb_full_target" in
     ;;
 
     *mingw*)        
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \

--- a/Q/Qt6Svg/build_tarballs.jl
+++ b/Q/Qt6Svg/build_tarballs.jl
@@ -23,7 +23,7 @@ qtsrcdir=`ls -d ../qtsvg-*`
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -54,7 +54,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \

--- a/Q/Qt6Tools/build_tarballs.jl
+++ b/Q/Qt6Tools/build_tarballs.jl
@@ -37,7 +37,7 @@ fi
 case "$bb_full_target" in
 
     x86_64-linux-musl*)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -45,7 +45,7 @@ case "$bb_full_target" in
     ;;
 
     *mingw*)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \

--- a/Q/Qt6Wayland/build_tarballs.jl
+++ b/Q/Qt6Wayland/build_tarballs.jl
@@ -26,7 +26,7 @@ qtsrcdir=`ls -d ../qtwayland-*`
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -34,7 +34,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \

--- a/Q/Qt6WebChannel/build_tarballs.jl
+++ b/Q/Qt6WebChannel/build_tarballs.jl
@@ -26,7 +26,7 @@ qtsrcdir=`ls -d ../qtwebchannel-*`
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -37,7 +37,7 @@ case "$bb_full_target" in
         apple_sdk_root=$WORKSPACE/srcdir/MacOSX11.1.sdk
         sed -i "s!/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root!$apple_sdk_root!" $CMAKE_TARGET_TOOLCHAIN
         deployarg="-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
@@ -52,7 +52,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/Q/Qt6WebSockets/build_tarballs.jl
+++ b/Q/Qt6WebSockets/build_tarballs.jl
@@ -26,7 +26,7 @@ qtsrcdir=`ls -d ../qtwebsockets-*`
 case "$bb_full_target" in
 
     x86_64-linux-musl-libgfortran5-cxx11)
-        cmake \
+        cmake -G Ninja \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
             -DCMAKE_FIND_ROOT_PATH=$prefix \
             -DCMAKE_BUILD_TYPE=Release \
@@ -37,7 +37,7 @@ case "$bb_full_target" in
         apple_sdk_root=$WORKSPACE/srcdir/MacOSX11.1.sdk
         sed -i "s!/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root!$apple_sdk_root!" $CMAKE_TARGET_TOOLCHAIN
         deployarg="-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \
@@ -52,7 +52,7 @@ case "$bb_full_target" in
     ;;
 
     *)
-        cmake \
+        cmake -G Ninja \
             -DQT_HOST_PATH=$host_prefix \
             -DPython_ROOT_DIR=/usr \
             -DCMAKE_INSTALL_PREFIX=${prefix} \


### PR DESCRIPTION
To stop the build system warning about bad things
that could happen when using make.

Should be merged with `[skip ci]`.

CC @barche 