### PR TITLE
[New Package] usecomputer_jll v0.1.9

### DIFF
--- a/U/usecomputer/build_tarballs.jl
+++ b/U/usecomputer/build_tarballs.jl
@@ -1,0 +1,51 @@
+using BinaryBuilder, Pkg
+
+name = "usecomputer"
+version = v"0.1.9"
+
+url_prefix = "https://github.com/remorses/usecomputer/releases/download/v$(version)"
+sources = [
+    ArchiveSource("$(url_prefix)/usecomputer-v$(version)-darwin-arm64.tar.gz",
+        "f48472ce934e6e563575bda2614ed3c1bff6db5c383ab2a64a816bbb0c43f1c4";
+        unpack_target = "aarch64-apple-darwin20"),
+    ArchiveSource("$(url_prefix)/usecomputer-v$(version)-darwin-x64.tar.gz",
+        "813b3482ed098690a87eb8047d65be0fc1b06a02243d37edb474f2ee39d1681f";
+        unpack_target = "x86_64-apple-darwin14"),
+    ArchiveSource("$(url_prefix)/usecomputer-v$(version)-linux-arm64.tar.gz",
+        "0b2bff41fde2ce0b3a73acc7e4b451c6587a960c35c9806318878430a3b96fd2";
+        unpack_target = "aarch64-linux-gnu"),
+    ArchiveSource("$(url_prefix)/usecomputer-v$(version)-linux-x64.tar.gz",
+        "380bf752722276d844bdfdbbef6bf82c7221e2e74ea224ab92809dbb88102b61";
+        unpack_target = "x86_64-linux-gnu"),
+    ArchiveSource("$(url_prefix)/usecomputer-v$(version)-win32-x64.zip",
+        "0fe023bc412bb4928a57a50cdda06c36076bb7d7aea24da8bfcb1aa26bcef9ab";
+        unpack_target = "x86_64-w64-mingw32"),
+    DirectorySource("./bundled"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/${target}/
+
+mkdir -p ${libdir} ${includedir}
+cp -v *usecomputer_c.${dlext} ${libdir}/
+cp -v usecomputer.h ${includedir}/
+install_license ${WORKSPACE}/srcdir/LICENSE
+"""
+
+platforms = [
+    Platform("aarch64", "macos"),
+    Platform("x86_64", "macos"),
+    Platform("aarch64", "linux"),
+    Platform("x86_64", "linux"),
+    Platform("x86_64", "windows"),
+]
+
+products = [
+    LibraryProduct(["libusecomputer_c", "usecomputer_c"], :libusecomputer_c),
+    FileProduct("include/usecomputer.h", :usecomputer_h),
+]
+
+dependencies = Dependency[]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    julia_compat="1.6")

--- a/U/usecomputer/build_tarballs.jl
+++ b/U/usecomputer/build_tarballs.jl
@@ -40,12 +40,19 @@ platforms = [
     Platform("x86_64", "windows"),
 ]
 
+linux_platforms = filter(Sys.islinux, platforms)
+
 products = [
     LibraryProduct(["libusecomputer_c", "usecomputer_c"], :libusecomputer_c),
     FileProduct("include/usecomputer.h", :usecomputer_h),
 ]
 
-dependencies = Dependency[]
+dependencies = [
+    Dependency("Xorg_libX11_jll"; platforms=linux_platforms),
+    Dependency("Xorg_libXext_jll"; platforms=linux_platforms),
+    Dependency("Xorg_libXtst_jll"; platforms=linux_platforms),
+    Dependency("libpng_jll"; platforms=linux_platforms),
+]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
     julia_compat="1.6")

--- a/U/usecomputer/bundled/LICENSE
+++ b/U/usecomputer/bundled/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 remorses (https://github.com/remorses/usecomputer)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- Adds JLL package for [usecomputer](https://github.com/remorses/usecomputer), a desktop automation CLI/library for AI agents (screenshot capture, mouse/keyboard control)
- Ships the C shared library (`libusecomputer_c`) and header for FFI from Julia
- Pre-built binaries for macOS (arm64, x64), Linux (arm64, x64), and Windows (x64)

## Test plan
- [x] `build_tarballs.jl --verbose` succeeds for all 5 platforms
- [x] `--deploy=local` generates working JLL wrapper
- [x] `using usecomputer_jll` loads and resolves `libusecomputer_c` correctly