### PR TITLE
[cpsig] Add build recipe

### DIFF
--- a/C/cpsig/build_tarballs.jl
+++ b/C/cpsig/build_tarballs.jl
@@ -1,5 +1,8 @@
 using BinaryBuilder
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
 name = "cpsig"
 version = v"3.1.0"
 
@@ -9,10 +12,21 @@ sources = [
         "377c712121cee078ec08bdf01cc6b76cc6f7fbd0";
         unpack_target = "pysiglib",
     ),
+    DirectorySource("./bundled"),
 ]
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/pysiglib/pySigLib
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mingw-getenv.patch
+
+# BinaryBuilder's macOS libc++ headers do not provide <concepts>.  cpsig only
+# uses std::floating_point as a light constraint on float/double internals, so
+# remove that constraint for this portable build.
+sed -i '/#include <concepts>/d' siglib/cpsig/cppch.h
+for f in $(grep -rl "std::floating_point" siglib/cpsig || true); do
+    sed -i 's/std::floating_point /typename /g' "${f}"
+done
 
 # Replace upstream Python/JAX/CUDA-oriented root CMake with a minimal one.
 # We only build siglib/cpsig, which provides the C ABI library libcpsig.
@@ -49,11 +63,17 @@ install(FILES
 )
 EOF
 
+CMAKE_FLAGS=()
+if [[ "${target}" == x86_64-apple-* ]]; then
+    CMAKE_FLAGS+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}")
+fi
+
 cmake -B build -S . \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_LIBDIR=lib
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    "${CMAKE_FLAGS[@]}"
 
 cmake --build build --parallel ${nproc}
 cmake --install build
@@ -61,7 +81,10 @@ cmake --install build
 install_license LICENSE
 """
 
-platforms = supported_platforms()
+# cpsig uses std::filesystem, which needs a newer macOS SDK on x86_64.
+sources, script = require_macos_sdk("10.15", sources, script)
+
+platforms = expand_cxxstring_abis(supported_platforms())
 
 products = [
     LibraryProduct(["libcpsig", "cpsig"], :libcpsig, ["lib", "bin"]),

--- a/C/cpsig/build_tarballs.jl
+++ b/C/cpsig/build_tarballs.jl
@@ -1,0 +1,87 @@
+using BinaryBuilder
+
+name = "cpsig"
+version = v"3.1.0"
+
+sources = [
+    GitSource(
+        "https://github.com/daniil-shmelev/pySigLib.git",
+        "377c712121cee078ec08bdf01cc6b76cc6f7fbd0";
+        unpack_target = "pysiglib",
+    ),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/pysiglib/pySigLib
+
+# Replace upstream Python/JAX/CUDA-oriented root CMake with a minimal one.
+# We only build siglib/cpsig, which provides the C ABI library libcpsig.
+cat > CMakeLists.txt <<'EOF'
+cmake_minimum_required(VERSION 3.16)
+project(cpsig_jll LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+include(GNUInstallDirs)
+find_package(Threads REQUIRED)
+
+# Portable JLL: avoid -march=native / host CPU feature probing.
+set(_enable_vec OFF CACHE BOOL "Disable cpsig vectorisation for portable JLL" FORCE)
+
+# Do not use upstream install path; install into the JLL prefix ourselves.
+set(CPSIG_SKIP_INSTALL ON CACHE BOOL "Skip upstream cpsig install rule" FORCE)
+
+add_subdirectory(siglib/cpsig)
+
+install(TARGETS cpsig
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(FILES
+    siglib/cpsig/cpsig.h
+    siglib/cpsig/cppch.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+EOF
+
+cmake -B build -S . \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_LIBDIR=lib
+
+cmake --build build --parallel ${nproc}
+cmake --install build
+
+install_license LICENSE
+"""
+
+platforms = supported_platforms()
+
+products = [
+    LibraryProduct(["libcpsig", "cpsig"], :libcpsig, ["lib", "bin"]),
+    FileProduct("include/cpsig.h", :cpsig_h),
+    FileProduct("include/cppch.h", :cppch_h),
+]
+
+dependencies = [
+    HostBuildDependency("CMake_jll"),
+]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    julia_compat = "1.6",
+    preferred_gcc_version = v"10",
+)

