### PR TITLE
[SCIP_PaPILO] Julia compat with Ipopt

### DIFF
--- a/S/SCIP_PaPILO/build_tarballs.jl
+++ b/S/SCIP_PaPILO/build_tarballs.jl
@@ -8,7 +8,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 name = "SCIP_PaPILO"
 
 upstream_version = v"10.0.0"
-version = VersionNumber(upstream_version.major * 100, upstream_version.minor * 100, upstream_version.patch * 100)
+version = VersionNumber(upstream_version.major * 100, upstream_version.minor * 100, upstream_version.patch * 100 + 1)
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
Make the compat bound on Julia correspond to that of the Ipopt_jll version