### PR TITLE
Add LSBoringSSL jll for LSQuic (v2025.8.7)

### DIFF
--- a/L/LSBoringSSL/build_tarballs.jl
+++ b/L/LSBoringSSL/build_tarballs.jl
@@ -12,18 +12,21 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/boringssl
 mkdir build && cd build
 
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
-   -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-   -DCMAKE_BUILD_TYPE=Release \
-   -DBUILD_SHARED_LIBS=ON \
-   -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-   ..
+cmake 
+-DCMAKE_INSTALL_PREFIX=${prefix} \
+-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+-DCMAKE_BUILD_TYPE=Release \
+-DBUILD_SHARED_LIBS=ON \
+-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON \
+-DGO_EXECUTABLE=$(which go) \
+..
 
-   make -j${nproc}
-   make install
+make -j${nproc}
+make install
 
-   install_license ../LICENSE
-   """
+install_license ../LICENSE
+"""
 
 platforms = supported_platforms()
 


### PR DESCRIPTION
This adds LSBoringSSL as a JLL. LSBoringSSL is not the current BoringSSL version; it is the version LiteSpeed specifies for use with their QUIC protocol. I added a comment specifically to not update the version.

In the near future when I have a moment, I'll also follow up with a standard BoringSSL JLL that'll be updated to track the current version, so that there's no confusion in future projects.