### PR TITLE
1. Bump DuckDB to v1.4.3

### DIFF
--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "DuckDB"
-version = v"1.4.2"
+version = v"1.4.3"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/duckdb/duckdb.git", "68d7555f68bd25c1a251ccca2e6338949c33986a"),
+    GitSource("https://github.com/duckdb/duckdb.git", "d1dc88f950d456d72493df452dabdcd13aa413dd"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
In this new version, DuckDB also added the [Windows ARM64](https://www.duckdb.org/2025/12/09/announcing-duckdb-143#extension-distribution-for-windows-arm64) support. If someone with more experience knew how to add new target, please feel free to modify this PR. Thanks!