### PR TITLE
[New recipe] fmusim

### DIFF
--- a/F/fmusim/build_tarballs.jl
+++ b/F/fmusim/build_tarballs.jl
@@ -1,0 +1,69 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "fmusim"
+version = v"0.0.39"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/modelica/Reference-FMUs.git",
+              "c8d4e6d90fa14be49d7622badf30e38eebea5e0a"),
+    # fmusim compiles three minizip sources (ioapi.c, unzip.c, iowin32.c)
+    # directly from a zlib source tree, so we ship one alongside.
+    GitSource("https://github.com/madler/zlib.git",
+              "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf"),
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/Reference-FMUs*/
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/use-shared-deps.patch
+
+case "${target}" in
+    aarch64-*) FMI_ARCH=aarch64 ;;
+    x86_64-*)  FMI_ARCH=x86_64  ;;
+    *) echo "Unsupported target ${target}"; exit 1 ;;
+esac
+
+mkdir build && cd build
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_FMUSIM=ON \
+    -DFMI_VERSION=3 \
+    -DFMI_ARCHITECTURE=${FMI_ARCH} \
+    -DFMUSIM_VERSION="\"0.0.39\"" \
+    -DZLIB_SRC_DIR=${WORKSPACE}/srcdir/zlib \
+    ..
+
+cmake --build . --target fmusim --parallel ${nproc}
+
+install -Dm755 fmusim/fmusim${exeext} ${bindir}/fmusim${exeext}
+install_license ../LICENSE.txt
+"""
+
+# Upstream supports only x86_64 / aarch64 on linux/macos/windows.
+platforms = filter(supported_platforms()) do p
+    os(p) in ("linux", "macos", "windows") &&
+        arch(p) in ("x86_64", "aarch64") &&
+        libc(p) != "musl"
+end
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("fmusim", :fmusim),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("XML2_jll"),
+    Dependency("Zlib_jll"),
+    Dependency("SUNDIALS_jll"; compat="~7"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")

--- a/F/fmusim/build_tarballs.jl
+++ b/F/fmusim/build_tarballs.jl
@@ -20,6 +20,11 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/Reference-FMUs*/
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/use-shared-deps.patch
+# MinGW cross-compilation: Linux is case-sensitive, fix Windows header capitalization
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i \
+    -e 's/#include <Windows\.h>/#include <windows.h>/g' \
+    -e 's/#include <Shlwapi\.h>/#include <shlwapi.h>/g' \
+    {} \;
 
 case "${target}" in
     aarch64-*) FMI_ARCH=aarch64 ;;
@@ -27,15 +32,17 @@ case "${target}" in
     *) echo "Unsupported target ${target}"; exit 1 ;;
 esac
 
-mkdir build && cd build
+mkdir -p build && cd build
 cmake \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_STANDARD=99 \
+    -DCMAKE_PREFIX_PATH=${prefix} \
     -DWITH_FMUSIM=ON \
     -DFMI_VERSION=3 \
     -DFMI_ARCHITECTURE=${FMI_ARCH} \
-    -DFMUSIM_VERSION="\"0.0.39\"" \
+    -DFMUSIM_VERSION=0.0.39 \
     -DZLIB_SRC_DIR=${WORKSPACE}/srcdir/zlib \
     ..
 
@@ -61,9 +68,9 @@ products = [
 dependencies = [
     Dependency("XML2_jll"),
     Dependency("Zlib_jll"),
-    Dependency("SUNDIALS_jll"; compat="~7"),
+    Dependency("Sundials_jll"; compat="7.4"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6")
+               julia_compat="1.6", preferred_gcc_version=v"9")

--- a/F/fmusim/build_tarballs.jl
+++ b/F/fmusim/build_tarballs.jl
@@ -43,7 +43,7 @@ cmake \
 
 cmake --build . --parallel ${nproc}
 
-install -Dm755 fmusim${exeext} ${bindir}/fmusim${exeext}
+install -Dvm 755 fmusim${exeext} ${bindir}/fmusim${exeext}
 install_license ../LICENSE.txt
 """
 

