### PR TITLE
Add libsemigroups v3.4.0

### DIFF
--- a/L/libsemigroups/build_tarballs.jl
+++ b/L/libsemigroups/build_tarballs.jl
@@ -22,7 +22,7 @@ export CPPFLAGS="-I${prefix}/include"
 
 # Disable HPCombi on 32-bit platforms (requires __int128)
 HPCOMBI_FLAG=""
-if [[ "${nbits}" == 32 ]]; then
+if [[ "${nbits}" == 32 ]] || [[ "${target}" == powerpc* ]]; then
     HPCOMBI_FLAG="--disable-hpcombi"
 fi
 


### PR DESCRIPTION
New package: [libsemigroups](https://github.com/libsemigroups/libsemigroups) C++ library for semigroups and monoids.

  - Version: 3.4.0
  - Source: https://github.com/libsemigroups/libsemigroups/releases/tag/v3.4.0
  - Builds the shared library `libsemigroups`
  - Disables HPCombi on non-x86_64 (requires AVX)
  - Tested locally
