### PR TITLE
New Recipe: ESBMC

### DIFF
--- a/E/ESBMC/build_tarballs.jl
+++ b/E/ESBMC/build_tarballs.jl
@@ -1,0 +1,161 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
+
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
+name = "ESBMC"
+version = v"8.0.0"
+
+llvm_versions = [v"18.1.7"]
+
+sources = [
+    GitSource("https://github.com/esbmc/esbmc.git",
+              "18a62e0b93f273dbdfcdc6e2338ad3c0b84129b8"),
+    DirectorySource("./bundled"),
+    # fmt has no JLL; bundle source for FetchContent
+    GitSource("https://github.com/fmtlib/fmt.git",
+              "407c905e45ad75fc29bf0f9bb7c5c2fd3475976f"),  # 12.1.0
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/esbmc*
+
+# Apply cross-compilation patches
+for f in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 "${f}"
+done
+
+# On macOS, llvm-ranlib doesn't support -no_warning_for_no_symbols and -c
+# flags that CMake adds on Darwin. Create a wrapper that strips them.
+RANLIB_FLAGS=""
+if [[ "${target}" == *-apple-darwin* ]]; then
+    real_ranlib=$(which ${target}-ranlib)
+    cat > /tmp/ranlib_wrapper <<WRAPPER
+#!/bin/bash
+args=()
+for arg in "\$@"; do
+    case "\$arg" in
+        -no_warning_for_no_symbols|-c) ;;
+        *) args+=("\$arg") ;;
+    esac
+done
+exec "${real_ranlib}" "\${args[@]}"
+WRAPPER
+    chmod +x /tmp/ranlib_wrapper
+    RANLIB_FLAGS="-DCMAKE_RANLIB=/tmp/ranlib_wrapper"
+fi
+
+mkdir build && cd build
+cmake .. \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_Z3=ON \
+    -DENABLE_SMTLIB=ON \
+    -DZ3_DIR=${prefix} \
+    -DLLVM_DIR=${prefix}/lib/cmake/llvm \
+    -DClang_DIR=${prefix}/lib/cmake/clang \
+    -DESBMC_BUNDLE_LIBC=OFF \
+    -DENABLE_SOLIDITY_FRONTEND=OFF \
+    -DENABLE_JIMPLE_FRONTEND=OFF \
+    -DENABLE_PYTHON_FRONTEND=OFF \
+    -DENABLE_GOTO_CONTRACTOR=OFF \
+    -DBUILD_TESTING=OFF \
+    -DENABLE_REGRESSION=OFF \
+    -DDOWNLOAD_DEPENDENCIES=OFF \
+    -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
+    -DFETCHCONTENT_SOURCE_DIR_FMT=${WORKSPACE}/srcdir/fmt \
+    -DCMAKE_EXE_LINKER_FLAGS="-lpthread" \
+    -DCCACHE_FOUND=CCACHE_FOUND-NOTFOUND \
+    ${RANLIB_FLAGS}
+cmake --build . --parallel ${nproc}
+cmake --install .
+
+install_license ${WORKSPACE}/srcdir/esbmc*/COPYING
+"""
+
+# ESBMC requires <cuchar> (available in libc++ from SDK 14.5+) and
+# std::filesystem (available from macOS 10.15+).
+sources, script = require_macos_sdk("14.5", sources, script; deployment_target="10.15")
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+    $(LLVM.augment)
+    augment_platform!(platform::Platform) = augment_llvm!(platform)
+"""
+
+# determine exactly which tarballs we should build
+builds = []
+for llvm_version in llvm_versions, llvm_assertions in (false, true)
+    # Dependencies that must be installed before this package can be built
+    llvm_name = llvm_assertions ? "LLVM_full_assert_jll" : "LLVM_full_jll"
+    dependencies = [
+        BuildDependency(PackageSpec(name=llvm_name, version=v"18.1.7+3")),
+        RuntimeDependency("Clang_jll"),
+        Dependency("z3_jll"; compat="4.13.3"),
+        Dependency("boost_jll"; compat="1.87.0"),
+        Dependency("GMP_jll"; compat="6.2.1"),
+        Dependency("Zlib_jll"),
+        Dependency("CompilerSupportLibraries_jll"),
+        BuildDependency("nlohmann_json_jll"),
+        Dependency("yaml_cpp_jll"),
+    ]
+
+    # The products that we will ensure are always built
+    products = Product[
+        ExecutableProduct("esbmc", :esbmc),
+    ]
+
+    # These are the platforms we will build for by default, unless further
+    # platforms are passed in on the command line
+    platforms = expand_cxxstring_abis(supported_platforms())
+    # ESBMC is C++23; only cxx11 ABI is relevant
+    filter!(p -> cxxstring_abi(p) != "cxx03", platforms)
+    # disable riscv64 (not supported by LLVM_full_jll)
+    filter!(p -> arch(p) != "riscv64", platforms)
+    # disable aarch64 freebsd (not supported by LLVM_full_jll)
+    filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
+    # disable i686-linux-musl (not supported by LLVM_full_jll)
+    filter!(p -> !(arch(p) == "i686" && libc(p) == "musl"), platforms)
+    # disable 32-bit and ARM platforms (ESBMC is 64-bit focused)
+    filter!(p -> arch(p) != "i686", platforms)
+    filter!(p -> arch(p) != "armv6l", platforms)
+    filter!(p -> arch(p) != "armv7l", platforms)
+    # disable Windows (ESBMC cross-compilation is cleaner on Unix)
+    filter!(p -> !Sys.iswindows(p), platforms)
+
+    for platform in platforms
+        augmented_platform = deepcopy(platform)
+        augmented_platform[LLVM.platform_name] = LLVM.platform(llvm_version, llvm_assertions)
+
+        platform_sources = BinaryBuilder.AbstractSource[sources...]
+
+        should_build_platform(triplet(augmented_platform)) || continue
+        push!(builds, (;
+            dependencies, products, sources=platform_sources,
+            platforms=[augmented_platform],
+        ))
+    end
+end
+
+# don't allow `build_tarballs` to override platform selection based on ARGS.
+# we handle that ourselves by calling `should_build_platform`
+non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
+
+# `--register` should only be passed to the latest `build_tarballs` invocation
+non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
+
+for (i,build) in enumerate(builds)
+    build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
+                   name, version, build.sources, script,
+                   build.platforms, build.products, build.dependencies;
+                   preferred_gcc_version=v"13", preferred_llvm_version=v"16",
+                   julia_compat="1.12",
+                   augment_platform_block)
+end

