### PR TITLE
[bacnet_stack] Enable macOS (x86_64, aarch64) builds

### DIFF
--- a/B/bacnet_stack/build_tarballs.jl
+++ b/B/bacnet_stack/build_tarballs.jl
@@ -36,10 +36,18 @@ mkdir -p ${prefix}/share/licenses/bacnet_stack
 cp bacnet-stack/license/* ${prefix}/share/licenses/bacnet_stack
 """
 
-# Currently linux, windows and apple are supported, but FreeBSD fails because it cannot find #include <dispatch/dispatch.h>
-# According to ChatGPT, one would have to explicitely install the libdispatch port of Apple’s Grand Central Dispatch APIs.
-# If you require FreeBSD support, maybe this is the way to go (add another build script for libdispatch and add it as a dependency?)
-platforms = supported_platforms(; exclude=(p) -> Sys.isbsd(p))
+# Linux, Windows and macOS are supported. bacnet-stack's CMakeLists.txt has a
+# dedicated `elseif(APPLE)` branch (it builds the ports/bsd datalink with
+# USE_MACH_TIME), so the Apple platforms build fine.
+#
+# FreeBSD still fails because it cannot find #include <dispatch/dispatch.h>;
+# supporting it would require building a libdispatch port and adding it as a
+# dependency. Therefore exclude only FreeBSD, not the whole BSD family.
+#
+# Note: the previous `Sys.isbsd` filter also matched Apple platforms (macOS is
+# BSD-derived), which is why no macOS artifact was ever produced even though the
+# comment claimed Apple was supported.
+platforms = supported_platforms(; exclude=Sys.isfreebsd)
 
 # The products that we will ensure are always built
 products = [

--- a/B/bacnet_stack/build_tarballs.jl
+++ b/B/bacnet_stack/build_tarballs.jl
@@ -36,17 +36,11 @@ mkdir -p ${prefix}/share/licenses/bacnet_stack
 cp bacnet-stack/license/* ${prefix}/share/licenses/bacnet_stack
 """
 
-# Linux, Windows and macOS are supported. bacnet-stack's CMakeLists.txt has a
-# dedicated `elseif(APPLE)` branch (it builds the ports/bsd datalink with
-# USE_MACH_TIME), so the Apple platforms build fine.
+# Upstream supports only Linux, Windows and macOS.
 #
-# FreeBSD still fails because it cannot find #include <dispatch/dispatch.h>;
+# FreeBSD fails because it cannot find #include <dispatch/dispatch.h>;
 # supporting it would require building a libdispatch port and adding it as a
-# dependency. Therefore exclude only FreeBSD, not the whole BSD family.
-#
-# Note: the previous `Sys.isbsd` filter also matched Apple platforms (macOS is
-# BSD-derived), which is why no macOS artifact was ever produced even though the
-# comment claimed Apple was supported.
+# dependency.
 platforms = supported_platforms(; exclude=Sys.isfreebsd)
 
 # The products that we will ensure are always built


### PR DESCRIPTION
## What

Re-enable the Apple platforms (`x86_64-apple-darwin`, `aarch64-apple-darwin`)
for `bacnet_stack` by excluding only FreeBSD instead of the whole BSD family.

## Why

`bacnet_stack_jll` currently ships no macOS artifact, so on macOS
`using bacnet_stack_jll` leaves `libbacnet_stack` undefined and
`is_available()` returns `false`.

The recipe filtered platforms with `exclude=(p) -> Sys.isbsd(p)`. `Sys.isbsd`
is also `true` for Apple platforms (macOS is BSD-derived), so this silently
dropped macOS — even though the recipe's own comment said "linux, windows and
apple are supported" and bacnet-stack's `CMakeLists.txt` has a dedicated
`elseif(APPLE)` branch (it builds the `ports/bsd` datalink with
`USE_MACH_TIME`). FreeBSD genuinely fails on `<dispatch/dispatch.h>`, so it
stays excluded via `Sys.isfreebsd`.

No version bump (same source commit); only the platform set changes.

## Verification

- Built `libbacnet-stack.dylib` locally from the same upstream sources for both
  `aarch64-apple-darwin` (native) and `x86_64-apple-darwin` (cross) with the
  same CMake options this recipe uses; both load via `dlopen`, export the
  expected symbols, and successfully perform a BACnet/IP ReadProperty against a
  live device on macOS (arm64 and x86_64 under Rosetta).
- Ran this recipe through BinaryBuilder for `aarch64-apple-darwin`: the sandbox
  starts, installs the macOS SDK, fetches the source, applies the bundled patch,
  and reaches CMake compiler detection. I could not complete the BB build on my
  macOS host due to an unrelated Docker-Desktop-on-macOS issue (kernel-protected
  `com.apple.provenance` xattrs cause both VirtioFS and gRPC FUSE to expose
  AppleDouble `._*` files on the bind-mounted shards, which CMake's
  `*-DetermineCompiler.cmake` glob then fails to parse). This affects any
  CMake-based recipe on that setup and should not occur on the Linux CI builders.
  Relying on CI here for the authoritative cross-build.

## Disclosure

This change (analysis and recipe edit) was prepared with the assistance of an AI
coding agent (Anthropic Claude, Opus 4). All claims above were checked against
the upstream sources and a local build by the submitter.
