### PR TITLE
[OpenVDB] new recipe for v13.0.0

### DIFF
--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -79,7 +79,7 @@ dependencies = [
     HostBuildDependency(PackageSpec(; name="CMake_jll", version="3.24")),
     Dependency("boost_jll"; compat="1.87"),
     Dependency("oneTBB_jll"; compat="2022.3"),
-    Dependency("Blosc_jll"; compat="1.21"),
+    Dependency("Blosc_jll"; compat="1.21.7"),
     Dependency("Zlib_jll"; compat="1.3"),
     # libopenvdb.so links libgcc_s; audit fails to auto-map without this.
     Dependency("CompilerSupportLibraries_jll"),

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -76,8 +76,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # OpenVDB 13's CMakeLists requires CMake >= 3.24.
-    HostBuildDependency("CMake_jll"),
+    HostBuildDependency(PackageSpec(; name="CMake_jll", version="3.24")),
     Dependency("boost_jll"),
     Dependency("oneTBB_jll"),
     Dependency("Blosc_jll"),

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -80,7 +80,7 @@ dependencies = [
     Dependency("boost_jll"; compat="1.87"),
     Dependency("oneTBB_jll"; compat="2022.3"),
     Dependency("Blosc_jll"; compat="1.21.7"),
-    Dependency("Zlib_jll"; compat="1.3"),
+    Dependency("Zlib_jll"; compat="1.3.2"),
     # libopenvdb.so links libgcc_s; audit fails to auto-map without this.
     Dependency("CompilerSupportLibraries_jll"),
 ]

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -2,6 +2,9 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
 name = "OpenVDB"
 version = v"13.0.0"
 
@@ -11,13 +14,6 @@ sources = [
         "https://github.com/AcademySoftwareFoundation/openvdb",
         "7c03e1f084873cd1b3422c7ff7aec6ee681b3b38",  # tag v13.0.0
     ),
-    # Newer macOS SDK for x86_64-apple-darwin. BB's default sysroot for that
-    # target is darwin14 (10.10), whose libc++ predates std::any_cast and
-    # aligned-deallocation operators that OpenVDB 13 + TBB depend on.
-    ArchiveSource(
-        "https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz",
-        "0f03869f72df8705b832910517b47dd5b79eb4e160512602f593ed243b28715f",
-    ),
 ]
 
 # Bash recipe for building across all platforms
@@ -26,20 +22,6 @@ script = raw"""
 apk del cmake
 
 cd $WORKSPACE/srcdir/openvdb
-
-# OpenVDB 13's PointDataGrid uses std::any_cast and TBB uses aligned
-# deallocation operators; both need libc++ symbols introduced in macOS
-# 10.14. Set deployment target on all darwin targets; for
-# x86_64-apple-darwin, redirect the toolchain at the bundled 10.14 SDK
-# (BB's default sysroot for that target is darwin14 / 10.10).
-# aarch64-apple-darwin's sysroot is already new.
-if [[ ${target} == *apple-darwin* ]]; then
-    export MACOSX_DEPLOYMENT_TARGET=10.14
-fi
-if [[ ${target} == x86_64-apple-darwin* ]]; then
-    apple_sdk_root=$WORKSPACE/srcdir/MacOSX10.14.sdk
-    sed -i "s!/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root!$apple_sdk_root!" $CMAKE_TARGET_TOOLCHAIN
-fi
 
 args=(
     -DCMAKE_BUILD_TYPE=Release
@@ -76,6 +58,8 @@ cmake --build build --parallel 2
 cmake --install build
 install_license LICENSE
 """
