### PR TITLE
[ROCmDeviceLibs] Fix source URLs and build scripts for 6.2.1

### DIFF
--- a/R/ROCmDeviceLibs/ROCmDeviceLibs@6.2.1/build_tarballs.jl
+++ b/R/ROCmDeviceLibs/ROCmDeviceLibs@6.2.1/build_tarballs.jl
@@ -9,23 +9,19 @@ const PRODUCTS = [FileProduct("amdgcn/bitcode/", :bitcode_path)]
 # TODO bundle multiple devlibs & select based on Julia LLVM.
 const URLS = Dict(
     v"6.2.1" => (
-        "https://www.rpmfind.net/linux/fedora/linux/updates/41/Everything/x86_64/Packages/r/rocm-device-libs-18-10.rocm6.2.1.fc41.x86_64.rpm",
-        "e5d6a983fadb89ab8c76d38485198efdbf031cb138a027247c7785d137c32ec0",
+        "https://repo.radeon.com/rocm/apt/6.2.1/pool/main/r/rocm-device-libs6.2.1/rocm-device-libs6.2.1_1.0.0.60201-112~22.04_amd64.deb",
+        "8517fde893bf284b4e8304e51b4829a8d2dd3458b11993081376ff7fbe01acb0",
     )
 )
 
 function configure_build(version)
     buildscript = raw"""
-    apk update
-    apk add rpm2cpio
-
-    echo ${prefix}
-
     cd ${WORKSPACE}/srcdir/
 
-    rpm2cpio rocm-device-libs-18-10.rocm6.2.1.fc41.x86_64.rpm | cpio -idmv
-    mv usr/lib/clang/18/amdgcn ${prefix}
-    mv usr/share/doc/ROCm-Device-Libs/LICENSE.TXT ${prefix}
+    ar x *.deb
+    tar xf data.tar.*
+    mv opt/rocm-6.2.1/lib/llvm/lib/clang/18/lib/amdgcn ${prefix}/amdgcn
+    install_license opt/rocm-6.2.1/share/doc/ROCm-Device-Libs/LICENSE.TXT
     """
 
     sources = [FileSource(URLS[version]...)]

--- a/R/ROCmDeviceLibs/ROCmDeviceLibs@6.2.1/build_tarballs.jl
+++ b/R/ROCmDeviceLibs/ROCmDeviceLibs@6.2.1/build_tarballs.jl
@@ -20,7 +20,7 @@ function configure_build(version)
 
     ar x *.deb
     tar xf data.tar.*
-    mv opt/rocm-6.2.1/lib/llvm/lib/clang/18/lib/amdgcn ${prefix}/amdgcn
+    mv -v opt/rocm-6.2.1/lib/llvm/lib/clang/18/lib/amdgcn ${prefix}/amdgcn
     install_license opt/rocm-6.2.1/share/doc/ROCm-Device-Libs/LICENSE.TXT
     """
 


### PR DESCRIPTION
All three recipes were sourcing prebuilt bitcode from Fedora RPM packages via `rpmfind.net`. These URLs are fragile as the 6.4.1 URL was already returning 404 (Fedora rawhide moves on).

This PR migrates all three to AMD's official stable apt repository (`repo.radeon.com/rocm/apt/{version}/`), which provides versioned .deb packages that don't disappear.