### PR TITLE
[FindMUS] Add recipe for findMUS v0.7.0

### DIFF
--- a/F/FindMUS/build_tarballs.jl
+++ b/F/FindMUS/build_tarballs.jl
@@ -14,6 +14,7 @@ sources = [
         "https://gitlab.com/minizinc/FindMUS.git",
         "d986e4e114a11eddb7def41837f900e00845a800",
     ),
+    DirectorySource("./bundled"),
 ]
 
 # find_package(libminizinc) resolves against MiniZinc_jll's
@@ -28,11 +29,13 @@ sources = [
 # <inttypes.h>/<stdint.h>. Define both globally via CMAKE_CXX_FLAGS.
 script = raw"""
 cd $WORKSPACE/srcdir/FindMUS
-# musl lacks glibc's <fpu_control.h>; the vendored MiniSat includes it under a
-# bare __linux__ guard but only uses it (in System.cc) when _FPU_* are defined.
-# Gate the include on __GLIBC__ so the build works on musl too.
-sed -i 's/#if defined(__linux__)/#if defined(__linux__) \&\& defined(__GLIBC__)/' \
-    mapsolvers/minisat/minisat/utils/System.h
+# Apply the bundled source patches. Currently just one: musl lacks glibc's
+# <fpu_control.h>, which the vendored MiniSat includes under a bare __linux__
+# guard (using it, in System.cc, only when _FPU_* are defined); the patch gates
+# the include on __GLIBC__ so the build works on musl too.
+for f in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 ${f}
+done
 cmake -B build \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \

--- a/F/FindMUS/build_tarballs.jl
+++ b/F/FindMUS/build_tarballs.jl
@@ -42,6 +42,10 @@ cmake -B build \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake --build build --parallel ${nproc}
 cmake --install build
+# findMUS is MPL-2.0; install its license explicitly rather than relying on the
+# single-source license auto-detection (which silently stops finding it if
+# another source is ever added).
+install_license LICENSE.txt
 """
 
 products = [

--- a/F/FindMUS/build_tarballs.jl
+++ b/F/FindMUS/build_tarballs.jl
@@ -28,6 +28,11 @@ sources = [
 # <inttypes.h>/<stdint.h>. Define both globally via CMAKE_CXX_FLAGS.
 script = raw"""
 cd $WORKSPACE/srcdir/FindMUS
+# musl lacks glibc's <fpu_control.h>; the vendored MiniSat includes it under a
+# bare __linux__ guard but only uses it (in System.cc) when _FPU_* are defined.
+# Gate the include on __GLIBC__ so the build works on musl too.
+sed -i 's/#if defined(__linux__)/#if defined(__linux__) \&\& defined(__GLIBC__)/' \
+    mapsolvers/minisat/minisat/utils/System.h
 cmake -B build \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
@@ -45,9 +50,12 @@ products = [
     FileProduct("share/minizinc/solvers/findmus.msc", :findmus_msc),
 ]
 
-# Mirror MiniZinc_jll's platform set: findMUS statically links libmzn.a.
+# findMUS statically links libmzn.a from MiniZinc_jll. Windows is excluded:
+# findMUS's CMake cannot locate libminizinc in the MiniZinc_jll Windows artifact
+# (libminizinc's own Windows support is a known work in progress), so drop all
+# Windows platforms rather than ship a broken build.
 platforms = expand_cxxstring_abis(
-    supported_platforms(; exclude = p -> arch(p) == "i686" && Sys.iswindows(p)),
+    supported_platforms(; exclude = Sys.iswindows),
 )
 
 dependencies = [

--- a/F/FindMUS/build_tarballs.jl
+++ b/F/FindMUS/build_tarballs.jl
@@ -19,8 +19,7 @@ sources = [
 
 # find_package(libminizinc) resolves against MiniZinc_jll's
 # lib/cmake/libminizinc config (shipped alongside lib/libmzn.a and
-# include/minizinc/). CMAKE_POLICY_VERSION_MINIMUM placates the vendored
-# MiniSat's pre-3.5 CMakeLists under modern CMake.
+# include/minizinc/).
 #
 # findMUS's own targets include the vendored MiniSat's Options.h, which uses
 # PRIi64 and INT64_MIN/INT64_MAX. MiniSat's CMakeLists defines
@@ -41,13 +40,9 @@ cmake -B build \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH=${prefix} \
-    -DCMAKE_CXX_FLAGS="-D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" \
-    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    -DCMAKE_CXX_FLAGS="-D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
 cmake --build build --parallel ${nproc}
 cmake --install build
-# findMUS is MPL-2.0; install its license explicitly rather than relying on the
-# single-source license auto-detection (which silently stops finding it if
-# another source is ever added).
 install_license LICENSE.txt
 """
 

--- a/F/FindMUS/build_tarballs.jl
+++ b/F/FindMUS/build_tarballs.jl
@@ -1,0 +1,64 @@
+# Recipe for FindMUS_jll: findMUS (https://gitlab.com/minizinc/FindMUS), the
+# Minimal Unsatisfiable Subset (MUS / IIS) tool for MiniZinc. Given an
+# unsatisfiable MiniZinc model it reports a minimal conflicting subset of
+# constraints, running as a MiniZinc pseudo-solver.
+
+using BinaryBuilder, Pkg
+
+name = "FindMUS"
+# findMUS has no release tags; findmus.msc reports 0.7.0, so pin a commit.
+version = v"0.7.0"
+
+sources = [
+    GitSource(
+        "https://gitlab.com/minizinc/FindMUS.git",
+        "d986e4e114a11eddb7def41837f900e00845a800",
+    ),
+]
+
+# find_package(libminizinc) resolves against MiniZinc_jll's
+# lib/cmake/libminizinc config (shipped alongside lib/libmzn.a and
+# include/minizinc/). CMAKE_POLICY_VERSION_MINIMUM placates the vendored
+# MiniSat's pre-3.5 CMakeLists under modern CMake.
+script = raw"""
+cd $WORKSPACE/srcdir/FindMUS
+cmake -B build \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH=${prefix} \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+cmake --build build --parallel ${nproc}
+cmake --install build
+"""
+
+products = [
+    ExecutableProduct("findMUS", :findMUS),
+    # findmus.msc lets MiniZinc locate findMUS the way it locates Chuffed.
+    FileProduct("share/minizinc/solvers/findmus.msc", :findmus_msc),
+]
+
+# Mirror MiniZinc_jll's platform set: findMUS statically links libmzn.a.
+platforms = expand_cxxstring_abis(
+    supported_platforms(; exclude = p -> arch(p) == "i686" && Sys.iswindows(p)),
+)
+
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
+    # findMUS links MiniZinc_jll's libmzn.a, so this is an exact pin that must
+    # move in lockstep with the MiniZinc_jll version.
+    Dependency("MiniZinc_jll"; compat = "=2.9.5"),
+]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    preferred_gcc_version = v"6",  # matches MiniZinc_jll for ABI compatibility
+    julia_compat = "1.10",
+)

--- a/F/FindMUS/build_tarballs.jl
+++ b/F/FindMUS/build_tarballs.jl
@@ -20,6 +20,12 @@ sources = [
 # lib/cmake/libminizinc config (shipped alongside lib/libmzn.a and
 # include/minizinc/). CMAKE_POLICY_VERSION_MINIMUM placates the vendored
 # MiniSat's pre-3.5 CMakeLists under modern CMake.
+#
+# findMUS's own targets include the vendored MiniSat's Options.h, which uses
+# PRIi64 and INT64_MIN/INT64_MAX. MiniSat's CMakeLists defines
+# __STDC_FORMAT_MACROS / __STDC_LIMIT_MACROS, but only in its subdirectory
+# scope, so findMUS's sources fail to compile against the older-glibc and musl
+# <inttypes.h>/<stdint.h>. Define both globally via CMAKE_CXX_FLAGS.
 script = raw"""
 cd $WORKSPACE/srcdir/FindMUS
 cmake -B build \
@@ -27,6 +33,7 @@ cmake -B build \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH=${prefix} \
+    -DCMAKE_CXX_FLAGS="-D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake --build build --parallel ${nproc}
 cmake --install build

--- a/F/FindMUS/bundled/patches/minisat-fpu_control-glibc-guard.patch
+++ b/F/FindMUS/bundled/patches/minisat-fpu_control-glibc-guard.patch
@@ -1,0 +1,21 @@
+Gate the vendored MiniSat's <fpu_control.h> include on __GLIBC__.
+
+musl libc lacks glibc's <fpu_control.h>, but MiniSat includes it under a bare
+__linux__ guard. The header is only actually used (in System.cc) when the _FPU_*
+macros are defined, so restricting the include to glibc lets the build succeed on
+musl targets while leaving glibc targets (where the header and macros remain
+available) unchanged.
+
+diff --git a/mapsolvers/minisat/minisat/utils/System.h b/mapsolvers/minisat/minisat/utils/System.h
+index a51d4c2..031014e 100644
+--- a/mapsolvers/minisat/minisat/utils/System.h
++++ b/mapsolvers/minisat/minisat/utils/System.h
+@@ -21,7 +21,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
+ #ifndef Minisat_System_h
+ #define Minisat_System_h
+ 
+-#if defined(__linux__)
++#if defined(__linux__) && defined(__GLIBC__)
+ #include <fpu_control.h>
+ #endif
+ 


### PR DESCRIPTION
## FindMUS v0.7.0

New recipe for [findMUS](https://gitlab.com/minizinc/FindMUS), the Minimal
Unsatisfiable Subset (MUS / IIS) tool for MiniZinc. Given an unsatisfiable
MiniZinc model, it reports a minimal conflicting subset of constraints. It runs
as a MiniZinc pseudo-solver and is the backend for constraint-conflict support
in MiniZinc.jl.

### Notes

- **No upstream release tags**, so the source is pinned to a commit; `findmus.msc` reports version 0.7.0.
- **ABI coupling with MiniZinc_jll.** findMUS statically links libminizinc (`libmzn.a`), so `MiniZinc_jll` is an exact-pinned dependency (`=2.9.5`), the platform set follows MiniZinc_jll's, and `preferred_gcc_version` matches it. The pin must move in lockstep with future MiniZinc_jll bumps.
- **Windows is excluded** (`exclude = Sys.iswindows`): the libminizinc/findMUS build is not viable under mingw, so the platform set is MiniZinc_jll's minus Windows.
- `CMAKE_POLICY_VERSION_MINIMUM=3.5` accommodates the vendored MiniSat's pre-3.5 CMakeLists under modern CMake.
- **musl portability patch.** The vendored MiniSat includes glibc's `<fpu_control.h>` under a bare `__linux__` guard, which breaks musl builds. A bundled patch (`F/FindMUS/bundled/patches/`, applied with `atomic_patch -p1` via a `DirectorySource`) gates the include on `__GLIBC__`. MiniSat only uses the header when the `_FPU_*` macros are defined, so glibc targets are unaffected.
- **License**: findMUS is MPL-2.0; its `LICENSE.txt` is installed explicitly with `install_license` rather than relying on single-source auto-detection, so it stays correct if more sources are added.
- Products: the `findMUS` executable and the `findmus.msc` solver configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
