### PR TITLE
[aff3ct] Bump libaff3ct_jl wrapper to add RSC, Viterbi, and feedforward conv codes

### DIFF
--- a/A/aff3ct/build_tarballs.jl
+++ b/A/aff3ct/build_tarballs.jl
@@ -7,13 +7,15 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "microarchitectures.jl"))
 
 name = "aff3ct"
-version = v"4.2.0"
+# Upstream aff3ct is still 4.2.0; bumping to 4.2.1 to publish an updated
+# libaff3ct_jl wrapper (BinaryBuilder rejects build-metadata versions).
+version = v"4.2.1"
 
 sources = [
     GitSource("https://github.com/aff3ct/aff3ct.git",
               "bd436ca2d8176983668d3dfbe231d6b52d9b5d06"),
     GitSource("https://github.com/JuliaGNSS/libaff3ct_jl.git",
-              "2d7645a4cae0ffd446bf51d0aef2bcbcac13a605"),
+              "7744526f265b2732d78bb7cd8c5da5b9ae6754f6"),
 ]
 
 script = raw"""


### PR DESCRIPTION
## Summary

Follow-up to #13371. Bumps the `libaff3ct_jl` source pin from
`JuliaGNSS/libaff3ct_jl@2d7645a` to
[`JuliaGNSS/libaff3ct_jl@7744526`](https://github.com/JuliaGNSS/libaff3ct_jl/commits/main),
adding C entry points that were missing from the initial wrapper:

- `aff3ct_rsc_encoder_*` + `aff3ct_viterbi_decoder_*` — RSC encoder and Viterbi decoder
- `aff3ct_conv_encoder_*` + `aff3ct_conv_viterbi_decoder_*` — feedforward convolutional encoder + Viterbi decoder (added upstream in [aff3ct/aff3ct#218](https://github.com/aff3ct/aff3ct/pull/218); useful for e.g. Galileo E1B `[0o171, 0o133]`)
- `aff3ct_sparse_matrix_info_bits_count` — small helper LDPC consumers need to size their info-bit buffer

Also fixes the `Decoder_Viterbi_SIHO` include path, which moved from `Module/Decoder/RSC/Viterbi/` to `Module/Decoder/Conv/Viterbi/` between the source pin in #13371 and the wrapper code added in this bump.

No changes to the `aff3ct` source pin, the build script, dependencies, or the product list — only the wrapper source SHA.

## Test plan

- [x] Wrapper builds against the existing `aff3ct_jll@4.2.0+0` artifact (libaff3ct CMake config)
- [x] All new symbols exported (`nm -D libaff3ct_jl.so` confirms `aff3ct_rsc_*`, `aff3ct_conv_*`, `aff3ct_viterbi_*`, `aff3ct_sparse_matrix_info_bits_count`)
- [x] [`AFF3CT.jl`](https://github.com/JuliaGNSS/AFF3CT.jl) test suite passes against the locally-built wrapper: 30/30 (Polar 7, Turbo 3, LDPC 7, RSC+Viterbi 6, feedforward conv+Viterbi 7)
- [x] Noiseless encode→decode roundtrip bit-exact for `{0o171, 0o133}` K=64 N=140 (Galileo E1B)