### PR TITLE
[CompilerSupportLibraries] Expand packaged "staticlibs" on Linux and Windows

### DIFF
--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v0.5/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v0.5/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"0.5.4"; preferred_gcc_version=v"11", windows_staticlibs=true, julia_compat="1.9")
+build_csl(ARGS, v"0.5.4"; preferred_gcc_version=v"11", unix_staticlibs=false, windows_staticlibs=true, julia_compat="1.9")
 
 # Build trigger: 1

--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.0/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.0/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"1.0.5"; preferred_gcc_version=v"12", windows_staticlibs=true, julia_compat="1.9")
+build_csl(ARGS, v"1.0.5"; preferred_gcc_version=v"12", unix_staticlibs=false, windows_staticlibs=true, julia_compat="1.9")
 
 # Build trigger: 3

--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.1/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.1/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"1.1.1"; preferred_gcc_version=v"13", windows_staticlibs=true, julia_compat="1.11")
+build_csl(ARGS, v"1.1.1"; preferred_gcc_version=v"13", unix_staticlibs=false, windows_staticlibs=true, julia_compat="1.11")
 
 # Build trigger: 1

--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.2/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.2/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"1.2.0"; preferred_gcc_version=v"13", windows_staticlibs=true, julia_compat="1.12")
+build_csl(ARGS, v"1.2.0"; preferred_gcc_version=v"13", unix_staticlibs=false, windows_staticlibs=true, julia_compat="1.12")
 
 # Build trigger: 0

--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.3/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.3/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"1.3.1"; preferred_gcc_version=v"14", windows_staticlibs=true, julia_compat="1.12")
+build_csl(ARGS, v"1.3.1"; preferred_gcc_version=v"14", unix_staticlibs=false, windows_staticlibs=true, julia_compat="1.12")
 
 # Build trigger: 0

--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.4/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.4/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"1.4.0"; preferred_gcc_version=v"15", windows_staticlibs=true, julia_compat="1.12")
+build_csl(ARGS, v"1.4.0"; preferred_gcc_version=v"15", unix_staticlibs=false, windows_staticlibs=true, julia_compat="1.12")
 
 # Build trigger: 0

--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.5/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.5/build_tarballs.jl
@@ -1,0 +1,5 @@
+include("../common.jl")
+
+build_csl(ARGS, v"1.5.0"; preferred_gcc_version=v"15", unix_staticlibs=true, windows_staticlibs=true, julia_compat="1.12")
+
+# Build trigger: 0

--- a/C/CompilerSupportLibraries/common.jl
+++ b/C/CompilerSupportLibraries/common.jl
@@ -9,6 +9,7 @@ function build_csl(ARGS, version::VersionNumber;
                    # latest compatible version.
                    preferred_gcc_version::VersionNumber,
                    windows_staticlibs::Bool,
+                   unix_staticlibs::Bool,
                    julia_compat::String,
                    )
     name = "CompilerSupportLibraries"
@@ -65,7 +66,7 @@ done
 
     ## Now that we've got those tarballs, we're going to use them as sources to overwrite
     ## the libstdc++ and libgomp that we would otherwise get from our compiler shards:
-    script = "WINDOWS_STATICLIBS=$(windows_staticlibs)\nPREFERRED_GCC_VERSION=$(preferred_gcc_version)\nVERSION=$(version.major * 100 ^ 2 + version.minor * 100 + version.patch)\n" * raw"""
+    script = "WINDOWS_STATICLIBS=$(windows_staticlibs)\nUNIX_STATICLIBS=$(unix_staticlibs)\nPREFERRED_GCC_VERSION=$(preferred_gcc_version)\nVERSION=$(version.major * 100 ^ 2 + version.minor * 100 + version.patch)\n" * raw"""
 # Start by extracting LatestLibraries
 tar -zxvf ${WORKSPACE}/srcdir/LatestLibraries*.tar.gz -C ${prefix}
 
@@ -87,14 +88,27 @@ if [[ ${target} == *mingw* ]]; then
         # From v1.1.0 of CSL we move the Windows `*.a` files to a subdir of `${prefix}/lib`.
         # See <https://github.com/JuliaLang/julia/issues/48081>.
         if [[ "${VERSION}" -ge 10100 ]]; then
-           destdir="${prefix}/lib/gcc/${target}/${PREFERRED_GCC_VERSION%.*.*}"
+           destdir="${prefix}/lib/gcc/${AATRIPLET}/${PREFERRED_GCC_VERSION%.*.*}"
         else
            destdir="${prefix}/lib"
         fi
         # Install also some static and import libraries, needed for linking of pkgimages.
