### PR TITLE
SCALAPACK64: new ILP64 build with `_64_`-suffixed exports

### DIFF
--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -132,8 +132,12 @@ find CMakeFiles/scalapack.dir -name "*.o" > /tmp/scalapack_objs.txt
 echo "=== symbols renamed ($(wc -l < /tmp/scalapack_redefine.txt) total) ==="
 cat /tmp/scalapack_redefine.txt
 
+# Some llvm-objcopy builds on BB don't support --redefine-syms=<file>;
+# expand the map into per-symbol --redefine-sym args, which is supported
+# across all objcopy variants we care about.
+OBJCOPY_ARGS=$(awk '{printf " --redefine-sym=%s=%s", $1, $2}' /tmp/scalapack_redefine.txt)
 while read -r o; do
-    ${OBJCOPY} --redefine-syms=/tmp/scalapack_redefine.txt "$o"
+    ${OBJCOPY} ${OBJCOPY_ARGS} "$o"
 done < /tmp/scalapack_objs.txt
 
 # Force re-link with renamed objects so `.dynsym` reflects the rewrite.

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -4,11 +4,11 @@ const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SCALAPACK64"
-version = v"2.2.2"
+version = v"2.2.3"
 ygg_version = v"2.2.3"
 
 sources = [
-  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "25935e1a7e022ede9fd71bd86dcbaa7a3f1846b7"),
+  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -101,6 +101,9 @@ make install
     done
 } > /tmp/scalapack_redefine.txt
 
