### PR TITLE
[aff3ct] Bump to v4.2.2; strip bundled share/conf data (fixes macOS Tree Hash Mismatch)

### DIFF
--- a/A/aff3ct/build_tarballs.jl
+++ b/A/aff3ct/build_tarballs.jl
@@ -7,9 +7,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "microarchitectures.jl"))
 
 name = "aff3ct"
-# Upstream aff3ct is still 4.2.0; bumping to 4.2.1 to publish an updated
-# libaff3ct_jl wrapper (BinaryBuilder rejects build-metadata versions).
-version = v"4.2.1"
+# Upstream aff3ct is still 4.2.0; bumping to 4.2.2 to republish with the
+# bundled `share/aff3ct` configuration data stripped (see below). 4.2.1
+# shipped that data, which contains a case-only-differing filename pair that
+# collapses on case-insensitive filesystems (macOS APFS), causing an artifact
+# "Tree Hash Mismatch" on install. BinaryBuilder rejects build-metadata
+# versions, so bump the patch version rather than the build number.
+version = v"4.2.2"
 
 sources = [
     GitSource("https://github.com/aff3ct/aff3ct.git",
@@ -63,6 +67,15 @@ cmake .. \
 
 make -j${nproc}
 make install
+
+# Drop aff3ct's bundled configuration/test-vector data. We build the shared
+# library only (AFF3CT_COMPILE_EXE=OFF), so the multi-thousand-file
+# `share/aff3ct-*/conf` tree is dead weight in the artifact. It also contains
+# a filename pair differing only in case
+# (conf/cde/awgn_polar_codes/TV/11/{N,n}2048_awgn_s0.944.pc) that collapses on
+# case-insensitive filesystems (macOS APFS), making the unpacked tree hash to
+# a different git-tree-sha1 than recorded → "Tree Hash Mismatch" on install.
+rm -rf ${prefix}/share/aff3ct*
 
 # ── Build libaff3ct_jl ────────────────────────────────────────
 cd ${WORKSPACE}/srcdir/libaff3ct_jl*


### PR DESCRIPTION
## What

Bumps `aff3ct` to v4.2.2 and removes aff3ct's bundled `share/aff3ct-*/conf`
configuration/test-vector tree from the artifact.

## Why

aff3ct 4.2.1's artifact ships `share/aff3ct-4.2.0/conf/...`, which contains a
filename pair differing only in case:

```
conf/cde/awgn_polar_codes/TV/11/N2048_awgn_s0.944.pc
conf/cde/awgn_polar_codes/TV/11/n2048_awgn_s0.944.pc
```

On case-insensitive filesystems (macOS APFS) these two collapse into one file
on extraction, so the unpacked artifact hashes to a different `git-tree-sha1`
than recorded in `Artifacts.toml`. Installing `aff3ct_jll` v4.2.1 on macOS
therefore fails:

```
Unable to automatically download/install artifact 'aff3ct' ...
  Error: Tree Hash Mismatch!
  Expected git-tree-sha1:   58e378436960b1a4c9dd4f14c2bf5dc87a1c4087
  Calculated git-tree-sha1: 07efda1f36511f652eb4ba9f83c51957beaadcbb
```

(The Linux/x86_64 artifact installs fine — the divergence only appears when the
tree is materialised on a case-insensitive filesystem.)

The recipe builds the shared library only (`AFF3CT_COMPILE_EXE=OFF`), so the
`conf` data is unused at runtime. Removing `${prefix}/share/aff3ct*` after
install fixes the macOS hash mismatch and substantially shrinks the artifact.