### PR TITLE
LibCppInterOp: Re-build after LLVM platform changes

### DIFF
--- a/L/libCppInterOp/build_tarballs.jl
+++ b/L/libCppInterOp/build_tarballs.jl
@@ -45,7 +45,7 @@ for llvm_version in llvm_versions, llvm_assertions in (false, true)
     llvm_name = llvm_assertions ? "LLVM_full_assert_jll" : "LLVM_full_jll"
     dependencies = [
         RuntimeDependency("Clang_jll"),
-        BuildDependency(PackageSpec(name=llvm_name, version=llvm_version))
+        BuildDependency(PackageSpec(name=llvm_name, version=string(llvm_version)))
     ]
 
     # The products that we will ensure are always built
@@ -97,4 +97,4 @@ for (i,build) in enumerate(builds)
                    augment_platform_block)
 end
 
-# bump
+# rebuild trigger: 1

--- a/L/libCppInterOpExtra/build_tarballs.jl
+++ b/L/libCppInterOpExtra/build_tarballs.jl
@@ -48,7 +48,7 @@ for llvm_version in llvm_versions, llvm_assertions in (false, true)
     dependencies = [
         RuntimeDependency("Clang_jll"),
         BuildDependency("libCppInterOp_jll"),
-        BuildDependency(PackageSpec(name=llvm_name, version=llvm_version))
+        BuildDependency(PackageSpec(name=llvm_name, version=string(llvm_version)))
     ]
 
     # The products that we will ensure are always built
@@ -100,3 +100,5 @@ for (i,build) in enumerate(builds)
                    preferred_gcc_version=v"12", julia_compat="1.7",
                    augment_platform_block, lazy_artifacts=true)
 end
+
+# rebuild trigger: 1


### PR DESCRIPTION
This should be the last follow-up to https://github.com/JuliaPackaging/Yggdrasil/pull/13664.