### PR TITLE
[Triangle] self-define REAL=double in installed triangle.h

### DIFF
--- a/T/Triangle/build_tarballs.jl
+++ b/T/Triangle/build_tarballs.jl
@@ -25,7 +25,16 @@ fi
 
 $CC "${ARCHFLAGS[@]}"  "${GENERICFLAGS[@]}" -O3 -fPIC -shared -o "${libdir}/libtriangle.${dlext}" triangle.c triwrapjulia.c
 
-install -Dm644 triangle.h ${includedir}/triangle.h
+# Triangle's struct layout depends on REAL.  libtriangle is built with
+# REAL=double; prepend a default to triangle.h so header consumers match
+# that ABI without having to define REAL themselves.
+mkdir -p ${includedir}
+{
+    echo '#ifndef REAL'
+    echo '#define REAL double'
+    echo '#endif'
+    cat triangle.h
+} > ${includedir}/triangle.h
 
 install_license README
 """


### PR DESCRIPTION
## Summary
Follow-up to #13796 (installing \`triangle.h\` alongside \`libtriangle\`).

Triangle's \`triangle.h\` uses \`REAL\` for struct fields but does **not** define it — callers are expected to \`#define REAL float\` or \`#define REAL double\` themselves before \`#include "triangle.h"\`. The shared library shipped by this recipe is built with \`-DREAL=double\`, so header consumers must match that to avoid an ABI mismatch.

PETSc with \`--with-triangle=1\` does a bare \`#include <triangle.h>\` and fails with:
\`\`\`
triangle.h:252:3: error: unknown type name 'REAL'
\`\`\`

Prepend a guarded \`#define REAL double\` to the installed header so the default matches the lib's ABI:

\`\`\`c
#ifndef REAL
#define REAL double
#endif
/* rest of triangle.h ... */
\`\`\`

Existing Julia consumers via \`dlopen(libtriangle)\` are unaffected. Source consumers that wanted \`REAL=float\` can still define it before include (the \`#ifndef\` guard preserves that), though they'll get a lib ABI mismatch — for that they'd need a separate \`Triangle_float_jll\` build.

## Test plan
- [x] Builds locally on \`x86_64-linux-gnu-libgfortran5-cxx11\`: header starts with \`#ifndef REAL / #define REAL double\`.
- [x] \`#include <triangle.h>\` + use of \`REAL\` in a test .c compiles cleanly with no caller-side flags.
- [x] CI builds across all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)