### PR TITLE
CUDA: Bump cuQuantum to v26.03.0

### DIFF
--- a/C/CUDA/cuQuantum/build_tarballs.jl
+++ b/C/CUDA/cuQuantum/build_tarballs.jl
@@ -8,7 +8,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "cuQuantum"
-version_str = "26.01.0"
+version_str = "26.03.0"
 version = VersionNumber(version_str)
 
 # Bash recipe for building across all platforms
@@ -26,7 +26,7 @@ augment_platform_block = CUDA.augment
 
 dependencies = [
     RuntimeDependency(PackageSpec(name="CUDA_Runtime_jll")),
-    RuntimeDependency(PackageSpec(name="CUTENSOR_jll"), compat="2.3.1")
+    RuntimeDependency(PackageSpec(name="CUTENSOR_jll"), compat="2.5.0")
 ]
 
 # The products that we will ensure are always built


### PR DESCRIPTION
- Bump cuQuantum from v26.01.0 to v26.03.0
- Bump CUTENSOR_jll compat from 2.3.1 to 2.5.0 (mentioned in release notes of cuDensityMat v0.5.0)

I some cuDensityMat stuff locally and cuQuantum v26.03.0 includes cuDensityMat v0.5.0. This version adds support for time-dependent variational principle (TDVP) propagator for MPS/MPO, JAX XLA/Autograd integration, and several bug fixes for multi-GPU/multi-node operator action computation which is great for us @harmoniqs!