### PR TITLE
[CompilerSupportLibraries] Include msvcrt-os import library

### DIFF
--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.5/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.5/build_tarballs.jl
@@ -2,4 +2,4 @@ include("../common.jl")
 
 build_csl(ARGS, v"1.5.4"; preferred_gcc_version=v"15", unix_staticlibs=true, windows_staticlibs=true, julia_compat="1.12")
 
-# Build trigger: 1
+# Build trigger: 2

--- a/C/CompilerSupportLibraries/common.jl
+++ b/C/CompilerSupportLibraries/common.jl
@@ -95,7 +95,7 @@ if [[ ${target} == *mingw* ]]; then
         # Install also some static and import libraries, needed for linking of pkgimages
         # and for direct ld links of Windows executables and DLLs.
         for lib in libadvapi32.a libdbghelp.a libgcc.a libgcc_s.a libiphlpapi.a libkernel32.a libmingwex.a \
-                   libmingw32.a libmsvcrt.a libmoldname.a libntdll.a libole32.a libpsapi.a libsecur32.a \
+                   libmingw32.a libmsvcrt.a libmsvcrt-os.a libmoldname.a libntdll.a libole32.a libpsapi.a libsecur32.a \
                    libshell32.a libssp.a libuser32.a libuserenv.a libuuid.a libwinmm.a libws2_32.a \
                    libpthread.dll.a libssp.dll.a dllcrt2.o crt2.o crt2u.o crtbegin.o crtend.o; do
             qfind "/opt/${target}" -name "${lib}" -exec install -Dvm 0644 '{}' "${destdir}/${lib}" \;
@@ -196,6 +196,7 @@ install_license /usr/share/licenses/GPL-3.0+
                                  FileProduct("$(destdir)/libmingwex.a", :libmingwex_a),
                                  FileProduct("$(destdir)/libmingw32.a", :libmingw32_a),
                                  FileProduct("$(destdir)/libmsvcrt.a", :libmsvcrt_a),
+                                 FileProduct("$(destdir)/libmsvcrt-os.a", :libmsvcrt_os_a),
                                  FileProduct("$(destdir)/libmoldname.a", :libmoldname_a),
                                  FileProduct("$(destdir)/libntdll.a", :libntdll_a),
                                  FileProduct("$(destdir)/libole32.a", :libole32_a),


### PR DESCRIPTION
Include the MinGW OS CRT import library alongside the other Windows CRT startup objects and import libraries so direct ld links can target the OS-provided CRT without falling back to host import libraries.