+echo "=== symbols renamed ($(wc -l < /tmp/scalapack_redefine.txt) total) ==="
+cat /tmp/scalapack_redefine.txt
+
 ${target}-objcopy --redefine-syms=/tmp/scalapack_redefine.txt \
     "${libdir}/libscalapack.${dlext}"
 

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -15,6 +15,8 @@ script = raw"""
 mkdir -p ${libdir}
 cd $WORKSPACE/srcdir/scalapack
 
+apk del cmake
+
 CFLAGS=(-Wno-error=implicit-function-declaration)
 FFLAGS=(-cpp -ffixed-line-length-none)
 
@@ -149,6 +151,7 @@ dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), compat="5.4.0"),
     Dependency("mpif_jll"; compat="0.1.5", platforms=filter(p -> p["mpi"] == "mpiabi", platforms)),
+    HostBuildDependency(PackageSpec(; name="CMake_jll")),
 ]
 append!(dependencies, platform_dependencies)
 

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -17,10 +17,7 @@ cd $WORKSPACE/srcdir/scalapack
 
 apk del cmake
 
-# v2.2.3 introduced an unconditional try_run() probe in
-# CMAKE/FortranMangling.cmake that fails under cross-compilation
-# (TryRunResults.cmake → xintface_res=PLEASE_FILL_OUT-FAILED_TO_RUN).
-# We already pass -DCDEFS=Add_; stub the probe out.
+# v2.2.3 try_run()s a Fortran-mangling probe; fails under cross-compile.
 cat > CMAKE/FortranMangling.cmake <<'EOF'
 include_guard()
 EOF
@@ -46,15 +43,11 @@ else
   LBT=(-lblastrampoline)
 fi
 
-# ILP64: 64-bit Fortran INTEGERs and 64-bit C `Int`.
 CPPFLAGS=(-DInt=long)
 FFLAGS+=(-fdefault-integer-8)
 
-# BLAS/LAPACK names that ScaLAPACK calls into.  Rewritten at compile
-# time to the `_64_` ABI via -D defines below.
 blas_lapack_syms=(caxpy cbdsqr ccopy cdotc cdotu cgbmv cgbtrf cgemm cgemv cgerc cgeru cgesv cgetrf cgetrs chbmv chemm chemv cher cher2 cher2k cherk chetrd clacgv clacpy cladiv clanhs clarfg clartg claset clasr classq claswp cpbtrf cpotrf cpttrf crot csbmv cscal csscal cswap csymm csyr2k csyrk ctbtrs ctrmm ctrmv ctrsm ctrsv ctrtrs dasum daxpy dbdsqr dcopy ddot dgbmv dgbtrf dgemm dgemv dger dgesv dgetrf dgetrs dhbmv disnan dlabad dlacpy dladiv dlae2 dlaebz dlaed4 dlaev2 dlagtf dlagts dlahqr dlamc3 dlamch dlange dlanst dlanv2 dlapy2 dlapy3 dlaqr0 dlaqr1 dlaqr3 dlaqr4 dlarfg dlarfx dlarnv dlarra dlarrb dlarrc dlarrd dlarrk dlarrv dlartg dlaruv dlascl dlaset dlasq2 dlasr dlasrt dlassq dlaswp dlasy2 dnrm2 dpbtrf dpotrf dpttrf drot dsbmv dscal dstedc dsteqr dsterf dswap dsymm dsymv dsyr dsyr2 dsyr2k dsyrk dsytrd dtbtrs dtrmm dtrmv dtrsm dtrsv dtrtrs dzasum dznrm2 dzsum1 icamax icmax1 idamax ieeeck ilaenv isamax izamax izmax1 lsame lsamen sasum saxpy sbdsqr scasum scnrm2 scopy scsum1 sdot sgbmv sgbtrf sgemm sgemv sger sgesv sgetrf sgetrs shbmv sisnan slabad slacpy sladiv slae2 slaebz slaed4 slaev2 slagtf slagts slahqr slamc3 slamch slange slanst slanv2 slapy2 slapy3 slaqr0 slaqr1 slaqr3 slaqr4 slarfg slarfx slarnv slarra slarrb slarrc slarrd slarrk slarrv slartg slaruv slascl slaset slasq2 slasr slasrt slassq slaswp slasy2 snrm2 spbtrf spotrf spttrf srot ssbmv sscal sstedc ssteqr ssterf sswap ssymm ssymv ssyr ssyr2 ssyr2k ssyrk ssytrd stbtrs strmm strmv strsm strsv strtrs xerbla zaxpy zbdsqr zcopy zdbmv zdotc zdotu zdscal zgbmv zgbtrf zgemm zgemv zgerc zgeru zgesv zgetrf zgetrs zhbmv zhemm zhemv zher zher2 zher2k zherk zhetrd zlacgv zlacpy zladiv zlanhs zlarfg zlartg zlaset zlasr zlassq zlaswp zpbtrf zpotrf zpttrf zrot zscal zswap zsymm zsyr2k zsyrk ztbtrs ztrmm ztrmv ztrsm ztrsv ztrtrs)
 
-# CMakeLists.txt doesn't add MPI libs to the link line; pass them explicitly.
 MPI_SETTINGS=(-DMPI_BASE_DIR="${prefix}")
 MPILIBS=()
 if [[ ${bb_full_target} == *microsoftmpi* ]]; then
@@ -81,10 +74,9 @@ CMAKE_FLAGS_BASE=(-DCMAKE_INSTALL_PREFIX=${prefix}
                   ${MPI_SETTINGS[*]}
                   -DCDEFS=Add_)
 
-# Pass 1: vanilla compile to enumerate ScaLAPACK's defined exports.
-# We need the symbol list to construct the -D rename defines below.
-# On Apple, ${target}-nm is missing — use llvm-nm and strip the Mach-O
-# leading underscore so the form matches ELF.
+# Pass 1: compile vanilla so we can nm-enumerate ScaLAPACK's exports.
+# Source-scanning is unreliable because BLACS C wrappers hide names
+# behind macros (F_VOID_FUNC, F_INT_FUNC, ...).
 mkdir build1
 cd build1
 cmake .. "${CMAKE_FLAGS_BASE[@]}" \
@@ -94,28 +86,23 @@ make -j${nproc} all
 
 if [[ ${target} == *apple* ]]; then
     NM=llvm-nm
-    NM_DEFINED_FILTER='$2 ~ /^[TW]$/ {sub(/^_/, "", $3); print $3}'
+    NM_FILTER='$2 ~ /^[TW]$/ {sub(/^_/, "", $3); print $3}'
 else
     NM=${target}-nm
-    NM_DEFINED_FILTER='$2 ~ /^[TW]$/ {print $3}'
+    NM_FILTER='$2 ~ /^[TW]$/ {print $3}'
 fi
 
 find CMakeFiles/scalapack.dir -name "*.o" > /tmp/scalapack_objs.txt
 ${NM} --defined-only $(cat /tmp/scalapack_objs.txt) 2>/dev/null \
-    | awk "${NM_DEFINED_FILTER}" \
+    | awk "${NM_FILTER}" \
     | grep -E '^[a-z][a-zA-Z0-9_]*_$' \
     | grep -v '_64_$' \
     | sed 's/_$//' \
     | sort -u > /tmp/scalapack_exports.txt
 cd ..
 
-echo "=== ScaLAPACK exports to rename ($(wc -l < /tmp/scalapack_exports.txt)) ==="
-
-# Build the -D rename defines.  ScaLAPACK Fortran source is UPPERCASE and
-# the compiler appends `_` for name mangling, so:
-#   Fortran source: -DPDGEMM=PDGEMM_64       (preprocessor sees PDGEMM, no _)
-#   C source:       -Dpdgemm_=pdgemm_64_     (C ref has trailing _)
-# Apply both to BLAS/LAPACK refs and to ScaLAPACK's own exports.
+# Fortran source is UPPERCASE without trailing `_` (compiler adds it);
+# C source has it. So we emit two sets of defines.
 : >/tmp/fortran_defines.txt
 : >/tmp/c_defines.txt
 { cat /tmp/scalapack_exports.txt; printf '%s\n' "${blas_lapack_syms[@]}"; } | sort -u \
@@ -127,9 +114,7 @@ echo "=== ScaLAPACK exports to rename ($(wc -l < /tmp/scalapack_exports.txt)) ==
 RENAME_F=$(tr '\n' ' ' < /tmp/fortran_defines.txt)
 RENAME_C=$(tr '\n' ' ' < /tmp/c_defines.txt)
 
-# Pass 2: rebuild from scratch with -D defines so the compiler emits
-# `_64_`-suffixed symbols directly. Works the same on ELF and Mach-O —
-# no post-link symbol manipulation required.
+# Pass 2: rebuild with -D defines so the compiler emits `_64_` directly.
 mkdir build
 cd build
 cmake .. "${CMAKE_FLAGS_BASE[@]}" \
@@ -138,7 +123,6 @@ cmake .. "${CMAKE_FLAGS_BASE[@]}" \
 make -j${nproc} all
 make install
 
-# Ship as libscalapack64 so it coexists with SCALAPACK_jll's libscalapack.
 mv -v ${libdir}/libscalapack.${dlext} ${libdir}/libscalapack64.${dlext}
 
 for l in $(find ${prefix}/lib -xtype l); do
@@ -148,7 +132,6 @@ for l in $(find ${prefix}/lib -xtype l); do
 done
 
 PATCHELF_FLAGS=()
-# aarch64 / ppc64le have 64 kB page sizes
 if [[ ${target} == aarch64-* || ${target} == powerpc64le-* ]]; then
   PATCHELF_FLAGS+=(--page-size 65536)
 fi
@@ -167,8 +150,8 @@ augment_platform_block = """
 """
 
 platforms = expand_gfortran_versions(supported_platforms())
-platforms = filter(p -> !Sys.iswindows(p), platforms)  # MPI on Windows not configured
-platforms = filter(p -> nbits(p) == 64, platforms)     # ILP64 needs 64-bit address space
+platforms = filter(p -> !Sys.iswindows(p), platforms)
+platforms = filter(p -> nbits(p) == 64, platforms)
 
 platforms, platform_dependencies = MPI.augment_platforms(platforms)
 
@@ -185,4 +168,4 @@ dependencies = [
 append!(dependencies, platform_dependencies)
 
 build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.9", preferred_gcc_version=v"5")
+               augment_platform_block, julia_compat="1.9", preferred_gcc_version=v"9")

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -17,6 +17,14 @@ cd $WORKSPACE/srcdir/scalapack
 
 apk del cmake
 
+# v2.2.3 introduced an unconditional try_run() probe in
+# CMAKE/FortranMangling.cmake that fails under cross-compilation
+# (TryRunResults.cmake → xintface_res=PLEASE_FILL_OUT-FAILED_TO_RUN).
+# We already pass -DCDEFS=Add_; stub the probe out.
+cat > CMAKE/FortranMangling.cmake <<'EOF'
+include_guard()
+EOF
+
 CFLAGS=(-Wno-error=implicit-function-declaration)
 FFLAGS=(-cpp -ffixed-line-length-none)
 
@@ -82,32 +90,42 @@ mkdir build
 cd build
 cmake .. "${CMAKE_FLAGS[@]}"
 make -j${nproc} all
-make install
 
 # Rewrite symbols to the `_64_` convention used by libblastrampoline-aware
-# callers (PETSc, MUMPS, ...).  Single objcopy pass over a rename map
-# built from two sources:
+# callers (PETSc, MUMPS, ...).  objcopy --redefine-sym only rewrites
+# `.symtab` — to land the rename in the shipped library's `.dynsym`,
+# we have to apply it at the `.o` stage, then force a relink.
+# Rename map is built from two sources:
 #   1. ScaLAPACK's own defined exports (pdgemm_, numroc_, ...) — every
 #      defined T/W text symbol ending in `_` and not already `_64_`,
-#      enumerated dynamically so future upstream additions are covered.
+#      enumerated dynamically from the .o files so future upstream
+#      additions are covered.
 #   2. BLAS/LAPACK undefined refs — drawn from blas_lapack_syms only,
 #      not a blanket sweep, so MPI/libc undefined refs aren't renamed.
+find CMakeFiles/scalapack.dir -name "*.o" > /tmp/scalapack_objs.txt
 {
-    nm -D --defined-only "${libdir}/libscalapack.${dlext}" \
+    ${target}-nm --defined-only $(cat /tmp/scalapack_objs.txt) 2>/dev/null \
         | awk '$2 ~ /^[TW]$/ {print $3}' \
         | grep -E '^[a-z][a-zA-Z0-9_]*_$' \
         | grep -v '_64_$' \
+        | sort -u \
         | awk '{print $1, substr($1, 1, length($1)-1) "_64_"}'
     for sym in "${blas_lapack_syms[@]}"; do
         echo "${sym}_ ${sym}_64_"
     done
-} > /tmp/scalapack_redefine.txt
+} | sort -u > /tmp/scalapack_redefine.txt
 
 echo "=== symbols renamed ($(wc -l < /tmp/scalapack_redefine.txt) total) ==="
 cat /tmp/scalapack_redefine.txt
 
-${target}-objcopy --redefine-syms=/tmp/scalapack_redefine.txt \
-    "${libdir}/libscalapack.${dlext}"
+while read -r o; do
+    ${target}-objcopy --redefine-syms=/tmp/scalapack_redefine.txt "$o"
+done < /tmp/scalapack_objs.txt
+
+# Force re-link with renamed objects so `.dynsym` reflects the rewrite.
+rm -f lib/libscalapack.${dlext}*
+make -j${nproc} all
+make install
 
 # Ship as libscalapack64 so it coexists with SCALAPACK_jll's libscalapack.
 mv -v ${libdir}/libscalapack.${dlext} ${libdir}/libscalapack64.${dlext}

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -102,10 +102,24 @@ make -j${nproc} all
 #      additions are covered.
 #   2. BLAS/LAPACK undefined refs — drawn from blas_lapack_syms only,
 #      not a blanket sweep, so MPI/libc undefined refs aren't renamed.
+# Apple toolchains don't ship working ${target}-{nm,objcopy} (Mach-O).
+# llvm-{nm,objcopy} understand both ELF and Mach-O and are host-side.
+if [[ ${target} == *apple* ]]; then
+    NM=llvm-nm
+    OBJCOPY=llvm-objcopy
+    # On Mach-O the symbol prefix is `_`; strip it so the dynamic
+    # enumeration produces the same `name_` form as ELF.
+    NM_DEFINED_FILTER='$2 ~ /^[TW]$/ {sub(/^_/, "", $3); print $3}'
+else
+    NM=${target}-nm
+    OBJCOPY=${target}-objcopy
+    NM_DEFINED_FILTER='$2 ~ /^[TW]$/ {print $3}'
+fi
+
 find CMakeFiles/scalapack.dir -name "*.o" > /tmp/scalapack_objs.txt
 {
-    ${target}-nm --defined-only $(cat /tmp/scalapack_objs.txt) 2>/dev/null \
-        | awk '$2 ~ /^[TW]$/ {print $3}' \
+    ${NM} --defined-only $(cat /tmp/scalapack_objs.txt) 2>/dev/null \
+        | awk "${NM_DEFINED_FILTER}" \
         | grep -E '^[a-z][a-zA-Z0-9_]*_$' \
         | grep -v '_64_$' \
         | sort -u \
@@ -119,7 +133,7 @@ echo "=== symbols renamed ($(wc -l < /tmp/scalapack_redefine.txt) total) ==="
 cat /tmp/scalapack_redefine.txt
 
 while read -r o; do
-    ${target}-objcopy --redefine-syms=/tmp/scalapack_redefine.txt "$o"
+    ${OBJCOPY} --redefine-syms=/tmp/scalapack_redefine.txt "$o"
 done < /tmp/scalapack_objs.txt
 
 # Force re-link with renamed objects so `.dynsym` reflects the rewrite.

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -46,15 +46,12 @@ else
   LBT=(-lblastrampoline)
 fi
 
-# ILP64: 64-bit Fortran INTEGERs and 64-bit C `Int`.  Symbol naming is
-# fixed up post-link with objcopy below.
+# ILP64: 64-bit Fortran INTEGERs and 64-bit C `Int`.
 CPPFLAGS=(-DInt=long)
 FFLAGS+=(-fdefault-integer-8)
 
-# BLAS/LAPACK names that ScaLAPACK calls into.  Used as the safety
-# boundary for the post-link rewrite: only these undefined refs get
-# redirected to libblastrampoline's `_64_` slot.  MPI/libc undefined
-# refs are not in the list and stay untouched.
+# BLAS/LAPACK names that ScaLAPACK calls into.  Rewritten at compile
+# time to the `_64_` ABI via -D defines below.
 blas_lapack_syms=(caxpy cbdsqr ccopy cdotc cdotu cgbmv cgbtrf cgemm cgemv cgerc cgeru cgesv cgetrf cgetrs chbmv chemm chemv cher cher2 cher2k cherk chetrd clacgv clacpy cladiv clanhs clarfg clartg claset clasr classq claswp cpbtrf cpotrf cpttrf crot csbmv cscal csscal cswap csymm csyr2k csyrk ctbtrs ctrmm ctrmv ctrsm ctrsv ctrtrs dasum daxpy dbdsqr dcopy ddot dgbmv dgbtrf dgemm dgemv dger dgesv dgetrf dgetrs dhbmv disnan dlabad dlacpy dladiv dlae2 dlaebz dlaed4 dlaev2 dlagtf dlagts dlahqr dlamc3 dlamch dlange dlanst dlanv2 dlapy2 dlapy3 dlaqr0 dlaqr1 dlaqr3 dlaqr4 dlarfg dlarfx dlarnv dlarra dlarrb dlarrc dlarrd dlarrk dlarrv dlartg dlaruv dlascl dlaset dlasq2 dlasr dlasrt dlassq dlaswp dlasy2 dnrm2 dpbtrf dpotrf dpttrf drot dsbmv dscal dstedc dsteqr dsterf dswap dsymm dsymv dsyr dsyr2 dsyr2k dsyrk dsytrd dtbtrs dtrmm dtrmv dtrsm dtrsv dtrtrs dzasum dznrm2 dzsum1 icamax icmax1 idamax ieeeck ilaenv isamax izamax izmax1 lsame lsamen sasum saxpy sbdsqr scasum scnrm2 scopy scsum1 sdot sgbmv sgbtrf sgemm sgemv sger sgesv sgetrf sgetrs shbmv sisnan slabad slacpy sladiv slae2 slaebz slaed4 slaev2 slagtf slagts slahqr slamc3 slamch slange slanst slanv2 slapy2 slapy3 slaqr0 slaqr1 slaqr3 slaqr4 slarfg slarfx slarnv slarra slarrb slarrc slarrd slarrk slarrv slartg slaruv slascl slaset slasq2 slasr slasrt slassq slaswp slasy2 snrm2 spbtrf spotrf spttrf srot ssbmv sscal sstedc ssteqr ssterf sswap ssymm ssymv ssyr ssyr2 ssyr2k ssyrk ssytrd stbtrs strmm strmv strsm strsv strtrs xerbla zaxpy zbdsqr zcopy zdbmv zdotc zdotu zdscal zgbmv zgbtrf zgemm zgemv zgerc zgeru zgesv zgetrf zgetrs zhbmv zhemm zhemv zher zher2 zher2k zherk zhetrd zlacgv zlacpy zladiv zlanhs zlarfg zlartg zlaset zlasr zlassq zlaswp zpbtrf zpotrf zpttrf zrot zscal zswap zsymm zsyr2k zsyrk ztbtrs ztrmm ztrmv ztrsm ztrsv ztrtrs)
 
 # CMakeLists.txt doesn't add MPI libs to the link line; pass them explicitly.
@@ -73,75 +70,71 @@ elif [[ ${bb_full_target} == *openmpi* ]]; then
     MPILIBS=(-lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh -lmpi)
 fi
 
-CMAKE_FLAGS=(-DCMAKE_INSTALL_PREFIX=${prefix}
-             -DCMAKE_FIND_ROOT_PATH=${prefix}
-             -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}"
-             -DCMAKE_Fortran_FLAGS="${CPPFLAGS[*]} ${FFLAGS[*]}"
-             -DCMAKE_C_FLAGS="${CPPFLAGS[*]} ${CFLAGS[*]}"
-             -DCMAKE_BUILD_TYPE=Release
-             -DBLAS_LIBRARIES="${LBT[*]} ${MPILIBS[*]}"
-             -DLAPACK_LIBRARIES="${LBT[*]}"
-             -DSCALAPACK_BUILD_TESTS=OFF
-             -DBUILD_SHARED_LIBS=ON
-             ${MPI_SETTINGS[*]}
-             -DCDEFS=Add_)
+CMAKE_FLAGS_BASE=(-DCMAKE_INSTALL_PREFIX=${prefix}
+                  -DCMAKE_FIND_ROOT_PATH=${prefix}
+                  -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}"
+                  -DCMAKE_BUILD_TYPE=Release
+                  -DBLAS_LIBRARIES="${LBT[*]} ${MPILIBS[*]}"
+                  -DLAPACK_LIBRARIES="${LBT[*]}"
+                  -DSCALAPACK_BUILD_TESTS=OFF
+                  -DBUILD_SHARED_LIBS=ON
+                  ${MPI_SETTINGS[*]}
+                  -DCDEFS=Add_)
 
-mkdir build
-cd build
-cmake .. "${CMAKE_FLAGS[@]}"
+# Pass 1: vanilla compile to enumerate ScaLAPACK's defined exports.
+# We need the symbol list to construct the -D rename defines below.
+# On Apple, ${target}-nm is missing — use llvm-nm and strip the Mach-O
+# leading underscore so the form matches ELF.
+mkdir build1
+cd build1
+cmake .. "${CMAKE_FLAGS_BASE[@]}" \
+    -DCMAKE_Fortran_FLAGS="${CPPFLAGS[*]} ${FFLAGS[*]}" \
+    -DCMAKE_C_FLAGS="${CPPFLAGS[*]} ${CFLAGS[*]}"
 make -j${nproc} all
 
-# Rewrite symbols to the `_64_` convention used by libblastrampoline-aware
-# callers (PETSc, MUMPS, ...).  objcopy --redefine-sym only rewrites
-# `.symtab` — to land the rename in the shipped library's `.dynsym`,
-# we have to apply it at the `.o` stage, then force a relink.
-# Rename map is built from two sources:
-#   1. ScaLAPACK's own defined exports (pdgemm_, numroc_, ...) — every
-#      defined T/W text symbol ending in `_` and not already `_64_`,
-#      enumerated dynamically from the .o files so future upstream
-#      additions are covered.
-#   2. BLAS/LAPACK undefined refs — drawn from blas_lapack_syms only,
-#      not a blanket sweep, so MPI/libc undefined refs aren't renamed.
-# Apple toolchains don't ship working ${target}-{nm,objcopy} (Mach-O).
-# llvm-{nm,objcopy} understand both ELF and Mach-O and are host-side.
 if [[ ${target} == *apple* ]]; then
     NM=llvm-nm
-    OBJCOPY=llvm-objcopy
-    # On Mach-O the symbol prefix is `_`; strip it so the dynamic
-    # enumeration produces the same `name_` form as ELF.
     NM_DEFINED_FILTER='$2 ~ /^[TW]$/ {sub(/^_/, "", $3); print $3}'
 else
     NM=${target}-nm
-    OBJCOPY=${target}-objcopy
     NM_DEFINED_FILTER='$2 ~ /^[TW]$/ {print $3}'
 fi
 
 find CMakeFiles/scalapack.dir -name "*.o" > /tmp/scalapack_objs.txt
-{
-    ${NM} --defined-only $(cat /tmp/scalapack_objs.txt) 2>/dev/null \
-        | awk "${NM_DEFINED_FILTER}" \
-        | grep -E '^[a-z][a-zA-Z0-9_]*_$' \
-        | grep -v '_64_$' \
-        | sort -u \
-        | awk '{print $1, substr($1, 1, length($1)-1) "_64_"}'
-    for sym in "${blas_lapack_syms[@]}"; do
-        echo "${sym}_ ${sym}_64_"
+${NM} --defined-only $(cat /tmp/scalapack_objs.txt) 2>/dev/null \
+    | awk "${NM_DEFINED_FILTER}" \
+    | grep -E '^[a-z][a-zA-Z0-9_]*_$' \
+    | grep -v '_64_$' \
+    | sed 's/_$//' \
+    | sort -u > /tmp/scalapack_exports.txt
+cd ..
+
+echo "=== ScaLAPACK exports to rename ($(wc -l < /tmp/scalapack_exports.txt)) ==="
+
+# Build the -D rename defines.  ScaLAPACK Fortran source is UPPERCASE and
+# the compiler appends `_` for name mangling, so:
+#   Fortran source: -DPDGEMM=PDGEMM_64       (preprocessor sees PDGEMM, no _)
+#   C source:       -Dpdgemm_=pdgemm_64_     (C ref has trailing _)
+# Apply both to BLAS/LAPACK refs and to ScaLAPACK's own exports.
+: >/tmp/fortran_defines.txt
+: >/tmp/c_defines.txt
+{ cat /tmp/scalapack_exports.txt; printf '%s\n' "${blas_lapack_syms[@]}"; } | sort -u \
+    | while read -r s; do
+        upper=$(echo "$s" | tr 'a-z' 'A-Z')
+        echo "-D${upper}=${upper}_64" >> /tmp/fortran_defines.txt
+        echo "-D${s}_=${s}_64_" >> /tmp/c_defines.txt
     done
-} | sort -u > /tmp/scalapack_redefine.txt
+RENAME_F=$(tr '\n' ' ' < /tmp/fortran_defines.txt)
+RENAME_C=$(tr '\n' ' ' < /tmp/c_defines.txt)
 
-echo "=== symbols renamed ($(wc -l < /tmp/scalapack_redefine.txt) total) ==="
-cat /tmp/scalapack_redefine.txt
-
-# Some llvm-objcopy builds on BB don't support --redefine-syms=<file>;
-# expand the map into per-symbol --redefine-sym args, which is supported
-# across all objcopy variants we care about.
-OBJCOPY_ARGS=$(awk '{printf " --redefine-sym=%s=%s", $1, $2}' /tmp/scalapack_redefine.txt)
-while read -r o; do
-    ${OBJCOPY} ${OBJCOPY_ARGS} "$o"
-done < /tmp/scalapack_objs.txt
-
-# Force re-link with renamed objects so `.dynsym` reflects the rewrite.
-rm -f lib/libscalapack.${dlext}*
+# Pass 2: rebuild from scratch with -D defines so the compiler emits
+# `_64_`-suffixed symbols directly. Works the same on ELF and Mach-O —
+# no post-link symbol manipulation required.
+mkdir build
+cd build
+cmake .. "${CMAKE_FLAGS_BASE[@]}" \
+    -DCMAKE_Fortran_FLAGS="${CPPFLAGS[*]} ${FFLAGS[*]} ${RENAME_F}" \
+    -DCMAKE_C_FLAGS="${CPPFLAGS[*]} ${CFLAGS[*]} ${RENAME_C}"
 make -j${nproc} all
 make install
 

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -1,0 +1,178 @@
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
+const YGGDRASIL_DIR = "../../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
+
+name = "SCALAPACK64"
+version = v"2.2.2"
+ygg_version = v"2.2.3"
+
+sources = [
+  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "25935e1a7e022ede9fd71bd86dcbaa7a3f1846b7"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+mkdir -p ${libdir}
+cd $WORKSPACE/srcdir/scalapack
+
+CPPFLAGS=()
+CFLAGS=(-Wno-error=implicit-function-declaration)
+FFLAGS=(-cpp -ffixed-line-length-none)
+
+# Add `-fallow-argument-mismatch` if supported
+: >empty.f
+if gfortran -c -fallow-argument-mismatch empty.f >/dev/null 2>&1; then
+    FFLAGS+=(-fallow-argument-mismatch)
+fi
+rm -f empty.*
+
+# Add `-fcray-pointer` if supported
+: >empty.f
+if gfortran -c -fcray-pointer empty.f >/dev/null 2>&1; then
+    FFLAGS+=(-fcray-pointer)
+fi
+rm -f empty.*
+
+if [[ "${target}" == *mingw* ]]; then
+  LBT=(-lblastrampoline-5)
+else
+  LBT=(-lblastrampoline)
+fi
+
+# This artifact is always ILP64: 64-bit Fortran INTEGERs internally,
+# every BLAS/LAPACK reference redirected to libblastrampoline's `_64_`
+# entry points at compile-time, and every ScaLAPACK export renamed to
+# the same `_64_` convention post-link with objcopy (see below).
+CPPFLAGS+=(-DInt=long)
+FFLAGS+=(-fdefault-integer-8)
+
+# BLAS/LAPACK routines that ScaLAPACK calls into.  Rewriting these via
+# CPP -D makes ScaLAPACK's internal references resolve to the ILP64
+# (`_64_`-suffixed) entry points in libblastrampoline.  Must happen at
+# compile-time because the references are external and post-link
+# objcopy can't redirect undefined refs to a different external lib.
+syms=(caxpy cbdsqr ccopy cdotc cdotu cgbmv cgbtrf cgemm cgemv cgerc cgeru cgesv cgetrf cgetrs chbmv chemm chemv cher cher2 cher2k cherk chetrd clacgv clacpy cladiv clanhs clarfg clartg claset clasr classq claswp cpbtrf cpotrf cpttrf crot csbmv cscal csscal cswap csymm csyr2k csyrk ctbtrs ctrmm ctrmv ctrsm ctrsv ctrtrs dasum daxpy dbdsqr dcopy ddot dgbmv dgbtrf dgemm dgemv dger dgesv dgetrf dgetrs dhbmv disnan dlabad dlacpy dladiv dlae2 dlaebz dlaed4 dlaev2 dlagtf dlagts dlahqr dlamc3 dlamch dlange dlanst dlanv2 dlapy2 dlapy3 dlaqr0 dlaqr1 dlaqr3 dlaqr4 dlarfg dlarfx dlarnv dlarra dlarrb dlarrc dlarrd dlarrk dlarrv dlartg dlaruv dlascl dlaset dlasq2 dlasr dlasrt dlassq dlaswp dlasy2 dnrm2 dpbtrf dpotrf dpttrf drot dsbmv dscal dstedc dsteqr dsterf dswap dsymm dsymv dsyr dsyr2 dsyr2k dsyrk dsytrd dtbtrs dtrmm dtrmv dtrsm dtrsv dtrtrs dzasum dznrm2 dzsum1 icamax icmax1 idamax ieeeck ilaenv isamax izamax izmax1 lsame lsamen sasum saxpy sbdsqr scasum scnrm2 scopy scsum1 sdot sgbmv sgbtrf sgemm sgemv sger sgesv sgetrf sgetrs shbmv sisnan slabad slacpy sladiv slae2 slaebz slaed4 slaev2 slagtf slagts slahqr slamc3 slamch slange slanst slanv2 slapy2 slapy3 slaqr0 slaqr1 slaqr3 slaqr4 slarfg slarfx slarnv slarra slarrb slarrc slarrd slarrk slarrv slartg slaruv slascl slaset slasq2 slasr slasrt slassq slaswp slasy2 snrm2 spbtrf spotrf spttrf srot ssbmv sscal sstedc ssteqr ssterf sswap ssymm ssymv ssyr ssyr2 ssyr2k ssyrk ssytrd stbtrs strmm strmv strsm strsv strtrs xerbla zaxpy zbdsqr zcopy zdbmv zdotc zdotu zdscal zgbmv zgbtrf zgemm zgemv zgerc zgeru zgesv zgetrf zgetrs zhbmv zhemm zhemv zher zher2 zher2k zherk zhetrd zlacgv zlacpy zladiv zlanhs zlarfg zlartg zlaset zlasr zlassq zlaswp zpbtrf zpotrf zpttrf zrot zscal zswap zsymm zsyr2k zsyrk ztbtrs ztrmm ztrmv ztrsm ztrsv ztrtrs)
+for sym in ${syms[@]}; do
+    CPPFLAGS+=("-D${sym}=${sym}_64")
+    CPPFLAGS+=("-D${sym}_=${sym}_64_")   # due to some evil #defines in SCALAPACK
+    CPPFLAGS+=("-D${sym^^}=${sym}_64")
+done
+
+# We need to specify the MPI libraries explicitly because the
+# CMakeLists.txt doesn't properly add them when linking
+MPI_SETTINGS=(-DMPI_BASE_DIR="${prefix}")
+MPILIBS=()
+if [[ ${bb_full_target} == *microsoftmpi* ]]; then
+    MPI_SETTINGS+=(-DMPI_GUESS_LIBRARY_NAME=MSMPI)
+    MPILIBS=(-lmsmpifec64 -lmsmpi64)
+elif [[ ${bb_full_target} == *mpiabi* ]]; then
+    MPILIBS=(-lmpif -lmpi_abi)
+elif [[ ${bb_full_target} == *mpich* ]]; then
+    MPILIBS=(-lmpifort -lmpi)
+elif [[ ${bb_full_target} == *mpitrampoline* ]]; then
+    MPILIBS=(-lmpitrampoline)
+elif [[ ${bb_full_target} == *openmpi* ]]; then
+    MPILIBS=(-lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh -lmpi)
+fi
+
+CMAKE_FLAGS=(-DCMAKE_INSTALL_PREFIX=${prefix}
+             -DCMAKE_FIND_ROOT_PATH=${prefix}
+             -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}"
+             -DCMAKE_Fortran_FLAGS="${CPPFLAGS[*]} ${FFLAGS[*]}"
+             -DCMAKE_C_FLAGS="${CPPFLAGS[*]} ${CFLAGS[*]}"
+             -DCMAKE_BUILD_TYPE=Release
+             -DBLAS_LIBRARIES="${LBT[*]} ${MPILIBS[*]}"
+             -DLAPACK_LIBRARIES="${LBT[*]}"
+             -DSCALAPACK_BUILD_TESTS=OFF
+             -DBUILD_SHARED_LIBS=ON
+             ${MPI_SETTINGS[*]}
+             -DCDEFS=Add_)
+
+mkdir build
+cd build
+cmake .. "${CMAKE_FLAGS[@]}"
+
+make -j${nproc} all
+make install
+
+# Rename ScaLAPACK's own exported Fortran-mangled symbols (pdgemm_,
+# pdgetrf_, infog2l_, numroc_, ...) to the `_64_` suffix convention
+# used by libblastrampoline-aware callers (PETSc, MUMPS, ...).
+#
+# We do this post-link with objcopy --redefine-syms over every defined
+# T/W text symbol that ends in `_` and isn't already `_64_`-suffixed,
+# rather than maintaining a curated symbol list.  That way the rewrite
+# covers every export the artifact actually produces — including
+# anything new the build emits after a future ScaLAPACK upgrade —
+# without a bundled list to keep in sync with upstream.
+#
+# References we already redirected at compile-time (BLAS/LAPACK calls)
+# show up as undefined `_64_`-suffixed external refs to libblastrampoline
+# and are skipped by the `_64_$` filter, so they stay correct.
+nm -D --defined-only "${libdir}/libscalapack.${dlext}" \
+    | awk '$2 ~ /^[TW]$/ {print $3}' \
+    | grep -E '^[a-z][a-zA-Z0-9_]*_$' \
+    | grep -v '_64_$' \
+    | awk '{print $1, substr($1, 1, length($1)-1) "_64_"}' \
+    > /tmp/scalapack_redefine.txt
+
+${target}-objcopy --redefine-syms=/tmp/scalapack_redefine.txt \
+    "${libdir}/libscalapack.${dlext}"
+
+# Rename the artifact so it ships as libscalapack64 alongside
+# SCALAPACK_jll's libscalapack.
+mv -v ${libdir}/libscalapack.${dlext} ${libdir}/libscalapack64.${dlext}
+
+# If there were links that are now broken, fix 'em up
+for l in $(find ${prefix}/lib -xtype l); do
+  if [[ $(basename $(readlink ${l})) == libscalapack ]]; then
+    ln -vsf libscalapack64.${dlext} ${l}
+  fi
+done
+
+PATCHELF_FLAGS=()
+
+# ppc64le and aarch64 have 64 kB page sizes, don't muck up the ELF section load alignment
+if [[ ${target} == aarch64-* || ${target} == powerpc64le-* ]]; then
+  PATCHELF_FLAGS+=(--page-size 65536)
+fi
+
+if [[ ${target} == *linux* ]] || [[ ${target} == *freebsd* ]]; then
+  patchelf ${PATCHELF_FLAGS[@]} --set-soname libscalapack64.${dlext} ${libdir}/libscalapack64.${dlext}
+elif [[ ${target} == *apple* ]]; then
+  install_name_tool -id libscalapack64.${dlext} ${libdir}/libscalapack64.${dlext}
+fi
+"""
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+    $(MPI.augment)
+    augment_platform!(platform::Platform) = augment_mpi!(platform)
+"""
+
+platforms = expand_gfortran_versions(supported_platforms())
+# Don't know how to configure MPI for Windows
+platforms = filter(p -> !Sys.iswindows(p), platforms)
+# This artifact is ILP64; restrict to 64-bit platforms.
+platforms = filter(p -> nbits(p) == 64, platforms)
+
+platforms, platform_dependencies = MPI.augment_platforms(platforms)
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libscalapack64", :libscalapack64),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
+    Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), compat="5.4.0"),
+    Dependency("mpif_jll"; compat="0.1.5", platforms=filter(p -> p["mpi"] == "mpiabi", platforms)), # MPI Fortran bindings
+]
+append!(dependencies, platform_dependencies)
+
+# Build the tarballs.
+# We need at least GCC 5 for MPICH
+build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
+               augment_platform_block, julia_compat="1.9", preferred_gcc_version=v"5")

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -11,23 +11,19 @@ sources = [
   GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
 ]
 
-# Bash recipe for building across all platforms
 script = raw"""
 mkdir -p ${libdir}
 cd $WORKSPACE/srcdir/scalapack
 
