### PR TITLE
[GAP_pkg_semigroups] Bump to v5.6.1 and use `libsemigroups_jll`

### DIFF
--- a/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
+++ b/G/GAP_pkg/GAP_pkg_semigroups/build_tarballs.jl
@@ -33,6 +33,11 @@ fi
 export TMPDIR=$WORKSPACE/tmp
 mkdir $TMPDIR
 
+if [[ "${target}" == powerpc64le* ]]; then
+    # work around https://gitlab.com/libeigen/eigen/-/work_items/2259 until the fixed eigen gets used in libsemigroups (https://github.com/libsemigroups/libsemigroups/issues/932)
+    export CXXFLAGS="-DEIGEN_ALTIVEC_DISABLE_MMA"
+fi
+
 ./configure \
     --build=${MACHTYPE} \
     --host=${target} \


### PR DESCRIPTION
Resolves https://github.com/oscar-system/GAP.jl/issues/1365.

Dependent on https://github.com/JuliaPackaging/Yggdrasil/pull/13397.

cc @fingolfin @jswent @james-d-mitchell 