### PR TITLE
[ModularForms] Upgrade to version 0.2.1

### DIFF
--- a/M/ModularForms/build_tarballs.jl
+++ b/M/ModularForms/build_tarballs.jl
@@ -33,7 +33,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="FLINT_jll"), compat = "~301.300")
+    Dependency(PackageSpec(name="FLINT_jll"), compat = "~301.400")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
In the meantime, FLINT has incorporated Arb, which is therefore no longer a separate dependency.

The skipped v0.2 was an internal build that contained an error.