### PR TITLE
LLVM: Bump Clang_unified for LLVM 21.

### DIFF
--- a/L/LLVM/Clang_unified/build_tarballs.jl
+++ b/L/LLVM/Clang_unified/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "llvm.jl"))
 include("../common.jl")
 
 name = "Clang_unified"
-version = v"0.1.4"
+version = v"0.1.5"
 llvm_full_versions = [
     v"15.0.7+12",               # Julia 1.10
     v"16.0.6+6",                # Julia 1.11
@@ -15,6 +15,7 @@ llvm_full_versions = [
     v"18.1.7+5",                # Julia 1.12
     # v"19.1.7+2",
     v"20.1.8+0",                # Julia 1.13
+    v"21.1.8+0",                # Julia 1.14
 ]
 
 augment_platform_block = """
@@ -61,5 +62,3 @@ for (i, build) in enumerate(builds)
                    skip_audit=true, dont_dlopen=true, julia_compat="1.10",
                    augment_platform_block)
 end
-
-# bump


### PR DESCRIPTION
Makes Clang.jl work on LLVM 21.

x-ref https://github.com/JuliaLang/julia/pull/59950