-CPPFLAGS=()
 CFLAGS=(-Wno-error=implicit-function-declaration)
 FFLAGS=(-cpp -ffixed-line-length-none)
 
-# Add `-fallow-argument-mismatch` if supported
 : >empty.f
 if gfortran -c -fallow-argument-mismatch empty.f >/dev/null 2>&1; then
     FFLAGS+=(-fallow-argument-mismatch)
 fi
 rm -f empty.*
 
-# Add `-fcray-pointer` if supported
 : >empty.f
 if gfortran -c -fcray-pointer empty.f >/dev/null 2>&1; then
     FFLAGS+=(-fcray-pointer)
@@ -40,27 +36,18 @@ else
   LBT=(-lblastrampoline)
 fi
 
-# This artifact is always ILP64: 64-bit Fortran INTEGERs internally,
-# every BLAS/LAPACK reference redirected to libblastrampoline's `_64_`
-# entry points at compile-time, and every ScaLAPACK export renamed to
-# the same `_64_` convention post-link with objcopy (see below).
-CPPFLAGS+=(-DInt=long)
+# ILP64: 64-bit Fortran INTEGERs and 64-bit C `Int`.  Symbol naming is
+# fixed up post-link with objcopy below.
+CPPFLAGS=(-DInt=long)
 FFLAGS+=(-fdefault-integer-8)
 
