### PR TITLE
oneAPI: Rebuild IGC.

### DIFF
--- a/L/libigc/build_tarballs.jl
+++ b/L/libigc/build_tarballs.jl
@@ -177,3 +177,5 @@ for platform in platforms, debug in (false, true)
                    products, dependencies; preferred_gcc_version=v"11", augment_platform_block,
                    julia_compat = "1.6", lock_microarchitecture=false)
 end
+
+# bump


### PR DESCRIPTION
The previous registration failed, and cannot be retried due to pipeline changes.