### PR TITLE
[msolve] v0.10.0

### DIFF
--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -24,7 +24,7 @@ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure --w
 make -j${nprocs}
 make install
 """
-
+sources, script = require_macos_sdk("10.15", sources, script)
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -3,16 +3,16 @@
 using BinaryBuilder, Pkg
 
 name = "msolve"
-upstream_version = v"0.9.5"
+upstream_version = v"0.10.0"
 
-version_offset = v"0.0.3"
+version_offset = v"0.0.0"
 version = VersionNumber(upstream_version.major*100+version_offset.major,
                         upstream_version.minor*100+version_offset.minor,
                         upstream_version.patch*100+version_offset.patch)
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/algebraic-solving/msolve.git", "7c4fbe08cf4dcaf73fad2ae2d3902795d040f290")
+    GitSource("https://github.com/algebraic-solving/msolve.git", "1c67c70365746f23c901a9e18d60f01b78d44dd7")
 ]
 
 # Bash recipe for building across all platforms

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -15,7 +15,7 @@ version = VersionNumber(upstream_version.major*100+version_offset.major,
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/algebraic-solving/msolve.git", "1c67c70365746f23c901a9e18d60f01b78d44dd7")
+    GitSource("https://github.com/algebraic-solving/msolve.git", "0441849e0655a901dcbbae7aa78b714bd7cafbe6")
 ]
 
 # Bash recipe for building across all platforms
@@ -27,7 +27,7 @@ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure --w
 make -j${nprocs}
 make install
 """
-sources, script = require_macos_sdk("10.15", sources, script)
+
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -2,9 +2,6 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
-const YGGDRASIL_DIR = "../.."
-include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
-
 name = "msolve"
 upstream_version = v"0.10.0"
 

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -2,6 +2,9 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
 name = "msolve"
 upstream_version = v"0.10.0"
 


### PR DESCRIPTION
msolve v0.10.0

Release notes:

- Adding tier policy
- Enabling build system for Windows and Android (on tier 3 level)
- Bug fixes and improvements to the Maple file interface
- Bug fixes in the handling of bad primes, shape position, lifting Gröbner bases, allocations, etc. 
- Standardization of stream printing
- Improving Gebauer-Möller implementation in F4