### PR TITLE
[f4ncgb] rebuild with flint 3.4, add version offset

### DIFF
--- a/F/f4ncgb/build_tarballs.jl
+++ b/F/f4ncgb/build_tarballs.jl
@@ -5,8 +5,8 @@ using BinaryBuilder
 name = "f4ncgb"
 upstream_version = v"0.3.3"
 version_offset = v"0.0.0"
-version = VersionNumber(upstream_version.major,
-                        upstream_version.minor,
+version = VersionNumber(upstream_version.major*100+version_offset.major,
+                        upstream_version.minor*100+version_offset.minor,
                         upstream_version.patch*100+version_offset.patch)
 
 sources = [


### PR DESCRIPTION
We need a version bump for the flint update, to simplify this in the future I am adding a version offset for the version.
This will change the version from 0.3.3 to 0.300.300.
~~For now only in the patchlevel to keep it compatible with current downstream packages.~~

cc: @Sequenzer 
