### PR TITLE
[Eigen] Update to v5.0.1

### DIFF
--- a/E/Eigen/build_tarballs.jl
+++ b/E/Eigen/build_tarballs.jl
@@ -1,11 +1,11 @@
 using BinaryBuilder
 
 name = "Eigen"
-version = v"3.4.1"
+version = v"5.0.1"
 
 sources = [
     GitSource("https://gitlab.com/libeigen/eigen.git",
-              "b66188b5dfd147265bfa9ec47595ca0db72d21f5")
+              "bc3b39870ecb690a623a3f49149a358b95c5781d")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
**Notice:** Since version 5.0.0, Eigen switched to semantic versioning. So the change from 3.4.1 to 5.0.1 actually corresponds to only one increase in the major version number.
More details here:
[https://gitlab.com/libeigen/eigen/-/releases/5.0.0](https://gitlab.com/libeigen/eigen/-/releases/5.0.0 )

Despite the major update, no significant changes in the recipe were needed.