### PR TITLE
[fmusim] Bump the bundled zlib to v1.3.2

### DIFF
--- a/F/fmusim/build_tarballs.jl
+++ b/F/fmusim/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
     # fmusim compiles three minizip sources (ioapi.c, unzip.c, iowin32.c)
     # directly from a zlib source tree, so we ship one alongside.
     GitSource("https://github.com/madler/zlib.git",
-              "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf"),
+              "da607da739fa6047df13e66a2af6b8bec7c2a498"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
That's the latest version and avoids a low-severity CVE.