### PR TITLE
[blasfeo] Working march specific builds for blasfeo

### DIFF
--- a/B/blasfeo/build_tarballs.jl
+++ b/B/blasfeo/build_tarballs.jl
@@ -1,6 +1,12 @@
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms: arch, os, tags
 
+const YGGDRASIL_DIR = "../.."
+# For MicroArchitectures
+include(joinpath(YGGDRASIL_DIR, "platforms", "microarchitectures.jl"))
+# For should_build_platform
+include(joinpath(YGGDRASIL_DIR,"fancy_toys.jl"))
+
 name = "blasfeo"
 version = v"0.1.4"
 
@@ -98,11 +104,18 @@ products = [
     LibraryProduct("libblasfeo", :blasfeo, "blasfeo/lib")
 ]
 
+# augment_platform so we get the correct, that is fast, build
+augment_platform_block = """
+$(MicroArchitectures.augment)
+
+function augment_platform!(platform::Platform)
+    augment_microarchitecture!(platform)
+end
+"""
+
 # Dependencies
 dependencies = Dependency[]
 
-# For should_build_platform
-include("../../fancy_toys.jl")
 
 for platform in platforms
     should_build_platform(platform) || continue # Don't build things on the wrong platforms
@@ -120,7 +133,8 @@ for platform in platforms
         [platform],
         products,
         dependencies,
-        julia_compat = "1.6",
+        julia_compat="1.6",
+        augment_platform_block=augment_platform_block,
         lock_microarchitecture=false, # blasfeo build handles march/m* flags
         preferred_gcc_version=gcc_ver,
     )

