### PR TITLE
[AlphaMolWrapper] Update to libcxxwrap_julia_jll 0.14.8

### DIFF
--- a/A/AlphaMolWrapper/build_tarballs.jl
+++ b/A/AlphaMolWrapper/build_tarballs.jl
@@ -28,7 +28,7 @@ products = [
 dependencies = [
     BuildDependency("libjulia_jll"),
     Dependency("libcxxwrap_julia_jll"; compat="0.14.8"),
-    Dependency("GMP_jll"; compat="6.2.1"),
+    Dependency("GMP_jll"; compat="6.3.0"),
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;


### PR DESCRIPTION
## Summary
- Update `libcxxwrap_julia_jll` compat from `0.11.2` to `0.14.8` (compatible with CxxWrap.jl 0.17.5)
- Bump version from `0.5.0` to `0.6.0`
- Drop Julia 1.7–1.9 support (CxxWrap.jl 0.17 requires Julia 1.10+)
- Update source SHA to include `CMAKE_CXX_STANDARD` fix (7 → 17)

## Test plan
- [ ] BinaryBuilder CI builds successfully for all platforms