### PR TITLE
[libblastrampoline 5.11] Rebuild to pick up riscv64

### DIFF
--- a/L/libblastrampoline/common.jl
+++ b/L/libblastrampoline/common.jl
@@ -3,8 +3,6 @@
 using BinaryBuilder, Pkg
 using BinaryBuilderBase: sanitize
 
-Pkg.status()
-
 name = "libblastrampoline"
 
 # Collection of sources required to build libblastrampoline

--- a/L/libblastrampoline/libblastrampoline@5.11/build_tarballs.jl
+++ b/L/libblastrampoline/libblastrampoline@5.11/build_tarballs.jl
@@ -11,4 +11,4 @@ build_tarballs(ARGS, name, version, sources, script, platforms, products, depend
                julia_compat="1.10",  preferred_llvm_version=llvm_version
 )
 
-# Build trigger: 4
+# Build trigger: 5


### PR DESCRIPTION
@giordano Is it ok to merge this? The reason is so that builds of Arpack can depend on julia 1.10 (which has LBT 5.11).