### PR TITLE
[Libcerf] Update to v2.5

### DIFF
--- a/L/Libcerf/build_tarballs.jl
+++ b/L/Libcerf/build_tarballs.jl
@@ -8,12 +8,23 @@ version = v"2.5"
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v$(version.major).$(version.minor)/libcerf-v$(version.major).$(version.minor).tar.gz",
-                  "b3a5e68a30bdbd3a58e9e7c038bd0aa2586b90bbb1c809f76665e176b2d42cdc")
+                  "b3a5e68a30bdbd3a58e9e7c038bd0aa2586b90bbb1c809f76665e176b2d42cdc"),
+    DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/libcerf-*/
+if [[ "${target}" == *-mingw* ]]; then
+    # ref:  https://github.com/msys2/MINGW-packages/commit/b3e9553aa603dc446af4a0610187c23ac8c9d97f
+    # fix wrong dll install path
+    atomic_patch -p1 ../patches/001-fix-install-dest.patch
+
+    # fix windows export symbols
+    LDFLAGS+=" -Wl,--export-all-symbols"
+    atomic_patch -p1 ../patches/002-fix-win-export.patch
+fi
+
 mkdir build && cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
 make -j${nproc}

--- a/L/Libcerf/bundled/patches/001-fix-install-dest.patch
+++ b/L/Libcerf/bundled/patches/001-fix-install-dest.patch
@@ -1,0 +1,11 @@
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -38,7 +38,7 @@
+ install(
+     TARGETS ${lib}
+     EXPORT ${intf}
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     COMPONENT Libraries)

--- a/L/Libcerf/bundled/patches/002-fix-win-export.patch
+++ b/L/Libcerf/bundled/patches/002-fix-win-export.patch
@@ -1,0 +1,12 @@
+@@ -0,0 +1,11 @@
+--- a/lib/err_fcts.c
++++ b/lib/err_fcts.c
+@@ -54,7 +54,7 @@
+ #include "defs.h" // defines _cerf_cmplx, NaN, C, cexp, ...
+ 
+ // for analysing the algorithm:
+-IMPORT extern int faddeeva_algorithm;
++extern int faddeeva_algorithm;
+ 
+ const double spi2 = 0.8862269254527580136490837416705725913990; // sqrt(pi)/2
+ const double s2pi = 2.5066282746310005024157652848110; // sqrt(2*pi)


### PR DESCRIPTION
## Release notes
- Piecewise polynomial approximation for functions im_w_of_c and erfcx rederived for guaranteed accuracy. Methods explained in Joachim Wuttke and Alexander Kleinsorge:"Code generation for piecewise Chebyshev approximation." Preprint available upon request.
- Required C standard is now C11 (we need the _Alignas specifier)

April 16, 2025
https://jugit.fz-juelich.de/mlz/libcerf/-/releases/v2.5
