### PR TITLE
[LLVM_full] Don't set -march in cmake tests for compiler-rt targets

### DIFF
--- a/L/LLVM/LLVM_full@20/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@20/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: #11667
+# Build trigger: #11668

--- a/L/LLVM/LLVM_full@20/bundled/crt_patches/0100-compiler-rt-cmake-test.patch
+++ b/L/LLVM/LLVM_full@20/bundled/crt_patches/0100-compiler-rt-cmake-test.patch
@@ -1,0 +1,16 @@
+diff --git i/cmake/base-config-ix.cmake w/cmake/base-config-ix.cmake
+index d92bc0e71fa1..d9a45a49ac5e 100644
+--- i/cmake/base-config-ix.cmake
++++ w/cmake/base-config-ix.cmake
+@@ -284,9 +284,9 @@ macro(test_targets)
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "avr")
+       test_target_arch(avr "__AVR__" "--target=avr")
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "aarch32")
+-      test_target_arch(aarch32 "" "-march=armv8-a")
++      test_target_arch(aarch32 "" "")
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "aarch64")
+-      test_target_arch(aarch64 "" "-march=armv8-a")
++      test_target_arch(aarch64 "" "")
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "riscv32")
+       test_target_arch(riscv32 "" "")
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "riscv64")

--- a/L/LLVM/LLVM_full@21/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@21/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 1
+# Build trigger: 2

--- a/L/LLVM/LLVM_full@21/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@21/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 0
+# Build trigger: 1

--- a/L/LLVM/LLVM_full@21/bundled/crt_patches/0100-compiler-rt-cmake-test.patch
+++ b/L/LLVM/LLVM_full@21/bundled/crt_patches/0100-compiler-rt-cmake-test.patch
@@ -1,0 +1,16 @@
+diff --git i/cmake/base-config-ix.cmake w/cmake/base-config-ix.cmake
+index d92bc0e71fa1..d9a45a49ac5e 100644
+--- i/cmake/base-config-ix.cmake
++++ w/cmake/base-config-ix.cmake
+@@ -284,9 +284,9 @@ macro(test_targets)
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "avr")
+       test_target_arch(avr "__AVR__" "--target=avr")
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "aarch32")
+-      test_target_arch(aarch32 "" "-march=armv8-a")
++      test_target_arch(aarch32 "" "")
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "aarch64")
+-      test_target_arch(aarch64 "" "-march=armv8-a")
++      test_target_arch(aarch64 "" "")
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "riscv32")
+       test_target_arch(riscv32 "" "")
+     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "riscv64")

--- a/L/LLVM/LLVM_full@21/bundled/crt_patches/0200-disable-aarch64-emupac.patch
+++ b/L/LLVM/LLVM_full@21/bundled/crt_patches/0200-disable-aarch64-emupac.patch
@@ -1,0 +1,12 @@
+diff --git i/lib/builtins/CMakeLists.txt w/lib/builtins/CMakeLists.txt
+index 3ab92403d416..582f0ac15bdd 100644
+--- i/lib/builtins/CMakeLists.txt
++++ w/lib/builtins/CMakeLists.txt
+@@ -591,7 +591,6 @@ set(aarch64_SOURCES
+   ${GENERIC_TF_SOURCES}
+   ${GENERIC_SOURCES}
+   cpu_model/aarch64.c
+-  aarch64/emupac.cpp
+   aarch64/fp_mode.c
+ )
+ 

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -396,6 +396,9 @@ if [[ "${target}" == *musl* ]]; then
     # Taken from https://git.alpinelinux.org/cgit/aports/tree/main/compiler-rt/APKBUILD
     CMAKE_FLAGS+=(-DCOMPILER_RT_BUILD_SANITIZERS=OFF)
     CMAKE_FLAGS+=(-DCOMPILER_RT_BUILD_XRAY=OFF)
+
+    CMAKE_FLAGS+=(-DCOMPILER_RT_BUILD_MEMPROF=OFF)
+    CMAKE_FLAGS+=(-DCOMPILER_RT_BUILD_CTX_PROFILE=OFF)
 fi
 
 if [[ "${target}" == *freebsd* ]]; then


### PR DESCRIPTION
BinaryBuilderBase's cc wrapper fails if `-march=` is provided and `lock_microarchitecture` is true.  This caused the cmake scripts for compiler-rt to fail when generating the list of target architectures to compile it for, leaving the Clang JLL for these platforms unable to use sanitizers.  This patch just removes all use of `-march` in these tests, since it is unnecessary.