--- a/E/ESBMC/bundled/patches/0001-cross-compile-fixes.patch
+++ b/E/ESBMC/bundled/patches/0001-cross-compile-fixes.patch
@@ -1,0 +1,126 @@
+diff --git a/scripts/cmake/FindLocalLLVM.cmake b/scripts/cmake/FindLocalLLVM.cmake
+index 8937b3a83..25e290baf 100644
+--- a/scripts/cmake/FindLocalLLVM.cmake
++++ b/scripts/cmake/FindLocalLLVM.cmake
+@@ -78,34 +78,52 @@ endif()
+ # clang executable, which in, e.g., Ubuntu, lives in a package separate from
+ # libclang-cpp.so.
+ 
+-try_run(TRY_CLANG_RUNS TRY_CLANG_COMPILES ${CMAKE_CURRENT_BINARY_DIR}
+-        ${PROJECT_SOURCE_DIR}/scripts/cmake/try_clang.cc
+-        CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CLANG_INCLUDE_DIRS}
+-        LINK_LIBRARIES ${ESBMC_CLANG_LIBS}
+-        COMPILE_OUTPUT_VARIABLE TRY_CLANG_COMPILE_OUTPUT
+-        RUN_OUTPUT_VARIABLE CLANG_RESOURCE_DIR)
+-
+-if (NOT TRY_CLANG_COMPILES)
+-  message(FATAL_ERROR "Cannot compile against Clang: ${TRY_CLANG_COMPILE_OUTPUT}")
++if(CMAKE_CROSSCOMPILING)
++  # When cross-compiling we cannot run host binaries, so just verify that
++  # we can compile against Clang and compute CLANG_RESOURCE_DIR from the
++  # LLVM version variables that are already available.
++  try_compile(TRY_CLANG_COMPILES ${CMAKE_CURRENT_BINARY_DIR}
++              ${PROJECT_SOURCE_DIR}/scripts/cmake/try_clang.cc
++              CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CLANG_INCLUDE_DIRS}
++              LINK_LIBRARIES ${ESBMC_CLANG_LIBS}
++              OUTPUT_VARIABLE TRY_CLANG_COMPILE_OUTPUT)
++  if (NOT TRY_CLANG_COMPILES)
++    message(FATAL_ERROR "Cannot compile against Clang: ${TRY_CLANG_COMPILE_OUTPUT}")
++  endif()
++else()
++  try_run(TRY_CLANG_RUNS TRY_CLANG_COMPILES ${CMAKE_CURRENT_BINARY_DIR}
++          ${PROJECT_SOURCE_DIR}/scripts/cmake/try_clang.cc
++          CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CLANG_INCLUDE_DIRS}
++          LINK_LIBRARIES ${ESBMC_CLANG_LIBS}
++          COMPILE_OUTPUT_VARIABLE TRY_CLANG_COMPILE_OUTPUT
++          RUN_OUTPUT_VARIABLE CLANG_RESOURCE_DIR)
++  if (NOT TRY_CLANG_COMPILES)
++    message(FATAL_ERROR "Cannot compile against Clang: ${TRY_CLANG_COMPILE_OUTPUT}")
++  endif()
++  if (TRY_CLANG_RUNS EQUAL 0)
++    string(STRIP "${CLANG_RESOURCE_DIR}" CLANG_RESOURCE_DIR)
++    # see clang-toolings's injectResourceDir():
++    # <https://clang.llvm.org/doxygen/Tooling_8cpp_source.html#l00462>
++    if (NOT ("${CLANG_RESOURCE_DIR}" STREQUAL ""))
++      set(CLANG_RESOURCE_DIR "${CLANG_INSTALL_PREFIX}/bin/${CLANG_RESOURCE_DIR}")
++    endif()
++  endif()
+ endif()
+ 
+-if (TRY_CLANG_RUNS EQUAL 0)
+-  string(STRIP "${CLANG_RESOURCE_DIR}" CLANG_RESOURCE_DIR)
+-  # see clang-toolings's injectResourceDir():
+-  # <https://clang.llvm.org/doxygen/Tooling_8cpp_source.html#l00462>
+-  if (NOT ("${CLANG_RESOURCE_DIR}" STREQUAL ""))
+-    set(CLANG_RESOURCE_DIR "${CLANG_INSTALL_PREFIX}/bin/${CLANG_RESOURCE_DIR}")
+-  elseif (${LLVM_VERSION_MAJOR} LESS 16)
++# Fallback: compute CLANG_RESOURCE_DIR from LLVM version if not yet determined
++if (NOT CLANG_RESOURCE_DIR OR "${CLANG_RESOURCE_DIR}" STREQUAL "")
++  if (${LLVM_VERSION_MAJOR} LESS 16)
+     set(CLANG_RESOURCE_DIR "${CLANG_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+   else()
+     set(CLANG_RESOURCE_DIR "${CLANG_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}/clang/${LLVM_VERSION_MAJOR}")
+   endif()
+-  message(STATUS "Clang resource dir: ${CLANG_RESOURCE_DIR}")
+-  set(ESBMC_CLANG_HEADER_DIR "${CLANG_RESOURCE_DIR}/include")
+-  if (NOT IS_DIRECTORY "${ESBMC_CLANG_HEADER_DIR}")
+-    message(STATUS "Failed to determine path to Clang headers: not a directory: ${ESBMC_CLANG_HEADER_DIR}")
+-    unset(ESBMC_CLANG_HEADER_DIR)
+-  endif()
++endif()
++
++message(STATUS "Clang resource dir: ${CLANG_RESOURCE_DIR}")
++set(ESBMC_CLANG_HEADER_DIR "${CLANG_RESOURCE_DIR}/include")
++if (NOT IS_DIRECTORY "${ESBMC_CLANG_HEADER_DIR}")
++  message(STATUS "Failed to determine path to Clang headers: not a directory: ${ESBMC_CLANG_HEADER_DIR}")
++  unset(ESBMC_CLANG_HEADER_DIR)
+ endif()
+ 
+ if (NOT ${OVERRIDE_CLANG_HEADER_DIR} STREQUAL "")
+diff --git a/src/solvers/z3/CMakeLists.txt b/src/solvers/z3/CMakeLists.txt
+index 1911c633e..facc24e89 100644
+--- a/src/solvers/z3/CMakeLists.txt
++++ b/src/solvers/z3/CMakeLists.txt
+@@ -24,19 +24,35 @@ if(ENABLE_Z3)
+         message(FATAL_ERROR "Could not find libz3, please check Z3_DIR")
+     endif()
+ 
+-    try_run(Z3_RUNS Z3_COMPILES ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/try_z3.c
+-            CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${Z3_INCLUDE_DIRS}
+-            LINK_LIBRARIES ${Z3_LIB} ${OS_Z3_LIBS}
+-            COMPILE_OUTPUT_VARIABLE Z3COMPILESTR
+-            RUN_OUTPUT_VARIABLE Z3_VERSION)
++    if(CMAKE_CROSSCOMPILING)
++        # When cross-compiling we cannot run target binaries.
++        # Verify Z3 compiles and extract version from header.
++        try_compile(Z3_COMPILES ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/try_z3.c
++                    CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${Z3_INCLUDE_DIRS}
++                    LINK_LIBRARIES ${Z3_LIB} ${OS_Z3_LIBS}
++                    OUTPUT_VARIABLE Z3COMPILESTR)
++        # Read version components from z3_version.h
++        foreach(_comp MAJOR MINOR BUILD REVISION)
++            file(STRINGS "${Z3_INCLUDE_DIRS}/z3_version.h" _line REGEX "#define Z3_${_comp}_VERSION +([0-9]+)")
++            string(REGEX REPLACE ".* ([0-9]+)" "\\1" _val "${_line}")
++            set(_z3_${_comp} "${_val}")
++        endforeach()
++        set(Z3_VERSION "${_z3_MAJOR}.${_z3_MINOR}.${_z3_BUILD}.${_z3_REVISION}")
++    else()
++        try_run(Z3_RUNS Z3_COMPILES ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/try_z3.c
++                CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${Z3_INCLUDE_DIRS}
++                LINK_LIBRARIES ${Z3_LIB} ${OS_Z3_LIBS}
++                COMPILE_OUTPUT_VARIABLE Z3COMPILESTR
++                RUN_OUTPUT_VARIABLE Z3_VERSION)
++        string(REGEX MATCH "(Z3 )?([0-9]+.[0-9]+.[0-9]+.[0-9]+)" REGEX_OUTPUT ${Z3_VERSION})
++        set(Z3_VERSION "${CMAKE_MATCH_2}")
++    endif()
+ 
+     if(NOT Z3_COMPILES)
+         message(FATAL_ERROR "Could not use Z3: \n${Z3COMPILESTR}")
+     endif()
+ 
+     message(STATUS "Using Z3 at: ${Z3_LIB}")
+-    string(REGEX MATCH "(Z3 )?([0-9]+.[0-9]+.[0-9]+.[0-9]+)"  REGEX_OUTPUT ${Z3_VERSION})
+-    set(Z3_VERSION "${CMAKE_MATCH_2}")
+     message(STATUS "Z3 version: ${Z3_VERSION}")
+     if(Z3_VERSION VERSION_LESS Z3_MIN_VERSION)
+         message(FATAL_ERROR "Expected version ${Z3_MIN_VERSION} or greater")

--- a/E/ESBMC/bundled/patches/0002-portable-backtrace-and-breakpoint.patch
+++ b/E/ESBMC/bundled/patches/0002-portable-backtrace-and-breakpoint.patch
@@ -1,0 +1,40 @@
+--- a/src/esbmc/esbmc_parseoptions.cpp
++++ b/src/esbmc/esbmc_parseoptions.cpp
+@@ -58,8 +58,10 @@
+
+ #ifndef _WIN32
+ #  include <sys/wait.h>
+-#  include <execinfo.h>
+ #  include <fcntl.h>
++#  ifdef __GLIBC__
++#    include <execinfo.h>
++#  endif
+ #endif
+
+ #ifdef ENABLE_GOTO_CONTRACTOR
+@@ -121,8 +123,10 @@
+ {
+   ::signal(sig, SIG_DFL);
+   void *buffer[BT_BUF_SIZE];
++#ifdef __GLIBC__
+   int n = backtrace(buffer, BT_BUF_SIZE);
+   dprintf(STDERR_FILENO, "\nSignal %d, backtrace:\n", sig);
+   backtrace_symbols_fd(buffer, n, STDERR_FILENO);
++#endif
+   int fd = open("/proc/self/maps", O_RDONLY);
+   if (fd != -1)
+--- a/src/util/breakpoint.h
++++ b/src/util/breakpoint.h
+@@ -3,10 +3,10 @@
+ static void breakpoint()
+ {
+ #ifndef _WIN32
+-#  if !(defined(__arm__) || defined(__aarch64__))
++#  if defined(__i386__) || defined(__x86_64__)
+   __asm__("int $3");
+ #  else
+-  log_error("Can't trap on ARM, sorry");
++  log_error("Can't trap on this platform, sorry");
+   abort();
+ #  endif
+ #else

--- a/E/ESBMC/bundled/patches/0003-use-system-json-and-yaml-cpp.patch
+++ b/E/ESBMC/bundled/patches/0003-use-system-json-and-yaml-cpp.patch
@@ -1,0 +1,37 @@
+--- a/scripts/cmake/ExternalDependencies.cmake	2026-02-15 04:59:35.589418776 +0000
++++ b/scripts/cmake/ExternalDependencies.cmake	2026-02-15 04:59:44.065421736 +0000
+@@ -2,20 +2,27 @@
+ # anywhere else
+ 
+ include(FetchContent)
++
+ # FMT
+ FetchContent_Declare(fmt
+   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+   GIT_TAG 12.1.0)
+ FetchContent_MakeAvailable(fmt)
+ 
+-#nlohmann json
+-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+-FetchContent_MakeAvailable(json)
++# nlohmann json: prefer system-installed, fall back to FetchContent
++find_package(nlohmann_json QUIET)
++if(NOT nlohmann_json_FOUND)
++  FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
++  FetchContent_MakeAvailable(json)
++endif()
+ 
+-# yaml-cpp
+-FetchContent_Declare(yaml-cpp
+-  GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git)
+-FetchContent_MakeAvailable(yaml-cpp)
++# yaml-cpp: prefer system-installed, fall back to FetchContent
++find_package(yaml-cpp QUIET)
++if(NOT yaml-cpp_FOUND)
++  FetchContent_Declare(yaml-cpp
++    GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git)
++  FetchContent_MakeAvailable(yaml-cpp)
++endif()
+ 
+ if(ESBMC_CHERI_CLANG)
+   FetchContent_Declare(cheri_compressed_cap


### PR DESCRIPTION
This adds a recipe for the ESBMC model checker [1] This was written by claude without human intervention as a test case for #13149. Results were mixed - it managed to use the MCP server for the initial debugging but then went back to individual runs for each platform.

That said, I do have independent interest in ESBMC and would like to try it out at some point in the future, so it's useful to have the jll. That said, I don't know whether the jll is useful as built - claude only managed to build the z3 backend and had to disable a number of platforms an options, but I'll cross that bridge when I get there.

[1] https://github.com/esbmc/esbmc.