### PR TITLE
[LaMEM] Update to v2.2.1

### DIFF
--- a/L/LaMEM/build_tarballs.jl
+++ b/L/LaMEM/build_tarballs.jl
@@ -8,7 +8,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 name = "LaMEM"
 version = v"2.2.1"
 
-PETSc_COMPAT_VERSION = "~3.22.0"    
+PETSc_COMPAT_VERSION = "~3.22.1"
 MPItrampoline_compat_version=" 5.5.0"
 MicrosoftMPI_compat_version="~10.1.4" 
 MPICH_compat_version="~4.2.3"    
@@ -106,11 +106,6 @@ platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "i686"), platforms
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
 
-# PETSc_jll's mpiabi build is configured without MPI and uses a different PETSc arch
-# layout, so LaMEM's hardcoded PETSC_OPT (double_real_Int32) is not present there.
-# Exclude mpiabi until PETSc ships an MPI-based mpiabi build (2.2.0 shipped no mpiabi).
-platforms = filter(p -> !(p["mpi"] == "mpiabi"), platforms)
-
 # powerpc64le only with libgfortran 5 or higher (as openblas is not defined for other cases)
 platforms = filter(p -> !(p["arch"] == "powerpc64le" && (libgfortran_version(p) == v"3" || libgfortran_version(p) == v"4")), platforms)
 
@@ -130,7 +125,11 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("PETSc_jll"; compat=PETSc_COMPAT_VERSION),
-    Dependency("CompilerSupportLibraries_jll")
+    Dependency("CompilerSupportLibraries_jll"),
+    # PETSc's mpiabi build links libmpif (Fortran MPI bindings); the MPI augmentation
+    # only provides MPIABI_jll (libmpi_abi), so add mpif_jll for mpiabi platforms to
+    # satisfy LaMEM's dlopen audit. Mirrors PETSc_jll's own recipe.
+    Dependency("mpif_jll"; compat="0.1.5", platforms=filter(p -> p["mpi"] == "mpiabi", platforms)),
 ]
 append!(dependencies, platform_dependencies)
 

--- a/L/LaMEM/build_tarballs.jl
+++ b/L/LaMEM/build_tarballs.jl
@@ -8,15 +8,17 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 name = "LaMEM"
 version = v"2.2.1"
 
-# NOTE: the MPI compat bounds below must match PETSc_jll 3.22.1's requirements, since LaMEM
-# and PETSc co-resolve the same MPI JLL per platform. PETSc 3.22.1 raised these floors
-# (MPICH >=4.3.0, MPItrampoline >=5.5.3, OpenMPI >=5.0.7); keeping the old 3.22.0-era bounds
-# makes mpich/openmpi/mpitrampoline unresolvable against PETSc 3.22.1.
+# NOTE: the MPI compat bounds below must match the EXACT MPI versions PETSc_jll 3.22.1 was
+# built against, since LaMEM and PETSc co-resolve the same MPI JLL per platform AND PETSc's
+# headers (petscsys.h) hard-error if the mpi.h version differs from what PETSc was configured
+# with. PETSc 3.22.1 was built with: MPICH >=4.3.0, MPItrampoline >=5.5.3, and OpenMPI 4.1.8
+# (its compat is the union [4.1.8-4, 5.0.7-5] but the published binary used 4.1.8 — pin EXACTLY
+# 4.1.8, since OpenMPI 4.1.9 exists and the petscsys.h check is strict to the subminor).
 PETSc_COMPAT_VERSION = "~3.22.1"
 MPItrampoline_compat_version="5.5.3 - 5"
 MicrosoftMPI_compat_version="~10.1.4"
 MPICH_compat_version="4.3.0 - 5"
