### PR TITLE
Rename `tracy-profiler` → `tracy`

### DIFF
--- a/T/TracyProfiler/build_tarballs.jl
+++ b/T/TracyProfiler/build_tarballs.jl
@@ -159,11 +159,11 @@ platforms = expand_cxxstring_abis(supported_platforms(; exclude=[
 ]))
 
 products = [
+    ExecutableProduct("tracy", :tracy),
     ExecutableProduct("tracy-capture", :tracy_capture),
     ExecutableProduct("tracy-csvexport", :tracy_csvexport),
     ExecutableProduct("tracy-import-chrome", :tracy_import_chrome),
     ExecutableProduct("tracy-import-fuchsia", :tracy_import_fuchsia),
-    ExecutableProduct("tracy-profiler", :tracy_profiler),
     ExecutableProduct("tracy-update", :tracy_update),
 ]
 


### PR DESCRIPTION
Turns out the `tracy` naming (not `tracy-profiler`) is necessary. Per https://topolarity.github.io/Tracy.jl/dev/ :
<img width="636" height="77" alt="image" src="https://github.com/user-attachments/assets/59a58b55-034f-412f-a1ba-7f1186de453b" />

If we name "tracy-profiler" here, `.tracy()` is not found.