### PR TITLE
[PARI] New recipe v2.17.3

### DIFF
--- a/P/PARI/build_tarballs.jl
+++ b/P/PARI/build_tarballs.jl
@@ -66,6 +66,14 @@ case "${target}" in
     *)                 pari_host="${target}" ;;
 esac
 
+# BinaryBuilder exports LD pointing at the raw `ld`. PARI's Configure honours
+# $LD and would then link executables with `ld` directly, bypassing the
+# compiler driver. That is harmless on Linux (the C-library symbols resolve
+# transitively through libpari's NEEDED entries) but fatal on macOS, where
+# libSystem never lands on the link line (undefined ___stdinp/___stderrp/...).
+# Unset LD so Configure falls back to LD=$CC and links via the driver.
+unset LD
+
 # Cross-compile friendly Configure invocation.
 #   --kernel=gmp  : skip native CPU kernel autodetect, always use GMP kernel
 #   --graphic=none: do not link any plotting backend

--- a/P/PARI/build_tarballs.jl
+++ b/P/PARI/build_tarballs.jl
@@ -54,12 +54,20 @@ make install-lib-dyn
 install_license ${WORKSPACE}/srcdir/pari-*/COPYING
 """
 
-# Start with all supported platforms, then exclude what we know won't build
-# on a first pass.
-platforms = supported_platforms()
-
+# Restricted to x86 Linux only for v1: PARI's Configure runs compiled test
+# binaries to verify the toolchain, which fails under cross-compilation
+# whenever the produced binary cannot run on the BB Linux sandbox (i.e.
+# everywhere except native x86 Linux). Keep the broader pattern below as
+# commented references for follow-up work.
+platforms = [
+    Platform("i686",   "linux"; libc="glibc"),
+    Platform("x86_64", "linux"; libc="glibc"),
+    Platform("i686",   "linux"; libc="musl"),
+    Platform("x86_64", "linux"; libc="musl"),
+]
+# platforms = supported_platforms()
 # Windows (mingw) needs extra work in PARI's Configure → defer to a follow-up.
-platforms = filter(p -> !Sys.iswindows(p), platforms)
+# platforms = filter(p -> !Sys.iswindows(p), platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/P/PARI/build_tarballs.jl
+++ b/P/PARI/build_tarballs.jl
@@ -98,11 +98,9 @@ make install-lib-dyn
 install_license ${WORKSPACE}/srcdir/pari-*/COPYING
 """
 
-# With the RUNTEST shim above, PARI's Configure cross-compiles cleanly, so we
-# build for every platform. Windows/mingw still needs mingw-specific Configure
-# work (DLL naming, winpthreads) and is deferred to a follow-up.
+# With the RUNTEST shim and the LD fix above, PARI's Configure cross-compiles
+# cleanly on every platform, Windows/mingw included.
 platforms = supported_platforms()
