### PR TITLE
CUDA_Driver_jll: Various improvements.

### DIFF
--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -84,24 +84,16 @@ non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
 # `--register` should only be passed to the latest `build_tarballs` invocation
 non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
 
+augment_platform_block = """
+augment_platform! = identity
+
+$(read(joinpath(@__DIR__, "inspect_driver.jl"), String))
+"""
+
 for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, cuda_version, build.sources, script,
                    build.platforms, products, dependencies;
                    skip_audit=true, init_block, julia_compat="1.10",
-                   augment_platform_block="""
-                   # Precompile the process-spawning and version-parsing hot path
-                   precompile(Tuple{typeof(Base.cmd_gen), Tuple{Tuple{Base.Cmd}, Tuple{String}, Tuple{Bool}, Tuple{Array{String, 1}}}})
-                   precompile(Tuple{typeof(Base.arg_gen), Bool})
-                   precompile(Tuple{typeof(Base.read), Base.Cmd, Type{String}})
-                   precompile(Tuple{typeof(Base.readlines), Base.IOBuffer})
-                   precompile(Tuple{typeof(Base.push!), Array{Base.VersionNumber, 1}, Base.VersionNumber})
-                   precompile(Tuple{typeof(Base.Iterators.enumerate), Array{Base.VersionNumber, 1}})
-                   precompile(Tuple{typeof(Base.iterate), Base.Iterators.Enumerate{Array{Base.VersionNumber, 1}}})
-                   precompile(Tuple{typeof(Base.iterate), Base.Iterators.Enumerate{Array{Base.VersionNumber, 1}}, Tuple{Int64, Int64}})
-                   precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Int64, Base.VersionNumber}, Int64})
-                   precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Int64, Base.VersionNumber}, Int64, Int64})
-
-                   augment_platform! = identity
-                   """)
+                   augment_platform_block)
 end

--- a/C/CUDA/CUDA_Driver/init.jl
+++ b/C/CUDA/CUDA_Driver/init.jl
@@ -55,35 +55,6 @@ if Libdl.dlopen(libcuda_system, Libdl.RTLD_NOLOAD; throw_error=false) !== nothin
     return
 end
 
-# helper function to load a driver, query its version, and optionally query device
-# capabilities. needs to happen in a separate process because dlclose is unreliable.
-function inspect_driver(driver, deps=String[]; inspect_devices=false)
-    # NOTE: no use of the executable helper or it would always end up using
-    #       the forwards-compatible driver library packaged next to it.
-    cmd = `$(cuda_inspect_driver_path) $driver $inspect_devices $deps`
-
-    # run the command
-    output = try
-        read(cmd, String)
-    catch _
-        return nothing
-    end
-
-    # parse the versions
-    lines = readlines(IOBuffer(output))
-    isempty(lines) && return nothing
-    driver_version = parse(VersionNumber, lines[1])
-    if inspect_devices
-        device_capabilities = VersionNumber[]
-        for i in 2:length(lines)
-            push!(device_capabilities, parse(VersionNumber, lines[i]))
-        end
-        return driver_version, device_capabilities
-    else
-        return driver_version
-    end
-end
-
 # fetch driver details
 compat_driver_task = @static if VERSION >= v"1.12-"
     # XXX: avoid concurrent compilation (JuliaLang/julia#59834)
@@ -93,40 +64,22 @@ else
 end
 system_driver_task = @static if VERSION >= v"1.12-"
     # XXX: avoid concurrent compilation (JuliaLang/julia#59834)
-    Threads.@spawn :samepool inspect_driver(libcuda_system; inspect_devices=true)
+    Threads.@spawn :samepool inspect_driver(libcuda_system)
 else
-    Threads.@spawn inspect_driver(libcuda_system; inspect_devices=true)
+    Threads.@spawn inspect_driver(libcuda_system)
 end
-compat_driver_details = fetch(compat_driver_task)
-if compat_driver_details === nothing
+compat_driver_info = fetch(compat_driver_task)
+if compat_driver_info === nothing
     @debug "Failed to load forwards-compatible driver."
     return
 end
-compat_driver_version = compat_driver_details::VersionNumber
-@debug "Forwards compatible driver version: $compat_driver_version"
-system_driver_details = fetch(system_driver_task)
-if system_driver_details === nothing
+@debug "Forwards compatible driver version: $(compat_driver_info.version)"
+system_driver_info = fetch(system_driver_task)
+if system_driver_info === nothing
     @debug "Failed to load system driver."
     return
 end
