### PR TITLE
LLVM: Add v22.1.8 toolchain

### DIFF
--- a/.buildkite/utils.jl
+++ b/.buildkite/utils.jl
@@ -74,7 +74,7 @@ function build_step(NAME, PLATFORM, PROJECT, IS_PR)
         :label => "build -- $PROJECT -- $PLATFORM",
         :agents => agent(),
         :plugins => build_plugins,
-        :timeout_in_minutes => 240,
+        :timeout_in_minutes => 300,
         :priority => IS_PR ? -2 : -1,
         :concurrency => 12,
         :concurrency_group => "yggdrasil/build/$NAME", # Could use ENV["BUILDKITE_JOB_ID"]

--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -41,7 +41,7 @@ version = "1.11.0"
 
 [[deps.BinaryBuilder]]
 deps = ["ArgParse", "BinaryBuilderBase", "Binutils_jll", "Dates", "Downloads", "GitHub", "HTTP", "JLD2", "JSON", "LibGit2", "Libdl", "Logging", "LoggingExtras", "ObjectFile", "Patchelf_jll", "Pkg", "PkgLicenses", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Scratch", "Sockets", "TOML", "UUIDs", "ghr_jll"]
-git-tree-sha1 = "cffe52b2025c9689f3868a3c87922a5a3ae9fc7a"
+git-tree-sha1 = "3d9e40c161317f83e9429063a95ace961b193460"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
@@ -390,9 +390,9 @@ version = "1.3.0"
 
 [[deps.ObjectFile]]
 deps = ["Reexport", "StructIO"]
-git-tree-sha1 = "09b1fe6ff16e6587fa240c165347474322e77cf1"
+git-tree-sha1 = "23c4d109603f7a7bfe888c1f63c5ab7be6183d0b"
 uuid = "d8793406-e978-5875-9003-1fc021f44a92"
-version = "0.4.4"
+version = "0.5.1"
 
 [[deps.OpenSSL]]
 deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "NetworkOptions", "OpenSSL_jll", "Sockets"]

--- a/L/LLVM/LLVM_full@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@22/build_tarballs.jl
@@ -1,0 +1,12 @@
+version = v"22.1.1"
+
+include("../common.jl")
+
+# Built with GCC 13: LLVM 22 is only consumed by recent Julia (the libLLVM/Clang/
+# etc. major version tracks the Julia version), which bundles a GCC-13-era
+# libstdc++, so the raised GLIBCXX floor (3.4.32) costs us nothing. GCC 13 is also
+# required on Windows to match the mingw-w64 v13 GCCBootstrap shards that
+# downstream consumers (e.g. PoCL) statically link against.
+build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
+               preferred_gcc_version=v"13", preferred_llvm_version=v"16", julia_compat="1.6")
+# Build trigger: 0

--- a/L/LLVM/LLVM_full@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@22/build_tarballs.jl
@@ -2,11 +2,15 @@ version = v"22.1.1"
 
 include("../common.jl")
 
-# Built with GCC 13: LLVM 22 is only consumed by recent Julia (the libLLVM/Clang/
-# etc. major version tracks the Julia version), which bundles a GCC-13-era
-# libstdc++, so the raised GLIBCXX floor (3.4.32) costs us nothing. GCC 13 is also
-# required on Windows to match the mingw-w64 v13 GCCBootstrap shards that
-# downstream consumers (e.g. PoCL) statically link against.
+# Built with GCC 10, matching LLVM 15-21. We initially tried GCC 13 to match the
+# mingw-w64 v13 GCCBootstrap that PoCL (#14048) statically links against, but that
+# was unnecessary: PoCL only uses GCC 13 on Windows (for `.drectve -exclude-symbols`
+# to dodge export-ordinal limits) and otherwise GCC 10, and it already links the
+# GCC-10-built LLVM 20. The `std::__get_once_mutex` ABI break seen when statically
+# linking LLVM into a GCC-13 build is a toolchain bug (the GCC-13 libstdc++ was
+# rebuilt with TLS without backporting the call_once ABI patch), being fixed
+# upstream -- not a reason to rebuild LLVM with GCC 13. GCC 10 keeps the GLIBCXX
+# floor low and stays on the well-tested toolchain.
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"13", preferred_llvm_version=v"16", julia_compat="1.6")
+               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
 # Build trigger: 0