+
+sources, script = require_macos_sdk("10.14", sources, script)
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -1,0 +1,70 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "OpenVDB"
+version = v"13.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    ArchiveSource(
+        "https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/v$(version).tar.gz",
+        "4d6a91df5f347017496fe8d22c3dbb7c4b5d7289499d4eb4d53dd2c75bb454e1",
+    ),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/openvdb-*/
+
+args=(
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=${prefix}
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
+    -DCMAKE_CXX_STANDARD=17
+    -DOPENVDB_BUILD_BINARIES=OFF
+    -DOPENVDB_BUILD_UNITTESTS=OFF
+    -DOPENVDB_BUILD_PYTHON_MODULE=OFF
+    -DOPENVDB_BUILD_HOUDINI_PLUGIN=OFF
+    -DOPENVDB_BUILD_MAYA_PLUGIN=OFF
+    -DOPENVDB_BUILD_AX=OFF
+    -DOPENVDB_BUILD_NANOVDB=OFF
+    -DOPENVDB_CORE_SHARED=ON
+    -DOPENVDB_CORE_STATIC=OFF
+    -DUSE_EXR=OFF
+)
+if [[ ${target} == *darwin* ]]; then
+   args+=(-DCMAKE_STRIP=${target}-strip)
+fi
+
+cmake -B build -G Ninja "${args[@]}"
+cmake --build build --parallel ${nproc}
+cmake --install build
+install_license LICENSE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# Disable platforms that we don't have oneTBB for
+filter!(p -> arch(p) ∉ ("armv6l", "armv7l"), platforms)
+filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libopenvdb", :libopenvdb),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("boost_jll"; compat="1.85"),
+    Dependency("oneTBB_jll"),
+    Dependency("Blosc_jll"),
+    Dependency("Zlib_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+# OpenVDB needs C++17, so use a gcc that supports it on every host.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version=v"10")

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -15,8 +15,8 @@ sources = [
     # target is darwin14 (10.10), whose libc++ predates std::any_cast and
     # aligned-deallocation operators that OpenVDB 13 + TBB depend on.
     ArchiveSource(
-        "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
-        "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4",
+        "https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz",
+        "0f03869f72df8705b832910517b47dd5b79eb4e160512602f593ed243b28715f",
     ),
 ]
 
@@ -29,18 +29,16 @@ cd $WORKSPACE/srcdir/openvdb
 
 # OpenVDB 13's PointDataGrid uses std::any_cast and TBB uses aligned
 # deallocation operators; both need libc++ symbols introduced in macOS
-# 10.14. Set deployment target on all darwin targets; overlay a newer
-# SDK on x86_64-apple-darwin since BB's default sysroot for that target
-# is darwin14 (10.10). aarch64-apple-darwin's sysroot is already new.
+# 10.14. Set deployment target on all darwin targets; for
+# x86_64-apple-darwin, redirect the toolchain at the bundled 10.14 SDK
+# (BB's default sysroot for that target is darwin14 / 10.10).
+# aarch64-apple-darwin's sysroot is already new.
 if [[ ${target} == *apple-darwin* ]]; then
     export MACOSX_DEPLOYMENT_TARGET=10.14
 fi
 if [[ ${target} == x86_64-apple-darwin* ]]; then
-    pushd $WORKSPACE/srcdir/MacOSX11.*.sdk
-    rm -rf /opt/${target}/${target}/sys-root/System
-    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
-    cp -ra System "/opt/${target}/${target}/sys-root/."
-    popd
+    apple_sdk_root=$WORKSPACE/srcdir/MacOSX10.14.sdk
+    sed -i "s!/opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root!$apple_sdk_root!" $CMAKE_TARGET_TOOLCHAIN
 fi
 
 args=(

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -86,7 +86,6 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-# OpenVDB 13's OpenVDBCXX.cmake requires g++ >= 11.2.1; pick the highest
-# bootstrap available in BB (13.2.0).
+# OpenVDB 13's OpenVDBCXX.cmake requires g++ >= 11.2.1.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"13")
+               julia_compat="1.6", preferred_gcc_version=v"12")

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -20,6 +20,14 @@ apk del cmake
 
 cd $WORKSPACE/srcdir/openvdb
 
+# OpenVDB 13's PointDataGrid uses std::any_cast and TBB uses aligned
+# deallocation operators; both have libc++ availability annotations
+# gating them to macOS >= 10.14 / 10.13. BB's darwin14 sysroot defaults
+# to 10.10 — raise it.
+if [[ ${target} == *apple-darwin* ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=10.14
+fi
+
 args=(
     -DCMAKE_BUILD_TYPE=Release
     -DCMAKE_INSTALL_PREFIX=${prefix}

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -77,10 +77,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     HostBuildDependency(PackageSpec(; name="CMake_jll", version="3.24")),
-    Dependency("boost_jll"),
-    Dependency("oneTBB_jll"),
-    Dependency("Blosc_jll"),
-    Dependency("Zlib_jll"),
+    Dependency("boost_jll"; compat="1.87"),
+    Dependency("oneTBB_jll"; compat="2022.3"),
+    Dependency("Blosc_jll"; compat="1.21"),
+    Dependency("Zlib_jll"; compat="1.3"),
     # libopenvdb.so links libgcc_s; audit fails to auto-map without this.
     Dependency("CompilerSupportLibraries_jll"),
 ]

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -11,6 +11,13 @@ sources = [
         "https://github.com/AcademySoftwareFoundation/openvdb",
         "7c03e1f084873cd1b3422c7ff7aec6ee681b3b38",  # tag v13.0.0
     ),
+    # Newer macOS SDK for x86_64-apple-darwin. BB's default sysroot for that
+    # target is darwin14 (10.10), whose libc++ predates std::any_cast and
+    # aligned-deallocation operators that OpenVDB 13 + TBB depend on.
+    ArchiveSource(
+        "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
+        "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4",
+    ),
 ]
 
 # Bash recipe for building across all platforms
@@ -21,11 +28,19 @@ apk del cmake
 cd $WORKSPACE/srcdir/openvdb
 
 # OpenVDB 13's PointDataGrid uses std::any_cast and TBB uses aligned
-# deallocation operators; both have libc++ availability annotations
-# gating them to macOS >= 10.14 / 10.13. BB's darwin14 sysroot defaults
-# to 10.10 — raise it.
+# deallocation operators; both need libc++ symbols introduced in macOS
+# 10.14. Set deployment target on all darwin targets; overlay a newer
+# SDK on x86_64-apple-darwin since BB's default sysroot for that target
+# is darwin14 (10.10). aarch64-apple-darwin's sysroot is already new.
 if [[ ${target} == *apple-darwin* ]]; then
     export MACOSX_DEPLOYMENT_TARGET=10.14
+fi
+if [[ ${target} == x86_64-apple-darwin* ]]; then
+    pushd $WORKSPACE/srcdir/MacOSX11.*.sdk
+    rm -rf /opt/${target}/${target}/sys-root/System
+    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
+    cp -ra System "/opt/${target}/${target}/sys-root/."
+    popd
 fi
 
 args=(

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -7,15 +7,18 @@ version = v"13.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    ArchiveSource(
-        "https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/v$(version).tar.gz",
-        "4d6a91df5f347017496fe8d22c3dbb7c4b5d7289499d4eb4d53dd2c75bb454e1",
+    GitSource(
+        "https://github.com/AcademySoftwareFoundation/openvdb",
+        "7c03e1f084873cd1b3422c7ff7aec6ee681b3b38",  # tag v13.0.0
     ),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/openvdb-*/
+# OpenVDB 13 needs CMake >= 3.24; the base image ships 3.21.
+apk del cmake
+
+cd $WORKSPACE/srcdir/openvdb
 
 args=(
     -DCMAKE_BUILD_TYPE=Release
@@ -38,7 +41,9 @@ if [[ ${target} == *darwin* ]]; then
 fi
 
 cmake -B build -G Ninja "${args[@]}"
-cmake --build build --parallel ${nproc}
+# OpenVDB template instantiations are memory-heavy at compile time;
+# cap parallelism to keep peak RSS bounded.
+cmake --build build --parallel 2
 cmake --install build
 install_license LICENSE
 """
@@ -58,13 +63,18 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("boost_jll"; compat="1.85"),
+    # OpenVDB 13's CMakeLists requires CMake >= 3.24.
+    HostBuildDependency("CMake_jll"),
+    Dependency("boost_jll"),
     Dependency("oneTBB_jll"),
     Dependency("Blosc_jll"),
     Dependency("Zlib_jll"),
+    # libopenvdb.so links libgcc_s; audit fails to auto-map without this.
+    Dependency("CompilerSupportLibraries_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-# OpenVDB needs C++17, so use a gcc that supports it on every host.
+# OpenVDB 13's OpenVDBCXX.cmake requires g++ >= 11.2.1; pick the highest
+# bootstrap available in BB (13.2.0).
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"10")
+               julia_compat="1.6", preferred_gcc_version=v"13")

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -48,6 +48,14 @@ if [[ ${target} == *darwin* ]]; then
    args+=(-DCMAKE_STRIP=${target}-strip)
 fi
 
+# boost_jll's mingw tarball installs BoostConfig.cmake under bin/cmake/
+# (Windows-native layout) rather than lib/cmake/ where CMake's config-mode
+# find_package looks. Point Boost_DIR at the actual location; the glob
+# keeps this robust to boost_jll version bumps.
+if [[ ${target} == *-mingw32* ]]; then
+    args+=(-DBoost_DIR=$(dirname $(ls ${prefix}/bin/cmake/Boost-*/BoostConfig.cmake | head -1)))
+fi
+
 cmake -B build -G Ninja "${args[@]}"
 # OpenVDB template instantiations are memory-heavy at compile time;
 # cap parallelism to keep peak RSS bounded.


### PR DESCRIPTION
Reviving #4316, which was closed years ago on a oneTBB musl issue that's since been fixed. Bumped to v13.0.0.

notes:

- `x86_64-apple-darwin`: bundled `MacOSX10.14.sdk` and sed-redirected `$CMAKE_TARGET_TOOLCHAIN` at it. BB's default darwin14 libc++ predates `std::any_cast` and aligned-dealloc operators that OpenVDB 13 + TBB use. Pattern taken from `G/GRCore`.
- `x86_64-w64-mingw32`: `Boost_DIR` pointed at `bin/cmake/Boost-*/`. `boost_jll`'s mingw layout puts cmake configs under `bin/` instead of `lib/`, so config-mode `find_package` can't see them by default.

---

_PR drafted with help from Claude Opus 4.7._
