### PR TITLE
[aws_lc] Update to version 1.66.0

### DIFF
--- a/A/aws_lc/build_tarballs.jl
+++ b/A/aws_lc/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_lc"
-version = v"1.65.1"
+version = v"1.66.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-lc.git", "b5e2f866efc0c7f90fcb6781281ea31063efbd96"),
+    GitSource("https://github.com/awslabs/aws-lc.git", "c23b2ae88deec89091d8eeb37178fbef24c96919"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
This PR updates aws_lc to version 1.66.0. cc: @quinnj @Octogonapus