### PR TITLE
[object_store_ffi] Bump to v0.12.7

### DIFF
--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -1,11 +1,11 @@
 using BinaryBuilder
 
 name = "object_store_ffi"
-version = v"0.12.6"
+version = v"0.12.7"
 
 sources = [
-    # https://github.com/RelationalAI/object_store_ffi/commit/86c31c96d7320f52e69080860581e160d32a1d87
-    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "86c31c96d7320f52e69080860581e160d32a1d87")
+    # https://github.com/RelationalAI/object_store_ffi/commit/9e2327a14f1a36c388c982e0a8264188e8f85380
+    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "9e2327a14f1a36c388c982e0a8264188e8f85380")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bumps `object_store_ffi` to v0.12.7.

Upstream release: https://github.com/RelationalAI/object_store_ffi/releases/tag/v0.12.7
Source commit: https://github.com/RelationalAI/object_store_ffi/commit/9e2327a14f1a36c388c982e0a8264188e8f85380

This release fixes a regression in v0.12.6 that broke Snowflake Azure content decryption for 128-bit (CLIENT_ENCRYPTION_KEY_SIZE=128) accounts. The content cipher key size is now derived from the unwrapped CEK length on both S3 and Azure read paths, rather than from the metadata algorithm string.