### PR TITLE
[TVMFFI] Disable backtrace on segfault

### DIFF
--- a/T/TVMFFI/build_tarballs.jl
+++ b/T/TVMFFI/build_tarballs.jl
@@ -21,6 +21,7 @@ cmake \
     -DTVM_FFI_ATTACH_DEBUG_SYMBOLS=ON \
     -DTVM_FFI_BUILD_TESTS=OFF \
     -DTVM_FFI_BUILD_PYTHON_MODULE=OFF \
+    -DTVM_FFI_BACKTRACE_ON_SEGFAULT=OFF \
     -B ../../build
 cmake --build ../../build
 cmake --install ../../build


### PR DESCRIPTION
`TVM_FFI_BACKTRACE_ON_SEGFAULT` seems to conflicts with Julia 1.12 on Ubuntu (MacOS does not have this issue).

Simply `using TVMFFI_jl` would result in

```julia
  File "src/ffi/backtrace.cc", line 154, in TVMFFISegFaultHandler(int)
  File "/cache/build/builder-amdci5-2/julialang/julia-release-1-dot-12/src/jlapi.c", line 786, in ijl_gc_safepoint
  File "/cache/build/builder-amdci5-2/julialang/julia-release-1-dot-12/src/scheduler.c", line 459, in ijl_task_get_next
  File "./task.jl", line 1216, in julia_poptask_1813
  File "./task.jl", line 1228, in julia_wait_1782
  File "./condition.jl", line 141, in julia_#wait#398_12604
  File "./condition.jl", line 136, in wait
  File "./stream.jl", line 416, in julia_wait_readnb_14531
```

I have tested locally that lib binaries built with this option off would not lead to this segfault.

@fingolfin How should I deal with the version number in this case? I want to keep with the upstream project, but I do not know whether there would be a new patch version registered if I do not bump the version number here.