### PR TITLE
llama_cpp: update to b7821

### DIFF
--- a/L/llama_cpp/build_tarballs.jl
+++ b/L/llama_cpp/build_tarballs.jl
@@ -4,7 +4,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "llama_cpp"
-version = v"0.0.19"  # fake version number
+version = v"0.0.20"  # fake version number
 
 # url = "https://github.com/ggerganov/llama.cpp"
 # description = "Port of Facebook's LLaMA model in C/C++"
@@ -59,9 +59,10 @@ version = v"0.0.19"  # fake version number
 # 0.0.17          2024-12-20       b4371             https://github.com/ggerganov/llama.cpp/releases/tag/b4371
 # 0.0.18          2025-12-10       b7347             https://github.com/ggml-org/llama.cpp/releases/tag/b7347
 # 0.0.19          2026-01-22       b7813             https://github.com/ggml-org/llama.cpp/releases/tag/b7813
+# 0.0.20          2026-01-24       b7821             https://github.com/ggml-org/llama.cpp/releases/tag/b7821
 
 sources = [
-    GitSource("https://github.com/ggml-org/llama.cpp.git", "51fa458a92d6a3f305f8fd76fc8f702e3e87ddb5"),
+    GitSource("https://github.com/ggml-org/llama.cpp.git", "81ab64f3c858c0db8c7c3a6bccd4cbbe624f52a3"),
 ]
 
 script = raw"""


### PR DESCRIPTION
Updates llama.cpp to b7821 (81ab64f3c858c0db8c7c3a6bccd4cbbe624f52a3).