### PR TITLE
Add vmecpp_julia v0.4.11

### DIFF
--- a/V/vmecpp_julia/build_tarballs.jl
+++ b/V/vmecpp_julia/build_tarballs.jl
@@ -1,0 +1,153 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "vmecpp_julia"
+version = v"0.4.11"
+
+# Julia versions to support
+julia_versions = [v"1.10", v"1.11", v"1.12"]
+julia_compat = join(map(julia_versions) do v "~$(v.major).$(v.minor)" end, ", ")
+
+# Collection of sources required to build vmecpp_julia
+sources = [
+    # Main vmecpp repository
+    GitSource("https://github.com/proximafusion/vmecpp.git",
+              "04f16f531ead8995b1f4a5a5f92024e82f83f86a"),  # v0.4.11
+
+    # Eigen 3.4.0 (header-only)
+    GitSource("https://gitlab.com/libeigen/eigen.git",
+              "3147391d946bb4b6c68edd901f2add6ac1f31f8c",  # 3.4.0
+              unpack_target="eigen"),
+
+    # Abseil-cpp (specific commit used by vmecpp)
+    GitSource("https://github.com/abseil/abseil-cpp.git",
+              "4447c7562e3bc702ade25105912dce503f0c4010",
+              unpack_target="abseil-cpp"),
+
+    # nlohmann_json v3.11.3
+    ArchiveSource("https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz",
+                  "d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d",
+                  unpack_target="nlohmann_json"),
+
+    # abscab-cpp
+    GitSource("https://github.com/jonathanschilling/abscab-cpp.git",
+              "5cfa473b90aab06d7f70d986da0c46c46c1ebe9c",
+              unpack_target="abscab-cpp"),
+
+    # indata2json
+    GitSource("https://github.com/jonathanschilling/indata2json.git",
+              "f59e3ddd66486b63536f141a786d39c23d654c77",
+              unpack_target="indata2json"),
+
+    # Julia wrapper sources (bundled)
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+
+# Debug: List source directories
+echo "Listing srcdir contents:"
+ls -la
+
+# ============================================
+# Step 1: Build Abseil as static libraries
+# ============================================
+echo "Building Abseil..."
+mkdir -p abseil-build && cd abseil-build
+cmake ../abseil-cpp/abseil-cpp \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DCMAKE_CXX_STANDARD=20 \
+    -DABSL_PROPAGATE_CXX_STD=ON \
+    -DABSL_BUILD_TESTING=OFF
+make -j${nproc}
+make install
+cd ..
+
+# ============================================
+# Step 2: Build vmecpp core (static library)
+# ============================================
+echo "Building vmecpp core..."
+mkdir -p vmecpp-build && cd vmecpp-build
+
+# Configure vmecpp with vendored dependencies
+cmake ../vmecpp \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=20 \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DFETCHCONTENT_SOURCE_DIR_EIGEN3=${WORKSPACE}/srcdir/eigen \
+    -DFETCHCONTENT_SOURCE_DIR_NLOHMANN_JSON=${WORKSPACE}/srcdir/nlohmann_json/json-3.11.3 \
+    -DFETCHCONTENT_SOURCE_DIR_ABSEIL=${WORKSPACE}/srcdir/abseil-cpp \
+    -DFETCHCONTENT_SOURCE_DIR_ABSCAB=${WORKSPACE}/srcdir/abscab-cpp \
+    -DFETCHCONTENT_SOURCE_DIR_INDATA2JSON=${WORKSPACE}/srcdir/indata2json \
+    -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
+    -Dabsl_DIR=${prefix}/lib/cmake/absl
+
+# Build only the core library (not Python bindings or standalone)
+make -j${nproc} vmecpp_core
+cd ..
+
+# ============================================
+# Step 3: Build Julia wrapper (shared library)
+# ============================================
+echo "Building Julia wrapper..."
+mkdir -p julia-build && cd julia-build
+cmake ../bundled \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_STANDARD=20 \
+    -DJulia_PREFIX=${prefix} \
+    -DVMECPP_SOURCE_DIR=${WORKSPACE}/srcdir/vmecpp \
+    -DVMECPP_BUILD_DIR=${WORKSPACE}/srcdir/vmecpp-build \
+    -DEIGEN_DIR=${WORKSPACE}/srcdir/eigen \
+    -Dabsl_DIR=${prefix}/lib/cmake/absl
+make -j${nproc}
+make install
+
+# Install license
+install_license ${WORKSPACE}/srcdir/vmecpp/LICENSE
+"""
+
+# Platforms - use libjulia_platforms from Yggdrasil's common.jl
+include("../../L/libjulia/common.jl")
+platforms = reduce(vcat, libjulia_platforms.(julia_versions))
+
+# Filter out unsupported platforms
+filter!(p -> arch(p) != "armv7l", platforms)  # ARM32 often problematic
+filter!(p -> arch(p) != "armv6l", platforms)  # Experimental
+filter!(p -> !Sys.iswindows(p), platforms)    # Windows not supported yet
+
+# Expand C++ string ABIs
+platforms = expand_cxxstring_abis(platforms)
+
+# Products
+products = [
+    LibraryProduct("libvmecpp_julia", :libvmecpp_julia; dlopen_flags=[:RTLD_GLOBAL]),
+]
+
+# Dependencies
+dependencies = [
+    # Build dependencies
+    BuildDependency("libjulia_jll"),
+
+    # Runtime dependencies
+    Dependency("libcxxwrap_julia_jll"; compat="~0.12"),
+    Dependency("HDF5_jll"; compat="~1.14"),
+    Dependency("NetCDF_jll"),
+    Dependency("OpenBLAS_jll"),
+    Dependency("LLVMOpenMP_jll"),
+    Dependency("CompilerSupportLibraries_jll"),
+]
+
+# Build the tarballs
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               preferred_gcc_version = v"10",  # C++20 support
+               julia_compat)

--- a/V/vmecpp_julia/bundled/CMakeLists.txt
+++ b/V/vmecpp_julia/bundled/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(vmecpp_julia CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# ============================================
+# Find JlCxx (CxxWrap) - provides Julia bindings
+# ============================================
+find_package(JlCxx REQUIRED)
+
+# Add JlCxx cmake modules to module path for FindJulia
+list(APPEND CMAKE_MODULE_PATH "${JlCxx_DIR}")
+
+# ============================================
+# External paths (set by build script)
+# ============================================
+set(VMECPP_SOURCE_DIR "" CACHE PATH "Path to VMECPP source directory")
+set(VMECPP_BUILD_DIR "" CACHE PATH "Path to VMECPP build directory")
+set(EIGEN_DIR "" CACHE PATH "Path to Eigen headers")
+
+if(NOT VMECPP_SOURCE_DIR)
+    message(FATAL_ERROR "VMECPP_SOURCE_DIR must be set")
+endif()
+if(NOT VMECPP_BUILD_DIR)
+    message(FATAL_ERROR "VMECPP_BUILD_DIR must be set")
+endif()
+
+message(STATUS "VMECPP source directory: ${VMECPP_SOURCE_DIR}")
+message(STATUS "VMECPP build directory: ${VMECPP_BUILD_DIR}")
+
+# ============================================
+# Find dependencies from JLL packages
+# ============================================
+find_package(HDF5 REQUIRED COMPONENTS CXX)
+find_package(netCDF REQUIRED)
+find_package(OpenMP REQUIRED)
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
+
+# Find Abseil (installed by build script)
+find_package(absl REQUIRED)
+
+# ============================================
+# Create the Julia wrapper shared library
+# ============================================
+add_library(vmecpp_julia SHARED
+    vmecpp_julia.cpp
+)
+
+# Include directories
+target_include_directories(vmecpp_julia PRIVATE
+    ${VMECPP_SOURCE_DIR}/src/vmecpp/cpp
+    ${EIGEN_DIR}
+)
+
+# Get all abseil libraries we need
+set(ABSL_LIBS
+    absl::status
+    absl::statusor
+    absl::strings
+    absl::str_format
+    absl::log
+    absl::check
+    absl::base
+    absl::synchronization
+)
+
+# Link libraries
+target_link_libraries(vmecpp_julia
+    PUBLIC
+        JlCxx::cxxwrap_julia
+        ${VMECPP_BUILD_DIR}/libvmecpp_core.a
+        ${ABSL_LIBS}
+        HDF5::HDF5
+        netCDF::netcdf
+        OpenMP::OpenMP_CXX
+        ${LAPACK_LIBRARIES}
+        ${BLAS_LIBRARIES}
+)
+
+# ============================================
+# Installation
+# ============================================
+install(TARGETS vmecpp_julia
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)

--- a/V/vmecpp_julia/bundled/vmecpp_julia.cpp
+++ b/V/vmecpp_julia/bundled/vmecpp_julia.cpp
@@ -1,0 +1,474 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// SPDX-License-Identifier: MIT
+
+// CxxWrap bindings for VMECPP Julia interface
+
+#include "jlcxx/jlcxx.hpp"
+#include "jlcxx/stl.hpp"
+
+#include <Eigen/Dense>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "vmecpp/common/magnetic_configuration_lib/magnetic_configuration_lib.h"
+#include "vmecpp/common/makegrid_lib/makegrid_lib.h"
+#include "vmecpp/common/util/util.h"
+#include "vmecpp/common/vmec_indata/vmec_indata.h"
+#include "vmecpp/vmec/output_quantities/output_quantities.h"
+#include "vmecpp/vmec/vmec/vmec.h"
+
+using Eigen::VectorXd;
+using Eigen::VectorXi;
+using Eigen::MatrixXd;
+using vmecpp::RowMatrixXd;
+using vmecpp::VmecINDATA;
+
+// Eigen type mappings for CxxWrap
+namespace jlcxx {
+  template<> struct IsMirroredType<Eigen::VectorXd> : std::false_type {};
+  template<> struct IsMirroredType<Eigen::VectorXi> : std::false_type {};
+  template<> struct IsMirroredType<Eigen::MatrixXd> : std::false_type {};
+  template<> struct IsMirroredType<vmecpp::RowMatrixXd> : std::false_type {};
+}  // namespace jlcxx
+
+namespace {
+
+// Helper function to throw on absl::Status errors
+template <typename T>
+T& GetValueOrThrow(absl::StatusOr<T>& s) {
+  if (!s.ok()) {
+    jl_error(s.status().message().data());
+  }
+  return s.value();
+}
+
+// Conversion helpers for Julia <-> Eigen
+VectorXi MakeVectorXi(jlcxx::ArrayRef<int> arr) {
+  return Eigen::Map<const VectorXi>(arr.data(), arr.size());
+}
+
+VectorXd MakeVectorXd(jlcxx::ArrayRef<double> arr) {
+  return Eigen::Map<const VectorXd>(arr.data(), arr.size());
+}
+
+RowMatrixXd MakeRowMatrixXd(jlcxx::ArrayRef<double> arr, int rows, int cols) {
+  return Eigen::Map<const RowMatrixXd>(arr.data(), rows, cols);
+}
+
+// Helper to create HotRestartState
+vmecpp::HotRestartState MakeHotRestartState(
+    vmecpp::WOutFileContents wout, const VmecINDATA& indata) {
+  return vmecpp::HotRestartState(std::move(wout), indata);
+}
+
+// Basic run() without hot restart
+vmecpp::OutputQuantities RunVmecBasic(
+    const VmecINDATA& indata,
+    bool verbose) {
+  auto ret = vmecpp::run(indata, std::nullopt, std::nullopt, verbose);
+  return GetValueOrThrow(ret);
+}
+
+// run() with max_threads
+vmecpp::OutputQuantities RunVmecWithThreads(
+    const VmecINDATA& indata,
+    int max_threads,
+    bool verbose) {
+  auto ret = vmecpp::run(indata, std::nullopt, max_threads, verbose);
+  return GetValueOrThrow(ret);
+}
+
+// run() with hot restart
+vmecpp::OutputQuantities RunVmecWithRestart(
+    const VmecINDATA& indata,
+    const vmecpp::HotRestartState& initial_state,
+    bool verbose) {
+  auto ret = vmecpp::run(indata, initial_state, std::nullopt, verbose);
+  return GetValueOrThrow(ret);
+}
+
+// run() with hot restart and threads
+vmecpp::OutputQuantities RunVmecWithRestartAndThreads(
+    const VmecINDATA& indata,
+    const vmecpp::HotRestartState& initial_state,
+    int max_threads,
+    bool verbose) {
+  auto ret = vmecpp::run(indata, initial_state, max_threads, verbose);
+  return GetValueOrThrow(ret);
+}
+
+// Free boundary - basic
+vmecpp::OutputQuantities RunVmecFreeBoundaryBasic(
+    const VmecINDATA& indata,
+    const makegrid::MagneticFieldResponseTable& magnetic_response_table,
+    bool verbose) {
+  auto ret = vmecpp::run(indata, magnetic_response_table,
+                         std::nullopt, std::nullopt, verbose);
+  return GetValueOrThrow(ret);
+}
+
+// Free boundary with threads
+vmecpp::OutputQuantities RunVmecFreeBoundaryWithThreads(
+    const VmecINDATA& indata,
+    const makegrid::MagneticFieldResponseTable& magnetic_response_table,
+    int max_threads,
+    bool verbose) {
+  auto ret = vmecpp::run(indata, magnetic_response_table,
+                         std::nullopt, max_threads, verbose);
+  return GetValueOrThrow(ret);
+}
+
+// Free boundary with hot restart
+vmecpp::OutputQuantities RunVmecFreeBoundaryWithRestart(
+    const VmecINDATA& indata,
+    const makegrid::MagneticFieldResponseTable& magnetic_response_table,
+    const vmecpp::HotRestartState& initial_state,
+    bool verbose) {
+  auto ret = vmecpp::run(indata, magnetic_response_table,
+                         initial_state, std::nullopt, verbose);
+  return GetValueOrThrow(ret);
+}
+
+// Free boundary with hot restart and threads
+vmecpp::OutputQuantities RunVmecFreeBoundaryWithRestartAndThreads(
+    const VmecINDATA& indata,
+    const makegrid::MagneticFieldResponseTable& magnetic_response_table,
+    const vmecpp::HotRestartState& initial_state,
+    int max_threads,
+    bool verbose) {
+  auto ret = vmecpp::run(indata, magnetic_response_table,
+                         initial_state, max_threads, verbose);
+  return GetValueOrThrow(ret);
+}
+
+} // anonymous namespace
+
+JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
+{
+  // ============================================================================
+  // Eigen types (must come first for type system)
+  // ============================================================================
+  mod.add_type<Eigen::VectorXd>("VectorXd")
+    .method("size", &Eigen::VectorXd::size)
+    .method("data", [](Eigen::VectorXd& v) {
+      return jlcxx::ArrayRef<double>(v.data(), v.size());
+    });
+
+  mod.add_type<Eigen::VectorXi>("VectorXi")
+    .method("size", &Eigen::VectorXi::size)
+    .method("data", [](Eigen::VectorXi& v) {
+      return jlcxx::ArrayRef<int>(v.data(), v.size());
+    });
+
+  mod.add_type<Eigen::MatrixXd>("MatrixXd")
+    .method("rows", &Eigen::MatrixXd::rows)
+    .method("cols", &Eigen::MatrixXd::cols)
+    .method("data", [](Eigen::MatrixXd& m) {
+      return jlcxx::ArrayRef<double>(m.data(), m.size());
+    });
+
+  mod.add_type<RowMatrixXd>("RowMatrixXd")
+    .method("rows", &RowMatrixXd::rows)
+    .method("cols", &RowMatrixXd::cols)
+    .method("data", [](RowMatrixXd& m) {
+      return jlcxx::ArrayRef<double>(m.data(), m.size());
+    });
+
+  // Conversion functions for Julia arrays -> Eigen types
+  mod.method("make_vector_xi", &MakeVectorXi);
+  mod.method("make_vector_xd", &MakeVectorXd);
+  mod.method("make_row_matrix_xd", &MakeRowMatrixXd);
+
+  mod.add_type<std::filesystem::path>("FilesystemPath")
+    .constructor<const std::string&>();
+
+  // ============================================================================
+  // FreeBoundaryMethod enum
+  // ============================================================================
+  mod.add_bits<vmecpp::FreeBoundaryMethod>("FreeBoundaryMethod", jlcxx::julia_type("CppEnum"));
+  mod.set_const("NESTOR", vmecpp::FreeBoundaryMethod::NESTOR);
+  mod.set_const("BIEST", vmecpp::FreeBoundaryMethod::BIEST);
+
+  // ============================================================================
+  // VmecINDATA - Input configuration
+  // ============================================================================
+  auto vmec_indata = mod.add_type<VmecINDATA>("VmecINDATA")
+    .constructor<>();
+
+  // Static methods for loading from file/json
+  mod.method("vmec_indata_from_file", [](const std::string& filename) -> VmecINDATA {
+    return VmecINDATA::FromFile(std::filesystem::path(filename));
+  });
+  mod.method("vmec_indata_from_json", [](const std::string& json_str) -> VmecINDATA {
+    auto result = VmecINDATA::FromJson(json_str);
+    return GetValueOrThrow(result);
+  });
+  mod.method("vmec_indata_to_json", [](const VmecINDATA& indata) -> std::string {
+    return indata.ToJsonOrException();
+  });
+
+  // Numerical resolution and symmetry
+  vmec_indata.method("lasym", [](VmecINDATA& w) { return w.lasym; });
+  vmec_indata.method("set_lasym!", [](VmecINDATA& w, bool v) { w.lasym = v; });
+  vmec_indata.method("nfp", [](VmecINDATA& w) { return w.nfp; });
+  vmec_indata.method("set_nfp!", [](VmecINDATA& w, int v) { w.nfp = v; });
+  vmec_indata.method("mpol", [](VmecINDATA& w) { return w.mpol; });
+  vmec_indata.method("ntor", [](VmecINDATA& w) { return w.ntor; });
+  vmec_indata.method("set_mpol_ntor!", [](VmecINDATA& w, int mpol, int ntor) { w.SetMpolNtor(mpol, ntor); });
+  vmec_indata.method("ntheta", [](VmecINDATA& w) { return w.ntheta; });
+  vmec_indata.method("set_ntheta!", [](VmecINDATA& w, int v) { w.ntheta = v; });
+  vmec_indata.method("nzeta", [](VmecINDATA& w) { return w.nzeta; });
+  vmec_indata.method("set_nzeta!", [](VmecINDATA& w, int v) { w.nzeta = v; });
+
+  // Multigrid arrays (Eigen vectors - mutable)
+  vmec_indata.method("ns_array", [](VmecINDATA& w) -> VectorXi& { return w.ns_array; });
+  vmec_indata.method("set_ns_array!", [](VmecINDATA& w, const VectorXi& v) { w.ns_array = v; });
+  vmec_indata.method("ftol_array", [](VmecINDATA& w) -> VectorXd& { return w.ftol_array; });
+  vmec_indata.method("set_ftol_array!", [](VmecINDATA& w, const VectorXd& v) { w.ftol_array = v; });
+  vmec_indata.method("niter_array", [](VmecINDATA& w) -> VectorXi& { return w.niter_array; });
+  vmec_indata.method("set_niter_array!", [](VmecINDATA& w, const VectorXi& v) { w.niter_array = v; });
+
+  // Physics parameters
+  vmec_indata.method("phiedge", [](VmecINDATA& w) { return w.phiedge; });
+  vmec_indata.method("set_phiedge!", [](VmecINDATA& w, double v) { w.phiedge = v; });
+  vmec_indata.method("ncurr", [](VmecINDATA& w) { return w.ncurr; });
+  vmec_indata.method("set_ncurr!", [](VmecINDATA& w, int v) { w.ncurr = v; });
+  vmec_indata.method("pmass_type", [](VmecINDATA& w) { return w.pmass_type; });
+  vmec_indata.method("set_pmass_type!", [](VmecINDATA& w, const std::string& v) { w.pmass_type = v; });
+
+  // Profile arrays
+  vmec_indata.method("am", [](VmecINDATA& w) -> VectorXd& { return w.am; });
+  vmec_indata.method("set_am!", [](VmecINDATA& w, const VectorXd& v) { w.am = v; });
+  vmec_indata.method("am_aux_s", [](VmecINDATA& w) -> VectorXd& { return w.am_aux_s; });
+  vmec_indata.method("set_am_aux_s!", [](VmecINDATA& w, const VectorXd& v) { w.am_aux_s = v; });
+  vmec_indata.method("am_aux_f", [](VmecINDATA& w) -> VectorXd& { return w.am_aux_f; });
+  vmec_indata.method("set_am_aux_f!", [](VmecINDATA& w, const VectorXd& v) { w.am_aux_f = v; });
+
+  vmec_indata.method("pres_scale", [](VmecINDATA& w) { return w.pres_scale; });
+  vmec_indata.method("set_pres_scale!", [](VmecINDATA& w, double v) { w.pres_scale = v; });
+  vmec_indata.method("gamma", [](VmecINDATA& w) { return w.gamma; });
+  vmec_indata.method("set_gamma!", [](VmecINDATA& w, double v) { w.gamma = v; });
+  vmec_indata.method("spres_ped", [](VmecINDATA& w) { return w.spres_ped; });
+  vmec_indata.method("set_spres_ped!", [](VmecINDATA& w, double v) { w.spres_ped = v; });
+
+  // Iota profile
+  vmec_indata.method("piota_type", [](VmecINDATA& w) { return w.piota_type; });
+  vmec_indata.method("set_piota_type!", [](VmecINDATA& w, const std::string& v) { w.piota_type = v; });
+  vmec_indata.method("ai", [](VmecINDATA& w) -> VectorXd& { return w.ai; });
+  vmec_indata.method("set_ai!", [](VmecINDATA& w, const VectorXd& v) { w.ai = v; });
+  vmec_indata.method("ai_aux_s", [](VmecINDATA& w) -> VectorXd& { return w.ai_aux_s; });
+  vmec_indata.method("set_ai_aux_s!", [](VmecINDATA& w, const VectorXd& v) { w.ai_aux_s = v; });
+  vmec_indata.method("ai_aux_f", [](VmecINDATA& w) -> VectorXd& { return w.ai_aux_f; });
+  vmec_indata.method("set_ai_aux_f!", [](VmecINDATA& w, const VectorXd& v) { w.ai_aux_f = v; });
+
+  // Current profile
+  vmec_indata.method("pcurr_type", [](VmecINDATA& w) { return w.pcurr_type; });
+  vmec_indata.method("set_pcurr_type!", [](VmecINDATA& w, const std::string& v) { w.pcurr_type = v; });
+  vmec_indata.method("ac", [](VmecINDATA& w) -> VectorXd& { return w.ac; });
+  vmec_indata.method("set_ac!", [](VmecINDATA& w, const VectorXd& v) { w.ac = v; });
+  vmec_indata.method("ac_aux_s", [](VmecINDATA& w) -> VectorXd& { return w.ac_aux_s; });
+  vmec_indata.method("set_ac_aux_s!", [](VmecINDATA& w, const VectorXd& v) { w.ac_aux_s = v; });
+  vmec_indata.method("ac_aux_f", [](VmecINDATA& w) -> VectorXd& { return w.ac_aux_f; });
+  vmec_indata.method("set_ac_aux_f!", [](VmecINDATA& w, const VectorXd& v) { w.ac_aux_f = v; });
+  vmec_indata.method("curtor", [](VmecINDATA& w) { return w.curtor; });
+  vmec_indata.method("set_curtor!", [](VmecINDATA& w, double v) { w.curtor = v; });
+  vmec_indata.method("bloat", [](VmecINDATA& w) { return w.bloat; });
+  vmec_indata.method("set_bloat!", [](VmecINDATA& w, double v) { w.bloat = v; });
+
+  // Free boundary parameters
+  vmec_indata.method("lfreeb", [](VmecINDATA& w) { return w.lfreeb; });
+  vmec_indata.method("set_lfreeb!", [](VmecINDATA& w, bool v) { w.lfreeb = v; });
+  vmec_indata.method("mgrid_file", [](VmecINDATA& w) { return w.mgrid_file; });
+  vmec_indata.method("set_mgrid_file!", [](VmecINDATA& w, const std::string& v) { w.mgrid_file = v; });
+  vmec_indata.method("extcur", [](VmecINDATA& w) -> VectorXd& { return w.extcur; });
+  vmec_indata.method("set_extcur!", [](VmecINDATA& w, const VectorXd& v) { w.extcur = v; });
+  vmec_indata.method("nvacskip", [](VmecINDATA& w) { return w.nvacskip; });
+  vmec_indata.method("set_nvacskip!", [](VmecINDATA& w, int v) { w.nvacskip = v; });
+  vmec_indata.method("free_boundary_method", [](VmecINDATA& w) { return w.free_boundary_method; });
+  vmec_indata.method("set_free_boundary_method!", [](VmecINDATA& w, vmecpp::FreeBoundaryMethod v) {
+    w.free_boundary_method = v;
+  });
+
+  // Tweaking parameters
+  vmec_indata.method("nstep", [](VmecINDATA& w) { return w.nstep; });
+  vmec_indata.method("set_nstep!", [](VmecINDATA& w, int v) { w.nstep = v; });
+  vmec_indata.method("aphi", [](VmecINDATA& w) -> VectorXd& { return w.aphi; });
+  vmec_indata.method("set_aphi!", [](VmecINDATA& w, const VectorXd& v) { w.aphi = v; });
+  vmec_indata.method("delt", [](VmecINDATA& w) { return w.delt; });
+  vmec_indata.method("set_delt!", [](VmecINDATA& w, double v) { w.delt = v; });
+  vmec_indata.method("tcon0", [](VmecINDATA& w) { return w.tcon0; });
+  vmec_indata.method("set_tcon0!", [](VmecINDATA& w, double v) { w.tcon0 = v; });
+  vmec_indata.method("lforbal", [](VmecINDATA& w) { return w.lforbal; });
+  vmec_indata.method("set_lforbal!", [](VmecINDATA& w, bool v) { w.lforbal = v; });
+  vmec_indata.method("return_outputs_even_if_not_converged", [](VmecINDATA& w) {
+    return w.return_outputs_even_if_not_converged;
+  });
+  vmec_indata.method("set_return_outputs_even_if_not_converged!", [](VmecINDATA& w, bool v) {
+    w.return_outputs_even_if_not_converged = v;
+  });
+
+  // Boundary shape (Fourier coefficients)
+  vmec_indata.method("rbc", [](VmecINDATA& w) -> vmecpp::RowMatrixXd& { return w.rbc; });
+  vmec_indata.method("set_rbc!", [](VmecINDATA& w, const RowMatrixXd& v) { w.rbc = v; });
+  vmec_indata.method("zbs", [](VmecINDATA& w) -> vmecpp::RowMatrixXd& { return w.zbs; });
+  vmec_indata.method("set_zbs!", [](VmecINDATA& w, const RowMatrixXd& v) { w.zbs = v; });
+
+  // Axis shape
+  vmec_indata.method("raxis_c", [](VmecINDATA& w) -> VectorXd& { return w.raxis_c; });
+  vmec_indata.method("set_raxis_c!", [](VmecINDATA& w, const VectorXd& v) { w.raxis_c = v; });
+  vmec_indata.method("zaxis_s", [](VmecINDATA& w) -> VectorXd& { return w.zaxis_s; });
+  vmec_indata.method("set_zaxis_s!", [](VmecINDATA& w, const VectorXd& v) { w.zaxis_s = v; });
+
+  // ============================================================================
+  // Output structures
+  // ============================================================================
+
+  // WOutFileContents - primary output
+  auto wout = mod.add_type<vmecpp::WOutFileContents>("WOutFileContents");
+
+  // Scalar outputs - floats
+  wout.method("aspect", [](const vmecpp::WOutFileContents& w) { return w.aspect; });
+  wout.method("betatot", [](const vmecpp::WOutFileContents& w) { return w.betatot; });
+  wout.method("betapol", [](const vmecpp::WOutFileContents& w) { return w.betapol; });
+  wout.method("betator", [](const vmecpp::WOutFileContents& w) { return w.betator; });
+  wout.method("b0", [](const vmecpp::WOutFileContents& w) { return w.b0; });
+  wout.method("volume_p", [](const vmecpp::WOutFileContents& w) { return w.volume_p; });
+  wout.method("ctor", [](const vmecpp::WOutFileContents& w) { return w.ctor; });
+  wout.method("rbtor", [](const vmecpp::WOutFileContents& w) { return w.rbtor; });
+  wout.method("rbtor0", [](const vmecpp::WOutFileContents& w) { return w.rbtor0; });
+  wout.method("fsqr", [](const vmecpp::WOutFileContents& w) { return w.fsqr; });
+  wout.method("ftolv", [](const vmecpp::WOutFileContents& w) { return w.ftolv; });
+
+  // Scalar outputs - integers
+  wout.method("ns", [](const vmecpp::WOutFileContents& w) { return w.ns; });
+  wout.method("mpol", [](const vmecpp::WOutFileContents& w) { return w.mpol; });
+  wout.method("ntor", [](const vmecpp::WOutFileContents& w) { return w.ntor; });
+  wout.method("nfp", [](const vmecpp::WOutFileContents& w) { return w.nfp; });
+  wout.method("mnmax", [](const vmecpp::WOutFileContents& w) { return w.mnmax; });
+  wout.method("niter", [](const vmecpp::WOutFileContents& w) { return w.maximum_iterations; });
+  wout.method("itfsq", [](const vmecpp::WOutFileContents& w) { return w.itfsq; });
+
+  // Scalar outputs - booleans
+  wout.method("lfreeb", [](const vmecpp::WOutFileContents& w) { return w.lfreeb; });
+  wout.method("lasym", [](const vmecpp::WOutFileContents& w) { return w.lasym; });
+
+  // Profile arrays - return by value (CxxWrap will handle conversion)
+  wout.method("iota_full", [](const vmecpp::WOutFileContents& w) { return w.iota_full; });
+  wout.method("pressure_full", [](const vmecpp::WOutFileContents& w) { return w.pressure_full; });
+  wout.method("toroidal_flux", [](const vmecpp::WOutFileContents& w) { return w.toroidal_flux; });
+  wout.method("iota_half", [](const vmecpp::WOutFileContents& w) { return w.iota_half; });
+
+  // Convergence arrays
+  wout.method("fsqt", [](const vmecpp::WOutFileContents& w) { return w.fsqt; });
+  wout.method("force_residual_r", [](const vmecpp::WOutFileContents& w) { return w.force_residual_r; });
+  wout.method("force_residual_z", [](const vmecpp::WOutFileContents& w) { return w.force_residual_z; });
+  wout.method("force_residual_lambda", [](const vmecpp::WOutFileContents& w) { return w.force_residual_lambda; });
+  wout.method("delbsq", [](const vmecpp::WOutFileContents& w) { return w.delbsq; });
+
+  // Mode number arrays
+  wout.method("xm", [](const vmecpp::WOutFileContents& w) { return w.xm; });
+  wout.method("xn", [](const vmecpp::WOutFileContents& w) { return w.xn; });
+  wout.method("xm_nyq", [](const vmecpp::WOutFileContents& w) { return w.xm_nyq; });
+  wout.method("xn_nyq", [](const vmecpp::WOutFileContents& w) { return w.xn_nyq; });
+
+  // Axis coefficients
+  wout.method("raxis_c", [](const vmecpp::WOutFileContents& w) { return w.raxis_c; });
+  wout.method("zaxis_s", [](const vmecpp::WOutFileContents& w) { return w.zaxis_s; });
+
+  // Fourier mode arrays - return by value (CxxWrap will handle conversion)
+  wout.method("rmnc", [](const vmecpp::WOutFileContents& w) { return w.rmnc; });
+  wout.method("zmns", [](const vmecpp::WOutFileContents& w) { return w.zmns; });
+  wout.method("bmnc", [](const vmecpp::WOutFileContents& w) { return w.bmnc; });
+  wout.method("lmns_full", [](const vmecpp::WOutFileContents& w) { return w.lmns_full; });
+
+  // Asymmetric Fourier mode arrays (only populated when lasym=true)
+  wout.method("rmns", [](const vmecpp::WOutFileContents& w) { return w.rmns; });
+  wout.method("zmnc", [](const vmecpp::WOutFileContents& w) { return w.zmnc; });
+  wout.method("bmns", [](const vmecpp::WOutFileContents& w) { return w.bmns; });
+  wout.method("lmnc", [](const vmecpp::WOutFileContents& w) { return w.lmnc; });
+
+  // Covariant B components (needed for Boozer transformation)
+  wout.method("bsubumnc", [](const vmecpp::WOutFileContents& w) { return w.bsubumnc; });
+  wout.method("bsubvmnc", [](const vmecpp::WOutFileContents& w) { return w.bsubvmnc; });
+  wout.method("bsubumns", [](const vmecpp::WOutFileContents& w) { return w.bsubumns; });
+  wout.method("bsubvmns", [](const vmecpp::WOutFileContents& w) { return w.bsubvmns; });
+
+  // JxBOutFileContents - force diagnostics
+  mod.add_type<vmecpp::JxBOutFileContents>("JxBOutFileContents")
+    .method("bdotk", [](const vmecpp::JxBOutFileContents& j) { return j.bdotk; })
+    .method("avforce", [](const vmecpp::JxBOutFileContents& j) { return j.avforce; });
+
+  // MercierFileContents - stability analysis
+  mod.add_type<vmecpp::MercierFileContents>("MercierFileContents")
+    .method("s", [](const vmecpp::MercierFileContents& m) { return m.s; })
+    .method("iota", [](const vmecpp::MercierFileContents& m) { return m.iota; });
+
+  // OutputQuantities - main result container
+  mod.add_type<vmecpp::OutputQuantities>("OutputQuantities")
+    .method("wout", [](vmecpp::OutputQuantities& o) -> vmecpp::WOutFileContents& { return o.wout; })
+    .method("jxbout", [](vmecpp::OutputQuantities& o) -> vmecpp::JxBOutFileContents& { return o.jxbout; })
+    .method("mercier", [](vmecpp::OutputQuantities& o) -> vmecpp::MercierFileContents& { return o.mercier; });
+
+  // HotRestartState
+  mod.add_type<vmecpp::HotRestartState>("HotRestartState");
+  mod.method("make_hot_restart_state", &MakeHotRestartState);
+
+  // ============================================================================
+  // Free boundary support
+  // ============================================================================
+
+  // MakegridParameters with file loading
+  mod.add_type<makegrid::MakegridParameters>("MakegridParameters")
+    .constructor<>();
+
+  // Add a method to load from file (since CxxWrap constructors can't use lambdas easily)
+  mod.method("load_makegrid_parameters", [](const std::string& filename) {
+    auto result = makegrid::ImportMakegridParametersFromFile(std::filesystem::path(filename));
+    return GetValueOrThrow(result);
+  });
+
+  // MagneticFieldResponseTable with constructor from coils file
+  mod.add_type<makegrid::MagneticFieldResponseTable>("MagneticFieldResponseTable")
+    .constructor<>();
+
+  // Add a method to create from coils file and parameters
+  mod.method("create_magnetic_response_table", [](const std::string& coils_file, const makegrid::MakegridParameters& params) {
+    auto config_result = magnetics::ImportMagneticConfigurationFromCoilsFile(std::filesystem::path(coils_file));
+    if (!config_result.ok()) {
+      jl_error(config_result.status().message().data());
+    }
+    auto table_result = makegrid::ComputeMagneticFieldResponseTable(params, config_result.value());
+    return GetValueOrThrow(table_result);
+  });
+
+  // Add field accessors and modifiers for MagneticFieldResponseTable
+  // These provide in-place scalar multiplication without broadcasting issues
+  mod.method("scale_b_r!", [](makegrid::MagneticFieldResponseTable& table, double factor) {
+    table.b_r *= factor;
+  });
+  mod.method("scale_b_p!", [](makegrid::MagneticFieldResponseTable& table, double factor) {
+    table.b_p *= factor;
+  });
+  mod.method("scale_b_z!", [](makegrid::MagneticFieldResponseTable& table, double factor) {
+    table.b_z *= factor;
+  });
+
+  // ============================================================================
+  // Main run() functions
+  // ============================================================================
+
+  // Fixed boundary modes
+  mod.method("run_basic", &RunVmecBasic);
+  mod.method("run_with_threads", &RunVmecWithThreads);
+  mod.method("run_with_restart", &RunVmecWithRestart);
+  mod.method("run_with_restart_and_threads", &RunVmecWithRestartAndThreads);
+
+  // Free boundary modes
+  mod.method("run_free_boundary_basic", &RunVmecFreeBoundaryBasic);
+  mod.method("run_free_boundary_with_threads", &RunVmecFreeBoundaryWithThreads);
+  mod.method("run_free_boundary_with_restart", &RunVmecFreeBoundaryWithRestart);
+  mod.method("run_free_boundary_with_restart_and_threads", &RunVmecFreeBoundaryWithRestartAndThreads);
+}


### PR DESCRIPTION
## Summary

Julia bindings for [VMECPP](https://github.com/proximafusion/vmecpp) - a modern C++ reimplementation of the VMEC magnetohydrodynamic equilibrium solver.

This JLL provides prebuilt binaries of `libvmecpp_julia`, which wraps the vmecpp library using CxxWrap for Julia interoperability.

## Dependencies

- `libcxxwrap_julia_jll` - CxxWrap bindings
- `HDF5_jll` - HDF5 file I/O
- `NetCDF_jll` - NetCDF file I/O  
- `LLVMOpenMP_jll` - OpenMP parallelization
- `OpenBLAS_jll` - LAPACK/BLAS

## Platforms

- Linux x86_64, aarch64
- macOS x86_64, aarch64
- Windows not supported (yet)

## Build Strategy

The recipe vendors several dependencies to ensure version compatibility:
- Abseil-cpp (specific commit matching vmecpp's requirements)
- Eigen 3.4.0 (header-only)
- nlohmann_json v3.11.3
- abscab-cpp and indata2json (small helper libraries)

## Julia Package

This JLL will be used by [VMECPP.jl](https://github.com/proximafusion/VMECPP.jl) to provide prebuilt binaries for the Julia package.