### PR TITLE
PIOLib buildscript

### DIFF
--- a/P/PIOLib/build_tarballs.jl
+++ b/P/PIOLib/build_tarballs.jl
@@ -1,0 +1,46 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "PIOlib"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/raspberrypi/utils.git", "0504cf3ba3eb31fd00ae8df4358b48d700ffcd16"),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+for f in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 ${f}
+done
+cd $WORKSPACE/srcdir/utils/piolib/
+cmake . -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel ${nproc}
+cmake --install build
+install_license $WORKSPACE/srcdir/LICENSE
+exit
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = [
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "musl")
+]
+
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libpio", :libpio)
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"15.2.0")

--- a/P/PIOLib/build_tarballs.jl
+++ b/P/PIOLib/build_tarballs.jl
@@ -21,7 +21,7 @@ cd $WORKSPACE/srcdir/utils/piolib/
 cmake . -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel ${nproc}
 cmake --install build
-install_license $WORKSPACE/srcdir/LICENSE
+install_license ${WORKSPACE}/srcdir/utils/LICENCE
 exit
 """
 

--- a/P/PIOLib/build_tarballs.jl
+++ b/P/PIOLib/build_tarballs.jl
@@ -2,7 +2,7 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-name = "PIOlib"
+name = "PIOLib"
 version = v"0.1.0"
 
 # Collection of sources required to complete build

--- a/P/PIOLib/build_tarballs.jl
+++ b/P/PIOLib/build_tarballs.jl
@@ -18,7 +18,7 @@ for f in ${WORKSPACE}/srcdir/patches/*.patch; do
     atomic_patch -p1 ${f}
 done
 cd $WORKSPACE/srcdir/utils/piolib/
-cmake . -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_STANDARD=23 -DCMAKE_C_STANDARD_REQUIRED=ON
+cmake . -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel ${nproc}
 cmake --install build
 install_license ${WORKSPACE}/srcdir/utils/LICENCE
@@ -43,4 +43,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"13")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"15")

--- a/P/PIOLib/build_tarballs.jl
+++ b/P/PIOLib/build_tarballs.jl
@@ -18,7 +18,7 @@ for f in ${WORKSPACE}/srcdir/patches/*.patch; do
     atomic_patch -p1 ${f}
 done
 cd $WORKSPACE/srcdir/utils/piolib/
-cmake . -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release
+cmake . -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_STANDARD=11 -DCMAKE_C_STANDARD_REQUIRED=ON
 cmake --build build --parallel ${nproc}
 cmake --install build
 install_license ${WORKSPACE}/srcdir/utils/LICENCE

--- a/P/PIOLib/build_tarballs.jl
+++ b/P/PIOLib/build_tarballs.jl
@@ -43,4 +43,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"6")

--- a/P/PIOLib/build_tarballs.jl
+++ b/P/PIOLib/build_tarballs.jl
@@ -18,7 +18,7 @@ for f in ${WORKSPACE}/srcdir/patches/*.patch; do
     atomic_patch -p1 ${f}
 done
 cd $WORKSPACE/srcdir/utils/piolib/
-cmake . -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_STANDARD=11 -DCMAKE_C_STANDARD_REQUIRED=ON
+cmake . -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_STANDARD=23 -DCMAKE_C_STANDARD_REQUIRED=ON
 cmake --build build --parallel ${nproc}
 cmake --install build
 install_license ${WORKSPACE}/srcdir/utils/LICENCE
@@ -43,4 +43,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"13")

--- a/P/PIOLib/build_tarballs.jl
+++ b/P/PIOLib/build_tarballs.jl
@@ -43,4 +43,4 @@ dependencies = Dependency[
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"15.2.0")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")

--- a/P/PIOLib/bundled/patches/shared-lib.patch
+++ b/P/PIOLib/bundled/patches/shared-lib.patch
@@ -1,0 +1,22 @@
+diff --git before/utils/piolib/CMakeLists.txt after/utils/piolib/CMakeLists.txt
+index 9e98d9b..3e5e131 100644
+--- before/utils/piolib/CMakeLists.txt
++++ after/utils/piolib/CMakeLists.txt
+@@ -15,7 +15,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
+    add_definitions (-ffunction-sections)
+ endif ()
+ 
+-add_library (pio piolib.c library_piochips.c pio_rp1.c)
++add_library (pio SHARED piolib.c library_piochips.c pio_rp1.c)
+ target_include_directories(pio PUBLIC include)
+ set_target_properties(pio PROPERTIES SOVERSION 0)
+ 
+@@ -30,7 +30,7 @@ set(INCLUDE_FILES
+     "pico/stdlib.h"
+ )
+ 
+-install(TARGETS pio ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT piolib)
++install(TARGETS pio LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT piolib)
+ foreach ( file ${INCLUDE_FILES} )
+     get_filename_component( dir ${file} DIRECTORY )
+     install( FILES "include/${file}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/piolib/${dir}" COMPONENT piolib)


### PR DESCRIPTION
PIO interface library for Raspberry Pi 5/CM5. Only targets Aarch64 because, well.

