### PR TITLE
[Uno] Upgrade to v2.4.2

### DIFF
--- a/U/Uno/build_tarballs.jl
+++ b/U/Uno/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder, Pkg
 
 name = "Uno"
 
-version = v"2.4.1"
+version = v"2.4.2"
 
 sources = [
     GitSource(
         "https://github.com/cvanaret/Uno.git",
-        "7bd0e25016c1b7c436c518bcf17919ccee97347d",
+        "1681d3d1ce52219c4db106b730b5b085737b1af9",
     ),
 ]
 
@@ -43,6 +43,7 @@ cmake \
     -DMUMPS_COMMON_LIBRARY="${libdir}/libmumps_common.${dlext}" \
     -DMUMPS_PORD_LIBRARY="${libdir}/libpord.${dlext}" \
     -DMUMPS_MPISEQ_LIBRARY="${libdir}/libmpiseq.${dlext}" \
+    -DSPRAL="${libdir}/libspral.${dlext}" \
     -DBLAS_LIBRARIES="${libdir}/lib${LBT}.${dlext}" \
     -DLAPACK_LIBRARIES="${libdir}/lib${LBT}.${dlext}" \
     -DBUILD_STATIC_LIBS=ON \
@@ -83,6 +84,7 @@ dependencies = [
     Dependency(PackageSpec(name="METIS_jll", uuid="d00139f3-1899-568f-a2f0-47f597d42d70")),
     Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), compat="0.1.3"),
     Dependency(PackageSpec(name="MUMPS_seq_jll", uuid="d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d")),
+    Dependency(PackageSpec(name="SPRAL_jll", uuid="319450e9-13b8-58e8-aa9f-8fd1420848ab")),
     Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), compat="5.4.0"),
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD systems),
     # and libgomp from `CompilerSupportLibraries_jll` everywhere else.


### PR DESCRIPTION
[Uno v2.4.2](https://github.com/cvanaret/Uno/releases/tag/v2.4.2) was released on March 12, 2026