### PR TITLE
refactor: switch GIAC build from autotools to Meson

### DIFF
--- a/G/GIAC/build_tarballs.jl
+++ b/G/GIAC/build_tarballs.jl
@@ -29,6 +29,7 @@ fi
 # Configure with Meson, disabling all optional dependencies
 meson setup build \
     --cross-file="${MESON_TARGET_TOOLCHAIN}" \
+    --buildtype=release \
     -Dgui=disabled \
     -Dpari=disabled \
     -Dntl=disabled \


### PR DESCRIPTION
- Use Meson-based fork (s-celles/giac) as GitSource instead of upstream tarball
- Bump version to 2.0.1
- Replace complex per-platform autotools workarounds with unified Meson setup
- Add icas executable and Readline_jll dependency
- Update to GCC 8+ and julia_compat 1.10


Related PR: https://github.com/JuliaPackaging/Yggdrasil/pull/13101