### PR TITLE
[librdkafka] Enable zstd support

### DIFF
--- a/L/librdkafka/build_tarballs.jl
+++ b/L/librdkafka/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder, Pkg
 
 name = "librdkafka"
-version = v"2.3.0"
+version = v"2.13.0"
 
 # Collection of sources required to complete build
 sources = [
-    # git rev-list -n 1 v2.3.0
-    GitSource("https://github.com/confluentinc/librdkafka.git", "95a542c87c61d2c45b445f91c73dd5442eb04f3c",),
+    # git rev-list -n 1 v2.13.0
+    GitSource("https://github.com/confluentinc/librdkafka.git", "59b2f66b95ce763c102437d50d4e2a548962e091",),
     DirectorySource("./bundled"),
 ]
 
@@ -22,6 +22,7 @@ if [[ "${target}" != *-freebsd* ]]; then
 fi
 
 atomic_patch -p1 ../patches/bsd_posix.patch
+atomic_patch -p1 ../patches/sys_random.patch
 
 mkdir build
 cd build/
@@ -51,11 +52,12 @@ products = [
 dependencies = [
     Dependency(PackageSpec(name="Lz4_jll", uuid="5ced341a-0733-55b8-9ab6-a4889d929147"); compat="1.9.4"),
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4"); compat="1.5.7"),
-    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"); compat="1.2.11"),
+    Dependency(PackageSpec(name="Zlib_jll", uuid="83775a58-1f1d-513f-b197-d71354ab007a"); compat="1.2.12"),
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.8"),
     Dependency(PackageSpec(name="CyrusSASL_jll", uuid="6422fedd-75a7-50c2-a7c3-a11dad25a896"); compat="2.1.29"),
+    Dependency("LibCURL_jll"; compat="7.73,8"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    julia_compat="1.6")
+    julia_compat="1.6", preferred_gcc_version=v"7")

--- a/L/librdkafka/bundled/patches/bsd_posix.patch
+++ b/L/librdkafka/bundled/patches/bsd_posix.patch
@@ -1,8 +1,8 @@
 diff --git a/src/rd.h b/src/rd.h
-index fd6c307f..7a7984d4 100644
+index e6c6b9b4..556d1a8d 100644
 --- a/src/rd.h
 +++ b/src/rd.h
-@@ -40,10 +40,12 @@
+@@ -41,9 +41,11 @@
  #endif
  
  #define __need_IOV_MAX
@@ -10,8 +10,7 @@ index fd6c307f..7a7984d4 100644
  #ifndef _POSIX_C_SOURCE
  #define _POSIX_C_SOURCE 200809L /* for timespec on solaris */
  #endif
- #endif
 +#endif
- 
- #include <stdio.h>
- #include <stdlib.h>
+ #else
+ #ifndef _CRT_RAND_S
+ #define _CRT_RAND_S  /* for rand_s() on MSVC. It needs to be defined before    \

--- a/L/librdkafka/bundled/patches/sys_random.patch
+++ b/L/librdkafka/bundled/patches/sys_random.patch
@@ -1,0 +1,15 @@
+diff --git a/src/rdrand.c b/src/rdrand.c
+index 77d02cfc..df562f7c 100644
+--- a/src/rdrand.c
++++ b/src/rdrand.c
+@@ -34,8 +34,10 @@
+ #ifndef _WIN32
+ /* getentropy() can be present in one of these two */
+ #include <unistd.h>
++#if HAVE_GETENTROPY /* sys/random.h is missing on glibc < 2.25; the getentropy() call is already guarded by this macro */
+ #include <sys/random.h>
+ #endif
++#endif
+ 
+ #ifdef HAVE_OSSL_SECURE_RAND_BYTES
+ #include <openssl/rand.h>


### PR DESCRIPTION
Zstd_jll is listed as a dependency but cmake's `find_package(ZSTD QUIET)` fails silently in the BB environment, so zstd was never actually linked. Adding `-DWITH_ZSTD=ON` forces it on.