### PR TITLE
[Libxc_GPU] Upgrade build recipe for CUDA v13

### DIFF
--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -285,43 +285,11 @@ function cuda_nvcc_redist_source(cuda_ver, arch)
             # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_12.9.0.json
             ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-12.9.41-archive.tar.xz",
                             "b3a0e115840e04c0cfa559263cbbe8b78a2455788e12605732aff68abc50dd34")
-        elseif cuda_ver == "13.0"
-            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.0.0.json
-            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-13.0.48-archive.tar.xz",
-                            "cc5ff4a00d3be7c6c86ff740de7672e142ec87fea74e7e46b1b142b59fd2ac51")
-        elseif cuda_ver == "13.1"
-            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.1.0.json
-            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-13.1.80-archive.tar.xz",
-                            "5ed3b7cfe7f12557199773e7769445357ee048958ff51e623e15f36d3393ca8b")
         else
             error("No CUDA redist available for CUDA version $cuda_ver on arch $arch")
         end
     else
         error("No CUDA redist available for arch $arch")
-    end
-end
-
-"""
-    cuda_nvvm_redist_source(cuda_ver, arch)
-
-Returns an ArchiveSource for the official NVIDIA redist of the given CUDA version and architecture.
-From CUDA version 13 on, nvvm is shiped in a different redist as nvcc.
-"""
-function cuda_nvvm_redist_source(cuda_ver, arch)
-    if arch == "x86_64"
-        if cuda_ver == "13.0"
-            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.0.0.json
-            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/linux-x86_64/libnvvm-linux-x86_64-13.0.48-archive.tar.xz",
-                          "8c5676a65a2e6d13e3c229f025af18677de46c220d77992fe932200fa798b19b")
-        elseif cuda_ver == "13.1"
-            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.1.0.json
-            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/linux-x86_64/libnvvm-linux-x86_64-13.1.80-archive.tar.xz",
-                          "1a102f6658b6ecaa7a3aae1aa85a61a9aa6ba197be9f6b185d906deb2a6c5afd")
-        else
-            error("No CUDA nvvm redist available for CUDA version $cuda_ver on arch $arch")
-        end
-    else
-        error("No CUDA nvvm redist available for arch $arch")
     end
 end
 


### PR DESCRIPTION
Upgraded the `build_tarball.jl` script to accommodate CUDA v13.

From v13 on, NVIDIA does not ship NVVM as part of the NVCC redist. For a successful build on `aarch64`, NVVM must now be downloaded separately. The `platforms/cuda.jl` file was modified in order to make these changes available to other packages.