### PR TITLE
[RadeonProRender] Update version to 3.1.6

### DIFF
--- a/R/RadeonProRender/build_tarballs.jl
+++ b/R/RadeonProRender/build_tarballs.jl
@@ -28,7 +28,7 @@ cp -Rv inc/* "${includedir}"
 
 # TODO, can we add centos7?
 platforms = [
-    Platform("x86_64", "linux"),
+    Platform("x86_64", "linux"; libc_version=v"2.34"),
     Platform("x86_64", "macos"),
     Platform("aarch64", "macos"),
     Platform("x86_64", "windows")
@@ -72,4 +72,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.10")


### PR DESCRIPTION
The exact release tag is called 3.1.6.patch1, which seems like something we shouldn't take over?