### PR TITLE
macos_sdks: Apply workaround by eschnett

### DIFF
--- a/platforms/macos_sdks.jl
+++ b/platforms/macos_sdks.jl
@@ -109,19 +109,54 @@ function get_macos_sdk_script(version::String; deployment_target::String = versi
         """ *
     raw"""
     if [[ "${target}" == """*arch*raw"""-apple-darwin* ]]; then
+        # echo "Extracting MacOSX${macos_sdk_version}.sdk.tar.xz (this may take a while)"
+        # rm -rf /opt/${target}/${target}/sys-root/System
+        # rm -rf /opt/${target}/${target}/sys-root/usr/include/libxml2/libxml
+        # # extract the tarball into the sys-root so all compilers pick it up
+        # # automatically, and use --warning=no-unknown-keyword to hide harmless
+        # # warnings about unsupported pax header keywords like "SCHILY.fflags"
+        # tar --extract \
+        #     --file=${WORKSPACE}/srcdir/MacOSX${macos_sdk_version}.sdk.tar.xz \
+        #     --directory="/opt/${target}/${target}/sys-root/." \
+        #     --strip-components=1 \
+        #     --warning=no-unknown-keyword \
+        #     MacOSX${macos_sdk_version}.sdk/System \
+        #     MacOSX${macos_sdk_version}.sdk/usr
+        # export MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
+
+        # Note: the code below works (almost!) for MacOSSDK 15.0 as well
+        # # Extract SDK
+        # sysroot=/opt/${target}/${target}/sys-root
+        # apple_sdk_root=${WORKSPACE}/srcdir/MacOSX15.0.sdk
+        # tar \
+        #     --extract \
+        #     --file=${WORKSPACE}/srcdir/MacOSX15.0.sdk.tar.xz \
+        #     --directory=${WORKSPACE}/srcdir \
+        #     --warning=no-unknown-keyword
+        # # Copy the old `include` directory, but only the files that don't exist in the new `include` directory
+        # rsync -a --ignore-existing ${sysroot}/usr/include/ ${apple_sdk_root}/usr/include
+        # # Remove old SDK
+        # rm -rf /opt/${target}/${target}/sys-root/System
+        # # Create symbolic link to new SDK
+        # ln -s ${apple_sdk_root}/System ${sysroot}/System
+        # Note: the code below works (almost!) for MacOSSDK 15.0 as well
+
+        # Extract SDK
         echo "Extracting MacOSX${macos_sdk_version}.sdk.tar.xz (this may take a while)"
-        rm -rf /opt/${target}/${target}/sys-root/System
-        rm -rf /opt/${target}/${target}/sys-root/usr/include/libxml2/libxml
-        # extract the tarball into the sys-root so all compilers pick it up
-        # automatically, and use --warning=no-unknown-keyword to hide harmless
-        # warnings about unsupported pax header keywords like "SCHILY.fflags"
-        tar --extract \
+        tar \
+            --extract \
             --file=${WORKSPACE}/srcdir/MacOSX${macos_sdk_version}.sdk.tar.xz \
-            --directory="/opt/${target}/${target}/sys-root/." \
-            --strip-components=1 \
-            --warning=no-unknown-keyword \
-            MacOSX${macos_sdk_version}.sdk/System \
-            MacOSX${macos_sdk_version}.sdk/usr
+            --directory=${WORKSPACE}/srcdir \
+            --warning=no-unknown-keyword
+        old_sdkroot=${SDKROOT}
+        new_sdkroot=${WORKSPACE}/srcdir/MacOSX${macos_sdk_version}.sdk
+        # Point to C++ header files (these are not shipped with the SDK)
+        ln -s ${old_sdkroot}/usr/include/c++ ${new_sdkroot}/usr/include/c++
+        # Fix toolchain files
+        sed -i -e "s+${old_sdkroot}+${new_sdkroot}+" ${MESON_TARGET_TOOLCHAIN} ${CMAKE_TARGET_TOOLCHAIN}
+        # Fix compiler wrappers
+        sed -i -e "s+${old_sdkroot}+${new_sdkroot}+" $(find /opt/bin/${target}* -type f -print)
+        SDKROOT=${new_sdkroot}
         export MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
     fi
     """


### PR DESCRIPTION
This contains the macOS SDK workaround by @eschnett from https://github.com/JuliaPackaging/Yggdrasil/pull/13842. As suggested by @fingolfin on Slack, we would like to get this in so that we can proceed with the various failing recipes. 

The more detailed issue analysis suggested by @staticfloat on Slack can be performed afterwards, without blocking various people's work any longer.