### PR TITLE
systemd: rebuild for riscv64-linux-gnu

### DIFF
--- a/S/systemd/build_tarballs.jl
+++ b/S/systemd/build_tarballs.jl
@@ -24,7 +24,9 @@ install_license LICENSE.GPL2
 
 # build-time dependencies that aren't packaged as JLLs
 apk add coreutils
-pip install jinja2
+# pin MarkupSafe to the 2.x series: 3.x only ships an sdist for our Python,
+# whose pyproject.toml trips up the sandbox's old pip
+pip install jinja2 "markupsafe<3"
 
 meson --cross-file=${MESON_TARGET_TOOLCHAIN} build \
     -Dmode=release \


### PR DESCRIPTION
riscv64 was added to supported_platforms() after the current release, so a rebuild picks it up; all of systemd's dependencies already provide riscv64. Pin MarkupSafe to the 2.x series so the build's old pip can install jinja2 (3.x ships only an sdist whose pyproject.toml the old pip fails to parse).