### PR TITLE
[CImPlot3D] new package, v0.4.0

### DIFF
--- a/C/CImPlot3D/build_tarballs.jl
+++ b/C/CImPlot3D/build_tarballs.jl
@@ -42,8 +42,13 @@ install_license $WORKSPACE/srcdir/cimplot3d/implot3d/LICENSE
 
 # Match CImGuiPack's platform filter (excludes armv6l, riscv64,
 # aarch64-freebsd because of GLFW_jll / dependency limitations).
+# We additionally exclude Windows: CImGuiPack's libcimgui.dll only
+# exports the cimgui C wrappers (`ig*`), not the underlying `ImGui::*`
+# C++ symbols that cimplot3d.cpp calls directly, so the link fails.
+# Revisit if cimgui-pack starts exporting all symbols on Windows.
 platforms = filter(p -> arch(p) ∉ ("armv6l", "riscv64") &&
-                        !(arch(p) == "aarch64" && os(p) == "freebsd"),
+                        !(arch(p) == "aarch64" && os(p) == "freebsd") &&
+                        os(p) != "windows",
                    supported_platforms())
 
 # The products that we will ensure are always built

--- a/C/CImPlot3D/build_tarballs.jl
+++ b/C/CImPlot3D/build_tarballs.jl
@@ -52,11 +52,11 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built.
-# We pin against the published CImGuiPack_jll v0.8.x line because the
-# unreleased Yggdrasil HEAD (v0.11.x) drops the libcxxwrap_julia_jll
-# dependency, which would change which ImGui symbols are reachable.
+# CImGuiPack_jll v0.11+ ships consistent imgui 1.92.x cimgui across all
+# platforms (the published v0.8 line was platform-skewed and lacked the
+# `_c`-suffixed types this wrapper requires).
 dependencies = [
-    Dependency("CImGuiPack_jll"; compat="0.8"),
+    Dependency("CImGuiPack_jll"; compat="0.11"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CImPlot3D/build_tarballs.jl
+++ b/C/CImPlot3D/build_tarballs.jl
@@ -1,0 +1,66 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "CImPlot3D"
+version = v"0.4.0" # tracking implot3d release tags
+
+# Sources required to build CImPlot3D
+sources = [
+    # cimplot3d ships the C wrapper; implot3d is its git submodule pinned at a
+    # SHA that matches the wrapper's generated bindings (currently v0.4 of
+    # implot3d). A recursive submodule init in the script keeps them locked.
+    GitSource("https://github.com/cimgui/cimplot3d.git",
+              "8c1c16e98fdddc4b3ee78bf0f89e0dd708be79e0"),
+
+    # Bundled CMakeLists.txt that links against CImGuiPack_jll's exported
+    # cimgui::cimgui target rather than rebuilding imgui sources locally —
+    # this is what keeps ImGuiContext / ImPlot3DContext globals shared with
+    # the libcimgui.dylib that CImGui.jl loads at runtime.
+    DirectorySource("./bundled"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+mv $WORKSPACE/srcdir/CMakeLists.txt $WORKSPACE/srcdir/cimplot3d.cmake
+cd $WORKSPACE/srcdir
+git -C cimplot3d submodule update --init --recursive --depth 1
+
+# Stage sources under a dedicated dir so the bundled CMakeLists' relative
+# paths (cimplot3d/cimplot3d.cpp, cimplot3d/implot3d/...) resolve cleanly.
+mkdir build
+mv cimplot3d.cmake build/CMakeLists.txt
+cd build
+
+cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
+         -DCMAKE_PREFIX_PATH=${prefix} \
+         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+         -DCMAKE_BUILD_TYPE=Release
+make -j${nproc}
+make install
+
+install_license $WORKSPACE/srcdir/cimplot3d/implot3d/LICENSE
+"""
+
+# Match CImGuiPack's platform filter (excludes armv6l, riscv64,
+# aarch64-freebsd because of GLFW_jll / dependency limitations).
+platforms = filter(p -> arch(p) ∉ ("armv6l", "riscv64") &&
+                        !(arch(p) == "aarch64" && os(p) == "freebsd"),
+                   supported_platforms())
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libcimplot3d", :libcimplot3d),
+]
+
+# Dependencies that must be installed before this package can be built.
+# We pin against the published CImGuiPack_jll v0.8.x line because the
+# unreleased Yggdrasil HEAD (v0.11.x) drops the libcxxwrap_julia_jll
+# dependency, which would change which ImGui symbols are reachable.
+dependencies = [
+    Dependency("CImGuiPack_jll"; compat="0.8"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.9", preferred_gcc_version=v"5")

--- a/C/CImPlot3D/build_tarballs.jl
+++ b/C/CImPlot3D/build_tarballs.jl
@@ -20,18 +20,16 @@ sources = [
     DirectorySource("./bundled"),
 ]
 
-# Bash recipe for building across all platforms
+# Bash recipe for building across all platforms.
+# DirectorySource("./bundled") copies bundled/CMakeLists.txt to
+# $WORKSPACE/srcdir/CMakeLists.txt; that CMakeLists references
+# cimplot3d/* paths relative to itself, which line up with where the
+# GitSource clones cimplot3d.
 script = raw"""
-mv $WORKSPACE/srcdir/CMakeLists.txt $WORKSPACE/srcdir/cimplot3d.cmake
 cd $WORKSPACE/srcdir
 git -C cimplot3d submodule update --init --recursive --depth 1
 
-# Stage sources under a dedicated dir so the bundled CMakeLists' relative
-# paths (cimplot3d/cimplot3d.cpp, cimplot3d/implot3d/...) resolve cleanly.
-mkdir build
-mv cimplot3d.cmake build/CMakeLists.txt
-cd build
-
+mkdir build && cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
          -DCMAKE_PREFIX_PATH=${prefix} \
          -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/C/CImPlot3D/build_tarballs.jl
+++ b/C/CImPlot3D/build_tarballs.jl
@@ -13,6 +13,12 @@ sources = [
     GitSource("https://github.com/cimgui/cimplot3d.git",
               "8c1c16e98fdddc4b3ee78bf0f89e0dd708be79e0"),
 
+    # cimplot3d's generator does `require"cpp2ffi"` and a `dofile` of cimgui's
+    # generator output, expecting cimgui as a sibling directory. Pinned to the
+    # commit that introduced GetScriptArgs (which cimplot3d 8c1c16e9 relies on).
+    GitSource("https://github.com/cimgui/cimgui.git",
+              "ad70f13873e0e9e7a8ba14aa8feebbcbff3b8098"),
+
     # Bundled CMakeLists.txt that links against CImGuiPack_jll's exported
     # cimgui::cimgui target rather than rebuilding imgui sources locally —
     # this is what keeps ImGuiContext / ImPlot3DContext globals shared with
@@ -29,6 +35,18 @@ script = raw"""
 cd $WORKSPACE/srcdir
 git -C cimplot3d submodule update --init --recursive --depth 1
 
+# Regenerate cimplot3d.cpp/.h/.json with comments enabled so docstrings can
+# be lifted into a future Julia wrapper. Mirrors the same pattern as
+# cimgui-pack's build.jl for cimgui itself. The wrapper script passes `gcc`
+# as the C preprocessor; we redirect to ${HOSTCC} so we use the host C
+# compiler (the default `gcc` would be the cross-compiler, wrong arch for
+# something that runs at build time).
+cd cimplot3d/generator
+sed -i 's|TARGETS="internal"|TARGETS="internal comments"|' generator.sh
+sed -i "s|gcc \"\$TARGETS\"|${HOSTCC} \"\$TARGETS\"|" generator.sh
+bash ./generator.sh
+cd $WORKSPACE/srcdir
+
 mkdir build && cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
          -DCMAKE_PREFIX_PATH=${prefix} \
@@ -36,6 +54,10 @@ cmake .. -DCMAKE_INSTALL_PREFIX=${prefix} \
          -DCMAKE_BUILD_TYPE=Release
 make -j${nproc}
 make install
+
+# Install the generator's JSON outputs so a future Julia wrapper can
+# auto-generate bindings (mirrors CImGuiPack's pattern for cimplot etc).
+install -Dvm 644 $WORKSPACE/srcdir/cimplot3d/generator/output/*.json -t ${prefix}/share/cimplot3d
 
 install_license $WORKSPACE/srcdir/cimplot3d/implot3d/LICENSE
 """
@@ -54,14 +76,16 @@ platforms = filter(p -> arch(p) ∉ ("armv6l", "riscv64") &&
 # The products that we will ensure are always built
 products = [
     LibraryProduct("libcimplot3d", :libcimplot3d),
+
+    FileProduct("share/cimplot3d/definitions.json",       :cimplot3d_definitions),
+    FileProduct("share/cimplot3d/structs_and_enums.json", :cimplot3d_structs_and_enums),
+    FileProduct("share/cimplot3d/typedefs_dict.json",     :cimplot3d_typedefs_dict),
+    FileProduct("share/cimplot3d/constants.json",         :cimplot3d_constants),
 ]
 
-# Dependencies that must be installed before this package can be built.
-# CImGuiPack_jll v0.11+ ships consistent imgui 1.92.x cimgui across all
-# platforms (the published v0.8 line was platform-skewed and lacked the
-# `_c`-suffixed types this wrapper requires).
 dependencies = [
     Dependency("CImGuiPack_jll"; compat="0.11"),
+    HostBuildDependency("LuaJIT_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/C/CImPlot3D/build_tarballs.jl
+++ b/C/CImPlot3D/build_tarballs.jl
@@ -15,9 +15,11 @@ sources = [
 
     # cimplot3d's generator does `require"cpp2ffi"` and a `dofile` of cimgui's
     # generator output, expecting cimgui as a sibling directory. Pinned to the
-    # commit that introduced GetScriptArgs (which cimplot3d 8c1c16e9 relies on).
+    # SAME cimgui SHA that CImGuiPack_jll 0.12's libcimgui submodule is built
+    # from, so the C struct types referenced by the generated cimplot3d.cpp
+    # match the layout inside libcimgui at runtime.
     GitSource("https://github.com/cimgui/cimgui.git",
-              "ad70f13873e0e9e7a8ba14aa8feebbcbff3b8098"),
+              "1261b231939fc210032f30c4ee8a8f0440372237"),
 
     # Bundled CMakeLists.txt that links against CImGuiPack_jll's exported
     # cimgui::cimgui target rather than rebuilding imgui sources locally —
@@ -84,7 +86,7 @@ products = [
 ]
 
 dependencies = [
-    Dependency("CImGuiPack_jll"; compat="0.11"),
+    Dependency("CImGuiPack_jll"; compat="0.12"),
     HostBuildDependency("LuaJIT_jll"),
 ]
 

--- a/C/CImPlot3D/build_tarballs.jl
+++ b/C/CImPlot3D/build_tarballs.jl
@@ -66,13 +66,8 @@ install_license $WORKSPACE/srcdir/cimplot3d/implot3d/LICENSE
 
 # Match CImGuiPack's platform filter (excludes armv6l, riscv64,
 # aarch64-freebsd because of GLFW_jll / dependency limitations).
-# We additionally exclude Windows: CImGuiPack's libcimgui.dll only
-# exports the cimgui C wrappers (`ig*`), not the underlying `ImGui::*`
-# C++ symbols that cimplot3d.cpp calls directly, so the link fails.
-# Revisit if cimgui-pack starts exporting all symbols on Windows.
 platforms = filter(p -> arch(p) ∉ ("armv6l", "riscv64") &&
-                        !(arch(p) == "aarch64" && os(p) == "freebsd") &&
-                        os(p) != "windows",
+                        !(arch(p) == "aarch64" && os(p) == "freebsd"),
                    supported_platforms())
 
 # The products that we will ensure are always built
@@ -86,7 +81,7 @@ products = [
 ]
 
 dependencies = [
-    Dependency("CImGuiPack_jll"; compat="0.12"),
+    Dependency("CImGuiPack_jll"; compat="0.12.1"),
     HostBuildDependency("LuaJIT_jll"),
 ]
 

--- a/C/CImPlot3D/bundled/CMakeLists.txt
+++ b/C/CImPlot3D/bundled/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.15)
+project(cimplot3d CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# CImGuiPack_jll exports a cmake target `cimgui::cimgui` via its
+# lib/cmake/cimgui/cimgui-config.cmake. Use it so headers, link line and
+# IMPORTED_LOCATION / SONAME are all picked up portably.
+find_package(cimgui REQUIRED)
+
+add_library(cimplot3d SHARED
+    cimplot3d/cimplot3d.cpp
+    cimplot3d/implot3d/implot3d.cpp
+    cimplot3d/implot3d/implot3d_items.cpp
+    cimplot3d/implot3d/implot3d_meshes.cpp
+    cimplot3d/implot3d/implot3d_demo.cpp
+)
+
+target_include_directories(cimplot3d PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/cimplot3d
+    ${CMAKE_CURRENT_SOURCE_DIR}/cimplot3d/implot3d
+)
+
+# These MUST match the flags CImGuiPack was built with; otherwise
+# ImGuiContext / ImGuiIO struct layouts diverge and ImPlot3D::BeginPlot
+# dereferences garbage. Keep in sync with JuliaImGui/cimgui-pack
+# CMakeLists.txt (target_compile_definitions section).
+target_compile_definitions(cimplot3d PRIVATE
+    IMGUI_DISABLE_OBSOLETE_FUNCTIONS=1
+    IMGUI_ENABLE_TEST_ENGINE
+)
+
+target_link_libraries(cimplot3d PRIVATE cimgui::cimgui)
+
+install(TARGETS cimplot3d
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+install(FILES
+        cimplot3d/cimplot3d.h
+        DESTINATION include)
+
+install(FILES
+        cimplot3d/implot3d/implot3d.h
+        cimplot3d/implot3d/implot3d_internal.h
+        DESTINATION include/implot3d)

--- a/C/CImPlot3D/bundled/CMakeLists.txt
+++ b/C/CImPlot3D/bundled/CMakeLists.txt
@@ -5,10 +5,14 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# CImGuiPack_jll exports a cmake target `cimgui::cimgui` via its
-# lib/cmake/cimgui/cimgui-config.cmake. Use it so headers, link line and
-# IMPORTED_LOCATION / SONAME are all picked up portably.
-find_package(cimgui REQUIRED)
+# Locate libcimgui (from CImGuiPack_jll) and its public headers directly,
+# rather than via find_package(cimgui). The exported cmake target
+# pulls in JlCxx::cxxwrap_julia in its INTERFACE_LINK_LIBRARIES on some
+# platforms; we don't use any cxxwrap symbols so we'd rather not depend
+# on JlCxx at build time.
+find_path(CIMGUI_INCLUDE_DIR cimgui.h REQUIRED)
+find_library(CIMGUI_LIBRARY NAMES cimgui REQUIRED)
+message(STATUS "Using cimgui: ${CIMGUI_LIBRARY} (headers in ${CIMGUI_INCLUDE_DIR})")
 
 add_library(cimplot3d SHARED
     cimplot3d/cimplot3d.cpp
@@ -19,6 +23,7 @@ add_library(cimplot3d SHARED
 )
 
 target_include_directories(cimplot3d PRIVATE
+    ${CIMGUI_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/cimplot3d
     ${CMAKE_CURRENT_SOURCE_DIR}/cimplot3d/implot3d
 )
@@ -32,7 +37,7 @@ target_compile_definitions(cimplot3d PRIVATE
     IMGUI_ENABLE_TEST_ENGINE
 )
 
-target_link_libraries(cimplot3d PRIVATE cimgui::cimgui)
+target_link_libraries(cimplot3d PRIVATE ${CIMGUI_LIBRARY})
 
 install(TARGETS cimplot3d
         RUNTIME DESTINATION bin


### PR DESCRIPTION
C wrapper for [brenocq/implot3d](https://github.com/brenocq/implot3d) via [cimgui/cimplot3d](https://github.com/cimgui/cimplot3d), pinned to `8c1c16e9` which currently tracks implot3d v0.4.

## How it links

Rather than embedding its own copy of imgui sources (the way cimplot3d's upstream CMakeLists does), this recipe `find_package(cimgui)` against the cmake config exported by `CImGuiPack_jll`. That keeps the `ImGuiContext` global shared with whatever else has loaded `libcimgui` at runtime (e.g. `CImGui.jl` on the Julia side), so `ImPlot3D::BeginPlot` operates on the same imgui state.

## Compile defines

Two defines are forced to match cimgui-pack's build (`IMGUI_DISABLE_OBSOLETE_FUNCTIONS=1`, `IMGUI_ENABLE_TEST_ENGINE`) — these change `ImGuiContext` / `ImGuiIO` struct layouts and must match the libcimgui this links against, otherwise `BeginPlot` segfaults inside imgui.

## Platform / compat choices

- Platform filter copied from CImGuiPack (drops armv6l, riscv64, aarch64-freebsd).
- `julia_compat="1.9"` and `preferred_gcc_version=v"5"` to match the parent JLL.
- `compat="0.11"` on `CImGuiPack_jll` — current published line. A bump on the parent will require re-rolling this.
