### PR TITLE
[aws_c_mqtt] Update to version 0.13.5

### DIFF
--- a/A/aws_c_mqtt/build_tarballs.jl
+++ b/A/aws_c_mqtt/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_mqtt"
-version = v"0.13.4"
+version = v"0.13.5"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
This PR updates aws_c_mqtt to version 0.13.5. cc: @quinnj @Octogonapus