### PR TITLE
Add Randompack v0.1.5

### DIFF
--- a/R/Randompack/build_tarballs.jl
+++ b/R/Randompack/build_tarballs.jl
@@ -1,0 +1,113 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "Randompack"
+version = v"0.1.1"
+
+sources = [
+  ArchiveSource(
+    "https://raw.githubusercontent.com/jonasson2/randompack-src/v0.1.1/randompack-0.1.1.tar.gz",
+    "db3f048ddce772a77cacdf2d23a6bed58db4836b9d60f3dc6d1d910662926294",
+  ),
+]
+    
+script = raw"""
+set -e
+# Work around stray AppleDouble files that can break Python site.py decoding.
+find /usr/lib/python3.9/site-packages -maxdepth 1 -name '._*' -delete \
+  2>/dev/null || true
+
+cd $WORKSPACE/srcdir
+SRC=$WORKSPACE/srcdir/randompack-0.1.1
+# Meson fails to detect the macOS/aarch64 linker in BinaryBuilder;
+# build manually here.
+if echo "$target" | grep -q 'apple-darwin'; then
+  BUILD=$WORKSPACE/build-manual
+  rm -rf $BUILD
+  mkdir -p $BUILD $prefix/lib $prefix/include \
+    $prefix/share/licenses/Randompack
+
+  CDEFS="-D_POSIX_C_SOURCE=200809L -D_DARWIN_C_SOURCE -DLOCAL_DPSTRF -DUSE_ACCEL_VV"
+  if echo "$target" | grep -q '^aarch64-apple-darwin'; then
+    COPTS="-O3 -mcpu=apple-m1 -fPIC -fno-math-errno -fno-trapping-math -fomit-frame-pointer -fno-semantic-interposition"
+  else
+    COPTS="-O3 -fPIC -fno-math-errno -fno-trapping-math -fomit-frame-pointer -fno-semantic-interposition"
+  fi
+
+  AR=${target}-ar
+  RANLIB=${target}-ranlib
+  $FC -O3 -c $SRC/src/lapack_dpstrf.f -o $BUILD/lapack_dpstrf.f.o
+  $CC -std=c11 $COPTS $CDEFS -I$SRC/src -c $SRC/src/printX.c \
+    -o $BUILD/printX.c.o
+  $CC -std=c11 $COPTS $CDEFS -I$SRC/src -c $SRC/src/randompack.c \
+    -o $BUILD/randompack.c.o
+
+  $CC -shared -o $prefix/lib/librandompack.dylib \
+    $BUILD/randompack.c.o $BUILD/printX.c.o $BUILD/lapack_dpstrf.f.o \
+    -framework Accelerate -lm -lgfortran \
+    -Wl,-install_name,@rpath/librandompack.dylib
+
+  $AR rcs $prefix/lib/librandompack.a \
+    $BUILD/randompack.c.o $BUILD/printX.c.o $BUILD/lapack_dpstrf.f.o
+  $RANLIB $prefix/lib/librandompack.a || true
+
+  if [ -f $SRC/src/randompack.h ]; then
+    cp $SRC/src/randompack.h $prefix/include/
+  fi
+  if [ -f $SRC/src/randompack_config.h ]; then
+    cp $SRC/src/randompack_config.h $prefix/include/
+  fi
+  if [ -f $SRC/randompack.h ]; then
+    cp $SRC/randompack.h $prefix/include/
+  fi
+  if [ -f $SRC/randompack_config.h ]; then
+    cp $SRC/randompack_config.h $prefix/include/
+  fi
+
+  cp $SRC/LICENSE $prefix/share/licenses/Randompack/LICENSE
+else
+  cd $WORKSPACE
+  rm -rf build
+
+  export PKG_CONFIG_PATH="${prefix}/lib/pkgconfig:${prefix}/lib64/pkg<config:${prefix}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
+  export CPPFLAGS="-I${prefix}/include ${CPPFLAGS:-}"
+  export LDFLAGS="-L${prefix}/lib -L${prefix}/lib64 ${LDFLAGS:-}"
+    
+  meson setup build $SRC \
+    --cross-file=${MESON_TARGET_TOOLCHAIN} \
+    --buildtype=release \
+    --prefix=${prefix} \
+    -Dblas=openblas \
+    -Dbuild_examples=false \
+    -Dbuild_tests=false \
+    -Dbuild_fortran_interface=false
+  ninja -C build
+  ninja -C build install
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+  Platform("aarch64", "macos",   libgfortran_version="5.0.0"),
+  Platform("x86_64",  "macos",   libgfortran_version="5.0.0"),
+  Platform("x86_64",  "linux";   libgfortran_version="5.0.0", cxxstring_abi="cxx11"),
+  Platform("aarch64", "linux";   libgfortran_version="5.0.0", cxxstring_abi="cxx11"),
+  Platform("x86_64",  "windows"; libgfortran_version="5.0.0"),
+]
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("librandompack", :librandompack)
+]
+
+dependencies = [
+  Dependency(PackageSpec(name="CompilerSupportLibraries_jll",
+                         uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+  Dependency(PackageSpec(name="OpenBLAS32_jll",
+                         uuid="656ef2d0-ae68-5445-9ca0-591084a874a2")),
+]
+		
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.10")

--- a/R/Randompack/build_tarballs.jl
+++ b/R/Randompack/build_tarballs.jl
@@ -54,9 +54,8 @@ export PKG_CONFIG_PATH="$P1:${PKG_CONFIG_PATH:-}"
 export CPPFLAGS="-I${prefix}/include ${CPPFLAGS:-}"
 export LDFLAGS="-L${prefix}/lib -L${prefix}/lib64 ${LDFLAGS:-}"
 
-EXTRA_MESON_FLAGS=""
 if [[ "${target}" == x86_64-w64-mingw32 ]]; then
-  EXTRA_MESON_FLAGS="-Dforce_nosimd=true"
+  sed -i "s/build_avx512 = build_avx512 and build_avx2/build_avx512 = build_avx512 and build_avx2 and host_system != 'windows'/" $SRC/meson.build
 fi
 
 meson setup build $SRC \
@@ -67,8 +66,7 @@ meson setup build $SRC \
   -Dblas=openblas \
   -Dbuild_examples=false \
   -Dbuild_tests=false \
-  -Dbuild_fortran_interface=false \
-  ${EXTRA_MESON_FLAGS}
+  -Dbuild_fortran_interface=false
 
 ninja -C build
 ninja -C build install

--- a/R/Randompack/build_tarballs.jl
+++ b/R/Randompack/build_tarballs.jl
@@ -54,6 +54,11 @@ export PKG_CONFIG_PATH="$P1:${PKG_CONFIG_PATH:-}"
 export CPPFLAGS="-I${prefix}/include ${CPPFLAGS:-}"
 export LDFLAGS="-L${prefix}/lib -L${prefix}/lib64 ${LDFLAGS:-}"
 
+EXTRA_MESON_FLAGS=""
+if [[ "${target}" == x86_64-w64-mingw32 ]]; then
+  EXTRA_MESON_FLAGS="-Dforce_nosimd=true"
+fi
+
 meson setup build $SRC \
   --cross-file=${MESON_TARGET_TOOLCHAIN} \
   --buildtype=release \
@@ -62,7 +67,8 @@ meson setup build $SRC \
   -Dblas=openblas \
   -Dbuild_examples=false \
   -Dbuild_tests=false \
-  -Dbuild_fortran_interface=false
+  -Dbuild_fortran_interface=false \
+  ${EXTRA_MESON_FLAGS}
 
 ninja -C build
 ninja -C build install

--- a/R/Randompack/build_tarballs.jl
+++ b/R/Randompack/build_tarballs.jl
@@ -1,113 +1,87 @@
-# Note that this script can accept some limited command-line arguments, run
-# `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
 name = "Randompack"
-version = v"0.1.1"
+version = v"0.1.5"
 
 sources = [
-  ArchiveSource(
-    "https://raw.githubusercontent.com/jonasson2/randompack-src/v0.1.1/randompack-0.1.1.tar.gz",
-    "db3f048ddce772a77cacdf2d23a6bed58db4836b9d60f3dc6d1d910662926294",
+  GitSource(
+    "https://github.com/jonasson2/randompack.git",
+    "4f91c55f93b027c72bc46971bf7c3df3a4960145",
   ),
 ]
-    
+
 script = raw"""
 set -e
 # Work around stray AppleDouble files that can break Python site.py decoding.
