### PR TITLE
PoCL: build with Clang/lld on Windows; inline drivers everywhere

### DIFF
--- a/P/pocl/common.jl
+++ b/P/pocl/common.jl
@@ -150,8 +150,24 @@ function build_script(standalone=false)
     # Install things into $prefix
     CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
 
-    # Explicitly use our cmake toolchain file and tell CMake we're cross-compiling
-    CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+    # Explicitly use our cmake toolchain file and tell CMake we're cross-compiling.
+    if [[ "${target}" == *mingw* ]]; then
+        # Build PoCL with the Clang/lld toolchain on Windows. The default GCC toolchain
+        # links with GNU ld, which is pathologically slow at producing a PE/COFF DLL out
+        # of the large static LLVM/Clang archives: the final libpocl link took ~25 min and
+        # CMake's LLVM/Clang link tests (try_compile against static LLVM) another ~13 min,
+        # together dominating the ~45 min Windows build. Clang defaults to lld, which links
+        # the same DLL in a fraction of the time; the link tests inherit the toolchain, so
+        # the configure-time cost disappears too. Clang also matches the Clang-built
+        # LLVM_full_jll and vendored translator, avoiding the GCC-vs-Clang COMDAT mismatch.
+        # The COFF export model this needs -- dllexport the public API + --exclude-all-symbols
+        # (lld can't --exclude-libs the static LLVM out of auto-export, which would overflow
+        # the 64K PE export limit) -- lives in the pinned pocl commit, and it requires the
+        # ENABLE_LOADABLE_DRIVERS=OFF set below.
+        CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake)
+    else
+        CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+    fi
     CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
 
     # Point to relevant LLVM tools (see above)
@@ -193,8 +209,6 @@ function build_script(standalone=false)
         # Rename PoCL's OpenCL entrypoints to PO<cl_function>, so the standalone library can
         # coexist in-process with a real OpenCL ICD loader (e.g. one targeting other GPUs).
         CMAKE_FLAGS+=(-DRENAME_POCL:BOOL=ON)
-        # The above only applies to public API, so link-in the drivers to avoid clashes.
-        CMAKE_FLAGS+=(-DENABLE_LOADABLE_DRIVERS:BOOL=OFF)
         # With ENABLE_ICD=OFF, PoCL names the library "OpenCL" (libOpenCL.so), which would
         # collide with the system ICD loader. Rename it so it ships as a distinct product.
         sed -i 's/set(POCL_LIBRARY_NAME "OpenCL")/set(POCL_LIBRARY_NAME "pocl_standalone")/' CMakeLists.txt
@@ -202,6 +216,16 @@ function build_script(standalone=false)
         # Build POCL as an dynamic library loaded by the OpenCL runtime
         CMAKE_FLAGS+=(-DENABLE_ICD:BOOL=ON)
     fi
+
+    # Link the CPU device drivers (basic, pthread) straight into libpocl on every platform
+    # rather than building them as separately-dlopen'd modules. We ship a fixed CPU-only set,
+    # so loadable modules add no capability; inlining keeps one self-contained library (no
+    # runtime driver-DLL discovery), consistent across platforms. It is also *required* on
+    # Windows, where libpocl is linked with lld and exports only its dllexport'd public API
+    # (--exclude-all-symbols): loadable modules can't import libpocl's internal pocl_driver_*
+    # ABI across that boundary. (For the standalone build it additionally avoids clashes, as
+    # RENAME_POCL only renames the public API.)
+    CMAKE_FLAGS+=(-DENABLE_LOADABLE_DRIVERS:BOOL=OFF)
 
     # XXX: work around pocl#1776, disabling FP16 support for FreeBSD
     if [[ ${target} == *-freebsd* ]]; then
@@ -213,14 +237,15 @@ function build_script(standalone=false)
     # XXX: we add -pthread to the flags used to link libLLVM, so need that here too
     #      (as that is not reflected by llvm-config)
     if [[ "${target}" == *mingw* ]]; then
-        # PoCL is built with GCC, but LLVM_full_jll and our vendored translator are
-        # clang-built. On PE/COFF the COMDAT section of <regex>'s function-local static
-        # `__nul` differs (.bss$ for clang vs .data$ for gcc), which GNU ld rejects as a
-        # multiple definition (ELF/Mach-O merge it silently). The definitions are the same
-        # template instantiation, so let ld keep the first.
+        # PoCL is built with the Clang/lld toolchain on Windows (see above). Add -pthread to
+        # every link mode (not just executables): it pulls in libwinpthread, which Clang's
+        # windows-gnu driver -- unlike GCC's -- does not link implicitly, and it matches the
+        # -pthread we use when linking libLLVM (not reflected by llvm-config). Keep
+        # --allow-multiple-definition as a guard against duplicate COMDAT/weak template
+        # instantiations across the statically-linked LLVM/Clang/translator archives.
         CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
