### PR TITLE
[libsparseir] Bump version to v0.7.5

### DIFF
--- a/L/libsparseir/build_tarballs.jl
+++ b/L/libsparseir/build_tarballs.jl
@@ -1,14 +1,14 @@
 using BinaryBuilder, Pkg
 
 name = "libsparseir"
-version = v"0.7.3"
+version = v"0.7.5"
 
 # Collection of sources required to complete build
 sources = [
-    # sparse-ir-rs v0.7.3
+    # sparse-ir-rs v0.7.5
     GitSource(
         "https://github.com/SpM-lab/sparse-ir-rs.git",
-        "594143f902ff2fe7371af0962591728898b67a75",
+        "a4bb6ac11de440f0ef1b1b83525ae2c39a45da98",
     ),
 ]
 


### PR DESCRIPTION
Update `libsparseir` version to v0.7.5