### PR TITLE
Bump BinaryBuilderBase.

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -49,7 +49,7 @@ version = "0.6.6"
 
 [[deps.BinaryBuilderBase]]
 deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "54e2df8ab0ead17de94c9c1f4406f6846bdf1d69"
+git-tree-sha1 = "372af0fae1fef30dc024f5dc8747ede789b96ed1"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"


### PR DESCRIPTION
Bumps to https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/481 to fix Windows builds.