### PR TITLE
SCALAPACK{,32,64}: derive ygg_version from upstream patch

### DIFF
--- a/S/SCALAPACK/SCALAPACK/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK/build_tarballs.jl
@@ -5,7 +5,9 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SCALAPACK"
 version = v"2.2.3"
-ygg_version = v"2.2.4"
+# ygg_version.patch = 100 * version.patch + offset; bump `offset` for rebuilds.
+offset = 0
+ygg_version = VersionNumber(version.major, version.minor, 100 * version.patch + offset)
 
 sources = [
   GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3

--- a/S/SCALAPACK/SCALAPACK/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK/build_tarballs.jl
@@ -10,7 +10,7 @@ offset = 0
 ygg_version = VersionNumber(version.major, version.minor, 100 * version.patch + offset)
 
 sources = [
-  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
+  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCALAPACK/SCALAPACK32/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK32/build_tarballs.jl
@@ -10,7 +10,7 @@ offset = 0
 ygg_version = VersionNumber(version.major, version.minor, 100 * version.patch + offset)
 
 sources = [
-  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
+  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCALAPACK/SCALAPACK32/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK32/build_tarballs.jl
@@ -5,7 +5,9 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SCALAPACK32"
 version = v"2.2.3"
-ygg_version = v"2.2.4"
+# ygg_version.patch = 100 * version.patch + offset; bump `offset` for rebuilds.
+offset = 0
+ygg_version = VersionNumber(version.major, version.minor, 100 * version.patch + offset)
 
 sources = [
   GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
@@ -131,4 +133,4 @@ append!(dependencies, platform_dependencies)
 
 # Build the tarballs.
 build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.9", preferred_gcc_version=v"9")
+               augment_platform_block, julia_compat="1.10", preferred_gcc_version=v"9")

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -5,7 +5,9 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SCALAPACK64"
 version = v"2.2.3"
-ygg_version = v"2.2.3"
+# ygg_version.patch = 100 * version.patch + offset; bump `offset` for rebuilds.
+offset = 0
+ygg_version = VersionNumber(version.major, version.minor, 100 * version.patch + offset)
 
 sources = [
   GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
@@ -168,4 +170,4 @@ dependencies = [
 append!(dependencies, platform_dependencies)
 
 build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.9", preferred_gcc_version=v"9")
+               augment_platform_block, julia_compat="1.10", preferred_gcc_version=v"9")

--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -10,7 +10,7 @@ offset = 0
 ygg_version = VersionNumber(version.major, version.minor, 100 * version.patch + offset)
 
 sources = [
-  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
+  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),
 ]
 
 script = raw"""


### PR DESCRIPTION
## Summary
- Replace hand-edited \`ygg_version\` literal with a formula:
  \`ygg_version.patch = 100 * version.patch + offset\` (offset starts at 0, bump for rebuilds).
- Yields \`v\"2.2.300\"\` for the current upstream v2.2.3 in all three packages.
- Side benefit: each rebuild against the same upstream becomes a new artifact version (\`2.2.301\`, \`2.2.302\`, ...) instead of a \`+N\` rebuild of an existing version, which avoids overlapping-Compat conflicts in the General registry (see [General#155777](https://github.com/JuliaRegistries/General/pull/155777)).
- Also bumps \`julia_compat\` to \"1.10\" in SCALAPACK32 and SCALAPACK64 to match SCALAPACK (MPICH_jll 5 requires Julia >= 1.10).

## Test plan
- [ ] CI builds all platform/MPI combinations.
- [ ] General registrator opens fresh SCALAPACK_jll / SCALAPACK32_jll / SCALAPACK64_jll v2.2.300+0 PRs without Compat overlap.