-        CMAKE_FLAGS+=(-DCMAKE_SHARED_LINKER_FLAGS="-Wl,--allow-multiple-definition")
-        CMAKE_FLAGS+=(-DCMAKE_MODULE_LINKER_FLAGS="-Wl,--allow-multiple-definition")
+        CMAKE_FLAGS+=(-DCMAKE_SHARED_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
+        CMAKE_FLAGS+=(-DCMAKE_MODULE_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
     else
         CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread")
     fi

--- a/P/pocl/pocl/build_tarballs.jl
+++ b/P/pocl/pocl/build_tarballs.jl
@@ -16,7 +16,7 @@ version = v"7.1.3"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/juliagpu/pocl",
-              "cd0d3970227e09382f57a5c715d42ed62e1baf00"),
+              "21d408ea0adbfd59934d5720132c0e7f412af98e"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).
@@ -97,8 +97,11 @@ for platform in platforms
     # TODO: libsvml for x86 (part of mkl)
     # TODO: libmvec as fallback (part of glibc 2.22+)
 
-    # on Windows, we need to use a version of GCC that supports `.drectve -exclude-symbols`
-    # or we run into export ordinal limits
+    # On Windows we now link PoCL with the Clang/lld toolchain, but still build against this
+    # GCC's MinGW sysroot and libstdc++, so its version must stay compatible with the
+    # Clang-built LLVM_full_jll's libstdc++ ABI. (Previously pinned to 13 for GNU ld's
+    # `.drectve -exclude-symbols`, used to dodge the PE export-ordinal limit; lld no longer
+    # needs that -- it exports only the dllexport'd public API instead.)
     preferred_gcc_version = if Sys.iswindows(platform)
         v"13"
     else

--- a/P/pocl/pocl_next/build_tarballs.jl
+++ b/P/pocl/pocl_next/build_tarballs.jl
@@ -55,7 +55,7 @@ version = v"7.2.0"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/JuliaGPU/pocl",
-              "49af20c4b429d607f9cdb1f40557826ca8926753"),
+              "bbd327c519d355e5e01b88f83b4ad4a57b61a176"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see above);
     # this commit is the LLVM-20.1-compatible revision (matches LLVM_full_jll 20.1.2).
     GitSource("https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",
@@ -212,8 +212,15 @@ function build_script()
     # Install things into $prefix
     CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
 
-    # Explicitly use our cmake toolchain file and tell CMake we're cross-compiling
-    CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+    # Explicitly use our cmake toolchain file and tell CMake we're cross-compiling.
+    if [[ "${target}" == *mingw* ]]; then
+        # Build PoCL with the Clang/lld toolchain on Windows; GNU ld is pathologically slow
+        # at producing a PE/COFF DLL from the large static LLVM/Clang archives (see the
+        # export-model notes above). Mirrors what the SPIR-V translator already uses.
+        CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake)
+    else
+        CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+    fi
     CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
 
     # PoCL 7.2 looks for the *host* LLVM tools (clang, opt, llc, ...) in the directory
@@ -273,6 +280,15 @@ function build_script()
     # Build PoCL as a dynamic library loaded by the OpenCL runtime
     CMAKE_FLAGS+=(-DENABLE_ICD:BOOL=ON)
 
+    # Link the CPU device drivers (basic, pthread) straight into libpocl on every platform
+    # rather than building them as separately-dlopen'd modules. We ship a fixed CPU-only set,
+    # so loadable modules add no capability; inlining keeps one self-contained library (no
+    # runtime driver-DLL discovery), consistent across platforms. It is also *required* on
+    # Windows, where libpocl is linked with lld and exports only its dllexport'd public API
+    # (--exclude-all-symbols): loadable modules can't import libpocl's internal pocl_driver_*
+    # ABI across that boundary.
+    CMAKE_FLAGS+=(-DENABLE_LOADABLE_DRIVERS:BOOL=OFF)
+
     # Load CPU host kernels in-process via ORC/JITLink instead of Clang+dlopen.
     # This is the whole point of pocl_next: it removes the external link step
     # (no lld, no startup files, no clang driver invocation at run time).
@@ -292,14 +308,15 @@ function build_script()
     # XXX: we add -pthread to the flags used to link libLLVM, so need that here too
     #      (as that is not reflected by llvm-config)
     if [[ "${target}" == *mingw* ]]; then
