### PR TITLE
GCCBootstrap@14: Bump to 14.3.0, adjust patches

### DIFF
--- a/0_RootFS/GCCBootstrap@14/build_tarballs.jl
+++ b/0_RootFS/GCCBootstrap@14/build_tarballs.jl
@@ -1,2 +1,2 @@
 include("../gcc_common.jl")
-build_and_upload_gcc(v"14.2.0")
+build_and_upload_gcc(v"14.3.0")

--- a/0_RootFS/GCCBootstrap@14/bundled/patches/gcc/gcc1420-Increase-fallback-min-macOS-version-for-libgcc-to-10.8.patch
+++ b/0_RootFS/GCCBootstrap@14/bundled/patches/gcc/gcc1420-Increase-fallback-min-macOS-version-for-libgcc-to-10.8.patch
@@ -6,6 +6,12 @@ Subject: [PATCH] Increase fallback min macOS version for libgcc to 10.8
 `-mmacosx-version-min=10.5` seems to cause problems with ld64 from cctools
 (https://github.com/JuliaPackaging/Yggdrasil/pull/10132#issuecomment-2569925646),
 and in any case in Julia/BinaryBuilder we support macOS 10.12 at minimum.
+
+Rebased onto gcc-14.3.0, whose libgcc/config.host reworked the Darwin
+`tmake_file` cases (split the old darwin9-17 branch and added
+t-darwin-libgccs1).  Bump the same min-5 -> min-8 in every branch that
+covers a BinaryBuilder host (x86_64-apple-darwin14 lands in the
+darwin1[0-5] case) plus the fallback, keeping the new libgccs1 fragment.
 ---
  libgcc/config.host | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
@@ -14,26 +20,29 @@ diff --git a/libgcc/config.host b/libgcc/config.host
 index e75a7af64..12aa05581 100644
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
-@@ -240,7 +240,7 @@ case ${host} in
+@@ -243,10 +243,10 @@ case ${host} in
        tmake_file="t-darwin-min-8 $tmake_file"
        ;;
-     *-*-darwin9* | *-*-darwin1[0-7]*)
+     *-*-darwin1[67]]*)
 -      tmake_file="t-darwin-min-5 $tmake_file"
 +      tmake_file="t-darwin-min-8 $tmake_file"
        ;;
+     *-*-darwin9* | *-*-darwin1[0-5]*)
+-      tmake_file="t-darwin-min-5 t-darwin-libgccs1 $tmake_file"
++      tmake_file="t-darwin-min-8 t-darwin-libgccs1 $tmake_file"
+       ;;
      *-*-darwin[4-8]*)
-       tmake_file="t-darwin-min-1 $tmake_file"
-@@ -248,8 +248,8 @@ case ${host} in
+       tmake_file="t-darwin-min-1 t-darwin-libgccs1 $tmake_file"
+@@ -254,8 +254,8 @@ case ${host} in
      *)
        # Fall back to configuring for the oldest system known to work with
        # all archs and the current sources.
--      tmake_file="t-darwin-min-5 $tmake_file"
+-      tmake_file="t-darwin-min-5 t-darwin-libgccs1 $tmake_file"
 -      echo "Warning: libgcc configured to support macOS 10.5" 1>&2
-+      tmake_file="t-darwin-min-8 $tmake_file"
++      tmake_file="t-darwin-min-8 t-darwin-libgccs1 $tmake_file"
 +      echo "Warning: libgcc configured to support macOS 10.8" 1>&2
        ;;
    esac
    # We are not using libtool to build the libs here, so we need to replicate
--- 
+--
 2.31.0
-

--- a/0_RootFS/GCCBootstrap@14/bundled/patches/gcc/gcc1430-libstdcxx-mingw-ios-init-export.patch
+++ b/0_RootFS/GCCBootstrap@14/bundled/patches/gcc/gcc1430-libstdcxx-mingw-ios-init-export.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliahub.com>
+Date: Mon, 22 Jun 2026 23:45:00 +0000
+Subject: [PATCH] libstdc++: Restore ios_base_library_init export on MinGW
+
+gcc-14.3.0 backported PR116159, which only emits the
+std::ios_base_library_init() ABI marker on ELF targets.  Keep the
+corresponding <iostream> reference disabled on MinGW (the header-side
+change is already upstream in 14.3.0), but provide the symbol in
+libstdc++ for compatibility with C++ objects that were linked against an
+import library exposing it (e.g. binaries built with the previous
+gcc-14.2.0 mingw runtime).
+---
+ libstdc++-v3/src/c++98/ios_init.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libstdc++-v3/src/c++98/ios_init.cc b/libstdc++-v3/src/c++98/ios_init.cc
+index a597a471d1e..c2030dde71c 100644
+--- a/libstdc++-v3/src/c++98/ios_init.cc
++++ b/libstdc++-v3/src/c++98/ios_init.cc
+@@ -199,7 +199,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+     return __ret;
+   }
+
+-#if defined(_GLIBCXX_SYMVER_GNU) && defined(__ELF__)
++#if defined(_GLIBCXX_SYMVER_GNU) && (defined(__ELF__) || defined(__MINGW32__))
+ #pragma GCC diagnostic ignored "-Wattribute-alias"
+
+   void ios_base_library_init (void)
+--
+2.43.0

--- a/0_RootFS/gcc_sources.jl
+++ b/0_RootFS/gcc_sources.jl
@@ -117,9 +117,9 @@ const gcc_version_sources = Dict{VersionNumber,Vector}(
         ArchiveSource("https://gcc.gnu.org/pub/gcc/infrastructure/isl-0.24.tar.bz2",
                         "fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0"),
     ],
-    v"14.2.0" => [
-        ArchiveSource("https://mirrors.kernel.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz",
-                      "a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9"),
+    v"14.3.0" => [
+        ArchiveSource("https://mirrors.kernel.org/gnu/gcc/gcc-14.3.0/gcc-14.3.0.tar.xz",
+                      "e0dc77297625631ac8e50fa92fffefe899a4eb702592da5c32ef04e2293aca3a"),
         ArchiveSource("https://mirrors.kernel.org/gnu/gmp/gmp-6.2.1.tar.xz",
                       "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2"),
         ArchiveSource("https://mirrors.kernel.org/gnu/mpfr/mpfr-4.1.0.tar.xz",
@@ -226,7 +226,7 @@ function gcc_sources(gcc_version::VersionNumber, compiler_target::Platform; kwar
             v"11.1.0" => v"2.36",
             v"12.1.0" => v"2.38",
             v"13.2.0" => v"2.41",
-            v"14.2.0" => v"2.43.1",
+            v"14.3.0" => v"2.43.1",
             v"15.2.0" => v"2.45.1",
         )
 


### PR DESCRIPTION
We've already rebuilt 15 and 13 with these patches, but we need to bump CSL for active release branches, some of which use GCC 14, so do that as well.