### PR TITLE
[0_RootFS] Add GCC 15.2 shard for aarch64-apple-darwin

### DIFF
--- a/0_RootFS/GCCBootstrap@15-IainS/build_tarballs.jl
+++ b/0_RootFS/GCCBootstrap@15-IainS/build_tarballs.jl
@@ -1,0 +1,2 @@
+include("../gcc_common.jl")
+build_and_upload_gcc(v"15.2.0-iains")

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/binutils_deterministic_dlltool.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/binutils_deterministic_dlltool.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@15/bundled/patches/binutils_deterministic_dlltool.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/binutils_freebsd_symbol_versioning.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/binutils_freebsd_symbol_versioning.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@15/bundled/patches/binutils_freebsd_symbol_versioning.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc/gcc1210-libcc1-musl-poisoned-calloc.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc/gcc1210-libcc1-musl-poisoned-calloc.patch
@@ -1,0 +1,1 @@
+../../../../GCCBootstrap@12/bundled/patches/gcc/gcc1210-libcc1-musl-poisoned-calloc.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc/gcc1520_mingw_include.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc/gcc1520_mingw_include.patch
@@ -1,0 +1,1 @@
+../../../../GCCBootstrap@15/bundled/patches/gcc/gcc1520_mingw_include.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc1020_revert-generic-morestack_c.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc1020_revert-generic-morestack_c.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@10/bundled/patches/gcc1020_revert-generic-morestack_c.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc152-aarch64-no-Werror.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc152-aarch64-no-Werror.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@15/bundled/patches/gcc152-aarch64-no-Werror.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc1520-basename.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc1520-basename.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@15/bundled/patches/gcc1520-basename.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc485_triplet_prefixed_cxx_headers.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc485_triplet_prefixed_cxx_headers.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/gcc485_triplet_prefixed_cxx_headers.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc520-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc520-libgomp-Don-t-hard-code-MS-printf-attributes.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@5/bundled/patches/gcc520-libgomp-Don-t-hard-code-MS-printf-attributes.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc9_vsnprintf-str.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/gcc9_vsnprintf-str.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@9/bundled/patches/gcc9_vsnprintf-str.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-01.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-01.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-01.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-02.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-02.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-02.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-03.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-03.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-03.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-04.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-04.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-04.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-05.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-05.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-05.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-06.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-06.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-06.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-07.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-07.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-07.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-08.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-08.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-08.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-09.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-09.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-09.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-10.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-10.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-10.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-11.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-11.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-11.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-12.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-12.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-12.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-13.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-13.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-13.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-14.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-14.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-14.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-15.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-15.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-15.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-16.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-16.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-16.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-17.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-17.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-17.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-18.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-18.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-18.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-19.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-19.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-19.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-20.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-20.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-20.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-21.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-21.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-21.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-22.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-22.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-22.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-23.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-23.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-23.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-24.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-24.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-24.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-25.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-25.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-25.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-26.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-26.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-26.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-27.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-27.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-27.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-28.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-28.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-28.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-29.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-29.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-29.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-30.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-30.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-30.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-31.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-31.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-31.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-32.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-32.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-32.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-33.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-33.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-33.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-34.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-34.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-34.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-35.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-35.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-35.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-36.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-36.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-36.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-37.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-37.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-37.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-38.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-38.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-38.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-39.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-39.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-39.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-40.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-40.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-40.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-41.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-41.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-41.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-42.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-42.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-42.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-43.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-43.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-43.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-44.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-44.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-44.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-45.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-45.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-45.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-46.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-46.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-46.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-47-pwr6-mtfsf.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-47-pwr6-mtfsf.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-47-pwr6-mtfsf.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-48-ldbl_high.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-48-ldbl_high.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc-ppc64le-48-ldbl_high.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-49-gcc10-cache_line_size-common.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-ppc64le-49-gcc10-cache_line_size-common.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@10/bundled/patches/glibc-ppc64le-49-gcc10-cache_line_size-common.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-remove-__ASSUME_AT_RANDOM-in-_dl_setup_stack_chk_guard.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc-remove-__ASSUME_AT_RANDOM-in-_dl_setup_stack_chk_guard.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@12/bundled/patches/glibc-remove-__ASSUME_AT_RANDOM-in-_dl_setup_stack_chk_guard.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc217_gcc_version.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc217_gcc_version.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@10/bundled/patches/glibc217_gcc_version.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc219_gcc_version.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc219_gcc_version.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@10/bundled/patches/glibc219_gcc_version.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_aarch64_relocation.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_aarch64_relocation.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc_aarch64_relocation.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_arm_gcc_fix.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_arm_gcc_fix.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc_arm_gcc_fix.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_gcc_version.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_gcc_version.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc_gcc_version.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_i686_asm.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_i686_asm.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc_i686_asm.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_make_version.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_make_version.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc_make_version.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_movq_fix.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_movq_fix.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@12/bundled/patches/glibc_movq_fix.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_musl_rejection.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_musl_rejection.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@14/bundled/patches/glibc_musl_rejection.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_nocommon.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_nocommon.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc_nocommon.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_powerpc64le_gcc_fix.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_powerpc64le_gcc_fix.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc_powerpc64le_gcc_fix.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_regexp_nocommon.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_regexp_nocommon.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc_regexp_nocommon.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_sunrpc.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/glibc_sunrpc.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/glibc_sunrpc.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/libtapi_fullyaml.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/libtapi_fullyaml.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/libtapi_fullyaml.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/libtapi_musl.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/libtapi_musl.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/libtapi_musl.patch