-        # PoCL is built with GCC, but LLVM_full_jll and our vendored translator are
-        # clang-built. On PE/COFF the COMDAT section of <regex>'s function-local static
-        # `__nul` differs (.bss$ for clang vs .data$ for gcc), which GNU ld rejects as a
-        # multiple definition (ELF/Mach-O merge it silently). The definitions are the same
-        # template instantiation, so let ld keep the first.
+        # PoCL is built with the Clang/lld toolchain on Windows (see above). Add -pthread to
+        # every link mode (not just executables): it pulls in libwinpthread, which Clang's
+        # windows-gnu driver -- unlike GCC's -- does not link implicitly, and it matches the
+        # -pthread we use when linking libLLVM (not reflected by llvm-config). Keep
+        # --allow-multiple-definition as a guard against duplicate COMDAT/weak template
+        # instantiations across the statically-linked LLVM/Clang/translator archives.
         CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
-        CMAKE_FLAGS+=(-DCMAKE_SHARED_LINKER_FLAGS="-Wl,--allow-multiple-definition")
-        CMAKE_FLAGS+=(-DCMAKE_MODULE_LINKER_FLAGS="-Wl,--allow-multiple-definition")
+        CMAKE_FLAGS+=(-DCMAKE_SHARED_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
+        CMAKE_FLAGS+=(-DCMAKE_MODULE_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
     else
         CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread")
     fi
@@ -408,8 +425,11 @@ for platform in platforms
     # TODO: libsvml for x86 (part of mkl)
     # TODO: libmvec as fallback (part of glibc 2.22+)
 
-    # on Windows, we need to use a version of GCC that supports `.drectve -exclude-symbols`
-    # or we run into export ordinal limits
+    # On Windows we now link PoCL with the Clang/lld toolchain, but still build against this
+    # GCC's MinGW sysroot and libstdc++, so its version must stay compatible with the
+    # Clang-built LLVM_full_jll's libstdc++ ABI. (Previously pinned to 13 for GNU ld's
+    # `.drectve -exclude-symbols`, used to dodge the PE export-ordinal limit; lld no longer
+    # needs that.)
     preferred_gcc_version = if Sys.iswindows(platform)
         v"13"
     else

--- a/P/pocl/pocl_standalone/build_tarballs.jl
+++ b/P/pocl/pocl_standalone/build_tarballs.jl
@@ -23,7 +23,7 @@ version = v"7.1.3"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/juliagpu/pocl",
-              "9d52d6600b5717f2c20a42d3862754014937f849"),
+              "21d408ea0adbfd59934d5720132c0e7f412af98e"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).
@@ -105,8 +105,11 @@ for platform in platforms
     # TODO: libsvml for x86 (part of mkl)
     # TODO: libmvec as fallback (part of glibc 2.22+)
 
-    # on Windows, we need to use a version of GCC that supports `.drectve -exclude-symbols`
-    # or we run into export ordinal limits
+    # On Windows we now link PoCL with the Clang/lld toolchain, but still build against this
+    # GCC's MinGW sysroot and libstdc++, so its version must stay compatible with the
+    # Clang-built LLVM_full_jll's libstdc++ ABI. (Previously pinned to 13 for GNU ld's
+    # `.drectve -exclude-symbols`, used to dodge the PE export-ordinal limit; lld no longer
+    # needs that -- it exports only the dllexport'd public API instead.)
     preferred_gcc_version = if Sys.iswindows(platform)
         v"13"
     else


### PR DESCRIPTION
The x86_64-w64-mingw32 builds were dominated by GNU ld linking the static LLVM/Clang archives into a PE/COFF DLL: ~13 min of CMake LLVM/Clang link tests plus a ~25 min final libpocl link, ~45 min total (vs ~5-18 min on other platforms). Build PoCL with the Clang/lld toolchain on Windows instead; lld links the same DLL in seconds, bringing the Windows builds to ~2 min. Compilation itself was never the bottleneck (~1 min everywhere).

Companion changes:
- -pthread on the shared/module link flags (Clang's windows-gnu driver, unlike GCC's, doesn't link libwinpthread implicitly);
- ENABLE_LOADABLE_DRIVERS=OFF on every platform: the CPU drivers (basic, pthread) are linked into libpocl instead of separately-dlopen'd modules. Done consistently across platforms; on Windows it is also required by the lld export model below.

That export model -- dllexport the public OpenCL API + --exclude-all-symbols (lld's COFF driver can't --exclude-libs the static LLVM out of auto-export, which would overflow the 64K PE export-ordinal limit) -- lives in the pinned pocl commits on JuliaGPU/pocl release_7_1 (21d408ea0) and release_7_2 (bbd327c51), so the GitSource pins are bumped to those and the per-recipe source seds removed. The Windows GCC-13 pin is kept (its MinGW sysroot and libstdc++ ABI must match the Clang-built LLVM_full_jll) but no longer for GNU ld's `.drectve -exclude-symbols`.