### PR TITLE
[OpenCV] Rebuild as 4.13.0+4 (fix load failure + features2d)

### DIFF
--- a/O/OpenCV/build_tarballs.jl
+++ b/O/OpenCV/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [
     # julia-bindings-upstream-contrib.patch folded in and made reproducible. We
     # overlay it onto opencv_contrib's julia module to build libopencv_julia.
     # Keep this commit's gen/OPENCV_VERSION in lockstep with the OpenCV sources above.
-    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "a8e1995f8ce79579313d7c7478d23caf6541d183"), 
+    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "7d86cca9494f92a96a75fcf3865409b8c7198ab5"),
     DirectorySource("./bundled"),
 ]
 

--- a/O/OpenCV/build_tarballs.jl
+++ b/O/OpenCV/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [
     # julia-bindings-upstream-contrib.patch folded in and made reproducible. We
     # overlay it onto opencv_contrib's julia module to build libopencv_julia.
     # Keep this commit's gen/OPENCV_VERSION in lockstep with the OpenCV sources above.
-    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "0245f70158c0c7cd010880c83d095b9b09de1e8e"),  # OpenCV.jl vs/fix-enum-return-cast (#89): cast enum return types to int64_t
+    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "a8e1995f8ce79579313d7c7478d23caf6541d183"), 
     DirectorySource("./bundled"),
 ]
 

--- a/O/OpenCV/build_tarballs.jl
+++ b/O/OpenCV/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [
     # julia-bindings-upstream-contrib.patch folded in and made reproducible. We
     # overlay it onto opencv_contrib's julia module to build libopencv_julia.
     # Keep this commit's gen/OPENCV_VERSION in lockstep with the OpenCV sources above.
-    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "20d709fc1b6cfaf73f3f4bb55f48e1c5e5f7c62c"),
+    GitSource("https://github.com/JuliaImages/OpenCV.jl.git", "0245f70158c0c7cd010880c83d095b9b09de1e8e"),  # OpenCV.jl vs/fix-enum-return-cast (#89): cast enum return types to int64_t
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
Rebuild `OpenCV_jll` as `4.13.0+4`, re-pinning OpenCV.jl to master `7d86cca` (merged JuliaImages/OpenCV.jl#89).

Fixes `using OpenCV` (the `ORB::ScoreType` factory error) by casting enum return types to `int64_t` in the generated glue, and pulls in the features2d wrapper fixes (ORB/SimpleBlobDetector default constructors, KeyPoint detect→compute round-trip). OpenCV.jl test suite: 208/208.

Please yank `v4.13.0+2` and `+3` once `+4` is verified — both have the load defect.