### PR TITLE
[libsemigroups] disable backward-cpp signal handler

### DIFF
--- a/L/libsemigroups/build_tarballs.jl
+++ b/L/libsemigroups/build_tarballs.jl
@@ -28,6 +28,7 @@ HPCOMBI_FLAG="--disable-hpcombi"
             --host=${target} \
             --enable-shared \
             --disable-static \
+            --disable-backward \
             ${HPCOMBI_FLAG}
 
 # Build and install (V=1 for verbose link commands)


### PR DESCRIPTION
This PR disables the `backward-cpp` signal handler in libsemigroups, which causes a segfault in multi-threaded Julia

Comment from our discussion at GAP.jl [#1329](https://github.com/oscar-system/GAP.jl/issues/1329):

"The issue was backward-cpp being enabled by default, since the global backward::SignalHandling object in src/exception.cpp installs a SIGSEGV signal handler during dlopen, which overwrites Julia's handler that uses SIGSEGV for GC safepoint synchronization. When Julia's garbage collector triggers a safepoint, backward's handler runs instead of Julia's, treating the intentional fault as a fatal crash."