--- a/L/LLVM/LLVM_full@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@22/build_tarballs.jl
@@ -12,5 +12,5 @@ include("../common.jl")
 # upstream -- not a reason to rebuild LLVM with GCC 13. GCC 10 keeps the GLIBCXX
 # floor low and stays on the well-tested toolchain.
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
+               preferred_gcc_version=v"10", preferred_llvm_version=v"18", julia_compat="1.6")
 # Build trigger: 0

--- a/L/LLVM/LLVM_full@22/bundled/libcxx_patches/7005_libcxx_musl.patch
+++ b/L/LLVM/LLVM_full@22/bundled/libcxx_patches/7005_libcxx_musl.patch
@@ -1,0 +1,22 @@
+diff --git a/include/__cxx03/locale b/include/__cxx03/locale
+index 6360bbc2f6b6..add75d2fc6f5 100644
+--- a/include/__cxx03/locale
++++ b/include/__cxx03/locale
+@@ -727,7 +727,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end, ios_base::iostat
+     __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
+     errno                                                     = 0;
+     char* __p2;
+-    long long __ll                                               = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++    long long __ll                                               = strtoll_l(__a, &__p2, __base);
+     __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
+     if (__current_errno == 0)
+       errno = __save_errno;
+@@ -759,7 +759,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end, ios_base::iost
+     __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
+     errno                                                     = 0;
+     char* __p2;
+-    unsigned long long __ll                                      = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++    unsigned long long __ll                                      = strtoull_l(__a, &__p2, __base);
+     __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
+     if (__current_errno == 0)
+       errno = __save_errno;

