### PR TITLE
[cephes]: init new pkg

### DIFF
--- a/C/cephes/build_tarballs.jl
+++ b/C/cephes/build_tarballs.jl
@@ -1,0 +1,40 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "cephes"
+version = v"1.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource("https://github.com/Cactus-proj/cephes/releases/download/v$(version)/cephes-$(version).tar.gz",
+                  "54549d5ec8560816fa6a98c048420832d337685ae739cecee56614dce032701d"),
+    # GitSource("https://github.com/Cactus-proj/cephes.git",
+    #           "efe835a0cb4c6c760ff6c803d1d9cfd1bfbded75"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/cephes*/
+
+cmake -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel ${nproc}
+cmake --install build
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libcephes", :libcephes)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
src repo: [Cactus-proj/cephes: Cephes Mathematical Functions library](https://github.com/Cactus-proj/cephes)

This release (v1.0.0) provides a subset of the Cephes mathematical library, focusing exclusively on **special functions with double precision**. Not all Cephes APIs are included in this fork at this time.

Future releases may expand the available API surface as needed.

## V1.0.0 Release Note
https://github.com/Cactus-proj/cephes/releases/tag/v1.0.0

> This release is derived from the Google DeepMind Torch Cephes repository:
> [google-deepmind/torch-cephes](https://github.com/google-deepmind/torch-cephes).
> The core source code remains unmodified from the upstream version, preserving its original behavior and implementation details.
> 
> Key Highlights:
> 
> Build System Enhancement : We have added build scripts to facilitate easier compilation and integration of the library.
> Code Formatting : The entire codebase has been formatted using clang-format to ensure a consistent and clean coding style.
> Double Precision Only : Please note that this release currently supports double-precision floating-point arithmetic only.
> Comparison with Netlib : Users should be aware that this version exhibits some differences compared to the standard Netlib version of Cephes.
> Diff: [Comparing v1.0.0...ref/netlib · Cactus-proj/cephes](https://github.com/Cactus-proj/cephes/compare/v1.0.0...ref/netlib)