-        for lib in libmsvcrt.a libgcc.a libgcc_s.a libssp.dll.a; do
+        for lib in libadvapi32.a libgcc.a libgcc_s.a libmingw32.a libmsvcrt.a libmoldname.a libshell32.a \
+                   libuser32.a libpthread.dll.a libssp.dll.a dllcrt2.o crtbegin.o crtend.o; do
             qfind "/opt/${target}" -name "${lib}" -exec install -Dvm 0644 '{}' "${destdir}/${lib}" \;
         done
+    fi
+fi
+if [[ "${UNIX_STATICLIBS}" == "true" ]] && [[ ${target} != *mingw* ]]; then
+    destdir="${prefix}/lib/gcc/${AATRIPLET}/${PREFERRED_GCC_VERSION%.*.*}"
+    qfind "/opt/${target}" -name "libgcc.a" -exec install -Dvm 0644 '{}' "${destdir}/libgcc.a" \;
+    if [[ ${target} == *linux* ]] || [[ ${target} == *freebsd* ]]; then
+        for lib in crti.o crtn.o crtbeginS.o crtendS.o; do
+            qfind "/opt/${target}" -name "${lib}" -exec install -Dvm 0644 '{}' "${destdir}/${lib}" \;
+        done
+        if [[ ${target} == *-linux-gnu* ]]; then
+            qfind "/opt/${target}" -name "libc_nonshared.a" -exec install -Dvm 0644 '{}' "${destdir}/libc_nonshared.a" \;
+        fi
     fi
 fi
 
@@ -165,16 +179,43 @@ install_license /usr/share/licenses/GPL-3.0+
             if windows_staticlibs && Sys.iswindows(platform)
                 destdir = version >= v"1.1.0" ? "lib/gcc/$(aatriplet(platform))/$(preferred_gcc_version.major)" : "lib"
                 products = vcat(products,
-                                [FileProduct("$(destdir)/libmsvcrt.a", :libmsvcrt_a),
+                                [FileProduct("$(destdir)/libadvapi32.a", :libadvapi32_a),
                                  FileProduct("$(destdir)/libgcc.a", :libgcc_a),
                                  FileProduct("$(destdir)/libgcc_s.a", :libgcc_s_a),
+                                 FileProduct("$(destdir)/libmingw32.a", :libmingw32_a),
+                                 FileProduct("$(destdir)/libmsvcrt.a", :libmsvcrt_a),
+                                 FileProduct("$(destdir)/libmoldname.a", :libmoldname_a),
+                                 FileProduct("$(destdir)/libshell32.a", :libshell32_a),
+                                 FileProduct("$(destdir)/libuser32.a", :libuser32_a),
+                                 FileProduct("$(destdir)/libpthread.dll.a", :libpthread_dll_a),
                                  FileProduct("$(destdir)/libssp.dll.a", :libssp_dll_a),
+                                 FileProduct("$(destdir)/dllcrt2.o", :dllcrt2_o),
+                                 FileProduct("$(destdir)/crtbegin.o", :crtbegin_o),
+                                 FileProduct("$(destdir)/crtend.o", :crtend_o),
                                  ])
+            end
+            if unix_staticlibs && !Sys.iswindows(platform)
+                destdir = version >= v"1.1.0" ? "lib/gcc/$(aatriplet(platform))/$(preferred_gcc_version.major)" : "lib"
+                products = vcat(products,
+                                [FileProduct("$(destdir)/libgcc.a", :libgcc_a)])
+                if Sys.islinux(platform) || Sys.isfreebsd(platform)
+                    products = vcat(products,
+                                    [FileProduct("$(destdir)/crti.o", :crti_o),
+                                     FileProduct("$(destdir)/crtn.o", :crtn_o),
+                                     FileProduct("$(destdir)/crtbeginS.o", :crtbeginS_o),
+                                     FileProduct("$(destdir)/crtendS.o", :crtendS_o),
+                                     ])
+                    if libc(platform) == "glibc"
+                        products = vcat(products,
+                                        [FileProduct("$(destdir)/libc_nonshared.a", :libc_nonshared_a)])
+                    end
+                end
             end
             if libc(platform) != "musl"
                 products = vcat(products, LibraryProduct("libssp", :libssp))
             end
-            build_tarballs(ARGS, name, version, sources, script, [platform], products, []; preferred_gcc_version, julia_compat)
+            platform_script = "AATRIPLET=$(aatriplet(platform))\n" * script
+            build_tarballs(ARGS, name, version, sources, platform_script, [platform], products, []; preferred_gcc_version, julia_compat)
         end
     end
 end


### PR DESCRIPTION
This expands the exported artifacts for `CompilerSupportLibraries_jll` to include all static libraries / objects that are linked by GCC on these platforms by default.

Motivated by https://github.com/JuliaLang/julia/pull/61631, which needs to be able to "properly" link the sysimage with `lld` instead of relying on undefined symbols as we do for pkgimages currently. This should also eventually allow `JuliaC` to generate executable files, libraries, etc. without relying on a system compiler.