### PR TITLE
Trigger rebuild for FFplay v8.1.0

### DIFF
--- a/F/FFMPEG/FFplay/build_tarballs.jl
+++ b/F/FFMPEG/FFplay/build_tarballs.jl
@@ -25,4 +25,4 @@ dependencies = [
 build_tarballs(ARGS, name, version, sources, script(; ffplay=true), platforms, products, dependencies;
                julia_compat="1.6", preferred_gcc_version, clang_use_lld=false)
 
-# Build trigger: 3
+# Build trigger: 4


### PR DESCRIPTION
The previous registration from #12836 failed — I think due to an order-of-operations thing with FFmpeg and friends.