### PR TITLE
[LibreDWG] new recipe for 0.13.4

### DIFF
--- a/L/LibreDWG/build_tarballs.jl
+++ b/L/LibreDWG/build_tarballs.jl
@@ -34,10 +34,8 @@ sources = [
 #   --disable-werror           Tolerates warnings on cross toolchains.
 #   --disable-static           Shared-only, matching JLL convention.
 #
-# PCRE2 (8 + 16 bit) activates `dwggrep` regex search. Libiconv provides
-# the codepage table for ~30 legacy DWG encodings. CPPFLAGS exports the
-# JLL include dir so configure detects both deps; libtool then picks up
-# `-liconv` transitively for the CLI tools that link libredwg.so.
+# CPPFLAGS export form (vs `--with-libiconv-prefix`) preserves libtool
+# dep tracking for CLI tools on musl. Matches `L/LibArchive`, `L/libpsl`.
 #
 # `-Wno-error=implicit-function-declaration` for FreeBSD: LibreDWG calls
 # `memmem` unguarded; FreeBSD hides the decl under `_POSIX_C_SOURCE`.
@@ -73,7 +71,7 @@ products = [
     ExecutableProduct("dwgread",    :dwgread),
     ExecutableProduct("dwgwrite",   :dwgwrite),
     ExecutableProduct("dwgrewrite", :dwgrewrite),
-    ExecutableProduct("dwggrep",    :dwggrep),
+    # `dwggrep` omitted: needs libpcre2-16, which Julia's stdlib PCRE2_jll lacks.
     ExecutableProduct("dwglayers",  :dwglayers),
     ExecutableProduct("dwgbmp",     :dwgbmp),
     ExecutableProduct("dwg2SVG",    :dwg2svg),
@@ -84,12 +82,8 @@ products = [
 # Dependencies that must be installed before this package can be built.
 #   Libiconv_jll  codepage conversion (musl/windows/freebsd need the JLL;
 #                 native on macOS/glibc, harmless to include unconditionally).
-#   PCRE2_jll     8 + 16 bit regex libraries; activates dwggrep regex
-#                 search. Without it dwggrep builds as a stripped-down
-#                 stub (string-match only).
 dependencies = [
     Dependency("Libiconv_jll"; compat="1.17"),
-    Dependency("PCRE2_jll"; compat="10.42"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/LibreDWG/build_tarballs.jl
+++ b/L/LibreDWG/build_tarballs.jl
@@ -93,8 +93,8 @@ products = [
 #                 search. Without it dwggrep builds as a stripped-down
 #                 stub (string-match only).
 dependencies = [
-    Dependency("Libiconv_jll"),
-    Dependency("PCRE2_jll"),
+    Dependency("Libiconv_jll"; compat="1.17"),
+    Dependency("PCRE2_jll"; compat="10.42"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/LibreDWG/build_tarballs.jl
+++ b/L/LibreDWG/build_tarballs.jl
@@ -38,9 +38,17 @@ sources = [
 # the codepage table for ~30 legacy DWG encodings. CPPFLAGS exports the
 # JLL include dir so configure detects both deps; libtool then picks up
 # `-liconv` transitively for the CLI tools that link libredwg.so.
+#
+# `-Wno-error=implicit-function-declaration` downgrades the newer clang
+# strict-mode error LibreDWG hits on FreeBSD: `decode.c` calls `memmem`
+# unguarded, and FreeBSD's `<string.h>` hides the declaration when
+# `_POSIX_C_SOURCE=900000L` is set (which LibreDWG's configure does).
+# The symbol exists in libc; only the declaration is missing, so the
+# link succeeds. Same workaround used in `M/MPIR` and `P/PTSCOTCH`.
 script = raw"""
 cd $WORKSPACE/srcdir/libredwg-*/
 export CPPFLAGS="-I${includedir}"
+export CFLAGS="-Wno-error=implicit-function-declaration"
 ./configure --prefix=${prefix} \
     --build=${MACHTYPE} \
     --host=${target} \

--- a/L/LibreDWG/build_tarballs.jl
+++ b/L/LibreDWG/build_tarballs.jl
@@ -61,10 +61,7 @@ export CFLAGS="-Wno-error=implicit-function-declaration"
     --disable-static
 make -j${nproc}
 make install
-
-# Yggdrasil license-file audit expects share/licenses/<name>/. LibreDWG
-# ships COPYING (GPL-3) at the source root; copy it to the canonical path.
-install -Dm644 COPYING ${prefix}/share/licenses/LibreDWG/COPYING
+install_license COPYING
 """
 
 # These are the platforms we will build for by default, unless further

--- a/L/LibreDWG/build_tarballs.jl
+++ b/L/LibreDWG/build_tarballs.jl
@@ -1,0 +1,102 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "LibreDWG"
+version = v"0.13.4"
+
+# Collection of sources required to build LibreDWG. Upstream release
+# tarball ships a pre-bootstrapped `configure`, so no autogen step is
+# needed.
+sources = [
+    ArchiveSource("https://github.com/LibreDWG/libredwg/releases/download/$(version)/libredwg-$(version).tar.xz",
+                  "7e153ea4dac4cbf3dc9c50b9ef7a5604e09cdd4c5520bcf8017877bbe1422cd5"),
+]
+
+# Bash recipe for building across all platforms.
+#
+# Flags chosen for the broadest production-grade JLL:
+#   --enable-release           Production-stable build (skips unstable DWG
+#                              features). Recommended for packagers per
+#                              upstream README.
+#   --enable-trace             Compiles in the LIBREDWG_TRACE env-var
+#                              diagnostic hook. Default verbosity 0
+#                              (silent), so zero runtime cost when off;
+#                              operators get a path to debug parse
+#                              failures without rebuilding.
+#   --disable-bindings         Drops the Python/Perl/Lua/Ruby wrappers;
+#                              Julia consumers use the C library + CLI
+#                              tools only.
+#   --disable-python           Paranoid pin against picking up host
+#                              Python in the cross-compile rootfs.
+#   --disable-docs             TeXinfo build chain is large; docs not
+#                              shipped in the JLL.
+#   --disable-werror           Tolerates warnings on cross toolchains.
+#   --disable-static           Shared-only, matching JLL convention.
+#
+# PCRE2 (8 + 16 bit) activates `dwggrep` regex search. Libiconv provides
+# the codepage table for ~30 legacy DWG encodings. CPPFLAGS exports the
+# JLL include dir so configure detects both deps; libtool then picks up
+# `-liconv` transitively for the CLI tools that link libredwg.so.
+script = raw"""
+cd $WORKSPACE/srcdir/libredwg-*/
+export CPPFLAGS="-I${includedir}"
+./configure --prefix=${prefix} \
+    --build=${MACHTYPE} \
+    --host=${target} \
+    --enable-release \
+    --enable-trace \
+    --disable-bindings \
+    --disable-python \
+    --disable-docs \
+    --disable-werror \
+    --disable-static
+make -j${nproc}
+make install
+
+# Yggdrasil license-file audit expects share/licenses/<name>/. LibreDWG
+# ships COPYING (GPL-3) at the source root; copy it to the canonical path.
+install -Dm644 COPYING ${prefix}/share/licenses/LibreDWG/COPYING
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line.
+platforms = supported_platforms()
+
+# The products that we will ensure are always built.
+products = [
+    LibraryProduct("libredwg",   :libredwg),
+    ExecutableProduct("dwg2dxf",    :dwg2dxf),
+    ExecutableProduct("dxf2dwg",    :dxf2dwg),
+    ExecutableProduct("dwgread",    :dwgread),
+    ExecutableProduct("dwgwrite",   :dwgwrite),
+    ExecutableProduct("dwgrewrite", :dwgrewrite),
+    ExecutableProduct("dwggrep",    :dwggrep),
+    ExecutableProduct("dwglayers",  :dwglayers),
+    ExecutableProduct("dwgbmp",     :dwgbmp),
+    ExecutableProduct("dwg2SVG",    :dwg2svg),
+    # `dwg2ps` is conditionally built only when pslib is present (configure
+    # emits "pslib for dwg2ps missing with release" otherwise). pslib has no
+    # JLL; dwg2ps is a niche PostScript exporter rarely needed by Julia
+    # consumers, so the product is omitted rather than carrying a fragile
+    # build-from-source dep.
+    ExecutableProduct("dxfwrite",   :dxfwrite),
+]
+
+# Dependencies that must be installed before this package can be built.
+#   Libiconv_jll  codepage conversion for the ~30 legacy DWG encodings.
+#                 macOS + glibc Linux ship iconv natively, but musl Linux
+#                 + Windows MinGW + FreeBSD need an external JLL; passing
+#                 it unconditionally is harmless on the natively-provided
+#                 platforms (ABI-compatible).
+#   PCRE2_jll     8 + 16 bit regex libraries; activates dwggrep regex
+#                 search. Without it dwggrep builds as a stripped-down
+#                 stub (string-match only).
+dependencies = [
+    Dependency("Libiconv_jll"),
+    Dependency("PCRE2_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")

--- a/L/LibreDWG/build_tarballs.jl
+++ b/L/LibreDWG/build_tarballs.jl
@@ -39,12 +39,9 @@ sources = [
 # JLL include dir so configure detects both deps; libtool then picks up
 # `-liconv` transitively for the CLI tools that link libredwg.so.
 #
-# `-Wno-error=implicit-function-declaration` downgrades the newer clang
-# strict-mode error LibreDWG hits on FreeBSD: `decode.c` calls `memmem`
-# unguarded, and FreeBSD's `<string.h>` hides the declaration when
-# `_POSIX_C_SOURCE=900000L` is set (which LibreDWG's configure does).
-# The symbol exists in libc; only the declaration is missing, so the
-# link succeeds. Same workaround used in `M/MPIR` and `P/PTSCOTCH`.
+# `-Wno-error=implicit-function-declaration` for FreeBSD: LibreDWG calls
+# `memmem` unguarded; FreeBSD hides the decl under `_POSIX_C_SOURCE`.
+# Same workaround as `M/MPIR`, `P/PTSCOTCH`.
 script = raw"""
 cd $WORKSPACE/srcdir/libredwg-*/
 export CPPFLAGS="-I${includedir}"
@@ -80,20 +77,13 @@ products = [
     ExecutableProduct("dwglayers",  :dwglayers),
     ExecutableProduct("dwgbmp",     :dwgbmp),
     ExecutableProduct("dwg2SVG",    :dwg2svg),
-    # `dwg2ps` is conditionally built only when pslib is present (configure
-    # emits "pslib for dwg2ps missing with release" otherwise). pslib has no
-    # JLL; dwg2ps is a niche PostScript exporter rarely needed by Julia
-    # consumers, so the product is omitted rather than carrying a fragile
-    # build-from-source dep.
+    # `dwg2ps` omitted: needs pslib, which has no JLL.
     ExecutableProduct("dxfwrite",   :dxfwrite),
 ]
 
 # Dependencies that must be installed before this package can be built.
-#   Libiconv_jll  codepage conversion for the ~30 legacy DWG encodings.
-#                 macOS + glibc Linux ship iconv natively, but musl Linux
-#                 + Windows MinGW + FreeBSD need an external JLL; passing
-#                 it unconditionally is harmless on the natively-provided
-#                 platforms (ABI-compatible).
+#   Libiconv_jll  codepage conversion (musl/windows/freebsd need the JLL;
+#                 native on macOS/glibc, harmless to include unconditionally).
 #   PCRE2_jll     8 + 16 bit regex libraries; activates dwggrep regex
 #                 search. Without it dwggrep builds as a stripped-down
 #                 stub (string-match only).


### PR DESCRIPTION
Adds a builder for [LibreDWG](https://savannah.gnu.org/projects/libredwg/), the GNU C library for reading and writing AutoCAD DWG / DXF files.

The JLL exposes `libredwg` plus the CLI tools `dwgread`, `dwgwrite`, `dwg2dxf`, `dxf2dwg`, `dwglayers`, `dwgbmp`, `dwg2SVG`, `dwgrewrite`, and `dxfwrite`. Two upstream tools are omitted: `dwg2ps` (needs `pslib`, which has no JLL) and `dwggrep` (needs `libpcre2-16`, which Julia's stdlib `PCRE2_jll` lacks; only `libpcre2-8` is bundled).

Build notes:
- `--enable-release` and `--enable-trace` per the upstream README (packager-recommended; the trace hook is gated on `LIBREDWG_TRACE` with verbosity 0 by default — zero runtime cost when off).
- `Libiconv_jll` for legacy DWG codepage conversion. `CPPFLAGS="-I${includedir}"` form (not `--with-libiconv-prefix`) preserves libtool dep tracking for CLI tools on musl; matches `L/LibArchive`, `L/libpsl`.
- `COPYING` installed to `${prefix}/share/licenses/LibreDWG/`.

Verified locally on `aarch64-apple-darwin`.
