### PR TITLE
MAGMA: update to v2.10.0

### DIFF
--- a/M/MAGMA/build_tarballs.jl
+++ b/M/MAGMA/build_tarballs.jl
@@ -38,9 +38,11 @@ if [[ "${target}" == aarch64-linux-* ]]; then
    NVCC_DIR=(/workspace/srcdir/cuda_nvcc-*-archive)
    rm -rf ${prefix}/cuda/bin
    cp -r ${NVCC_DIR}/bin ${prefix}/cuda/bin
-   
-   rm -rf ${prefix}/cuda/nvvm/bin
-   cp -r ${NVCC_DIR}/nvvm/bin ${prefix}/cuda/nvvm/bin
+
+   if [[ -d "${NVCC_DIR}/nvvm/bin" ]]; then
+      rm -rf ${prefix}/cuda/nvvm/bin
+      cp -r ${NVCC_DIR}/nvvm/bin ${prefix}/cuda/nvvm/bin
+   fi
 
    # Workaround failed execution of sizeptr in cross-compile builds
    PTROPT="PTRSIZE=8"

--- a/M/MAGMA/build_tarballs.jl
+++ b/M/MAGMA/build_tarballs.jl
@@ -7,16 +7,15 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "MAGMA"
-version = v"2.9.0"
+version = v"2.10.0"
 
-# Note: Hopper should still build with CUDA v11.8
-# on x86_64, but aarch64 requires CUDA v12.0
-MIN_CUDA_VERSION = v"12"
+# Note: Blackwell requires CUDA v12.8
+MIN_CUDA_VERSION = v"12.8"
 
 # Collection of sources required to complete build
 sources = [
     ArchiveSource("http://icl.utk.edu/projectsfiles/magma/downloads/magma-$(version).tar.gz",
-                  "ff77fd3726b3dfec3bfb55790b06480aa5cc384396c2db35c56fdae4a82c641c"),
+                  "ea0c57fcb64ac2fd7ffe8f02d8fe18f07055c5b7fba0164f565d1e3a85148fb5"),
     DirectorySource("./bundled")
 ]
 

--- a/M/MAGMA/build_tarballs.jl
+++ b/M/MAGMA/build_tarballs.jl
@@ -36,13 +36,19 @@ if [[ "${target}" == aarch64-linux-* ]]; then
    
    # Make sure we use host CUDA executable by copying from the x86_64 CUDA redist
    NVCC_DIR=(/workspace/srcdir/cuda_nvcc-*-archive)
+   NVVM_DIR=(/workspace/srcdir/libnvvm-*-archive)
    rm -rf ${prefix}/cuda/bin
    cp -r ${NVCC_DIR}/bin ${prefix}/cuda/bin
 
    rm -rf ${prefix}/cuda/nvvm/bin
    if [[ -d "${NVCC_DIR}/nvvm/bin" ]]; then
-      # Copy nvvm only if it exists. CUDA 13+ requires a separate download for nvvm.
+      # CUDA 12 bundles nvvm, so we can copy it form there.
       cp -r ${NVCC_DIR}/nvvm/bin ${prefix}/cuda/nvvm/bin
+   elif [[ -d "${NVVM_DIR}/nvvm/bin" ]]; then
+      # CUDA 13+ has a separate download for nvvm.
+      cp -r ${NVVM_DIR}/nvvm/bin ${prefix}/cuda/nvvm/bin
+   else
+      exit 1
    fi
 
    # Workaround failed execution of sizeptr in cross-compile builds
@@ -102,6 +108,9 @@ for platform in platforms
 
     if arch(platform) == "aarch64"
         push!(platform_sources, CUDA.cuda_nvcc_redist_source(cuda_ver, "x86_64"))
