### PR TITLE
SCALAPACK: bump julia_compat to 1.10

### DIFF
--- a/S/SCALAPACK/SCALAPACK/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK/build_tarballs.jl
@@ -5,7 +5,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SCALAPACK"
 version = v"2.2.3"
-ygg_version = v"2.2.4"
+ygg_version = v"2.2.5"
 
 sources = [
   GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
@@ -125,4 +125,4 @@ append!(dependencies, platform_dependencies)
 
 # Build the tarballs.
 build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.9", preferred_gcc_version=v"9")
+               augment_platform_block, julia_compat="1.10", preferred_gcc_version=v"9")

--- a/S/SCALAPACK/SCALAPACK/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK/build_tarballs.jl
@@ -5,7 +5,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SCALAPACK"
 version = v"2.2.3"
-ygg_version = v"2.2.5"
+ygg_version = v"2.2.4"
 
 sources = [
   GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3


### PR DESCRIPTION
v2.2.4 registration ([General#155774](https://github.com/JuliaRegistries/General/pull/155774)) fails Pkg.add on Julia 1.9 because MPICH_jll 5.0.1 (pulled in by the augmented MPI deps) is only compatible with Julia >= 1.10. The PR still merged via the production AutoMerge, but users on 1.9 cannot install the resulting JLL.

Bump julia_compat to \"1.10\" and re-release as ygg_version 2.2.5.

Same latent issue exists in SCALAPACK64 (General#155748 had the same staging failure); happy to send a follow-up if desired.