### PR TITLE
[ORTools] Expand the supported platforms

### DIFF
--- a/O/ORTools/build_tarballs.jl
+++ b/O/ORTools/build_tarballs.jl
@@ -117,6 +117,11 @@ install -Dvm 644 ortools/scheduling/jobshop_scheduling.proto ${prefix}/include/o
 """
 
 platforms = supported_platforms()
+# Filter out RISC-V, Windows, and macOS x86_64 platforms
+platforms = filter(p -> arch(p) != "riscv64", platforms)
+platforms = filter(p -> !Sys.iswindows(p), platforms)
+platforms = filter(p -> !(arch(p) == "x86_64" && Sys.isapple(p)), platforms)
+
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built


### PR DESCRIPTION
Fixed the problem where the -march flags didn't work with BinaryBuilder by adding a patch for Abseil.
 `-DBUILD_TESTING:BOOL=OFF` was also incorporated to ensure that the builds pass on i686.

Supports now all platforms except:
- Windows, 
- macOS on x86, and 
- Linux on RISC-V.