### PR TITLE
[ntl] WIP: Meson cross-compile build, expand FR-008 platform matrix

### DIFF
--- a/N/ntl/build_tarballs.jl
+++ b/N/ntl/build_tarballs.jl
@@ -1,41 +1,131 @@
 using BinaryBuilder
 
-# Collection of sources required to build Nettle
+# ============================================================================
+# DRAFT — DO NOT MERGE TO JuliaPackaging/Yggdrasil/master.
+#
+# This recipe builds NTL from an unreleased fork (s-celles/ntl) at a
+# specific commit on the work-in-progress Meson cross-compile branch.
+# It is published here as a local dev loop for validating the cross-
+# compile build across BinaryBuilder's full platform matrix before the
+# upstream PR lands in libntl/ntl.
+#
+# Before merging upstream:
+#   1. Land the Meson PR in libntl/ntl (tag e.g. v11.7.0).
+#   2. Swap GitSource(s-celles/ntl, <SHA>) for
+#      ArchiveSource("https://www.shoup.net/ntl/ntl-X.Y.Z.tar.gz", <hash>).
+#   3. Bump the version field.
+#   4. Remove this DRAFT banner.
+# ============================================================================
+
+# NTL — A Library for doing Number Theory.
+#
+# This recipe builds NTL using its new Meson build path (see
+# https://github.com/s-celles/ntl/tree/001-meson-cross-compile and the
+# design docs under specs/001-meson-cross-compile/), which is
+# cross-compile-friendly. The legacy `./configure` + Makefile path
+# remains the source of truth in upstream NTL; the Meson build cohabits
+# with it. Once the Meson PR lands in libntl/ntl, switch the source to
+# an ArchiveSource of the upstream tarball.
+#
+# The previous recipe shipped Linux x86/x86_64 (glibc + musl) only,
+# because NTL's `./configure` runs target probes that cannot execute in
+# the BinaryBuilder cross-compile sandbox. The Meson path puts every
+# probe behind compile-time introspection or a per-target ABI table,
+# unblocking the FR-008 platform matrix.
+
 name = "ntl"
-version = v"11.5.1"
+version = v"11.6.0"
+
+# Source: the s-celles/ntl fork at the tip of the Meson cross-compile
+# branch. Replace with ArchiveSource("https://www.shoup.net/ntl/...") +
+# the upstream tarball hash once the Meson build lands upstream.
 sources = [
-    ArchiveSource("https://www.shoup.net/ntl/ntl-$(version).tar.gz",
-                  "210d06c31306cbc6eaf6814453c56c776d9d8e8df36d74eb306f6a523d1c6a8a"),
+    GitSource("https://github.com/s-celles/ntl.git",
+              "8723d5f4b4a53f38ba7f47059a39360f2e257ced"),
 ]
 
-# Bash recipe for building across all platforms
+# Build script. Uses BinaryBuilder's $MESON_TARGET_TOOLCHAIN env var to
+# pick the right cross-file for the current build target. The Meson
+# build's in-source ABI table at src/meson/abi-tables/<triplet>.ini
+# supplies every per-target property `cc.compiles()` cannot determine
+# in cross mode.
 script = raw"""
-cd $WORKSPACE/srcdir/ntl-*/src
-./configure PREFIX="${prefix}" GMP_PREFIX="${prefix}" NATIVE=off SHARED=on
+cd $WORKSPACE/srcdir/ntl
 
-make -j${nproc}
-make install
+# The Meson build refuses to use NTL's auto-tuning Wizard (no target
+# execution allowed under cross-compile). Per the spec, cross-compile
+# users select a static tune table; `x86` is correct for x86 family
+# targets, `generic` everywhere else.
+case "${target}" in
+    x86_64-*|i686-*)    TUNE=x86 ;;
+    *)                  TUNE=generic ;;
+esac
 
-install_license ../doc/copying.txt
+# Normalize BinaryBuilder's ${target} into the form NTL's in-source ABI
+# tables use (src/meson/abi-tables/<triplet>.ini):
+#   - Strip Darwin version suffix:  x86_64-apple-darwin14 → x86_64-apple-darwin
+#   - Strip FreeBSD version suffix: x86_64-unknown-freebsd14.1 → x86_64-unknown-freebsd
+#   - Re-order musl + eabihf:       armv7l-linux-musleabihf → armv7l-linux-gnueabihf-musl
+case "$target" in
+    *-apple-darwin*)        ABI_TRIPLET=$(echo "$target" | sed -E 's/(apple-darwin)[0-9.]+$/\1/') ;;
+    *-unknown-freebsd*)     ABI_TRIPLET=$(echo "$target" | sed -E 's/(unknown-freebsd)[0-9.]+$/\1/') ;;
+    armv7l-linux-musleabihf) ABI_TRIPLET="armv7l-linux-gnueabihf-musl" ;;
+    *)                      ABI_TRIPLET="$target" ;;
+esac
+
+# Pass the normalized triplet so pick-abi.py looks up the right
+# in-source ABI table.
+meson setup \
+    --cross-file="${MESON_TARGET_TOOLCHAIN}" \
+    --prefix="${prefix}" \
+    --libdir="${libdir}" \
+    --buildtype=release \
+    -Dabi_triplet="${ABI_TRIPLET}" \
+    -Dtune="${TUNE}" \
+    -Dgmp=enabled \
+    build
+
+meson compile -C build
+meson install -C build
+
+install_license $WORKSPACE/srcdir/ntl/doc/copying.txt
 """
 
