### PR TITLE
[tcl 9.0] Modify build_tarballs.jl for GCC version and flags

### DIFF
--- a/T/Tcl/build_tarballs.jl
+++ b/T/Tcl/build_tarballs.jl
@@ -15,6 +15,8 @@ sources = [
 script = raw"""
 if [[ "${target}" == *-mingw* ]]; then
     cd $WORKSPACE/srcdir/tcl/win/
+    # `make install` calls `tclsh` on Windows
+    apk add tcl
 else
     cd $WORKSPACE/srcdir/tcl/unix/
 fi


### PR DESCRIPTION
Updated build script to include preferred GCC version and modified flags for configuration.