### PR TITLE
[OpenVDB] fix stdlib JLL compat for v13.0.0+1 republish

### DIFF
--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "OpenVDB"
-version = v"13.0.0"
+version = v"13.0.0+1"
 
 # Collection of sources required to complete build
 sources = [

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "OpenVDB"
-version = v"13.0.0+1"
+version = v"13.0.0"
 
 # Collection of sources required to complete build
 sources = [

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -68,6 +68,9 @@ platforms = expand_cxxstring_abis(supported_platforms())
 # Disable platforms that we don't have oneTBB for
 filter!(p -> arch(p) ∉ ("armv6l", "armv7l"), platforms)
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
+# Zlib_jll's stdlib version on Julia 1.10/1.11 (1.2.13+1) doesn't ship a
+# riscv64 binary; BB pins stdlib JLLs to the julia_compat floor's version.
+filter!(p -> arch(p) != "riscv64", platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -80,12 +80,12 @@ dependencies = [
     Dependency("boost_jll"; compat="1.87"),
     Dependency("oneTBB_jll"; compat="2022.3"),
     Dependency("Blosc_jll"; compat="1.21.7"),
-    Dependency("Zlib_jll"; compat="1.3.2"),
+    Dependency("Zlib_jll"; compat="1.2.13"),
     # libopenvdb.so links libgcc_s; audit fails to auto-map without this.
-    Dependency("CompilerSupportLibraries_jll"),
+    Dependency("CompilerSupportLibraries_jll"; compat="1.0.5"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 # OpenVDB 13's OpenVDBCXX.cmake requires g++ >= 11.2.1.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"12")
+               julia_compat="1.10", preferred_gcc_version=v"12")

--- a/O/OpenVDB/build_tarballs.jl
+++ b/O/OpenVDB/build_tarballs.jl
@@ -68,9 +68,9 @@ platforms = expand_cxxstring_abis(supported_platforms())
 # Disable platforms that we don't have oneTBB for
 filter!(p -> arch(p) ∉ ("armv6l", "armv7l"), platforms)
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
-# Zlib_jll's stdlib version on Julia 1.10/1.11 (1.2.13+1) doesn't ship a
-# riscv64 binary; BB pins stdlib JLLs to the julia_compat floor's version.
+# Zlib_jll stdlib on Julia 1.10-1.12 has neither riscv64 nor aarch64-freebsd.
 filter!(p -> arch(p) != "riscv64", platforms)
+filter!(p -> !(arch(p) == "aarch64" && Sys.isfreebsd(p)), platforms)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
Fixes the `Zlib_jll` compat in #13687 that blocked AutoMerge on `JuliaRegistries/General#156243`.

Changes:
- `Zlib_jll`: `1.2.13`.
- `CompilerSupportLibraries_jll`: `1.0.5`.
- `julia_compat`: `1.10`. Allows the stdlib compats to stay single-range.
- `riscv64` and `aarch64-unknown-freebsd` dropped: Julia 1.10-1.12 stdlib `Zlib_jll` (1.2.13+1, 1.3.1+0) has neither binary; BB pins stdlib JLLs to the `julia_compat` floor's version.

Verified locally on `aarch64-apple-darwin`, `libopenvdb.13.0.0.dylib` dlopens.
