### PR TITLE
OpenBLAS32: Auto-forward into libblastrampoline LP64 slot

### DIFF
--- a/O/OpenBLAS/OpenBLAS32@0.3.33/build_tarballs.jl
+++ b/O/OpenBLAS/OpenBLAS32@0.3.33/build_tarballs.jl
@@ -14,6 +14,9 @@ products = openblas_products()
 preferred_gcc_version = v"12"
 preferred_llvm_version = v"18.1.7"
 dependencies = openblas_dependencies(platforms; llvm_compilerrt_version=preferred_llvm_version)
+push!(dependencies,
+      Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93");
+                 compat="5.11.0"))
 
 # Do we build all platforms, or those specified as arguments?
 platform_args = filter(arg -> !startswith(arg, "--"), ARGS)
@@ -39,7 +42,13 @@ for (n,platform) in enumerate(platforms)
                    lock_microarchitecture=false,
                    preferred_gcc_version=pref_gcc,
                    preferred_llvm_version=preferred_llvm_version,
+                   init_block = raw"""
+                       try
+                           ccall((:lbt_forward, libblastrampoline_jll.libblastrampoline), Int32,
+                                 (Cstring, Int32, Int32, Cstring),
+                                 libopenblas_path, Int32(0), Int32(0), C_NULL)
+                       catch
+                       end
+                   """,
                    )
 end
-
-# Build trigger: 0


### PR DESCRIPTION
Adds an `init_block` to OpenBLAS32_jll v0.3.33 that calls `lbt_forward` into libblastrampoline's LP64 slot when the JLL is loaded — mirroring what Julia's stdlib already does for `libopenblas64_` in the ILP64 slot.

Today, JLLs that link against `libblastrampoline_jll` (`MUMPS_jll`, `SuperLU_DIST_jll@9` after #13695, future `PETSc_jll`) call plain `dgemm_` through LBT, but Julia's stdlib leaves LBT's LP64 slot unpopulated. Each consumer has to wire it up themselves. After this PR, just `using OpenBLAS32_jll` populates the slot.

- Adds `libblastrampoline_jll` (compat `5.11.0`, matching Julia 1.11.0+ stdlib) as a runtime dep.
- Uses `libblastrampoline_jll.libblastrampoline` for the SONAME (no hardcoded strings, no `Sys.iswindows()` branch).
- `clear=0` preserves existing forwards in other slots.
- Wrapped in `try/catch` so loading without LBT in the process is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)