### PR TITLE
CUDA: Add an out-of-process NVPTX back-end binary.

### DIFF
--- a/C/CUDA/NVPTX_LLVM_Backend/build_tarballs.jl
+++ b/C/CUDA/NVPTX_LLVM_Backend/build_tarballs.jl
@@ -1,0 +1,99 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "NVPTX_LLVM_Backend"
+version = v"22.1.5"
+
+# Collection of sources required to build NVPTX_LLVM_Backend.
+# LLVM 22 ships a single monorepo source archive (`llvm-project-X.Y.Z.src.tar.xz`).
+sources = [
+    ArchiveSource("https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/llvm-project-$(version).src.tar.xz",
+                  "7972b87b705a003ce70ab55f9f0fb495d156887cba0eb296d284731139118e2c"),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+mv llvm-project-* llvm-project
+
+cd llvm-project/llvm
+LLVM_SRCDIR=$(pwd)
+
+install_license LICENSE.TXT
+
+# The very first thing we need to do is to build llvm-tblgen for x86_64-linux-muslc
+# This is because LLVM's cross-compile setup is kind of borked, so we just
+# build the tools natively ourselves, directly.  :/
+
+# Build llvm-tblgen and llvm-config
+mkdir ${WORKSPACE}/bootstrap
+pushd ${WORKSPACE}/bootstrap
+CMAKE_FLAGS=()
+CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD:STRING=host)
+CMAKE_FLAGS+=(-DLLVM_HOST_TRIPLE=${MACHTYPE})
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='llvm')
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING=False)
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_HOST_TOOLCHAIN})
+cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]}
+ninja -j${nproc} llvm-tblgen llvm-config
+popd
+
+# Let's do the actual build within the `build` subdirectory
+mkdir ${WORKSPACE}/build && cd ${WORKSPACE}/build
+CMAKE_FLAGS=()
+
+# Tell LLVM where our pre-built tblgen tools are
+CMAKE_FLAGS+=(-DLLVM_TABLEGEN=${WORKSPACE}/bootstrap/bin/llvm-tblgen)
+CMAKE_FLAGS+=(-DLLVM_CONFIG_PATH=${WORKSPACE}/bootstrap/bin/llvm-config)
+
+# Install things into $prefix
+CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+
+# Explicitly use our cmake toolchain file and tell CMake we're cross-compiling
+CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
+
+# Release build for best performance
+CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+
+# Only build the NVPTX back-end
+CMAKE_FLAGS+=(-DLLVM_TARGETS_TO_BUILD=NVPTX)
+
+# Turn on ZLIB
+CMAKE_FLAGS+=(-DLLVM_ENABLE_ZLIB=ON)
+# Turn off XML2 and ZSTD to avoid unnecessary dependencies
+CMAKE_FLAGS+=(-DLLVM_ENABLE_ZSTD=OFF)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_LIBXML2=OFF)
+
+# Disable useless things like docs, terminfo, etc....
+CMAKE_FLAGS+=(-DLLVM_INCLUDE_DOCS=Off)
+CMAKE_FLAGS+=(-DLLVM_ENABLE_TERMINFO=Off)
+CMAKE_FLAGS+=(-DHAVE_HISTEDIT_H=Off)
+CMAKE_FLAGS+=(-DHAVE_LIBEDIT=Off)
+
+cmake -GNinja ${LLVM_SRCDIR} ${CMAKE_FLAGS[@]}
+ninja -j${nproc} tools/llc/install
+"""
+
+# Only build for the host platforms where CUDA itself runs.
+platforms = [
+    Platform("x86_64",  "linux";   libc="glibc"),
+    Platform("aarch64", "linux";   libc="glibc"),
+    Platform("x86_64",  "windows"),
+]
+platforms = expand_cxxstring_abis(platforms)
+
+# The products that we will ensure are always built
+products = Product[
+    ExecutableProduct("llc", :llc),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Zlib_jll")
+]
+
+build_tarballs(ARGS, name, version, sources, script,
+               platforms, products, dependencies;
+               preferred_gcc_version=v"10", julia_compat="1.6")


### PR DESCRIPTION
To experiment with in GPUCompiler.jl, because it's becoming annoying to have to support Julia's ancient LLVM (and actually loading multiple copies of LLVM in a robust cross-platform manner seems, well, ambitious).

cc @gbaraldi, @vchuravy