### PR TITLE
platforms/mpi: Update compat ranges

### DIFF
--- a/platforms/mpi.jl
+++ b/platforms/mpi.jl
@@ -49,10 +49,10 @@ using Base.BinaryPlatforms
 
 mpi_abis = (
     ("MPIABI", PackageSpec(name="MPIABI_jll"), "0.1.3", p -> !Sys.iswindows(p)),
-    ("MPICH", PackageSpec(name="MPICH_jll"), "4.3.0, 5", p -> !Sys.iswindows(p)),
-    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5.5.3", p -> !Sys.iswindows(p) && !(libc(p) == "musl")),
+    ("MPICH", PackageSpec(name="MPICH_jll"), "5.0.1", p -> !Sys.iswindows(p)),
+    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5.5.6", p -> !Sys.iswindows(p) && !(libc(p) == "musl")),
     ("MicrosoftMPI", PackageSpec(name="MicrosoftMPI_jll"), "", Sys.iswindows),
-    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "4.1.8, 5.0.7", p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc")),
+    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "4.1.9, 5.0.11", p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc")),
 )
 
 """


### PR DESCRIPTION
Update compat ranges so that building with the new MPI ABI works.

(This excludes old MPI builds which produce an error when loading because their `augment_mpi!` function does not recognize `MPIABI_jll`.)