### PR TITLE
[LSBoringSSL] Add BoringSSL for LSQuic (v2025.8.7)

### DIFF
--- a/L/LSBoringSSL/build_tarballs.jl
+++ b/L/LSBoringSSL/build_tarballs.jl
@@ -1,0 +1,44 @@
+using BinaryBuilder
+
+name = "LSBoringSSL"
+version = v"2025.8.7" #Do not edit/update unless LSQUIC README has a new version requirement listed
+
+sources = [
+   GitSource("https://github.com/google/boringssl.git", 
+              "0.20250807.0")
+]
+
+script = raw"""
+cd  ${WORKSPACE}/srcdir/boringssl*
+
+mkdir build && cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+   ..
+
+make -j${nproc}
+
+mkdir -p ${prefix}/lib
+mkdir -p ${prefix}/include
+cp crypto/libcrypto.a ssl/libssl.a ${prefix}/lib/
+cp -r ../include/* ${prefix}/include/
+
+mkdir -p ${prefix}/share/licenses/LSBoringSSL
+cp ../LICENSE ${prefix}/share/licenses/LSBoringSSL/
+"""
+
+platforms = supported_platforms()
+
+products = [
+   LibraryProduct("libcrypto", :libcrypto),
+   LibraryProduct("libssl", :libssl)
+]
+
+dependencies = []
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; 
+               compilers=[:c, :go], julia_compat="1.6")


### PR DESCRIPTION
This adds LSBoringSSL as a JLL. LSBoringSSL is not the current BoringSSL version; it is the version LiteSpeed specifies for use with their QUIC protocol. I added a comment specifically to not update the version. 

In the near future when I have a moment, I'll also follow up with a standard BoringSSL JLL that'll be updated to track the current version, so that there's no confusion in future projects. 