### PR TITLE
[CUDA_Driver] Bump JLL version

### DIFF
--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -13,7 +13,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Driver"
-cuda_version = v"13.1"
+cuda_version = v"13.1.1"
 driver_version = "590.48.01"
 
 script = raw"""


### PR DESCRIPTION
@maleadt I think this is necessary because we changed `julia_compat` in #13116: https://github.com/JuliaRegistries/General/pull/149854

The specific automerge error is:
```julia
CUDA_Driver_jll: Error During Test at /home/runner/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:240
  Test threw exception
  Expression: load_compat(compatfile, vnums)
  Overlapping ranges for julia in "/home/runner/work/General/General/jll/C/CUDA_Driver_jll/Compat.toml" for version 13.1.0+0.
  Stacktrace:
   [1] error(s::String)
     @ Base ./error.jl:44
   [2] load_package_data(::Type{Pkg.Versions.VersionSpec}, path::String, versions::Vector{VersionNumber})
     @ RegistryCI ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:109
   [3] load_compat
     @ ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:132 [inlined]
   [4] macro expansion
     @ ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:240 [inlined]
   [5] macro expansion
     @ /opt/hostedtoolcache/julia/1.12.5/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:677 [inlined]
   [6] macro expansion
     @ ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:240 [inlined]
   [7] macro expansion
     @ /opt/hostedtoolcache/julia/1.12.5/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:1865 [inlined]
   [8] (::RegistryCI.var"#22#23"{Vector{String}})()
     @ RegistryCI ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:161
CUDA_Driver_jll: Error During Test at /home/runner/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:161
  Got exception outside of a @test
  Overlapping ranges for julia in Compat. Detected for version 13.1.0+0.
  Stacktrace:
    [1] error(s::String)
      @ Base ./error.jl:44
    [2] load(path::String, versions::Vector{VersionNumber})
      @ RegistryTools.Compress ~/.julia/packages/RegistryTools/aXJ1T/src/Compress.jl:64
    [3] load(path::String)
      @ RegistryTools.Compress ~/.julia/packages/RegistryTools/aXJ1T/src/Compress.jl:55
    [4] macro expansion
      @ ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:244 [inlined]
    [5] macro expansion
      @ /opt/hostedtoolcache/julia/1.12.5/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:1865 [inlined]
    [6] (::RegistryCI.var"#22#23"{Vector{String}})()
      @ RegistryCI ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:161
    [7] cd(f::RegistryCI.var"#22#23"{Vector{String}}, dir::String)
      @ Base.Filesystem ./file.jl:112
    [8] test(path::String; registry_deps::Vector{String})
      @ RegistryCI ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:150
    [9] test
      @ ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:150 [inlined]
   [10] test()
      @ RegistryCI ~/.julia/packages/RegistryCI/hORYl/src/registry_testing.jl:150
   [11] top-level scope
      @ none:1
   [12] eval(m::Module, e::Any)
      @ Core ./boot.jl:489
   [13] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:283
   [14] _start()
      @ Base ./client.jl:550
```