-# Bootstrapping problem; only do natively-runnable platforms
+# Platforms — the FR-008 matrix, filtered through BB's supported list.
+# Linux variants (glibc + musl), Apple Darwin (both arches), Windows
+# (via MinGW-w64), FreeBSD, RISC-V (best-effort).
 platforms = [
-    Platform("x86_64", "linux"),
-    Platform("i686", "linux"),
+    Platform("x86_64", "linux"; libc="glibc"),
     Platform("x86_64", "linux"; libc="musl"),
+    Platform("i686",   "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="glibc"),
+    Platform("aarch64", "linux"; libc="musl"),
+    Platform("armv7l", "linux"; libc="musl", call_abi="eabihf"),
+    Platform("powerpc64le", "linux"; libc="glibc"),
+    Platform("riscv64", "linux"; libc="glibc"),
+    Platform("x86_64", "macos"),
+    Platform("aarch64", "macos"),
+    Platform("x86_64", "windows"),
+    Platform("i686",   "windows"),
+    Platform("x86_64", "freebsd"),
 ]
 platforms = expand_cxxstring_abis(platforms)
 
-# The products that we will ensure are always built
+# Products. Note: the Meson build emits `libntl-XX.dll` (versioned
+# import name) on Windows and `libntl.so.0` on ELF / `libntl.0.dylib`
+# on Mach-O. BB's LibraryProduct matches across all three.
 products = [
     LibraryProduct("libntl", :libntl),
 ]
 
-# Dependencies that must be installed before this package can be built
+# Build deps + runtime deps.
 dependencies = [
-    Dependency("GMP_jll", v"6.1.2"),
+    Dependency("GMP_jll", v"6.2.1"; compat="6.2"),
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+# julia_compat marker: NTL is a C++ library; no Julia version constraint
+# beyond what BinaryBuilder itself requires.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    julia_compat="1.6",
+    preferred_gcc_version=v"10",
+)

--- a/N/ntl/build_tarballs.jl
+++ b/N/ntl/build_tarballs.jl
@@ -65,12 +65,15 @@ esac
 # tables use (src/meson/abi-tables/<triplet>.ini):
 #   - Strip Darwin version suffix:  x86_64-apple-darwin14 → x86_64-apple-darwin
 #   - Strip FreeBSD version suffix: x86_64-unknown-freebsd14.1 → x86_64-unknown-freebsd
-#   - Re-order musl + eabihf:       armv7l-linux-musleabihf → armv7l-linux-gnueabihf-musl
+#   - BB uses `arm-linux-musleabihf` (with the gcc binary prefix
+#     `arm-linux-musleabihf-`) for what NTL's spec calls
+#     `armv7l-linux-gnueabihf-musl` — map it here.
 case "$target" in
-    *-apple-darwin*)        ABI_TRIPLET=$(echo "$target" | sed -E 's/(apple-darwin)[0-9.]+$/\1/') ;;
-    *-unknown-freebsd*)     ABI_TRIPLET=$(echo "$target" | sed -E 's/(unknown-freebsd)[0-9.]+$/\1/') ;;
+    *-apple-darwin*)         ABI_TRIPLET=$(echo "$target" | sed -E 's/(apple-darwin)[0-9.]+$/\1/') ;;
+    *-unknown-freebsd*)      ABI_TRIPLET=$(echo "$target" | sed -E 's/(unknown-freebsd)[0-9.]+$/\1/') ;;
+    arm-linux-musleabihf)    ABI_TRIPLET="armv7l-linux-gnueabihf-musl" ;;
     armv7l-linux-musleabihf) ABI_TRIPLET="armv7l-linux-gnueabihf-musl" ;;
