### PR TITLE
New build of `sequentialknn`

### DIFF
--- a/S/sequentialknn/build_tarballs.jl
+++ b/S/sequentialknn/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, BinaryBuilderBase
 
 name = "sequentialknn"
-version = v"0.1"
+version = v"0.2"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
Hello---

This is a small new build update of this small library I have for a specific KNN-type problem that the Julia ecosystem does not have a very optimized library for at present. This new release fixes a bug where a `panic!` is triggered when building KD-trees for points on a lattice with any edge length above 32. 

I have tested this build locally with `julia +1.7 --project build_tarballs.jl --deploy=local` and everything works as expected. 

My apologies to ask for another build here. Thanks in advance!