### PR TITLE
[ROOT_julia] Fix for ROOT.jl v0.4.0

### DIFF
--- a/R/ROOT_julia/build_tarballs.jl
+++ b/R/ROOT_julia/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"1.1.0"
 
 # Collection of sources required to complete build
 sources = [
-   GitSource("https://github.com/JuliaHEP/ROOT.jl.git", "cf68f4ec3409f3fd37805726fb7f7180acfbf62e")
+   GitSource("https://github.com/JuliaHEP/ROOT.jl.git", "56147f26b44e833b776d7cfc648c8e723910f9d0")
 ]
 
 # See https://github.com/JuliaLang/Pkg.jl/issues/2942


### PR DESCRIPTION
Update the ROOT_julia_jll recipe for the ROOT.jl v.0.4.0 release.

Note: only build number is updated, because this package is tightly linked with ROOT.jl and this update is done in the context of releasing version 0.4.0 of ROOT.jl. The version number of ROOT_julia_jll has already been updated in the merged PR #12560.