### PR TITLE
CUDA: Bump driver JLL and use redist sources.

### DIFF
--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -6,35 +6,24 @@
 
 using BinaryBuilder, Pkg
 
+include("../common.jl")
+
 const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Driver"
-version = v"13.1.0"
-
-version_str = "$(version.major)-$(version.minor)"
-driver_str = "590.44.01"
-build = 1
-
-sources_linux_x86 = [
-    FileSource("https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-compat-$(version_str)-$(driver_str)-$(build).el8.x86_64.rpm",
-               "a1c9f934c6c5b4a566c907f9cc55e8505b17b00b35163fdb5342c4811cd33798", "compat.rpm")
-]
-sources_linux_aarch64 = [
-    FileSource("https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/cuda-compat-$(version_str)-$(driver_str)-$(build).el8.aarch64.rpm",
-               "e7233912d7a2f4529673a70702f3dd5a1350228db51e31c0f160468fde2663bf", "compat.rpm")
-]
-
-dependencies = []
+cuda_version = v"13.1"
+driver_version = "590.48.01"
 
 script = raw"""
-    apk update
-    apk add rpm2cpio
-    rpm2cpio compat.rpm | cpio -idmv
-
     mkdir -p ${libdir}
 
-    mv usr/local/cuda-*/compat/* ${libdir}
+    cd ${WORKSPACE}/srcdir/cuda_compat*
+
+    install_license LICENSE
+
+    mv compat/* ${libdir}
 """
 
 # CUDA_Driver_jll provides libcuda_compat, but we can't always use that driver: It requires
@@ -59,16 +48,33 @@ products = [
     LibraryProduct("libnvidia-ptxjitcompiler", :libnvidia_ptxjitcompiler; dont_dlopen=true),
 ]
 
-non_reg_ARGS = filter(arg -> arg != "--register", ARGS)
+dependencies = []
 
-if should_build_platform("x86_64-linux-gnu")
-    build_tarballs(non_reg_ARGS, name, version, sources_linux_x86, script,
-                   [Platform("x86_64", "linux")], products, dependencies;
-                   skip_audit=true, init_block)
+platforms = [Platform("x86_64", "linux"),
+             Platform("aarch64", "linux")]
+
+builds = []
+for platform in platforms
+    augmented_platform = deepcopy(platform)
+    augmented_platform["cuda"] = CUDA.platform(cuda_version)
+    should_build_platform(triplet(augmented_platform)) || continue
+
+    sources = get_sources("nvidia-driver", ["cuda_compat"]; version=driver_version,
+                          platform=augmented_platform, variant="cuda$(cuda_version.major).$(cuda_version.minor)")
+
+    push!(builds, (; platforms=[platform], sources))
 end
 
-if should_build_platform("aarch64-linux-gnu")
-    build_tarballs(ARGS, name, version, sources_linux_aarch64, script,
-                   [Platform("aarch64", "linux")], products, dependencies;
+# don't allow `build_tarballs` to override platform selection based on ARGS.
+# we handle that ourselves by calling `should_build_platform`
+non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
+
+# `--register` should only be passed to the latest `build_tarballs` invocation
+non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
+
+for (i,build) in enumerate(builds)
+    build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
+                   name, cuda_version, build.sources, script,
+                   build.platforms, products, dependencies;
                    skip_audit=true, init_block)
 end


### PR DESCRIPTION
I'll probably switch to driver-based versioning after this, but let's make a regular release first.