### PR TITLE
[object_store_ffi] Bump to v0.12.8

### DIFF
--- a/O/object_store_ffi/build_tarballs.jl
+++ b/O/object_store_ffi/build_tarballs.jl
@@ -1,11 +1,11 @@
 using BinaryBuilder
 
 name = "object_store_ffi"
-version = v"0.12.7"
+version = v"0.12.8"
 
 sources = [
-    # https://github.com/RelationalAI/object_store_ffi/commit/9e2327a14f1a36c388c982e0a8264188e8f85380
-    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "9e2327a14f1a36c388c982e0a8264188e8f85380")
+    # https://github.com/RelationalAI/object_store_ffi/commit/57dd2a7637872affe84e0410c3a66197fc008a34
+    GitSource("https://github.com/RelationalAI/object_store_ffi.git", "57dd2a7637872affe84e0410c3a66197fc008a34")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bumps `object_store_ffi` to v0.12.8.

Upstream release: https://github.com/RelationalAI/object_store_ffi/releases/tag/v0.12.8
Source commit: https://github.com/RelationalAI/object_store_ffi/commit/57dd2a7637872affe84e0410c3a66197fc008a34

This release adds dynamic Snowflake cipher selection (derives the content crypto scheme from the cipher type and master key length, with a stage-info consistency check) and two new Snowflake authentication methods (programmatic access token and key-pair JWT).