### PR TITLE
[liblsl] Update to v1.17.7

### DIFF
--- a/L/liblsl/build_tarballs.jl
+++ b/L/liblsl/build_tarballs.jl
@@ -23,7 +23,8 @@ install_license LICENSE
 options=(
     -DCMAKE_BUILD_TYPE=Release 
     -DCMAKE_INSTALL_PREFIX=${prefix}
-    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN}
+    # Changing to gcc, because for freebsd and macos it failed to find CMAKE_CXX_COMPILER_AR
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_gcc.cmake
 )
 if [[ "${target}" == x86_64-apple-darwin* ]]; then
     # We need at least MacOS 10.12 for `shared_mutex`

--- a/L/liblsl/build_tarballs.jl
+++ b/L/liblsl/build_tarballs.jl
@@ -3,16 +3,19 @@
 using BinaryBuilder, Pkg
 
 name = "liblsl"
-version = v"1.16.2"
+version = v"1.17.7"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/sccn/liblsl", "6ca188c266c21f7228dc67077303fa6abaf2e8be"),
+    GitSource("https://github.com/sccn/liblsl", "64988c6a14b8dc3b3f270ece58eab4f480bfab43"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/liblsl
+
+# Remove system CMake to use the jll version
+apk del cmake
 
 # Add license file
 install_license LICENSE
@@ -49,8 +52,9 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
+dependencies = [
+    HostBuildDependency("CMake_jll"),   # Need CMake > 3.23
 ]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               julia_compat="1.6", preferred_gcc_version=v"5")
+               julia_compat="1.6", preferred_gcc_version=v"7")


### PR DESCRIPTION
I made two changes to the recipe:
- Added CMake as a dependency as the new build required CMake > 3.23
- Bumped the gcc version to 7 (new build used inline strings which are available from this version)

Locally, this worked for me on majority of builds but for risc, apple, and aarch64 I got different errors which I could not easily resolve.