--- a/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/mingw_gcc710_i686.patch
+++ b/0_RootFS/GCCBootstrap@15-IainS/bundled/patches/mingw_gcc710_i686.patch
@@ -1,0 +1,1 @@
+../../../GCCBootstrap@4/bundled/patches/mingw_gcc710_i686.patch

--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -157,6 +157,26 @@ function gcc_script(gcc_version::VersionNumber, compiler_target::Platform)
         # that are available only starting in later macOS versions such as `clock_gettime` or `mkostemp`
         export ac_cv_func_clock_gettime=no
         export ac_cv_func_mkostemp=no
+
+        # Without `-sdk_version`, cctools ld64 stamps LC_BUILD_VERSION.sdk with the Darwin major
+        # (e.g. 20.0), which trips macOS 26's stricter dyld LINKEDIT validator and makes the runtime
+        # dylibs (-> CompilerSupportLibraries) fail to load.  Pin the (grandfathered) SDK version
+        # explicitly, like conda-forge's clang driver does.
+        if [[ "${GCC_VERSION_MAJOR}" -ge 14 ]]; then
+            export LDFLAGS_FOR_TARGET="${LDFLAGS_FOR_TARGET} -Wl,-sdk_version,11.0"
+        fi
+
+        # cctools' `as` runs clang without `-mcpu`, whose default CPU rejects the Apple-Silicon
+        # instructions GCC emits ("instruction requires: rcpc-immo").
+        if [[ "${GCC_VERSION_MAJOR}" -ge 14 ]] && [[ "${COMPILER_TARGET}" == aarch64-* ]]; then
+            mkdir -p "${prefix}/bin"
+            cat > "${prefix}/bin/clang-as-wrapper" <<'WRAP'
+#!/bin/sh
+exec clang -mcpu=apple-m1 "$@"
+WRAP
+            chmod +x "${prefix}/bin/clang-as-wrapper"
+            export CCTOOLS_CLANG_AS_EXECUTABLE="${prefix}/bin/clang-as-wrapper"
+        fi
     fi
 
     # Link dependent packages into gcc build root:
@@ -206,9 +226,17 @@ function gcc_script(gcc_version::VersionNumber, compiler_target::Platform)
 
         TAPI_CMAKE_FLAGS=()
         if [[ "${GCC_VERSION_MAJOR}" -ge 14 ]]; then
+            # libtapi 1500's LLVM tree is pruned of docs/examples/benchmarks; these flags
+            # match tpoechtrager's own build.sh.  Keep TAPI_*_VERSION in sync with the
+            # apple-libtapi pin in gcc_sources.jl.
             TAPI_CMAKE_FLAGS+=(
                 -DLLVM_ENABLE_PROJECTS="tapi;clang"
                 -DLLVM_TARGETS_TO_BUILD:STRING="host"
+                -DLLVM_INCLUDE_DOCS=OFF
+                -DLLVM_INCLUDE_EXAMPLES=OFF
+                -DLLVM_INCLUDE_BENCHMARKS=OFF
+                -DTAPI_REPOSITORY_STRING=1500.0.12.3
+                -DTAPI_FULL_VERSION=1500.0.12.3
             )
         fi
 
@@ -222,7 +250,18 @@ function gcc_script(gcc_version::VersionNumber, compiler_target::Platform)
             "${TAPI_CMAKE_FLAGS[@]}"
         make -j${nproc} VERBOSE=1 clangBasic
         make -j${nproc} VERBOSE=1 libtapi
-        make -j${nproc} VERBOSE=1 install
+        if [[ "${GCC_VERSION_MAJOR}" -ge 14 ]]; then
+            # libtapi 1500's optional tapi tools don't link on Linux (bad static-archive
+            # order, known upstream), and a plain `make install` would build them.  Install
+            # only what we use: libtapi for ld64, clang for the assembler, LLVM binutils
+            # and dsymutil for the *_FOR_TARGET tools.
+            make -j${nproc} VERBOSE=1 install-libtapi install-tapi-headers \
+                install-clang install-clang-resource-headers \
+                install-llvm-as install-llvm-ar install-llvm-nm install-llvm-ranlib \
+                install-dsymutil
+        else
+            make -j${nproc} VERBOSE=1 install
+        fi
 
         # Install cctools
         cd ${WORKSPACE}/srcdir/cctools-port/cctools
