### PR TITLE
[new package] CSXCAD v0.6.3

### DIFF
--- a/C/CSXCAD/build_tarballs.jl
+++ b/C/CSXCAD/build_tarballs.jl
@@ -11,6 +11,7 @@ sources = [
         "https://github.com/thliebig/CSXCAD.git",
         "3861f2102aa9d13fbb0edb115fe446aeca6a0c13",  # tag v0.6.3
     ),
+    DirectorySource("./bundled"),
 ]
 
 # ---------------------------------------------------------------------------
@@ -31,8 +32,7 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/CSXCAD
 
 # Fix bare 'cout' in CSPropDiscMaterial.cpp (upstream bug in v0.6.3)
-sed -i 's/^\tcout << __func__/\tstd::cout << __func__/' \
-    ${WORKSPACE}/srcdir/CSXCAD/src/CSPropDiscMaterial.cpp
+atomic_patch -p1 "${WORKSPACE}/srcdir/patches/fix_bare_cout.patch"
 
 cmake -B build \
     -DCMAKE_INSTALL_PREFIX=${prefix} \

--- a/C/CSXCAD/build_tarballs.jl
+++ b/C/CSXCAD/build_tarballs.jl
@@ -70,7 +70,7 @@ products = [
 # Dependencies
 # ---------------------------------------------------------------------------
 dependencies = [
-    Dependency("fparser_jll"),
+    Dependency("Fparser_jll"),
     Dependency("TinyXML_jll"),
     Dependency("HDF5_jll"),
     Dependency("CGAL_jll"),

--- a/C/CSXCAD/build_tarballs.jl
+++ b/C/CSXCAD/build_tarballs.jl
@@ -1,0 +1,87 @@
+using BinaryBuilder, Pkg
+
+name = "CSXCAD"
+version = v"0.6.3"
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+sources = [
+    GitSource(
+        "https://github.com/thliebig/CSXCAD.git",
+        "3861f2102aa9d13fbb0edb115fe446aeca6a0c13",  # tag v0.6.3
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Build script
+#
+# Key cmake variables:
+#   FPARSER_ROOT_DIR / FPARSER_INCLUDE_DIR  — required; no auto-detection
+#   TinyXML_ROOT_DIR                        — for the custom FindTinyXML.cmake
+#   CMAKE_PREFIX_PATH=$prefix               — covers HDF5, CGAL
+#
+# VTK: find_package(VTK REQUIRED ...) — hard dependency, cannot be omitted.
+#
+# Patch: CSPropDiscMaterial.cpp:330 uses bare 'cout' (missing std::) — upstream
+# bug in v0.6.3 exposed by VTK 9.6 headers which no longer pull in
+# 'using namespace std'.
+# ---------------------------------------------------------------------------
+script = raw"""
+cd ${WORKSPACE}/srcdir/CSXCAD
+
+# Fix bare 'cout' in CSPropDiscMaterial.cpp (upstream bug in v0.6.3)
+sed -i 's/^\tcout << __func__/\tstd::cout << __func__/' \
+    ${WORKSPACE}/srcdir/CSXCAD/src/CSPropDiscMaterial.cpp
+
+cmake -B build \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH=${prefix} \
+    -DFPARSER_ROOT_DIR=${prefix} \
+    -DFPARSER_INCLUDE_DIR=${prefix}/include \
+    -DTinyXML_ROOT_DIR=${prefix}
+
+cmake --build build --parallel ${nproc}
+cmake --install build
+
+install_license ${WORKSPACE}/srcdir/CSXCAD/COPYING
+"""
+
+# ---------------------------------------------------------------------------
+# Platforms
+# FreeBSD and musl excluded: CGAL requires Boost.GMP/MPFR not reliably
+# available in those sysroots.
+# ---------------------------------------------------------------------------
+platforms = supported_platforms(; experimental = false)
+filter!(p -> !(Sys.isfreebsd(p)), platforms)
+filter!(p -> libc(p) != "musl", platforms)
+platforms = expand_cxxstring_abis(platforms)
+
+# ---------------------------------------------------------------------------
+# Products
+# ---------------------------------------------------------------------------
+products = [
+    LibraryProduct("libCSXCAD", :libCSXCAD),
+]
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+dependencies = [
+    Dependency("fparser_jll"),
+    Dependency("TinyXML_jll"),
+    Dependency("HDF5_jll"),
+    Dependency("CGAL_jll"),
+    Dependency("boost_jll"),
+    Dependency("VTK_jll"),
+    BuildDependency("Zlib_jll"),
+]
+
+build_tarballs(
+    ARGS,
+    name, version, sources, script, platforms, products, dependencies;
+    julia_compat = "1.6",
+    preferred_gcc_version = v"9",
+)

--- a/C/CSXCAD/bundled/patches/fix_bare_cout.patch
+++ b/C/CSXCAD/bundled/patches/fix_bare_cout.patch
@@ -1,0 +1,10 @@
+--- a/src/CSPropDiscMaterial.cpp
++++ b/src/CSPropDiscMaterial.cpp
+@@ -327,7 +327,7 @@
+ bool CSPropDiscMaterial::ReadHDF5( std::string filename )
+ {
+-	cout << __func__ << ": Reading \"" << filename << "\"" << std::endl;
++	std::cout << __func__ << ": Reading \"" << filename << "\"" << std::endl;
+ 
+ 	// open hdf5 file
+ 	hid_t file_id = H5Fopen( filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT );


### PR DESCRIPTION
## New package: CSXCAD v0.6.3

Adds a JLL wrapper for [thliebig/CSXCAD](https://github.com/thliebig/CSXCAD) (Continuous Structure for X-FDTD), the geometry library used by the openEMS FDTD simulator.

**Depends on #13804 (fparser_jll) being merged and released first.**

### Notes
- Requires `fparser_jll`, `TinyXML_jll`, `HDF5_jll`, `CGAL_jll`, `boost_jll`, `VTK_jll`
- FreeBSD and musl excluded (CGAL dependency)
- Patch: fixes bare `cout` in `CSPropDiscMaterial.cpp` (upstream bug in v0.6.3, exposed by VTK 9.6 headers)
- CSXCAD headers install to `include/CSXCAD/`

This is the second of three related new packages (fparser → **CSXCAD** → openEMS).