### PR TITLE
[libsemigroups] Update to v3.5.5

### DIFF
--- a/L/libsemigroups/build_tarballs.jl
+++ b/L/libsemigroups/build_tarballs.jl
@@ -4,12 +4,12 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "libsemigroups"
-version = v"3.5.4"
+version = v"3.5.5"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/libsemigroups/libsemigroups.git",
-              "d044c6bfefbff48c8ae7547d760215d14d843376"),  # v3.5.4
+              "452e635acf4c03a843ffb64d562632364237a756"),  # v3.5.5
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Updates `libsemigroups` to [v3.5.5](https://github.com/libsemigroups/libsemigroups/releases/tag/v3.5.5).

**Changes to `L/libsemigroups/build_tarballs.jl`:**
- `version`: `v3.5.5`
- `GitSource` commit: [`452e635acf4c`](https://github.com/libsemigroups/libsemigroups/commit/452e635acf4c03a843ffb64d562632364237a756)

---
_This PR was opened automatically by the [libsemigroups release workflow](https://github.com/libsemigroups/libsemigroups/actions/workflows/update-yggdrasil.yml)._

_Note that this account is not managed, please direct any queries towards @james-d-mitchell or @jswent._