### PR TITLE
Update alsa_plugins: FFMPEG 8 compat and ALSA_PLUGIN_DIR

### DIFF
--- a/A/alsa_plugins/build_tarballs.jl
+++ b/A/alsa_plugins/build_tarballs.jl
@@ -62,5 +62,5 @@ ENV["ALSA_PLUGIN_DIR"] = get(ENV, "ALSA_PLUGIN_DIR", joinpath(artifact_dir, "lib
 """
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies; julia_compat="1.6", init_block)
+build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies; julia_compat="1.6", init_block, dont_dlopen=true)
 


### PR DESCRIPTION
## Summary
- Bump `ygg_version` to 1.2.13 for JLL rebuild with new wrapper code
- Add FFMPEG 8 compat (`"7.1, 8"`)
- Add `init_block` setting `ALSA_PLUGIN_DIR` so ALSA finds plugins at runtime
- Require `alsa_jll >= 1.2.15` for `ALSA_CONFIG_DIR` support
- Add `dont_dlopen=true`: these are ALSA plugin modules loaded at runtime, not directly dlopen'd (fixes build failure from missing transitive dep `libFLAC.so.12` via PulseAudio_jll)

Fixes #12836. Together with #13385 (`alsa_jll` `ALSA_CONFIG_DIR`), also fixes #8073 and #1432.

## Test plan
- [x] Local build passes for x86_64-linux-gnu
- [x] CI builds pass for all Linux platforms