### PR TITLE
[Patchelf] Rebuild to pick up additional platforms

### DIFF
--- a/P/Patchelf/build_tarballs.jl
+++ b/P/Patchelf/build_tarballs.jl
@@ -33,4 +33,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version=v"8")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6", preferred_gcc_version=v"8")

--- a/P/Patchelf/build_tarballs.jl
+++ b/P/Patchelf/build_tarballs.jl
@@ -3,7 +3,12 @@
 using BinaryBuilder
 
 name = "Patchelf"
+
+# NOTE: The version used for the JLL deviated from the upstream version to accommodate
+# updated Julia package compatibility constraints for JLLs. We can re-sync the versions
+# once upstream releases v0.18.2 or higher.
 version = v"0.18.0"
+ygg_version = v"0.18.1"
 
 sources = [
     ArchiveSource("https://github.com/NixOS/patchelf/releases/download/$(version)/patchelf-$(version).tar.bz2",
@@ -33,5 +38,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+build_tarballs(ARGS, name, ygg_version, sources, script, platforms, products, dependencies;
                julia_compat="1.6", preferred_gcc_version=v"8")


### PR DESCRIPTION
The Patchelf_jll v0.18.0+0 build is from 3 years ago, when our platform support landscape looked a bit different, e.g. no FreeBSD AArch64 nor Linux RISC-V. Let's build v0.18.0+1 to pick up our new friends.