### PR TITLE
Avoid dynamic `cglobal` in `augment_llvm!`

### DIFF
--- a/platforms/llvm.jl
+++ b/platforms/llvm.jl
@@ -2,13 +2,15 @@ module LLVM
 
 const platform_name = "llvm_version"
 const augment = """
+    using Libdl: dlopen, dlsym
+
     function augment_llvm!(platform::Platform)
         haskey(platform, "llvm_version") && return platform
 
         llvm_version = Base.libllvm_version
         # does our LLVM build use assertions?
         llvm_assertions = try
-            cglobal((:_ZN4llvm24DisableABIBreakingChecksE, Base.libllvm_path()), Cvoid)
+            dlsym(dlopen(Base.libllvm_path()), "_ZN4llvm24DisableABIBreakingChecksE")
             false
         catch
             true


### PR DESCRIPTION
This kind of dynamic `foo()` library call inside `cglobal` is looking to be restricted in https://github.com/JuliaLang/julia/pull/61709
(just like it was for `ccall` in https://github.com/JuliaLang/julia/pull/59165)

Luckily we can just perform a dlsym, which is essentially equivalent anyway