### PR TITLE
[libsemigroups_jll] Enable hpcombi on macOS arm

### DIFF
--- a/L/libsemigroups/build_tarballs.jl
+++ b/L/libsemigroups/build_tarballs.jl
@@ -20,8 +20,11 @@ cd libsemigroups
 ./autogen.sh
 export CPPFLAGS="-I${prefix}/include"
 
-# Disable HPCombi on all platforms
+# Enable HPCombi only on macOS arm builds
 HPCOMBI_FLAG="--disable-hpcombi"
+if [[ "${target}" == aarch64-apple-darwin* ]]; then
+    HPCOMBI_FLAG="--enable-hpcombi"
+fi
 
 ./configure --prefix=${prefix} \
             --build=${MACHTYPE} \


### PR DESCRIPTION
This PR enables HPCombi only on MacOS arm systems, which we know the instruction set is well-supported for. Sadly there is no (good?) way to disambiguate via microarch, so x86 will have to remain disabled for now.