### PR TITLE
MAGEMin v1.9.0

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 name = "MAGEMin"
-version = v"1.8.9"
+version = v"1.9.0"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "ec8b672ae53d066c0e61b0059d0fd1f48d27552d")                 ]
+                    "eac83684200fdc350a829c7f31d6e4a2a8ae625f")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Added CO2 to ultramafic extended database (Ume)
- Added missing corundum pure phases to all TC databases
- Corrected conversion from smt (spinel magnetite) to sp model for metapelite
- Corrected calculations of seismic velocities for sb24 database
- Updated tests that now stabilize corumdum