### PR TITLE
SCALAPACK64: derive ygg_version from upstream patch; bump julia_compat to 1.10

### DIFF
--- a/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
+++ b/S/SCALAPACK/SCALAPACK64/build_tarballs.jl
@@ -5,10 +5,12 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "SCALAPACK64"
 version = v"2.2.3"
-ygg_version = v"2.2.3"
+# ygg_version.patch = 100 * version.patch + offset; bump `offset` for rebuilds.
+offset = 0
+ygg_version = VersionNumber(version.major, version.minor, 100 * version.patch + offset)
 
 sources = [
-  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),  # v2.2.3
+  GitSource("https://github.com/Reference-ScaLAPACK/scalapack", "3e0da655fb07de5f1d76d6afb43f16ae17ca98c4"),
 ]
 
 script = raw"""
@@ -168,4 +170,4 @@ dependencies = [
 append!(dependencies, platform_dependencies)
 
 build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
-               augment_platform_block, julia_compat="1.9", preferred_gcc_version=v"9")
+               augment_platform_block, julia_compat="1.10", preferred_gcc_version=v"9")


### PR DESCRIPTION
Same formula as the SCALAPACK PR (`ygg_version.patch = 100 * version.patch + offset`). Also bumps `julia_compat` to "1.10" — MPICH_jll 5 (pulled in by the augmented MPI deps) requires Julia >= 1.10, so the previous `julia_compat="1.9"` produced a JLL that fails `Pkg.add` on Julia 1.9.