-platforms = filter(p -> !Sys.iswindows(p), platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/P/PARI/build_tarballs.jl
+++ b/P/PARI/build_tarballs.jl
@@ -1,0 +1,78 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+# Inside julia, run once: using Pkg; Pkg.add("BinaryBuilder")
+# Example: julia build_tarballs.jl --verbose --debug x86_64-linux-gnu
+
+using BinaryBuilder, Pkg
+
+name = "PARI"
+version = v"2.17.3"
+
+sources = [
+    ArchiveSource(
+        "https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-$(version).tar.gz",
+        "8d9c4fcd584c468d27e0f23c36836587284452094c4b1c404c20c4b810462dcb",
+    ),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/pari-*
+
+# PARI's Configure expects target_host in the form "arch-osname"
+# (its config/get_archos splits on the LAST dash). BB triplets like
+# x86_64-linux-gnu have an extra component, so we normalise them.
+case "${target}" in
+    *-linux-*)         pari_host="$(echo ${target} | cut -d- -f1)-linux" ;;
+    *-apple-darwin*)   pari_host="$(echo ${target} | cut -d- -f1)-darwin" ;;
+    *-freebsd*)        pari_host="$(echo ${target} | cut -d- -f1)-freebsd" ;;
+    *-mingw32*)        pari_host="$(echo ${target} | cut -d- -f1)-mingw" ;;
+    *)                 pari_host="${target}" ;;
+esac
+
+# Cross-compile friendly Configure invocation.
+#   --kernel=gmp  : skip native CPU kernel autodetect, always use GMP kernel
+#   --graphic=none: do not link any plotting backend
+#   --without-readline : no readline dep (libpari is what JLL consumers want)
+#   --mt=pthread  : enable parboundary threading (matches Nemo/Hecke usage)
+./Configure \
+    --prefix=${prefix} \
+    --host=${pari_host} \
+    --with-gmp=${prefix} \
+    --without-readline \
+    --graphic=none \
+    --kernel=gmp \
+    --mt=pthread \
+    --time=clock_gettime
+
+# Configure creates an Oxxx-pthread/ directory; cd in and build.
+cd O*
+make -j${nproc} gp
+make install
+make install-lib-dyn
+
+install_license ${WORKSPACE}/srcdir/pari-*/COPYING
+"""
+
+# Start with all supported platforms, then exclude what we know won't build
+# on a first pass.
+platforms = supported_platforms()
+
+# Windows (mingw) needs extra work in PARI's Configure → defer to a follow-up.
+platforms = filter(p -> !Sys.iswindows(p), platforms)
+
+# The products that we will ensure are always built
+products = [
+    ExecutableProduct("gp", :gp),
+    LibraryProduct("libpari", :libpari),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("GMP_jll"; compat="6.2.1"),
+    Dependency("CompilerSupportLibraries_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat = "1.6", preferred_gcc_version = v"10")

--- a/P/PARI/build_tarballs.jl
+++ b/P/PARI/build_tarballs.jl
@@ -19,6 +19,42 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/pari-*
 
+# --- Cross-compilation shim for PARI's Configure --------------------------
+# PARI's Configure probes the target by COMPILING and then RUNNING small C
+# programs (config/ansi.c, config/gnu.c, config/endian.c, config/gmp_version.c).
+# Under BinaryBuilder everything is cross-compiled, so those probe binaries are
+# foreign and cannot execute on the builder; Configure then aborts with
+# "C compiler does not work" (this is what broke aarch64, darwin, ... ).
+# Configure honours a $RUNTEST hook precisely for cross-compilation, so we
+# point it at a shim that answers each probe from values we already know for
+# ${target}. Note: the has_*.c feature probes use link-only tests already, so
+# RUNTEST is the *only* thing standing between PARI and cross-compilation.
+if [ "${nbits}" -eq 64 ]; then
+    pari_endian="-"          # config/endian.c: '-'  => sizeof(long) == 8
+else
+    pari_endian="1"          # config/endian.c: '1'  => 32-bit IEEE little-endian
+fi
+# config/gmp_version.c only needs a non-empty, non-"unsupported" string.
+pari_gmp_version=$(awk '/define __GNU_MP_VERSION /         {maj=$3}
+                        /define __GNU_MP_VERSION_MINOR /    {min=$3}
+                        /define __GNU_MP_VERSION_PATCHLEVEL /{pat=$3}
+                        END {print maj"."min"."pat}' "${prefix}/include/gmp.h")
+[ -n "${pari_gmp_version}" ] && [ "${pari_gmp_version}" != ".." ] || pari_gmp_version="6.0.0"
+
+cat > "${WORKSPACE}/pari_runtest" <<EOF
+#!/bin/sh
+# Configure calls us as: pari_runtest <freshly-built-probe-binary>.
+# The probe binary's name encodes which check Configure is performing.
+case "\$1" in
+    *-endian*) echo "${pari_endian}" ;;
+    *-gmp*)    echo "${pari_gmp_version}" ;;
+    *)         : ;;   # ansi.c / gnu.c: a 0 exit status is all Configure needs
+esac
+exit 0
+EOF
+chmod +x "${WORKSPACE}/pari_runtest"
+export RUNTEST="${WORKSPACE}/pari_runtest"
+
 # PARI's Configure expects target_host in the form "arch-osname"
 # (its config/get_archos splits on the LAST dash). BB triplets like
 # x86_64-linux-gnu have an extra component, so we normalise them.
@@ -54,20 +90,11 @@ make install-lib-dyn
 install_license ${WORKSPACE}/srcdir/pari-*/COPYING
 """
 
