### PR TITLE
feat: add libntl_julia_jll recipe

### DIFF
--- a/L/libntl_julia/build_tarballs.jl
+++ b/L/libntl_julia/build_tarballs.jl
@@ -11,7 +11,7 @@ version = v"0.2.0"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/s-celles/libntl-julia-wrapper.git",
-              "2d7ccbe0572840c476273509b7b52bd6d18ca2d5"),
+              "9de5aeb7d2971c83a46a95ccf4cf4dd20425ca28"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
CxxWrap-based Julia wrapper for NTL (Number Theory Library).

Provides bindings for:
- ZZ: Arbitrary-precision integers
- ZZ_p: Modular integers (Z/pZ)
- ZZX: Polynomials over integers

Dependencies:
- ntl_jll ~10.5
- libcxxwrap_julia_jll ~0.13
- GMP_jll 6