### PR TITLE
[LASzip] Update to 3.4.4

### DIFF
--- a/L/LASzip/build_tarballs.jl
+++ b/L/LASzip/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "LASzip"
-version = v"3.4.3000"
+version = v"3.4.4000"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/LASzip/LASzip.git", "1ab671e42ff1f086e29d5b7e300a5026e7b8d69b")
+    GitSource("https://github.com/LASzip/LASzip.git", "b6412aa4ac3f1fd44874c862de8e3eb7f672d495")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Might fix https://github.com/evetion/LazIO.jl/issues/44, as 3.4.4 has an seek fix (https://github.com/LASzip/LASzip/commit/4aada844e87066533619bcf0abec32ebee7da5d7).