### PR TITLE
[OpenCV] Rebuild as 4.13.0+2 (fix ORB ScoreType factory error)

### DIFF
--- a/O/OpenCV/build_tarballs.jl
+++ b/O/OpenCV/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [
     # julia-bindings-upstream-contrib.patch folded in and made reproducible. We
     # overlay it onto opencv_contrib's julia module to build libopencv_julia.
     # Keep this commit's gen/OPENCV_VERSION in lockstep with the OpenCV sources above.
-    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "ac677e09dd7bf6504849c8567b287eaf68d54c38"),  # OpenCV.jl master (incl. #80 macOS C++17 fix + #81 features2d gen)
+    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "bf25f74aed56d8fa5d66c6b6dcd3efd952886078"),  # OpenCV.jl vs/fix-enum-add-type (#87): skip enum typedefs in mod.add_type<T>
     DirectorySource("./bundled"),
 ]
 

--- a/O/OpenCV/build_tarballs.jl
+++ b/O/OpenCV/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [
     # julia-bindings-upstream-contrib.patch folded in and made reproducible. We
     # overlay it onto opencv_contrib's julia module to build libopencv_julia.
     # Keep this commit's gen/OPENCV_VERSION in lockstep with the OpenCV sources above.
-    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "bf25f74aed56d8fa5d66c6b6dcd3efd952886078"),  # OpenCV.jl vs/fix-enum-add-type (#87): skip enum typedefs in mod.add_type<T>
+    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "52c3c7f306891f25027f9db97066909b13f4fffd"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
Rebuild `OpenCV_jll` as `4.13.0+2`. Re-pins the `OpenCV.jl` `GitSource` to JuliaImages/OpenCV.jl#87 (`bf25f74`); no other changes.

`+1` added `features2d` to `BUILD_LIST` (#13882), which exposed a generator bug: enum typedefs like `cv::ORB::ScoreType` were emitted as `mod.add_type<...>` but the Julia side declares them as `const ORB_ScoreType = Int64`, so `using OpenCV` fails with `No appropriate factory for type N2cv3ORB9ScoreTypeE`. #87 fixes the generator to skip enum typedefs.

A General-registry yank of `v4.13.0+1` is being filed in parallel.