### PR TITLE
[Triangle] install triangle.h alongside libtriangle

### DIFF
--- a/T/Triangle/build_tarballs.jl
+++ b/T/Triangle/build_tarballs.jl
@@ -25,6 +25,8 @@ fi
 
 $CC "${ARCHFLAGS[@]}"  "${GENERICFLAGS[@]}" -O3 -fPIC -shared -o "${libdir}/libtriangle.${dlext}" triangle.c triwrapjulia.c
 
+install -Dm644 triangle.h ${includedir}/triangle.h
+
 install_license README
 """
 


### PR DESCRIPTION
## Summary
Install \`triangle.h\` to \`\${includedir}/\` so that C/C++ consumers compiling against \`libtriangle\` can include it.

Existing Julia consumers that \`dlopen(libtriangle)\` through Triangle.jl / TriangleMesh.jl are unaffected — they don't need the header.

## Motivation
PETSc with \`--with-triangle=1 --with-triangle-include=\${includedir} --with-triangle-lib=\${libdir}/libtriangle.\${dlext}\` requires the header. Today PETSc has to \`--download-triangle\` and rebuild from source instead of using Triangle_jll.

## Test plan
- [x] Builds locally on \`x86_64-linux-gnu-libgfortran5-cxx11\`: \`libtriangle.so\` and \`include/triangle.h\` both installed.
- [ ] CI builds across all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)