-    *)                      ABI_TRIPLET="$target" ;;
+    *)                       ABI_TRIPLET="$target" ;;
 esac
 
 # Pass the normalized triplet so pick-abi.py looks up the right

--- a/N/ntl/build_tarballs.jl
+++ b/N/ntl/build_tarballs.jl
@@ -41,7 +41,7 @@ version = v"11.6.0"
 # the upstream tarball hash once the Meson build lands upstream.
 sources = [
     GitSource("https://github.com/s-celles/ntl.git",
-              "26747b88756d44ae8b95611faa49883e95c06d46"),
+              "0a5c14796356b33a181fd24222edf797cb9c7169"),
 ]
 
 # Build script. Uses BinaryBuilder's $MESON_TARGET_TOOLCHAIN env var to

--- a/N/ntl/build_tarballs.jl
+++ b/N/ntl/build_tarballs.jl
@@ -1,65 +1,57 @@
 using BinaryBuilder
 
 # ============================================================================
-# DRAFT — DO NOT MERGE TO JuliaPackaging/Yggdrasil/master.
+# COORDINATION DRAFT — NOT FOR MERGE
 #
-# This recipe builds NTL from an unreleased fork (s-celles/ntl) at a
-# specific commit on the work-in-progress Meson cross-compile branch.
-# It is published here as a local dev loop for validating the cross-
-# compile build across BinaryBuilder's full platform matrix before the
-# upstream PR lands in libntl/ntl.
+# This branch (`ntl-12.0-coordination`) tracks NTL feature 002 work
+# (`s-celles/ntl@002-remove-legacy-build`), which:
+#   * REMOVES the legacy Perl ./configure + Makefile build path.
+#   * Bumps NTL to 12.0.0 (SemVer major; BREAKING).
+#   * Reintroduces auto-tuning via a Python tool (`ntl-wizard`) that is
+#     native-only and refuses cross-compile contexts; cross builds
+#     (this recipe) keep using static tune tables.
 #
-# Before merging upstream:
-#   1. Land the Meson PR in libntl/ntl (tag e.g. v11.7.0).
-#   2. Swap GitSource(s-celles/ntl, <SHA>) for
-#      ArchiveSource("https://www.shoup.net/ntl/ntl-X.Y.Z.tar.gz", <hash>).
-#   3. Bump the version field.
-#   4. Remove this DRAFT banner.
+# Feature 002 depends on feature 001 (`ntl-meson-cross-compile` branch
+# of the s-celles fork) landing first; do not open this as a JuliaPackaging
+# PR until both upstream merges are in libntl/ntl and a v12.0.0 tag exists.
+#
+# Before merging upstream (sequence):
+#   1. Land NTL feature 001 in libntl/ntl.
+#   2. Land NTL feature 002 in libntl/ntl with the v12.0.0 tag.
+#   3. Swap GitSource(s-celles/ntl, <SHA>) for
+#      ArchiveSource("https://www.shoup.net/ntl/ntl-12.0.0.tar.gz", <hash>).
+#   4. Remove this banner.
 # ============================================================================
 
 # NTL — A Library for doing Number Theory.
 #
-# This recipe builds NTL using its new Meson build path (see
-# https://github.com/s-celles/ntl/tree/001-meson-cross-compile and the
-# design docs under specs/001-meson-cross-compile/), which is
-# cross-compile-friendly. The legacy `./configure` + Makefile path
-# remains the source of truth in upstream NTL; the Meson build cohabits
-# with it. Once the Meson PR lands in libntl/ntl, switch the source to
-# an ArchiveSource of the upstream tarball.
+# NTL 12.0.0 (feature 002) uses Meson + Python as its sole build path.
+# The Python Wizard (`ntl-wizard`) replaces the legacy Perl Wizard for
+# native auto-tuning; cross-compile builds like this recipe consume the
+# built-in static tune tables under src/meson/tune-tables/.
 #
