### PR TITLE
[libtakum] Update to v2.0.0

### DIFF
--- a/L/libtakum/build_tarballs.jl
+++ b/L/libtakum/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "libtakum"
-version = v"1.0.2"
+version = v"2.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/takum-arithmetic/libtakum.git", "ba39720749a42611403873267de2ffb8f1f1b3e5")
+    GitSource("https://github.com/takum-arithmetic/libtakum.git", "776ac0ca7855f640100731ed8bbb0c7cf83b2d94")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Major version update due to API changes. Changes to Takums.jl are already lined up and will be quickly automerged.

**Release Notes**

Make floating-point takums instead of the logarithmic ones the default type: Instead of takum{8,16,32,64} and takum_linear{8,16,32,64} we now have takum{8,16,32,64} and takum_log{8,16,32,64}. The rest of the API was changed accordingly.

This reflects common usage of number formats in the field. While logarithmic number systems are great, it brought a bit of confusion insofar that merits of the takum format couldn't be properly discerned to be originating from the format or the property of being a logarithmic number system. For this reason, in everyday use and for evaluation, linear takums will prevail for now, and should be the default.

This change is only possible now, as libtakum is not yet seeing much usage. Regardless, to properly reflect this in semantic versioning, a major version bump is done.