### PR TITLE
Bump version for xkbcommon

### DIFF
--- a/X/xkbcommon/build_tarballs.jl
+++ b/X/xkbcommon/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder
 
 name = "xkbcommon"
-version = v"1.9.2"
+version = v"1.13.0"
 
 # Collection of sources required to build xkbcommon
 sources = [
-    GitSource("https://github.com/xkbcommon/libxkbcommon", "dd642359f8d43c09968e34ca7f1eb1121b2dfd70"),
+    GitSource("https://github.com/xkbcommon/libxkbcommon", "3049d310694fd70f1269bf48a1200aa4259e79b1"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Just hoping this could fix:
```
xkbcommon: ERROR: couldn't find a Compose file for locale "en_US.UTF-8" (mapped to "en_US.UTF-8")
┌ Warning: GLFW.GLFWError(GLFW.PLATFORM_ERROR, "Wayland: Failed to create XKB compose table")
└ @ GLFW /sim/Programmieren/MakieDev/dev/GLFW/src/GLFW.jl:66
```
Which I'm getting in https://github.com/JuliaGL/GLFW.jl/pull/244#issuecomment-3580954630
We dont need to rebuild GLFW_jll for this to get picked up, right? The deps for a jll are downloaded fresh on install?