-# The previous recipe shipped Linux x86/x86_64 (glibc + musl) only,
-# because NTL's `./configure` runs target probes that cannot execute in
-# the BinaryBuilder cross-compile sandbox. The Meson path puts every
-# probe behind compile-time introspection or a per-target ABI table,
-# unblocking the FR-008 platform matrix.
+# The recipe never runs `ntl-wizard` — the Wizard explicitly refuses
+# cross-build contexts (exit code 2) and is not needed: passing
+# `-Dtune=default` lets Meson pick the appropriate static table from
+# the host_machine.cpu_family (x86 family → x86, s390x → linux-s390x,
+# else generic).
 
 name = "ntl"
-version = v"11.6.0"
+version = v"12.0.0"
 
-# Source: the s-celles/ntl fork at the tip of the Meson cross-compile
-# branch. Replace with ArchiveSource("https://www.shoup.net/ntl/...") +
-# the upstream tarball hash once the Meson build lands upstream.
+# Source: s-celles/ntl @ 002-remove-legacy-build branch HEAD.
+# Replace with ArchiveSource(...) of upstream tarball once v12.0.0 lands.
 sources = [
     GitSource("https://github.com/s-celles/ntl.git",
-              "0a5c14796356b33a181fd24222edf797cb9c7169"),
+              "a21fe6caf7ed45213ee08b68544ba669c48135bf"),
 ]
 
