### PR TITLE
[nuSQuIDS] Add new JLL package v1.13.3

### DIFF
--- a/N/nuSQuIDS/build_tarballs.jl
+++ b/N/nuSQuIDS/build_tarballs.jl
@@ -182,13 +182,10 @@ products = [
 dependencies = [
     Dependency("GSL_jll"; compat="~2.8"),
     Dependency("HDF5_jll"; compat="~1.14"),
-    Dependency("LibCURL_jll"),  # Required by HDF5_jll for ROS3 VFD support
+    Dependency("LibCURL_jll"; compat="7.73,8"),  # Required by HDF5_jll for ROS3 VFD support
     Dependency("CompilerSupportLibraries_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-# Note: dont_dlopen=true because HDF5_jll's libcurl dependency has version
-# symbol issues in the BinaryBuilder audit environment (CURL_4 not found).
-# The library works correctly at runtime when all JLL dependencies are loaded.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"8", dont_dlopen=true)
+               julia_compat="1.6", preferred_gcc_version=v"8")


### PR DESCRIPTION
## Summary

This PR adds `nuSQuIDS_jll`, a JLL package for the nuSQuIDS neutrino propagation library.

**nuSQuIDS** is a C++ library that solves the neutrino evolution equations including:
- Neutrino oscillations in vacuum and matter
- Non-coherent interactions (CC, NC, tau regeneration, Glashow resonance)
- Support for Earth (PREM model), Sun, and custom density profiles
- Single energy and multiple energy modes
- Atmospheric neutrino propagation (nuSQUIDSAtm)

This JLL bundles both **SQuIDS** (the underlying quantum state evolution library, v1.3.1) and **nuSQuIDS** (v1.13.3) together, along with physics data files (cross-sections, Earth model, etc.).

## Links

- nuSQuIDS: https://github.com/arguelles/nuSQuIDS
- SQuIDS: https://github.com/jsalvado/SQuIDS
- Paper: [arXiv:1412.3832](https://arxiv.org/abs/1412.3832)

## Products

- `libSQuIDS` - SQuIDS library
- `libnuSQuIDS` - nuSQuIDS library  
- `nuSQuIDS_data` - Physics data files (cross-sections, Earth model, etc.)

## Platforms

Initial build targets (can expand after testing):
- Linux x86_64 (glibc)
- Linux aarch64 (glibc)
- macOS x86_64
- macOS aarch64 (Apple Silicon)

## Dependencies

- `GSL_jll` - GNU Scientific Library
- `HDF5_jll` - HDF5 for state serialization

## Usage

This JLL will enable Julia bindings for nuSQuIDS via CxxWrap.jl, allowing users to compute neutrino oscillation probabilities and propagate neutrino fluxes through matter.