### PR TITLE
[C] Add CubicInterpolation_jll v0.1.5

### DIFF
--- a/C/CubicInterpolation/build_tarballs.jl
+++ b/C/CubicInterpolation/build_tarballs.jl
@@ -44,7 +44,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("boost_jll"; compat="1.79.0"),
+    Dependency("boost_jll"; compat="=1.79.0"),
     BuildDependency("Eigen_jll"),
 ]
 


### PR DESCRIPTION
Cubic spline interpolation library based on boost and eigen. Repository: https://github.com/MaxSac/cubic_interpolation

This is a dependency for PROPOSAL, a Monte Carlo lepton propagation library.