### PR TITLE
[Musica] New package

### DIFF
--- a/M/Musica/build_tarballs.jl
+++ b/M/Musica/build_tarballs.jl
@@ -55,7 +55,7 @@ if [[ "${target}" == *-mingw* ]]; then
 fi
 """
 
-sources, script = require_macos_sdk("14.5", sources, script, deployment_target="15.0")
+sources, script = require_macos_sdk("14.5", sources, script)
 
 # grab all of the platforms supported by libjulia
 include(joinpath(YGGDRASIL_DIR, "L", "libjulia", "common.jl"))


### PR DESCRIPTION
Adds tarball build support for [musica](https://github.com/NCAR/musica). Musica provides functionality to study atmospheric chemistry. This tarball is preparing us to begin implementing our julia bindings

- targets julia 1.10+
- ignores armv6/7 and musl linux