### PR TITLE
[libva] New package for Video Acceleration API

### DIFF
--- a/L/libva/build_tarballs.jl
+++ b/L/libva/build_tarballs.jl
@@ -16,12 +16,10 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/libva
 
-# libva requires C99 for for-loop initial declarations
-export CFLAGS="-std=gnu99 $CFLAGS"
-
 meson setup builddir \
     --cross-file=${MESON_TARGET_TOOLCHAIN} \
     --buildtype=release \
+    -Dc_args="-std=gnu99" \
     -Dwith_x11=yes \
     -Dwith_wayland=no
 


### PR DESCRIPTION
libva provides a unified API for video hardware acceleration on Linux and FreeBSD systems. This package builds libva, libva-drm, and libva-x11 libraries version 2.23.0.

This will be used as a dependency for FFMPEG hardware acceleration support.

Developed with Claude