### PR TITLE
[HYPRE64] new recipe: ILP64 hypre against libblastrampoline

### DIFF
--- a/H/HYPRE/HYPRE64/build_tarballs.jl
+++ b/H/HYPRE/HYPRE64/build_tarballs.jl
@@ -98,6 +98,7 @@ augment_platform_block = """
 """
 
 platforms = supported_platforms()
+filter!(p -> nbits(p) == 64, platforms)
 platforms, platform_dependencies = MPI.augment_platforms(platforms)
 
 products = [
@@ -105,10 +106,7 @@ products = [
 ]
 
 dependencies = [
-    Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93");
-               compat="5.4.0", platforms=filter(!Sys.iswindows, platforms)),
-    Dependency(PackageSpec(name="OpenBLAS_jll", uuid="4536629a-c528-5b80-bd46-f80d51c5b363");
-               platforms=filter(Sys.iswindows, platforms)),
+    Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"); compat="5.4.0"),
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
                platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");

--- a/H/HYPRE/HYPRE64/build_tarballs.jl
+++ b/H/HYPRE/HYPRE64/build_tarballs.jl
@@ -1,0 +1,110 @@
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
+const YGGDRASIL_DIR = "../../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
+
+name = "HYPRE64"
+version = v"3.1.0"
+offset = 0
+ygg_version = VersionNumber(version.major, version.minor, 100 * version.patch + offset)
+
+sources = [
+    GitSource("https://github.com/hypre-space/hypre.git", "9dc9e18aed6a945a95f966e57daacfb1c269f6ec") # Tag v3.1.0
+]
+
+script = raw"""
+cd $WORKSPACE/srcdir/hypre/src
+
+if [[ "${target}" == *mingw* ]]; then
+    LBT=(-lblastrampoline-5)
+else
+    LBT=(-lblastrampoline)
+fi
+
+MPI_SETTINGS=(-DMPI_HOME=${prefix})
+if [[ "${target}" == x86_64-w64-mingw32 ]]; then
+    MPI_SETTINGS+=(
+        -DMPI_GUESS_LIBRARY_NAME=MSMPI
+        -DMPI_C_LIBRARIES=msmpi64
+        -DMPI_CXX_LIBRARIES=msmpi64
+    )
+fi
+
+mkdir build
+cd build
+
+cmake .. \
+    -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DHYPRE_ENABLE_BIGINT=ON \
+    -DHYPRE_ENABLE_HYPRE_BLAS=OFF \
+    -DHYPRE_ENABLE_HYPRE_LAPACK=OFF \
+    -DTPL_BLAS_LIBRARIES="${LBT[*]}" \
+    -DTPL_LAPACK_LIBRARIES="${LBT[*]}" \
+    -DHYPRE_ENABLE_OPENMP=ON \
+    -DHYPRE_ENABLE_CUDA_STREAMS=OFF \
+    -DHYPRE_ENABLE_CUSPARSE=OFF \
+    -DHYPRE_ENABLE_CURAND=OFF \
+    "${MPI_SETTINGS[@]}"
+
+make -j${nproc}
+make install
+
+cd ${libdir}
+old_files=$(ls libHYPRE.* 2>/dev/null || true)
+for f in $old_files; do
+    new=${f/libHYPRE/libHYPRE64}
+    if [ -L "$f" ]; then
+        tgt=$(readlink "$f")
+        rm -f "$f"
+        ln -sf "${tgt/libHYPRE/libHYPRE64}" "$new"
+    elif [ -f "$f" ]; then
+        mv -v "$f" "$new"
+    fi
+done
+
+if [[ "${target}" == *apple* ]]; then
+    install_name_tool -id "@rpath/libHYPRE64.${dlext}" ${libdir}/libHYPRE64.${dlext}
+elif [[ "${target}" == *mingw* ]]; then
+    :
+else
+    real_lib=$(find ${libdir} -maxdepth 1 -name 'libHYPRE64.so.*' -not -type l | head -1)
+    if [ -n "$real_lib" ]; then
+        soname=$(patchelf --print-soname "$real_lib")
+        case "$soname" in
+            libHYPRE64.*) ;;
+            libHYPRE.*) patchelf --set-soname "${soname/libHYPRE/libHYPRE64}" "$real_lib" ;;
+        esac
+    fi
+fi
+"""
+
+augment_platform_block = """
+    using Base.BinaryPlatforms
+    $(MPI.augment)
+    augment_platform!(platform::Platform) = augment_mpi!(platform)
+"""
+
+platforms = supported_platforms()
+platforms, platform_dependencies = MPI.augment_platforms(platforms)
+
+products = [
+    LibraryProduct("libHYPRE64", :libHYPRE)
+]
+
+dependencies = [
+    Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93");
+               compat="5.4.0", platforms=filter(!Sys.iswindows, platforms)),
+    Dependency(PackageSpec(name="OpenBLAS_jll", uuid="4536629a-c528-5b80-bd46-f80d51c5b363");
+               platforms=filter(Sys.iswindows, platforms)),
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae");
+               platforms=filter(!Sys.isbsd, platforms)),
+    Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e");
+               platforms=filter(Sys.isbsd, platforms))
+]
+append!(dependencies, platform_dependencies)
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               augment_platform_block, julia_compat="1.10", preferred_gcc_version = v"8")

