### PR TITLE
MAGEMin v1.9.6

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 name = "MAGEMin"
-version = v"1.9.5"
+version = v"1.9.6"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "3b21510e10cd7c65094cca4d85e4110f84885a75")                 ]
+                    "40ed109d07d4246001cab59382596d33fed79086")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Fixed missing hash table resets when switching databases between TC and SLB groups.