### PR TITLE
[qiskit_ibm_runtime] Bump compat version of Qiskit_jll to 2.4.1

### DIFF
--- a/Q/qiskit_ibm_runtime/build_tarballs.jl
+++ b/Q/qiskit_ibm_runtime/build_tarballs.jl
@@ -51,7 +51,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     BuildDependency(PackageSpec(name="cbindgen_jll", uuid="a52b955f-5256-5bb0-8795-313e28591558"))
-    Dependency(PackageSpec(name="Qiskit_jll", uuid="b54e8e98-f244-53b3-a8e8-4727a4907f76"); compat="~2.2.3")
+    Dependency(PackageSpec(name="Qiskit_jll", uuid="b54e8e98-f244-53b3-a8e8-4727a4907f76"); compat="~2.4.1")
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/Q/qiskit_ibm_runtime/build_tarballs.jl
+++ b/Q/qiskit_ibm_runtime/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "qiskit_ibm_runtime"
-version = v"0.38.0"
+version = v"0.38.1"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
This modifies the qiskit_ibm_runtime build script to bump the compat version of Qiskit_jll to `~2.4.1`.  I chose not to include both versions because Qiskit currently breaks the ABI with each minor release.