+        if VersionNumber(cuda_ver) >= v"13.0"
+            push!(platform_sources, CUDA.cuda_nvvm_redist_source(cuda_ver, "x86_64"))
+        end
     end
 
     build_tarballs(ARGS, name, version, platform_sources, script, [platform],

--- a/M/MAGMA/build_tarballs.jl
+++ b/M/MAGMA/build_tarballs.jl
@@ -39,8 +39,9 @@ if [[ "${target}" == aarch64-linux-* ]]; then
    rm -rf ${prefix}/cuda/bin
    cp -r ${NVCC_DIR}/bin ${prefix}/cuda/bin
 
+   rm -rf ${prefix}/cuda/nvvm/bin
    if [[ -d "${NVCC_DIR}/nvvm/bin" ]]; then
-      rm -rf ${prefix}/cuda/nvvm/bin
+      # Copy nvvm only if it exists. CUDA 13+ requires a separate download for nvvm.
       cp -r ${NVCC_DIR}/nvvm/bin ${prefix}/cuda/nvvm/bin
    fi
 

--- a/M/MAGMA/build_tarballs.jl
+++ b/M/MAGMA/build_tarballs.jl
@@ -5,6 +5,7 @@ using BinaryBuilder, Pkg
 const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
+include(joinpath(YGGDRASIL_DIR, "C/CUDA", "common.jl"))
 
 name = "MAGMA"
 version = v"2.10.0"
@@ -36,20 +37,17 @@ if [[ "${target}" == aarch64-linux-* ]]; then
    
    # Make sure we use host CUDA executable by copying from the x86_64 CUDA redist
    NVCC_DIR=(/workspace/srcdir/cuda_nvcc-*-archive)
-   NVVM_DIR=(/workspace/srcdir/libnvvm-*-archive)
    rm -rf ${prefix}/cuda/bin
    cp -r ${NVCC_DIR}/bin ${prefix}/cuda/bin
 
-   rm -rf ${prefix}/cuda/nvvm/bin
-   if [[ -d "${NVCC_DIR}/nvvm/bin" ]]; then
-      # CUDA 12 bundles nvvm, so we can copy it form there.
-      cp -r ${NVCC_DIR}/nvvm/bin ${prefix}/cuda/nvvm/bin
-   elif [[ -d "${NVVM_DIR}/nvvm/bin" ]]; then
-      # CUDA 13+ has a separate download for nvvm.
-      cp -r ${NVVM_DIR}/nvvm/bin ${prefix}/cuda/nvvm/bin
+   # From CUDA v13 on, nvvm is not distributed in the NVCC redist anymore
+   if [[ "${bb_full_target}" == *cuda+13* ]]; then
+      NVVM_DIR=(/workspace/srcdir/libnvvm-*-archive)
    else
-      exit 1
+      NVVM_DIR=${NVCC_DIR}
    fi
+   rm -rf ${prefix}/cuda/nvvm/bin
+   cp -r ${NVVM_DIR}/nvvm/bin ${prefix}/cuda/nvvm/bin
 
    # Workaround failed execution of sizeptr in cross-compile builds
    PTROPT="PTRSIZE=8"
@@ -107,10 +105,15 @@ for platform in platforms
     platform_sources = BinaryBuilder.AbstractSource[sources...]
 
     if arch(platform) == "aarch64"
-        push!(platform_sources, CUDA.cuda_nvcc_redist_source(cuda_ver, "x86_64"))
+        components = ["cuda_nvcc"]
+        # From CUDA v13 on, nvvm is not shipped with nvcc anymore
         if VersionNumber(cuda_ver) >= v"13.0"
-            push!(platform_sources, CUDA.cuda_nvvm_redist_source(cuda_ver, "x86_64"))
+           push!(components, "libnvvm")
         end
+        x86_platform = deepcopy(platform)
+        x86_platform["arch"] = "x86_64"
+        append!(platform_sources, get_sources("cuda", components; platform=x86_platform,
+                                              version=CUDA.full_version(VersionNumber(cuda_ver))))
     end
 
     build_tarballs(ARGS, name, version, platform_sources, script, [platform],

--- a/M/MAGMA/bundled/make.inc
+++ b/M/MAGMA/bundled/make.inc
@@ -52,7 +52,7 @@ RANLIB    = ranlib
 
 # set our GPU targets
 ifeq ($(BACKEND),cuda)
-    GPU_TARGET = Pascal sm_61 Volta Turing Ampere sm_86 Ada Hopper Blackwell
+    GPU_TARGET = Turing Ampere sm_86 Ada Hopper Blackwell
 else ifeq ($(BACKEND),hip)
     GPU_TARGET = gfx900 gfx902 gfx904 gfx906 gfx908 gfx909 gfx90a gfx940 gfx941 gfx942 gfx90c gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1033
 endif

--- a/M/MAGMA/bundled/make.inc
+++ b/M/MAGMA/bundled/make.inc
@@ -52,7 +52,7 @@ RANLIB    = ranlib
 
 # set our GPU targets
 ifeq ($(BACKEND),cuda)
-    GPU_TARGET = Pascal sm_61 Volta Turing Ampere sm_86 Ada Hopper
+    GPU_TARGET = Pascal sm_61 Volta Turing Ampere sm_86 Ada Hopper Blackwell
 else ifeq ($(BACKEND),hip)
     GPU_TARGET = gfx900 gfx902 gfx904 gfx906 gfx908 gfx909 gfx90a gfx940 gfx941 gfx942 gfx90c gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1033
 endif

--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -315,4 +315,31 @@ function cuda_nvcc_redist_source(cuda_ver, arch)
     end
 end
 
+"""
+    cuda_nvvm_redist_source(cuda_ver, arch)
+
+Returns an ArchiveSource for the official NVIDIA libnvvm redist of the given CUDA version and architecture.
+"""
+function cuda_nvvm_redist_source(cuda_ver, arch)
+    if arch == "x86_64"
+        if cuda_ver == "13.0"
+            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.0.0.json
+            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/linux-x86_64/libnvvm-linux-x86_64-13.0.48-archive.tar.xz",
+                          "8c5676a65a2e6d13e3c229f025af18677de46c220d77992fe932200fa798b19b")
+        elseif cuda_ver == "13.1"
+            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.1.0.json
+            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/linux-x86_64/libnvvm-linux-x86_64-13.1.80-archive.tar.xz",
+                        "1a102f6658b6ecaa7a3aae1aa85a61a9aa6ba197be9f6b185d906deb2a6c5afd")
+        elseif cuda_ver == "13.2"
+            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.2.0.json
+            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/linux-x86_64/libnvvm-linux-x86_64-13.2.51-archive.tar.xz",
+                          "e013fce38130d2337ea695aadc5ddd5dcfb78f9107903d72492b9819539749bb")
+        else
+            error("No CUDA libnvvm redist available for CUDA version $cuda_ver on arch $arch")
+        end
+    else
+        error("No CUDA libnvvm redist available for arch $arch")
+    end
+end
+
 end

