### PR TITLE
New Recipe: UCC_jll

### DIFF
--- a/U/UCC/build_tarballs.jl
+++ b/U/UCC/build_tarballs.jl
@@ -59,7 +59,7 @@ products = [
 ]
 
 dependencies = [
-    Dependency("UCX_jll"),
+    Dependency("UCX_jll"; compat="~1.20.0"),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
 ]
 


### PR DESCRIPTION
This recipe adds [UCC](https://github.com/openucx/ucc) v1.6.0 with built with UCX and CUDA on x86 platforms. In addition, it supports CPU only on x86 and aarch64. 

I am waiting for #13039 to be merged as this build depends directly on this. This PR will be set as a draft until then. This build recipe matches the platform configuration in the UCX PR.

LICENSE: [BSD-3-Clause](https://github.com/openucx/ucc/blob/master/LICENSE)