### PR TITLE
[Libxc] Rebuild with CUDA v13.2 and v13.3

### DIFF
--- a/L/Libxc/Libxc_GPU/build_tarballs.jl
+++ b/L/Libxc/Libxc_GPU/build_tarballs.jl
@@ -69,7 +69,7 @@ fi
 """
 
 # Override the default platforms
-platforms = CUDA.supported_platforms(; min_version=v"11.8")
+platforms = CUDA.supported_platforms(; min_version=v"11.8", max_version=v"13.3")
 platforms = expand_gfortran_versions(platforms)
 platforms = remove_unsupported_platforms(platforms)
 


### PR DESCRIPTION
No change to the recipe. But this should trigger the build of `Libxc_GPU_jll` for newer versions of CUDA (currently capped at `v13.1` in `JuliaBinaryWrappers`).