### PR TITLE
[OpenFHE_julia] and [OpenFHE_julia_int128] version 0.6.1, compat bounds

### DIFF
--- a/O/openfhe_julia/build_tarballs.jl
+++ b/O/openfhe_julia/build_tarballs.jl
@@ -5,13 +5,13 @@ include("common.jl")
 # If you make changes in this file, e.g., to release a new version,
 # be sure to also release a new version of `openfhe_julia_int128` as well (see `../openfhe_julia_int128/build_tarballs.jl`)
 name = "openfhe_julia"
-version = v"0.6.0"
+version = v"0.6.1"
 
-git_hash = "66b903eca1c2742268c740581bfaae4a49cb444d"
+git_hash = "4ab65278eecee883b0211cde40210286341cb771"
 
 sources, script, platforms, products, dependencies = prepare_openfhe_julia_build(name, git_hash)
 
-push!(dependencies, Dependency(PackageSpec(name="OpenFHE_jll", uuid="a2687184-f17b-54bc-b2bb-b849352af807"); compat="1.5.0"))
+push!(dependencies, Dependency(PackageSpec(name="OpenFHE_jll", uuid="a2687184-f17b-54bc-b2bb-b849352af807"); compat="1.5.0 - 1.5.1"))
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;

--- a/O/openfhe_julia_int128/build_tarballs.jl
+++ b/O/openfhe_julia_int128/build_tarballs.jl
@@ -5,13 +5,13 @@ include(joinpath(@__DIR__, "..", "openfhe_julia", "common.jl"))
 # If you make changes in this file, e.g., to release a new version,
 # be sure to also release a new version of `openfhe_julia` as well (see `../openfhe_julia/build_tarballs.jl`)
 name = "openfhe_julia_int128"
-version = v"0.6.0"
+version = v"0.6.1"
 
-git_hash = "66b903eca1c2742268c740581bfaae4a49cb444d"
+git_hash = "4ab65278eecee883b0211cde40210286341cb771"
 
 sources, script, platforms, products, dependencies = prepare_openfhe_julia_build(name, git_hash)
 
-push!(dependencies, Dependency(PackageSpec(name="OpenFHE_int128_jll", uuid="a89a0bdd-1663-5679-8b21-c3a5388322bc"); compat="1.5.0"))
+push!(dependencies, Dependency(PackageSpec(name="OpenFHE_int128_jll", uuid="a89a0bdd-1663-5679-8b21-c3a5388322bc"); compat="1.5.0 - 1.5.1"))
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;


### PR DESCRIPTION
Setting specific lower and upper compatibility bounds to guard against breaking changes in OpenFHE-development patch releases. See https://github.com/hpsc-lab/SecureArithmetic.jl/issues/102.