--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -315,31 +315,4 @@ function cuda_nvcc_redist_source(cuda_ver, arch)
     end
 end
 
-"""
-    cuda_nvvm_redist_source(cuda_ver, arch)
-
-Returns an ArchiveSource for the official NVIDIA libnvvm redist of the given CUDA version and architecture.
-"""
-function cuda_nvvm_redist_source(cuda_ver, arch)
-    if arch == "x86_64"
-        if cuda_ver == "13.0"
-            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.0.0.json
-            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/linux-x86_64/libnvvm-linux-x86_64-13.0.48-archive.tar.xz",
-                          "8c5676a65a2e6d13e3c229f025af18677de46c220d77992fe932200fa798b19b")
-        elseif cuda_ver == "13.1"
-            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.1.0.json
-            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/linux-x86_64/libnvvm-linux-x86_64-13.1.80-archive.tar.xz",
-                        "1a102f6658b6ecaa7a3aae1aa85a61a9aa6ba197be9f6b185d906deb2a6c5afd")
-        elseif cuda_ver == "13.2"
-            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.2.0.json
-            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/linux-x86_64/libnvvm-linux-x86_64-13.2.51-archive.tar.xz",
-                          "e013fce38130d2337ea695aadc5ddd5dcfb78f9107903d72492b9819539749bb")
-        else
-            error("No CUDA libnvvm redist available for CUDA version $cuda_ver on arch $arch")
-        end
-    else
-        error("No CUDA libnvvm redist available for arch $arch")
-    end
-end
-
 end


### PR DESCRIPTION
- Enabled compilation for Blackwell GPUs
- Bumped minimum CUDA version to 12.8 (required for Blackwell)
- ~If builds fail on CUDA 13+, I might have to drop older GPU archs in the Makefile (up to Volta included)~
  _Edit_: as suspected, I had to remove `Pascal` to `Volta` from the targets
- Refactored cross-platform builds to use `get_sources` and `libnvvm` on CUDA 13+