-# BLAS/LAPACK routines that ScaLAPACK calls into.  Rewriting these via
-# CPP -D makes ScaLAPACK's internal references resolve to the ILP64
-# (`_64_`-suffixed) entry points in libblastrampoline.  Must happen at
-# compile-time because the references are external and post-link
-# objcopy can't redirect undefined refs to a different external lib.
-syms=(caxpy cbdsqr ccopy cdotc cdotu cgbmv cgbtrf cgemm cgemv cgerc cgeru cgesv cgetrf cgetrs chbmv chemm chemv cher cher2 cher2k cherk chetrd clacgv clacpy cladiv clanhs clarfg clartg claset clasr classq claswp cpbtrf cpotrf cpttrf crot csbmv cscal csscal cswap csymm csyr2k csyrk ctbtrs ctrmm ctrmv ctrsm ctrsv ctrtrs dasum daxpy dbdsqr dcopy ddot dgbmv dgbtrf dgemm dgemv dger dgesv dgetrf dgetrs dhbmv disnan dlabad dlacpy dladiv dlae2 dlaebz dlaed4 dlaev2 dlagtf dlagts dlahqr dlamc3 dlamch dlange dlanst dlanv2 dlapy2 dlapy3 dlaqr0 dlaqr1 dlaqr3 dlaqr4 dlarfg dlarfx dlarnv dlarra dlarrb dlarrc dlarrd dlarrk dlarrv dlartg dlaruv dlascl dlaset dlasq2 dlasr dlasrt dlassq dlaswp dlasy2 dnrm2 dpbtrf dpotrf dpttrf drot dsbmv dscal dstedc dsteqr dsterf dswap dsymm dsymv dsyr dsyr2 dsyr2k dsyrk dsytrd dtbtrs dtrmm dtrmv dtrsm dtrsv dtrtrs dzasum dznrm2 dzsum1 icamax icmax1 idamax ieeeck ilaenv isamax izamax izmax1 lsame lsamen sasum saxpy sbdsqr scasum scnrm2 scopy scsum1 sdot sgbmv sgbtrf sgemm sgemv sger sgesv sgetrf sgetrs shbmv sisnan slabad slacpy sladiv slae2 slaebz slaed4 slaev2 slagtf slagts slahqr slamc3 slamch slange slanst slanv2 slapy2 slapy3 slaqr0 slaqr1 slaqr3 slaqr4 slarfg slarfx slarnv slarra slarrb slarrc slarrd slarrk slarrv slartg slaruv slascl slaset slasq2 slasr slasrt slassq slaswp slasy2 snrm2 spbtrf spotrf spttrf srot ssbmv sscal sstedc ssteqr ssterf sswap ssymm ssymv ssyr ssyr2 ssyr2k ssyrk ssytrd stbtrs strmm strmv strsm strsv strtrs xerbla zaxpy zbdsqr zcopy zdbmv zdotc zdotu zdscal zgbmv zgbtrf zgemm zgemv zgerc zgeru zgesv zgetrf zgetrs zhbmv zhemm zhemv zher zher2 zher2k zherk zhetrd zlacgv zlacpy zladiv zlanhs zlarfg zlartg zlaset zlasr zlassq zlaswp zpbtrf zpotrf zpttrf zrot zscal zswap zsymm zsyr2k zsyrk ztbtrs ztrmm ztrmv ztrsm ztrsv ztrtrs)
-for sym in ${syms[@]}; do
-    CPPFLAGS+=("-D${sym}=${sym}_64")
-    CPPFLAGS+=("-D${sym}_=${sym}_64_")   # due to some evil #defines in SCALAPACK
-    CPPFLAGS+=("-D${sym^^}=${sym}_64")
-done
+# BLAS/LAPACK names that ScaLAPACK calls into.  Used as the safety
+# boundary for the post-link rewrite: only these undefined refs get
+# redirected to libblastrampoline's `_64_` slot.  MPI/libc undefined
+# refs are not in the list and stay untouched.
+blas_lapack_syms=(caxpy cbdsqr ccopy cdotc cdotu cgbmv cgbtrf cgemm cgemv cgerc cgeru cgesv cgetrf cgetrs chbmv chemm chemv cher cher2 cher2k cherk chetrd clacgv clacpy cladiv clanhs clarfg clartg claset clasr classq claswp cpbtrf cpotrf cpttrf crot csbmv cscal csscal cswap csymm csyr2k csyrk ctbtrs ctrmm ctrmv ctrsm ctrsv ctrtrs dasum daxpy dbdsqr dcopy ddot dgbmv dgbtrf dgemm dgemv dger dgesv dgetrf dgetrs dhbmv disnan dlabad dlacpy dladiv dlae2 dlaebz dlaed4 dlaev2 dlagtf dlagts dlahqr dlamc3 dlamch dlange dlanst dlanv2 dlapy2 dlapy3 dlaqr0 dlaqr1 dlaqr3 dlaqr4 dlarfg dlarfx dlarnv dlarra dlarrb dlarrc dlarrd dlarrk dlarrv dlartg dlaruv dlascl dlaset dlasq2 dlasr dlasrt dlassq dlaswp dlasy2 dnrm2 dpbtrf dpotrf dpttrf drot dsbmv dscal dstedc dsteqr dsterf dswap dsymm dsymv dsyr dsyr2 dsyr2k dsyrk dsytrd dtbtrs dtrmm dtrmv dtrsm dtrsv dtrtrs dzasum dznrm2 dzsum1 icamax icmax1 idamax ieeeck ilaenv isamax izamax izmax1 lsame lsamen sasum saxpy sbdsqr scasum scnrm2 scopy scsum1 sdot sgbmv sgbtrf sgemm sgemv sger sgesv sgetrf sgetrs shbmv sisnan slabad slacpy sladiv slae2 slaebz slaed4 slaev2 slagtf slagts slahqr slamc3 slamch slange slanst slanv2 slapy2 slapy3 slaqr0 slaqr1 slaqr3 slaqr4 slarfg slarfx slarnv slarra slarrb slarrc slarrd slarrk slarrv slartg slaruv slascl slaset slasq2 slasr slasrt slassq slaswp slasy2 snrm2 spbtrf spotrf spttrf srot ssbmv sscal sstedc ssteqr ssterf sswap ssymm ssymv ssyr ssyr2 ssyr2k ssyrk ssytrd stbtrs strmm strmv strsm strsv strtrs xerbla zaxpy zbdsqr zcopy zdbmv zdotc zdotu zdscal zgbmv zgbtrf zgemm zgemv zgerc zgeru zgesv zgetrf zgetrs zhbmv zhemm zhemv zher zher2 zher2k zherk zhetrd zlacgv zlacpy zladiv zlanhs zlarfg zlartg zlaset zlasr zlassq zlaswp zpbtrf zpotrf zpttrf zrot zscal zswap zsymm zsyr2k zsyrk ztbtrs ztrmm ztrmv ztrsm ztrsv ztrtrs)
 
