### PR TITLE
[libsemigroups] Update to v3.6.0

### DIFF
--- a/L/libsemigroups/build_tarballs.jl
+++ b/L/libsemigroups/build_tarballs.jl
@@ -4,12 +4,12 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "libsemigroups"
-version = v"3.5.5"
+version = v"3.6.0"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/libsemigroups/libsemigroups.git",
-              "452e635acf4c03a843ffb64d562632364237a756"),  # v3.5.5
+              "b998baf4e6ac0c9a8d6ac9fe74b02babcda6ec3e"),  # v3.6.0
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Updates `libsemigroups` to [v3.6.0](https://github.com/libsemigroups/libsemigroups/releases/tag/v3.6.0).

**Changes to `L/libsemigroups/build_tarballs.jl`:**
- `version`: `v3.6.0`
- `GitSource` commit: [`b998baf4e6ac`](https://github.com/libsemigroups/libsemigroups/commit/b998baf4e6ac0c9a8d6ac9fe74b02babcda6ec3e)

---
_This PR was opened automatically by the [libsemigroups release workflow](https://github.com/libsemigroups/libsemigroups/actions/workflows/update-yggdrasil.yml)._

_Note that this account is not managed, please direct any queries towards @james-d-mitchell or @jswent._