### PR TITLE
[ROOT] Remove UNIX signal handlers

### DIFF
--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -30,7 +30,7 @@ else
 fi
 
 # Required to compile graf3d/ftgl/src/FTVectoriser.cxx (for gcc to accept a conversion from char* to unsigned char*)
-CMAKE_EXTRA_OPTS+=(-DCMAKE_CXX_FLAGS=-fpermissive)
+CMAKE_CXX_FLAGS=(-fpermissive)
 
 # Uncomment for a minimal build for debugging purposes
 #CMAKE_EXTRA_OPTS+=(-Dclad=OFF -Dhtml=OFF -Dwebgui=OFF -Dcxxmodules=OFF -Dproof=OFF -Dtmva=OFF -Drootfit=OFF -Dxproofd=OFF -Dxrootd=OFF -Dssl=OFF -Dpyroot=OFF -Dtesting=OFF -Droot7=OFF -Dspectrum=OFF -Dunfold=OFF -Dasimage=OFF -Dgviz=OFF -Dfitiso=OFF -Dcocoa=OFF -Dopengl=OFF -Dproof=OFF -Dxml=OFF -Dgfal=OFF -Dmpi=OFF)
@@ -73,7 +73,14 @@ int main(){
 EOF
 
 ./need_variant_patch && (cd / && atomic_patch -p1 ${WORKSPACE}/srcdir/patches/$target-variant.patch)
+ 
+(cd srcdir
+ # patch to add ONLY_SIGALARM_ROOT_HANDLER macro
+ atomic_patch -p1 patches/signal_handler.patch
+)
 
+CMAKE_CXX_FLAGS+=(-DONLY_SIGALARM_ROOT_HANDLER)
+ 
 if [ $target != $MACHTYPE ]; then #cross compilation
 
    (cd srcdir
@@ -82,7 +89,7 @@ if [ $target != $MACHTYPE ]; then #cross compilation
 
    # patch to fix cross-compilation for afterimage
    atomic_patch -p1 patches/afterimage-cross-compile.patch
-   )
+  )
 
    # Compile for the host binary used in the build process
    # Davix is switched off, as otherwise build fails in buildkite CI. It should not be
@@ -95,6 +102,7 @@ if [ $target != $MACHTYPE ]; then #cross compilation
          -DCXX_STANDARD=c++17 \
          -DCLANG_DEFAULT_STD_CXX=cxx17 \
          "${CMAKE_EXTRA_OPTS[@]}" \
+         -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS[*]}" \
          -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DLLVM_BUILD_TYPE=$BUILD_TYPE \
          -DCLING_CXX_PATH=g++ \
          -DCLING_TARGET_GLIBC=1 \
@@ -105,7 +113,7 @@ if [ $target != $MACHTYPE ]; then #cross compilation
 
    cmake --build NATIVE -- -j$njobs rootcling_stage1 rootcling llvm-tblgen clang-tblgen llvm-config llvm-symbolizer
 
-   CMAKE_EXTRA_OPTS+=($CMAKE_EXTRA_OPTS "-DNATIVE_BINARY_DIR=$PWD/NATIVE" \
+   CMAKE_EXTRA_OPTS+=("-DNATIVE_BINARY_DIR=$PWD/NATIVE" \
       "-DLLVM_TABLEGEN=$PWD/NATIVE/interpreter/llvm-project/llvm/bin/llvm-tblgen" \
       "-DCLANG_TABLEGEN=$PWD/NATIVE/interpreter/llvm-project/llvm/bin/clang-tblgen" \
       "-DLLVM_CONFIG_PATH=$PWD/NATIVE/interpreter/llvm-project/llvm/bin/llvm-config" \
@@ -126,6 +134,7 @@ cmake -GNinja \
       -DCXX_STANDARD=c++17 \
       -DCLANG_DEFAULT_STD_CXX=cxx17 \
       "${CMAKE_EXTRA_OPTS[@]}" \
+      -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS[*]}" \
       -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DLLVM_BUILD_TYPE=$BUILD_TYPE \
       -DCLING_CXX_PATH=g++ \
       -Dfound_urandom_EXITCODE=0 \

--- a/R/ROOT/bundled/patches/signal_handler.patch
+++ b/R/ROOT/bundled/patches/signal_handler.patch
@@ -1,0 +1,23 @@
+--- a/root/core/unix/src/TUnixSystem.cxx	2024-11-14 10:27:26.000000000 +0100
++++ b/root/core/unix/src/TUnixSystem.cxx	2026-01-04 02:08:46.383417890 +0100
+@@ -604,17 +604,19 @@
+    fSignals    = new TFdSet;
+ 
+    //--- install default handlers
++#ifndef ONLY_SIGALARM_ROOT_HANDLER
+    UnixSignal(kSigChild,                 SigHandler);
+    UnixSignal(kSigBus,                   SigHandler);
+    UnixSignal(kSigSegmentationViolation, SigHandler);
+    UnixSignal(kSigIllegalInstruction,    SigHandler);
+    UnixSignal(kSigAbort,                 SigHandler);
+    UnixSignal(kSigSystem,                SigHandler);
+-   UnixSignal(kSigAlarm,                 SigHandler);
+    UnixSignal(kSigUrgent,                SigHandler);
+    UnixSignal(kSigFloatingException,     SigHandler);
+    UnixSignal(kSigWindowChanged,         SigHandler);
+    UnixSignal(kSigUser2,                 SigHandler);
++#endif //ONLY_SIGALARM_ROOT_HANDLER
++   UnixSignal(kSigAlarm,                 SigHandler);
+ 
+ #if defined(R__MACOSX)
+    // trap loading of all dylibs to register dylib name,


### PR DESCRIPTION
This update fixes an issue with Julia 1.12.x: the REPL was crashing after import of [ROOT](https://github.com/JuliaHEP/ROOT.jl) and a short time of REPL usage. 

It patches upstream code to disable the installation of a signal handler that was interfering with the Julia signal usage.