### PR TITLE
[Montre] Add Montre v0.6.0

### DIFF
--- a/M/Montre/build_tarballs.jl
+++ b/M/Montre/build_tarballs.jl
@@ -18,15 +18,13 @@ install -Dvm 755 \
 	${libdir}/libmontre_ffi.${dlext}
 """
 
-# note: I'll see if build works this time without these exclusions,
-# then will modify these comments depending on the outcome
 excluded = [
 	# Rust 1.94.0 toolchain not available for this platform target
 	# (confirmed still failing as of 2026-03-21, after Rust 1.94 was added to Yggdrasil)
-#	"riscv64-linux-gnu",
-#	"aarch64-unknown-freebsd",
+	"riscv64-linux-gnu",
+	"aarch64-unknown-freebsd",
 	# _Unwind linker errors:
-#	"i686-w64-mingw32",
+	"i686-w64-mingw32",
 ]
 
 platforms = filter(supported_platforms()) do p
@@ -37,9 +35,7 @@ products = [
 	LibraryProduct("libmontre_ffi", :libmontre),
 ]
 
-dependencies = [
-    Dependency("CompilerSupportLibraries_jll"),
-]
+dependencies = []
 
 build_tarballs(
 	ARGS, name, version, sources, script, platforms, products, dependencies;


### PR DESCRIPTION
Added a build_tarballs.jl for my new package [Montre.jl](https://github.com/myersm0/Montre.jl), which contains bindings for my [montre](https://github.com/myersm0/montre) Rust app.

(Note: second attempt at this PR. See [here](https://github.com/JuliaPackaging/Yggdrasil/pull/13344#issuecomment-4185250501) for the previous blocker.)