### PR TITLE
[fmusim] Invent a phony version number

### DIFF
--- a/F/fmusim/build_tarballs.jl
+++ b/F/fmusim/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "fmusim"
-version = v"0.0.39"
+version = v"0.0.39001"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
Let's have the upstream version be the patch÷1000 to enable meaningful version numbers for updates like #13814

cc @asinghvi17 