### PR TITLE
[New Package] TypeDBDriverClib_jll v3.8.1

### DIFF
--- a/T/TypeDBDriverClib/build_tarballs.jl
+++ b/T/TypeDBDriverClib/build_tarballs.jl
@@ -49,5 +49,4 @@ dependencies = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                compilers             = [:c, :rust],
                julia_compat          = "1.6",
-               preferred_gcc_version = v"5",
-               dont_dlopen           = true)
+               preferred_gcc_version = v"5")


### PR DESCRIPTION
## New JLL package: TypeDBDriverClib_jll

### What
Adds a BinaryBuilder recipe for `libtypedb_driver_clib`, the C FFI layer of the
[TypeDB Driver](https://github.com/typedb/typedb-driver) (TypeDB 3.x).

The library is implemented in Rust (`c/` crate in the typedb-driver workspace)
and exposes a C-compatible API for use by language bindings.

### Source
- Repository: https://github.com/typedb/typedb-driver
- Tag: `3.8.1` (commit `8e8d4a43da32adc1c56084f4d34174bebd0ce34a`)

### Platforms
- `x86_64-linux-gnu`
- `aarch64-linux-gnu`
- `x86_64-apple-darwin`
- `aarch64-apple-darwin`
- `x86_64-w64-mingw32`

### Build
Uses `compilers = [:c, :rust]` and `dont_dlopen = true`. Builds the
`typedb_driver_clib` crate via `cargo build -p typedb_driver_clib` from the
workspace root. On Windows, Rust omits the `lib` prefix; the
`LibraryProduct` accepts both `libtypedb_driver_clib` and `typedb_driver_clib`.

### v1 CI failure (fixed)
The first CI run failed because of three mistakes in the recipe:
- Directory was named `T/TypeDBDriverClib_jll/` instead of `T/TypeDBDriverClib/`
- `name` included the `_jll` suffix (BinaryBuilder appends it automatically)
- Used `${CARGO_BUILD_TARGET}` instead of the correct `${rust_target}`

### Consumer
Intended for use by
[TypeDBClient_2.jl](https://github.com/FrankUrbach/TypeDBClient_2.jl),
a Julia FFI client for TypeDB 3.x.