### PR TITLE
[biome] Update to version to 2.4.8

### DIFF
--- a/B/biome/build_tarballs.jl
+++ b/B/biome/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/biome--biomejs-biome-*/
+cd $WORKSPACE/srcdir/biome*
 # The BIOME_VERSION stuff is some weird stuff you need to do. From
 # Biome's CONTRIBUTING.md about production builds:
 #


### PR DESCRIPTION
This is the currently latest version. This was originally held back because we didn't have a new enough Rust toolchain here (x-ref: https://github.com/JuliaPackaging/Yggdrasil/pull/12543#issue-3629007911).