### PR TITLE
[Thrift] Update gcc to align with boost dependency

### DIFF
--- a/T/Thrift/build_tarballs.jl
+++ b/T/Thrift/build_tarballs.jl
@@ -64,6 +64,6 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"7")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"11.1")
 
 # Build trigger: 1


### PR DESCRIPTION
The current linked boost dependency https://github.com/JuliaPackaging/Yggdrasil/blob/05345d261dd96ec573100b03b1a1260e7c05ed12/B/boost/build_tarballs.jl#L138, has gcc v11.1.

Follows advice from https://docs.binarybuilder.org/stable/troubleshooting/#Building-with-an-old-GCC-version-a-library-that-has-dependencies-built-with-newer-GCC-versions

Might help with JuliaGeo/GDAL.jl/issues/146

Should this also be done for GDAL (preferred_gcc_version v11 vs v11.1 in its deps?)
