### PR TITLE
[Singular] require GCC 8

### DIFF
--- a/S/Singular/build_tarballs.jl
+++ b/S/Singular/build_tarballs.jl
@@ -113,9 +113,8 @@ dependencies = [
     Dependency(PackageSpec(name="FLINT_jll"), compat = "~301.400.000"),
     Dependency("GMP_jll", v"6.2.1"),
     Dependency("MPFR_jll", v"4.1.1"),
-    BuildDependency(PackageSpec(name="OpenBLAS32_jll", version="0.3.29")),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    preferred_gcc_version=v"6", julia_compat = "1.10")
+    preferred_gcc_version=v"8", julia_compat = "1.10")


### PR DESCRIPTION
This switches the ABI to libgfortran 5, and should avoid the FLINT issue without us needing to pull in OpenBLAS32_jll. So we can revert the change I made in PR #13130.

Many thanks to @giordano for pointing me to <https://github.com/JuliaPackaging/Yggdrasil/blob/4d19665ae44cb1ee3c24d8ade9e8228363e19bfa/RootFS.md#compiler-shards>

CC @ederc @benlorenz @lgoettgens 