### PR TITLE
[casacorecxx] Update to 0.4.0

### DIFF
--- a/C/casacorecxx/build_tarballs.jl
+++ b/C/casacorecxx/build_tarballs.jl
@@ -4,7 +4,7 @@ using BinaryBuilder, Pkg
 
 # Get a full list of platforms supported by Libjulia
 include("../../L/libjulia/common.jl")
-filter!(x -> x >= v"1.10", julia_versions)
+filter!(x -> v"1.10" <= x <= v"1.13", julia_versions)
 
 name = "casacorecxx"
 version = v"0.4.0"


### PR DESCRIPTION
Updates `casacorecxx` for compatibility with version of Julia >=1.10, as part of an ongoing work on [Casacore.jl](https://github.com/JuliaAstro/Casacore.jl/pull/13).