### PR TITLE
[mpv] Update to v0.41.0

### DIFF
--- a/M/mpv/build_tarballs.jl
+++ b/M/mpv/build_tarballs.jl
@@ -57,8 +57,10 @@ if [[ "${target}" == *-apple-* ]]; then
     )
 fi
 
-# SDL2 video/audio are disabled by default in mpv; enable them explicitly
-FLAGS+=(-Dsdl2-video=enabled -Dsdl2-audio=enabled)
+# SDL2 video/audio are disabled by default in mpv 0.41; enable them explicitly
+# Vulkan is disabled: not native on macOS, stdcall ABI issues on 32-bit Windows,
+# and SDL2+OpenGL provide sufficient video output for a JLL package
+FLAGS+=(-Dsdl2-video=enabled -Dsdl2-audio=enabled -Dvulkan=disabled)
 
 meson setup build --cross-file=${MESON_TARGET_TOOLCHAIN} --buildtype=release "${FLAGS[@]}"
 meson compile -C build
@@ -82,7 +84,6 @@ products = [
 dependencies = [
     HostBuildDependency("CMake_jll"),
     BuildDependency("Xorg_xorgproto_jll"),
-    BuildDependency("Vulkan_Headers_jll"),
     Dependency("Libiconv_jll"),
     Dependency("SDL2_jll"),
     Dependency("Shaderc_jll"),
@@ -93,7 +94,6 @@ dependencies = [
     Dependency("Xorg_libXrandr_jll"),
     Dependency("Xorg_libXinerama_jll"),
     Dependency("Libglvnd_jll"),
-    Dependency("Vulkan_Loader_jll"),
     Dependency("Xorg_libX11_jll"),
 ]
 


### PR DESCRIPTION
## Summary
- Update mpv from v0.32.0 to v0.41.0
- Migrate build system from WAF to Meson
- Add libplacebo v7.349.0 as a meson subproject for GPU-accelerated rendering
- Add Shaderc_jll for GLSL shader compilation (required by libplacebo)
- Explicitly enable sdl2-video and sdl2-audio (disabled by default in mpv 0.41)
- Disable Vulkan (stdcall ABI issues on i686 Windows, not native on macOS)
- Add macOS 11.3 SDK overlay for x86_64-darwin14 framework headers
- Disable Cocoa/Swift features on macOS (no Swift compiler in BinaryBuilder)
- Update FFMPEG_jll compat to 7.1, preferred GCC to v8

## Why
Without Shaderc, libplacebo has no GLSL compiler, making GPU rendering non-functional.
Without explicit SDL2 video/audio flags, mpv 0.41 has no fallback VO on any platform.
Together these caused: "Error opening/initializing the selected video_out (--vo) device."

## Video output backends
- `vo=gpu` — OpenGL + libplacebo + shaderc
- `vo=sdl` — SDL2 fallback (works everywhere)

## Test plan
- [x] Build succeeds for `aarch64-apple-darwin20`
- [x] Build succeeds for `i686-w64-mingw32` (previously failing)
- [x] CI: all Linux, macOS, FreeBSD platforms pass
- [ ] Verify `x86_64-w64-mingw32` CI pass
- [ ] Test video playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)