### PR TITLE
[aws_c_cal] Update to version 0.9.13

### DIFF
--- a/A/aws_c_cal/build_tarballs.jl
+++ b/A/aws_c_cal/build_tarballs.jl
@@ -6,11 +6,11 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "aws_c_cal"
-version = v"0.9.12"
+version = v"0.9.13"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-cal.git", "c2b06adb83ec733f8a37f66d56caac31d52c44ef"),
+    GitSource("https://github.com/awslabs/aws-c-cal.git", "1cb9412158890201a6ffceed779f90fe1f48180c"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_c_cal to version 0.9.13. cc: @quinnj @Octogonapus