### PR TITLE
[GANAK] fix compat

### DIFF
--- a/G/GANAK/build_tarballs.jl
+++ b/G/GANAK/build_tarballs.jl
@@ -188,7 +188,7 @@ products = [
 dependencies = [
     Dependency("GMP_jll"; compat="6.2.1"),
     Dependency("MPFR_jll"),
-    Dependency("FLINT_jll"; compat="~301.300"),
+    Dependency("FLINT_jll"; compat="~301.300.101"),
     Dependency("Zlib_jll"),
     Dependency("cereal_jll"),
     Dependency("armadillo_jll"),


### PR DESCRIPTION
The new version of [FLINT_jll](https://github.com/JuliaPackaging/Yggdrasil/pull/12634) seems to have unfortunately introduced a compatibility issue (new .so version number) making GANAK_jll not work anymore if the previous version of FLINT_jll is not explicitly requested.

A fix would be adding the compat entry for this dependency as I did in the commit for this PR.

I additionally have these questions:
- Should we add compat specifications for all or some other dependencies as well? What are the current best practices for this?
- Do we need to increase the GANAK_jll version?

Appreciate any help or feedback. Thanks!