### PR TITLE
Add `sequentialknn` library

### DIFF
--- a/S/sequentialknn/build_tarballs.jl
+++ b/S/sequentialknn/build_tarballs.jl
@@ -29,7 +29,7 @@ platforms = [
             ]
 
 # The products that we will ensure are always built
-products = [LibraryProduct("libsequentialknn", :libsequentialknn)]
+products = [LibraryProduct(["libsequentialknn", "sequentialknn"], :libsequentialknn)]
 
 # Dependencies that must be installed before this package can be built
 dependencies = Dependency[Dependency("Libiconv_jll")]


### PR DESCRIPTION
Hello,

This `build_tarballs.jl` is for a (very) small Rust library I have written that wraps aperformance-critical piece of code that I would like to depend on in several Julia packages and does not (presently) have any analogs in the Julia ecosystem. It is a small routine dependent on [kiddo](https://github.com/sdd/kiddo), a very fast adaptive k-d tree library.

Looking at the other entries in this repository, clearly this small piece of code is less substantial and popular than is usual. If it is your assessment that this isn't really a proper use of Yggdrasil and the `BinaryBuilder.jl` ecosystem, I understand (but would appreciate guidance on how else I could make this very simple but significantly important wrapper available to several of my packages that would benefit from it). With that said, I don't expect to _ever_ need to change it, and so I am hoping that it is agreeable for this to get built once and live peacefully as a couple MB of artifacts somewhere. 

As an additional note: you'll see that in the `script` object, I have to play some extension games manually. I found that `${libext}` and friends were not expanding to the correct values, and from googling wonder if the combination of (1) rust and (2) producing a library instead of an executable means that `${libext}` is often blank when it shouldn't be (which was the issue for me). If there is a more idiomatic way you would like for me to address this issue, I'm very happy to do that as well. The build platforms here are also somewhat narrow based on `rustc` issues I was getting about certain combinations (like `freebsd` and `linux musl`) not being supported by the crates.

Thanks very much in advance for your time!