### PR TITLE
[.claude] mcp-bb-sandbox: detach session subprocess from controlling TTY

### DIFF
--- a/.claude/mcp-bb-sandbox/server.jl
+++ b/.claude/mcp-bb-sandbox/server.jl
@@ -48,6 +48,18 @@ function make_sandbox_cmd(params::AbstractDict)
         cmd = Cmd(`$(JULIA_CMD) --project=$CI_PROJECT $RUN_SHELL_SCRIPT $platform $PROJECT_ROOT`; dir=PROJECT_ROOT)
     end
 
+    # Detach the subprocess from the parent's controlling TTY (this MCP server
+    # is itself spawned by Claude Code, whose stdin is the user's terminal).
+    # Without this, the sandbox bind-mounts the host /dev/tty into the
+    # container, and any descendant — bash, configure, meson, … — that opens
+    # /dev/tty writes escape sequences (focus reporting, raw mode, ^Z) directly
+    # to the user's terminal, leaving it in a broken state that `reset` cannot
+    # recover.  `detach=true` calls setsid() in the child, so /dev/tty resolves
+    # to ENXIO across the whole subtree.  See
+    # JuliaContainerization/Sandbox.jl#159.  Upstream fix:
+    # JuliaBench/ClaudeMCPTools.jl#4.
+    cmd = Cmd(cmd; detach=true)
+
     return (cmd, metadata)
 end
 


### PR DESCRIPTION
The `bb-sandbox` MCP server is spawned by Claude Code on the user's terminal. Without `detach=true`, the Julia subprocess that runs the BinaryBuilder sandbox inherits Claude's controlling TTY — and so does everything inside the sandbox, because `Sandbox.jl` bind-mounts the host's `/dev/tty` into the container.

Build tools, `bash`, `configure` scripts — anything that opens `/dev/tty` — then writes escape sequences (focus reporting, raw mode, occasional `^Z`) directly to the user's terminal, leaving it in a state that `reset` cannot recover. Reported in JuliaContainerization/Sandbox.jl#159.

This patches `make_sandbox_cmd` so the spawned Julia subprocess is started with `detach=true`, which calls `setsid()` in the child. The whole subtree is then sessionless, and `/dev/tty` access from inside the sandbox fails cleanly with `ENXIO`.

This is a local backstop matching the upstream fix in JuliaBench/ClaudeMCPTools.jl#4 — having it here means the bb-sandbox MCP keeps working correctly regardless of which `ClaudeMCPTools` version the user happens to have resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)