### PR TITLE
[SQLCipher] Update to v4.13.0

### DIFF
--- a/S/SQLCipher/build_tarballs.jl
+++ b/S/SQLCipher/build_tarballs.jl
@@ -38,7 +38,6 @@ export CPPFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1 \
 make -j${nproc}
 make install
 
-cd $WORKSPACE/srcdir/sqlcipher
 # SQLCipher and SQLite licenses
 install_license LICENSE*
 """


### PR DESCRIPTION
Adapt build to breaking changes from v4.7.0:
- --enable-tempstore=yes renamed to --with-tempstore=yes
- --enable-json1 removed (JSON enabled by default with autosetup)
- SQLITE_EXTRA_INIT/SHUTDOWN now required at compile time
- Library/binary outputs renamed from sqlcipher to sqlite3