### PR TITLE
[PROPOSAL_cxxwrap] Bump to v0.1.1

### DIFF
--- a/P/PROPOSAL_cxxwrap/build_tarballs.jl
+++ b/P/PROPOSAL_cxxwrap/build_tarballs.jl
@@ -6,12 +6,12 @@ using BinaryBuilder, Pkg
 include("../../L/libjulia/common.jl")
 
 name = "PROPOSAL_cxxwrap"
-version = v"0.1.0"
+version = v"0.1.1"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/jlazar17/PROPOSAL_cxxwrap.git",
-              "5ea111580ef1e11f0e23810b861213ff063e181f"),
+              "f0cbc2bcd40ea9e326661ac42137f138bff5a3dc"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
## Summary
- Bumps PROPOSAL_cxxwrap_jll from v0.1.0 to v0.1.1
- Fixes ParticleType enum class incompatibility with CxxWrap 0.17: `SetWeakPartner` was exposing a C++ `enum class` parameter which CxxWrap 0.17 cannot handle. The fix casts to `int` at the binding layer.
- Adds integration tests and CI that load the wrapper into Julia via `@wrapmodule`/`@initcxx` to catch this class of runtime errors that BinaryBuilder's compile-only check misses.

## Source changes
https://github.com/jlazar17/PROPOSAL_cxxwrap/compare/5ea1115...f0cbc2b