### PR TITLE
[gametracer] Add v0.2.1

### DIFF
--- a/G/gametracer/build_tarballs.jl
+++ b/G/gametracer/build_tarballs.jl
@@ -10,9 +10,6 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/gametracer
 
-# Remove any corrupted Mac OS resource fork files that may interfere with CMake
-rm -f /usr/share/cmake/Modules/Compiler/._*
-
 cmake -S c_api -B build \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \


### PR DESCRIPTION
## Summary

This PR adds a new Yggdrasil recipe to build **gametracer** as a JLL package, producing a single shared library **`libgametracer`**.

The build uses the `c_api/` CMake entrypoint in `QuantEcon/gametracer`, which provides a stable C ABI shim over the upstream C++ codebase and exports:
- `ipa`
- `gnm`
- `gametracer_free`

## Source
- Repository: https://github.com/QuantEcon/gametracer
- Pinned SHA: `12aa4bb906a9d5a6ecd804cd26e7a2757a9cce50` (from the `c_api` work)
  - Version set in the recipe: `v0.2.1`
  - **Note:** the upstream tag `0.2.1` is planned but not yet finalized on the upstream side. This recipe is intentionally SHA-pinned for reproducibility. Once the tag is pushed (and/or the corresponding SHA is confirmed after merging upstream fixes), I can update the recipe to pin to the final tag commit.

## Build details

- CMake configure/build/install:
  - `cmake -S c_api -B build ...`
  - `cmake --build build`
  - `cmake --install build`
- Installs:
  - library: `${prefix}/lib/libgametracer.*` (Linux/macOS), `${prefix}/bin/libgametracer.dll` (Windows)
  - header: `${prefix}/include/gametracer_c_api.h`
  - license: `${prefix}/share/licenses/gametracer/COPYING`
- No CLI (`gt`) is built or shipped (library-only).

## Products
- `LibraryProduct("libgametracer", :libgametracer)`

## Testing
I did not run a full local cross build for all targets; this PR relies on Yggdrasil CI  to validate all platforms.