### PR TITLE
[MuesliMaterials] Update version to 1.16.1

### DIFF
--- a/M/MuesliMaterials/build_tarballs.jl
+++ b/M/MuesliMaterials/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "MuesliMaterials"
-version = v"1.16"
+version = v"1.16.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://bitbucket.org/ignromero/muesli.git", "27e8204971602cb042d633b8b5f87761272b10df")
+    GitSource("https://bitbucket.org/ignromero/muesli.git", "be3500e9958ef79974fb1f588a8f885c442448ce")
     DirectorySource("bundled")
 ]
 


### PR DESCRIPTION
As the source does not really do version numbering, I've incremented the version number by 0.1 manually, as  new commits includes mostly bug fixes