### PR TITLE
AGENTS.md: document bb-sandbox MCP + review fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,10 @@ Some dependencies require special handling:
 
 - **LLVM packages**: Must use `LLVM_full_jll` and match the version used by the Julia version. Requires careful ABI compatibility.
 - **MPI packages**: Need `MPIPreferences.jl` configuration and must use `MPItrampoline_jll` for cross-implementation compatibility.
+- **BLAS/LAPACK packages**: Should link against `libblastrampoline_jll` rather than a concrete BLAS implementation, so downstream Julia users can swap implementations at runtime.
 - **CUDA packages**: Use `CUDA.required_dependencies` to get the necessary runtime dependencies. Must handle different CUDA versions. GPU code needs special compilation flags.
 
-For these complex dependencies, consult existing recipes in the repository (search for `LLVM_full_jll`, `MPItrampoline_jll`, or `CUDA.required_dependencies`).
+For these complex dependencies, consult existing recipes in the repository (search for `LLVM_full_jll`, `MPItrampoline_jll`, `libblastrampoline_jll`, or `CUDA.required_dependencies`).
 
 ## Essential Structure
 
@@ -55,6 +56,10 @@ build_tarballs(ARGS, name, version, sources, script, platforms, products, depend
 ```
 
 ## Critical Rules
+
+These are the hard requirements every recipe must satisfy. The "Build Script Reference"
+section below is non-normative reference material (env vars, common build systems,
+optional arguments).
 
 ### Naming
 
@@ -97,9 +102,62 @@ To find the commit hash for a tag:
 git ls-remote https://github.com/owner/repo.git refs/tags/v1.0.0
 ```
 
-### Build Script
+### Products
 
-The script runs in `x86_64-linux-musl` environment. Key variables:
+- **LibraryProduct**: Shared libraries (`.so`, `.dylib`, `.dll`)
+- **ExecutableProduct**: Binary executables
+- **FileProduct**: Other files (headers, data files)
+- **FrameworkProduct**: macOS frameworks
+
+### Dependencies
+
+- **Dependency**: Runtime dependency (will be a dependency of the generated JLL package)
+- **BuildDependency**: Build-time only (not a dependency for the final JLL)
+- **HostBuildDependency**: Build-time only dependency that needs to run on the build host, not target (not a dependency for the final JLL)
+
+Always add `_jll` suffix: `Dependency("Zlib_jll")`
+
+### GCC Version Selection
+
+Use `preferred_gcc_version=v"X"` for (see [available GCC versions](https://github.com/JuliaPackaging/Yggdrasil/blob/master/RootFS.md#compiler-shards)):
+
+- **C++ code**: Use oldest GCC that compiles (≤10 for Julia v1.6 compatibility)
+- **Dependencies built with newer GCC**: Match or exceed their GCC version
+- **Musl bugs**: Use GCC ≥6 to avoid `posix_memalign` issues
+- Default is GCC 4.8.5 for maximum compatibility
+
+### Unsupported Build Flags
+
+Products should not force using certain CPUs or instruction sets (e.g., the `march` or `mcpu` flags), unless they perform their own selection of the appropriate code for the current processor at runtime.
+They also should not use unsafe math operations or fast-math mode in compilers.
+
+To remove the `march` and `mcpu` flags in a list of files:
+
+```bash
+for i in ${files}; do
+    sed -i "s/-march[^ ]*//g" $i
+    sed -i "s/-mcpu[^ ]*//g" $i
+done
+```
+
+To remove the fast math and unsafe math optimizations in a list of files:
+
+```bash
+for i in ${files}; do
+    sed -i "s/-ffast-math//g" $i
+    sed -i "s/-funsafe-math-optimizations//g" $i
+done
+```
+
+## Build Script Reference
+
+Reference material for writing the `script` block — environment variables, common
+build-system invocations, platform branching, and optional `build_tarballs` keyword
+arguments.
+
+### Environment Variables
+
+The script runs in an `x86_64-linux-musl` environment. Key variables:
 
 - `${prefix}`: Install root (target for all outputs)
 - `${bindir}`: Executables go here (= `${prefix}/bin`)
@@ -177,35 +235,11 @@ if [[ ${nbits} == 32 ]]; then
 fi
 ```
 
-### Products
-
-- **LibraryProduct**: Shared libraries (`.so`, `.dylib`, `.dll`)
-- **ExecutableProduct**: Binary executables
-- **FileProduct**: Other files (headers, data files)
-- **FrameworkProduct**: macOS frameworks
-
-### Dependencies
-
-- **Dependency**: Runtime dependency (will be a dependency of the generated JLL package)
-- **BuildDependency**: Build-time only (not a dependency for the final JLL)
-- **HostBuildDependency**: Build-time only dependency that needs to run on the build host, not target (not a dependency for the final JLL)
-
-Always add `_jll` suffix: `Dependency("Zlib_jll")`
-
-### GCC Version Selection
-
-Use `preferred_gcc_version=v"X"` for (see [available GCC versions](https://github.com/JuliaPackaging/Yggdrasil/blob/master/RootFS.md#compiler-shards)):
-
-- **C++ code**: Use oldest GCC that compiles (≤10 for Julia v1.6 compatibility)
-- **Dependencies built with newer GCC**: Match or exceed their GCC version
-- **Musl bugs**: Use GCC ≥6 to avoid `posix_memalign` issues
-- Default is GCC 4.8.5 for maximum compatibility
-
-### Optional Arguments
+### Optional Arguments to `build_tarballs`
 
 ```julia
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-    julia_compat="1.10",                   # Minimum Julia version
+    julia_compat="1.10",                   # Minimum Julia version for the JLL
     preferred_gcc_version=v"8",            # GCC version
     preferred_llvm_version=v"13",          # LLVM version
     compilers=[:c, :rust],                 # Additional compilers
@@ -213,28 +247,8 @@ build_tarballs(ARGS, name, version, sources, script, platforms, products, depend
 )
 ```
 
-### Unsupported Build Flags
-
-Products should not force using certain CPUs or instruction sets (e.g., the `march` or `mcpu` flags), unless they perform their own selection of the appropriate code for the current processor at runtime.
-They also should not use unsafe math operations or the "fast math" mode in compilters.
-
-To remove the `march` and `mcpu` flags in a list of files:
-
-```bash
-for i in ${files}
-    sed -i "s/-march[^ ]*//g" $i
-    sed -i "s/-mcpu[^ ]*//g" $i
-done
-```
-
-To remove the fast math and unsafe math optimizations in a list of files:
-
-```bash
-for i in ${files}
-    sed -i "s/-ffast-math//g" $i
-    sed -i "s/-funsafe-math-optimizations//g" $i
-done
-```
+Note: `julia_compat` is the **JLL's** Julia compat bound, independent of the Julia
+version required to *run* BinaryBuilder.jl itself (see [Prerequisites](#prerequisites)).
 
 ## Common Patterns
 
@@ -407,7 +421,12 @@ using PackageName_jll
 
 # Test that products are accessible
 @info "Package path:" PackageName_jll.artifact_dir
-@info "Executable path:" PackageName_jll.executable_name()
+
+# JLLs export each ExecutableProduct as a function named after its symbol.
+# E.g. for `ExecutableProduct("zstd", :zstd)` the wrapper is `Zstd_jll.zstd()`,
+# which returns a Cmd usable with `run` or string interpolation.
+# Replace `executable_name` below with your actual product symbol.
+@info "Executable Cmd:" PackageName_jll.executable_name()
 
 # Try running the executable (if applicable)
 run(`$(PackageName_jll.executable_name()) --version`)
@@ -488,6 +507,25 @@ For complex packages, you can also:
 - **Autotools with patches**: Look for recipes with `bundled/patches/`
 - **Platform-specific builds**: `G/Git/build_tarballs.jl`
 - **Multiple sources**: `L/libftd2xx/build_tarballs.jl`
+
+## MCP Tooling
+
+This repo ships an MCP server for Claude Code, configured in `.mcp.json`:
+
+- **`bb-sandbox`** (`.claude/mcp-bb-sandbox/server.jl`) — launches and drives an
+  interactive BinaryBuilder cross-compilation sandbox. Tools: `sandbox_start`,
+  `sandbox_exec`, `sandbox_stop`, `sandbox_list`, `sandbox_str_replace_editor`.
+
+The server runs from the `.ci/` Julia environment. On a fresh checkout it must
+be instantiated once, otherwise Claude Code reports
+`Failed to reconnect to bb-sandbox` because the server crashes on startup with
+a missing-package error (e.g. `ClaudeMCPTools`). From the repo root:
+
+```bash
+julia --project=.ci -e 'using Pkg; Pkg.instantiate()'
+```
+
+After that, `/mcp` in Claude Code should show `bb-sandbox` connected.
 
 ## Additional Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,22 +510,22 @@ For complex packages, you can also:
 
 ## MCP Tooling
 
-This repo ships an MCP server for Claude Code, configured in `.mcp.json`:
+This repo ships an MCP server for AI coding agents, configured in `.mcp.json`:
 
 - **`bb-sandbox`** (`.claude/mcp-bb-sandbox/server.jl`) — launches and drives an
   interactive BinaryBuilder cross-compilation sandbox. Tools: `sandbox_start`,
   `sandbox_exec`, `sandbox_stop`, `sandbox_list`, `sandbox_str_replace_editor`.
 
 The server runs from the `.ci/` Julia environment. On a fresh checkout it must
-be instantiated once, otherwise Claude Code reports
-`Failed to reconnect to bb-sandbox` because the server crashes on startup with
-a missing-package error (e.g. `ClaudeMCPTools`). From the repo root:
+be instantiated once, otherwise the agent will fail to connect to `bb-sandbox`
+because the server crashes on startup with a missing-package error
+(e.g. `ClaudeMCPTools`). From the repo root:
 
 ```bash
 julia --project=.ci -e 'using Pkg; Pkg.instantiate()'
 ```
 
-After that, `/mcp` in Claude Code should show `bb-sandbox` connected.
+After that, the agent's MCP status should show `bb-sandbox` connected.
 
 ## Additional Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,8 @@ git ls-remote https://github.com/owner/repo.git refs/tags/v1.0.0
 - **FileProduct**: Other files (headers, data files)
 - **FrameworkProduct**: macOS frameworks
 
+Every declared product must actually be produced by the build on every supported platform — BinaryBuilder audits the install prefix after the script runs and fails the build if any listed product is missing. Gate platform-specific products with `Platform`-aware filters (e.g. only declare a `.dll` on Windows) rather than listing them unconditionally.
+
 ### Dependencies
 
 - **Dependency**: Runtime dependency (will be a dependency of the generated JLL package)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,84 +8,6 @@ This guide helps AI agents generate correct `build_tarballs.jl` recipes for Bina
 - **Supported Platforms**: Linux (glibc and musl for x86_64, i686, aarch64, armv7l, armv6l, ppc64le, riscv64), Windows (x86_64, i686), macOS (x86_64, aarch64), FreeBSD (x86_64, aarch64)
 - Use `supported_platforms()` to get all available platforms
 
-## Special Dependencies
-
-Some dependencies require special handling:
-
-- **LLVM packages**: Must use `LLVM_full_jll` and match the version used by the Julia version. Requires careful ABI compatibility.
-- **MPI packages**: Need `MPIPreferences.jl` configuration and must use `MPItrampoline_jll` for cross-implementation compatibility.
-- **BLAS/LAPACK packages**: Should link against `libblastrampoline_jll` rather than a concrete BLAS implementation, so downstream Julia users can swap implementations at runtime.
-- **CUDA packages**: Use `CUDA.required_dependencies` to get the necessary runtime dependencies. Must handle different CUDA versions. GPU code needs special compilation flags.
-
-For these complex dependencies, consult existing recipes in the repository (search for `LLVM_full_jll`, `MPItrampoline_jll`, `libblastrampoline_jll`, or `CUDA.required_dependencies`).
-
-### MPI packages
-
-MPI recipes use a platform-tag augmentation scheme so a single set of JLLs can be retargeted at runtime via `MPIPreferences.jl`. Five ABIs are supported (`MPIABI`, `MPICH`, `MPItrampoline`, `OpenMPI`, `MicrosoftMPI`); the orchestration lives in `platforms/mpi.jl`.
-
-Standard recipe shape (see `H/HYPRE/build_tarballs.jl`, `P/PETSc/build_tarballs.jl`, `S/SCALAPACK/build_tarballs.jl`):
-
-```julia
-include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
-# ...
-platforms = supported_platforms()
-platforms = expand_gfortran_versions(platforms)   # if Fortran code
-platforms, platform_dependencies = MPI.augment_platforms(platforms;
-                                                        MPICH_compat="5",
-                                                        OpenMPI_compat="4.1.9, 5.0.11")
-augment_platform_block = """
-    using Base.BinaryPlatforms
-    $(MPI.augment)
-    augment_platform!(platform::Platform) = augment_mpi!(platform)
-"""
-append!(dependencies, platform_dependencies)
-build_tarballs(...; augment_platform_block, ...)
-```
-
-`MPI.augment_platforms` expands each base platform into one variant per allowed ABI, adds an `mpi=<abi>` tag, and returns the matching `Dependency` list (including `MPIPreferences`).
-
-Recurring gotchas:
-
-- **MPItrampoline** does not support musl, Windows, or FreeBSD; **OpenMPI** is unavailable on `armv6l-linux-gnu`. The `mpi_abis` table in `platforms/mpi.jl` encodes most of this, but downstream recipes often still drop unsupported combinations with `filter!(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)` etc. (see `C/COSMA`, `C/COSTA`, `C/CryptoMiniSat`).
-- **Fortran-bearing libraries** must call `expand_gfortran_versions(platforms)` *before* `MPI.augment_platforms`; C++-heavy packages often also need `expand_cxxstring_abis`.
-- **Per-ABI linking** is selected with `if [[ ${bb_full_target} == *mpiabi* ]]; then …` blocks; each ABI exposes a different set of libraries (`libmpitrampoline`, `libmpi`+`libmpifort`, `libmpi`+`libmpi_mpifh`+`libmpi_usempif08`, `msmpi64`). `P/PETSc/build_tarballs.jl` is the canonical reference.
-- **Windows (MicrosoftMPI)** needs `-DMPI_HOME=${prefix} -DMPI_GUESS_LIBRARY_NAME=MSMPI` and `-DMPI_${lang}_LIBRARIES=msmpi64` for CMake; see `H/HYPRE/build_tarballs.jl`.
-
-### CUDA packages
-
-CUDA tooling and platform augmentation live in `platforms/cuda.jl` (with the underlying JLLs under `C/CUDA/`). Depend on the right combination via `CUDA.required_dependencies(platform)` rather than naming the JLLs directly:
-
-- `CUDA_SDK_jll` / `CUDA_SDK_static_jll` — full toolkit (headers + libs), build-only (`BuildDependency`).
-- `CUDA_Runtime_jll` — slim redistributable runtime libs (cudart, cublas, cufft, curand, cusolver, cusparse, nvrtc, nvjitlink); the user-facing artifact.
-- `CUDA_Driver_jll` — wraps the system driver and provides `inspect_driver` for compute-capability detection during platform augmentation.
-
-Standard recipe shape (see `A/AMGX/build_tarballs.jl`, `H/HeFFTe/build_tarballs.jl`):
-
-```julia
-include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
-platforms = CUDA.supported_platforms()           # one platform per CUDA minor version
-filter!(p -> arch(p) == "x86_64", platforms)     # optional
-
-for platform in platforms
-    should_build_platform(triplet(platform)) || continue
-    dependencies = CUDA.required_dependencies(platform; static_sdk=true)
-    build_tarballs(ARGS, name, version, sources, script, [platform],
-                   products, dependencies; lazy_artifacts=true,
-                   augment_platform_block=CUDA.augment,
-                   dont_dlopen=true, preferred_gcc_version=v"9")
-end
-```
-
-Concrete rules:
-
-- **Platforms:** Linux `x86_64-glibc`, Linux `aarch64-glibc` (split into `cuda_platform=jetson` vs `sbsa` for CUDA <13; unified for CUDA ≥13), and Windows `x86_64` (with caveats — `nvcc` is not a cross-compiler, so most recipes skip Windows). Musl and macOS are unsupported.
-- **Supported toolkit versions** are listed in `CUDA.cuda_full_versions` in `platforms/cuda.jl`. Build one variant per CUDA minor; the `cuda=$MAJOR.$MINOR` platform tag drives selection.
-- **`CUDA.augment` block is required** on consumers — it reads `CUDA_Runtime_jll` `Preferences` (`version`, `local`), detects driver capabilities via `CUDA_Driver_jll.inspect_driver`, and picks the highest-compatible toolkit. Compute-capability support is encoded in `cuda_cap_db` in `C/CUDA/CUDA_Runtime/platform_augmentation.jl`.
-- **Build flags:** point CMake at the bundled toolkit with `-DCMAKE_CUDA_COMPILER=$prefix/cuda/bin/nvcc -DCMAKE_CUDA_FLAGS="-L${prefix}/cuda/lib"`. `nvcc` writes scratch to `/tmp` (small tmpfs in the sandbox); redirect with `export TMPDIR=${WORKSPACE}/tmpdir`.
-- Pass **`static_sdk=true`** to `required_dependencies` when linking static CUDA libs (e.g. AMGX); this adds `CUDA_SDK_static_jll` as a `BuildDependency`.
-- Always pass **`dont_dlopen=true`** and **`lazy_artifacts=true`** to `build_tarballs` for CUDA consumers — the runtime libs must not be dlopened at JLL init time.
-- **NVIDIA redistributable archive** SHAs are published per CUDA release in `redistrib_<version>.json`; `cuda_nvcc_redist_source` / `get_sources` in `platforms/cuda.jl` and `C/CUDA/common.jl` handle this — prefer them over hand-rolled `ArchiveSource` URLs.
-
 ## Essential Structure
 
 Every `build_tarballs.jl` file follows this pattern:
@@ -217,6 +139,84 @@ for i in ${files}; do
     sed -i "s/-funsafe-math-optimizations//g" $i
 done
 ```
+
+## Special Dependencies
+
+Some dependencies require special handling:
+
+- **LLVM packages**: Must use `LLVM_full_jll` and match the version used by the Julia version. Requires careful ABI compatibility.
+- **MPI packages**: Need `MPIPreferences.jl` configuration and must use `MPItrampoline_jll` for cross-implementation compatibility.
+- **BLAS/LAPACK packages**: Should link against `libblastrampoline_jll` rather than a concrete BLAS implementation, so downstream Julia users can swap implementations at runtime.
+- **CUDA packages**: Use `CUDA.required_dependencies` to get the necessary runtime dependencies. Must handle different CUDA versions. GPU code needs special compilation flags.
+
+For these complex dependencies, consult existing recipes in the repository (search for `LLVM_full_jll`, `MPItrampoline_jll`, `libblastrampoline_jll`, or `CUDA.required_dependencies`).
+
+### MPI packages
+
+MPI recipes use a platform-tag augmentation scheme so a single set of JLLs can be retargeted at runtime via `MPIPreferences.jl`. Five ABIs are supported (`MPIABI`, `MPICH`, `MPItrampoline`, `OpenMPI`, `MicrosoftMPI`); the orchestration lives in `platforms/mpi.jl`.
+
+Standard recipe shape (see `H/HYPRE/build_tarballs.jl`, `P/PETSc/build_tarballs.jl`, `S/SCALAPACK/build_tarballs.jl`):
+
+```julia
+include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
+# ...
+platforms = supported_platforms()
+platforms = expand_gfortran_versions(platforms)   # if Fortran code
+platforms, platform_dependencies = MPI.augment_platforms(platforms;
+                                                        MPICH_compat="5",
+                                                        OpenMPI_compat="4.1.9, 5.0.11")
+augment_platform_block = """
+    using Base.BinaryPlatforms
+    $(MPI.augment)
+    augment_platform!(platform::Platform) = augment_mpi!(platform)
+"""
+append!(dependencies, platform_dependencies)
+build_tarballs(...; augment_platform_block, ...)
+```
+
+`MPI.augment_platforms` expands each base platform into one variant per allowed ABI, adds an `mpi=<abi>` tag, and returns the matching `Dependency` list (including `MPIPreferences`).
+
+Recurring gotchas:
+
+- **MPItrampoline** does not support musl, Windows, or FreeBSD; **OpenMPI** is unavailable on `armv6l-linux-gnu`. The `mpi_abis` table in `platforms/mpi.jl` encodes most of this, but downstream recipes often still drop unsupported combinations with `filter!(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)` etc. (see `C/COSMA`, `C/COSTA`, `C/CryptoMiniSat`).
+- **Fortran-bearing libraries** must call `expand_gfortran_versions(platforms)` *before* `MPI.augment_platforms`; C++-heavy packages often also need `expand_cxxstring_abis`.
+- **Per-ABI linking** is selected with `if [[ ${bb_full_target} == *mpiabi* ]]; then …` blocks; each ABI exposes a different set of libraries (`libmpitrampoline`, `libmpi`+`libmpifort`, `libmpi`+`libmpi_mpifh`+`libmpi_usempif08`, `msmpi64`). `P/PETSc/build_tarballs.jl` is the canonical reference.
+- **Windows (MicrosoftMPI)** needs `-DMPI_HOME=${prefix} -DMPI_GUESS_LIBRARY_NAME=MSMPI` and `-DMPI_${lang}_LIBRARIES=msmpi64` for CMake; see `H/HYPRE/build_tarballs.jl`.
+
+### CUDA packages
+
+CUDA tooling and platform augmentation live in `platforms/cuda.jl` (with the underlying JLLs under `C/CUDA/`). Depend on the right combination via `CUDA.required_dependencies(platform)` rather than naming the JLLs directly:
+
+- `CUDA_SDK_jll` / `CUDA_SDK_static_jll` — full toolkit (headers + libs), build-only (`BuildDependency`).
+- `CUDA_Runtime_jll` — slim redistributable runtime libs (cudart, cublas, cufft, curand, cusolver, cusparse, nvrtc, nvjitlink); the user-facing artifact.
+- `CUDA_Driver_jll` — wraps the system driver and provides `inspect_driver` for compute-capability detection during platform augmentation.
+
+Standard recipe shape (see `A/AMGX/build_tarballs.jl`, `H/HeFFTe/build_tarballs.jl`):
+
+```julia
+include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
+platforms = CUDA.supported_platforms()           # one platform per CUDA minor version
+filter!(p -> arch(p) == "x86_64", platforms)     # optional
+
+for platform in platforms
+    should_build_platform(triplet(platform)) || continue
+    dependencies = CUDA.required_dependencies(platform; static_sdk=true)
+    build_tarballs(ARGS, name, version, sources, script, [platform],
+                   products, dependencies; lazy_artifacts=true,
+                   augment_platform_block=CUDA.augment,
+                   dont_dlopen=true, preferred_gcc_version=v"9")
+end
+```
+
+Concrete rules:
+
+- **Platforms:** Linux `x86_64-glibc`, Linux `aarch64-glibc` (split into `cuda_platform=jetson` vs `sbsa` for CUDA <13; unified for CUDA ≥13), and Windows `x86_64` (with caveats — `nvcc` is not a cross-compiler, so most recipes skip Windows). Musl and macOS are unsupported.
+- **Supported toolkit versions** are listed in `CUDA.cuda_full_versions` in `platforms/cuda.jl`. Build one variant per CUDA minor; the `cuda=$MAJOR.$MINOR` platform tag drives selection.
+- **`CUDA.augment` block is required** on consumers — it reads `CUDA_Runtime_jll` `Preferences` (`version`, `local`), detects driver capabilities via `CUDA_Driver_jll.inspect_driver`, and picks the highest-compatible toolkit. Compute-capability support is encoded in `cuda_cap_db` in `C/CUDA/CUDA_Runtime/platform_augmentation.jl`.
+- **Build flags:** point CMake at the bundled toolkit with `-DCMAKE_CUDA_COMPILER=$prefix/cuda/bin/nvcc -DCMAKE_CUDA_FLAGS="-L${prefix}/cuda/lib"`. `nvcc` writes scratch to `/tmp` (small tmpfs in the sandbox); redirect with `export TMPDIR=${WORKSPACE}/tmpdir`.
+- Pass **`static_sdk=true`** to `required_dependencies` when linking static CUDA libs (e.g. AMGX); this adds `CUDA_SDK_static_jll` as a `BuildDependency`.
+- Always pass **`dont_dlopen=true`** and **`lazy_artifacts=true`** to `build_tarballs` for CUDA consumers — the runtime libs must not be dlopened at JLL init time.
+- **NVIDIA redistributable archive** SHAs are published per CUDA release in `redistrib_<version>.json`; `cuda_nvcc_redist_source` / `get_sources` in `platforms/cuda.jl` and `C/CUDA/common.jl` handle this — prefer them over hand-rolled `ArchiveSource` URLs.
 
 ## Build Script Reference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,73 @@ Some dependencies require special handling:
 
 For these complex dependencies, consult existing recipes in the repository (search for `LLVM_full_jll`, `MPItrampoline_jll`, `libblastrampoline_jll`, or `CUDA.required_dependencies`).
 
+### MPI packages
+
+MPI recipes use a platform-tag augmentation scheme so a single set of JLLs can be retargeted at runtime via `MPIPreferences.jl`. Five ABIs are supported (`MPIABI`, `MPICH`, `MPItrampoline`, `OpenMPI`, `MicrosoftMPI`); the orchestration lives in `platforms/mpi.jl`.
+
+Standard recipe shape (see `H/HYPRE/build_tarballs.jl`, `P/PETSc/build_tarballs.jl`, `S/SCALAPACK/build_tarballs.jl`):
+
+```julia
+include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
+# ...
+platforms = supported_platforms()
+platforms = expand_gfortran_versions(platforms)   # if Fortran code
+platforms, platform_dependencies = MPI.augment_platforms(platforms;
+                                                        MPICH_compat="5",
+                                                        OpenMPI_compat="4.1.9, 5.0.11")
+augment_platform_block = """
+    using Base.BinaryPlatforms
+    $(MPI.augment)
+    augment_platform!(platform::Platform) = augment_mpi!(platform)
+"""
+append!(dependencies, platform_dependencies)
+build_tarballs(...; augment_platform_block, ...)
+```
+
+`MPI.augment_platforms` expands each base platform into one variant per allowed ABI, adds an `mpi=<abi>` tag, and returns the matching `Dependency` list (including `MPIPreferences`).
+
+Recurring gotchas:
+
+- **MPItrampoline** does not support musl, Windows, or FreeBSD; **OpenMPI** is unavailable on `armv6l-linux-gnu`. The `mpi_abis` table in `platforms/mpi.jl` encodes most of this, but downstream recipes often still drop unsupported combinations with `filter!(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)` etc. (see `C/COSMA`, `C/COSTA`, `C/CryptoMiniSat`).
+- **Fortran-bearing libraries** must call `expand_gfortran_versions(platforms)` *before* `MPI.augment_platforms`; C++-heavy packages often also need `expand_cxxstring_abis`.
+- **Per-ABI linking** is selected with `if [[ ${bb_full_target} == *mpiabi* ]]; then …` blocks; each ABI exposes a different set of libraries (`libmpitrampoline`, `libmpi`+`libmpifort`, `libmpi`+`libmpi_mpifh`+`libmpi_usempif08`, `msmpi64`). `P/PETSc/build_tarballs.jl` is the canonical reference.
+- **Windows (MicrosoftMPI)** needs `-DMPI_HOME=${prefix} -DMPI_GUESS_LIBRARY_NAME=MSMPI` and `-DMPI_${lang}_LIBRARIES=msmpi64` for CMake; see `H/HYPRE/build_tarballs.jl`.
+
+### CUDA packages
+
+CUDA tooling and platform augmentation live in `platforms/cuda.jl` (with the underlying JLLs under `C/CUDA/`). Depend on the right combination via `CUDA.required_dependencies(platform)` rather than naming the JLLs directly:
+
+- `CUDA_SDK_jll` / `CUDA_SDK_static_jll` — full toolkit (headers + libs), build-only (`BuildDependency`).
+- `CUDA_Runtime_jll` — slim redistributable runtime libs (cudart, cublas, cufft, curand, cusolver, cusparse, nvrtc, nvjitlink); the user-facing artifact.
+- `CUDA_Driver_jll` — wraps the system driver and provides `inspect_driver` for compute-capability detection during platform augmentation.
+
+Standard recipe shape (see `A/AMGX/build_tarballs.jl`, `H/HeFFTe/build_tarballs.jl`):
+
+```julia
+include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
+platforms = CUDA.supported_platforms()           # one platform per CUDA minor version
+filter!(p -> arch(p) == "x86_64", platforms)     # optional
+
+for platform in platforms
+    should_build_platform(triplet(platform)) || continue
+    dependencies = CUDA.required_dependencies(platform; static_sdk=true)
+    build_tarballs(ARGS, name, version, sources, script, [platform],
+                   products, dependencies; lazy_artifacts=true,
+                   augment_platform_block=CUDA.augment,
+                   dont_dlopen=true, preferred_gcc_version=v"9")
+end
+```
+
+Concrete rules:
+
+- **Platforms:** Linux `x86_64-glibc`, Linux `aarch64-glibc` (split into `cuda_platform=jetson` vs `sbsa` for CUDA <13; unified for CUDA ≥13), and Windows `x86_64` (with caveats — `nvcc` is not a cross-compiler, so most recipes skip Windows). Musl and macOS are unsupported.
+- **Supported toolkit versions** are listed in `CUDA.cuda_full_versions` in `platforms/cuda.jl`. Build one variant per CUDA minor; the `cuda=$MAJOR.$MINOR` platform tag drives selection.
+- **`CUDA.augment` block is required** on consumers — it reads `CUDA_Runtime_jll` `Preferences` (`version`, `local`), detects driver capabilities via `CUDA_Driver_jll.inspect_driver`, and picks the highest-compatible toolkit. Compute-capability support is encoded in `cuda_cap_db` in `C/CUDA/CUDA_Runtime/platform_augmentation.jl`.
+- **Build flags:** point CMake at the bundled toolkit with `-DCMAKE_CUDA_COMPILER=$prefix/cuda/bin/nvcc -DCMAKE_CUDA_FLAGS="-L${prefix}/cuda/lib"`. `nvcc` writes scratch to `/tmp` (small tmpfs in the sandbox); redirect with `export TMPDIR=${WORKSPACE}/tmpdir`.
+- Pass **`static_sdk=true`** to `required_dependencies` when linking static CUDA libs (e.g. AMGX); this adds `CUDA_SDK_static_jll` as a `BuildDependency`.
+- Always pass **`dont_dlopen=true`** and **`lazy_artifacts=true`** to `build_tarballs` for CUDA consumers — the runtime libs must not be dlopened at JLL init time.
+- **NVIDIA redistributable archive** SHAs are published per CUDA release in `redistrib_<version>.json`; `cuda_nvcc_redist_source` / `get_sources` in `platforms/cuda.jl` and `C/CUDA/common.jl` handle this — prefer them over hand-rolled `ArchiveSource` URLs.
+
 ## Essential Structure
 
 Every `build_tarballs.jl` file follows this pattern:


### PR DESCRIPTION
Documentation-only changes to `AGENTS.md`.

**1. New "MCP Tooling" section** — documents the `bb-sandbox` MCP server (`.mcp.json`, added in #13149) and the one-time setup that fixes `Failed to reconnect to bb-sandbox`:

```bash
julia --project=.ci -e 'using Pkg; Pkg.instantiate()'
```

**2. Review fixes while in the file:**

- 🔴 Two `for i in ${files} … done` blocks under *Unsupported Build Flags* now have `; do` (were syntax-error on copy-paste).
- 🔴 Typo `compilters` → `compilers`.
- 🟡 Added `libblastrampoline_jll` to *Special Dependencies*.
- 🟡 Clarified the JLL test example: `ExecutableProduct`s are exported as functions returning a `Cmd` (e.g. `Zstd_jll.zstd()`).
- 🟢 Split *Critical Rules* (rules-only) from a new *Build Script Reference* section (env vars, build systems, platform branching, optional kwargs).

CI green; no recipes touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)