### PR TITLE
SuperLU_DIST: Move v8 build into versioned directory

### DIFF
--- a/S/SuperLU_DIST/SuperLU_DIST@8/build_tarballs.jl
+++ b/S/SuperLU_DIST/SuperLU_DIST@8/build_tarballs.jl
@@ -2,11 +2,11 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
-const YGGDRASIL_DIR = "../.."
+const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SuperLU_DIST"
-version = v"8.2.2"
+version = v"8.2.3"
 superlu_dist_version = v"8.2.1"
 
 # Collection of sources required to complete build
@@ -106,7 +106,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2")),
+    Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2"); compat="0.3.33"),
     Dependency(PackageSpec(name="PARMETIS_jll", uuid="b247a4be-ddc1-5759-8008-7e02fe3dbdaa"); platforms=filter(!Sys.iswindows, platforms), compat="4.0.7"),
     Dependency("METIS_jll"; compat="5.1.3"),
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD


### PR DESCRIPTION
Moves the existing `S/SuperLU_DIST/build_tarballs.jl` into `S/SuperLU_DIST/SuperLU_DIST@8/` to make room for a parallel v9 build (#13691 PETSc 3.24 needs v9).

## Changes

- Rename `S/SuperLU_DIST/build_tarballs.jl` → `S/SuperLU_DIST/SuperLU_DIST@8/build_tarballs.jl`.
- Fix up `YGGDRASIL_DIR` for the new depth (`"../../.."`).
- Bump `version` from `v"8.2.2"` to `v"8.2.3"` to signal the OpenBLAS32_jll compat-pin change explicitly.
- Pin `OpenBLAS32_jll` to `compat="0.3.33"`.

The v9 build is split into a separate PR.  Together these supersede #13695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)