-# We need to specify the MPI libraries explicitly because the
-# CMakeLists.txt doesn't properly add them when linking
+# CMakeLists.txt doesn't add MPI libs to the link line; pass them explicitly.
 MPI_SETTINGS=(-DMPI_BASE_DIR="${prefix}")
 MPILIBS=()
 if [[ ${bb_full_target} == *microsoftmpi* ]]; then
@@ -92,39 +79,34 @@ CMAKE_FLAGS=(-DCMAKE_INSTALL_PREFIX=${prefix}
 mkdir build
 cd build
 cmake .. "${CMAKE_FLAGS[@]}"
-
 make -j${nproc} all
 make install
 
-# Rename ScaLAPACK's own exported Fortran-mangled symbols (pdgemm_,
-# pdgetrf_, infog2l_, numroc_, ...) to the `_64_` suffix convention
-# used by libblastrampoline-aware callers (PETSc, MUMPS, ...).
-#
-# We do this post-link with objcopy --redefine-syms over every defined
-# T/W text symbol that ends in `_` and isn't already `_64_`-suffixed,
-# rather than maintaining a curated symbol list.  That way the rewrite
-# covers every export the artifact actually produces — including
-# anything new the build emits after a future ScaLAPACK upgrade —
-# without a bundled list to keep in sync with upstream.
-#
-# References we already redirected at compile-time (BLAS/LAPACK calls)
-# show up as undefined `_64_`-suffixed external refs to libblastrampoline
-# and are skipped by the `_64_$` filter, so they stay correct.
-nm -D --defined-only "${libdir}/libscalapack.${dlext}" \
-    | awk '$2 ~ /^[TW]$/ {print $3}' \
-    | grep -E '^[a-z][a-zA-Z0-9_]*_$' \
-    | grep -v '_64_$' \
-    | awk '{print $1, substr($1, 1, length($1)-1) "_64_"}' \
-    > /tmp/scalapack_redefine.txt
+# Rewrite symbols to the `_64_` convention used by libblastrampoline-aware
+# callers (PETSc, MUMPS, ...).  Single objcopy pass over a rename map
+# built from two sources:
+#   1. ScaLAPACK's own defined exports (pdgemm_, numroc_, ...) — every
+#      defined T/W text symbol ending in `_` and not already `_64_`,
+#      enumerated dynamically so future upstream additions are covered.
+#   2. BLAS/LAPACK undefined refs — drawn from blas_lapack_syms only,
+#      not a blanket sweep, so MPI/libc undefined refs aren't renamed.
+{
+    nm -D --defined-only "${libdir}/libscalapack.${dlext}" \
+        | awk '$2 ~ /^[TW]$/ {print $3}' \
+        | grep -E '^[a-z][a-zA-Z0-9_]*_$' \
+        | grep -v '_64_$' \
+        | awk '{print $1, substr($1, 1, length($1)-1) "_64_"}'
+    for sym in "${blas_lapack_syms[@]}"; do
+        echo "${sym}_ ${sym}_64_"
+    done
+} > /tmp/scalapack_redefine.txt
 
 ${target}-objcopy --redefine-syms=/tmp/scalapack_redefine.txt \
     "${libdir}/libscalapack.${dlext}"
 
-# Rename the artifact so it ships as libscalapack64 alongside
-# SCALAPACK_jll's libscalapack.
+# Ship as libscalapack64 so it coexists with SCALAPACK_jll's libscalapack.
 mv -v ${libdir}/libscalapack.${dlext} ${libdir}/libscalapack64.${dlext}
 
-# If there were links that are now broken, fix 'em up
 for l in $(find ${prefix}/lib -xtype l); do
   if [[ $(basename $(readlink ${l})) == libscalapack ]]; then
     ln -vsf libscalapack64.${dlext} ${l}
@@ -132,8 +114,7 @@ for l in $(find ${prefix}/lib -xtype l); do
 done
 
 PATCHELF_FLAGS=()
-
-# ppc64le and aarch64 have 64 kB page sizes, don't muck up the ELF section load alignment
+# aarch64 / ppc64le have 64 kB page sizes
 if [[ ${target} == aarch64-* || ${target} == powerpc64le-* ]]; then
   PATCHELF_FLAGS+=(--page-size 65536)
 fi
@@ -152,27 +133,21 @@ augment_platform_block = """
 """
 
 platforms = expand_gfortran_versions(supported_platforms())
-# Don't know how to configure MPI for Windows
-platforms = filter(p -> !Sys.iswindows(p), platforms)
-# This artifact is ILP64; restrict to 64-bit platforms.
-platforms = filter(p -> nbits(p) == 64, platforms)
+platforms = filter(p -> !Sys.iswindows(p), platforms)  # MPI on Windows not configured
+platforms = filter(p -> nbits(p) == 64, platforms)     # ILP64 needs 64-bit address space
 
 platforms, platform_dependencies = MPI.augment_platforms(platforms)
 
-# The products that we will ensure are always built
 products = [
     LibraryProduct("libscalapack64", :libscalapack64),
 ]
 
-# Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
     Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), compat="5.4.0"),
