### PR TITLE
[libosrmc] Add build recipe

### DIFF
--- a/L/libosrmc/build_tarballs.jl
+++ b/L/libosrmc/build_tarballs.jl
@@ -1,10 +1,10 @@
 using BinaryBuilder, Pkg
 
 name = "libosrmc"
-version = v"6.0.0"
+version = v"6.0.1"
 
 sources = [
-    GitSource("https://github.com/moviro-hub/libosrmc.git", "c288319ee34b4132033dd149cc3655ed74621151"),
+    GitSource("https://github.com/moviro-hub/libosrmc.git", "08ae197fec79dc2f16ee9fa6370f14b8dc052aca"),
 ]
 
 script = raw"""


### PR DESCRIPTION
This PR focuses on the `libosrmc` wrapper on top of the `libosrm` provided by #12743.

In addition, there is this [repo](https://github.com/moviro-hub/OpenSourceRoutingMachine.jl), the actual Julia package, which depends on both libraries.

Pair-programmed with an AI agent