### PR TITLE
[aws_c_mqtt] Update to version 0.15.2

### DIFF
--- a/A/aws_c_mqtt/build_tarballs.jl
+++ b/A/aws_c_mqtt/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_mqtt"
-version = v"0.15.1"
+version = v"0.15.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-mqtt.git", "e924c6c3031a2c9336fe052399f36048e8b79431"),
+    GitSource("https://github.com/awslabs/aws-c-mqtt.git", "3c2ceee52b66db42228053a4fb55210c8f8433a0"),
 ]
 
 # Bash recipe for building across all platforms
@@ -37,7 +37,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("aws_c_http_jll"; compat="0.10.11"),
-    Dependency("aws_c_io_jll"; compat="0.26.2"),
+    Dependency("aws_c_io_jll"; compat="0.26.3"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_mqtt to version 0.15.2. cc: @quinnj @Octogonapus