--- a/L/LLVM/LLVM_full@22/bundled/patches/0050-unique_function_clang-sa.patch
+++ b/L/LLVM/LLVM_full@22/bundled/patches/0050-unique_function_clang-sa.patch
@@ -1,0 +1,28 @@
+From 1fa6efaa946243004c45be92e66b324dc980df7d Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Thu, 17 Sep 2020 23:22:45 +0200
+Subject: [PATCH] clang-sa can't determine that !RHS implies !LHS
+
+---
+ llvm/include/llvm/ADT/FunctionExtras.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/llvm/include/llvm/ADT/FunctionExtras.h b/llvm/include/llvm/ADT/FunctionExtras.h
+index 121aa527a5d..b9b6d829b14 100644
+--- a/llvm/include/llvm/ADT/FunctionExtras.h
++++ b/llvm/include/llvm/ADT/FunctionExtras.h
+@@ -193,9 +193,11 @@ public:
+     // Copy the callback and inline flag.
+     CallbackAndInlineFlag = RHS.CallbackAndInlineFlag;
+ 
++#ifndef __clang_analyzer__
+     // If the RHS is empty, just copying the above is sufficient.
+     if (!RHS)
+       return;
++#endif
+ 
+     if (!isInlineStorage()) {
+       // The out-of-line case is easiest to move.
+-- 
+2.28.0
+

--- a/L/LLVM/LLVM_full@22/bundled/patches/0100-llvm-12-musl-bb.patch
+++ b/L/LLVM/LLVM_full@22/bundled/patches/0100-llvm-12-musl-bb.patch
@@ -1,0 +1,37 @@
+From f1901de14ff1f1abcc729c4adccfbd5017e30357 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 7 May 2021 13:54:41 -0400
+Subject: [PATCH] [Compiler-RT] Fix compilation on musl
+
+---
+ compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp                    | 1 +
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.cpp     | 1 -
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+index b87798603fda..452a08aafe0e 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+@@ -27,6 +27,7 @@
+ #include <cassert>
+ #include <cstddef> // for size_t
+ #include <cstdint>
++#include <stddef.h>
+ #include <dlfcn.h> // for dlsym()
+
+ static void *getFuncAddr(const char *name, uintptr_t wrapper_addr) {
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 12dd39e674ac..bb0f7a2daa8c 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -69,7 +69,6 @@
+ #include <malloc.h>
+ #include <mntent.h>
+ #include <netinet/ether.h>
+-#include <sys/sysinfo.h>
+ #include <sys/vt.h>
+ #include <linux/cdrom.h>
+ #include <linux/fd.h>
+--
+2.31.1
+

--- a/L/LLVM/LLVM_full@22/bundled/patches/0200-templates.patch
+++ b/L/LLVM/LLVM_full@22/bundled/patches/0200-templates.patch
@@ -1,0 +1,40 @@
+From ad520c15cc2dae3231c38cca916f93c8347c1bd9 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Tue, 8 Nov 2022 13:18:59 -0500
+Subject: [PATCH] handle template weirdness
+
+---
+ lld/ELF/InputFiles.cpp        |    2 +-
+ lld/ELF/SyntheticSections.cpp |    2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lld/ELF/InputFiles.cpp b/lld/ELF/InputFiles.cpp
+index 6c7ef27cbd49..7dcf1cc5b877 100644
+--- a/lld/ELF/InputFiles.cpp
++++ b/lld/ELF/InputFiles.cpp
+@@ -310,7 +310,7 @@ template <class ELFT> static void doParseFile(InputFile *file) {
+     ctx.objectFiles.push_back(cast<ELFFileBase>(file));
+     cast<ObjFile<ELFT>>(file)->parse();
+   } else if (auto *f = dyn_cast<SharedFile>(file)) {
+-    f->parse<ELFT>();
++    f->template parse<ELFT>();
+   } else if (auto *f = dyn_cast<BitcodeFile>(file)) {
+     ctx.bitcodeFiles.push_back(f);
+     f->parse();
+
+diff --git a/lld/ELF/SyntheticSections.cpp b/lld/ELF/SyntheticSections.cpp
+index b359c2e7bcea..812d38ca81de 100644
+--- a/lld/ELF/SyntheticSections.cpp
++++ b/lld/ELF/SyntheticSections.cpp
+@@ -3360,7 +3360,7 @@ template <class ELFT> void elf::splitSections() {
+       if (auto *s = dyn_cast<MergeInputSection>(sec))
+         s->splitIntoPieces();
+       else if (auto *eh = dyn_cast<EhInputSection>(sec))
+-        eh->split<ELFT>();
++        eh->template split<ELFT>();
+     }
+   });
+ }
+--
+2.38.1
+

--- a/L/LLVM/LLVM_full@22/bundled/patches/0300-mingw-mlir-visibility-hidden.patch
+++ b/L/LLVM/LLVM_full@22/bundled/patches/0300-mingw-mlir-visibility-hidden.patch
@@ -1,0 +1,17 @@
+diff --git a/mlir/CMakeLists.txt b/mlir/CMakeLists.txt
+index c91e9cd93dc8..9260cdc1c83e 100644
+--- a/mlir/CMakeLists.txt
++++ b/mlir/CMakeLists.txt
+@@ -17,6 +17,12 @@ endif()
+ include(GNUInstallDirs)
+ set(CMAKE_CXX_STANDARD 17)
+ 
++if(MINGW OR CYGWIN)
++  set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
++  set(CMAKE_C_VISIBILITY_PRESET hidden)
++  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
++endif()
++
+ if(MLIR_STANDALONE_BUILD)
+   find_package(LLVM CONFIG REQUIRED)
+   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${LLVM_CMAKE_DIR})

