### PR TITLE
[iceberg_rust_ffi] Bump to 0.9.0

### DIFF
--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -1,10 +1,10 @@
 using BinaryBuilder
 
 name = "iceberg_rust_ffi"
-version = v"0.8.3"
+version = v"0.9.0"
 
 sources = [
-    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "96c2b19ceaaba0f135c9660fb40062cd037d6fca"),
+    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "5493fe407bb6fd9d7c2ff607ad8447a64b32dfd4"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bumps `iceberg_rust_ffi` to **v0.9.0**, built from RustyIceberg.jl commit [`5493fe4`](https://github.com/RelationalAI/RustyIceberg.jl/commit/5493fe407bb6fd9d7c2ff607ad8447a64b32dfd4).

This is the native side of an ABI-breaking change that consolidates all Iceberg scan tuning parameters into a single by-value `IcebergPerfConfig` struct (new `#[repr(C)] IcebergPerfConfigFFI`, removed per-knob FFI setters, removed the dead `0 = auto`/`Option` defaults). See RelationalAI/RustyIceberg.jl#108.

The recipe change is just the version + `GitSource` commit; build script, platforms, and dependencies are unchanged.

Prior bump for reference: #13839 (0.8.3), #13808 (0.8.0).
