### PR TITLE
[libsemigroups] Update to v3.5.4

### DIFF
--- a/L/libsemigroups/build_tarballs.jl
+++ b/L/libsemigroups/build_tarballs.jl
@@ -14,7 +14,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd libsemigroups-*
+cd libsemigroups
 
 # Generate configure script
 ./autogen.sh


### PR DESCRIPTION
Updates `libsemigroups` to [v3.5.4](https://github.com/libsemigroups/libsemigroups/releases/tag/v3.5.4).

**Changes to `L/libsemigroups/build_tarballs.jl`:**
- `version`: `v3.5.4`
- `GitSource` commit: [`d044c6bfefbf`](https://github.com/libsemigroups/libsemigroups/commit/d044c6bfefbff48c8ae7547d760215d14d843376)

---
_This PR was opened automatically by the [libsemigroups release workflow](https://github.com/libsemigroups/libsemigroups/actions/workflows/update-yggdrasil.yml)._

_Note that this account is not managed, please direct any queries towards @james-d-mitchell or @jswent._