### PR TITLE
[aws_c_http_jq] Update to version 0.10.12

### DIFF
--- a/A/aws_c_http_jq/build_tarballs.jl
+++ b/A/aws_c_http_jq/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_http_jq"
-version = v"0.10.11"
+version = v"0.10.12"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/quinnj/aws-c-http.git", "fe3a08809eba5687b9c8aa459cd892ca607853c4"),
+    GitSource("https://github.com/quinnj/aws-c-http.git", "999931035cba4dd49687ea1cfe715ba16b7c8b25"),
 ]
 
 # Bash recipe for building across all platforms
@@ -38,7 +38,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("aws_c_compression_jll"; compat="0.3.2"),
-    Dependency("aws_c_io_jll"; compat="0.26.1"),
+    Dependency("aws_c_io_jll"; compat="0.26.3"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_http_jq to version 0.10.12. cc: @quinnj @Octogonapus