### PR TITLE
[LibUV] Add to CFLAGS using env var, not ./configure (fix -O0)

### DIFF
--- a/L/LibUV/build_tarballs.jl
+++ b/L/LibUV/build_tarballs.jl
@@ -41,11 +41,11 @@ products = [
     LibraryProduct("libuv", :libuv),
 ]
 
-llvm_version = v"13.0.1+1"
+llvm_version = v"13.0.1"
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    BuildDependency(PackageSpec(; name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=llvm_version); platforms=filter(p -> sanitize(p)=="memory", platforms)),
+    BuildDependency(PackageSpec(; name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=string(llvm_version)); platforms=filter(p -> sanitize(p)=="memory", platforms)),
 ]
 
 # Note: we explicitly lie about this because we don't have the new


### PR DESCRIPTION
The configure script will pick up our modified CFLAGS from the environment variable and append them to the default optimization flags from autoconf. Setting them by passing CFLAGS= to the configure script removes all the default flags, leaving us shipping an unoptimized build with Julia.

Still haven't written the scanner I mentioned in #10645, but libuv ships with Julia and I noticed this one while stepping through it in the debugger.