### PR TITLE
[GLPK] Rebuild with riscv64-linux-gnu support

### DIFF
--- a/G/GLPK/build_tarballs.jl
+++ b/G/GLPK/build_tarballs.jl
@@ -34,9 +34,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # GMP_jll v6.3.0 is the first release with riscv64-linux-gnu artifacts
-    # (still Julia 1.6+ compatible per the General registry).
-    Dependency("GMP_jll"; compat="6.3.0"),
+    Dependency("GMP_jll", v"6.2.1"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/G/GLPK/build_tarballs.jl
+++ b/G/GLPK/build_tarballs.jl
@@ -18,6 +18,7 @@ else
     export CPPFLAGS="-I${prefix}/include"
 fi
 autoreconf -vi
+update_configure_scripts
 ./configure --prefix=${prefix} --host=${target} --build=${MACHTYPE} --with-gmp
 make -j${nproc}
 make install
@@ -33,8 +34,9 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    # We use GMP_jll v6.2.0 because we're requiring Julia v1.6+
-    Dependency("GMP_jll", v"6.2.0"),
+    # GMP_jll v6.3.0 is the first release with riscv64-linux-gnu artifacts
+    # (still Julia 1.6+ compatible per the General registry).
+    Dependency("GMP_jll"; compat="6.3.0"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
@@ -42,4 +44,4 @@ dependencies = [
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; 
                preferred_gcc_version=v"6", julia_compat="1.6")
 
-# Build trigger: 1
+# Build trigger: 2

--- a/G/GLPK/build_tarballs.jl
+++ b/G/GLPK/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder, Pkg
 
 name = "GLPK"
-version = v"5.0.1" # <-- This is a lie, we're bumping from 5.0 to 5.0.1 to create a Julia v1.6+ release with experimental platforms
+version = v"5.0.2" # <-- This is a lie, we're bumping from 5.0 to 5.0.2 to create a Julia v1.6+ release with experimental platforms
 
 # Collection of sources required to build GLPK
 sources = [


### PR DESCRIPTION
## Goal

Publish a `riscv64-linux-gnu` artifact for `GLPK_jll`. The most recent release `GLPK-v5.0.1+1` does not include one, even though the recipe declares `supported_platforms(; experimental=true)` (which lists `riscv64`). The build silently failed on that platform in the previous CI run.

## Why

Downstream packages depending on `GLPK_jll` are forced to filter out `riscv64` (e.g. `Dependency("GLPK_jll"; platforms=filter(p -> arch(p) != "riscv64", platforms))`). With a riscv64 artifact in place, that filter can be removed.

Related #13717 

## Changes

- Call `update_configure_scripts` after `autoreconf -vi` — GLPK 5.0's bundled `config.sub` (2020) does not recognise the `riscv64` host triplet (`Invalid configuration 'riscv64-linux-gnu': machine 'riscv64' not recognized`).
- Bump `GMP_jll` compat from `v"6.2.0"` (positional, resolves to `6.2.0+8` which has no riscv64 artifact) to `compat="6.3.0"`, the first GMP_jll release that ships riscv64-linux-gnu artifacts. GMP_jll 6.3.0 still has `julia = "1.6.0-1"` in the General registry, so `julia_compat="1.6"` is preserved.
- Bump `# Build trigger: 1` → `2` to publish a new release.

## Local validation

Cross-built locally on x86_64-linux-musl host:

```
[ Info: SHA256 of GLPK.v5.0.1.riscv64-linux-gnu.tar.gz: 20fe8291934a2886641e0acfda70d1477a46b8a78aa55fa616eedabc2ad9c10a
[ Info: Timings: setup: 26.17s, build: 47.81s, audit: 12.34s, packaging: 4.69s
```

Audit confirms `libglpk.so.40.3.1` links against `libgmp.so.10`.


AI generated initial PR