### PR TITLE
[SCS] update to 3.2.10

### DIFF
--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -2,11 +2,11 @@ using Pkg
 using BinaryBuilder
 
 name = "SCS"
-version = v"300.200.900"
+version = v"300.200.1000"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "c8297172633bcb3a10d4781a19d4769ce5282d29")
+    GitSource("https://github.com/cvxgrp/scs.git", "3bb046910ef5f0bd248f76c140d274cdbf6d2a2b")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -6,11 +6,11 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "SCS_GPU"
-version = v"300.200.900"
+version = v"300.200.1000"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "c8297172633bcb3a10d4781a19d4769ce5282d29")
+    GitSource("https://github.com/cvxgrp/scs.git", "3bb046910ef5f0bd248f76c140d274cdbf6d2a2b")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -2,11 +2,11 @@ using Pkg
 using BinaryBuilder
 
 name = "SCS_MKL"
-version = v"300.200.900"
+version = v"300.200.1000"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "c8297172633bcb3a10d4781a19d4769ce5282d29")
+    GitSource("https://github.com/cvxgrp/scs.git", "3bb046910ef5f0bd248f76c140d274cdbf6d2a2b")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Contains a massive speedup for SDPs due to swapping `syev` with `syevr`. cc @odow @kalmarek 