### PR TITLE
[gecko] Rebuild for julia 1.12 compatibility

### DIFF
--- a/G/gecko/build_tarballs.jl
+++ b/G/gecko/build_tarballs.jl
@@ -2,14 +2,9 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-# See https://github.com/JuliaLang/Pkg.jl/issues/2942
-# Once this Pkg issue is resolved, this must be removed
-uuid = Base.UUID("a83860b7-747b-57cf-bf1f-3e79990d037f")
-delete!(Pkg.Types.get_last_stdlibs(v"1.6.3"), uuid)
-
 # The version of this JLL is decoupled from the upstream version.
 name = "gecko"
-version = v"1.0.1"
+version = v"1.1.0"
 
 # Collection of sources required to complete build
 sources = [
@@ -50,11 +45,8 @@ cmake --install build
 # Only support Linux and FreeBSD
 include("../../L/libjulia/common.jl")
 platforms = reduce(vcat, libjulia_platforms.(julia_versions))
-# platforms = supported_platforms()
 platforms = expand_cxxstring_abis(platforms)
 filter!(p -> (Sys.islinux(p) || Sys.isfreebsd(p)), platforms)
-# filter!(p -> v"1.11" ≤ VersionNumber(p["julia_version"]), platforms)
-
 
 # The products that we will ensure are always built
 products = [
@@ -64,10 +56,14 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("libcxxwrap_julia_jll"; compat="0.14.2"),
+    Dependency("libcxxwrap_julia_jll"; compat = "~0.14.5"),
     Dependency("CompilerSupportLibraries_jll"),
-    BuildDependency("libjulia_jll"),
+    BuildDependency(PackageSpec(;name="libjulia_jll", version="1.11.0")),
 ]
 
+# we want to get notified of any changes to julia_compat, and adapt `version` accordingly
+@assert libjulia_min_julia_version <= v"1.10.0"
+
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8", julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    preferred_gcc_version=v"8", julia_compat=libjulia_julia_compat(julia_versions))

--- a/G/gecko/bundled/geckowrapper/geckowrapper.cxx
+++ b/G/gecko/bundled/geckowrapper/geckowrapper.cxx
@@ -8,24 +8,24 @@
 // Can we automate this process here in WrapIt? We are essentially emulating C++ v-table behavior manually.
 class JuliaProgressWrapper final : public Gecko::Progress {
 private:
-    jl_value_t*    data;
-    jl_function_t* fbeginorder;
-    jl_function_t* fendorder;
-    jl_function_t* fbeginiter;
-    jl_function_t* fenditer;
-    jl_function_t* fbeginphase;
-    jl_function_t* fendphase;
-    jl_function_t* fquit;
+    jl_value_t* data;
+    jl_value_t* fbeginorder;
+    jl_value_t* fendorder;
+    jl_value_t* fbeginiter;
+    jl_value_t* fenditer;
+    jl_value_t* fbeginphase;
+    jl_value_t* fendphase;
+    jl_value_t* fquit;
 
 public:
-    JuliaProgressWrapper( jl_value_t*    data_
-                        , jl_function_t* fbeginorder_
-                        , jl_function_t* fendorder_
-                        , jl_function_t* fbeginiter_
-                        , jl_function_t* fenditer_
-                        , jl_function_t* fbeginphase_
-                        , jl_function_t* fendphase_
-                        , jl_function_t* fquit_
+    JuliaProgressWrapper( jl_value_t* data_
+                        , jl_value_t* fbeginorder_
+                        , jl_value_t* fendorder_
+                        , jl_value_t* fbeginiter_
+                        , jl_value_t* fenditer_
+                        , jl_value_t* fbeginphase_
+                        , jl_value_t* fendphase_
+                        , jl_value_t* fquit_
                     )
     : data(data_)
     , fbeginorder(fbeginorder_)
@@ -189,5 +189,5 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& gecko)
     progress_type.method("endorder", [](const Gecko::Progress* a)-> bool {return a->quit(); } );
 
     auto jlprogress_type = gecko.add_type<JuliaProgressWrapper>("JuliaProgressWrapper", jlcxx::julia_base_type<Gecko::Progress>());
-    jlprogress_type.constructor<jl_value_t*, jl_function_t*, jl_function_t*, jl_function_t*, jl_function_t*, jl_function_t*, jl_function_t*, jl_function_t*>();
+    jlprogress_type.constructor<jl_value_t*, jl_value_t*, jl_value_t*, jl_value_t*, jl_value_t*, jl_value_t*, jl_value_t*, jl_value_t*>();
 }


### PR DESCRIPTION
Resolves https://github.com/JuliaPackaging/Yggdrasil/issues/13262 (cc https://github.com/termi-official)

Since I was touching the recipe anyway, I also cleaned up some older things and made it a bit more consistent with other cxxwrap dependents.

I bumped the minor part of the jll version, as this PR changes the julia compat from 1.6 to 1.10 (following a change in libjulia_jll v1.11.0) 