--- a/B/blasfeo/build_tarballs.jl
+++ b/B/blasfeo/build_tarballs.jl
@@ -17,7 +17,7 @@ sources = [
 # Some notes from out of band conversations with @giaf:
 #    - It only makes sense to build for the following platforms:
 #        - X64_AMD_ZEN5: Specifically for AMD chips with good AVX512 implementation (desktop)
-#            - Currently don't support this because it is _only_ useful for specifically Zen5
+#            - Currently support this but questionably useful because it is _only_ good on specifically Zen5
 #        - X64_INTEL_HASWELL: Generically for any 64 bit hardware supporting AVX2 and FMA (including AMD chips?)
 #        - X64_INTEL_SANDY_BRIDGE: For older Intel/AMD chips with avx support (what about chips with avx+fma?)
 #        - ARMV8A_APPLE_M1: Same as other ARMV8 just with different alignment due to cache size difference?

--- a/B/blasfeo/build_tarballs.jl
+++ b/B/blasfeo/build_tarballs.jl
@@ -100,7 +100,11 @@ products = [
 # Dependencies
 dependencies = Dependency[]
 
+# For should_build_platform
+include("../../fancy_toys.jl")
+
 for platform in platforms
+    should_build_platform(platform) || continue # Don't build things on the wrong platforms
     # This is necessary because for mingw-gcc has problems with xmm registers on <v8.4 <v9.3 <10.
     # See this bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
     # We set to v"10" because of how `preferred_gcc_version` works:

--- a/B/blasfeo/build_tarballs.jl
+++ b/B/blasfeo/build_tarballs.jl
@@ -40,7 +40,7 @@ function get_script(; platform::Platform)
             LA = "HIGH_PERFORMANCE"
         else
             TARGET = "GENERIC"
-            LA = "REFERENCE"
+            LA = "HIGH_PERFORMANCE"
         end
     elseif arch(platform) == "aarch64" && os(platform) == "macos"
         if platform["march"] == "apple_m1"
@@ -48,10 +48,11 @@ function get_script(; platform::Platform)
             LA = "HIGH_PERFORMANCE"
         else
             TARGET = "GENERIC"
-            LA = "REFERENCE"
+            LA = "HIGH_PERFORMANCE"
         end
     else
         TARGET = "GENERIC"
+        LA = "HIGH_PERFORMANCE"
     end
     # Set OS variable
     if Sys.islinux(platform)

--- a/B/blasfeo/build_tarballs.jl
+++ b/B/blasfeo/build_tarballs.jl
@@ -7,8 +7,8 @@ version = v"0.1.4"
 # Source
 sources = [
     GitSource(
-        "https://github.com/apozharski/blasfeo.git",
-        "698489feaf3c89c44f28ce2d58163bdf9859085b",  # current master branch
+        "https://github.com/giaf/blasfeo.git",
+        "2825f3368c3e02003a0c42500a0605f687c9ccc8",  # current master branch
     ),
 ]
 
@@ -17,7 +17,7 @@ sources = [
 # Some notes from out of band conversations with @giaf:
 #    - It only makes sense to build for the following platforms:
 #        - X64_AMD_ZEN5: Specifically for AMD chips with good AVX512 implementation (desktop)
-#            - Currently support this but questionably useful because it is _only_ good on specifically Zen5
+#            - Currently support this but questionably useful because it is _only_ good on specifically Zen5 workstation
 #        - X64_INTEL_HASWELL: Generically for any 64 bit hardware supporting AVX2 and FMA (including AMD chips?)
 #        - X64_INTEL_SANDY_BRIDGE: For older Intel/AMD chips with avx support (what about chips with avx+fma?)
 #        - ARMV8A_APPLE_M1: Same as other ARMV8 just with different alignment due to cache size difference?

--- a/B/blasfeo/build_tarballs.jl
+++ b/B/blasfeo/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"0.1.4"
 sources = [
     GitSource(
         "https://github.com/apozharski/blasfeo.git",
-        "268f5244cc1e434b5dd5a5eceb6e42e9e3f0e849",  # current master branch
+        "698489feaf3c89c44f28ce2d58163bdf9859085b",  # current master branch
     ),
 ]
 
@@ -88,7 +88,7 @@ end
 # Platforms
 platforms = [
     expand_microarchitectures(filter!((p) -> Sys.islinux(p) && arch(p) == "x86_64",supported_platforms()), ["x86_64","avx", "avx2","avx512"]);
-    #expand_microarchitectures(filter!((p) -> Sys.iswindows(p) && arch(p) == "x86_64",supported_platforms()), ["x86_64","avx", "avx2","avx512"]); # windows support would require work in blasfeo
+    expand_microarchitectures(filter!((p) -> Sys.iswindows(p) && arch(p) == "x86_64",supported_platforms()), ["x86_64","avx", "avx2","avx512"]);
     expand_microarchitectures(filter!((p) -> Sys.isapple(p) && arch(p) == "x86_64",supported_platforms()), ["x86_64","avx", "avx2"]);
     expand_microarchitectures(filter!((p) -> Sys.isapple(p) && arch(p) == "aarch64",supported_platforms()), ["apple_m1"])
 ]
@@ -101,6 +101,11 @@ products = [
 dependencies = Dependency[]
 
 for platform in platforms
+    # This is necessary because for mingw-gcc has problems with xmm registers on <v8.4 <v9.3 <10.
+    # See this bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
+    # We set to v"10" because of how `preferred_gcc_version` works:
+    # https://github.com/JuliaPackaging/Yggdrasil/pull/6843#issuecomment-1585288925
+    gcc_ver = (Sys.iswindows(platform) && platform["march"] == "avx512") ? v"10" : nothing
     build_tarballs(
         ARGS,
         name,
@@ -112,5 +117,6 @@ for platform in platforms
         dependencies,
         julia_compat = "1.6",
         lock_microarchitecture=false, # blasfeo build handles march/m* flags
+        preferred_gcc_version=gcc_ver,
     )
 end

--- a/B/blasfeo/build_tarballs.jl
+++ b/B/blasfeo/build_tarballs.jl
@@ -1,71 +1,116 @@
 using BinaryBuilder, Pkg
+using Base.BinaryPlatforms: arch, os, tags
 
 name = "blasfeo"
-version = v"0.1.3"
+version = v"0.1.4"
 
 # Source
 sources = [
     GitSource(
-        "https://github.com/giaf/blasfeo.git",
-        "386e6556ce643e9863458c2479192de4c9689b81",  # current master branch
+        "https://github.com/apozharski/blasfeo.git",
+        "268f5244cc1e434b5dd5a5eceb6e42e9e3f0e849",  # current master branch
     ),
 ]
 
-# Build instructions
-# NOTE:
-#  This builds the library for the GENERIC target
-#  In the future it'd be nice to specialize the TARGET flag to the build target
-#  Sorta blocked by unclear mapping, and lack of specific options (like aarch64 apple) 
-#    in the CMake interface in blasfeo
-script = raw"""
+
+# Build
+# Some notes from out of band conversations with @giaf:
+#    - It only makes sense to build for the following platforms:
+#        - X64_AMD_ZEN5: Specifically for AMD chips with good AVX512 implementation (desktop)
+#            - Currently don't support this because it is _only_ useful for specifically Zen5
+#        - X64_INTEL_HASWELL: Generically for any 64 bit hardware supporting AVX2 and FMA (including AMD chips?)
+#        - X64_INTEL_SANDY_BRIDGE: For older Intel/AMD chips with avx support (what about chips with avx+fma?)
+#        - ARMV8A_APPLE_M1: Same as other ARMV8 just with different alignment due to cache size difference?
+#    - COLMAJ overhead for things e.g. HPIPM does is not so bad (@giaf wrote specific code to handle different sizes)
+#      but best performance is still PANELMAJ.
+#    - It does not make sense to compile the BLAS API because BLASFEO doesn't implement well or at all some things
+#      that supporting this would require. Therefore, supporting this with libblastrampoline does not make sense.
+function get_script(; platform::Platform)
+    # Set TARGET and LA
+    if arch(platform) == "x86_64"
+        march = platform["march"]
+        if platform["march"] == "avx"
+            TARGET = "X64_INTEL_SANDY_BRIDGE"
+            LA = "HIGH_PERFORMANCE"
+        elseif platform["march"] == "avx2"
+            TARGET = "X64_INTEL_HASWELL"
+            LA = "HIGH_PERFORMANCE"
+        elseif platform["march"] == "avx512" # TODO(@apozharski) This may not _actually_ make sense for SKYLAKE-X chips, but alas
+            TARGET = "X64_AMD_ZEN5"
+            LA = "HIGH_PERFORMANCE"
+        else
+            TARGET = "GENERIC"
+            LA = "REFERENCE"
+        end
+    elseif arch(platform) == "aarch64" && os(platform) == "macos"
+        if platform["march"] == "apple_m1"
+            TARGET = "ARMV8A_APPLE_M1"
+            LA = "HIGH_PERFORMANCE"
+        else
+            TARGET = "GENERIC"
+            LA = "REFERENCE"
+        end
+    else
+        TARGET = "GENERIC"
+    end
+    # Set OS variable
+    if Sys.islinux(platform)
+        OS = "LINUX"
+    elseif Sys.isapple(platform)
+        OS = "MAC"
+    elseif Sys.iswindows(platform)
+        OS = "WINDOWS"
+    else
+        error("unsupported platform")
+    end
+
+    script = raw"""
 cd $WORKSPACE/srcdir/blasfeo
-mkdir build
-cd build/
-cmake \
-    -D TARGET=GENERIC \
-    -D MF=PANELMAJ \
-    -D LA=HIGH_PERFORMANCE \
-    -D CMAKE_INSTALL_PREFIX=${prefix} \
-    -D CMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
-    -D CMAKE_BUILD_TYPE=Release \
-    -D BUILD_SHARED_LIBS=ON \
-    ..
+echo "
+TARGET= """ * TARGET *
+raw"""
 
-echo "Finished cmake config"
-if [[ "${target}" == *-linux-* ]]; then 
-    echo "System is Linux"
-    cmake -D CMAKE_C_FLAGS="-lrt" ..
-fi
-echo "Finished first conditional"
-if [[ "${target}" == *-apple-* ]]; then 
-    echo "Setting RPATH"
-    cmake -D CMAKE_MACOSX_RPATH=1 ..
-fi
+LA= """ * LA *
+raw"""
 
-cmake --build . --target install -j${nproc}
+OS= """ * OS *
+raw"""
+
+MF = PANELMAJ
+BLAS_API = 0
+PREFIX = ${prefix}
+" > Makefile.local
+make shared_library -j ${nproc}
+make install_shared
 """
-
+end
 
 # Platforms
-platforms = supported_platforms(exclude=Sys.iswindows)
-
+platforms = [
+    expand_microarchitectures(filter!((p) -> Sys.islinux(p) && arch(p) == "x86_64",supported_platforms()), ["x86_64","avx", "avx2","avx512"]);
+    #expand_microarchitectures(filter!((p) -> Sys.iswindows(p) && arch(p) == "x86_64",supported_platforms()), ["x86_64","avx", "avx2","avx512"]); # windows support would require work in blasfeo
+    expand_microarchitectures(filter!((p) -> Sys.isapple(p) && arch(p) == "x86_64",supported_platforms()), ["x86_64","avx", "avx2"]);
+    expand_microarchitectures(filter!((p) -> Sys.isapple(p) && arch(p) == "aarch64",supported_platforms()), ["apple_m1"])
+]
 # Products
 products = [
-    LibraryProduct("libblasfeo", :blasfeo)
+    LibraryProduct("libblasfeo", :blasfeo, "blasfeo/lib")
 ]
 
 # Dependencies
 dependencies = Dependency[]
 
-# Build the tarballs
-build_tarballs(
-    ARGS,
-    name,
-    version,
-    sources,
-    script,
-    platforms,
-    products,
-    dependencies,
-    julia_compat = "1.6"
-)
+for platform in platforms
+    build_tarballs(
+        ARGS,
+        name,
+        version,
+        sources,
+        get_script(;platform=platform),
+        [platform],
+        products,
+        dependencies,
+        julia_compat = "1.6",
+        lock_microarchitecture=false, # blasfeo build handles march/m* flags
+    )
+end

--- a/B/blasfeo/build_tarballs.jl
+++ b/B/blasfeo/build_tarballs.jl
@@ -14,7 +14,7 @@ version = v"0.1.4"
 sources = [
     GitSource(
         "https://github.com/giaf/blasfeo.git",
-        "2825f3368c3e02003a0c42500a0605f687c9ccc8",  # current master branch
+        "0ab5db3259c009ea62318a5e35622fe6de7ae554",  # current master branch
     ),
 ]
 


### PR DESCRIPTION
This adds support for building shared libraries with the `LA=HIGH_PERFORMANCE` presets in blasfeo.

~~Currently points to a fork of `blasfeo` (with some minor build fixes) hence marked WIP until https://github.com/giaf/blasfeo/pull/211 is merged. I will then update the branch.~~

This works also for intel and M1 macs as well as windows.