### PR TITLE
MAGEMin v1.8.7

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 name = "MAGEMin"
-version = v"1.8.6"
+version = v"1.8.7"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "db62e3337247997ae90d67ad2f633b67502896de")                 ]
+                    "61954d3ca9755c83661215d9c3d81ddf0cf6a6df")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
-  Fixed day-1 issue of pseudocompounds not respecting site mixing constraints. This issue was leading to over-iteration during global minimization, substantially decreasing performances and leading to wrong phase equilibrium prediction in some cases.
-  Performance increase from 30 to 60% depending on the database
