### PR TITLE
[Legate] Add patch to export specific symbols

### DIFF
--- a/L/legate/build_tarballs.jl
+++ b/L/legate/build_tarballs.jl
@@ -12,7 +12,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 include("make_script.jl")
 
 name = "legate"
-version = v"25.10.1" # Year.Month
+version = v"25.10.2" # Year.Month
 sources = [
     GitSource("https://github.com/nv-legate/legate.git","b0a20719ce9c5f63e8b1c3ddd1e592af5e7a3df6"),
     DirectorySource("./bundled"),

--- a/L/legate/bundled/proc_local_h.patch
+++ b/L/legate/bundled/proc_local_h.patch
@@ -1,0 +1,13 @@
+diff --git a/proc_local.old b/proc_local.new
+index 667939f..f9d514f 100644
+--- a/legate/src/cpp/legate/utilities/proc_local_storage.h
++++ b/legate/src/cpp/legate/utilities/proc_local_storage.h
+@@ -64,7 +64,7 @@ namespace legate {
+  * @tparam T Type of values stored in this `ProcLocalStorage`.
+  */
+ template <typename T>
+-class ProcLocalStorage {
++class LEGATE_EXPORT ProcLocalStorage {
+  public:
+   /**
+    * @brief The type of stored objects.

--- a/L/legate/bundled/proc_local_inl.patch
+++ b/L/legate/bundled/proc_local_inl.patch
@@ -1,0 +1,15 @@
+diff --git a/original.h b/new.h
+index 1bae8ab..d936dbf 100644
+--- a/legate/src/cpp/legate/utilities/proc_local_storage.inl
++++ b/legate/src/cpp/legate/utilities/proc_local_storage.inl
+@@ -15,9 +15,9 @@ namespace legate {
+
+ namespace detail {
+
+-[[nodiscard]] std::size_t processor_id();
++[[nodiscard]] LEGATE_EXPORT std::size_t processor_id();
+
+-[[noreturn]] void throw_invalid_proc_local_storage_access(const std::type_info&);
++[[noreturn]] LEGATE_EXPORT void throw_invalid_proc_local_storage_access(const std::type_info&);
+
+ }  // namespace detail

--- a/L/legate/make_script.jl
+++ b/L/legate/make_script.jl
@@ -76,8 +76,11 @@ function get_script(cuda::Val{true})
 
 
     # Patch redop header that is installed by configure script
+    # Patch in macro to export specific symbols 
     cd ${WORKSPACE}/srcdir
     atomic_patch -p1 ./legion_redop.patch
+    atomic_patch -p1 ./proc_local_h.patch
+    atomic_patch -p1 ./proc_local_inl.patch
 
     # Go back to main dir
     cd ${WORKSPACE}/srcdir/legate
@@ -146,8 +149,11 @@ function get_script(cuda::Val{false})
 
 
     # Patch redop header that is installed by configure script
+    # Patch in macro to export specific symbols 
     cd ${WORKSPACE}/srcdir
     atomic_patch -p1 ./legion_redop.patch
+    atomic_patch -p1 ./proc_local_h.patch
+    atomic_patch -p1 ./proc_local_inl.patch
 
     # Go back to main dir
     cd ${WORKSPACE}/srcdir/legate


### PR DESCRIPTION
Apparently upstream decided to hide all symbols by default. These patches explicitly export some of the symbols we need that are not already exported.