--- a/F/fmusim/build_tarballs.jl
+++ b/F/fmusim/build_tarballs.jl
@@ -26,29 +26,24 @@ find . \( -name "*.c" -o -name "*.h" \) -exec sed -i \
     -e 's/#include <Shlwapi\.h>/#include <shlwapi.h>/g' \
     {} \;
 
-case "${target}" in
-    aarch64-*) FMI_ARCH=aarch64 ;;
-    x86_64-*)  FMI_ARCH=x86_64  ;;
-    *) echo "Unsupported target ${target}"; exit 1 ;;
-esac
-
 mkdir -p build && cd build
+# Configure fmusim's own CMakeLists.txt directly (it has its own project() call)
+# rather than the root, which would otherwise force -DFMI_VERSION=3 just to
+# satisfy the reference-FMU model configure step. fmusim itself always
+# compiles support for FMI 1/2/3.
 cmake \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_STANDARD=99 \
     -DCMAKE_PREFIX_PATH=${prefix} \
-    -DWITH_FMUSIM=ON \
-    -DFMI_VERSION=3 \
-    -DFMI_ARCHITECTURE=${FMI_ARCH} \
-    -DFMUSIM_VERSION=0.0.39 \
+    -DFMUSIM_VERSION=${version} \
     -DZLIB_SRC_DIR=${WORKSPACE}/srcdir/zlib \
-    ..
+    ../fmusim
 
-cmake --build . --target fmusim --parallel ${nproc}
+cmake --build . --parallel ${nproc}
 
