### PR TITLE
[mpv] Add libmpv library product

### DIFF
--- a/M/mpv/build_tarballs.jl
+++ b/M/mpv/build_tarballs.jl
@@ -77,7 +77,8 @@ filter!(p -> arch(p) != "riscv64", platforms)
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("mpv", :mpv)
+    ExecutableProduct("mpv", :mpv),
+    LibraryProduct("libmpv", :libmpv),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
## Summary
- Add `LibraryProduct("libmpv", :libmpv)` alongside the existing executable product
- Allows Julia applications to use libmpv's render API with their own windowing (e.g. SDL2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)