### PR TITLE
[TetGen] install tetgen.h alongside libtet

### DIFF
--- a/T/TetGen/TetGen@1.6/build_tarballs.jl
+++ b/T/TetGen/TetGen@1.6/build_tarballs.jl
@@ -40,6 +40,8 @@ ${CXX} -c -fPIC -std=c++11 -O3 -c -DTETLIBRARY tetgen.cxx -o tetgen.o
 ${CXX} -c -fPIC -std=c++11 -O3 -c -DTETLIBRARY predicates.cxx -o predicates.o
 ${CXX} $LDFLAGS -shared -fPIC tetgen.o predicates.o cwrapper.o -o ${libdir}/libtet.${dlext}
 
+install -Dm644 tetgen.h ${includedir}/tetgen.h
+
 install_license $WORKSPACE/srcdir/cwrapper/LICENSE
 """
 


### PR DESCRIPTION
## Summary
Install \`tetgen.h\` to \`\${includedir}/\` so that C/C++ consumers compiling against \`libtet\` can include it.

Existing Julia consumers that \`dlopen(libtet)\` through TetGen.jl are unaffected — they don't need the header.

## Motivation
PETSc with \`--with-tetgen=1 --with-tetgen-include=\${includedir} --with-tetgen-lib=\${libdir}/libtet.\${dlext}\` requires the header. Today PETSc has to \`--download-tetgen\` and rebuild from source instead of using TetGen_jll.

## Test plan
- [x] Builds locally on \`x86_64-linux-gnu-libgfortran5-cxx11\`: \`libtet.so\` and \`include/tetgen.h\` both installed.
- [ ] CI builds across all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)