--- a/H/HYPRE/HYPRE64/build_tarballs.jl
+++ b/H/HYPRE/HYPRE64/build_tarballs.jl
@@ -15,6 +15,16 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/hypre/src
 
+sed -i '$i\
+\
+/* HYPRE64 override: rename external BLAS\/LAPACK calls to _64_-suffixed names\
+   so they resolve to libblastrampoline'\''s ILP64 slot. */\
+#undef hypre_F90_NAME_BLAS\
+#undef hypre_F90_NAME_LAPACK\
+#define hypre_F90_NAME_BLAS(name,NAME)   name##_64_\
+#define hypre_F90_NAME_LAPACK(name,NAME) name##_64_\
+' utilities/_hypre_fortran.h
+
 if [[ "${target}" == *mingw* ]]; then
     LBT=(-lblastrampoline-5)
 else


### PR DESCRIPTION
## Summary
Adds a new `HYPRE64_jll` recipe that builds hypre with 64-bit integers (HYPRE_BIGINT) against `libblastrampoline_jll`, mirroring the SCALAPACK / SCALAPACK64 split.

- `HYPRE_ENABLE_BIGINT=ON` — both `HYPRE_Int` and `HYPRE_BigInt` are `long long`. Required by PETSc when configured with `--with-64-bit-indices=1`.
- External BLAS/LAPACK via libblastrampoline: `HYPRE_ENABLE_HYPRE_BLAS=OFF`, `HYPRE_ENABLE_HYPRE_LAPACK=OFF`, `TPL_BLAS_LIBRARIES=-lblastrampoline`, `TPL_LAPACK_LIBRARIES=-lblastrampoline`.
- `HYPRE_ENABLE_OPENMP=ON` (matches the existing HYPRE_jll).
- MPI: MPIABI, MicrosoftMPI, MPICH, MPItrampoline, OpenMPI via the standard `MPI.augment_platforms`.
- Installed library renamed to `libHYPRE64.so` / `.dylib` with SONAME `libHYPRE64.so.301` (via patchelf on Linux, `install_name_tool -id` on macOS) so it doesn't clash with `HYPRE_jll`.

Lives at `H/HYPRE/HYPRE64/` next to the existing `H/HYPRE/build_tarballs.jl`.

## Test plan
- [x] Builds on `x86_64-linux-gnu-libgfortran5-cxx11-mpi+mpiabi`: produces `libHYPRE64.so.3.1.0` with SONAME `libHYPRE64.so.301`, `HYPRE_BIGINT=1` in `HYPRE_config.h`, NEEDED includes `libblastrampoline.so.5` and `libmpi_abi.so.0`.
- [ ] CI builds across all platforms.
- [ ] Verify mingw branch (CMake `MSMPI` settings) on a Windows target build.
- [ ] Smoke-test downstream consumer (PETSc with `--with-64-bit-indices=1 --with-hypre-lib=libHYPRE64`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)