### PR TITLE
[GAP] Always build with GCC, even on macOS

### DIFF
--- a/G/GAP/build_tarballs.jl
+++ b/G/GAP/build_tarballs.jl
@@ -27,7 +27,7 @@ delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
 
 name = "GAP"
 upstream_version = v"4.15.1"
-version = v"400.1500.100"
+version = v"400.1500.101"
 
 # Collection of sources required to complete build
 sources = [
@@ -60,6 +60,10 @@ julia_version=$(./julia_version)
 # must run autogen.sh if compiling from git snapshot and/or if configure was patched;
 # it doesn't hurt otherwise, too, so just always do it
 ./autogen.sh
+
+# force use of GCC, even under macOS, to get proper stack unwinding
+export CC=gcc
+export CXX=g++
 
 # configure GAP
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} \


### PR DESCRIPTION
This allows Base.stacktrace() from inside GAP to traverse back into Julia code. This will allow us to produce much more helpful backtraces in GAP.jl.

Note that GAP does *not* link against the C++ standard library, does not use C++ exceptions, or expose or consume any C++ ABIs. So I *think* this should be fine without applying a similar treatment to GAP packages which use C++, such as semigroups or normalizinterface.