### PR TITLE
[numav_julia] fix dlopen problem in version 0.1.0.

### DIFF
--- a/N/numav_julia/build_tarballs.jl
+++ b/N/numav_julia/build_tarballs.jl
@@ -1,5 +1,3 @@
-# Copyright (c) 2026 Matheus Machado Fiuza <matheusmachadofiuza@gmail.com>
-
 using BinaryBuilder, Pkg
 
 name = "numav_julia"
@@ -8,7 +6,7 @@ version = v"0.1.0"
 sources = [ 
     GitSource(
         "https://github.com/mmfiuza/numav.git", 
-        "f0f0b67e98ad47b2a0e9b451f9e97fffa7d6bc8a"
+        "bee6a3c00fa959bf1a3766a27d26aec9c2837b43"
     )
 ]
 


### PR DESCRIPTION
This is a fix for the new recipe submitted in #13852. It had a dlopen issue that failed in the registration step, as can be seen in [https://github.com/JuliaRegistries/General/pull/157003](https://github.com/JuliaRegistries/General/pull/157003).

**_Notice:_** The GitSource URL had to be changed for the fix, but i didn't bump the version number to 0.1.1, as suggested [here](https://github.com/JuliaPackaging/Yggdrasil/pull/13852#issuecomment-4619539646). If any reviewer thinks it is better to create a new version (0.1.1) of numav_julia for this fix, I'm ok with that.