-OpenMPI_compat_version="5.0.7 - 5"
+OpenMPI_compat_version="4.1.8 - 4.1.8"
 
 # Collection of sources required to complete build
 sources = [
@@ -134,6 +136,10 @@ dependencies = [
     # only provides MPIABI_jll (libmpi_abi), so add mpif_jll for mpiabi platforms to
     # satisfy LaMEM's dlopen audit. Mirrors PETSc_jll's own recipe.
     Dependency("mpif_jll"; compat="0.1.5", platforms=filter(p -> p["mpi"] == "mpiabi", platforms)),
+    # On Windows, PETSc_jll 3.22.1 links libscalapack32 statically into LaMEM's executable,
+    # so SCALAPACK32_jll must be present in the prefix or the link fails with
+    # `ld: cannot find -lscalapack32`. (On Linux/macOS it's resolved via libpetsc itself.)
+    Dependency("SCALAPACK32_jll"; compat="2.2.3", platforms=filter(p -> Sys.iswindows(p), platforms)),
 ]
 append!(dependencies, platform_dependencies)
 

--- a/L/LaMEM/build_tarballs.jl
+++ b/L/LaMEM/build_tarballs.jl
@@ -8,11 +8,15 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 name = "LaMEM"
 version = v"2.2.1"
 
+# NOTE: the MPI compat bounds below must match PETSc_jll 3.22.1's requirements, since LaMEM
+# and PETSc co-resolve the same MPI JLL per platform. PETSc 3.22.1 raised these floors
+# (MPICH >=4.3.0, MPItrampoline >=5.5.3, OpenMPI >=5.0.7); keeping the old 3.22.0-era bounds
+# makes mpich/openmpi/mpitrampoline unresolvable against PETSc 3.22.1.
 PETSc_COMPAT_VERSION = "~3.22.1"
-MPItrampoline_compat_version=" 5.5.0"
-MicrosoftMPI_compat_version="~10.1.4" 
-MPICH_compat_version="~4.2.3"    
-OpenMPI_compat_version="~5.0.5"
+MPItrampoline_compat_version="5.5.3 - 5"
+MicrosoftMPI_compat_version="~10.1.4"
+MPICH_compat_version="4.3.0 - 5"
+OpenMPI_compat_version="5.0.7 - 5"
 
 # Collection of sources required to complete build
 sources = [

--- a/L/LaMEM/build_tarballs.jl
+++ b/L/LaMEM/build_tarballs.jl
@@ -6,7 +6,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "LaMEM"
-version = v"2.2.0"
+version = v"2.2.1"
 
 PETSc_COMPAT_VERSION = "~3.22.0"    
 MPItrampoline_compat_version=" 5.5.0"
@@ -16,8 +16,8 @@ OpenMPI_compat_version="~5.0.5"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/UniMainzGeo/LaMEM", 
-    "0f6a5a82f32a3db59871d6e254ae570a3100edad")
+    GitSource("https://github.com/UniMainzGeo/LaMEM",
+    "88f7ba72cadae8549690abf1018b31490750a589")
 ]
 
 # Bash recipe for building across all platforms

--- a/L/LaMEM/build_tarballs.jl
+++ b/L/LaMEM/build_tarballs.jl
@@ -106,6 +106,11 @@ platforms = filter(p -> !(p["mpi"] == "openmpi" && arch(p) == "i686"), platforms
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && libc(p) == "musl"), platforms)
 platforms = filter(p -> !(p["mpi"] == "mpitrampoline" && Sys.isfreebsd(p)), platforms)
 
+# PETSc_jll's mpiabi build is configured without MPI and uses a different PETSc arch
+# layout, so LaMEM's hardcoded PETSC_OPT (double_real_Int32) is not present there.
+# Exclude mpiabi until PETSc ships an MPI-based mpiabi build (2.2.0 shipped no mpiabi).
+platforms = filter(p -> !(p["mpi"] == "mpiabi"), platforms)
+
 # powerpc64le only with libgfortran 5 or higher (as openblas is not defined for other cases)
 platforms = filter(p -> !(p["arch"] == "powerpc64le" && (libgfortran_version(p) == v"3" || libgfortran_version(p) == v"4")), platforms)
 


### PR DESCRIPTION
Updates LaMEM_jll to **v2.2.1** (from LaMEM [v2.2.1](https://github.com/UniMainzGeo/LaMEM/releases/tag/v2.2.1), commit `88f7ba72cadae8549690abf1018b31490750a589`).

Only the `version` and the source commit changed — the LaMEM build system (`src/Makefile`) and all dependency / compat bounds (PETSc `~3.22.0`, MPItrampoline `5.5.0`, MPICH `~4.2.3`, MicrosoftMPI `~10.1.4`, OpenMPI `~5.0.5`) are unchanged from the 2.2.0 recipe.

Built and audited locally with BinaryBuilder on `x86_64-linux-gnu-libgfortran5-mpi+mpich` (produces `bin/LaMEM` + `lib/LaMEMLib.so`, dlopen audit passes).

Ref: JuliaGeodynamics/LaMEM.jl#106
