### PR TITLE
Add compat ranges to all `Giflib_jll` users

### DIFF
--- a/L/Leptonica/build_tarballs.jl
+++ b/L/Leptonica/build_tarballs.jl
@@ -43,7 +43,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="Giflib_jll", uuid="59f7168a-df46-5410-90c8-f2779963d0ec")),
+    Dependency(PackageSpec(name="Giflib_jll", uuid="59f7168a-df46-5410-90c8-f2779963d0ec"); compat="5.2.3"),
     Dependency(PackageSpec(name="JpegTurbo_jll", uuid="aacddb02-875f-59d6-b918-886e6ef4fbf8")),
     Dependency(PackageSpec(name="libpng_jll", uuid="b53b4c65-9356-5827-b1ea-8c7a1a84506f")),
     Dependency("Libtiff_jll"; compat="4.7"),

--- a/L/libgifextra/build_tarballs.jl
+++ b/L/libgifextra/build_tarballs.jl
@@ -28,7 +28,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="Giflib_jll", uuid="59f7168a-df46-5410-90c8-f2779963d0ec"))
+    Dependency(PackageSpec(name="Giflib_jll", uuid="59f7168a-df46-5410-90c8-f2779963d0ec"); compat="5.2.3")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libwebp/build_tarballs.jl
+++ b/L/libwebp/build_tarballs.jl
@@ -46,7 +46,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Giflib_jll"),
+    Dependency("Giflib_jll"; compat="5.2.3"),
     Dependency("JpegTurbo_jll"),
     Dependency("libpng_jll"),
     Dependency("Libtiff_jll"; compat="4.7.1"),

--- a/R/ROOT/build_tarballs.jl
+++ b/R/ROOT/build_tarballs.jl
@@ -198,7 +198,7 @@ dependencies = [
     Dependency(PackageSpec(name="XRootD_jll", uuid="b6113df7-b24e-50c0-846f-35a2e36cb9d5"))
     Dependency(PackageSpec(name="Lz4_jll", uuid="5ced341a-0733-55b8-9ab6-a4889d929147"))
     Dependency(PackageSpec(name="FFTW_jll", uuid="f5851436-0d7a-5f13-b9de-f02708fd171a"))
-    Dependency(PackageSpec(name="Giflib_jll", uuid="59f7168a-df46-5410-90c8-f2779963d0ec"))
+    Dependency(PackageSpec(name="Giflib_jll", uuid="59f7168a-df46-5410-90c8-f2779963d0ec"); compat="5.2.3")
     Dependency(PackageSpec(name="Zstd_jll", uuid="3161d3a3-bdf6-5164-811a-617609db77b4"))
     Dependency(PackageSpec(name="PCRE2_jll", uuid="efcefdf7-47ab-520b-bdef-62a2eaa19f15"))
     Dependency(PackageSpec(name="Graphviz_jll", uuid="3c863552-8265-54e4-a6dc-903eb78fde85"))

--- a/T/Tesseract/build_tarballs.jl
+++ b/T/Tesseract/build_tarballs.jl
@@ -38,7 +38,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Giflib_jll"),
+    Dependency("Giflib_jll"; compat="5.2.3"),
     Dependency("JpegTurbo_jll"),
     Dependency("libpng_jll"),
     Dependency("Libtiff_jll"; compat="~4.3, ~4.4"),


### PR DESCRIPTION
We currently ship Giflib 5. Giflib 6 is out and is not ABI compatible. Add compat ranges to all recipies so that they won't break when/if they are rebuilt.

[skip build]