### PR TITLE
[Qt6Base] switch to using `require_macos_sdk`

### DIFF
--- a/Q/Qt6Base/build_tarballs.jl
+++ b/Q/Qt6Base/build_tarballs.jl
@@ -14,8 +14,6 @@ const host_build = false
 sources = [
     ArchiveSource("https://download.qt.io/official_releases/qt/$(version.major).$(version.minor)/$version/submodules/qtbase-everywhere-src-$version.tar.xz",
                   "012043ce6d411e6e8a91fdc4e05e6bedcfa10fcb1347d3c33908f7fdd10dfe05"),
-    ArchiveSource("https://github.com/roblabla/MacOSX-SDKs/releases/download/macosx14.0/MacOSX14.0.sdk.tar.xz",
-                  "4a31565fd2644d1aec23da3829977f83632a20985561a2038e198681e7e7bf49"),
     DirectorySource("./bundled"),
 ]
 
@@ -69,28 +67,16 @@ case "$bb_full_target" in
     ;;
 
     *apple-darwin*)
-        apple_sdk_root=$WORKSPACE/srcdir/MacOSX14.0.sdk
-        sed -i "s!/opt/$target/$target/sys-root!$apple_sdk_root!" $CMAKE_TARGET_TOOLCHAIN
-        sed -i "s!/opt/$target/$target/sys-root!$apple_sdk_root!" /opt/bin/$bb_full_target/$target-clang++
-        deployarg="-DCMAKE_OSX_DEPLOYMENT_TARGET=12"
         export LDFLAGS="-L${libdir}/darwin -lclang_rt.osx"
-        export MACOSX_DEPLOYMENT_TARGET=12
         export OBJCFLAGS="-D__ENVIRONMENT_OS_VERSION_MIN_REQUIRED__=120000"
         export OBJCXXFLAGS=$OBJCFLAGS
         export CXXFLAGS=$OBJCFLAGS
-        # Override SDK root of BB tooling, which Qt queries
-        export SDKROOT=$apple_sdk_root
         sed -i 's/exit 1/#exit 1/' /opt/bin/$bb_full_target/$target-clang++
         ../qtbase-everywhere-src-*/configure -prefix $prefix \
             $commonoptions \
             -- $commoncmakeoptions \
             -DQT_INTERNAL_APPLE_SDK_VERSION=14 \
             -DQT_INTERNAL_XCODE_VERSION=15 \
-            -DCMAKE_SYSROOT=$apple_sdk_root \
-            -DCMAKE_FRAMEWORK_PATH=$apple_sdk_root/System/Library/Frameworks \
-            $deployarg \
-            -DCUPS_INCLUDE_DIR=$apple_sdk_root/usr/include \
-            -DCUPS_LIBRARIES=$apple_sdk_root/usr/lib/libcups.tbd \
             -DQT_FEATURE_vulkan=OFF
         sed -i 's/#exit 1/exit 1/' /opt/bin/$bb_full_target/$target-clang++
     ;;

--- a/Q/Qt6Base/common.jl
+++ b/Q/Qt6Base/common.jl
@@ -2,6 +2,7 @@ using BinaryBuilder, Pkg
 
 const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 if !@isdefined host_build
   host_build = false
@@ -16,7 +17,7 @@ platforms_win = filter(Sys.iswindows, platforms)
 platforms = setdiff(platforms, platforms_macos, platforms_win)
 
 # We must use the same version of LLVM for the build toolchain and LLVMCompilerRT_jll
-qt_llvm_version = v"16.0.6"
+qt_llvm_version = "16.0.6"
 
 make_mac_product(p::Product) = p
 function make_mac_product(lp::LibraryProduct)
@@ -30,10 +31,11 @@ end
 
 function build_qt(name, version, sources, script, products, dependencies; products_win=products, ARGS=ARGS)
   products_macos = make_mac_product.(products)
-  preferred_llvm_version = qt_llvm_version
+  preferred_llvm_version = VersionNumber(qt_llvm_version)
   julia_compat="1.6"
   if any(should_build_platform.(triplet.(platforms_macos)))
-      build_tarballs(ARGS, name, version, sources, script, platforms_macos, products_macos, dependencies; preferred_llvm_version, julia_compat)
+      sources_macos, script_macos = require_macos_sdk("14.0", sources, script; deployment_target="12")
+      build_tarballs(ARGS, name, version, sources_macos, script_macos, platforms_macos, products_macos, dependencies; preferred_llvm_version, julia_compat)
   end
   # GCC 12 and before fail with internal compiler error on mingw
   if any(should_build_platform.(triplet.(platforms_win)))


### PR DESCRIPTION
Should be merged with `[skip ci]`.

It may be that some of the macOS specific things will have to be added back (e.g. I have no idea why it was setting custom `LDFLAGS` and `OBJCFLAGS`). My idea here was to remove everything, then add things back as needed, but this time perhaps with a comment or two indicating the reason.

@barch Please let me know uf you have any explanations or additional thoughts on this!