-system_driver_version = system_driver_details[1]::VersionNumber
-device_capabilities = system_driver_details[2]::Vector{VersionNumber}
-@debug "System driver version: $system_driver_version"
-
-# determine if loading the forwards-compatible driver would exclude devices
-for (dev, cap) in enumerate(device_capabilities)
-    # CUDA 12 deprecated Kepler
-    if compat_driver_version >= v"12" && system_driver_version < v"12" && v"3.0" <= cap <= v"3.5"
-        @debug "Loading forwards-compatible driver would exclude device $dev with capability $cap"
-        return
-    end
-
-    # CUDA 13 deprecated Maxwell, Pascal, and Volta
-    if compat_driver_version >= v"13" && system_driver_version < v"13" && v"5.0" <= cap <= v"7.2"
-        @debug "Loading forwards-compatible driver would exclude device $dev with capability $cap"
-        return
-    end
-end
+@debug "System driver version: $(system_driver_info.version)"
 
 # finally, load the forwards-compatible driver
 @debug "Using forwards-compatible CUDA driver."

--- a/C/CUDA/CUDA_Driver/inspect_driver.jl
+++ b/C/CUDA/CUDA_Driver/inspect_driver.jl
@@ -1,0 +1,46 @@
+# Precompile the process-spawning and version-parsing hot path of `inspect_driver`,
+# because platform augmentation runs under Pkg's `select_artifacts.jl` subprocess
+# with `--compile=min`, where non-precompiled methods are interpreted (and slow).
+precompile(Tuple{typeof(Base.cmd_gen), Tuple{Tuple{Base.Cmd}, Tuple{String}, Tuple{Bool}, Tuple{Array{String, 1}}}})
+precompile(Tuple{typeof(Base.arg_gen), Bool})
+precompile(Tuple{typeof(Base.read), Base.Cmd, Type{String}})
+precompile(Tuple{typeof(Base.readlines), Base.IOBuffer})
+precompile(Tuple{typeof(Base.push!), Array{Base.VersionNumber, 1}, Base.VersionNumber})
+precompile(Tuple{typeof(Base.Iterators.enumerate), Array{Base.VersionNumber, 1}})
+precompile(Tuple{typeof(Base.iterate), Base.Iterators.Enumerate{Array{Base.VersionNumber, 1}}})
+precompile(Tuple{typeof(Base.iterate), Base.Iterators.Enumerate{Array{Base.VersionNumber, 1}}, Tuple{Int64, Int64}})
+precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Int64, Base.VersionNumber}, Int64})
+precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Int64, Base.VersionNumber}, Int64, Int64})
+
+"""
+    inspect_driver(driver, deps=String[]; inspect_devices=false)
+
+Invoke the `cuda_inspect_driver` helper in a subprocess to query a CUDA driver
+without dlopen'ing it in the caller's process. Returns `nothing` on failure,
+otherwise a NamedTuple `(; path, version, capabilities)` where `path` is the
+resolved absolute path to the driver, `version` is the driver's reported
+version, and `capabilities` is a `Vector{VersionNumber}` of device compute
+capabilities — empty when `inspect_devices` is `false`.
+"""
+function inspect_driver(driver, deps=String[]; inspect_devices::Bool=false)
+    cmd = `$cuda_inspect_driver_path $driver $inspect_devices $deps`
+    output = try
+        read(cmd, String)
+    catch _
+        return nothing
+    end
+    lines = readlines(IOBuffer(output))
+    length(lines) < 2 && return nothing
+    path = lines[1]
+    version = tryparse(VersionNumber, lines[2])
+    version === nothing && return nothing
+    capabilities = VersionNumber[]
+    if inspect_devices
+        for i in 3:length(lines)
+            cap = tryparse(VersionNumber, lines[i])
+            cap === nothing && continue
+            push!(capabilities, cap)
+        end
+    end
+    return (; path, version, capabilities)
+end

--- a/C/CUDA/CUDA_Driver/src/cuda_inspect_driver.c
+++ b/C/CUDA/CUDA_Driver/src/cuda_inspect_driver.c
@@ -1,6 +1,8 @@
 /* Script to check the usability of CUDA drivers. */
 
+#define _GNU_SOURCE
 #include <dlfcn.h>
+#include <link.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,6 +40,15 @@ int main(int argc, char *argv[]) {
     if (library_handle == NULL) {
         return -1;
     }
+
+    /* Report the resolved absolute path of the loaded driver, so that callers
+     * can register it as a file dependency (e.g. for cache invalidation) without
+     * having to dlopen the library themselves. */
+    struct link_map *lm = NULL;
+    if (dlinfo(library_handle, RTLD_DI_LINKMAP, &lm) != 0 || lm == NULL) {
+        return -1;
+    }
+    printf("%s\n", lm->l_name);
 
     cuInit_t cuInit = (cuInit_t)dlsym(library_handle, "cuInit");
     if (cuInit == NULL) {


### PR DESCRIPTION
- Make the driver inspection utility reusable
- Also have it inspect the driver's full path (for include_dependency)
- Don't have it inspect device capabilities, as that's unneeded (drivers are backwards compatible) and hurts load time.