### PR TITLE
iceberg_rust_ffi: New version 0.8.0

### DIFF
--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -1,10 +1,10 @@
 using BinaryBuilder
 
 name = "iceberg_rust_ffi"
-version = v"0.7.21"
+version = v"0.8.0"
 
 sources = [
-    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "f4425f483bdd6bf4c2d36c119f1b7720956fe2f1"),
+    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "3730bafee5b55eff4192f528936abf70c1a08abb"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
## Summary
- Bump `iceberg_rust_ffi` from v0.7.21 → v0.8.0
- Source SHA updated to `3730bafe`, the current tip of `main` on [RelationalAI/RustyIceberg.jl](https://github.com/RelationalAI/RustyIceberg.jl) (merge of RelationalAI/RustyIceberg.jl#100, "Switch batch scan from Arrow IPC to Arrow C Data Interface"). The Rust crate's `iceberg_rust_ffi/Cargo.toml` declares `version = "0.8.0"` at that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)