--- a/L/LLVM/LLVM_full@22/bundled/patches/0400-MLIR-Disable-tblgen-lsp-server-and-tblgen-to-irdl.patch
+++ b/L/LLVM/LLVM_full@22/bundled/patches/0400-MLIR-Disable-tblgen-lsp-server-and-tblgen-to-irdl.patch
@@ -1,0 +1,51 @@
+From f3d0b3b681d1e3955e08dc1adf26040094a6df70 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mos=C3=A8=20Giordano?= <mose@gnu.org>
+Date: Fri, 3 May 2024 12:47:19 +0100
+Subject: [PATCH] [MLIR] Disable `tblgen-lsp-server` and `tblgen-to-irdl`
+
+---
+ mlir/lib/Tools/CMakeLists.txt | 2 +-
+ mlir/test/CMakeLists.txt      | 4 ++--
+ mlir/tools/CMakeLists.txt     | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/mlir/lib/Tools/CMakeLists.txt b/mlir/lib/Tools/CMakeLists.txt
+index 01270fa4b0fc..7688c31bf26b 100644
+--- a/mlir/lib/Tools/CMakeLists.txt
++++ b/mlir/lib/Tools/CMakeLists.txt
+@@ -8,4 +8,4 @@ add_subdirectory(mlir-tblgen)
+ add_subdirectory(mlir-translate)
+ add_subdirectory(PDLL)
+ add_subdirectory(Plugins)
+-add_subdirectory(tblgen-lsp-server)
++# add_subdirectory(tblgen-lsp-server)
+diff --git a/mlir/test/CMakeLists.txt b/mlir/test/CMakeLists.txt
+index 69c2e5978689..1a5dabd33e3f 100644
+--- a/mlir/test/CMakeLists.txt
++++ b/mlir/test/CMakeLists.txt
+@@ -117,8 +117,8 @@ set(MLIR_TEST_DEPENDS
+   mlir-rewrite
+   mlir-tblgen
+   mlir-translate
+-  tblgen-lsp-server
+-  tblgen-to-irdl
++  # tblgen-lsp-server
++  # tblgen-to-irdl
+   )
+ if(NOT MLIR_STANDALONE_BUILD)
+   list(APPEND MLIR_TEST_DEPENDS FileCheck count not split-file)
+diff --git a/mlir/tools/CMakeLists.txt b/mlir/tools/CMakeLists.txt
+index 72a857b114fb..c606a3b3dd1d 100644
+--- a/mlir/tools/CMakeLists.txt
++++ b/mlir/tools/CMakeLists.txt
+@@ -7,8 +7,8 @@ add_subdirectory(mlir-reduce)
+ add_subdirectory(mlir-rewrite)
+ add_subdirectory(mlir-shlib)
+ add_subdirectory(mlir-translate)
+-add_subdirectory(tblgen-lsp-server)
+-add_subdirectory(tblgen-to-irdl)
++# add_subdirectory(tblgen-lsp-server)
++# add_subdirectory(tblgen-to-irdl)
+
+ # mlir-cpu-runner requires ExecutionEngine.
+ if(MLIR_ENABLE_EXECUTION_ENGINE)

--- a/L/LLVM/LLVM_full@22/bundled/patches/0704-no-codesign.patch
+++ b/L/LLVM/LLVM_full@22/bundled/patches/0704-no-codesign.patch
@@ -1,0 +1,25 @@
+From 811bde347d425929813cbf40620f497b924c2c45 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Tue, 8 Nov 2022 19:52:32 -0500
+Subject: [PATCH] no codesign
+
+---
+ compiler-rt/cmake/Modules/AddCompilerRT.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/cmake/Modules/AddCompilerRT.cmake b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+index 298093462f80..34b9daf97400 100644
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -413,7 +413,7 @@ function(add_compiler_rt_runtime name type)
+
+         add_custom_command(TARGET ${libname}
+           POST_BUILD
+-          COMMAND ${CODESIGN} --sign - ${EXTRA_CODESIGN_ARGUMENTS} $<TARGET_FILE:${libname}>
++          # COMMAND ${CODESIGN} --sign - ${EXTRA_CODESIGN_ARGUMENTS} $<TARGET_FILE:${libname}>
+           WORKING_DIRECTORY ${COMPILER_RT_OUTPUT_LIBRARY_DIR}
+           COMMAND_EXPAND_LISTS
+         )
+--
+2.38.1
+

