### PR TITLE
Switch to alternative macOS 14.5 SDK

### DIFF
--- a/platforms/macos_sdks.jl
+++ b/platforms/macos_sdks.jl
@@ -41,8 +41,8 @@ const macos_sdk_sources = Dict{String,FileSource}(
         FileSource("https://github.com/roblabla/MacOSX-SDKs/releases/download/macosx14.0/MacOSX14.0.sdk.tar.xz",
                    "4a31565fd2644d1aec23da3829977f83632a20985561a2038e198681e7e7bf49"),
     "14.5" =>
-        FileSource("https://github.com/alexey-lysiuk/macos-sdk/releases/download/14.5/MacOSX14.5.tar.xz",
-                   "f6acc6209db9d56b67fcaf91ec1defe48722e9eb13dc21fb91cfeceb1489e57e"),
+        FileSource("https://github.com/roblabla/MacOSX-SDKs/releases/download/macosx14.5/MacOSX14.5.sdk.tar.xz",
+                   "d2b7784a8b63cfcc686059aef6f1065dc8d2aaeddc39245738f4c0cd9ca6165a"),
     "15.0" =>
         FileSource("https://github.com/joseluisq/MacOSX-SDKs/releases/download/15.0/MacOSX15.0.sdk.tar.xz",
                    "9df0293776fdc8a2060281faef929bf2fe1874c1f9368993e7a4ef87b1207f98"),


### PR DESCRIPTION
... so that the filename ends with .sdk.tar.gz

The new one is also smaller, by retaining symlinks instead
of duplicating files.
