### PR TITLE
[aws_c_mqtt] Update to version 0.15.0

### DIFF
--- a/A/aws_c_mqtt/build_tarballs.jl
+++ b/A/aws_c_mqtt/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_mqtt"
-version = v"0.14.0"
+version = v"0.15.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-mqtt.git", "41b6a7d6d566a56eff69743df66c077d56a80c9d"),
+    GitSource("https://github.com/awslabs/aws-c-mqtt.git", "dc2fe7be81070f7c5095ad386d9a23c180a4276b"),
 ]
 
 # Bash recipe for building across all platforms
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("aws_c_http_jll"; compat="0.10.10"),
+    Dependency("aws_c_http_jll"; compat="0.10.11"),
     Dependency("aws_c_io_jll"; compat="0.26.1"),
     BuildDependency("aws_lc_jll"),
 ]


### PR DESCRIPTION
This PR updates aws_c_mqtt to version 0.15.0. cc: @quinnj @Octogonapus