### PR TITLE
SCALAPACK: bump ygg_version to 2.2.4

### DIFF
--- a/S/SCALAPACK/SCALAPACK/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK/build_tarballs.jl
@@ -5,6 +5,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SCALAPACK"
 version = v"2.2.3"
+ygg_version = v"2.2.4"
 
 sources = [
   GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
@@ -123,5 +124,5 @@ dependencies = [
 append!(dependencies, platform_dependencies)
 
 # Build the tarballs.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
                augment_platform_block, julia_compat="1.9", preferred_gcc_version=v"9")


### PR DESCRIPTION
Re-release SCALAPACK as artifact v2.2.4 (source remains at upstream v2.2.3).