### PR TITLE
platforms/mpi: Require MPIABI 0.1.2

### DIFF
--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -48,7 +48,7 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 mpi_abis = (
-    ("MPIABI", PackageSpec(name="MPIABI_jll"), "0.1.1", p -> !Sys.iswindows(p)),
+    ("MPIABI", PackageSpec(name="MPIABI_jll"), "0.1.2", p -> !Sys.iswindows(p)),
     ("MPICH", PackageSpec(name="MPICH_jll"), "4.3.0, 5", p -> !Sys.iswindows(p)),
     ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5.5.3", p -> !Sys.iswindows(p) && !(libc(p) == "musl")),
     ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),


### PR DESCRIPTION
MPIABI 0.1.1 had a bug in its Fortran compatibility bindings (`MPI_F_STATUS_IGNORE` was missing).