### PR TITLE
MQLib: add C ABI library product

### DIFF
--- a/M/MQLib/build_tarballs.jl
+++ b/M/MQLib/build_tarballs.jl
@@ -30,7 +30,7 @@ if [[ ! -f "${MQLIB_JL_SRC}/c_api/src/mqlib_c_api.cpp" ]]; then
     exit 1
 fi
 
-mkdir -p "${bindir}" "${libdir}" "${includedir}"
+mkdir -p "${bindir}" "${libdir}" "${includedir}" "${datadir}/mqlib/hhdata"
 
 cd "${MQLIB_SRC}"
 make -j${nproc}
@@ -38,6 +38,7 @@ install -Dvm 0755 bin/MQLib "${bindir}/MQLib${exeext}"
 install -Dvm 0644 \
     "${MQLIB_JL_SRC}/c_api/include/mqlib_c_api.h" \
     "${includedir}/mqlib_c_api.h"
+install -vm 0644 hhdata/*.rf "${datadir}/mqlib/hhdata/"
 
 MQLIB_LIBRARY_SOURCES="$(find src -name '*.cpp' ! -name main.cpp | sort)"
 

--- a/M/MQLib/build_tarballs.jl
+++ b/M/MQLib/build_tarballs.jl
@@ -43,21 +43,19 @@ install -vm 0644 hhdata/*.rf "${datadir}/mqlib/hhdata/"
 MQLIB_LIBRARY_SOURCES="$(find src -name '*.cpp' ! -name main.cpp | sort)"
 
 if [[ "${target}" == *-mingw* ]]; then
-    MQLIB_C_API_LIBRARY="${bindir}/libmqlib_c_api.${dlext}"
     MQLIB_C_API_SHARED_FLAGS=(
         -shared
         -Wl,--out-implib,"${libdir}/libmqlib_c_api.dll.a"
     )
 elif [[ "${target}" == *-apple-darwin* ]]; then
-    MQLIB_C_API_LIBRARY="${libdir}/libmqlib_c_api.${dlext}"
     MQLIB_C_API_SHARED_FLAGS=(
         -dynamiclib
         -Wl,-install_name,@rpath/libmqlib_c_api.${dlext}
     )
 else
-    MQLIB_C_API_LIBRARY="${libdir}/libmqlib_c_api.${dlext}"
     MQLIB_C_API_SHARED_FLAGS=(-shared)
 fi
+MQLIB_C_API_LIBRARY="${libdir}/libmqlib_c_api.${dlext}"
 
 "${CXX}" \
     -std=c++11 \

--- a/M/MQLib/build_tarballs.jl
+++ b/M/MQLib/build_tarballs.jl
@@ -39,7 +39,7 @@ install -Dvm 0644 \
     "${MQLIB_JL_SRC}/c_api/include/mqlib_c_api.h" \
     "${includedir}/mqlib_c_api.h"
 
-mapfile -t MQLIB_LIBRARY_SOURCES < <(find src -name '*.cpp' ! -name main.cpp | sort)
+MQLIB_LIBRARY_SOURCES="$(find src -name '*.cpp' ! -name main.cpp | sort)"
 
 if [[ "${target}" == *-mingw* ]]; then
     MQLIB_C_API_LIBRARY="${bindir}/libmqlib_c_api.${dlext}"
@@ -65,7 +65,7 @@ fi
     -DMQLIB_C_BUILD_SHARED \
     -Iinclude \
     -I"${MQLIB_JL_SRC}/c_api/include" \
-    "${MQLIB_LIBRARY_SOURCES[@]}" \
+    ${MQLIB_LIBRARY_SOURCES} \
     "${MQLIB_JL_SRC}/c_api/src/mqlib_c_api.cpp" \
     "${MQLIB_C_API_SHARED_FLAGS[@]}" \
     -o "${MQLIB_C_API_LIBRARY}" \

--- a/M/MQLib/build_tarballs.jl
+++ b/M/MQLib/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "MQLib"
-version = v"0.1.1"
+version = v"0.1.2"
 
 # Collection of sources required to complete build
 sources = [
@@ -11,13 +11,65 @@ sources = [
         "https://github.com/MQLib/MQLib.git",
         "585496274af5abb0849d0d47e135496b4688680b",
     ),
+    GitSource(
+        "https://github.com/JuliaQUBO/MQLib.jl.git",
+        "3160500db96ca1a1bb1271897c4141b9124676cf",
+    ),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd ${WORKSPACE}/srcdir/MQLib/
+cd "${WORKSPACE}/srcdir"
+
+MQLIB_SRC="${WORKSPACE}/srcdir/MQLib"
+MQLIB_C_HEADER="$(find "${WORKSPACE}/srcdir" -path '*/c_api/include/mqlib_c_api.h' -print -quit)"
+MQLIB_JL_SRC="${MQLIB_C_HEADER%/c_api/include/mqlib_c_api.h}"
+
+if [[ ! -f "${MQLIB_JL_SRC}/c_api/src/mqlib_c_api.cpp" ]]; then
+    echo "Could not find MQLib.jl C ABI sources" >&2
+    exit 1
+fi
+
+mkdir -p "${bindir}" "${libdir}" "${includedir}"
+
+cd "${MQLIB_SRC}"
 make -j${nproc}
 install -Dvm 0755 bin/MQLib "${bindir}/MQLib${exeext}"
