### PR TITLE
VNNLIB for Julia

### DIFF
--- a/V/VNNLIB/build_tarballs.jl
+++ b/V/VNNLIB/build_tarballs.jl
@@ -38,6 +38,7 @@ products = [
 dependencies = [
     Dependency("libcxxwrap_julia_jll"; compat="0.14.7"),
     Dependency("libjulia_jll"; compat="1.11"),
+    Dependency("CompilerSupportLibraries_jll"),
     HostBuildDependency("Bison_jll"),
     HostBuildDependency("flex_jll")
 ]


### PR DESCRIPTION
Hello,
we are currently setting up a (new version of a) standard for specifications of neural networks called "VNNLIB".
To this end, we plan to soon publish a Julia parser for such specifications [1] which requires the shared library from [2].
This pull request is supposed to add the shared library from [2] to Yggdrasil.

This is my first time contributing to Yggdrasil, so I'm happy about any feedback in case I overlooked something...

[1] [https://github.com/VNNLIB/VNNLIB.jl](https://github.com/VNNLIB/VNNLIB.jl)
[2] [https://github.com/VNNLIB/VNNLIB-CPP](https://github.com/VNNLIB/VNNLIB-CPP)