### PR TITLE
LLVM: Add a patch to the NVPTX back-end.

### DIFF
--- a/C/CUDA/NVPTX_LLVM_Backend/build_tarballs.jl
+++ b/C/CUDA/NVPTX_LLVM_Backend/build_tarballs.jl
@@ -10,6 +10,7 @@ version = v"22.1.7"
 sources = [
     ArchiveSource("https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/llvm-project-$(version).src.tar.xz",
                   "5cc4a3f12bba50b6bdfb4b61bdc852117a0ff2517807c3902fc13267fb93562e"),
+    DirectorySource("./bundled")
 ]
 
 # Bash recipe for building across all platforms
@@ -18,6 +19,12 @@ mv llvm-project-* llvm-project
 
 cd llvm-project/llvm
 LLVM_SRCDIR=$(pwd)
+
+# Backport of https://github.com/llvm/llvm-project/pull/201772 ("[SelectionDAG]
+# Look through addrspacecasts when raising stack object alignment"), fixing
+# byte-per-byte expansion of small unaligned memcpys on NVPTX
+# (JuliaGPU/CUDA.jl#3162).
+atomic_patch -p1 $WORKSPACE/srcdir/patches/memcpy_alloca_align.patch
 
 install_license LICENSE.TXT
 

--- a/C/CUDA/NVPTX_LLVM_Backend/bundled/patches/memcpy_alloca_align.patch
+++ b/C/CUDA/NVPTX_LLVM_Backend/bundled/patches/memcpy_alloca_align.patch
@@ -1,0 +1,596 @@
+From bea9786cab0ac275c9d6a62f4253096c06ec7a20 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Fri, 5 Jun 2026 08:31:03 +0200
+Subject: [PATCH] [SelectionDAG] Look through addrspacecasts when raising stack
+ object alignment
+
+The expansion of small memcpy/memmove/memset intrinsics can raise the
+alignment of the stack object being written to (DstAlignCanChange),
+avoiding inefficient under-aligned lowering. This only worked when the
+destination operand was a bare FrameIndex node: targets that lower
+allocas to a non-generic address space via addrspacecast instructions
+(e.g. NVPTX) hide the frame index behind an ADDRSPACECAST node, causing
+e.g. the 7-byte padding copies SROA generates for non-power-of-two
+aggregates to be expanded byte-per-byte.
+
+Identify the underlying stack object by peeking through ADDRSPACECAST
+nodes (via a new peekThroughAddrSpaceCasts helper, alongside the other
+peekThrough* functions), and by falling back to the IR value from the
+MachinePointerInfo. The latter also handles pointers defined in a
+different basic block than the memory operation, where instruction
+selection only sees a CopyFromReg node. Use the same lookup to consult
+the stack object's (possibly already raised) alignment for the source
+operand, and teach InferPtrAlign to look through address space casts as
+well.
+
+Backport of https://github.com/llvm/llvm-project/pull/201772 to the
+released 22.x branch.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ include/llvm/CodeGen/SelectionDAG.h       |   2 +
+ include/llvm/CodeGen/SelectionDAGNodes.h  |   4 +
+ lib/CodeGen/SelectionDAG/SelectionDAG.cpp |  87 +++++++++++---
+ test/CodeGen/NVPTX/lower-byval-args.ll    |  78 ++++++-------
+ test/CodeGen/NVPTX/memcpy-alloca-align.ll | 132 ++++++++++++++++++++++
+ test/CodeGen/NVPTX/variadics-backend.ll   |  22 ++--
+ 6 files changed, 260 insertions(+), 65 deletions(-)
+ create mode 100644 test/CodeGen/NVPTX/memcpy-alloca-align.ll
+
+diff --git a/include/llvm/CodeGen/SelectionDAG.h b/include/llvm/CodeGen/SelectionDAG.h
+index e70a59d..88b0343 100644
+--- a/include/llvm/CodeGen/SelectionDAG.h
++++ b/include/llvm/CodeGen/SelectionDAG.h
+@@ -486,6 +486,8 @@ public:
+     FLI = FuncInfo;
+   }
+ 
++  FunctionLoweringInfo *getFunctionLoweringInfo() const { return FLI; }
++
+   /// Clear state and free memory necessary to make this
+   /// SelectionDAG ready to process a new block.
+   LLVM_ABI void clear();
+diff --git a/include/llvm/CodeGen/SelectionDAGNodes.h b/include/llvm/CodeGen/SelectionDAGNodes.h
+index aa72e81..87549e7 100644
+--- a/include/llvm/CodeGen/SelectionDAGNodes.h
++++ b/include/llvm/CodeGen/SelectionDAGNodes.h
+@@ -1906,6 +1906,10 @@ LLVM_ABI SDValue peekThroughInsertVectorElt(SDValue V,
+ /// If \p V is not a truncation, it is returned as-is.
+ LLVM_ABI SDValue peekThroughTruncates(SDValue V);
+ 
++/// Return the non-addrspacecasted source operand of \p V if it exists.
++/// If \p V is not an addrspacecast, it is returned as-is.
++LLVM_ABI SDValue peekThroughAddrSpaceCasts(SDValue V);
++
+ /// Returns true if \p V is a bitwise not operation. Assumes that an all ones
+ /// constant is canonicalized to be operand 1.
+ LLVM_ABI bool isBitwiseNot(SDValue V, bool AllowUndefs = false);
+diff --git a/lib/CodeGen/SelectionDAG/SelectionDAG.cpp b/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+index 5a926b8..6658137 100644
+--- a/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
++++ b/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+@@ -56,6 +56,7 @@
+ #include "llvm/IR/DerivedTypes.h"
+ #include "llvm/IR/Function.h"
+ #include "llvm/IR/GlobalValue.h"
++#include "llvm/IR/Instructions.h"
+ #include "llvm/IR/Metadata.h"
+ #include "llvm/IR/Type.h"
+ #include "llvm/Support/Casting.h"
+@@ -8655,6 +8656,32 @@ static bool shouldLowerMemFuncForSize(const MachineFunction &MF,
+   return DAG.shouldOptForSize();
+ }
+ 
++/// Try to identify the stack object a memory function operand refers to.
++/// Targets such as NVPTX lower allocas to a non-generic address space, hiding
++/// the frame index behind an addrspacecast: peek through those, and fall back
++/// to the IR value from the pointer info, which also covers pointers defined
++/// in a different basic block where ISel only sees a CopyFromReg.
++static std::optional<int> findStackObject(SDValue Ptr,
++                                          const MachinePointerInfo &PtrInfo,
++                                          SelectionDAG &DAG) {
++  if (auto *FI = dyn_cast<FrameIndexSDNode>(peekThroughAddrSpaceCasts(Ptr)))
++    return FI->getIndex();
++
++  const Value *V = dyn_cast_if_present<const Value *>(PtrInfo.V);
++  if (!V || PtrInfo.Offset != 0)
++    return std::nullopt;
++  const auto *AI = dyn_cast<AllocaInst>(V->stripPointerCasts());
++  if (!AI)
++    return std::nullopt;
++  FunctionLoweringInfo *FLI = DAG.getFunctionLoweringInfo();
++  if (!FLI)
++    return std::nullopt;
++  auto It = FLI->StaticAllocaMap.find(AI);
++  if (It == FLI->StaticAllocaMap.end())
++    return std::nullopt;
++  return It->second;
++}
++
+ static void chainLoadsAndStoresForMemcpy(SelectionDAG &DAG, const SDLoc &dl,
+                           SmallVector<SDValue, 32> &OutChains, unsigned From,
+                           unsigned To, SmallVector<SDValue, 16> &OutLoadChains,
+@@ -8702,10 +8729,18 @@ static SDValue getMemcpyLoadsAndStores(
+   MachineFunction &MF = DAG.getMachineFunction();
+   MachineFrameInfo &MFI = MF.getFrameInfo();
+   bool OptSize = shouldLowerMemFuncForSize(MF, DAG);
+-  FrameIndexSDNode *FI = dyn_cast<FrameIndexSDNode>(Dst);
+-  if (FI && !MFI.isFixedObjectIndex(FI->getIndex()))
++  std::optional<int> DstFI = findStackObject(Dst, DstPtrInfo, DAG);
++  if (DstFI && !MFI.isFixedObjectIndex(*DstFI))
+     DstAlignCanChange = true;
+   MaybeAlign SrcAlign = DAG.InferPtrAlign(Src);
++  // The source may be a stack object whose alignment is not visible through
++  // the DAG-level pointer; in particular one whose alignment was raised when
++  // it was the destination of a previously expanded memory function.
++  if (std::optional<int> SrcFI = findStackObject(Src, SrcPtrInfo, DAG)) {
++    Align SrcObjAlign = MFI.getObjectAlign(*SrcFI);
++    if (!SrcAlign || SrcObjAlign > *SrcAlign)
++      SrcAlign = SrcObjAlign;
++  }
+   if (!SrcAlign || Alignment > *SrcAlign)
+     SrcAlign = Alignment;
+   assert(SrcAlign && "SrcAlign must be set");
+@@ -8738,8 +8773,8 @@ static SDValue getMemcpyLoadsAndStores(
+ 
+     if (NewAlign > Alignment) {
+       // Give the stack frame object a larger alignment if needed.
+-      if (MFI.getObjectAlign(FI->getIndex()) < NewAlign)
+-        MFI.setObjectAlignment(FI->getIndex(), NewAlign);
++      if (MFI.getObjectAlign(*DstFI) < NewAlign)
++        MFI.setObjectAlignment(*DstFI, NewAlign);
+       Alignment = NewAlign;
+     }
+   }
+@@ -8903,10 +8938,18 @@ static SDValue getMemmoveLoadsAndStores(SelectionDAG &DAG, const SDLoc &dl,
+   MachineFunction &MF = DAG.getMachineFunction();
+   MachineFrameInfo &MFI = MF.getFrameInfo();
+   bool OptSize = shouldLowerMemFuncForSize(MF, DAG);
+-  FrameIndexSDNode *FI = dyn_cast<FrameIndexSDNode>(Dst);
+-  if (FI && !MFI.isFixedObjectIndex(FI->getIndex()))
++  std::optional<int> DstFI = findStackObject(Dst, DstPtrInfo, DAG);
++  if (DstFI && !MFI.isFixedObjectIndex(*DstFI))
+     DstAlignCanChange = true;
+   MaybeAlign SrcAlign = DAG.InferPtrAlign(Src);
++  // The source may be a stack object whose alignment is not visible through
++  // the DAG-level pointer; in particular one whose alignment was raised when
++  // it was the destination of a previously expanded memory function.
++  if (std::optional<int> SrcFI = findStackObject(Src, SrcPtrInfo, DAG)) {
++    Align SrcObjAlign = MFI.getObjectAlign(*SrcFI);
++    if (!SrcAlign || SrcObjAlign > *SrcAlign)
++      SrcAlign = SrcObjAlign;
++  }
+   if (!SrcAlign || Alignment > *SrcAlign)
+     SrcAlign = Alignment;
+   assert(SrcAlign && "SrcAlign must be set");
+@@ -8933,8 +8976,8 @@ static SDValue getMemmoveLoadsAndStores(SelectionDAG &DAG, const SDLoc &dl,
+ 
+     if (NewAlign > Alignment) {
+       // Give the stack frame object a larger alignment if needed.
+-      if (MFI.getObjectAlign(FI->getIndex()) < NewAlign)
+-        MFI.setObjectAlignment(FI->getIndex(), NewAlign);
++      if (MFI.getObjectAlign(*DstFI) < NewAlign)
++        MFI.setObjectAlignment(*DstFI, NewAlign);
+       Alignment = NewAlign;
+     }
+   }
+@@ -9025,8 +9068,8 @@ static SDValue getMemsetStores(SelectionDAG &DAG, const SDLoc &dl,
+   MachineFunction &MF = DAG.getMachineFunction();
+   MachineFrameInfo &MFI = MF.getFrameInfo();
+   bool OptSize = shouldLowerMemFuncForSize(MF, DAG);
+-  FrameIndexSDNode *FI = dyn_cast<FrameIndexSDNode>(Dst);
+-  if (FI && !MFI.isFixedObjectIndex(FI->getIndex()))
++  std::optional<int> DstFI = findStackObject(Dst, DstPtrInfo, DAG);
++  if (DstFI && !MFI.isFixedObjectIndex(*DstFI))
+     DstAlignCanChange = true;
+   bool IsZeroVal = isNullConstant(Src);
+   unsigned Limit = AlwaysInline ? ~0 : TLI.getMaxStoresPerMemset(OptSize);
+@@ -9052,8 +9095,8 @@ static SDValue getMemsetStores(SelectionDAG &DAG, const SDLoc &dl,
+ 
+     if (NewAlign > Alignment) {
+       // Give the stack frame object a larger alignment if needed.
+-      if (MFI.getObjectAlign(FI->getIndex()) < NewAlign)
+-        MFI.setObjectAlignment(FI->getIndex(), NewAlign);
++      if (MFI.getObjectAlign(*DstFI) < NewAlign)
++        MFI.setObjectAlignment(*DstFI, NewAlign);
+       Alignment = NewAlign;
+     }
+   }
+@@ -13002,6 +13045,12 @@ SDValue llvm::peekThroughTruncates(SDValue V) {
+   return V;
+ }
+ 
++SDValue llvm::peekThroughAddrSpaceCasts(SDValue V) {
++  while (V.getOpcode() == ISD::ADDRSPACECAST)
++    V = V.getOperand(0);
++  return V;
++}
++
+ bool llvm::isBitwiseNot(SDValue V, bool AllowUndefs) {
+   if (V.getOpcode() != ISD::XOR)
+     return false;
+@@ -13592,6 +13641,10 @@ bool SelectionDAG::areNonVolatileConsecutiveLoads(LoadSDNode *LD,
+ /// InferPtrAlignment - Infer alignment of a load / store address. Return
+ /// std::nullopt if it cannot be inferred.
+ MaybeAlign SelectionDAG::InferPtrAlign(SDValue Ptr) const {
++  // Address space casts do not change the underlying object, whose alignment
++  // is what is being inferred here; look through them.
++  Ptr = peekThroughAddrSpaceCasts(Ptr);
++
+   // If this is a GlobalAddress + cst, return the alignment.
+   const GlobalValue *GV = nullptr;
+   int64_t GVOffset = 0;
+@@ -13610,11 +13663,13 @@ MaybeAlign SelectionDAG::InferPtrAlign(SDValue Ptr) const {
+   int64_t FrameOffset = 0;
+   if (FrameIndexSDNode *FI = dyn_cast<FrameIndexSDNode>(Ptr)) {
+     FrameIdx = FI->getIndex();
+-  } else if (isBaseWithConstantOffset(Ptr) &&
+-             isa<FrameIndexSDNode>(Ptr.getOperand(0))) {
++  } else if (isBaseWithConstantOffset(Ptr)) {
+     // Handle FI+Cst
+-    FrameIdx = cast<FrameIndexSDNode>(Ptr.getOperand(0))->getIndex();
+-    FrameOffset = Ptr.getConstantOperandVal(1);
++    SDValue Base = peekThroughAddrSpaceCasts(Ptr.getOperand(0));
++    if (auto *FI = dyn_cast<FrameIndexSDNode>(Base)) {
++      FrameIdx = FI->getIndex();
++      FrameOffset = Ptr.getConstantOperandVal(1);
++    }
+   }
+ 
+   if (FrameIdx != INT_MIN) {
+diff --git a/test/CodeGen/NVPTX/lower-byval-args.ll b/test/CodeGen/NVPTX/lower-byval-args.ll
+index ca2914a..b6b7911 100644
+--- a/test/CodeGen/NVPTX/lower-byval-args.ll
++++ b/test/CodeGen/NVPTX/lower-byval-args.ll
+@@ -135,21 +135,21 @@ define dso_local ptx_kernel void @escape_ptr(ptr nocapture noundef readnone %out
+ ;
+ ; PTX-LABEL: escape_ptr(
+ ; PTX:       {
+-; PTX-NEXT:    .local .align 4 .b8 __local_depot2[8];
++; PTX-NEXT:    .local .align 8 .b8 __local_depot2[8];
+ ; PTX-NEXT:    .reg .b64 %SP;
+ ; PTX-NEXT:    .reg .b64 %SPL;
+-; PTX-NEXT:    .reg .b32 %r<3>;
+-; PTX-NEXT:    .reg .b64 %rd<3>;
++; PTX-NEXT:    .reg .b64 %rd<7>;
+ ; PTX-EMPTY:
+ ; PTX-NEXT:  // %bb.0: // %entry
+ ; PTX-NEXT:    mov.b64 %SPL, __local_depot2;
+ ; PTX-NEXT:    cvta.local.u64 %SP, %SPL;
+ ; PTX-NEXT:    add.u64 %rd1, %SP, 0;
+ ; PTX-NEXT:    add.u64 %rd2, %SPL, 0;
+-; PTX-NEXT:    ld.param.b32 %r1, [escape_ptr_param_1+4];
+-; PTX-NEXT:    st.local.b32 [%rd2+4], %r1;
+-; PTX-NEXT:    ld.param.b32 %r2, [escape_ptr_param_1];
+-; PTX-NEXT:    st.local.b32 [%rd2], %r2;
++; PTX-NEXT:    ld.param.b32 %rd3, [escape_ptr_param_1+4];
++; PTX-NEXT:    shl.b64 %rd4, %rd3, 32;
++; PTX-NEXT:    ld.param.b32 %rd5, [escape_ptr_param_1];
++; PTX-NEXT:    or.b64 %rd6, %rd4, %rd5;
++; PTX-NEXT:    st.local.b64 [%rd2], %rd6;
+ ; PTX-NEXT:    { // callseq 0, 0
+ ; PTX-NEXT:    .param .b64 param0;
+ ; PTX-NEXT:    st.param.b64 [param0], %rd1;
+@@ -175,25 +175,25 @@ define dso_local ptx_kernel void @escape_ptr_gep(ptr nocapture noundef readnone
+ ;
+ ; PTX-LABEL: escape_ptr_gep(
+ ; PTX:       {
+-; PTX-NEXT:    .local .align 4 .b8 __local_depot3[8];
++; PTX-NEXT:    .local .align 8 .b8 __local_depot3[8];
+ ; PTX-NEXT:    .reg .b64 %SP;
+ ; PTX-NEXT:    .reg .b64 %SPL;
+-; PTX-NEXT:    .reg .b32 %r<3>;
+-; PTX-NEXT:    .reg .b64 %rd<4>;
++; PTX-NEXT:    .reg .b64 %rd<8>;
+ ; PTX-EMPTY:
+ ; PTX-NEXT:  // %bb.0: // %entry
+ ; PTX-NEXT:    mov.b64 %SPL, __local_depot3;
+ ; PTX-NEXT:    cvta.local.u64 %SP, %SPL;
+ ; PTX-NEXT:    add.u64 %rd1, %SP, 0;
+ ; PTX-NEXT:    add.u64 %rd2, %SPL, 0;
+-; PTX-NEXT:    ld.param.b32 %r1, [escape_ptr_gep_param_1+4];
+-; PTX-NEXT:    st.local.b32 [%rd2+4], %r1;
+-; PTX-NEXT:    ld.param.b32 %r2, [escape_ptr_gep_param_1];
+-; PTX-NEXT:    st.local.b32 [%rd2], %r2;
+-; PTX-NEXT:    add.s64 %rd3, %rd1, 4;
++; PTX-NEXT:    ld.param.b32 %rd3, [escape_ptr_gep_param_1+4];
++; PTX-NEXT:    shl.b64 %rd4, %rd3, 32;
++; PTX-NEXT:    ld.param.b32 %rd5, [escape_ptr_gep_param_1];
++; PTX-NEXT:    or.b64 %rd6, %rd4, %rd5;
++; PTX-NEXT:    st.local.b64 [%rd2], %rd6;
++; PTX-NEXT:    or.b64 %rd7, %rd1, 4;
+ ; PTX-NEXT:    { // callseq 1, 0
+ ; PTX-NEXT:    .param .b64 param0;
+-; PTX-NEXT:    st.param.b64 [param0], %rd3;
++; PTX-NEXT:    st.param.b64 [param0], %rd7;
+ ; PTX-NEXT:    call.uni _Z6escapePv, (param0);
+ ; PTX-NEXT:    } // callseq 1
+ ; PTX-NEXT:    ret;
+@@ -216,11 +216,10 @@ define dso_local ptx_kernel void @escape_ptr_store(ptr nocapture noundef writeon
+ ;
+ ; PTX-LABEL: escape_ptr_store(
+ ; PTX:       {
+-; PTX-NEXT:    .local .align 4 .b8 __local_depot4[8];
++; PTX-NEXT:    .local .align 8 .b8 __local_depot4[8];
+ ; PTX-NEXT:    .reg .b64 %SP;
+ ; PTX-NEXT:    .reg .b64 %SPL;
+-; PTX-NEXT:    .reg .b32 %r<3>;
+-; PTX-NEXT:    .reg .b64 %rd<5>;
++; PTX-NEXT:    .reg .b64 %rd<9>;
+ ; PTX-EMPTY:
+ ; PTX-NEXT:  // %bb.0: // %entry
+ ; PTX-NEXT:    mov.b64 %SPL, __local_depot4;
+@@ -229,10 +228,11 @@ define dso_local ptx_kernel void @escape_ptr_store(ptr nocapture noundef writeon
+ ; PTX-NEXT:    cvta.to.global.u64 %rd2, %rd1;
+ ; PTX-NEXT:    add.u64 %rd3, %SP, 0;
+ ; PTX-NEXT:    add.u64 %rd4, %SPL, 0;
+-; PTX-NEXT:    ld.param.b32 %r1, [escape_ptr_store_param_1+4];
+-; PTX-NEXT:    st.local.b32 [%rd4+4], %r1;
+-; PTX-NEXT:    ld.param.b32 %r2, [escape_ptr_store_param_1];
+-; PTX-NEXT:    st.local.b32 [%rd4], %r2;
++; PTX-NEXT:    ld.param.b32 %rd5, [escape_ptr_store_param_1+4];
++; PTX-NEXT:    shl.b64 %rd6, %rd5, 32;
++; PTX-NEXT:    ld.param.b32 %rd7, [escape_ptr_store_param_1];
++; PTX-NEXT:    or.b64 %rd8, %rd6, %rd7;
++; PTX-NEXT:    st.local.b64 [%rd4], %rd8;
+ ; PTX-NEXT:    st.global.b64 [%rd2], %rd3;
+ ; PTX-NEXT:    ret;
+ entry:
+@@ -254,11 +254,10 @@ define dso_local ptx_kernel void @escape_ptr_gep_store(ptr nocapture noundef wri
+ ;
+ ; PTX-LABEL: escape_ptr_gep_store(
+ ; PTX:       {
+-; PTX-NEXT:    .local .align 4 .b8 __local_depot5[8];
++; PTX-NEXT:    .local .align 8 .b8 __local_depot5[8];
+ ; PTX-NEXT:    .reg .b64 %SP;
+ ; PTX-NEXT:    .reg .b64 %SPL;
+-; PTX-NEXT:    .reg .b32 %r<3>;
+-; PTX-NEXT:    .reg .b64 %rd<6>;
++; PTX-NEXT:    .reg .b64 %rd<10>;
+ ; PTX-EMPTY:
+ ; PTX-NEXT:  // %bb.0: // %entry
+ ; PTX-NEXT:    mov.b64 %SPL, __local_depot5;
+@@ -267,12 +266,13 @@ define dso_local ptx_kernel void @escape_ptr_gep_store(ptr nocapture noundef wri
+ ; PTX-NEXT:    cvta.to.global.u64 %rd2, %rd1;
+ ; PTX-NEXT:    add.u64 %rd3, %SP, 0;
+ ; PTX-NEXT:    add.u64 %rd4, %SPL, 0;
+-; PTX-NEXT:    ld.param.b32 %r1, [escape_ptr_gep_store_param_1+4];
+-; PTX-NEXT:    st.local.b32 [%rd4+4], %r1;
+-; PTX-NEXT:    ld.param.b32 %r2, [escape_ptr_gep_store_param_1];
+-; PTX-NEXT:    st.local.b32 [%rd4], %r2;
+-; PTX-NEXT:    add.s64 %rd5, %rd3, 4;
+-; PTX-NEXT:    st.global.b64 [%rd2], %rd5;
++; PTX-NEXT:    ld.param.b32 %rd5, [escape_ptr_gep_store_param_1+4];
++; PTX-NEXT:    shl.b64 %rd6, %rd5, 32;
++; PTX-NEXT:    ld.param.b32 %rd7, [escape_ptr_gep_store_param_1];
++; PTX-NEXT:    or.b64 %rd8, %rd6, %rd7;
++; PTX-NEXT:    st.local.b64 [%rd4], %rd8;
++; PTX-NEXT:    or.b64 %rd9, %rd3, 4;
++; PTX-NEXT:    st.global.b64 [%rd2], %rd9;
+ ; PTX-NEXT:    ret;
+ entry:
+   %b = getelementptr inbounds nuw i8, ptr %s, i64 4
+@@ -294,11 +294,10 @@ define dso_local ptx_kernel void @escape_ptrtoint(ptr nocapture noundef writeonl
+ ;
+ ; PTX-LABEL: escape_ptrtoint(
+ ; PTX:       {
+-; PTX-NEXT:    .local .align 4 .b8 __local_depot6[8];
++; PTX-NEXT:    .local .align 8 .b8 __local_depot6[8];
+ ; PTX-NEXT:    .reg .b64 %SP;
+ ; PTX-NEXT:    .reg .b64 %SPL;
+-; PTX-NEXT:    .reg .b32 %r<3>;
+-; PTX-NEXT:    .reg .b64 %rd<5>;
++; PTX-NEXT:    .reg .b64 %rd<9>;
+ ; PTX-EMPTY:
+ ; PTX-NEXT:  // %bb.0: // %entry
+ ; PTX-NEXT:    mov.b64 %SPL, __local_depot6;
+@@ -307,10 +306,11 @@ define dso_local ptx_kernel void @escape_ptrtoint(ptr nocapture noundef writeonl
+ ; PTX-NEXT:    cvta.to.global.u64 %rd2, %rd1;
+ ; PTX-NEXT:    add.u64 %rd3, %SP, 0;
+ ; PTX-NEXT:    add.u64 %rd4, %SPL, 0;
+-; PTX-NEXT:    ld.param.b32 %r1, [escape_ptrtoint_param_1+4];
+-; PTX-NEXT:    st.local.b32 [%rd4+4], %r1;
+-; PTX-NEXT:    ld.param.b32 %r2, [escape_ptrtoint_param_1];
+-; PTX-NEXT:    st.local.b32 [%rd4], %r2;
++; PTX-NEXT:    ld.param.b32 %rd5, [escape_ptrtoint_param_1+4];
++; PTX-NEXT:    shl.b64 %rd6, %rd5, 32;
++; PTX-NEXT:    ld.param.b32 %rd7, [escape_ptrtoint_param_1];
++; PTX-NEXT:    or.b64 %rd8, %rd6, %rd7;
++; PTX-NEXT:    st.local.b64 [%rd4], %rd8;
+ ; PTX-NEXT:    st.global.b64 [%rd2], %rd3;
+ ; PTX-NEXT:    ret;
+ entry:
+diff --git a/test/CodeGen/NVPTX/memcpy-alloca-align.ll b/test/CodeGen/NVPTX/memcpy-alloca-align.ll
+new file mode 100644
+index 0000000..601ce94
+--- /dev/null
++++ b/test/CodeGen/NVPTX/memcpy-alloca-align.ll
+@@ -0,0 +1,132 @@
++; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_50 | FileCheck %s
++; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64 -mcpu=sm_50 | %ptxas-verify %}
++
++; The expansion of small memcpy/memmove/memset can raise the alignment of
++; under-aligned stack objects. Verify this also works on NVPTX, which lowers
++; allocas to the local address space via addrspacecast instructions that hide
++; the frame index, both when the pointer is materialized in the same basic
++; block as the memory operation and when it is defined in a different one.
++
++target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64"
++target triple = "nvptx64-nvidia-cuda"
++
++declare void @use(ptr)
++
++define void @memcpy_alloca() {
++; CHECK-LABEL: memcpy_alloca(
++; CHECK: .local .align 4 .b8 __local_depot{{[0-9]+}}[16];
++; CHECK: st.local.b8
++; CHECK: st.local.b16
++; CHECK: st.local.b32
++; CHECK-NOT: st.local.b8
++; CHECK: ret;
++  %a = alloca [7 x i8], align 1
++  %b = alloca [7 x i8], align 1
++  call void @use(ptr %a)
++  call void @use(ptr %b)
++  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %a, ptr align 1 %b, i64 7, i1 false)
++  call void @use(ptr %a)
++  ret void
++}
++
++define void @memcpy_alloca_cross_bb(i1 %c) {
++; CHECK-LABEL: memcpy_alloca_cross_bb(
++; CHECK: .local .align 4 .b8 __local_depot{{[0-9]+}}[16];
++; CHECK: st.local.b8
++; CHECK: st.local.b16
++; CHECK: st.local.b32
++; CHECK-NOT: st.local.b8
++; CHECK: ret;
++entry:
++  %a = alloca [7 x i8], align 1
++  %b = alloca [7 x i8], align 1
++  call void @use(ptr %a)
++  call void @use(ptr %b)
++  br i1 %c, label %copy, label %exit
++
++copy:
++  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %a, ptr align 1 %b, i64 7, i1 false)
++  call void @use(ptr %a)
++  br label %exit
++
++exit:
++  ret void
++}
++
++; The source object's alignment was raised when expanding the first memcpy;
++; the loads of the second copy can only learn about it through the frame index.
++define void @memcpy_alloca_raised_src(i1 %c, ptr %p) {
++; CHECK-LABEL: memcpy_alloca_raised_src(
++; CHECK: .local .align 4 .b8 __local_depot{{[0-9]+}}[16];
++; CHECK: ld.local.b8
++; CHECK: ld.local.b16
++; CHECK: ld.local.b32
++; CHECK-NOT: ld.local.b8
++; CHECK: ret;
++entry:
++  %a = alloca [7 x i8], align 1
++  %b = alloca [7 x i8], align 1
++  call void @use(ptr %a)
++  call void @use(ptr %b)
++  br i1 %c, label %copy1, label %exit
++
++copy1:
++  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %b, ptr align 1 %p, i64 7, i1 false)
++  br label %copy2
++
++copy2:
++  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %a, ptr align 1 %b, i64 7, i1 false)
++  call void @use(ptr %a)
++  br label %exit
++
++exit:
++  ret void
++}
++
++define void @memmove_alloca() {
++; CHECK-LABEL: memmove_alloca(
++; CHECK: .local .align 4 .b8 __local_depot{{[0-9]+}}[16];
++; CHECK: st.local.b8
++; CHECK: st.local.b16
++; CHECK: st.local.b32
++; CHECK-NOT: st.local.b8
++; CHECK: ret;
++  %a = alloca [7 x i8], align 1
++  %b = alloca [7 x i8], align 1
++  call void @use(ptr %a)
++  call void @use(ptr %b)
++  call void @llvm.memmove.p0.p0.i64(ptr align 1 %a, ptr align 1 %b, i64 7, i1 false)
++  call void @use(ptr %a)
++  ret void
++}
++
++define void @memset_alloca() {
++; CHECK-LABEL: memset_alloca(
++; CHECK: .local .align 4 .b8 __local_depot{{[0-9]+}}[8];
++; CHECK: st.local.b8
++; CHECK: st.local.b16
++; CHECK: st.local.b32
++; CHECK-NOT: st.local.b8
++; CHECK: ret;
++  %a = alloca [7 x i8], align 1
++  call void @use(ptr %a)
++  call void @llvm.memset.p0.i64(ptr align 1 %a, i8 0, i64 7, i1 false)
++  call void @use(ptr %a)
++  ret void
++}
++
++; InferPtrAlign also looks through the addrspacecast, letting DAGCombiner
++; refine the alignment of under-aligned plain loads and stores.
++define i32 @underaligned_load_store(i32 %v) {
++; CHECK-LABEL: underaligned_load_store(
++; CHECK: ld.local.b32
++; CHECK: st.local.b32
++; CHECK-NOT: .local.b8
++; CHECK: ret;
++  %a = alloca i32, align 4
++  call void @use(ptr %a)
++  %l = load i32, ptr %a, align 1
++  store i32 %v, ptr %a, align 1
++  call void @use(ptr %a)
++  ret i32 %l
++}
+diff --git a/test/CodeGen/NVPTX/variadics-backend.ll b/test/CodeGen/NVPTX/variadics-backend.ll
+index 61ff806..190371b 100644
+--- a/test/CodeGen/NVPTX/variadics-backend.ll
++++ b/test/CodeGen/NVPTX/variadics-backend.ll
+@@ -138,10 +138,10 @@ entry:
+ define dso_local i32 @variadics2(i32 noundef %first, ...) {
+ ; CHECK-PTX-LABEL: variadics2(
+ ; CHECK-PTX:       {
+-; CHECK-PTX-NEXT:    .local .align 1 .b8 __local_depot2[3];
++; CHECK-PTX-NEXT:    .local .align 2 .b8 __local_depot2[4];
+ ; CHECK-PTX-NEXT:    .reg .b64 %SP;
+ ; CHECK-PTX-NEXT:    .reg .b64 %SPL;
+-; CHECK-PTX-NEXT:    .reg .b16 %rs<4>;
++; CHECK-PTX-NEXT:    .reg .b16 %rs<6>;
+ ; CHECK-PTX-NEXT:    .reg .b32 %r<6>;
+ ; CHECK-PTX-NEXT:    .reg .b64 %rd<8>;
+ ; CHECK-PTX-EMPTY:
+@@ -156,10 +156,11 @@ define dso_local i32 @variadics2(i32 noundef %first, ...) {
+ ; CHECK-PTX-NEXT:    ld.s8 %r3, [%rd4+4];
+ ; CHECK-PTX-NEXT:    ld.b8 %rs1, [%rd4+7];
+ ; CHECK-PTX-NEXT:    st.local.b8 [%rd2+2], %rs1;
+-; CHECK-PTX-NEXT:    ld.b8 %rs2, [%rd4+6];
+-; CHECK-PTX-NEXT:    st.local.b8 [%rd2+1], %rs2;
+-; CHECK-PTX-NEXT:    ld.b8 %rs3, [%rd4+5];
+-; CHECK-PTX-NEXT:    st.local.b8 [%rd2], %rs3;
++; CHECK-PTX-NEXT:    ld.b8 %rs2, [%rd4+5];
++; CHECK-PTX-NEXT:    ld.b8 %rs3, [%rd4+6];
++; CHECK-PTX-NEXT:    shl.b16 %rs4, %rs3, 8;
++; CHECK-PTX-NEXT:    or.b16 %rs5, %rs4, %rs2;
++; CHECK-PTX-NEXT:    st.local.b16 [%rd2], %rs5;
+ ; CHECK-PTX-NEXT:    ld.b64 %rd5, [%rd4+8];
+ ; CHECK-PTX-NEXT:    add.s32 %r4, %r1, %r2;
+ ; CHECK-PTX-NEXT:    add.s32 %r5, %r4, %r3;
+@@ -201,7 +202,7 @@ define dso_local i32 @bar() {
+ ; CHECK-PTX-NEXT:    .local .align 8 .b8 __local_depot3[24];
+ ; CHECK-PTX-NEXT:    .reg .b64 %SP;
+ ; CHECK-PTX-NEXT:    .reg .b64 %SPL;
+-; CHECK-PTX-NEXT:    .reg .b16 %rs<4>;
++; CHECK-PTX-NEXT:    .reg .b16 %rs<6>;
+ ; CHECK-PTX-NEXT:    .reg .b32 %r<2>;
+ ; CHECK-PTX-NEXT:    .reg .b64 %rd<3>;
+ ; CHECK-PTX-EMPTY:
+@@ -212,9 +213,10 @@ define dso_local i32 @bar() {
+ ; CHECK-PTX-NEXT:    ld.global.nc.b8 %rs1, [__const_$_bar_$_s1+7];
+ ; CHECK-PTX-NEXT:    st.local.b8 [%rd1+2], %rs1;
+ ; CHECK-PTX-NEXT:    ld.global.nc.b8 %rs2, [__const_$_bar_$_s1+6];
+-; CHECK-PTX-NEXT:    st.local.b8 [%rd1+1], %rs2;
+-; CHECK-PTX-NEXT:    ld.global.nc.b8 %rs3, [__const_$_bar_$_s1+5];
+-; CHECK-PTX-NEXT:    st.local.b8 [%rd1], %rs3;
++; CHECK-PTX-NEXT:    shl.b16 %rs3, %rs2, 8;
++; CHECK-PTX-NEXT:    ld.global.nc.b8 %rs4, [__const_$_bar_$_s1+5];
++; CHECK-PTX-NEXT:    or.b16 %rs5, %rs3, %rs4;
++; CHECK-PTX-NEXT:    st.local.b16 [%rd1], %rs5;
+ ; CHECK-PTX-NEXT:    st.b32 [%SP+8], 1;
+ ; CHECK-PTX-NEXT:    st.b8 [%SP+12], 1;
+ ; CHECK-PTX-NEXT:    st.b64 [%SP+16], 1;


### PR DESCRIPTION
Backports https://github.com/llvm/llvm-project/pull/201772 to fix performance regressions after moving CUDA.jl to LLVM 22.