+install -Dvm 0644 \
+    "${MQLIB_JL_SRC}/c_api/include/mqlib_c_api.h" \
+    "${includedir}/mqlib_c_api.h"
+
+mapfile -t MQLIB_LIBRARY_SOURCES < <(find src -name '*.cpp' ! -name main.cpp | sort)
+
+if [[ "${target}" == *-mingw* ]]; then
+    MQLIB_C_API_LIBRARY="${bindir}/libmqlib_c_api.${dlext}"
+    MQLIB_C_API_SHARED_FLAGS=(
+        -shared
+        -Wl,--out-implib,"${libdir}/libmqlib_c_api.dll.a"
+    )
+elif [[ "${target}" == *-apple-darwin* ]]; then
+    MQLIB_C_API_LIBRARY="${libdir}/libmqlib_c_api.${dlext}"
+    MQLIB_C_API_SHARED_FLAGS=(
+        -dynamiclib
+        -Wl,-install_name,@rpath/libmqlib_c_api.${dlext}
+    )
+else
+    MQLIB_C_API_LIBRARY="${libdir}/libmqlib_c_api.${dlext}"
+    MQLIB_C_API_SHARED_FLAGS=(-shared)
+fi
+
+"${CXX}" \
+    -std=c++11 \
+    -O2 \
+    -fPIC \
+    -DMQLIB_C_BUILD_SHARED \
+    -Iinclude \
+    -I"${MQLIB_JL_SRC}/c_api/include" \
+    "${MQLIB_LIBRARY_SOURCES[@]}" \
+    "${MQLIB_JL_SRC}/c_api/src/mqlib_c_api.cpp" \
+    "${MQLIB_C_API_SHARED_FLAGS[@]}" \
+    -o "${MQLIB_C_API_LIBRARY}" \
+    -lm
 """
 
 # These are the platforms we will build for by default, unless further
@@ -27,7 +79,8 @@ platforms = expand_cxxstring_abis(supported_platforms())
 
 # The products that we will ensure are always built
 products = [
-    ExecutableProduct("MQLib", :MQLib)
+    ExecutableProduct("MQLib", :MQLib),
+    LibraryProduct("libmqlib_c_api", :libmqlib_c_api),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
## Summary

This updates the MQLib BinaryBuilder recipe to ship the C ABI wrapper added in JuliaQUBO/MQLib.jl v0.5.0.

- Keep the existing `ExecutableProduct("MQLib", :MQLib)`.
- Add `LibraryProduct("libmqlib_c_api", :libmqlib_c_api)`.
- Add JuliaQUBO/MQLib.jl v0.5.0 as a `GitSource` for `c_api/include/mqlib_c_api.h` and `c_api/src/mqlib_c_api.cpp`.
- Build the shared library from upstream MQLib implementation sources plus the C ABI wrapper, excluding the upstream executable entry point `src/main.cpp`.
- Install `mqlib_c_api.h` into `includedir`.
- Install upstream hyperheuristic model files under `share/mqlib/hhdata`.
- Export symbols on Windows with `MQLIB_C_BUILD_SHARED` and place the DLL under `bindir`.

## Validation

- `julia +1.12 --startup-file=no -e 'Meta.parseall(read("M/MQLib/build_tarballs.jl", String)); println("recipe parse ok")'`
- `git diff --check`
- Yggdrasil Buildkite build #29731 passed across the refreshed MQLib platform matrix, including Linux, macOS, Windows, and FreeBSD targets.

I did not run a local full cross-platform BinaryBuilder build. This PR relies on Yggdrasil CI for the authoritative artifact builds.

## Related

- JuliaQUBO/MQLib.jl#7
- JuliaQUBO/MQLib.jl#11
