### PR TITLE
[SQLite] Restore versioned libsqlite3 install name on macOS

### DIFF
--- a/S/SQLite/build_tarballs.jl
+++ b/S/SQLite/build_tarballs.jl
@@ -42,6 +42,11 @@ export CPPFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1 \
     --enable-rtree
 make -j${nproc}
 make install
+
+if [[ "${target}" == *-apple-darwin* ]]; then
+    install_name_tool -id @rpath/libsqlite3.0.dylib ${libdir}/libsqlite3.dylib
+fi
+
 install_license "${WORKSPACE}/srcdir/LICENSE"
 """
 

--- a/S/SQLite/build_tarballs.jl
+++ b/S/SQLite/build_tarballs.jl
@@ -43,6 +43,9 @@ export CPPFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1 \
 make -j${nproc}
 make install
 
+# The autosetup build system drops .so version names, marking them as v0.0.0
+# This causes downstream libraries like GDAL to fail on macos, so we use 
+# install_name_tool to stamp the library with the correct version number.
 if [[ "${target}" == *-apple-darwin* ]]; then
     install_name_tool -id @rpath/libsqlite3.0.dylib ${libdir}/libsqlite3.dylib
 fi


### PR DESCRIPTION
SQLite's new autosetup build system (3.49.0+) drops versioned naming for shared libraries by default. On macOS, the installed `libsqlite3` ends up with the unversioned install name `@rpath/libsqlite3.dylib` (current version `0.0.0`), where it previously was `@rpath/libsqlite3.0.dylib` (current version `9.6.0`).

Consumers built against the earlier SQLite_jll, like `GDAL_jll` and `PROJ_jll`, still link to `@rpath/libsqlite3.0.dylib`. With the unversioned id, macOS `dyld` can no longer match the preloaded SQLite_jll and silently falls back to the system `/usr/lib/libsqlite3.dylib`, so two copies of sqlite load in the same process. That breaks GDAL's SQLite driver:

```
OGR2SQLITE_Setup() failed due to sqlite3_api == nullptr
```

This restores the versioned macOS install name so consumers resolve back to SQLite_jll. No consumer rebuilds are required, since they already link `@rpath/libsqlite3.0.dylib`.

Verified locally: forcing `GDAL_jll` to resolve `libsqlite3.0.dylib` to SQLite_jll makes the failing SQLite/GPKG operations succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
