### PR TITLE
SCALAPACK: derive ygg_version from upstream patch

### DIFF
--- a/S/SCALAPACK/SCALAPACK/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK/build_tarballs.jl
@@ -5,10 +5,12 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SCALAPACK"
 version = v"2.2.3"
-ygg_version = v"2.2.4"
+# ygg_version.patch = 100 * version.patch + offset; bump `offset` for rebuilds.
+offset = 0
+ygg_version = VersionNumber(version.major, version.minor, 100 * version.patch + offset)
 
 sources = [
-  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
+  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Replace hand-edited `ygg_version` literal with `ygg_version.patch = 100 * version.patch + offset` (offset starts at 0). Yields `v"2.2.300"` for the current upstream v2.2.3. Bumping the offset for a rebuild produces a fresh artifact version (`2.2.301`, ...) rather than a same-version `+N` rebuild that conflicts with prior Compat.toml entries in the General registry (see [General#155777](https://github.com/JuliaRegistries/General/pull/155777)).