### PR TITLE
Give pipelines some explicit priorities

### DIFF
--- a/.buildkite/0_webui.yml
+++ b/.buildkite/0_webui.yml
@@ -2,6 +2,7 @@
 # It is purely for keeping track of the changes we make to the webUI configuration; modifying this file has no effect.
 steps:
   - label: ":buildkite: Pipeline upload"
+    priority: 100
     command: buildkite-agent pipeline upload
     branches: "!gh-pages"
     agents:

--- a/.buildkite/0_webui_yggdrasil_register.yml
+++ b/.buildkite/0_webui_yggdrasil_register.yml
@@ -6,6 +6,7 @@
 # Buildkite secret used to publish the `*_jll` packages.
 steps:
   - label: ":buildkite: Pipeline upload"
+    priority: 100
     command: buildkite-agent pipeline upload
     branches: "master"
     agents:

--- a/.buildkite/generator.jl
+++ b/.buildkite/generator.jl
@@ -117,7 +117,7 @@ if SKIP_BUILD
 else
     for PLATFORM in PLATFORMS
         println("    $(PLATFORM): building")
-        push!(STEPS, build_step(NAME, PLATFORM, PROJECT))
+        push!(STEPS, build_step(NAME, PLATFORM, PROJECT, IS_PR))
     end
 end
 if !IS_PR

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 steps:
   - label: ":runner: Dynamically launch Pipelines"
+    priority: 0
     plugins:
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled

--- a/.buildkite/register_pipeline.yml
+++ b/.buildkite/register_pipeline.yml
@@ -14,6 +14,7 @@
 # environment variables are supplied by the triggering build.
 steps:
   - label: "register -- ${NAME}"
+    priority: 10
     agents:
       queue: "yggdrasil"
       arch: "x86_64"

--- a/.buildkite/utils.jl
+++ b/.buildkite/utils.jl
@@ -52,7 +52,7 @@ safe_name(fn::AbstractString) = replace(fn, r"[^A-Za-z0-9_\-:]"=>"-")
 wait_step() = Dict(:wait => nothing)
 group_step(name, steps) = Dict(:group => name, :steps => steps)
 
-function build_step(NAME, PLATFORM, PROJECT)
+function build_step(NAME, PLATFORM, PROJECT, IS_PR)
     script = raw"""
     .buildkite/build.sh
     """
@@ -75,7 +75,7 @@ function build_step(NAME, PLATFORM, PROJECT)
         :agents => agent(),
         :plugins => build_plugins,
         :timeout_in_minutes => 240,
-        :priority => -1,
+        :priority => IS_PR ? -2 : -1,
         :concurrency => 12,
         :concurrency_group => "yggdrasil/build/$NAME", # Could use ENV["BUILDKITE_JOB_ID"]
         :commands => [script],


### PR DESCRIPTION
Since we don't have caching I would like to prioritize short jobs and jobs running on master over PR builds.