### PR TITLE
[FINUFFT] GCC build for MacOS

### DIFF
--- a/F/finufft/build_tarballs.jl
+++ b/F/finufft/build_tarballs.jl
@@ -28,7 +28,7 @@ if [[ "${target}" == *-apple-* ]]; then
     toolchain="${CMAKE_TARGET_TOOLCHAIN%.*}_gcc.cmake"
     
     # Apparently, we also need to remove the -ld_classic link option
-    sed -i '/add_link_options("-ld_classic")/d' CMakeLists.txt
+    sed -i '/add_link_options("-ld_classic")/d' src/CMakeLists.txt
 fi
 
 cmake -B build \


### PR DESCRIPTION
This PR switches the MacOS build process from Clang to GCC to resolve a thread-stability issue on Apple Silicon.

While the library compiles successfully with Clang, it exhibits crashes when invoked within multi-threaded Julia environments on MacOS (ARM64). This behavior is documented in [FINUFFT.jl Issue #63](https://github.com/ludvigak/FINUFFT.jl/issues/63). Switching to GCC for MacOS builds resolves these instabilities. While my initial testing has not shown any performance regressions, I should note that my benchmarking has been limited to very specific FINUFFT use cases.

Does anyone have insight into fundamental differences between the LLVM/Clang OpenMP runtime and the GNU/GCC libgomp implementation on MacOS? Maybe there is another solution to this problem that does not require switching to GCC.