### PR TITLE
[libgiac_julia] New recipe v0.5.0

### DIFF
--- a/L/libgiac_julia/build_tarballs.jl
+++ b/L/libgiac_julia/build_tarballs.jl
@@ -53,6 +53,8 @@ install_license LICENSE
 # platforms are passed in on the command line
 include("../../L/libjulia/common.jl")
 platforms = vcat(libjulia_platforms.(julia_versions)...)
+# libcxxwrap_julia_jll v0.14.x does not yet have artifacts for Julia 1.13+
+filter!(p -> VersionNumber(p["julia_version"]) < v"1.13", platforms)
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built


### PR DESCRIPTION
 - New BinaryBuilder recipe for `libgiac_julia` v0.5.0
 - Julia/CxxWrap wrapper for the GIAC computer algebra system
 - Provides `libgiac_wrapper` shared library with Gen type operations, function dispatch, type introspection, and value extraction
 - Depends on `GIAC_jll` (merged in #13324), `libcxxwrap_julia_jll`, `GMP_jll`, `MPFR_jll`