### PR TITLE
GCCBootstrap@15: Address GCC 13->15 mingw ABI incompatibility 

### DIFF
--- a/0_RootFS/GCCBootstrap@13/bundled/patches/gcc/gcc1320-libstdcxx-ios-init-reference-elf-only.patch
+++ b/0_RootFS/GCCBootstrap@13/bundled/patches/gcc/gcc1320-libstdcxx-ios-init-reference-elf-only.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliahub.com>
+Date: Mon, 22 Jun 2026 23:55:00 +0000
+Subject: [PATCH] libstdc++: Only use iostream init reference for ELF
+
+Backport the header-side portion of PR116159 to GCC 13.  The reference to
+std::ios_base_library_init() is an ELF symbol-versioning mechanism and should
+not be emitted by MinGW headers.
+---
+ libstdc++-v3/include/std/iostream | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libstdc++-v3/include/std/iostream b/libstdc++-v3/include/std/iostream
+index 384f0380265..bb8661c4dd1 100644
+--- a/libstdc++-v3/include/std/iostream
++++ b/libstdc++-v3/include/std/iostream
+@@ -78,6 +78,6 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+       && __has_attribute(__init_priority__))
+   static ios_base::Init __ioinit;
+-#elif defined(_GLIBCXX_SYMVER_GNU)
++#elif defined(_GLIBCXX_SYMVER_GNU) && defined(__ELF__)
+   __extension__ __asm (".globl _ZSt21ios_base_library_initv");
+ #endif
+ 
+-- 
+2.43.0

--- a/0_RootFS/GCCBootstrap@15/bundled/patches/gcc/gcc1420-libstdcpp-tls-abi.patch
+++ b/0_RootFS/GCCBootstrap@15/bundled/patches/gcc/gcc1420-libstdcpp-tls-abi.patch
@@ -1,0 +1,1 @@
+../../../../GCCBootstrap@14/bundled/patches/gcc/gcc1420-libstdcpp-tls-abi.patch

--- a/0_RootFS/GCCBootstrap@15/bundled/patches/gcc/gcc1520-libstdcxx-mingw-ios-init-export.patch
+++ b/0_RootFS/GCCBootstrap@15/bundled/patches/gcc/gcc1520-libstdcxx-mingw-ios-init-export.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliahub.com>
+Date: Mon, 22 Jun 2026 23:45:00 +0000
+Subject: [PATCH] libstdc++: Restore ios_base_library_init export on MinGW
+
+GCC 15 only emits the std::ios_base_library_init() ABI marker on ELF
+targets. Keep the corresponding <iostream> reference disabled on MinGW,
+but provide the symbol in libstdc++ for compatibility with C++ objects
+that were linked against an import library exposing it.
+---
+ libstdc++-v3/src/c++98/ios_init.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libstdc++-v3/src/c++98/ios_init.cc b/libstdc++-v3/src/c++98/ios_init.cc
+index a597a471d1e..c2030dde71c 100644
+--- a/libstdc++-v3/src/c++98/ios_init.cc
++++ b/libstdc++-v3/src/c++98/ios_init.cc
+@@ -200,7 +200,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+     return __ret;
+   }
+ 
+-#if defined(_GLIBCXX_SYMVER_GNU) && defined(__ELF__)
++#if defined(_GLIBCXX_SYMVER_GNU) && (defined(__ELF__) || defined(__MINGW32__))
+ #pragma GCC diagnostic ignored "-Wattribute-alias"
+ 
+   void ios_base_library_init (void)
+-- 
+2.43.0
+


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/62152 we bumped the libstdc++ version that we ship with Julia on Windows from GCC 13 to 15. This resulted in previously-built binary artifacts no longer loading (https://github.com/JuliaLang/julia/issues/62184) with errors complaining about `_ZSt21ios_base_library_initv`. This issue has a bit of history, split over at least three different issue trackers, so because I'm about to add a fourth chapter, allow me to recap the full story:

Essentially, libstdc++'s iostream code needs to run some global initializers (for the std::count/cin, etc support). Prior to GCC 13, this was done by emitting a global initializer into every translation unit. However, in https://github.com/gcc-mirror/gcc/commit/4e4e3ffd10f53ef71696bc728ab40258751a2df4, this was changed to instead have one global initializer within libstdc++ (on platforms that support __init_priority, which is all of ours).

This caused a problem when users accidentally tried to use a GCC-12 libstdc++ with a GCC-13-built binary: The binary expects the library to do the initialization and vice versa. However, because this move was a removal of ABI-symbols, it didn't cause any loud failures at link or load time and instead segfaulted at runtime.

To attempt to resolve that issue, https://github.com/gcc-mirror/gcc/commit/9a41d2cdbcd2af77a3a91a840a3a13f0eb39971b (GCC 13 backport https://github.com/gcc-mirror/gcc/commit/9c9061e0418ded473672069aac43b25f6fd491b8) introduced a symbol-adding ABI marker, so that load attempts would complain about not having `GLIBCXX_3.4.32` in the symbol versioning, hopefully clueing users into the version mismatch issue.

Unfortunately, this ABI marker hardcoded `_ZNSt8ios_base4InitC1Ev` as the mangling of `std::ios_base_library_init`. This mangling does not match the i386 Windows Itanium mangling, which demands an extra underscore.

What happens next depends on the linker:
- GNU `ld` simply appears to ignore the missing import when linking and simply doesn't generate an import reference (although it does on `x86_64`, because the symbol there matches). Do note however that this means the mechanism was ineffective on mingw in the first place.
- `lld` loudly complains on all architectures. This was reported as https://github.com/llvm/llvm-project/issues/99286, respectively https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116159

Upstream decided to fix this issue by disabling the ABI marker again on mingw in GCC 15 (https://github.com/gcc-mirror/gcc/commit/fc7a1fb0238e379d466316aa219734ac61f4bc0e) with backports to GCC 14 (https://github.com/gcc-mirror/gcc/commit/2003f890b13b8ec35b6112fc13c7e69e61cd9162), but not GCC 13 (https://github.com/gcc-mirror/gcc/blob/e2c77890066695a3b92a7e05bb848778a12815de/libstdc%2B%2B-v3/include/std/iostream#L78-L83)

The net result of this is that our `GCC 13`-built binaries are ABI incompatible with our GCC 15 libstdc++ on mingw x86_64. Unfortunately, we have a fair number of those. This PR attempts to resolve that by adding back the ABI marker (but not the header path that emits it into the .o files) for GCC 15 and the inverse for GCC 13 (i.e. backporting the removal of the ABI marker). That should make everything work and once all GCC 13-built binaries have cycled out in a few years, we can drop the patch again.