### PR TITLE
MPIABI: New release 0.1.2

### DIFF
--- a/M/MPIABI/build_tarballs.jl
+++ b/M/MPIABI/build_tarballs.jl
@@ -9,7 +9,7 @@ name = "MPIABI"
 # OpenMPI's released versions.
 #
 # We are currently at version 0.1 because some details of the ABI are still being hashed out, e.g. the library SOVERSION.
-version = v"0.1.1"
+version = v"0.1.2"
 
 # The MPI ABI does not provide Fortran bindings. Packages using this
 # ABI should use a different package, e.g.


### PR DESCRIPTION
No functional changes. Release a new version to un-break packages that depend on MPIABI 0.1.2 because I set the wrong compat bounds in `platforms/mpi.jl`.