### PR TITLE
[CompilerSupportLibraries] Rebuild v1.5.4 against mingw-w64 v13.0.0 s…

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -49,7 +49,7 @@ version = "0.6.6"
 
 [[deps.BinaryBuilderBase]]
 deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll", "unzip_jll"]
-git-tree-sha1 = "bfd75ee02d5082b141fc046e0bc34332df437004"
+git-tree-sha1 = "823b661d4cb7092d77a97619a060b4a9e89c10df"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"

--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.5/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.5/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"1.5.3"; preferred_gcc_version=v"15", unix_staticlibs=true, windows_staticlibs=true, julia_compat="1.12")
+build_csl(ARGS, v"1.5.4"; preferred_gcc_version=v"15", unix_staticlibs=true, windows_staticlibs=true, julia_compat="1.12")
 
 # Build trigger: 0


### PR DESCRIPTION
…hards

Bumps CSL v1.5.3 -> v1.5.4 to rebuild against the GCC 15.2.0 mingw compiler shards that were rebuilt from mingw-w64 v13.0.0 (#11664), fixing the msvcrt.a `_initterm_e` incompatibility with current msys2 (JuliaLang/julia#56840).

Also bumps the BinaryBuilderBase pin in .ci/Manifest.toml to master (JuliaPackaging/BinaryBuilderBase.jl#475), which is the only change since the previous pin and is required for CI to pick up the updated GCCBootstrap-v15.2.0+0 mingw artifacts.