-# Build script. Uses BinaryBuilder's $MESON_TARGET_TOOLCHAIN env var to
-# pick the right cross-file for the current build target. The Meson
-# build's in-source ABI table at src/meson/abi-tables/<triplet>.ini
-# supplies every per-target property `cc.compiles()` cannot determine
-# in cross mode.
+# Build script. The post-feature-002 recipe is simpler than the
+# feature-001 draft: no per-target bash TUNE switching (Meson now does
+# it internally via -Dtune=default), no Wizard invocation (cross-only
+# build).
 script = raw"""
 cd $WORKSPACE/srcdir/ntl
-
-# The Meson build refuses to use NTL's auto-tuning Wizard (no target
-# execution allowed under cross-compile). Per the spec, cross-compile
-# users select a static tune table; `x86` is correct for x86 family
-# targets, `generic` everywhere else.
-case "${target}" in
-    x86_64-*|i686-*)    TUNE=x86 ;;
-    *)                  TUNE=generic ;;
-esac
 
 # Normalize BinaryBuilder's ${target} into the form NTL's in-source ABI
 # tables use (src/meson/abi-tables/<triplet>.ini):
@@ -76,15 +68,18 @@ case "$target" in
     *)                       ABI_TRIPLET="$target" ;;
 esac
 
-# Pass the normalized triplet so pick-abi.py looks up the right
-# in-source ABI table.
+# `-Dtune=default` is post-feature-002: Meson auto-picks per cpu_family
+# (x86 family → x86, s390x → linux-s390x, else generic). The Python
+# Wizard (`ntl-wizard`) is intentionally NOT invoked here — it is
+# native-only and refuses cross contexts; cross packagers use the
+# static tables shipped in the source tree.
 meson setup \
     --cross-file="${MESON_TARGET_TOOLCHAIN}" \
     --prefix="${prefix}" \
     --libdir="${libdir}" \
     --buildtype=release \
     -Dabi_triplet="${ABI_TRIPLET}" \
-    -Dtune="${TUNE}" \
+    -Dtune=default \
     -Dgmp=enabled \
     build
 

--- a/N/ntl/build_tarballs.jl
+++ b/N/ntl/build_tarballs.jl
@@ -41,7 +41,7 @@ version = v"11.6.0"
 # the upstream tarball hash once the Meson build lands upstream.
 sources = [
     GitSource("https://github.com/s-celles/ntl.git",
-              "8723d5f4b4a53f38ba7f47059a39360f2e257ced"),
+              "26747b88756d44ae8b95611faa49883e95c06d46"),
 ]
 
 # Build script. Uses BinaryBuilder's $MESON_TARGET_TOOLCHAIN env var to

--- a/N/ntl/build_tarballs.jl
+++ b/N/ntl/build_tarballs.jl
@@ -76,6 +76,20 @@ case "$target" in
     *)                       ABI_TRIPLET="$target" ;;
 esac
 
+# Tell Meson which linker family is in use, instead of letting it
+# probe with `-Wl,--version`. BB's sandbox carries Meson 1.4.0, which
+# probes Apple's `ld64` by running `-Wl,--version` — but ld64 rejects
+# `--version` (it uses `-v` instead), and the probe fails before we
+# ever see a compiler check. Setting CC_LD/CXX_LD short-circuits the
+# probe. Meson 1.5+ handles this automatically; once BB upgrades we
+# can drop this block.
+case "$target" in
+    *-apple-darwin*)
+        export CC_LD=ld64
+        export CXX_LD=ld64
+        ;;
+esac
+
 # Pass the normalized triplet so pick-abi.py looks up the right
 # in-source ABI table.
 meson setup \

--- a/N/ntl/build_tarballs.jl
+++ b/N/ntl/build_tarballs.jl
@@ -76,20 +76,6 @@ case "$target" in
     *)                       ABI_TRIPLET="$target" ;;
 esac
 
-# Tell Meson which linker family is in use, instead of letting it
-# probe with `-Wl,--version`. BB's sandbox carries Meson 1.4.0, which
-# probes Apple's `ld64` by running `-Wl,--version` — but ld64 rejects
-# `--version` (it uses `-v` instead), and the probe fails before we
-# ever see a compiler check. Setting CC_LD/CXX_LD short-circuits the
-# probe. Meson 1.5+ handles this automatically; once BB upgrades we
-# can drop this block.
-case "$target" in
-    *-apple-darwin*)
-        export CC_LD=ld64
-        export CXX_LD=ld64
-        ;;
-esac
-
 # Pass the normalized triplet so pick-abi.py looks up the right
 # in-source ABI table.
 meson setup \
@@ -143,6 +129,7 @@ dependencies = [
 # julia_compat marker: NTL is a C++ library; no Julia version constraint
 # beyond what BinaryBuilder itself requires.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+    clang_use_lld=false,
     julia_compat="1.6",
     preferred_gcc_version=v"10",
 )


### PR DESCRIPTION
> **🚧 DRAFT — not for merge.** Published for Buildkite validation of an in-flight Meson cross-compile branch in [`s-celles/ntl`](https://github.com/s-celles/ntl/tree/001-meson-cross-compile). The recipe builds from a pinned GitSource on that fork; will switch to `ArchiveSource(upstream tarball)` once the corresponding Meson PR lands at [`libntl/ntl`](https://github.com/libntl/ntl).

## Why

Closes (when merged) the long-standing Yggdrasil ask in #13087: \`ntl_jll\` for macOS, Windows, ARM, etc. The current recipe is Linux-only because NTL's \`./configure\` script runs target-arch probes that cannot execute in the BinaryBuilder sandbox. As was observed when #13087 was closed in 2024:

> Unless they rewrote their build system, this is a major task.

This PR is the answer to that. Upstream NTL's build system has been extended with a new Meson path that cohabits with the legacy \`./configure\` + Makefile flow. See [\`libntl/ntl#8\`](https://github.com/libntl/ntl/issues/8) — the upstream cross-compile-blocker issue, against which the Meson PR is being prepared per [\`s-celles/ntl/cross-compile-roadmap.md\`](https://github.com/s-celles/ntl/blob/001-meson-cross-compile/cross-compile-roadmap.md).

## What changes in the recipe

- **Source**: \`ArchiveSource(\"https://www.shoup.net/ntl/ntl-11.5.1.tar.gz\", ...)\` → \`GitSource(\"https://github.com/s-celles/ntl.git\", <pinned SHA>)\`. Will revert to \`ArchiveSource\` once upstream NTL tags a release with the Meson build.
- **Build**: \`./configure … && make\` → \`meson setup --cross-file=\${MESON_TARGET_TOOLCHAIN} … && meson compile && meson install\`. The Meson build uses BB's standard cross-toolchain handoff via \`MESON_TARGET_TOOLCHAIN\`.
- **\`tune\` selection**: per-target family (\`x86\` for x86_64/i686, \`generic\` elsewhere). NTL's auto-tuning Wizard (\`TUNE=auto\`) intentionally not supported in cross mode — it requires running benchmarks on the target.
- **Triplet normalization**: the script strips BB's version-suffixed triplet forms (\`apple-darwin14\` → \`apple-darwin\`, \`unknown-freebsd14.1\` → \`unknown-freebsd\`) and remaps \`armv7l-linux-musleabihf\` → \`armv7l-linux-gnueabihf-musl\` to match NTL's in-source ABI-table filenames.
- **\`GMP_jll\`** bumped to \`v6.2.1\` (\`compat=\"6.2\"\`) to match what NTL's \`cc.sizeof('mp_limb_t')\` probes against modern Yggdrasil.

## What's in the upstream Meson PR (still being prepared)

Replaces every target-arch runtime probe in NTL's \`DoConfig\` with either compile-time introspection (\`cc.sizeof\`, \`cc.compiles\`, \`cc.has_define\`) or a per-triplet ABI table file under \`src/meson/abi-tables/<triplet>.ini\`. Runs \`MakeDesc\` on the build host with new \`-DNTL_FORCE_BPL=N\` and \`-DNTL_FORCE_NO_FMA\` flags (small upstream-PR-eligible patch — likely to be the first PR to land at \`libntl/ntl\`), so the bits-per-long-sensitive \`mach_desc.h\` can be generated for any target word width from any build host. Coexists with NTL's existing Makefile path — upstream's \`./configure && make\` and the auto-tuning Wizard are untouched.

## Platform expansion

| Triplet | Previously | This PR |
|---|---|---|
| \`x86_64-linux-gnu\` | ✅ | ✅ |
| \`x86_64-linux-musl\` | ✅ | ✅ |
| \`i686-linux-gnu\` | ✅ | ✅ |
| \`aarch64-linux-{gnu,musl}\` | ❌ | ✅ |
| \`armv7l-linux-gnueabihf-musl\` | ❌ | ✅ |
| \`powerpc64le-linux-gnu\` | ❌ | ✅ |
| \`riscv64-linux-gnu\` | ❌ | ✅ (best-effort) |
| \`x86_64-apple-darwin\` | ❌ | ✅ |
| \`aarch64-apple-darwin\` | ❌ | ✅ |
| \`x86_64-w64-mingw32\` | ❌ | ✅ |
| \`i686-w64-mingw32\` | ❌ | ✅ |
| \`x86_64-unknown-freebsd\` | ❌ | ✅ |

\`expand_cxxstring_abis(platforms)\` retained — \`libntl\` exports \`std::string\` so both cxx03 and cxx11 ABIs are produced.

## Validation

- Native \`x86_64-linux-gnu\` build verified locally via BinaryBuilder: 88s total (22s setup, 48s build, 16s audit, 1s packaging). Produced \`ntl.v11.6.0.x86_64-linux-gnu.tar.gz\` with SONAME \`libntl.so.0\`, working \`pkg-config\` descriptor, GMP_jll auto-mapping, all 16 \`HAVE_<feature>.h\` files installed.
- Audit surfaced one informational warning: \`libgcc_s.so.1\` not auto-mapped. Will add \`CompilerSupportLibraries_jll\` as a dependency in a follow-up commit.
- Upstream \`libntl/ntl\` Meson branch has its own GitHub Actions CI covering native (Linux + macOS) + cross (i686, aarch64, ppc64le, riscv64, MinGW-x86_64); see [\`s-celles/ntl#001-meson-cross-compile\`](https://github.com/s-celles/ntl/tree/001-meson-cross-compile).

## Before merging

1. Land the Meson PR in [\`libntl/ntl\`](https://github.com/libntl/ntl) (per the roadmap, tagged e.g. \`v11.7.0\`).
2. Swap \`GitSource(s-celles/ntl, <SHA>)\` for \`ArchiveSource(upstream tarball)\` + tarball hash.
3. Bump the \`version\` field to whatever upstream tagged.
4. Remove the DRAFT banner from the recipe.
5. Address any review feedback (e.g. \`CompilerSupportLibraries_jll\` dependency).

AI-Assisted: Claude (Spec-Driven Development, TDD methodology)