### PR TITLE
[aws_c_http_jq] Update to version 0.10.9

### DIFF
--- a/A/aws_c_http_jq/build_tarballs.jl
+++ b/A/aws_c_http_jq/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_http_jq"
-version = v"0.10.8"
+version = v"0.10.9"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/quinnj/aws-c-http.git", "c9e62e6c90882da912b4a07455df93ab8bf9a418"),
+    GitSource("https://github.com/quinnj/aws-c-http.git", "2d7e4f5a0c01a57d261619931963418790cc7309"),
 ]
 
 # Bash recipe for building across all platforms
@@ -38,7 +38,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("aws_c_compression_jll"; compat="0.3.2"),
-    Dependency("aws_c_io_jll"; compat="0.24.2"),
+    Dependency("aws_c_io_jll"; compat="0.25.0"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_http_jq to version 0.10.9. cc: @quinnj @Octogonapus