### PR TITLE
Update RDKit to 2026.03.1

### DIFF
--- a/R/RDKit/build_tarballs.jl
+++ b/R/RDKit/build_tarballs.jl
@@ -1,10 +1,13 @@
 using BinaryBuilder, Pkg
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
 name = "RDKit"
-version = v"2022.09.5"
+version = v"2026.03.1"
 
 sources = [
-    GitSource("https://github.com/rdkit/rdkit.git", "723e05d46f4c91988622a4035433d016729e2ed2"),
+    GitSource("https://github.com/rdkit/rdkit.git", "351f8f378f8ad6bbd517980c38896e66bf907af8"),
     DirectorySource("./bundled"),
 ]
 
@@ -39,14 +42,19 @@ make -j${nproc}
 make install
 """
 
-platforms = [
-    Platform("x86_64", "linux"; libc="glibc"),
-    Platform("i686", "linux"; libc="glibc"),
-    Platform("aarch64", "linux"; libc="glibc"),
-    Platform("x86_64", "macos"),
-    Platform("aarch64", "macos"),
-    Platform("x86_64", "windows"),
-]
+# macOS requires a newer SDK for C++20 shared_ptr<T[]> support
+sources, script = require_macos_sdk("10.14", sources, script)
+
+platforms = supported_platforms()
+# Filter out Windows: boost_jll 1.87.0 does not provide mingw artifacts
+filter!(!Sys.iswindows, platforms)
+# Filter out FreeBSD: Boost.Stacktrace incompatible with FreeBSD unwind
+filter!(!Sys.isfreebsd, platforms)
+# Filter out macOS: BinaryBuilder's macOS cross-compilation toolchain uses an
+# older libc++ that lacks C++20 std::shared_ptr<T[]> specialization support.
+# RDKit 2026.03 uses shared_ptr<double[]> extensively in Code/Numerics/Vector.h.
+# This requires an upstream toolchain upgrade, not an SDK version bump.
+filter!(!Sys.isapple, platforms)
 
 platforms = expand_cxxstring_abis(platforms)
 
@@ -55,12 +63,12 @@ products = [
 ]
 
 dependencies = [
-    Dependency("FreeType2_jll"; compat="2.10.4"),
-    Dependency("boost_jll"; compat="=1.76.0"),
+    Dependency("FreeType2_jll"; compat="2.13.4"),
+    Dependency("boost_jll"; compat="1.87.0"),
     BuildDependency("Eigen_jll"),
     Dependency("Zlib_jll"),
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               # GCC 8 is needed for `std::from_chars`
-               preferred_gcc_version=v"8", julia_compat="1.6")
+               # GCC 11 is needed for C++20
+               preferred_gcc_version=v"11", julia_compat="1.10")

--- a/R/RDKit/bundled/patches/do-not-build-cffi-test.patch
+++ b/R/RDKit/bundled/patches/do-not-build-cffi-test.patch
@@ -1,21 +1,24 @@
 --- a/Code/MinimalLib/CMakeLists.txt
 +++ b/Code/MinimalLib/CMakeLists.txt
-@@ -65,11 +65,11 @@ if(MSVC OR WIN32)
+@@ -94,13 +94,13 @@
  endif()
  
  
 -    add_executable(cffi_test cffi_test.c)
 -    target_link_libraries(cffi_test rdkitcffi)
+-    set_target_properties(cffi_test PROPERTIES LINKER_LANGUAGE CXX)
++#     add_executable(cffi_test cffi_test.c)
++#     target_link_libraries(cffi_test rdkitcffi)
++#     set_target_properties(cffi_test PROPERTIES LINKER_LANGUAGE CXX)
+ 
 -#if(NOT MSVC)
 -    # doesn't work as a test on windows because the DLL needs to be either in the PATH OR
 -	# in the same dir as the executable
 -    add_test(cffi_test ${EXECUTABLE_OUTPUT_PATH}/cffi_test)
 -#endif
-+#     add_executable(cffi_test cffi_test.c)
-+#     target_link_libraries(cffi_test rdkitcffi)
-+# #if(NOT MSVC)
++#if(NOT MSVC)
 +#     # doesn't work as a test on windows because the DLL needs to be either in the PATH OR
-+# 	# in the same dir as the executable
++#		# in the same dir as the executable
 +#     add_test(cffi_test ${EXECUTABLE_OUTPUT_PATH}/cffi_test)
-+# #endif
++#endif
  endif(RDK_BUILD_CFFI_LIB)


### PR DESCRIPTION
## Summary

Update RDKit from 2022.09.5 to 2026.03.1 (Release_2026_03_1).

### Changes
- Version: `2022.09.5` → `2026.03.1`
- Source: updated to Release_2026_03_1 commit
- GCC: `8` → `11` (C++20 required by RDKit 2026.03)
- boost_jll: `=1.76.0` → `1.87.0` (RDKit 2026.03 requires Boost >= 1.81.0)
- FreeType2_jll: `2.10.4` → `2.13.4`
- julia_compat: `1.6` → `1.10`
- Platforms: use `supported_platforms()` + filter instead of hardcoded list (reviewer feedback)
- Windows: filtered out because boost_jll 1.87.0 has no mingw artifacts
- FreeBSD: filtered out because Boost.Stacktrace incompatible with FreeBSD unwind
- macOS: filtered out — BinaryBuilder's macOS cross-compilation toolchain uses an older libc++ that lacks C++20 `std::shared_ptr<T[]>` specialization. RDKit 2026.03 relies on this in `Code/Numerics/Vector.h`. The #13880 SDK workaround successfully fixed the I/O error, but the libc++ version limitation remains.
- Updated Windows CFFI test patch for new `set_target_properties` line in CMakeLists.txt

### New CFFI functions (25 added, 0 removed)
RDKit 2026.03 exports 72 CFFI functions (up from 47 in 2022.09), including:
- Properties: `has_prop`, `get_prop`, `set_prop`, `clear_prop`, `get_prop_list`, `keep_props`
- PNG metadata: `add_mol_to_png_blob`, `get_mol_from_png_blob`, `get_mols_from_png_blob`, `free_mol_array`
- Logging: `enable_logger`, `disable_logger`, `set_log_tee`, `set_log_capture`, `destroy_log_handle`, `get_log_buffer`, `clear_log_buffer`
- Chirality: `use_legacy_stereo_perception`, `allow_non_tetrahedral_chirality`
- Fingerprints: `get_maccs_fp`, `get_maccs_fp_as_bytes`
- I/O: `get_cxsmarts`, `get_v2kmolblock`, `get_mol_frags`
- Modification: `remove_hs`

### Testing
Built successfully on Linux platforms (x86_64, i686, aarch64).
Verified all 72 CFFI functions are exported in `librdkitcffi`.

### Notes
- RDKit 2026.03 requires C++20 (hence GCC 11)
- RDKit 2026.03 requires Boost >= 1.81.0 (hence boost_jll 1.87)
- Windows excluded: boost_jll 1.87.0 does not provide mingw artifacts
- FreeBSD excluded: Boost.Stacktrace requires `_Unwind_Backtrace` which is unavailable on FreeBSD
- macOS excluded: The #13880 SDK workaround successfully resolved the I/O error during SDK installation. However, both `x86_64-apple-darwin` and `aarch64-apple-darwin` still fail to compile because BinaryBuilder's macOS toolchain libc++ does not support the C++20 `std::shared_ptr<T[]>` specialization (missing `operator[]`, `get()` returns `T (*)[]` instead of `T*`, etc.). RDKit 2026.03 uses `shared_ptr<double[]>` in `Code/Numerics/Vector.h`. This requires an upstream libc++ upgrade, not merely a newer SDK.
