### PR TITLE
[CI] Use Julia v1.12.6 for update manifest workflow

### DIFF
--- a/.github/workflows/update_manifest.yml
+++ b/.github/workflows/update_manifest.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
-          version: '1.12.4' # Use the version of Julia used on the build machine
+          version: '1.12.6' # Use the version of Julia used on the build machine
           arch: x64
       - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
         with:


### PR DESCRIPTION
Match the Julia version set in #14018.