### PR TITLE
[0_RootFS] Update CSL to 1.3.1, Glibc runtime to 2.34.0+1, bump meson

### DIFF
--- a/0_RootFS/Rootfs/build_tarballs.jl
+++ b/0_RootFS/Rootfs/build_tarballs.jl
@@ -128,7 +128,7 @@ sources = [
               "bf3f37ec29edcdb3e2a163edaf84aeece39f8c9d"), # v0.14.3
     # We need a very recent version of meson to build gtk stuffs, so let's just grab the latest
     GitSource("https://github.com/mesonbuild/meson.git",
-              "eaefe29463a61a311a6b1de6cd539f39500399ff"), # v1.4.0
+              "39be44fed2938ad03f8e2bc183401a121387bf50"), # v1.8.0
     # We're going to bundle a version of `ldid` into the rootfs for now.  When we split this up,
     # we'll do this in a nicer way by using JLLs directly, but until then, this is what we've got.
     ArchiveSource("https://github.com/JuliaBinaryWrappers/ldid_jll.jl/releases/download/ldid-v2.1.3%2B0/ldid.v2.1.3.x86_64-linux-musl-cxx11.tar.gz",

--- a/0_RootFS/Rootfs/bundled/libs/csl/download_csls.sh
+++ b/0_RootFS/Rootfs/bundled/libs/csl/download_csls.sh
@@ -2,7 +2,7 @@
 cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1
 
 # Download and extract the lib folders from our CompilerSupportLibraries_jll.jl releases
-CSL_VERSION="0.5.1+0"
+CSL_VERSION="1.3.1+0"
 for arch in i686 x86_64; do
     rm -rf glibc-${arch} musl-${arch}
     mkdir -p glibc-${arch} musl-${arch}

--- a/0_RootFS/Rootfs/bundled/libs/libc/download_libcs.sh
+++ b/0_RootFS/Rootfs/bundled/libs/libc/download_libcs.sh
@@ -5,7 +5,7 @@ cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1
 for arch in i686 x86_64; do
     rm -rf glibc-${arch}
     mkdir -p glibc-${arch}
-    curl -L "https://github.com/JuliaBinaryWrappers/Glibc_jll.jl/releases/download/Glibc-v2.34.0%2B0/Glibc.v2.34.0.${arch}-linux-gnu.tar.gz" | tar --wildcards --strip-components=1 -zxv -C glibc-${arch} "lib*/"
+    curl -L "https://github.com/JuliaBinaryWrappers/Glibc_jll.jl/releases/download/Glibc-v2.34.0%2B1/Glibc.v2.34.0.${arch}-linux-gnu.tar.gz" | tar --wildcards --strip-components=1 -zxv -C glibc-${arch} "lib*/"
 done
 
 # Next, do the same for musl


### PR DESCRIPTION
Redo of #11095 now that the musl-library rejection fix in the glibc loader has landed (#13930): the CSL 0.5.1 -> 1.3.1 (GCC 14) upgrade previously broke the BinaryBuilderBase C++ tests because the new patchelf-rewritten musl CSL libraries evaded the rejection check in the bundled glibc loader and got loaded into glibc processes. The Glibc_jll v2.34.0+1 loader rejects them correctly (verified against the released artifact).

Companion to JuliaPackaging/BinaryBuilderBase.jl#423.