### PR TITLE
[iceberg_rust_ffi_jll] upgrade to 0.5

### DIFF
--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -1,10 +1,10 @@
 using BinaryBuilder
 
 name = "iceberg_rust_ffi"
-version = v"0.4.2"
+version = v"0.5.0"
 
 sources = [
-    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "996294c95f93305d5758f508846e30560bfcb7f5"),
+    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "506489c26b1a6735cc1776a62f00274dcd2fdd67"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
breaking change because we switched one column (position) from unsigned int to signed int, according to iceberg spec. This will be reflected as a breaking change in RustyIceberg.jl as well