### PR TITLE
FreeType2: Do not load HarfBuzz dynamically

### DIFF
--- a/F/FreeType2/build_tarballs.jl
+++ b/F/FreeType2/build_tarballs.jl
@@ -4,7 +4,6 @@ using BinaryBuilder
 
 name = "FreeType2"
 version = v"2.14.3"
-ygg_version = v"2.14.4"
 
 # Collection of sources required to build FreeType2
 sources = [
@@ -20,10 +19,10 @@ flags=(
     -DCMAKE_INSTALL_PREFIX=${prefix}
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
     -DBUILD_SHARED_LIBS=ON
-    -DFT_REQUIRE_BROTLI=ON
+    -DFT_DISABLE_BROTLI=ON
+    -DFT_DISABLE_HARFBUZZ=ON
+    -DFT_DISABLE_PNG=ON
     -DFT_REQUIRE_BZIP2=ON
-    -DFT_REQUIRE_HARFBUZZ=ON
-    -DFT_REQUIRE_PNG=ON
     -DFT_REQUIRE_ZLIB=ON
     -DFT_DYNAMIC_HARFBUZZ=OFF   # leave this off -- this could load a system library which can be disastrous when the versions don't match
 )
@@ -45,11 +44,8 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("Bzip2_jll"; compat="1.0.9"),
-    Dependency("HarfBuzz_jll"; compat="8.5.1"),
     Dependency("Zlib_jll"; compat="1.2.12"),
-    Dependency("brotli_jll"; compat="1.2.0"),
-    Dependency("libpng_jll"; compat="1.6.55"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")


### PR DESCRIPTION
@ViralBShah Sorry, we have to introduce `ygg_version` again. The current FreeType2_jll loads HarfBuzz dynamically (even though it's not built against it), which pulls in the wrong version of glib, which crashes Makie.

("dynamically" means it loads a system library if present.)