### PR TITLE
[Xorg_xkeyboard_config] Build per-platform to fix Windows install

### DIFF
--- a/X/Xorg_xkeyboard_config/build_tarballs.jl
+++ b/X/Xorg_xkeyboard_config/build_tarballs.jl
@@ -22,9 +22,14 @@ ninja -j${nproc}
 ninja install
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = [AnyPlatform()]
+# The files are identical for all platforms, and in principle we could
+# use `AnyPlatform()` instead. However, starting with 2.47 the upstream
+# install creates symlinks (`share/X11/xkb`,
+# `share/pkgconfig/xkeyboard-config.pc`,
+# `share/man/man7/xkeyboard-config.7`) which have to be replaced with
+# copies on Windows, and for that to happen we need to build it for
+# Windows specifically (and hence for all other platforms as well).
+platforms = supported_platforms()
 
 products = Product[
 ]


### PR DESCRIPTION
Starting with 2.47, the upstream `xkeyboard-config` `ninja install` step creates symlinks at:

- `share/X11/xkb`
- `share/pkgconfig/xkeyboard-config.pc`
- `share/man/man7/xkeyboard-config.7`

where 2.44's install did not. With the recipe set to `[AnyPlatform()]`, those symlinks end up in the universal `Xorg_xkeyboard_config.v2.47.0.any.tar.gz` and prevent extraction on Windows for users who don't hold `SeCreateSymbolicLinkPrivilege` (developer mode off, non-elevated shell — the default for end users).

Verified directly:

| Artifact | Version | Symlinks |
|---|---|---|
| `051bcd87a956c48ab829b7da04a56222c10f0a47` | `v2.47.0+0` | 3 |
| `23d821271a00e164eb2b5c273985da44f9a831a1` | `v2.44.0+0` | 0 |

Switching to `supported_platforms()` matches the precedent in `iso_codes` (#7926, refined in #10894) and `adwaita_icon_theme` (#7930): BinaryBuilder's per-platform packaging materialises the symlinks as copies on Windows, while the contents remain identical across platforms. The recipe comment is reused verbatim from the iso_codes 4.17 PR for consistency.

The artifact is data-only (no native code), so per-platform builds are straightforward.

_Disclaimer: investigated and generated by Claude. Surfaced in a private repository._