-find /usr/lib/python3.9/site-packages -maxdepth 1 -name '._*' -delete \
-  2>/dev/null || true
+find /usr/lib/python3.9/site-packages -maxdepth 1 -name '._*' -delete 2>/dev/null || true
 
 cd $WORKSPACE/srcdir
-SRC=$WORKSPACE/srcdir/randompack-0.1.1
-# Meson fails to detect the macOS/aarch64 linker in BinaryBuilder;
-# build manually here.
-if echo "$target" | grep -q 'apple-darwin'; then
+SRC=$WORKSPACE/srcdir/randompack
+
+manual_apple_build_backup() {
+  # Backup of the previous manual macOS build path. Keep this until the Meson
+  # macOS/aarch64 BinaryBuilder build has been verified.
   BUILD=$WORKSPACE/build-manual
   rm -rf $BUILD
-  mkdir -p $BUILD $prefix/lib $prefix/include \
-    $prefix/share/licenses/Randompack
+  mkdir -p $BUILD $prefix/lib $prefix/include $prefix/share/licenses/Randompack
 
   CDEFS="-D_POSIX_C_SOURCE=200809L -D_DARWIN_C_SOURCE -DLOCAL_DPSTRF -DUSE_ACCEL_VV"
+  COPTS="-O3 -fPIC -fno-math-errno -fno-trapping-math -fomit-frame-pointer"
+  COPTS="$COPTS -fno-semantic-interposition"
   if echo "$target" | grep -q '^aarch64-apple-darwin'; then
-    COPTS="-O3 -mcpu=apple-m1 -fPIC -fno-math-errno -fno-trapping-math -fomit-frame-pointer -fno-semantic-interposition"
-  else
-    COPTS="-O3 -fPIC -fno-math-errno -fno-trapping-math -fomit-frame-pointer -fno-semantic-interposition"
+    COPTS="$COPTS -mcpu=apple-m1"
   fi
 
-  AR=${target}-ar
-  RANLIB=${target}-ranlib
-  $FC -O3 -c $SRC/src/lapack_dpstrf.f -o $BUILD/lapack_dpstrf.f.o
-  $CC -std=c11 $COPTS $CDEFS -I$SRC/src -c $SRC/src/printX.c \
-    -o $BUILD/printX.c.o
-  $CC -std=c11 $COPTS $CDEFS -I$SRC/src -c $SRC/src/randompack.c \
-    -o $BUILD/randompack.c.o
+  $CC -std=c11 $COPTS $CDEFS -I$SRC/src -c $SRC/src/printX.c -o $BUILD/printX.c.o
+  $CC -std=c11 $COPTS $CDEFS -I$SRC/src -c $SRC/src/rp_dpstrf.c -o $BUILD/rp_dpstrf.c.o
+  $CC -std=c11 $COPTS $CDEFS -I$SRC/src -c $SRC/src/randompack.c -o $BUILD/randompack.c.o
 
   $CC -shared -o $prefix/lib/librandompack.dylib \
-    $BUILD/randompack.c.o $BUILD/printX.c.o $BUILD/lapack_dpstrf.f.o \
-    -framework Accelerate -lm -lgfortran \
+    $BUILD/randompack.c.o $BUILD/printX.c.o $BUILD/rp_dpstrf.c.o \
+    -framework Accelerate -lm \
     -Wl,-install_name,@rpath/librandompack.dylib
 
-  $AR rcs $prefix/lib/librandompack.a \
-    $BUILD/randompack.c.o $BUILD/printX.c.o $BUILD/lapack_dpstrf.f.o
-  $RANLIB $prefix/lib/librandompack.a || true
-
-  if [ -f $SRC/src/randompack.h ]; then
-    cp $SRC/src/randompack.h $prefix/include/
-  fi
-  if [ -f $SRC/src/randompack_config.h ]; then
-    cp $SRC/src/randompack_config.h $prefix/include/
-  fi
-  if [ -f $SRC/randompack.h ]; then
-    cp $SRC/randompack.h $prefix/include/
-  fi
-  if [ -f $SRC/randompack_config.h ]; then
-    cp $SRC/randompack_config.h $prefix/include/
-  fi
-
+  cp $SRC/src/randompack.h $prefix/include/
+  cp $SRC/src/randompack_config.h $prefix/include/
   cp $SRC/LICENSE $prefix/share/licenses/Randompack/LICENSE
-else
-  cd $WORKSPACE
-  rm -rf build
+}
 