-install -Dm755 fmusim/fmusim${exeext} ${bindir}/fmusim${exeext}
+install -Dm755 fmusim${exeext} ${bindir}/fmusim${exeext}
 install_license ../LICENSE.txt
 """
 

--- a/F/fmusim/bundled/patches/use-shared-deps.patch
+++ b/F/fmusim/bundled/patches/use-shared-deps.patch
@@ -1,0 +1,70 @@
+--- a/fmusim/CMakeLists.txt	2026-05-14 08:50:31
++++ b/fmusim/CMakeLists.txt	2026-05-14 08:51:04
+@@ -12,10 +12,12 @@
+ 
+ set(FMUSIM_VERSION "" CACHE STRING "")
+ 
+-set(CVODE_DIR    ${CMAKE_SOURCE_DIR}/build/cvode-${FMI_PLATFORM}/install/)
+-set(LIBXML2_DIR  ${CMAKE_SOURCE_DIR}/build/libxml2-${FMI_PLATFORM}/install/)
+-set(ZLIB_DIR     ${CMAKE_SOURCE_DIR}/build/zlib-${FMI_PLATFORM}/install/)
+-set(ZLIB_SRC_DIR ${CMAKE_SOURCE_DIR}/build/zlib-1.3.1/)
++find_package(LibXml2 REQUIRED)
++find_package(ZLIB REQUIRED)
++find_package(SUNDIALS REQUIRED)
++if (NOT ZLIB_SRC_DIR)
++    message(FATAL_ERROR "ZLIB_SRC_DIR must be set to a zlib source tree (for contrib/minizip).")
++endif ()
+ 
+ if (WIN32)
+     set(FMUSIM_DIST_DIR ${CMAKE_BINARY_DIR}/dist/fmusim-windows/)
+@@ -90,44 +92,21 @@
+ target_include_directories(fmusim PRIVATE
+   .
+   ../include
+-  ${LIBXML2_DIR}/include/libxml2
+-  ${ZLIB_DIR}/include
+   ${ZLIB_SRC_DIR}/contrib/minizip
+-  ${CVODE_DIR}/include
+ )
+ 
+ if (WIN32)
+-    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION} YY_NO_UNISTD_H LIBXML_STATIC)
++    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION} YY_NO_UNISTD_H)
+ else ()
+-    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION} LIBXML_STATIC)
++    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION})
+ endif ()
+ 
++set(libraries LibXml2::LibXml2 ZLIB::ZLIB SUNDIALS::cvode SUNDIALS::core)
++
+ if (WIN32)
+-    set(libraries
+-      ${LIBXML2_DIR}/lib/libxml2s.lib
+-      ${ZLIB_DIR}/lib/zlibstatic.lib
+-      ${CVODE_DIR}/lib/sundials_cvode_static.lib
+-      ${CVODE_DIR}/lib/sundials_core_static.lib
+-      wsock32
+-      ws2_32
+-      bcrypt
+-    )
++    list(APPEND libraries wsock32 ws2_32 bcrypt)
+ elseif(UNIX AND NOT APPLE)
+-    set(libraries
+-      ${LIBXML2_DIR}/lib/libxml2.a
+-      ${ZLIB_DIR}lib/libz.a
+-      ${CVODE_DIR}/lib/libsundials_cvode.a
+-      ${CVODE_DIR}/lib/libsundials_core.a
+-      ${CMAKE_DL_LIBS}
+-      m
+-    )
+-else ()
+-    set(libraries
+-      ${LIBXML2_DIR}/lib/libxml2.a
+-      ${ZLIB_DIR}lib/libz.a
+-      ${CVODE_DIR}/lib/libsundials_cvode.a
+-      ${CVODE_DIR}/lib/libsundials_core.a
+-    )
++    list(APPEND libraries ${CMAKE_DL_LIBS} m)
+ endif ()
+ 
+ target_link_libraries(fmusim ${libraries})

--- a/F/fmusim/bundled/patches/use-shared-deps.patch
+++ b/F/fmusim/bundled/patches/use-shared-deps.patch
@@ -1,6 +1,6 @@
---- a/fmusim/CMakeLists.txt	2026-05-14 08:50:31
-+++ b/fmusim/CMakeLists.txt	2026-05-14 08:51:04
-@@ -12,10 +12,12 @@
+--- a/fmusim/CMakeLists.txt
++++ b/fmusim/CMakeLists.txt
+@@ -12,10 +12,9 @@
  
  set(FMUSIM_VERSION "" CACHE STRING "")
  
@@ -11,13 +11,10 @@
 +find_package(LibXml2 REQUIRED)
 +find_package(ZLIB REQUIRED)
 +find_package(SUNDIALS REQUIRED)
-+if (NOT ZLIB_SRC_DIR)
-+    message(FATAL_ERROR "ZLIB_SRC_DIR must be set to a zlib source tree (for contrib/minizip).")
-+endif ()
  
  if (WIN32)
      set(FMUSIM_DIST_DIR ${CMAKE_BINARY_DIR}/dist/fmusim-windows/)
-@@ -90,44 +92,21 @@
+@@ -90,44 +89,19 @@
  target_include_directories(fmusim PRIVATE
    .
    ../include
@@ -27,16 +24,15 @@
 -  ${CVODE_DIR}/include
  )
  
++target_compile_definitions(fmusim PRIVATE "FMUSIM_VERSION=\"${FMUSIM_VERSION}\"")
  if (WIN32)
 -    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION} YY_NO_UNISTD_H LIBXML_STATIC)
-+    target_compile_definitions(fmusim PRIVATE "FMUSIM_VERSION=\"${FMUSIM_VERSION}\"" YY_NO_UNISTD_H STRSAFE_NO_DEPRECATE)
- else ()
+-else ()
 -    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION} LIBXML_STATIC)
-+    target_compile_definitions(fmusim PRIVATE "FMUSIM_VERSION=\"${FMUSIM_VERSION}\"")
++    target_compile_definitions(fmusim PRIVATE YY_NO_UNISTD_H STRSAFE_NO_DEPRECATE)
  endif ()
  
 +set(libraries LibXml2::LibXml2 ZLIB::ZLIB SUNDIALS::cvode SUNDIALS::core)
-+
  if (WIN32)
 -    set(libraries
 -      ${LIBXML2_DIR}/lib/libxml2s.lib

--- a/F/fmusim/bundled/patches/use-shared-deps.patch
+++ b/F/fmusim/bundled/patches/use-shared-deps.patch
@@ -29,10 +29,10 @@
  
  if (WIN32)
 -    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION} YY_NO_UNISTD_H LIBXML_STATIC)
-+    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION} YY_NO_UNISTD_H)
++    target_compile_definitions(fmusim PRIVATE "FMUSIM_VERSION=\"${FMUSIM_VERSION}\"" YY_NO_UNISTD_H STRSAFE_NO_DEPRECATE)
  else ()
 -    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION} LIBXML_STATIC)
-+    target_compile_definitions(fmusim PRIVATE FMUSIM_VERSION=${FMUSIM_VERSION})
++    target_compile_definitions(fmusim PRIVATE "FMUSIM_VERSION=\"${FMUSIM_VERSION}\"")
  endif ()
  
 +set(libraries LibXml2::LibXml2 ZLIB::ZLIB SUNDIALS::cvode SUNDIALS::core)
@@ -47,7 +47,7 @@
 -      ws2_32
 -      bcrypt
 -    )
-+    list(APPEND libraries wsock32 ws2_32 bcrypt)
++    list(APPEND libraries wsock32 ws2_32 bcrypt shlwapi)
  elseif(UNIX AND NOT APPLE)
 -    set(libraries
 -      ${LIBXML2_DIR}/lib/libxml2.a

--- a/F/fmusim/bundled/patches/use-shared-deps.patch
+++ b/F/fmusim/bundled/patches/use-shared-deps.patch
@@ -1,6 +1,6 @@
 --- a/fmusim/CMakeLists.txt
 +++ b/fmusim/CMakeLists.txt
-@@ -12,10 +12,9 @@
+@@ -12,11 +12,6 @@
  
  set(FMUSIM_VERSION "" CACHE STRING "")
  
@@ -8,12 +8,21 @@
 -set(LIBXML2_DIR  ${CMAKE_SOURCE_DIR}/build/libxml2-${FMI_PLATFORM}/install/)
 -set(ZLIB_DIR     ${CMAKE_SOURCE_DIR}/build/zlib-${FMI_PLATFORM}/install/)
 -set(ZLIB_SRC_DIR ${CMAKE_SOURCE_DIR}/build/zlib-1.3.1/)
+-
+ if (WIN32)
+     set(FMUSIM_DIST_DIR ${CMAKE_BINARY_DIR}/dist/fmusim-windows/)
+ elseif (APPLE)
+@@ -27,6 +22,10 @@
+ 
+ project (FMUSim)
+ 
 +find_package(LibXml2 REQUIRED)
 +find_package(ZLIB REQUIRED)
 +find_package(SUNDIALS REQUIRED)
++
+ file(MAKE_DIRECTORY ${FMUSIM_DIST_DIR})
  
- if (WIN32)
-     set(FMUSIM_DIST_DIR ${CMAKE_BINARY_DIR}/dist/fmusim-windows/)
+ set(sources
 @@ -90,44 +89,19 @@
  target_include_directories(fmusim PRIVATE
    .


### PR DESCRIPTION
`fmusim` is a program from https://github.com/modelica/Reference-FMUs to simulate [Functional Mockup Units](https://fmi-standard.org/).  This PR creates a new recipe which will add a JLL containing a prebuilt version of that executable.

Unfortunately the upstream build script seems to want static libraries for libxml2, zlib and Sundials.  So this also contains a (vibe coded) patch for the build script.  Completely open to better ways of doing that if there are any.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>