-    Dependency("mpif_jll"; compat="0.1.5", platforms=filter(p -> p["mpi"] == "mpiabi", platforms)), # MPI Fortran bindings
+    Dependency("mpif_jll"; compat="0.1.5", platforms=filter(p -> p["mpi"] == "mpiabi", platforms)),
 ]
 append!(dependencies, platform_dependencies)
 
-# Build the tarballs.
-# We need at least GCC 5 for MPICH
 build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
                augment_platform_block, julia_compat="1.9", preferred_gcc_version=v"5")


### PR DESCRIPTION
Adds `SCALAPACK64_jll` at `S/SCALAPACK/SCALAPACK64/build_tarballs.jl`. `SCALAPACK_jll` and `SCALAPACK32_jll` are not touched.

`libscalapack64` is consistently ILP64 end-to-end:
- 64-bit Fortran `INTEGER`s (`-fdefault-integer-8`, `-DInt=long`).
- BLAS/LAPACK refs rewritten at compile-time via `-D${sym}_=${sym}_64_` to libblastrampoline's ILP64 entry points.
- ScaLAPACK's own exports (`pdgemm_`, `numroc_`, …) renamed to `_64_` post-link with `objcopy --redefine-syms`, over a map generated dynamically from `nm` — covers every export, no curated list.

Ships as `libscalapack64.${dlext}` (soname / install_name fixed up the SCALAPACK32 way) so it coexists with `libscalapack`. 64-bit platforms only.

**Scope:** SCALAPACK64 only. Downstream rewires (PETSc, MUMPS) and any SCALAPACK/SCALAPACK32 changes are deferred to separate PRs.