-# Restricted to x86 Linux only for v1: PARI's Configure runs compiled test
-# binaries to verify the toolchain, which fails under cross-compilation
-# whenever the produced binary cannot run on the BB Linux sandbox (i.e.
-# everywhere except native x86 Linux). Keep the broader pattern below as
-# commented references for follow-up work.
-platforms = [
-    Platform("i686",   "linux"; libc="glibc"),
-    Platform("x86_64", "linux"; libc="glibc"),
-    Platform("i686",   "linux"; libc="musl"),
-    Platform("x86_64", "linux"; libc="musl"),
-]
-# platforms = supported_platforms()
-# Windows (mingw) needs extra work in PARI's Configure → defer to a follow-up.
-# platforms = filter(p -> !Sys.iswindows(p), platforms)
+# With the RUNTEST shim above, PARI's Configure cross-compiles cleanly, so we
+# build for every platform. Windows/mingw still needs mingw-specific Configure
+# work (DLL naming, winpthreads) and is deferred to a follow-up.
+platforms = supported_platforms()
+platforms = filter(p -> !Sys.iswindows(p), platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/P/PARI/build_tarballs.jl
+++ b/P/PARI/build_tarballs.jl
@@ -106,6 +106,13 @@ platforms = supported_platforms()
 products = [
     ExecutableProduct("gp", :gp),
     LibraryProduct("libpari", :libpari),
+    # pari.desc: the machine-readable database of every GP function (name, C
+    # symbol, prototype, help text). `make install` always installs it under
+    # share/pari/ (install-cfg target). Declaring it as a product exposes it
+    # as PARI_jll.pari_desc and makes the audit fail loudly if a future PARI
+    # release stops shipping it -- it is the source consumed by auto-generated
+    # high-level wrappers (e.g. a Julia binding generator, like cypari2's).
+    FileProduct("share/pari/pari.desc", :pari_desc),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
## Summary

First BinaryBuilder recipe for [PARI/GP](https://pari.math.u-bordeaux.fr/), the
number-theoretic computer algebra system. There is currently no `PARI_jll` on
Yggdrasil — this recipe adds one.

Long-standing interest from the Julia community: see
[rfourquet/PARI.jl#3](https://github.com/rfourquet/PARI.jl/issues/3) (2020),
where moving to a BinaryBuilder-provided binary was proposed but never
followed through.

## What's in the recipe

- PARI 2.17.3 (latest stable, tarball from pari.math.u-bordeaux.fr)
- Configured with `--kernel=gmp --mt=pthread --without-readline --graphic=none`
- BB triplets normalised to PARI's `arch-osname` form (`config/get_archos`
  splits on the LAST dash, so `x86_64-linux-gnu` must become `x86_64-linux`)
- `GMP_jll` + `CompilerSupportLibraries_jll` as dependencies
- Products: `gp` executable and `libpari` shared library
- Builds for the full `supported_platforms()` set

## Cross-compilation

PARI's `Configure` is not autoconf-based and is hostile to cross-compilation:
it **compiles and then runs** small C probe programs (`config/ansi.c`,
`gnu.c`, `endian.c`, `gmp_version.c`) to detect the toolchain, `sizeof(long)`,
the IEEE double layout and the GMP version. Under BinaryBuilder those probe
binaries are foreign and cannot execute on the builder, so `Configure` aborted
with `### C compiler does not work`.

Two recipe-side fixes make it cross-compile cleanly, with **no patch to PARI's
sources**:

1. **`RUNTEST` shim.** `Configure` honours a `$RUNTEST` hook precisely for
   cross-compilation. The recipe points it at a small script that answers each
   probe from values already known for the target — `sizeof(long)`/endianness
   from `${nbits}`, the GMP version from `gmp.h`. The `has_*.c` feature probes
   already use link-only tests, so `RUNTEST` was the only blocker.
2. **`unset LD`.** BinaryBuilder exports `LD` pointing at the raw `ld`, which
   `Configure` honours; executables were then linked with `ld` directly,
   bypassing the compiler driver. Harmless on Linux but fatal on macOS
   (libSystem never reaches the link line). Unsetting `LD` makes `Configure`
   fall back to `LD=$CC`.

## Tested

Full cross-builds run locally — `Configure`, build, BinaryBuilder audit and
tarball generation all pass:

| Triplet | Result |
|---|---|
| `x86_64-linux-gnu` | ✅ |
| `i686-linux-gnu` | ✅ |
| `aarch64-linux-musl` | ✅ |
| `x86_64-apple-darwin` | ✅ |
| `aarch64-apple-darwin` | ✅ |
| `x86_64-w64-mingw32` | ✅ |
| `i686-w64-mingw32` | ✅ |

These seven cover every OS family (Linux glibc + musl, macOS Intel/ARM,
Windows 32/64-bit) and both word sizes. The remaining `supported_platforms()`
targets (`powerpc64le`, `riscv64`, `armv6l`, `armv7l`, FreeBSD) share the exact
code paths exercised above — CI is the final check.

Smoke test on a native build: `gp -q` runs basic arithmetic, `factor(2^67-1)`
and `polgalois(x^5-x-1)` end-to-end.

## Not bundled

Optional data packages (`elldata`, `galdata`, `seadata`, `galpol`,
`nflistdata`) are not shipped here. They are external downloads from PARI's
site and would be better as separate JLLs, matching Sage's packaging.

## Open question for maintainers

**JLL name capitalisation.** `PARI_jll` (matches PARI's official
capitalisation) vs `Pari_jll` (more conventional Yggdrasil style). Currently
`PARI`.

This PR description and content are AI generated and may be imperfect and provide as draft for discussion.

This could also be used to enable PARI in https://github.com/s-celles/Yggdrasil/blob/4119109471fe80ee07725b66c8e23790ed746ba1/G/GIAC/build_tarballs.jl#L77
