### PR TITLE
[object_store_ffi] Bump to v0.12.6

### DIFF
--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -1,11 +1,11 @@
 using BinaryBuilder
 
 name = "object_store_ffi"
-version = v"0.12.5"
+version = v"0.12.6"
 
 sources = [
-    # https://github.com/RelationalAI/object_store_ffi/commit/7d019071c6d73df1e6e80629a9160eb4638eb644
-    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "7d019071c6d73df1e6e80629a9160eb4638eb644")
+    # https://github.com/RelationalAI/object_store_ffi/commit/86c31c96d7320f52e69080860581e160d32a1d87
+    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "86c31c96d7320f52e69080860581e160d32a1d87")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bumps `object_store_ffi` to v0.12.6.

Upstream release: https://github.com/RelationalAI/object_store_ffi/releases/tag/v0.12.6
Source commit: https://github.com/RelationalAI/object_store_ffi/commit/86c31c96d7320f52e69080860581e160d32a1d87

This release fixes AES-256-CBC content decryption for Snowflake stages configured with `CLIENT_ENCRYPTION_KEY_SIZE=256`.