-  export PKG_CONFIG_PATH="${prefix}/lib/pkgconfig:${prefix}/lib64/pkg<config:${prefix}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
-  export CPPFLAGS="-I${prefix}/include ${CPPFLAGS:-}"
-  export LDFLAGS="-L${prefix}/lib -L${prefix}/lib64 ${LDFLAGS:-}"
-    
-  meson setup build $SRC \
-    --cross-file=${MESON_TARGET_TOOLCHAIN} \
-    --buildtype=release \
-    --prefix=${prefix} \
-    -Dblas=openblas \
-    -Dbuild_examples=false \
-    -Dbuild_tests=false \
-    -Dbuild_fortran_interface=false
-  ninja -C build
-  ninja -C build install
-fi
+cd $WORKSPACE
+rm -rf build
+
+P1="${prefix}/lib/pkgconfig:${prefix}/lib64/pkgconfig:${prefix}/share/pkgconfig"
+export PKG_CONFIG_PATH="$P1:${PKG_CONFIG_PATH:-}"
+export CPPFLAGS="-I${prefix}/include ${CPPFLAGS:-}"
+export LDFLAGS="-L${prefix}/lib -L${prefix}/lib64 ${LDFLAGS:-}"
+
+meson setup build $SRC \
+  --cross-file=${MESON_TARGET_TOOLCHAIN} \
+  --buildtype=release \
+  --prefix=${prefix} \
+  -Ddefault_library=shared \
+  -Dblas=openblas \
+  -Dbuild_examples=false \
+  -Dbuild_tests=false \
+  -Dbuild_fortran_interface=false
+
+ninja -C build
+ninja -C build install
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = [
-  Platform("aarch64", "macos",   libgfortran_version="5.0.0"),
-  Platform("x86_64",  "macos",   libgfortran_version="5.0.0"),
-  Platform("x86_64",  "linux";   libgfortran_version="5.0.0", cxxstring_abi="cxx11"),
-  Platform("aarch64", "linux";   libgfortran_version="5.0.0", cxxstring_abi="cxx11"),
-  Platform("x86_64",  "windows"; libgfortran_version="5.0.0"),
+# Randompack requires 64-bit platforms.
+platforms = filter(p -> nbits(p) == 64, supported_platforms())
+
+dependencies = [
+  Dependency(PackageSpec(name="OpenBLAS32_jll",
+                         uuid="656ef2d0-ae68-5445-9ca0-591084a874a2")),
 ]
 
 # The products that we will ensure are always built
 products = [
     LibraryProduct("librandompack", :librandompack)
 ]
-
-dependencies = [
-  Dependency(PackageSpec(name="CompilerSupportLibraries_jll",
-                         uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
-  Dependency(PackageSpec(name="OpenBLAS32_jll",
-                         uuid="656ef2d0-ae68-5445-9ca0-591084a874a2")),
-]
 		
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.10")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.10", clang_use_lld=false, dont_dlopen=true,
+               preferred_gcc_version=v"8")

--- a/R/Randompack/build_tarballs.jl
+++ b/R/Randompack/build_tarballs.jl
@@ -56,6 +56,7 @@ export LDFLAGS="-L${prefix}/lib -L${prefix}/lib64 ${LDFLAGS:-}"
 
 if [[ "${target}" == x86_64-w64-mingw32 ]]; then
   sed -i "s/build_avx512 = build_avx512 and build_avx2/build_avx512 = build_avx512 and build_avx2 and host_system != 'windows'/" $SRC/meson.build
+  sed -i "/randompack_avx2_used/d; /randompack_avx2_reset/d" $SRC/src/randompack.def
 fi
 
 meson setup build $SRC \


### PR DESCRIPTION
New package: Randompack, a random number generation library.

Updated for v0.1.5 after review feedback:
- switched the source to the public main repository, https://github.com/jonasson2/randompack.git
- uses GitSource at the v0.1.5 release commit
- builds all supported 64-bit platforms
- disables the Fortran interface and depends on OpenBLAS32_jll
- uses the Meson build path for macOS/aarch64; the previous manual Apple build path is kept only as an inactive backup function

Validation:
- native Apple Silicon: julia +1.10 R/Randompack/build_tarballs.jl --debug --verbose --deploy=local aarch64-apple-darwin
- Linux: verified successfully separately
