### PR TITLE
[Xorg_xorgproto] Remove dependency to Pkg

### DIFF
--- a/X/Xorg_xorgproto/build_tarballs.jl
+++ b/X/Xorg_xorgproto/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "Xorg_xorgproto"
-version = v"2024.1"
+version = v"2024.1.1"
 
 # Collection of sources required to build xproto
 sources = [
@@ -35,4 +35,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
We need to remove the dependency to Pkg in oder to avoid the following error when building the binaries of a package that depends on `Xorg_xorgproto`:
```
ERROR: LoadError: MethodError: no method matching haskey(::Vector{Base.UUID}, ::String)
The function `haskey` exists, but no method is defined for this combination of argument types.  
```