--- a/C/cpsig/build_tarballs.jl
+++ b/C/cpsig/build_tarballs.jl
@@ -4,12 +4,13 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "cpsig"
-version = v"3.1.0"
+# Upstream main currently identifies as v4.0.0rc2; Yggdrasil recipe versions use X.Y.Z.
+version = v"4.0.0"
 
 sources = [
     GitSource(
         "https://github.com/daniil-shmelev/pySigLib.git",
-        "377c712121cee078ec08bdf01cc6b76cc6f7fbd0";
+        "8bbd69c2779a3d51cb7ddbd59a302b4654d00e80";
         unpack_target = "pysiglib",
     ),
     DirectorySource("./bundled"),
@@ -20,6 +21,7 @@ cd ${WORKSPACE}/srcdir/pysiglib/pySigLib
 
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mingw-getenv.patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/concepts-compat.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/onetbb-jll.patch
 
 # Replace upstream Python/JAX/CUDA-oriented root CMake with a minimal one.
 # We only build siglib/cpsig, which provides the C ABI library libcpsig.
@@ -86,6 +88,9 @@ products = [
 ]
 
 dependencies = [
+    Dependency("oneTBB_jll"; compat = "2022.3"),
+    # libcpsig links libgcc_s on Linux; the auditor needs an explicit JLL mapping.
+    Dependency("CompilerSupportLibraries_jll"),
 ]
 
 build_tarballs(

--- a/C/cpsig/build_tarballs.jl
+++ b/C/cpsig/build_tarballs.jl
@@ -19,14 +19,7 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/pysiglib/pySigLib
 
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/mingw-getenv.patch
-
-# BinaryBuilder's macOS libc++ headers do not provide <concepts>.  cpsig only
-# uses std::floating_point as a light constraint on float/double internals, so
-# remove that constraint for this portable build.
-sed -i '/#include <concepts>/d' siglib/cpsig/cppch.h
-for f in $(grep -rl "std::floating_point" siglib/cpsig || true); do
-    sed -i 's/std::floating_point /typename /g' "${f}"
-done
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/concepts-compat.patch
 
 # Replace upstream Python/JAX/CUDA-oriented root CMake with a minimal one.
 # We only build siglib/cpsig, which provides the C ABI library libcpsig.
@@ -93,7 +86,6 @@ products = [
 ]
 
 dependencies = [
-    HostBuildDependency("CMake_jll"),
 ]
 
 build_tarballs(

--- a/C/cpsig/build_tarballs.jl
+++ b/C/cpsig/build_tarballs.jl
@@ -58,6 +58,11 @@ install(FILES
 )
 EOF
 
+# The macOS libc++ lacks <concepts>; search this shim only after system headers.
+if [[ "${target}" == *-apple-* ]]; then
+    export CXXFLAGS="-idirafter ${WORKSPACE}/srcdir/macos-compat ${CXXFLAGS}"
+fi
+
 CMAKE_FLAGS=()
 if [[ "${target}" == x86_64-apple-* ]]; then
     CMAKE_FLAGS+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}")

--- a/C/cpsig/bundled/macos-compat/concepts
+++ b/C/cpsig/bundled/macos-compat/concepts
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <type_traits>
+
+namespace std {
+template<typename T>
+concept floating_point = is_floating_point<T>::value;
+
+template<typename T, typename U>
+concept same_as = is_same<T, U>::value && is_same<U, T>::value;
+}

--- a/C/cpsig/bundled/patches/concepts-compat.patch
+++ b/C/cpsig/bundled/patches/concepts-compat.patch
@@ -2,7 +2,7 @@ diff --git a/siglib/cpsig/cppch.h b/siglib/cpsig/cppch.h
 index 98b384e..b5a7e0b 100644
 --- a/siglib/cpsig/cppch.h
 +++ b/siglib/cpsig/cppch.h
-@@ -36,7 +36,15 @@
+@@ -31,7 +31,15 @@
  #include <mutex>
  #include <shared_mutex>
  #include <functional>

--- a/C/cpsig/bundled/patches/concepts-compat.patch
+++ b/C/cpsig/bundled/patches/concepts-compat.patch
@@ -1,0 +1,20 @@
+diff --git a/siglib/cpsig/cppch.h b/siglib/cpsig/cppch.h
+index 98b384e..b5a7e0b 100644
+--- a/siglib/cpsig/cppch.h
++++ b/siglib/cpsig/cppch.h
+@@ -36,7 +36,15 @@
+ #include <mutex>
+ #include <shared_mutex>
+ #include <functional>
++#if __has_include(<concepts>)
+ #include <concepts>
++#else
++#include <type_traits>
++namespace std {
++template<typename T>
++concept floating_point = is_floating_point<T>::value;
++}
++#endif
+ #include <variant>
+ #include <set>
+ #include <map>

--- a/C/cpsig/bundled/patches/mingw-getenv.patch
+++ b/C/cpsig/bundled/patches/mingw-getenv.patch
@@ -1,0 +1,32 @@
+diff --git a/siglib/cpsig/log_sig_cache.cpp b/siglib/cpsig/log_sig_cache.cpp
+index 7d7f94d..55f7565 100644
+--- a/siglib/cpsig/log_sig_cache.cpp
++++ b/siglib/cpsig/log_sig_cache.cpp
+@@ -98,15 +98,9 @@ void set_cache_dir_(const char* dir) {
+ 
+ void set_default_cache_dir() {
+ #ifdef _WIN32
+-	char* dir = nullptr;
+-	size_t len;
+-
+-	const errno_t err = _dupenv_s(&dir, &len, "LOCALAPPDATA");
+-
+-	if (err || !dir) {
++	const char* dir = std::getenv("LOCALAPPDATA");
++	if (!dir)
+ 		throw default_cache_dir_error("Failed to get default cache directory.");
+-	}
+-
+ #elif __APPLE__
+ 	const char* home = std::getenv("HOME");
+ 	if (!home)
+@@ -136,9 +130,6 @@ void set_default_cache_dir() {
+ 			cache_dir = dir_path;
+ 	}
+ 
+-#ifdef _WIN32
+-	free(dir);
+-#endif
+ }
+ 
+ void set_basis_cache(uint64_t dimension, uint64_t degree, int method, bool use_disk) {

--- a/C/cpsig/bundled/patches/mingw-getenv.patch
+++ b/C/cpsig/bundled/patches/mingw-getenv.patch
@@ -1,8 +1,8 @@
-diff --git a/siglib/cpsig/log_sig_cache.cpp b/siglib/cpsig/log_sig_cache.cpp
-index 7d7f94d..55f7565 100644
---- a/siglib/cpsig/log_sig_cache.cpp
-+++ b/siglib/cpsig/log_sig_cache.cpp
-@@ -98,15 +98,9 @@ void set_cache_dir_(const char* dir) {
+diff --git a/siglib/cpsig/cache_lifecycle/log_sig_cache.cpp b/siglib/cpsig/cache_lifecycle/log_sig_cache.cpp
+index 047dcf0..84e560e 100644
+--- a/siglib/cpsig/cache_lifecycle/log_sig_cache.cpp
++++ b/siglib/cpsig/cache_lifecycle/log_sig_cache.cpp
+@@ -72,15 +72,9 @@ void set_cache_dir_(const char* dir) {
  
  void set_default_cache_dir() {
  #ifdef _WIN32
@@ -20,7 +20,7 @@ index 7d7f94d..55f7565 100644
  #elif __APPLE__
  	const char* home = std::getenv("HOME");
  	if (!home)
-@@ -136,9 +130,6 @@ void set_default_cache_dir() {
+@@ -108,9 +102,6 @@ void set_default_cache_dir() {
  			cache_dir = dir_path;
  	}
  
@@ -29,4 +29,4 @@ index 7d7f94d..55f7565 100644
 -#endif
  }
  
- void set_basis_cache(uint64_t dimension, uint64_t degree, int method, bool use_disk) {
+ void prepare_basis_cache(uint64_t dimension, uint64_t degree, int method, bool use_disk) {

--- a/C/cpsig/bundled/patches/onetbb-jll.patch
+++ b/C/cpsig/bundled/patches/onetbb-jll.patch
@@ -1,0 +1,46 @@
+diff --git a/siglib/cpsig/CMakeLists.txt b/siglib/cpsig/CMakeLists.txt
+index 66a6204..3304a88 100644
+--- a/siglib/cpsig/CMakeLists.txt
++++ b/siglib/cpsig/CMakeLists.txt
+@@ -27,24 +27,7 @@ add_library(cpsig SHARED
+     cache_lifecycle/log_sig_cache.cpp
+ )
+
+-include(FetchContent)
+-
+-set(TBB_TEST OFF CACHE BOOL "" FORCE)
+-set(TBB_EXAMPLES OFF CACHE BOOL "" FORCE)
+-set(TBB_STRICT OFF CACHE BOOL "" FORCE)
+-set(TBBMALLOC_BUILD OFF CACHE BOOL "" FORCE)
+-set(TBBMALLOC_PROXY_BUILD OFF CACHE BOOL "" FORCE)
+-set(TBB_INSTALL OFF CACHE BOOL "" FORCE)
+-set(_pysiglib_build_shared_libs "${BUILD_SHARED_LIBS}")
+-set(BUILD_SHARED_LIBS ON)
+-FetchContent_Declare(
+-    oneTBB
+-    GIT_REPOSITORY https://github.com/uxlfoundation/oneTBB.git
+-    GIT_TAG 2fea40755cccad7eb8b0ee0c07ed0c4e75bf562c
+-)
+-FetchContent_MakeAvailable(oneTBB)
+-set(BUILD_SHARED_LIBS "${_pysiglib_build_shared_libs}")
+-unset(_pysiglib_build_shared_libs)
++find_package(TBB REQUIRED COMPONENTS tbb)
+
+ set_target_properties(cpsig PROPERTIES
+     CXX_STANDARD 20
+@@ -69,15 +52,7 @@ target_link_libraries(cpsig
+     PUBLIC TBB::tbb
+ )
+
+-if(WIN32)
+-    add_custom_command(TARGET cpsig POST_BUILD
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+-            $<TARGET_FILE:tbb>
+-            $<TARGET_FILE_DIR:cpsig>
+-    )
+-endif()
+-
+ if(MSVC)
+     target_compile_options(cpsig PRIVATE /Zi)
+     target_link_options(cpsig PRIVATE /DEBUG /OPT:REF /OPT:ICF)
+ endif()


### PR DESCRIPTION
- Add a new `cpsig` BinaryBuilder recipe for the `siglib/cpsig` C ABI library from [pySigLib](https://github.com/daniil-shmelev/pySigLib).
- Install `libcpsig` plus the public headers `cpsig.h` and `cppch.h`.
- Disable upstream CPU vectorisation for portable JLL artifacts.

I have not contributed to Yggdrasil before, so please let me know if anything is wrong here. Codex assisted in drafting this PR.