### PR TITLE
MPIABI: Update to version 0.1.3

### DIFF
--- a/M/MPIABI/build_tarballs.jl
+++ b/M/MPIABI/build_tarballs.jl
@@ -9,7 +9,7 @@ name = "MPIABI"
 # OpenMPI's released versions.
 #
 # We are currently at version 0.1 because some details of the ABI are still being hashed out, e.g. the library SOVERSION.
-version = v"0.1.2"
+version = v"0.1.3"
 
 # The MPI ABI does not provide Fortran bindings. Packages using this
 # ABI should use a different package, e.g.

--- a/M/MPIABI/bundled/patches/fortran.patch
+++ b/M/MPIABI/bundled/patches/fortran.patch
@@ -1,10 +1,10 @@
 --- a/mpi.h
 +++ b/mpi.h
-@@ -559,7 +559,23 @@
- typedef void (MPI_T_event_cb_function)(MPI_T_event_instance event_instance, MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, void *user_data);
- typedef void (MPI_T_event_free_cb_function)(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, void *user_data);
- typedef void (MPI_T_event_dropped_cb_function)(MPI_Count count, MPI_T_event_registration event_registration, int source_index, MPI_T_cb_safety cb_safety, void *user_data);
- 
+@@ -1899,7 +1899,105 @@
+ int PMPI_T_source_get_info(int source_index, char *name, int *name_len, char *desc, int *desc_len, MPI_T_source_order *ordering, MPI_Count *ticks_per_second, MPI_Count *max_ticks, MPI_Info *info);
+ int PMPI_T_source_get_num(int *num_sources);
+ int PMPI_T_source_get_timestamp(int source_index, MPI_Count *timestamp);
++
 +/* Fortran declarations */
 +
 +typedef int MPI_Fint;
@@ -16,11 +16,93 @@
 +#define MPI_F08_STATUS_IGNORE   ((MPI_F08_Status*)MPI_STATUS_IGNORE)
 +#define MPI_F08_STATUSES_IGNORE ((MPI_F08_Status*)MPI_STATUSES_IGNORE)
 +
-+int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
-+int MPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status);
-+int MPI_Status_f082c(const MPI_F08_Status *f08_status, MPI_Status *c_status);
-+int MPI_Status_c2f08(const MPI_Status *c_status, MPI_F08_Status *f08_status);
++static inline int PMPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status)
++{
++  if (f_status == MPI_F_STATUS_IGNORE || f_status == MPI_F_STATUSES_IGNORE ||
++      c_status == MPI_STATUS_IGNORE || c_status == MPI_STATUSES_IGNORE)
++    return MPI_ERR_ARG;
++  *c_status = *(const MPI_Status*)f_status;
++  return MPI_SUCCESS;
++}
 +
