### PR TITLE
[new package] fparser v4.5.1

### DIFF
--- a/F/Fparser/build_tarballs.jl
+++ b/F/Fparser/build_tarballs.jl
@@ -1,6 +1,6 @@
 using BinaryBuilder, Pkg
 
-name = "fparser"
+name = "Fparser"
 version = v"4.5.1"
 
 # ---------------------------------------------------------------------------

--- a/F/fparser/build_tarballs.jl
+++ b/F/fparser/build_tarballs.jl
@@ -1,0 +1,57 @@
+using BinaryBuilder, Pkg
+
+name = "fparser"
+version = v"4.5.1"
+
+# ---------------------------------------------------------------------------
+# Sources
+# thliebig's fork of the fparser library (warp.povusers.org/FunctionParser),
+# maintained as a git repository and used as a submodule by openEMS-Project.
+# ---------------------------------------------------------------------------
+sources = [
+    GitSource(
+        "https://github.com/thliebig/fparser.git",
+        "ee15c675514e53b37304179b4a91319d44ba9a85",  # master HEAD (no release tags)
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Build script
+# ---------------------------------------------------------------------------
+script = raw"""
+cd ${WORKSPACE}/srcdir/fparser
+
+cmake -B build \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build --parallel ${nproc}
+cmake --install build
+
+install_license ${WORKSPACE}/srcdir/fparser/docs/lgpl.txt
+"""
+
+# ---------------------------------------------------------------------------
+# Platforms
+# ---------------------------------------------------------------------------
+platforms = expand_cxxstring_abis(supported_platforms())
+
+# ---------------------------------------------------------------------------
+# Products
+# ---------------------------------------------------------------------------
+products = [
+    LibraryProduct("libfparser", :libfparser),
+]
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+dependencies = Dependency[]
+
+build_tarballs(
+    ARGS,
+    name, version, sources, script, platforms, products, dependencies;
+    julia_compat = "1.6",
+    preferred_gcc_version = v"9",
+)


### PR DESCRIPTION
## New package: fparser v4.5.1

Adds a JLL wrapper for [thliebig/fparser](https://github.com/thliebig/fparser), a fork of the [fparser library](http://warp.povusers.org/FunctionParser/) maintained as part of the openEMS-Project.

This library is a mathematical expression parser/evaluator used by CSXCAD and openEMS.

### Notes
- No release tags in the upstream repo; the pinned commit is the current master HEAD
- No external dependencies
- Builds a single shared library `libfparser`
- C++11 ABI variants expanded

This is the first of three related new packages (fparser → CSXCAD → openEMS).