### PR TITLE
New recipe: blockSQP2 v0.1.0

### DIFF
--- a/B/blockSQP2/build_tarballs.jl
+++ b/B/blockSQP2/build_tarballs.jl
@@ -9,9 +9,8 @@ sources = [
 
 script = raw"""
 apk del cmake
-cd ${WORKSPACE}/srcdir
-mv blockSQP2/CMake/CMakeListsBinaryBuilderjl.cmake blockSQP2/CMakeLists.txt
-cd blockSQP2
+cd ${WORKSPACE}/srcdir/blockSQP2
+mv CMake/CMakeListsBinaryBuilderjl.cmake CMakeLists.txt
 
 LOBSUFFIX=""
 
@@ -33,8 +32,11 @@ cmake \
 make
 make install
 install_license ${WORKSPACE}/srcdir/blockSQP2/LICENSE
-mkdir ${prefix}/share/licenses/blockSQP && cp ${WORKSPACE}/srcdir/blockSQP2/blockSQP2/LICENSE ${prefix}/share/licenses/blockSQP/LICENSE
-mkdir ${prefix}/share/licenses/qpOASES && cp ${WORKSPACE}/srcdir/blockSQP2/blockSQP2/dep/modified_qpOASES/LICENSE ${prefix}/share/licenses/qpOASES/LICENSE
+mkdir ${prefix}/share/licenses/blockSQP
+cp ${WORKSPACE}/srcdir/blockSQP2/blockSQP2/LICENSE ${prefix}/share/licenses/blockSQP/LICENSE
+
+mkdir ${prefix}/share/licenses/qpOASES 
+cp ${WORKSPACE}/srcdir/blockSQP2/blockSQP2/dep/modified_qpOASES/LICENSE ${prefix}/share/licenses/qpOASES/LICENSE
 """
 
 platforms = supported_platforms()


### PR DESCRIPTION
I wish to add [blockSQP2](https://github.com/ReWittmann/blockSQP2/tree/v0.1.0), an NLP-solver based on [blockSQP](https://github.com/djanka2/blockSQP) whose Julia bindings already have a [recipe](https://github.com/JuliaPackaging/Yggdrasil/tree/master/B/blockSQP). For now, only the C-interface is made available, to be wrapped by [blockSQP2.jl](https://github.com/ReWittmann/blockSQP2.jl). blockSQP2 includes a [modified version](https://github.com/ReWittmann/blockSQP2/tree/v0.1.0/blockSQP2/dep/modified_qpOASES) of [qpOASES](https://github.com/coin-or/qpOASES), its license will be installed as well. 

Edit: This is a reopen of [#13176](https://github.com/JuliaPackaging/Yggdrasil/pull/13176) from branch ReWittmann:blockSQP2 instead of ReWittmann:master