--- a/L/LLVM/LLVM_full@22/bundled/patches/0800-mingw-fix.patch
+++ b/L/LLVM/LLVM_full@22/bundled/patches/0800-mingw-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp b/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
+index dfc32ac9db29..7d0c7573f2e0 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
+@@ -24,7 +24,7 @@ using namespace fuzzer;
+ #if LIBFUZZER_MSVC
+ #define GET_FUNCTION_ADDRESS(fn) &fn
+ #else
+-#define GET_FUNCTION_ADDRESS(fn) __builtin_function_start(fn)
++#define GET_FUNCTION_ADDRESS(fn) (void *)(&fn)
+ #endif // LIBFUZER_MSVC
+
+ // Copied from compiler-rt/lib/sanitizer_common/sanitizer_win_defs.h

--- a/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
@@ -1,0 +1,8 @@
+version = v"22.1.1"
+
+include("../common.jl")
+
+# Built with GCC 13; see LLVM_full@22 for rationale.
+build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
+               preferred_gcc_version=v"13", preferred_llvm_version=v"16", julia_compat="1.6")
+# Build trigger: 0

--- a/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
@@ -4,5 +4,5 @@ include("../common.jl")
 
 # Built with GCC 10; see LLVM_full@22 for rationale.
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
-               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
+               preferred_gcc_version=v"10", preferred_llvm_version=v"18", julia_compat="1.6")
 # Build trigger: 0

--- a/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
@@ -2,7 +2,7 @@ version = v"22.1.1"
 
 include("../common.jl")
 
-# Built with GCC 13; see LLVM_full@22 for rationale.
+# Built with GCC 10; see LLVM_full@22 for rationale.
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
-               preferred_gcc_version=v"13", preferred_llvm_version=v"16", julia_compat="1.6")
+               preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
 # Build trigger: 0

--- a/L/LLVM/LLVM_full_assert@22/bundled
+++ b/L/LLVM/LLVM_full_assert@22/bundled
@@ -1,0 +1,1 @@
+../LLVM_full@22/bundled

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -29,7 +29,7 @@ const llvm_tags = Dict(
     v"19.1.7" => "ccda9ec62497d9de88ca7090a749e52a89f62132", # julia-19.1.7-2
     v"20.1.8" => "5b9f96366ce26dfc8ca91697ef0a57894791d95e", # julia-20.1.8-0
     v"21.1.8" => "7cd4442d4a6c949de43c1e2c0e20334ee59aa154", # julia-21.1.8-0
-    v"22.1.1" => "c7b8aa1a7f4f46f79224d3269ce6f25cd75a4549", # julia-release/22.x
+    v"22.1.1" => "bb28dd22e7ad95ca869437f5e773603b6561fc9b", # julia-22.1.8-0
 )
 
 const buildscript = raw"""


### PR DESCRIPTION
Seems like we already had an LLVM 22 branch on https://github.com/JuliaLang/llvm-project/, so let's build a JLL.

I'm also bumping the build to GCC 13; since this JLL is almost exclusively going to be used by Julia sessions on 1.14 or higher, the raised libstdcxx requirement (3.4.28 -> 3.4.32) shouldn't pose a practical concern, while fixing the issue I'm having with linking against LLVM statically in https://github.com/JuliaPackaging/Yggdrasil/pull/14048