### PR TITLE
[Uno] Upgrade to v2.6.0

### DIFF
--- a/U/Uno/build_tarballs.jl
+++ b/U/Uno/build_tarballs.jl
@@ -4,12 +4,12 @@ using BinaryBuilder, Pkg
 
 name = "Uno"
 
-version = v"2.5.1"
+version = v"2.6.0"
 
 sources = [
     GitSource(
         "https://github.com/cvanaret/Uno.git",
-        "4e6a8c44f30333f65327f36f3e02446ac5be148b",
+        "4dfa0243a5ea238dfafe263032fe3e4c62fadc3e",
     ),
 ]
 


### PR DESCRIPTION
[Uno v2.6.0](https://github.com/cvanaret/Uno/releases/tag/v2.6.0) released on March 24, 2026

cc @giordano 