### PR TITLE
New package: Cairo_NoGPL

### DIFF
--- a/C/Cairo/Cairo/build_tarballs.jl
+++ b/C/Cairo/Cairo/build_tarballs.jl
@@ -2,25 +2,12 @@ include(joinpath("..", "common.jl"))
 
 name = "Cairo"
 
-# Dependencies that must be installed before this package can be built
+# Dependencies: common set plus LZO
 dependencies = [
-    BuildDependency("Xorg_xorgproto_jll"; platforms=linux_freebsd),
-    Dependency("Glib_jll"; compat="2.84.0"),
-    Dependency("Pixman_jll"; compat="0.44.2"),
-    Dependency("libpng_jll"; compat="1.6.47"),
-    Dependency("Fontconfig_jll"; compat="2.16.0"),
-    Dependency("FreeType2_jll"; compat="2.13.4"),
-    Dependency("Bzip2_jll"; compat="1.0.9"),
-    Dependency("Xorg_libXext_jll"; platforms=linux_freebsd),
-    Dependency("Xorg_libXrender_jll"; platforms=linux_freebsd),
+    common_dependencies;
     # Build with LZO errors on macOS:
     # /workspace/destdir/include/lzo/lzodefs.h:2197:1: error: 'lzo_cta__3' declared as an array with a negative size
-    Dependency("LZO_jll"; compat="2.10.3", platforms=filter(!Sys.isapple, platforms)),
-    Dependency("Zlib_jll"; compat="1.2.12"),
-    # libcairo needs libssp on Windows, which is provided by CSL, but not in all versions of
-    # Julia.  Note that above we're copying libssp to libdir for the versions of Julia where
-    # this wasn't available.
-    Dependency("CompilerSupportLibraries_jll"; platforms=filter(Sys.iswindows, platforms)),
+    Dependency("LZO_jll"; compat="2.10.3", platforms=filter(!Sys.isapple, platforms));
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/Cairo/Cairo_NoGPL/build_tarballs.jl
+++ b/C/Cairo/Cairo_NoGPL/build_tarballs.jl
@@ -11,22 +11,9 @@ if [ -f "${includedir}/lzo/lzoconf.h" ]; then
 fi
 """ * script
 
-# Dependencies that must be installed before this package can be built
-# This is the same as Cairo, but without LZO_jll (which is GPL-licensed).
+# Dependencies: common set without LZO (which is GPL-licensed).
 # LZO is auto-detected by Cairo's meson build system; if absent, Cairo builds without it.
-dependencies = [
-    BuildDependency("Xorg_xorgproto_jll"; platforms=linux_freebsd),
-    Dependency("Glib_jll"; compat="2.84.0"),
-    Dependency("Pixman_jll"; compat="0.44.2"),
-    Dependency("libpng_jll"; compat="1.6.47"),
-    Dependency("Fontconfig_jll"; compat="2.16.0"),
-    Dependency("FreeType2_jll"; compat="2.13.4"),
-    Dependency("Bzip2_jll"; compat="1.0.9"),
-    Dependency("Xorg_libXext_jll"; platforms=linux_freebsd),
-    Dependency("Xorg_libXrender_jll"; platforms=linux_freebsd),
-    Dependency("Zlib_jll"; compat="1.2.12"),
-    Dependency("CompilerSupportLibraries_jll"; platforms=filter(Sys.iswindows, platforms)),
-]
+dependencies = copy(common_dependencies)
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;

--- a/C/Cairo/common.jl
+++ b/C/Cairo/common.jl
@@ -66,3 +66,21 @@ products = [
 
 # Some dependencies are needed only on Linux and FreeBSD
 linux_freebsd = filter(p->Sys.islinux(p) || Sys.isfreebsd(p), platforms)
+
+# Common dependencies shared by Cairo and Cairo_NoGPL
+common_dependencies = [
+    BuildDependency("Xorg_xorgproto_jll"; platforms=linux_freebsd),
+    Dependency("Glib_jll"; compat="2.84.0"),
+    Dependency("Pixman_jll"; compat="0.44.2"),
+    Dependency("libpng_jll"; compat="1.6.47"),
+    Dependency("Fontconfig_jll"; compat="2.16.0"),
+    Dependency("FreeType2_jll"; compat="2.13.4"),
+    Dependency("Bzip2_jll"; compat="1.0.9"),
+    Dependency("Xorg_libXext_jll"; platforms=linux_freebsd),
+    Dependency("Xorg_libXrender_jll"; platforms=linux_freebsd),
+    Dependency("Zlib_jll"; compat="1.2.12"),
+    # libcairo needs libssp on Windows, which is provided by CSL, but not in all versions of
+    # Julia.  Note that above we're copying libssp to libdir for the versions of Julia where
+    # this wasn't available.
+    Dependency("CompilerSupportLibraries_jll"; platforms=filter(Sys.iswindows, platforms)),
+]


### PR DESCRIPTION
## Summary

This creates a new JLL for Cairo which excises the LZO_jll dependency.  That gets used for the internal debug/replay stuff which folks may want, so I figured it was easiest to just create a separate JLL, which users could use for overrides if needed.

## Changes
- Add a GPL-free variant of Cairo (`Cairo_nogpl`) that builds without the GPL-licensed `LZO_jll` dependency
- Restructure `C/Cairo/` into a multi-variant layout with shared `common.jl` and separate `Cairo/` and `Cairo_nogpl/` subdirectories
- The nogpl build script includes a guard that fails the build if LZO is found in the environment

## Test plan
- [ ] Build `Cairo/build_tarballs.jl` and verify it produces identical output to the previous single-file build
- [ ] Build `Cairo_nogpl/build_tarballs.jl` and verify it builds successfully without LZO
- [ ] Verify the LZO guard in the nogpl script catches accidental LZO presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)