### PR TITLE
[iceberg-rust-ffi] upgrade to 0.6

### DIFF
--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -1,10 +1,10 @@
 using BinaryBuilder
 
 name = "iceberg_rust_ffi"
-version = v"0.5.0"
+version = v"0.6.0"
 
 sources = [
-    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "506489c26b1a6735cc1776a62f00274dcd2fdd67"),
+    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "9a1a8c0d520f332d8988d7d679b6082e7cf76d9d"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Contains deadlock fix + some API renaming, hence bump to 0.6