### PR TITLE
Avoid MariaDB Connector/C Windows vectorization crash

### DIFF
--- a/M/MariaDB_Connector_C/build_tarballs.jl
+++ b/M/MariaDB_Connector_C/build_tarballs.jl
@@ -32,7 +32,9 @@ if [[ "${target}" == *-mingw* ]]; then
     for p in ../patches/{0004-Add-ws2_32-to-remoteio-libraries,001-mingw-build,002-fix-prototype,003-gcc-fix-use_VA_ARGS,005-Add-definition-of-macros-and-structs-missing-in-MinG,fix-undefined-sec-e-invalid-parameter}.patch; do
         atomic_patch -p1 "${p}"
     done
-    export CFLAGS="${CFLAGS} -std=c99"
+    # GCC can vectorize Connector/C's unaligned protocol-buffer writes into
+    # aligned SSE stores on Windows, causing statement execution crashes.
+    export CFLAGS="${CFLAGS} -std=c99 -fno-tree-vectorize"
     # Minimum version of Windows supported by MariaDB is 7,
     # see tables in https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
     if [[ "${nbits}" == 64 ]]; then


### PR DESCRIPTION
## Summary

- publish a fixed MariaDB Connector/C JLL rebuild as `3.4.9+1`
- keep the upstream Connector/C source version at `3.4.9`
- add `-fno-tree-vectorize` to MariaDB Connector/C MinGW builds

## Rationale

JuliaDatabases/MySQL.jl#236 reproduces a Windows crash in the released `MariaDB_Connector_C_jll` `3.4.9+0` artifact during prepared statement execution. Diagnostics in JuliaDatabases/MySQL.jl#237 showed:

- the released JLL `3.4.9+0` artifact fails on both `windows-2022` and `windows-2025`
- the official MariaDB Connector/C 3.4.9 Windows DLL passes on both images
- a Yggdrasil rebuild with `-fno-tree-vectorize` passes on both images
- disassembly of the released DLL shows GCC vectorized the Connector/C statement request type-info loop into aligned SSE stores; that loop writes into a protocol packet buffer that is not guaranteed to be 16-byte aligned

The diagnostic run with the passing `-fno-tree-vectorize` rebuild is here: https://github.com/JuliaDatabases/MySQL.jl/actions/runs/27571414885

## Testing

- `julia --startup-file=no -e 's = read("M/MariaDB_Connector_C/build_tarballs.jl", String); Meta.parseall(s); println("parse ok")'`
- `git diff --check`
- JuliaDatabases/MySQL.jl Actions run 27571414885: released JLL fails on both Windows images; `yggdrasil-fno-tree-vectorize` passes on both Windows images

Co-authored by Codex
