### PR TITLE
[LibCURL] Build --with-apple-sectrust

### DIFF
--- a/L/LibCURL/LibCURL@8/build_tarballs.jl
+++ b/L/LibCURL/LibCURL@8/build_tarballs.jl
@@ -2,4 +2,4 @@ include("../common.jl")
 
 build_libcurl(ARGS, "LibCURL", v"8.18.0"; with_zstd=true)
 
-# Build trigger: 2
+# Build trigger: 3

--- a/L/LibCURL/common.jl
+++ b/L/LibCURL/common.jl
@@ -110,17 +110,24 @@ function build_libcurl(ARGS, name::String, version::VersionNumber; with_zstd=fal
 
         # We also need to tell it to link against schannel (native TLS library)
         FLAGS+=(--with-schannel)
-    elif [[ ${MACOS_USE_OPENSSL} == false && ${target} == *darwin* ]]; then
-        # On Darwin, we need to use SecureTransport (native TLS library) for pre-8.15 versions of CURL
-        FLAGS+=(--with-secure-transport)
+    elif [[ ${target} == *darwin* ]]; then
+        if [[ ${MACOS_USE_OPENSSL} == false ]]; then
+            # On Darwin, we need to use SecureTransport (native TLS library) for pre-8.15 versions of CURL
+            FLAGS+=(--with-secure-transport)
 
-        # We need to explicitly request a higher `-mmacosx-version-min` here, so that it doesn't
-        # complain about: `Symbol not found: ___isOSVersionAtLeast`
-        if [[ "${target}" == *x86_64* ]]; then
-            export CFLAGS=-mmacosx-version-min=10.11
+            # We need to explicitly request a higher `-mmacosx-version-min` here, so that it doesn't
+            # complain about: `Symbol not found: ___isOSVersionAtLeast`
+            if [[ "${target}" == *x86_64* ]]; then
+                export CFLAGS=-mmacosx-version-min=10.11
+            fi
+        else
+            # Otherwise we use OpenSSL (but without a certificate store on 8.15 and 8.16)
+            FLAGS+=(--with-openssl)
         fi
-    elif [[ ${MACOS_USE_SECTRUST} == true && ${target} == *darwin* ]]; then
-        FLAGS+=(--with-apple-sectrust)
+        if [[ ${MACOS_USE_SECTRUST} == true ]]; then
+            # On Darwin, we use SecTrust for certificate validation starting with CURL 8.17
+            FLAGS+=(--with-apple-sectrust)
+        fi  
     else
         # On all other systems, we use OpenSSL
         FLAGS+=(--with-openssl)


### PR DESCRIPTION
This is an attempt to have a default certificate store on macOS again, hopefully fixing https://github.com/JuliaLang/julia/issues/60610#issuecomment-4020258369.

Sectrust is introduced in [Curl 8.17](https://daniel.haxx.se/blog/2025/11/05/curl-8-17-0/#:~:text=support%20Apple%20SecTrust%20%E2%80%93%20use%20the%20native%20CA%20store)