### PR TITLE
Add builder for CJOSE

### DIFF
--- a/C/CJOSE/build_tarballs.jl
+++ b/C/CJOSE/build_tarballs.jl
@@ -15,6 +15,7 @@ sources = [
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/cjose
+autoreconf -fiv
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
 make install
 """


### PR DESCRIPTION
Specifically the OpenIDC maintenance fork, v0.6.2.4.