@@ -668,14 +707,18 @@ function build_and_upload_gcc(version::VersionNumber, ARGS=ARGS)
     script = gcc_script(version, compiler_target)
     products = gcc_products()
 
+    # Apple/arm64 recipes key their source off a `-iains` prerelease tag (e.g. v"15.2.0-iains"),
+    # but BinaryBuilder refuses prerelease versions, so strip the tag for build & upload.
+    build_version = VersionNumber(version.major, version.minor, version.patch)
+
     # Build the tarballs, and possibly a `build.jl` as well.
     ndARGS, deploy_target = find_deploy_arg(ARGS)
-    build_info = build_tarballs(ndARGS, name, version, sources, script, [compiler_target], products, Dependency[]; skip_audit=true, julia_compat="1.6")
+    build_info = build_tarballs(ndARGS, name, build_version, sources, script, [compiler_target], products, Dependency[]; skip_audit=true, julia_compat="1.6")
     build_info = Dict(host_platform => first(values(build_info)))
 
     # Upload the artifacts (if requested)
     if deploy_target !== nothing
-        upload_and_insert_shards(deploy_target, name, version, build_info; target=compiler_target)
+        upload_and_insert_shards(deploy_target, name, build_version, build_info; target=compiler_target)
     end
     return build_info
 end

--- a/0_RootFS/gcc_sources.jl
+++ b/0_RootFS/gcc_sources.jl
@@ -178,6 +178,21 @@ function gcc_sources(gcc_version::VersionNumber, compiler_target::Platform; kwar
             ArchiveSource("https://mirrors.kernel.org/gnu/gmp/gmp-6.2.0.tar.xz",
                           "258e6cd51b3fbdfc185c716d55f82c08aff57df0c6fbd143cf6ed561267a1526"),
         ]
+        # Iain Sandoe's GCC 15 Darwin/arm64 release branch (gcc-15-2-darwin-pre-0):
+        # upstream GCC 15.2.0 + Darwin/arm64 patches, same base as Homebrew's `gcc`.
+        # Deps match GCC 15.2's `contrib/download_prerequisites`.
+        gcc_version_sources[v"15.2.0-iains"] = [
+            GitSource("https://github.com/iains/gcc-15-branch.git",
+                      "bf0bb1095eb8440457658fad903cca575dbde3e9"),
+            ArchiveSource("https://mirrors.kernel.org/gnu/gmp/gmp-6.2.1.tar.xz",
+                          "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2"),
+            ArchiveSource("https://mirrors.kernel.org/gnu/mpfr/mpfr-4.1.0.tar.xz",
+                          "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"),
+            ArchiveSource("https://mirrors.kernel.org/gnu/mpc/mpc-1.2.1.tar.gz",
+                          "17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459"),
+            ArchiveSource("https://gcc.gnu.org/pub/gcc/infrastructure/isl-0.24.tar.bz2",
+                          "fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0"),
+        ]
         # MacOS doesn't actually use binutils, it uses cctools
         if gcc_version < v"14"
             binutils_sources = [
@@ -187,11 +202,15 @@ function gcc_sources(gcc_version::VersionNumber, compiler_target::Platform; kwar
                           "634a084377ee2e2932c66459b0396edf76da2e9f"),
             ]
         else
+            # cctools-port pinned to conda-forge's cctools-and-ld64-feedstock commit
+            # (cctools 1030.6.3 / ld64 956.6, branch `1030.6.3-ld64-956.6`) -- a widely
+            # deployed cross-linker.  apple-libtapi 1500.0.12.3 (Xcode 15 era); when bumping
+            # it, also update TAPI_REPOSITORY_STRING/TAPI_FULL_VERSION in gcc_common.jl.
             binutils_sources = [
                 GitSource("https://github.com/tpoechtrager/apple-libtapi.git",
-                          "54c9044082ba35bdb2b0edf282ba1a340096154c"),
+                          "fbe6e2ae9dab1768ffb22a0d64d525fb7bdf9be6"), # 1500.0.12.3
                 GitSource("https://github.com/tpoechtrager/cctools-port.git",
-                          "81f205e8ca6bbf2fdbcb6948132454fd1f97839e"),
+                          "e5dfc5633cb9060a94d16b8d78a01eb0b3620021"), # 1030.6.3-ld64-956.6 (conda-forge pin)
             ]
         end
     else


### PR DESCRIPTION
Build GCCBootstrap 15.2.0 for aarch64-apple-darwin from Iain Sandoe's
gcc-15-branch (gcc-15-2-darwin-pre-0), bumping cctools-port to
conda-forge's pin (cctools 1030.6.3 / ld64 956.6) and apple-libtapi to
1500.0.12.3.  Pass -Wl,-sdk_version,11.0 when linking the GCC runtime
dylibs so they stay loadable under macOS 26's stricter dyld validation,
and wrap the cctools assembler clang with -mcpu=apple-m1 so it accepts
GCC's Apple-Silicon codegen.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
