### PR TITLE
[SuiteSparse] Bump to v7.12.1

### DIFF
--- a/S/SuiteSparse/SuiteSparse32@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse32@7/build_tarballs.jl
@@ -2,7 +2,7 @@
 include("../common.jl")
 
 name = "SuiteSparse32"
-version = v"7.11.0"
+version = v"7.12.1"
 
 sources = suitesparse_sources(version)
 

--- a/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
@@ -2,7 +2,7 @@
 include("../common.jl")
 
 name = "SuiteSparse"
-version = v"7.11.0"
+version = v"7.12.1"
 
 sources = suitesparse_sources(version)
 

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -63,6 +63,10 @@ function suitesparse_sources(version::VersionNumber; kwargs...)
             GitSource("https://github.com/DrTimothyAldenDavis/SuiteSparse.git",
                       "b35a1f9318f4bd42085f4b5ea56f29c89d342d4d")
         ],
+        v"7.12.1" => [
+            GitSource("https://github.com/DrTimothyAldenDavis/SuiteSparse.git",
+                      "901381cd753c004cc2db8e91bdb48f1b51212d3d")
+        ],
     )
     return Any[
         suitesparse_version_sources[version]...,


### PR DESCRIPTION
## Summary

Bump SuiteSparse and SuiteSparse32 from v7.11.0 to v7.12.1.

## Changes

- `S/SuiteSparse/SuiteSparse@7/build_tarballs.jl`: 7.11.0 → 7.12.1
- `S/SuiteSparse/SuiteSparse32@7/build_tarballs.jl`: 7.11.0 → 7.12.1
- `S/SuiteSparse/common.jl`: Add v7.12.1 source

## Context

This is a focused PR addressing feedback from #12519. Per @ViralBShah's suggestion, this PR contains only the core SuiteSparse version bump.

**Separate PRs will be submitted for:**
- SSGraphBLAS (10.1.1 → 10.2.0)
- SuiteSparse_GPU (7.11.0 → 7.12.1)

**Deferred (pending discussion with @imciner2 about compat bounds):**
- CXSparse, ParU, SPEX - these would change compat bounds without bumping package version

## Release Notes
- https://github.com/DrTimothyAldenDavis/SuiteSparse/releases/tag/v7.12.1
