### PR TITLE
[Singular] rebuild with FLINT working

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -67,7 +67,8 @@ fi
     --enable-p-procs-static \
     --disable-p-procs-dynamic \
     --enable-gfanlib \
-    --with-readline=no \
+    --without-readline \
+    --without-ntl \
     --with-gmp=$prefix \
     --with-flint=$prefix \
     --without-python \
@@ -112,6 +113,7 @@ dependencies = [
     Dependency(PackageSpec(name="FLINT_jll"), compat = "~301.400.000"),
     Dependency("GMP_jll", v"6.2.1"),
     Dependency("MPFR_jll", v"4.1.1"),
+    BuildDependency(PackageSpec(name="OpenBLAS32_jll", version="0.3.29")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
See <https://github.com/JuliaPackaging/Yggdrasil/pull/13119#issuecomment-3898124384> for the problem: for some reason Singular was built without FLINT, and that in turn seems to be caused by the upgrade of OpenBLA32 from 0.3.29 to 0.3.30 in PR #12866.

This attempts to work around the issue by adding `OpenBLAS32_jll v0.3.29` as a build dependency.

Comparing https://github.com/JuliaBinaryWrappers/OpenBLAS32_jll.jl/releases/tag/OpenBLAS32-v0.3.30%2B0 and https://github.com/JuliaBinaryWrappers/OpenBLAS32_jll.jl/releases/tag/OpenBLAS32-v0.3.29%2B0 an obvious difference is that the new version only has libgfortran5 ABI variants, the old one has libgfortran3 and libgfortran4 as well. I did not yet dig deeper to see if that is relevant.

CC @ederc @benlorenz @eschnett 