### PR TITLE
[p7zip_alone2] new package for 7-Zip

### DIFF
--- a/P/p7zip_alone2/build_tarballs.jl
+++ b/P/p7zip_alone2/build_tarballs.jl
@@ -3,13 +3,16 @@ using BinaryBuilder, Pkg
 const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
-name = "p7zip_standalone"
+name = "p7zip_alone2"
 # This package is closely related to p7zip
 # p7zip builds the Alone bundle to provide 7za.exe which supports only the major formats.
-# p7zip_standalone builds the Alone2 bundle to provide 7zz.exe which supports the full set of formats except RAR.
-# Upstream uses CalVer
+# p7zip_alone2 builds the Alone2 bundle to provide 7zz.exe which supports the full set of formats except RAR.
 upstream_version = "25.01"
 compact_version = replace(upstream_version, "."=>"")
+# Upstream uses CalVer
+# This package uses an independent SemVer version number
+# to avoid dependent packages needing to update compat every year
+# even if there are no breaking changes.
 version = v"1.0.0"
 
 # Collection of sources required to build p7zip


### PR DESCRIPTION
This is the same as the p7zip recipe except using the `Alone2` bundle, which supports many more formats, instead of the `Alone` bundle.

The RAR format is still being disabled with `export DISABLE_RAR=1` because the RAR code has an unfree license.

I set the version to `1.0.0` because upstream is using CalVer, so it doesn't make sense to try to use the same version for the jll. Maybe it would make more sense to match the version of p7zip?