- /* MPI functions */
- int MPI_Abi_get_fortran_booleans(int logical_size, void *logical_true, void *logical_false, int *is_set);
- int MPI_Abi_get_fortran_info(MPI_Info *info);
++static inline int PMPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status)
++{
++  if (c_status == MPI_STATUS_IGNORE || c_status == MPI_STATUSES_IGNORE ||
++      f_status == MPI_F_STATUS_IGNORE || f_status == MPI_F_STATUSES_IGNORE)
++    return MPI_ERR_ARG;
++  *(MPI_Status*)f_status = *c_status;
++  return MPI_SUCCESS;
++}
++
++static inline int PMPI_Status_f082c(const MPI_F08_Status *f08_status, MPI_Status *c_status)
++{
++  if (f08_status == MPI_F08_STATUS_IGNORE || f08_status == MPI_F08_STATUSES_IGNORE ||
++      c_status == MPI_STATUS_IGNORE || c_status == MPI_STATUSES_IGNORE)
++    return MPI_ERR_ARG;
++  *c_status = *(const MPI_Status*)f08_status;
++  return MPI_SUCCESS;
++}
++
++static inline int PMPI_Status_c2f08(const MPI_Status *c_status, MPI_F08_Status *f08_status)
++{
++  if (c_status == MPI_STATUS_IGNORE || c_status == MPI_STATUSES_IGNORE ||
++      f08_status == MPI_F08_STATUS_IGNORE || f08_status == MPI_F08_STATUSES_IGNORE)
++    return MPI_ERR_ARG;
++  *(MPI_Status*)f08_status = *c_status;
++  return MPI_SUCCESS;
++}
++
++static inline int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status) { return PMPI_Status_f2c(f_status, c_status); }
++static inline int MPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status) { return PMPI_Status_c2f(c_status, f_status); }
++static inline int MPI_Status_f082c(const MPI_F08_Status *f08_status, MPI_Status *c_status) { return PMPI_Status_f082c(f08_status, c_status); }
++static inline int MPI_Status_c2f08(const MPI_Status *c_status, MPI_F08_Status *f08_status) { return PMPI_Status_c2f08(c_status, f08_status); }
++
++static inline MPI_Comm PMPI_Comm_f2c(MPI_Fint comm) { return MPI_Comm_fromint(comm); }
++static inline MPI_Fint PMPI_Comm_c2f(MPI_Comm comm) { return MPI_Comm_toint(comm); }
++static inline MPI_Errhandler PMPI_Errhandler_f2c(MPI_Fint errhandler) { return MPI_Errhandler_fromint(errhandler); }
++static inline MPI_Fint PMPI_Errhandler_c2f(MPI_Errhandler errhandler) { return MPI_Errhandler_toint(errhandler); }
++static inline MPI_File PMPI_File_f2c(MPI_Fint file) { return MPI_File_fromint(file); }
++static inline MPI_Fint PMPI_File_c2f(MPI_File file) { return MPI_File_toint(file); }
++static inline MPI_Group PMPI_Group_f2c(MPI_Fint group) { return MPI_Group_fromint(group); }
++static inline MPI_Fint PMPI_Group_c2f(MPI_Group group) { return MPI_Group_toint(group); }
++static inline MPI_Info PMPI_Info_f2c(MPI_Fint info) { return MPI_Info_fromint(info); }
++static inline MPI_Fint PMPI_Info_c2f(MPI_Info info) { return MPI_Info_toint(info); }
++static inline MPI_Message PMPI_Message_f2c(MPI_Fint message) { return MPI_Message_fromint(message); }
++static inline MPI_Fint PMPI_Message_c2f(MPI_Message message) { return MPI_Message_toint(message); }
++static inline MPI_Op PMPI_Op_f2c(MPI_Fint op) { return MPI_Op_fromint(op); }
++static inline MPI_Fint PMPI_Op_c2f(MPI_Op op) { return MPI_Op_toint(op); }
++static inline MPI_Request PMPI_Request_f2c(MPI_Fint request) { return MPI_Request_fromint(request); }
++static inline MPI_Fint PMPI_Request_c2f(MPI_Request request) { return MPI_Request_toint(request); }
++static inline MPI_Session PMPI_Session_f2c(MPI_Fint session) { return MPI_Session_fromint(session); }
++static inline MPI_Fint PMPI_Session_c2f(MPI_Session session) { return MPI_Session_toint(session); }
++static inline MPI_Datatype PMPI_Type_f2c(MPI_Fint datatype) { return MPI_Type_fromint(datatype); }
++static inline MPI_Fint PMPI_Type_c2f(MPI_Datatype datatype) { return MPI_Type_toint(datatype); }
++static inline MPI_Win PMPI_Win_f2c(MPI_Fint win) { return MPI_Win_fromint(win); }
++static inline MPI_Fint PMPI_Win_c2f(MPI_Win win) { return MPI_Win_toint(win); }
++
++static inline MPI_Comm MPI_Comm_f2c(MPI_Fint comm) { return PMPI_Comm_f2c(comm); }
++static inline MPI_Fint MPI_Comm_c2f(MPI_Comm comm) { return PMPI_Comm_c2f(comm); }
++static inline MPI_Errhandler MPI_Errhandler_f2c(MPI_Fint errhandler) { return MPI_Errhandler_f2c(errhandler); }
++static inline MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler) { return PMPI_Errhandler_c2f(errhandler); }
++static inline MPI_File MPI_File_f2c(MPI_Fint file) { return PMPI_File_f2c(file); }
++static inline MPI_Fint MPI_File_c2f(MPI_File file) { return PMPI_File_c2f(file); }
++static inline MPI_Group MPI_Group_f2c(MPI_Fint group) { return PMPI_Group_f2c(group); }
++static inline MPI_Fint MPI_Group_c2f(MPI_Group group) { return PMPI_Group_c2f(group); }
++static inline MPI_Info MPI_Info_f2c(MPI_Fint info) { return PMPI_Info_f2c(info); }
++static inline MPI_Fint MPI_Info_c2f(MPI_Info info) { return PMPI_Info_c2f(info); }
++static inline MPI_Message MPI_Message_f2c(MPI_Fint message) { return PMPI_Message_f2c(message); }
++static inline MPI_Fint MPI_Message_c2f(MPI_Message message) { return PMPI_Message_c2f(message); }
++static inline MPI_Op MPI_Op_f2c(MPI_Fint op) { return PMPI_Op_f2c(op); }
++static inline MPI_Fint MPI_Op_c2f(MPI_Op op) { return PMPI_Op_c2f(op); }
++static inline MPI_Request MPI_Request_f2c(MPI_Fint request) { return PMPI_Request_f2c(request); }
++static inline MPI_Fint MPI_Request_c2f(MPI_Request request) { return PMPI_Request_c2f(request); }
++static inline MPI_Session MPI_Session_f2c(MPI_Fint session) { return PMPI_Session_f2c(session); }
++static inline MPI_Fint MPI_Session_c2f(MPI_Session session) { return PMPI_Session_c2f(session); }
++static inline MPI_Datatype MPI_Type_f2c(MPI_Fint datatype) { return PMPI_Type_f2c(datatype); }
++static inline MPI_Fint MPI_Type_c2f(MPI_Datatype datatype) { return PMPI_Type_c2f(datatype); }
++static inline MPI_Win MPI_Win_f2c(MPI_Fint win) { return PMPI_Win_f2c(win); }
++static inline MPI_Fint MPI_Win_c2f(MPI_Win win) { return PMPI_Win_c2f(win); }
+ 
+ #if defined(__cplusplus)
+ }
+ #endif


### PR DESCRIPTION
This corrects `MPI_Comm_c2f` and friends.