### PR TITLE
CUDA: Bump CUDA_Compiler_jll version.

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
 name = "CUDA_Compiler"
-version = v"0.3.0"
+version = v"0.3.1"
 
 augment_platform_block = read(joinpath(@__DIR__, "platform_augmentation.jl"), String)
 


### PR DESCRIPTION
We recently added `tileiras`, so there's a need for a version bump.