### PR TITLE
[P] Add PROPOSAL_jll v7.6.2

### DIFF
--- a/P/PROPOSAL/build_tarballs.jl
+++ b/P/PROPOSAL/build_tarballs.jl
@@ -53,7 +53,7 @@ dependencies = [
     Dependency("boost_jll"; compat="=1.79.0"),
     BuildDependency("Eigen_jll"),
     Dependency("spdlog_jll"),
-    Dependency("nlohmann_json_jll"),
+    BuildDependency("nlohmann_json_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
## New Package: PROPOSAL_jll

  This adds [PROPOSAL](https://github.com/tudo-astroparticlephysics/PROPOSAL) v7.6.2, a Monte Carlo simulation library for lepton and photon
  propagation through media. PROPOSAL is widely used in astroparticle physics for modeling energy losses and interactions of high-energy leptons
  (muons, taus, electrons) and photons as they traverse matter.

  **Repository:** https://github.com/tudo-astroparticlephysics/PROPOSAL
  **License:** LGPL-3.0

### Dependencies
  - `CubicInterpolation_jll` ≥ 0.1.5 (merged in #12971)
  - `boost_jll` ≥ 1.79.0
  - `Eigen_jll`
  - `spdlog_jll`
  - `nlohmann_json_jll`

### Excluded platforms
  - **Windows** (i686-w64-mingw32, x86_64-w64-mingw32) — linking issues with shared library exports
  - **RISC-V** (riscv64-linux-gnu) — not yet supported by dependencies

### Checklist
  - [x] Recipe builds successfully
  - [x] Shared library (`libPROPOSAL`) is produced
  - [x] License is installed