### PR TITLE
PoCL: 7.2 standalone build

### DIFF
--- a/P/pocl/common.jl
+++ b/P/pocl/common.jl
@@ -1,9 +1,59 @@
+#=
+
+Shared build logic for the PoCL 7.2 JLLs (`pocl_next` and `pocl_standalone`).
+
+This is the 7.2 track of PoCL. The goal is a JLL that needs *no* run-time helper tooling:
+no wrapper scripts, no bundled startup files, no external clang/lld/llvm-spirv. The init
+block does nothing but (for the ICD build) register the driver.
+
+Two upstream/build changes make that possible:
+
+1. JIT (upstream PR #2190): CPU host kernels are loaded in-process via LLVM ORC/JITLink
+   instead of being compiled to a shared object and dlopen()ed. JITLink is both the
+   linker and the loader, so there is no external link step:
+
+     - no `lld` invocation       -> no LLD wrapper, no LLD_unified_jll
+     - no Clang driver link step -> no Clang wrapper (the frontend runs in-process via
+                                    libclang, and codegen emits the object in-process)
+     - no startup files / libc   -> the JIT resolves libc/libm/compiler-rt via normal
+       / libgcc to bundle           process-symbol lookup, so we drop the `share/lib`
+                                    staging the 7.1 recipe needed for the external link
+
+   We also build without the Level Zero driver (`-DENABLE_LEVEL0=OFF`), the only consumer
+   of `spirv-link`, so SPIRV_Tools_jll goes away too.
+
+2. SPIR-V via the translator *library*, vendored. PoCL converts SPIR-V <-> LLVM IR with
+   the SPIRV-LLVM-Translator. Using its `llvm-spirv` *binary* would mean shipping it and
+   wrapping it (to set up its library path) at run time. Instead we build the translator
+   here as a static library and link it into libpocl. The catch (which bit us before, on
+   macOS especially) is that the translator API passes `llvm::Module`s across the ABI
+   boundary, so it must share a *single* LLVM with PoCL -- two LLVM copies means two sets
+   of global state / type uniquing and is undefined behavior. We therefore build the
+   translator against the *same* LLVM_full_jll and link it statically against LLVM's
+   component libraries (DISABLE_LLVM_LINK_LLVM_DYLIB), so libLLVMSPIRVLib.a carries only
+   translator objects whose LLVM references resolve against PoCL's own statically-linked
+   LLVM at the final link. One LLVM copy, ODR-safe, and no SPIRV_LLVM_Translator_jll.
+
+The `standalone` argument selects between two variants of this same build:
+
+- standalone=false (`pocl_next`): an OpenCL ICD driver (ENABLE_ICD=ON) loaded by an ICD
+  loader; the init block registers it with OpenCL_jll.
+- standalone=true (`pocl_standalone`): a directly-linkable library (ENABLE_ICD=OFF) whose
+  OpenCL entrypoints are renamed to `PO<cl_function>` (RENAME_POCL), so it can be used as
+  a CPU back-end (e.g. by KernelAbstractions.jl's nanoOpenCL) without an OpenCL.jl/ICD
+  dependency while coexisting in-process with a real OpenCL ICD targeting other GPUs.
+
+The stable 7.1 `pocl` recipe is intentionally *not* built from here: its 7.1 build system
+and external-link/wrapper machinery differ enough that it carries its own self-contained
+build script.
+
+=#
+
 function build_script(standalone=false)
     preheader = """
     STANDALONE=$(standalone)
     """
 
-    # Bash recipe for building across all platforms
     script = preheader * raw"""
     # macOS SDK setup, shared by both the translator and PoCL builds below (it redirects
     # the toolchain, so it must run before either of them).
@@ -34,21 +84,13 @@ function build_script(standalone=false)
     ##########################################################################
     # 1. Build the vendored SPIRV-LLVM-Translator as a static library.
     #
-    # PoCL converts SPIR-V <-> LLVM IR with the SPIRV-LLVM-Translator. Using its
-    # `llvm-spirv` *binary* would mean shipping it (SPIRV_LLVM_Translator_jll) and
-    # wrapping it (to set up its library path) at run time. Instead we build the
-    # translator here as a static library and link it into libpocl. The catch (which
-    # bit us before, on macOS especially) is that the translator API passes
-    # `llvm::Module`s across the ABI boundary, so it must share a *single* LLVM with
-    # PoCL -- two LLVM copies means two sets of global state / type uniquing and is
-    # undefined behavior. We therefore build the translator against the same
-    # LLVM_full_jll and link it statically against LLVM's component libs
-    # (DISABLE_LLVM_LINK_LLVM_DYLIB), so libLLVMSPIRVLib.a contains only translator
-    # objects; their LLVM references resolve against PoCL's own statically-linked
-    # LLVM at the final libpocl link (single LLVM, ODR-safe).
+    # Built against the same LLVM_full_jll as PoCL and linked statically against
+    # LLVM's component libs (DISABLE_LLVM_LINK_LLVM_DYLIB), so libLLVMSPIRVLib.a
+    # contains only translator objects; their LLVM references resolve against
+    # PoCL's own static LLVM at the final libpocl link (single LLVM, ODR-safe).
     ##########################################################################
     # BB's cmake toolchain pins CMAKE_INSTALL_PREFIX to ${prefix}, so the translator
-    # installs there -- conveniently right where PoCL's cmake/LLVM.cmake looks
+    # installs there -- conveniently right where PoCL's SetupLLVMSPIRV.cmake looks
     # (LLVM_INCLUDE_DIRS / LLVM_LIBDIR). We link it into libpocl below and then delete
     # its artifacts from ${prefix} at the end, so they don't ship in the JLL.
     spirv_src=$WORKSPACE/srcdir/SPIRV-LLVM-Translator
@@ -95,12 +137,6 @@ function build_script(standalone=false)
         echo "ERROR: vendored translator library/headers not found" >&2
         exit 1
     fi
-    # Derive the maximum supported SPIR-V version from the translator headers, like
-    # PoCL >= 7.2 does. PoCL 7.1 instead derives it with a try_run, which cannot
-    # execute when cross-compiling, so we pre-seed the result below.
-    spirv_maxver_minor=$(grep -oE 'MaximumVersion = SPIRV_1_[0-9]+' ${spirv_inc}/LLVMSPIRVOpts.h | grep -oE '[0-9]+$')
-    spirv_maxver=$((65536 + spirv_maxver_minor * 256))
-    echo "Maximum SPIR-V version supported by the translator: ${spirv_maxver}"
 
     ##########################################################################
     # 2. Build PoCL.
@@ -152,27 +188,39 @@ function build_script(standalone=false)
 
     # Explicitly use our cmake toolchain file and tell CMake we're cross-compiling.
     if [[ "${target}" == *mingw* ]]; then
-        # Build PoCL with the Clang/lld toolchain on Windows. The default GCC toolchain
-        # links with GNU ld, which is pathologically slow at producing a PE/COFF DLL out
-        # of the large static LLVM/Clang archives: the final libpocl link took ~25 min and
-        # CMake's LLVM/Clang link tests (try_compile against static LLVM) another ~13 min,
-        # together dominating the ~45 min Windows build. Clang defaults to lld, which links
-        # the same DLL in a fraction of the time; the link tests inherit the toolchain, so
-        # the configure-time cost disappears too. Clang also matches the Clang-built
-        # LLVM_full_jll and vendored translator, avoiding the GCC-vs-Clang COMDAT mismatch.
-        # The COFF export model this needs -- dllexport the public API + --exclude-all-symbols
-        # (lld can't --exclude-libs the static LLVM out of auto-export, which would overflow
-        # the 64K PE export limit) -- lives in the pinned pocl commit, and it requires the
-        # ENABLE_LOADABLE_DRIVERS=OFF set below.
+        # Build PoCL with the Clang/lld toolchain on Windows; GNU ld is pathologically slow
+        # at producing a PE/COFF DLL from the large static LLVM/Clang archives (see the
+        # export-model notes above). Mirrors what the SPIR-V translator already uses.
         CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake)
     else
         CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
     fi
     CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
 
-    # Point to relevant LLVM tools (see above)
+    # PoCL 7.2 looks for the *host* LLVM tools (clang, opt, llc, ...) in the directory
+    # of the llvm-config we pass (LLVM_CONFIG_LOCATION), whereas 7.1 used LLVM_BINDIR.
+    # Our llvm-config is a wrapper script living alone in srcdir, so assemble a bin dir
+    # that holds it alongside symlinks to the native host LLVM tools, and point
+    # WITH_LLVM_CONFIG there.
+    llvm_host_bin=$WORKSPACE/srcdir/llvm-host-bin
+    mkdir -p $llvm_host_bin
+    cp $WORKSPACE/srcdir/llvm-config $llvm_host_bin/llvm-config
+    chmod +x $llvm_host_bin/llvm-config
+    for tool in clang clang++ opt llc llvm-as llvm-dis llvm-link; do
+        ln -sf /opt/$MACHTYPE/bin/$tool $llvm_host_bin/$tool
+        # on mingw targets CMake appends .exe when searching, so provide that name too
+        # (the host tools are ELF binaries; the suffix is just what find_program looks for)
+        ln -sf /opt/$MACHTYPE/bin/$tool $llvm_host_bin/$tool.exe
+    done
+
+    # Point to relevant LLVM tools (see above). The target-side dependencies live
+    # under ${prefix} (which is a symlink to the per-target destdir).
+    ## Target-side LLVM CMake package. PoCL 7.2 requires LLVM_DIR (the target
+    ## LLVMConfig.cmake) *in addition* to the spoofed llvm-config when cross-compiling
+    ## (cmake/LLVM.cmake); their major.minor versions must agree (both LLVM 20).
+    CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
     ## HostDependency: llvm-config, but spoofed to return Dependency's paths
-    CMAKE_FLAGS+=(-DWITH_LLVM_CONFIG=$WORKSPACE/srcdir/llvm-config)
+    CMAKE_FLAGS+=(-DWITH_LLVM_CONFIG=$llvm_host_bin/llvm-config)
     ## Native toolchain: for LLVM tools to ensure they can target the right architecture
     CMAKE_FLAGS+=(-DLLVM_BINDIR=/opt/$MACHTYPE/bin)
     if [[ "${target}" == *mingw* ]]; then
@@ -213,7 +261,7 @@ function build_script(standalone=false)
         # collide with the system ICD loader. Rename it so it ships as a distinct product.
         sed -i 's/set(POCL_LIBRARY_NAME "OpenCL")/set(POCL_LIBRARY_NAME "pocl_standalone")/' CMakeLists.txt
     else
-        # Build POCL as an dynamic library loaded by the OpenCL runtime
+        # Build PoCL as a dynamic library loaded by the OpenCL runtime.
         CMAKE_FLAGS+=(-DENABLE_ICD:BOOL=ON)
     fi
 
@@ -226,6 +274,15 @@ function build_script(standalone=false)
     # ABI across that boundary. (For the standalone build it additionally avoids clashes, as
     # RENAME_POCL only renames the public API.)
     CMAKE_FLAGS+=(-DENABLE_LOADABLE_DRIVERS:BOOL=OFF)
+
+    # Load CPU host kernels in-process via ORC/JITLink instead of Clang+dlopen.
+    # This is the whole point of the 7.2 track: it removes the external link step
+    # (no lld, no startup files, no clang driver invocation at run time).
+    CMAKE_FLAGS+=(-DHOST_CPU_ENABLE_JIT:BOOL=ON)
+
+    # Build without the (experimental) Level Zero driver. It is the only consumer
+    # of spirv-link, so disabling it lets us drop SPIRV_Tools_jll entirely.
+    CMAKE_FLAGS+=(-DENABLE_LEVEL0:BOOL=OFF)
 
     # XXX: work around pocl#1776, disabling FP16 support for FreeBSD
     if [[ ${target} == *-freebsd* ]]; then
@@ -250,18 +307,20 @@ function build_script(standalone=false)
         CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread")
     fi
 
+    # Our sysroot ships an old glibc whose <inttypes.h> only defines the PRI* format
+    # macros for C++ when __STDC_FORMAT_MACROS is set. PoCL's C++ sources include LLVM
+    # headers (which pull <inttypes.h>) before pocl_debug.h, so pocl_debug.h's own
+    # late `#define __STDC_FORMAT_MACROS` is too late (the include guard is already set)
+    # and PRId64/PRIu64 end up undefined (e.g. pocl_llvm_utils.cc's "Created context %"
+    # PRId64). Define it on the command line so it's set before the first include.
+    CMAKE_FLAGS+=(-DCMAKE_CXX_FLAGS="-D__STDC_FORMAT_MACROS")
+
     # Enable SPIR-V support via the vendored translator *library* (built above), linked
-    # statically into libpocl (the macOS ODR hazard that previously forced the binary
-    # path is gone now that the translator shares PoCL's static LLVM, whose symbols are
-    # hidden on macOS via -hidden-l). Pre-seed the cache variables cmake/LLVM.cmake
-    # would otherwise probe: the lib/include paths it searches for, and the
-    # HAVE/MAXVER results it would derive from a try_run (which cannot execute when
-    # cross-compiling). We do NOT provide an llvm-spirv binary, so the binary code
-    # path stays off and no run-time translator package or wrapper is needed.
+    # statically into libpocl. Pre-seed the cache vars SetupLLVMSPIRV.cmake would otherwise
+    # search for, so it uses our copy and enables HAVE_LLVM_SPIRV_LIB. We do NOT set any
+    # llvm-spirv binary path, so the binary code path stays off and no wrapper is needed.
     CMAKE_FLAGS+=(-DLLVM_SPIRV_INCLUDEDIR=${spirv_inc})
     CMAKE_FLAGS+=(-DLLVM_SPIRV_LIB=${spirv_lib})
-    CMAKE_FLAGS+=(-DHAVE_LLVM_SPIRV_LIB:BOOL=ON)
-    CMAKE_FLAGS+=(-DLLVM_SPIRV_LIB_MAXVER=${spirv_maxver})
 
     # PoCL's CPU autodetection doesn't work on RISC-V
     if [[ ${target} == riscv64-* ]]; then
@@ -283,206 +342,30 @@ function build_script(standalone=false)
     rm -f ${prefix}/lib/libLLVMSPIRVLib.a \
           ${prefix}/lib/pkgconfig/LLVMSPIRVLib.pc \
           ${prefix}/bin/llvm-spirv ${prefix}/bin/llvm-spirv.exe
-
-    # PoCL uses Clang, which relies on certain system libraries Clang_jll.jl doesn't provide
-    mkdir -p $prefix/share/lib
-    if [[ ${target} == *-linux-gnu ]]; then
-        if [[ ${target} == riscv64-* ]]; then
-            cp -va $sysroot/lib64/lp64d/libc.* $prefix/share/lib
-            cp -va $sysroot/usr/lib64/lp64d/libm.* $prefix/share/lib
-            ln -vsf libm.so.6 $prefix/share/lib/libm.so
-            cp -va $sysroot/lib64/lp64d/libm.* $prefix/share/lib
-            cp -va /opt/${target}/${target}/lib/libgcc_s.* $prefix/share/lib
-        elif [[ "${nbits}" == 64 ]]; then
-            cp -va $sysroot/lib64/libc{.,-}* $prefix/share/lib
-            cp -va $sysroot/usr/lib64/libm.* $prefix/share/lib
-            ln -vsf libm.so.6 $prefix/share/lib/libm.so
-            cp -va $sysroot/lib64/libm{.,-}* $prefix/share/lib
-            cp -va /opt/${target}/${target}/lib64/libgcc_s.* $prefix/share/lib
-        else
-            cp -va $sysroot/lib/libc{.,-}* $prefix/share/lib
-            cp -va $sysroot/usr/lib/libm.* $prefix/share/lib
-            ln -vsf libm.so.6 $prefix/share/lib/libm.so
-            cp -va $sysroot/lib/libm{.,-}* $prefix/share/lib
-            cp -va /opt/${target}/${target}/lib/libgcc_s.* $prefix/share/lib
-        fi
-        cp -va /opt/$target/lib/gcc/$target/*/*.{o,a} $prefix/share/lib
-    elif [[ ${target} == *-linux-musl ]]; then
-        cp -va $sysroot/usr/lib/*.{o,a} $prefix/share/lib
-        cp -va /opt/$target/lib/gcc/$target/*/*.{o,a} $prefix/share/lib
-    elif [[ "${target}" == *-mingw* ]]; then
-        cp -va $sysroot/lib/*.o $prefix/share/lib
-        cp -va $sysroot/lib/libmsvcrt*.a $prefix/share/lib
-        cp -va $sysroot/lib/libucrt*.a $prefix/share/lib
-        cp -va $sysroot/lib/libm.a $prefix/share/lib
-        cp -va $sysroot/lib/lib{kernel,user,shell}32.a $prefix/share/lib
-        cp -va $sysroot/lib/libmingw*.a $prefix/share/lib
-        cp -va $sysroot/lib/libmoldname.a $prefix/share/lib
-        cp -va $sysroot/lib/libadvapi32.a $prefix/share/lib
-        cp -va /opt/${target}/${target}/lib/libgcc* $prefix/share/lib
-        cp -va /opt/$target/lib/gcc/$target/*/*.{o,a} $prefix/share/lib
-    elif [[ "${target}" == *-apple-darwin* ]]; then
-        cp -va $sysroot/usr/lib/crt1.o $prefix/share/lib
-        cp -va $sysroot/usr/lib/libSystem.*tbd $prefix/share/lib
-        cp -va $sysroot/usr/lib/libm.*tbd $prefix/share/lib
-        cp -va $sysroot/usr/lib/libgcc_s.*tbd $prefix/share/lib
-    fi
     """
+
+    return script
 end
 
 function init_block(standalone=false)
-
-    opencl = raw"""
-    # Register this driver with OpenCL_jll
-    if OpenCL_jll.is_available()
-        push!(OpenCL_jll.drivers, libpocl)
-
-        # XXX: Clang_jll does not have a functional clang binary on macOS,
-        #      as it's configured without a default sdkroot (see #9221)
-        if Sys.isapple()
-            ENV["SDKROOT"] = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
-        end
-    end
-    """
-
-    # The standalone build is linked directly rather than loaded through an OpenCL ICD
-    # loader, so it has no driver to register (and no OpenCL_jll dependency). It still uses
-    # Clang_jll at run time to compile kernels, so it needs the same macOS SDK fix that the
-    # regular build applies inside the OpenCL block above.
-    macos_sdk = raw"""
-    # XXX: Clang_jll does not have a functional clang binary on macOS,
-    #      as it's configured without a default sdkroot (see #9221)
-    if Sys.isapple()
-        ENV["SDKROOT"] = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
-    end
-    """
-
-    pocl_binaries = raw"""
-    # expose JLL binaries to the library
-    # XXX: Scratch.jl is unusably slow with JLLWrapper-emitted @compiler_options
-    #bindir = @get_scratch!("bin")
-    bindir = abspath(first(Base.DEPOT_PATH), "scratchspaces", string(Base.PkgId(@__MODULE__).uuid), "bin")
-    mkpath(bindir)
-    function generate_wrapper_script(name, path, LIBPATH, PATH)
-        if Sys.iswindows()
-            LIBPATH_env = "PATH"
-            LIBPATH_default = ""
-            pathsep = ';'
-        elseif Sys.isapple()
-            LIBPATH_env = "DYLD_FALLBACK_LIBRARY_PATH"
-            LIBPATH_default = "~/lib:/usr/local/lib:/lib:/usr/lib"
-            pathsep = ':'
-        else
-            LIBPATH_env = "LD_LIBRARY_PATH"
-            LIBPATH_default = ""
-            pathsep = ':'
-        end
-
-        # XXX: cache, but invalidate when deps change
-
-        # write to temporary script
-        temp_script, io = mktemp(bindir; cleanup=false)
-        script = if Sys.isunix()
-            println(io, "#!/bin/bash")
-
-            LIBPATH_base = get(ENV, LIBPATH_env, expanduser(LIBPATH_default))
-            LIBPATH_value = if !isempty(LIBPATH_base)
-                string(LIBPATH, pathsep, LIBPATH_base)
-            else
-                LIBPATH
-            end
-            println(io, "export $LIBPATH_env=\\"$LIBPATH_value\\"")
-
-            if LIBPATH_env != "PATH"
-                PATH_base = get(ENV, "PATH", "")
-                PATH_value = if !isempty(PATH_base)
-                    string(PATH, pathsep, ENV["PATH"])
-                else
-                    PATH
-                end
-                println(io, "export PATH=\\"$PATH_value\\"")
-            end
-
-            println(io, "exec \\"$path\\" \\"\$@\\"")
-            close(io)
-            chmod(temp_script, 0o755)
-            joinpath(bindir, name)
-        elseif Sys.iswindows()
-            println(io, "@echo off")
-
-            LIBPATH_base = get(ENV, LIBPATH_env, expanduser(LIBPATH_default))
-            LIBPATH_value = if !isempty(LIBPATH_base)
-                string(LIBPATH, pathsep, LIBPATH_base)
-            else
-                LIBPATH
-            end
-            println(io, "set \\"$LIBPATH_env=$LIBPATH_value\\"")
-
-            println(io, "call \\"$path\\" %*")
-
-            # XXX: on Windows, the Base.rename below often throws EBUSY, so include the PID
-            joinpath(bindir, "$(name).$(getpid()).bat")
-        else
-            error("Unsupported platform")
-        end
-        close(io)
-
-        # atomically move to the final location
-        @static if VERSION >= v"1.12.0-DEV.1023"
-            mv(temp_script, script; force=true)
-        else
-            Base.rename(temp_script, script, force=true)
-        end
-
-        return script
-    end
-    ENV["POCL_PATH_SPIRV_LINK"] =
-        generate_wrapper_script("spirv_link", SPIRV_Tools_jll.spirv_link_path,
-                                SPIRV_Tools_jll.LIBPATH[], SPIRV_Tools_jll.PATH[])
-    ENV["POCL_PATH_CLANG"] =
-        generate_wrapper_script("clang", Clang_unified_jll.clang_path,
-                                Clang_unified_jll.LIBPATH[], Clang_unified_jll.PATH[])
-    ld_path = if Sys.islinux()
-            LLD_unified_jll.ld_lld_path
-        elseif Sys.isapple()
-            LLD_unified_jll.ld64_lld_path
-        elseif Sys.iswindows()
-            # PoCL doesn't use MSVC-style linker arguments, so still use the GNU ld wrapper.
-            LLD_unified_jll.ld_lld_path
-        else
-            error("Unsupported platform")
-        end
-    ld_wrapper = generate_wrapper_script("lld", ld_path,
-                                         LLD_unified_jll.LIBPATH[],
-                                         LLD_unified_jll.PATH[])
-
-    # expose libc to Clang, even if the system doesn't have development symlinks
-    libdir = abspath(first(Base.DEPOT_PATH), "scratchspaces", string(Base.PkgId(@__MODULE__).uuid), "lib")
-    mkpath(libdir)
-    for lib in Libdl.dllist()
-        startswith(basename(lib), "libc.so.6") || continue
-        link = joinpath(libdir, "libc.so")
-        try
-            symlink(lib, link)
-        catch
-            # can't safely check first, because multiple processes may be running
-            islink(link) || rethrow()
-        end
-    end
-    if Sys.iswindows()
-        # BUG: using native (backwards) slashes breaks Clang's --ld-path
-        ld_wrapper = replace(ld_wrapper, '\\' => '/')
-    end
-    ENV["POCL_ARGS_CLANG"] = join([
-            "-fuse-ld=lld", "--ld-path=$ld_wrapper",
-            "-L", joinpath(artifact_dir, "share", "lib"),
-            "-L", libdir
-        ], ";")
-    """
-
     if standalone
-        return macos_sdk * pocl_binaries
+        # The standalone build is linked directly rather than loaded through an OpenCL ICD
+        # loader, so it has no driver to register (and no OpenCL_jll dependency). And because
+        # CPU host kernels are loaded in-process via the JIT (no external clang/lld/spirv-link),
+        # there are no tools to locate at run time either -- so there is nothing to initialize.
+        raw"""
+        # Nothing to initialize: the standalone JIT build is fully self-contained
+        # (no ICD driver to register, no external tools to locate).
+        """
     else
-        return opencl * pocl_binaries
+        # No wrappers, no environment hacks: the JIT build links everything it needs
+        # (LLVM, clang, the SPIR-V translator) statically into libpocl, so there are no
+        # external tools to locate at run time. We only register the driver with the loader.
+        raw"""
+        # Register this driver with OpenCL_jll
+        if OpenCL_jll.is_available()
+            push!(OpenCL_jll.drivers, libpocl)
+        end
+        """
     end
 end

--- a/P/pocl/pocl/build_tarballs.jl
+++ b/P/pocl/pocl/build_tarballs.jl
@@ -18,7 +18,7 @@ sources = [
     GitSource("https://github.com/juliagpu/pocl",
               "21d408ea0adbfd59934d5720132c0e7f412af98e"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
-    # common.jl); this commit is the LLVM-20.1-compatible revision (matches
+    # the build script below); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).
     GitSource("https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",
               "dee371987a59ed8654083c09c5f1d5c54f5db318"),
@@ -49,11 +49,504 @@ filter!(p -> !(arch(p) == "i686" && libc(p) == "musl"), platforms)
 ## PoCL doesn't support 32-bit Windows
 filter!(p -> !(arch(p) == "i686" && os(p) == "windows"), platforms)
 
-include("../common.jl")
+
+# `pocl` is the stable 7.1 release of PoCL, and the odd one out: the `pocl_next` and
+# `pocl_standalone` recipes share the 7.2 JIT build in ../common.jl, but 7.1's build system
+# and its external-link/wrapper machinery differ enough that this recipe carries its own
+# self-contained build script and init block (inlined below).
+
+function build_script(standalone=false)
+    preheader = """
+    STANDALONE=$(standalone)
+    """
+
+    # Bash recipe for building across all platforms
+    script = preheader * raw"""
+    # macOS SDK setup, shared by both the translator and PoCL builds below (it redirects
+    # the toolchain, so it must run before either of them).
+    if [[ "${target}" == x86_64-apple-darwin* ]]; then
+        # LLVM 20 was built against the macOS 10.14 SDK, so PoCL needs it too.
+        # We can't upgrade the SDK in the real sys-root: it lives on a read-only
+        # overlay lower layer where removing/replacing directories fails with
+        # I/O errors, and merging the SDK on top hits symlink-vs-directory
+        # conflicts. So assemble a combined sysroot in a writable scratch dir
+        # and point the toolchain at it. The copy of the sys-root carries the
+        # things the bare SDK lacks (the toolchain's C++ headers, the build-time
+        # LLVM headers under usr/local), and in the scratch copy we can replace
+        # System the usual way.
+        apple_sysroot=$WORKSPACE/srcdir/sysroot
+        cp -a /opt/${target}/${target}/sys-root $apple_sysroot
+        tar --extract --file=$WORKSPACE/srcdir/MacOSX10.14.sdk.tar.xz \
+            --directory=$WORKSPACE/srcdir --warning=no-unknown-keyword \
+            MacOSX10.14.sdk/System MacOSX10.14.sdk/usr
+        rm -rf $apple_sysroot/System
+        cp -ra $WORKSPACE/srcdir/MacOSX10.14.sdk/usr/* $apple_sysroot/usr/.
+        cp -ra $WORKSPACE/srcdir/MacOSX10.14.sdk/System $apple_sysroot/.
+        # redirect every sys-root reference (--sysroot and -isysroot) at it
+        sed -i "s!/opt/${target}/${target}/sys-root!$apple_sysroot!g" ${CMAKE_TARGET_TOOLCHAIN}
+        sed -i "s!/opt/${target}/${target}/sys-root!$apple_sysroot!g" /opt/bin/${bb_full_target}/${target}-clang*
+        export MACOSX_DEPLOYMENT_TARGET=10.14
+    fi
+
+    ##########################################################################
+    # 1. Build the vendored SPIRV-LLVM-Translator as a static library.
+    #
+    # PoCL converts SPIR-V <-> LLVM IR with the SPIRV-LLVM-Translator. Using its
+    # `llvm-spirv` *binary* would mean shipping it (SPIRV_LLVM_Translator_jll) and
+    # wrapping it (to set up its library path) at run time. Instead we build the
+    # translator here as a static library and link it into libpocl. The catch (which
+    # bit us before, on macOS especially) is that the translator API passes
+    # `llvm::Module`s across the ABI boundary, so it must share a *single* LLVM with
+    # PoCL -- two LLVM copies means two sets of global state / type uniquing and is
+    # undefined behavior. We therefore build the translator against the same
+    # LLVM_full_jll and link it statically against LLVM's component libs
+    # (DISABLE_LLVM_LINK_LLVM_DYLIB), so libLLVMSPIRVLib.a contains only translator
+    # objects; their LLVM references resolve against PoCL's own statically-linked
+    # LLVM at the final libpocl link (single LLVM, ODR-safe).
+    ##########################################################################
+    # BB's cmake toolchain pins CMAKE_INSTALL_PREFIX to ${prefix}, so the translator
+    # installs there -- conveniently right where PoCL's cmake/LLVM.cmake looks
+    # (LLVM_INCLUDE_DIRS / LLVM_LIBDIR). We link it into libpocl below and then delete
+    # its artifacts from ${prefix} at the end, so they don't ship in the JLL.
+    spirv_src=$WORKSPACE/srcdir/SPIRV-LLVM-Translator
+    pushd $spirv_src
+    install_license LICENSE.TXT
+    atomic_patch -p1 $WORKSPACE/srcdir/patches/spirv-translator-addrspacecast_null.patch
+    # link statically against LLVM's component libraries rather than the LLVM dylib.
+    # Patch both the library and the llvm-spirv tool: otherwise the tool links *both*
+    # the LLVM dylib import-lib and the static components, which is fatal on COFF/lld
+    # (duplicate symbols). The tool is built by `ninja install` (and removed afterwards),
+    # but its link must succeed for the install -- hence the lib+headers we actually use.
+    sed -i '/add_llvm_library(/a DISABLE_LLVM_LINK_LLVM_DYLIB' lib/SPIRV/CMakeLists.txt
+    sed -i '/add_llvm_tool(/a DISABLE_LLVM_LINK_LLVM_DYLIB' tools/llvm-spirv/CMakeLists.txt
+
+    SPIRV_CMAKE_FLAGS=()
+    SPIRV_CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+    SPIRV_CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+    if [[ "${target}" == *mingw* ]]; then
+        # on Windows, we run into "multiple definition" errors when linking with gcc
+        SPIRV_CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake)
+        SPIRV_CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread")
+    else
+        SPIRV_CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+    fi
+    SPIRV_CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
+    # the static lib is linked into the shared libpocl, so it must be PIC
+    SPIRV_CMAKE_FLAGS+=(-DCMAKE_POSITION_INDEPENDENT_CODE=ON)
+    SPIRV_CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
+    SPIRV_CMAKE_FLAGS+=(-DBASE_LLVM_VERSION=20.1)
+    SPIRV_CMAKE_FLAGS+=(-DLLVM_SPIRV_INCLUDE_TESTS=OFF)
+    if [[ "${target}" == *-apple-darwin* ]]; then
+        cmake -B build -S . -GNinja ${SPIRV_CMAKE_FLAGS[@]} \
+            -DCMAKE_CXX_FLAGS="-Wno-error=enum-constexpr-conversion -include vector"
+    else
+        cmake -B build -S . -GNinja ${SPIRV_CMAKE_FLAGS[@]}
+    fi
+    ninja -C build -j ${nproc} install
+    popd
+
+    spirv_inc=${prefix}/include/LLVMSPIRVLib
+    spirv_lib=${prefix}/lib/libLLVMSPIRVLib.a
+    echo "Vendored SPIR-V translator: lib=${spirv_lib} include=${spirv_inc}"
+    if [[ ! -f "${spirv_lib}" || ! -f "${spirv_inc}/LLVMSPIRVLib.h" ]]; then
+        echo "ERROR: vendored translator library/headers not found" >&2
+        exit 1
+    fi
+    # Derive the maximum supported SPIR-V version from the translator headers, like
+    # PoCL >= 7.2 does. PoCL 7.1 instead derives it with a try_run, which cannot
+    # execute when cross-compiling, so we pre-seed the result below.
+    spirv_maxver_minor=$(grep -oE 'MaximumVersion = SPIRV_1_[0-9]+' ${spirv_inc}/LLVMSPIRVOpts.h | grep -oE '[0-9]+$')
+    spirv_maxver=$((65536 + spirv_maxver_minor * 256))
+    echo "Maximum SPIR-V version supported by the translator: ${spirv_maxver}"
+
+    ##########################################################################
+    # 2. Build PoCL.
+    ##########################################################################
+    cd $WORKSPACE/srcdir/pocl/
+    install_license LICENSE
+
+    # POCL wants a target sysroot for compiling the host kernellib (for `math.h` etc)
+    sysroot=/opt/${target}/${target}/sys-root
+    if [[ "${target}" == x86_64-apple-darwin* ]]; then
+        # use the combined sysroot assembled above
+        sysroot=$apple_sysroot
+    fi
+    if [[ "${target}" == *-mingw* ]]; then
+        sysroot_include=$sysroot/include
+    else
+        sysroot_include=$sysroot/usr/include
+    fi
+    if [[ "${target}" == *apple* ]]; then
+        # XXX: including the sysroot like this doesn't work on Apple, missing definitions like
+        #      TARGET_OS_IPHONE. it seems like these headers should be included using -isysroot,
+        #      but (a) that doesn't seem to work, and (b) isn't that already done by the cmake
+        #      toolchain file? work around the issue by inserting an include for the missing
+        #      definitions at the top of the headers included from POCL's kernel library.
+        sed -i '1s/^/#include <TargetConditionals.h>\n/' $sysroot_include/stdio.h
+    fi
+    sed -i "s|COMMENT \\"Building C to LLVM bitcode \${BC_FILE}\\"|\\"-I$sysroot_include\\"|" \
+        cmake/bitcode_rules.cmake
+
+    # our version of MinGW is ancient (?) and lacks `_aligned_malloc`
+    sed -i 's/_aligned_malloc/__mingw_aligned_malloc/g' include/vccompat.hpp
+
+    CMAKE_FLAGS=()
+
+    # Release build for best performance
+    CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
+
+    # Disable build mode
+    CMAKE_FLAGS+=(-DENABLE_POCL_BUILDING:Bool=OFF)
+
+    # Don't build tests
+    CMAKE_FLAGS+=(-DENABLE_TESTS:Bool=OFF)
+
+    # Enable optional debug messages for debuggability
+    CMAKE_FLAGS+=(-DPOCL_DEBUG_MESSAGES:Bool=ON)
+
+    # Install things into $prefix
+    CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
+
+    # Explicitly use our cmake toolchain file and tell CMake we're cross-compiling.
+    if [[ "${target}" == *mingw* ]]; then
+        # Build PoCL with the Clang/lld toolchain on Windows. The default GCC toolchain
+        # links with GNU ld, which is pathologically slow at producing a PE/COFF DLL out
+        # of the large static LLVM/Clang archives: the final libpocl link took ~25 min and
+        # CMake's LLVM/Clang link tests (try_compile against static LLVM) another ~13 min,
+        # together dominating the ~45 min Windows build. Clang defaults to lld, which links
+        # the same DLL in a fraction of the time; the link tests inherit the toolchain, so
+        # the configure-time cost disappears too. Clang also matches the Clang-built
+        # LLVM_full_jll and vendored translator, avoiding the GCC-vs-Clang COMDAT mismatch.
+        # The COFF export model this needs -- dllexport the public API + --exclude-all-symbols
+        # (lld can't --exclude-libs the static LLVM out of auto-export, which would overflow
+        # the 64K PE export limit) -- lives in the pinned pocl commit, and it requires the
+        # ENABLE_LOADABLE_DRIVERS=OFF set below.
+        CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake)
+    else
+        CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+    fi
+    CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
+
+    # Point to relevant LLVM tools (see above)
+    ## HostDependency: llvm-config, but spoofed to return Dependency's paths
+    CMAKE_FLAGS+=(-DWITH_LLVM_CONFIG=$WORKSPACE/srcdir/llvm-config)
+    ## Native toolchain: for LLVM tools to ensure they can target the right architecture
+    CMAKE_FLAGS+=(-DLLVM_BINDIR=/opt/$MACHTYPE/bin)
+    if [[ "${target}" == *mingw* ]]; then
+        # XXX: fake .exe binaries so CMake finds them (PoCL isn't good at cross-compilation)
+        for tool in clang clang++ llvm-as llvm-dis llvm-link opt llc lli; do
+            ln -s /opt/$MACHTYPE/bin/$tool /opt/$MACHTYPE/bin/$tool.exe
+        done
+    fi
+
+    # Override the target and triple, which POCL takes from `llvm-config --host-target`
+    triple=$(clang -print-target-triple)
+    CMAKE_FLAGS+=(-DLLVM_HOST_TARGET=$triple)
+    CMAKE_FLAGS+=(-DLLC_TRIPLE=$triple)
+
+    # Override the auto-detected target CPU (which POCL takes from `llc --version`)
+    CPU=$(clang --print-supported-cpus 2>&1 | grep -P '\t' | head -n 1 | sed 's/\s//g')
+    CMAKE_FLAGS+=(-DLLC_HOST_CPU_AUTO=$CPU)
+
+    # Generate a portable build
+    CMAKE_FLAGS+=(-DKERNELLIB_HOST_CPU_VARIANTS=distro)
+
+    # Each work-item's private memory is laid out on the worker thread's stack
+    # and replicated across the work-group, so a private-heavy kernel at a large
+    # work-group size can overflow the default thread stack (only 512 KB on
+    # macOS, 1 MB on Windows) and crash. Enabling this makes PoCL estimate the
+    # per-work-item stack usage and clamp the kernel's reported
+    # CL_KERNEL_WORK_GROUP_SIZE accordingly, so launches fit (and over-large ones
+    # are rejected with CL_INVALID_WORK_GROUP_SIZE) instead of segfaulting.
+    CMAKE_FLAGS+=(-DHOST_CPU_ENABLE_STACK_SIZE_CHECK:Bool=ON)
+
+    if [[ "${STANDALONE}" == "true" ]]; then
+        # Build a directly-linkable library instead of an OpenCL ICD driver.
+        CMAKE_FLAGS+=(-DENABLE_ICD:BOOL=OFF)
+        # Rename PoCL's OpenCL entrypoints to PO<cl_function>, so the standalone library can
+        # coexist in-process with a real OpenCL ICD loader (e.g. one targeting other GPUs).
+        CMAKE_FLAGS+=(-DRENAME_POCL:BOOL=ON)
+        # With ENABLE_ICD=OFF, PoCL names the library "OpenCL" (libOpenCL.so), which would
+        # collide with the system ICD loader. Rename it so it ships as a distinct product.
+        sed -i 's/set(POCL_LIBRARY_NAME "OpenCL")/set(POCL_LIBRARY_NAME "pocl_standalone")/' CMakeLists.txt
+    else
+        # Build POCL as an dynamic library loaded by the OpenCL runtime
+        CMAKE_FLAGS+=(-DENABLE_ICD:BOOL=ON)
+    fi
+
+    # Link the CPU device drivers (basic, pthread) straight into libpocl on every platform
+    # rather than building them as separately-dlopen'd modules. We ship a fixed CPU-only set,
+    # so loadable modules add no capability; inlining keeps one self-contained library (no
+    # runtime driver-DLL discovery), consistent across platforms. It is also *required* on
+    # Windows, where libpocl is linked with lld and exports only its dllexport'd public API
+    # (--exclude-all-symbols): loadable modules can't import libpocl's internal pocl_driver_*
+    # ABI across that boundary. (For the standalone build it additionally avoids clashes, as
+    # RENAME_POCL only renames the public API.)
+    CMAKE_FLAGS+=(-DENABLE_LOADABLE_DRIVERS:BOOL=OFF)
+
+    # XXX: work around pocl#1776, disabling FP16 support for FreeBSD
+    if [[ ${target} == *-freebsd* ]]; then
+        CMAKE_FLAGS+=(-DHOST_COMPILER_SUPPORTS_FLOAT16:BOOL=OFF)
+    fi
+
+    # Link LLVM statically so that we don't have to worry about versioning the JLL against it
+    CMAKE_FLAGS+=(-DSTATIC_LLVM:Bool=ON)
+    # XXX: we add -pthread to the flags used to link libLLVM, so need that here too
+    #      (as that is not reflected by llvm-config)
+    if [[ "${target}" == *mingw* ]]; then
+        # PoCL is built with the Clang/lld toolchain on Windows (see above). Add -pthread to
+        # every link mode (not just executables): it pulls in libwinpthread, which Clang's
+        # windows-gnu driver -- unlike GCC's -- does not link implicitly, and it matches the
+        # -pthread we use when linking libLLVM (not reflected by llvm-config). Keep
+        # --allow-multiple-definition as a guard against duplicate COMDAT/weak template
+        # instantiations across the statically-linked LLVM/Clang/translator archives.
+        CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
+        CMAKE_FLAGS+=(-DCMAKE_SHARED_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
+        CMAKE_FLAGS+=(-DCMAKE_MODULE_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
+    else
+        CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread")
+    fi
+
+    # Enable SPIR-V support via the vendored translator *library* (built above), linked
+    # statically into libpocl (the macOS ODR hazard that previously forced the binary
+    # path is gone now that the translator shares PoCL's static LLVM, whose symbols are
+    # hidden on macOS via -hidden-l). Pre-seed the cache variables cmake/LLVM.cmake
+    # would otherwise probe: the lib/include paths it searches for, and the
+    # HAVE/MAXVER results it would derive from a try_run (which cannot execute when
+    # cross-compiling). We do NOT provide an llvm-spirv binary, so the binary code
+    # path stays off and no run-time translator package or wrapper is needed.
+    CMAKE_FLAGS+=(-DLLVM_SPIRV_INCLUDEDIR=${spirv_inc})
+    CMAKE_FLAGS+=(-DLLVM_SPIRV_LIB=${spirv_lib})
+    CMAKE_FLAGS+=(-DHAVE_LLVM_SPIRV_LIB:BOOL=ON)
+    CMAKE_FLAGS+=(-DLLVM_SPIRV_LIB_MAXVER=${spirv_maxver})
+
+    # PoCL's CPU autodetection doesn't work on RISC-V
+    if [[ ${target} == riscv64-* ]]; then
+        CMAKE_FLAGS+=(-DLLC_HOST_CPU=rv64gc)
+        # forcing a CPU disables distro kernellib mode, so only provide a native build
+        CMAKE_FLAGS+=(-DKERNELLIB_HOST_CPU_VARIANTS=native)
+    fi
+
+    # XXX: PoCL defaults to not using shared libraries on MinGW -- this seems to work fine?
+    CMAKE_FLAGS+=(-DBUILD_SHARED_LIBS=ON)
+
+    cmake -B build -S . -GNinja ${CMAKE_FLAGS[@]}
+    ninja -C build -j ${nproc} install
+
+    # The vendored translator is now statically linked into libpocl; remove its build
+    # artifacts (static lib, generated headers, pkg-config, the unused llvm-spirv binary)
+    # from the prefix so they don't ship in the JLL.
+    rm -rf ${prefix}/include/LLVMSPIRVLib
+    rm -f ${prefix}/lib/libLLVMSPIRVLib.a \
+          ${prefix}/lib/pkgconfig/LLVMSPIRVLib.pc \
+          ${prefix}/bin/llvm-spirv ${prefix}/bin/llvm-spirv.exe
+
+    # PoCL uses Clang, which relies on certain system libraries Clang_jll.jl doesn't provide
+    mkdir -p $prefix/share/lib
+    if [[ ${target} == *-linux-gnu ]]; then
+        if [[ ${target} == riscv64-* ]]; then
+            cp -va $sysroot/lib64/lp64d/libc.* $prefix/share/lib
+            cp -va $sysroot/usr/lib64/lp64d/libm.* $prefix/share/lib
+            ln -vsf libm.so.6 $prefix/share/lib/libm.so
+            cp -va $sysroot/lib64/lp64d/libm.* $prefix/share/lib
+            cp -va /opt/${target}/${target}/lib/libgcc_s.* $prefix/share/lib
+        elif [[ "${nbits}" == 64 ]]; then
+            cp -va $sysroot/lib64/libc{.,-}* $prefix/share/lib
+            cp -va $sysroot/usr/lib64/libm.* $prefix/share/lib
+            ln -vsf libm.so.6 $prefix/share/lib/libm.so
+            cp -va $sysroot/lib64/libm{.,-}* $prefix/share/lib
+            cp -va /opt/${target}/${target}/lib64/libgcc_s.* $prefix/share/lib
+        else
+            cp -va $sysroot/lib/libc{.,-}* $prefix/share/lib
+            cp -va $sysroot/usr/lib/libm.* $prefix/share/lib
+            ln -vsf libm.so.6 $prefix/share/lib/libm.so
+            cp -va $sysroot/lib/libm{.,-}* $prefix/share/lib
+            cp -va /opt/${target}/${target}/lib/libgcc_s.* $prefix/share/lib
+        fi
+        cp -va /opt/$target/lib/gcc/$target/*/*.{o,a} $prefix/share/lib
+    elif [[ ${target} == *-linux-musl ]]; then
+        cp -va $sysroot/usr/lib/*.{o,a} $prefix/share/lib
+        cp -va /opt/$target/lib/gcc/$target/*/*.{o,a} $prefix/share/lib
+    elif [[ "${target}" == *-mingw* ]]; then
+        cp -va $sysroot/lib/*.o $prefix/share/lib
+        cp -va $sysroot/lib/libmsvcrt*.a $prefix/share/lib
+        cp -va $sysroot/lib/libucrt*.a $prefix/share/lib
+        cp -va $sysroot/lib/libm.a $prefix/share/lib
+        cp -va $sysroot/lib/lib{kernel,user,shell}32.a $prefix/share/lib
+        cp -va $sysroot/lib/libmingw*.a $prefix/share/lib
+        cp -va $sysroot/lib/libmoldname.a $prefix/share/lib
+        cp -va $sysroot/lib/libadvapi32.a $prefix/share/lib
+        cp -va /opt/${target}/${target}/lib/libgcc* $prefix/share/lib
+        cp -va /opt/$target/lib/gcc/$target/*/*.{o,a} $prefix/share/lib
+    elif [[ "${target}" == *-apple-darwin* ]]; then
+        cp -va $sysroot/usr/lib/crt1.o $prefix/share/lib
+        cp -va $sysroot/usr/lib/libSystem.*tbd $prefix/share/lib
+        cp -va $sysroot/usr/lib/libm.*tbd $prefix/share/lib
+        cp -va $sysroot/usr/lib/libgcc_s.*tbd $prefix/share/lib
+    fi
+    """
+end
+
+function init_block(standalone=false)
+
+    opencl = raw"""
+    # Register this driver with OpenCL_jll
+    if OpenCL_jll.is_available()
+        push!(OpenCL_jll.drivers, libpocl)
+
+        # XXX: Clang_jll does not have a functional clang binary on macOS,
+        #      as it's configured without a default sdkroot (see #9221)
+        if Sys.isapple()
+            ENV["SDKROOT"] = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+        end
+    end
+    """
+
+    # The standalone build is linked directly rather than loaded through an OpenCL ICD
+    # loader, so it has no driver to register (and no OpenCL_jll dependency). It still uses
+    # Clang_jll at run time to compile kernels, so it needs the same macOS SDK fix that the
+    # regular build applies inside the OpenCL block above.
+    macos_sdk = raw"""
+    # XXX: Clang_jll does not have a functional clang binary on macOS,
+    #      as it's configured without a default sdkroot (see #9221)
+    if Sys.isapple()
+        ENV["SDKROOT"] = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+    end
+    """
+
+    pocl_binaries = raw"""
+    # expose JLL binaries to the library
+    # XXX: Scratch.jl is unusably slow with JLLWrapper-emitted @compiler_options
+    #bindir = @get_scratch!("bin")
+    bindir = abspath(first(Base.DEPOT_PATH), "scratchspaces", string(Base.PkgId(@__MODULE__).uuid), "bin")
+    mkpath(bindir)
+    function generate_wrapper_script(name, path, LIBPATH, PATH)
+        if Sys.iswindows()
+            LIBPATH_env = "PATH"
+            LIBPATH_default = ""
+            pathsep = ';'
+        elseif Sys.isapple()
+            LIBPATH_env = "DYLD_FALLBACK_LIBRARY_PATH"
+            LIBPATH_default = "~/lib:/usr/local/lib:/lib:/usr/lib"
+            pathsep = ':'
+        else
+            LIBPATH_env = "LD_LIBRARY_PATH"
+            LIBPATH_default = ""
+            pathsep = ':'
+        end
+
+        # XXX: cache, but invalidate when deps change
+
+        # write to temporary script
+        temp_script, io = mktemp(bindir; cleanup=false)
+        script = if Sys.isunix()
+            println(io, "#!/bin/bash")
+
+            LIBPATH_base = get(ENV, LIBPATH_env, expanduser(LIBPATH_default))
+            LIBPATH_value = if !isempty(LIBPATH_base)
+                string(LIBPATH, pathsep, LIBPATH_base)
+            else
+                LIBPATH
+            end
+            println(io, "export $LIBPATH_env=\\"$LIBPATH_value\\"")
+
+            if LIBPATH_env != "PATH"
+                PATH_base = get(ENV, "PATH", "")
+                PATH_value = if !isempty(PATH_base)
+                    string(PATH, pathsep, ENV["PATH"])
+                else
+                    PATH
+                end
+                println(io, "export PATH=\\"$PATH_value\\"")
+            end
+
+            println(io, "exec \\"$path\\" \\"\$@\\"")
+            close(io)
+            chmod(temp_script, 0o755)
+            joinpath(bindir, name)
+        elseif Sys.iswindows()
+            println(io, "@echo off")
+
+            LIBPATH_base = get(ENV, LIBPATH_env, expanduser(LIBPATH_default))
+            LIBPATH_value = if !isempty(LIBPATH_base)
+                string(LIBPATH, pathsep, LIBPATH_base)
+            else
+                LIBPATH
+            end
+            println(io, "set \\"$LIBPATH_env=$LIBPATH_value\\"")
+
+            println(io, "call \\"$path\\" %*")
+
+            # XXX: on Windows, the Base.rename below often throws EBUSY, so include the PID
+            joinpath(bindir, "$(name).$(getpid()).bat")
+        else
+            error("Unsupported platform")
+        end
+        close(io)
+
+        # atomically move to the final location
+        @static if VERSION >= v"1.12.0-DEV.1023"
+            mv(temp_script, script; force=true)
+        else
+            Base.rename(temp_script, script, force=true)
+        end
+
+        return script
+    end
+    # NOTE: no spirv-link wrapper -- that tool (SPIRV_Tools_jll) is only used by the
+    # Level Zero driver, which this CPU-only build does not enable (ENABLE_LEVEL0=OFF).
+    ENV["POCL_PATH_CLANG"] =
+        generate_wrapper_script("clang", Clang_unified_jll.clang_path,
+                                Clang_unified_jll.LIBPATH[], Clang_unified_jll.PATH[])
+    ld_path = if Sys.islinux()
+            LLD_unified_jll.ld_lld_path
+        elseif Sys.isapple()
+            LLD_unified_jll.ld64_lld_path
+        elseif Sys.iswindows()
+            # PoCL doesn't use MSVC-style linker arguments, so still use the GNU ld wrapper.
+            LLD_unified_jll.ld_lld_path
+        else
+            error("Unsupported platform")
+        end
+    ld_wrapper = generate_wrapper_script("lld", ld_path,
+                                         LLD_unified_jll.LIBPATH[],
+                                         LLD_unified_jll.PATH[])
+
+    # expose libc to Clang, even if the system doesn't have development symlinks
+    libdir = abspath(first(Base.DEPOT_PATH), "scratchspaces", string(Base.PkgId(@__MODULE__).uuid), "lib")
+    mkpath(libdir)
+    for lib in Libdl.dllist()
+        startswith(basename(lib), "libc.so.6") || continue
+        link = joinpath(libdir, "libc.so")
+        try
+            symlink(lib, link)
+        catch
+            # can't safely check first, because multiple processes may be running
+            islink(link) || rethrow()
+        end
+    end
+    if Sys.iswindows()
+        # BUG: using native (backwards) slashes breaks Clang's --ld-path
+        ld_wrapper = replace(ld_wrapper, '\\' => '/')
+    end
+    ENV["POCL_ARGS_CLANG"] = join([
+            "-fuse-ld=lld", "--ld-path=$ld_wrapper",
+            "-L", joinpath(artifact_dir, "share", "lib"),
+            "-L", libdir
+        ], ";")
+    """
+
+    if standalone
+        return macos_sdk * pocl_binaries
+    else
+        return opencl * pocl_binaries
+    end
+end
+
 
 # LLVM 20 was built against the macOS 10.14 SDK, so ship it. We only use the
 # helper for the (centralized) SDK source; the install itself is done
-# non-destructively in common.jl, which extracts the SDK to a scratch dir and
+# non-destructively in the build script below, which extracts the SDK to a scratch dir and
 # redirects the toolchain at it, rather than overwriting the read-only sys-root
 # (whose `System` tree can no longer be `rm`'d on the current rootfs).
 sources = vcat(sources, get_macos_sdk_sources("10.14"))
@@ -72,11 +565,12 @@ dependencies = [
     Dependency("OpenCL_Headers_jll"),
     Dependency("Hwloc_jll"),
     Dependency("Zstd_jll"), # our LLVM 20 build has LLVM_ENABLE_ZSTD=ON
-    # the SPIR-V translator is vendored and statically linked (see common.jl), so
-    # SPIRV_LLVM_Translator_jll is no longer needed at run time.
-    # only used at run time, but also detected by the build
-    Dependency("SPIRV_Tools_jll"),
-    # only used at run time
+    # the SPIR-V translator is vendored and statically linked (see the build script
+    # below), so SPIRV_LLVM_Translator_jll is no longer needed at run time. SPIRV_Tools_jll
+    # (spirv-link) is not needed either: it is only consumed by the Level Zero driver, which
+    # this CPU-only build does not enable.
+    # clang + lld are invoked at run time to compile and link CPU kernels (the 7.1 series has
+    # no in-process JIT), so these two are still required.
     RuntimeDependency("Clang_unified_jll"),
     RuntimeDependency("LLD_unified_jll")
 ]

--- a/P/pocl/pocl_next/build_tarballs.jl
+++ b/P/pocl/pocl_next/build_tarballs.jl
@@ -7,44 +7,10 @@ const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
-#=
-
-`pocl_next` is the experimental track of PoCL, built from the upcoming 7.2 branch
-(JuliaGPU/pocl#release_7_2). It is intentionally self-contained (no shared `common.jl`)
-so we are free to iterate on it without touching the stable `pocl`/`pocl_standalone`
-recipes. The goal is a JLL that needs *no* run-time helper tooling: no wrapper scripts,
-no bundled startup files, no external clang/lld/llvm-spirv. The init block does nothing
-but register the driver.
-
-Two upstream/build changes make that possible:
-
-1. JIT (upstream PR #2190): CPU host kernels are loaded in-process via LLVM ORC/JITLink
-   instead of being compiled to a shared object and dlopen()ed. JITLink is both the
-   linker and the loader, so there is no external link step:
-
-     - no `lld` invocation       -> no LLD wrapper, no LLD_unified_jll
-     - no Clang driver link step -> no Clang wrapper (the frontend runs in-process via
-                                    libclang, and codegen emits the object in-process)
-     - no startup files / libc   -> the JIT resolves libc/libm/compiler-rt via normal
-       / libgcc to bundle           process-symbol lookup, so we drop the `share/lib`
-                                    staging the 7.1 recipe needed for the external link
-
-   We also build without the Level Zero driver (`-DENABLE_LEVEL0=OFF`), the only consumer
-   of `spirv-link`, so SPIRV_Tools_jll goes away too.
-
-2. SPIR-V via the translator *library*, vendored. PoCL converts SPIR-V <-> LLVM IR with
-   the SPIRV-LLVM-Translator. Using its `llvm-spirv` *binary* would mean shipping it and
-   wrapping it (to set up its library path) at run time. Instead we build the translator
-   here as a static library and link it into libpocl. The catch (which bit us before, on
-   macOS especially) is that the translator API passes `llvm::Module`s across the ABI
-   boundary, so it must share a *single* LLVM with PoCL -- two LLVM copies means two sets
-   of global state / type uniquing and is undefined behavior. We therefore build the
-   translator against the *same* LLVM_full_jll and link it statically against LLVM's
-   component libraries (DISABLE_LLVM_LINK_LLVM_DYLIB), so libLLVMSPIRVLib.a carries only
-   translator objects whose LLVM references resolve against PoCL's own statically-linked
-   LLVM at the final link. One LLVM copy, ODR-safe, and no SPIRV_LLVM_Translator_jll.
-
-=#
+# `pocl_next` is the 7.2 track of PoCL: an OpenCL ICD driver built with the in-process
+# JIT (no run-time clang/lld/llvm-spirv tooling). The actual build lives in ../common.jl,
+# shared with the `pocl_standalone` (OpenCL-less) variant and selected via its `standalone`
+# argument (false here). See ../common.jl for the full rationale.
 
 name = "pocl_next"
 version = v"7.2.0"
@@ -55,9 +21,10 @@ version = v"7.2.0"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/JuliaGPU/pocl",
-              "c0f035dcfafb1d412adc3d5c1015f90fd7f81d27"),
-    # vendored SPIR-V translator, built as a static library against our LLVM (see above);
-    # this commit is the LLVM-20.1-compatible revision (matches LLVM_full_jll 20.1.2).
+              "88a7a839b58ff7f0e3720f58ed858eaf1480111b"),
+    # vendored SPIR-V translator, built as a static library against our LLVM (see
+    # common.jl); this commit is the LLVM-20.1-compatible revision (matches
+    # LLVM_full_jll 20.1.2).
     GitSource("https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",
               "dee371987a59ed8654083c09c5f1d5c54f5db318"),
 ]
@@ -79,298 +46,6 @@ builds of LLVM we need:
 
 =#
 
-function build_script()
-    raw"""
-    # macOS SDK setup, shared by both the translator and PoCL builds below (it redirects
-    # the toolchain, so it must run before either of them).
-    if [[ "${target}" == x86_64-apple-darwin* ]]; then
-        # LLVM 20 was built against the macOS 10.14 SDK, so PoCL needs it too.
-        # We can't upgrade the SDK in the real sys-root: it lives on a read-only
-        # overlay lower layer where removing/replacing directories fails with
-        # I/O errors, and merging the SDK on top hits symlink-vs-directory
-        # conflicts. So assemble a combined sysroot in a writable scratch dir
-        # and point the toolchain at it. The copy of the sys-root carries the
-        # things the bare SDK lacks (the toolchain's C++ headers, the build-time
-        # LLVM headers under usr/local), and in the scratch copy we can replace
-        # System the usual way.
-        apple_sysroot=$WORKSPACE/srcdir/sysroot
-        cp -a /opt/${target}/${target}/sys-root $apple_sysroot
-        tar --extract --file=$WORKSPACE/srcdir/MacOSX10.14.sdk.tar.xz \
-            --directory=$WORKSPACE/srcdir --warning=no-unknown-keyword \
-            MacOSX10.14.sdk/System MacOSX10.14.sdk/usr
-        rm -rf $apple_sysroot/System
-        cp -ra $WORKSPACE/srcdir/MacOSX10.14.sdk/usr/* $apple_sysroot/usr/.
-        cp -ra $WORKSPACE/srcdir/MacOSX10.14.sdk/System $apple_sysroot/.
-        # redirect every sys-root reference (--sysroot and -isysroot) at it
-        sed -i "s!/opt/${target}/${target}/sys-root!$apple_sysroot!g" ${CMAKE_TARGET_TOOLCHAIN}
-        sed -i "s!/opt/${target}/${target}/sys-root!$apple_sysroot!g" /opt/bin/${bb_full_target}/${target}-clang*
-        export MACOSX_DEPLOYMENT_TARGET=10.14
-    fi
-
-    ##########################################################################
-    # 1. Build the vendored SPIRV-LLVM-Translator as a static library.
-    #
-    # Built against the same LLVM_full_jll as PoCL and linked statically against
-    # LLVM's component libs (DISABLE_LLVM_LINK_LLVM_DYLIB), so libLLVMSPIRVLib.a
-    # contains only translator objects; their LLVM references resolve against
-    # PoCL's own static LLVM at the final libpocl link (single LLVM, ODR-safe).
-    ##########################################################################
-    # BB's cmake toolchain pins CMAKE_INSTALL_PREFIX to ${prefix}, so the translator
-    # installs there -- conveniently right where PoCL's SetupLLVMSPIRV.cmake looks
-    # (LLVM_INCLUDE_DIRS / LLVM_LIBDIR). We link it into libpocl below and then delete
-    # its artifacts from ${prefix} at the end, so they don't ship in the JLL.
-    spirv_src=$WORKSPACE/srcdir/SPIRV-LLVM-Translator
-    pushd $spirv_src
-    install_license LICENSE.TXT
-    atomic_patch -p1 $WORKSPACE/srcdir/patches/spirv-translator-addrspacecast_null.patch
-    # link statically against LLVM's component libraries rather than the LLVM dylib.
-    # Patch both the library and the llvm-spirv tool: otherwise the tool links *both*
-    # the LLVM dylib import-lib and the static components, which is fatal on COFF/lld
-    # (duplicate symbols). The tool is built by `ninja install` (and removed afterwards),
-    # but its link must succeed for the install -- hence the lib+headers we actually use.
-    sed -i '/add_llvm_library(/a DISABLE_LLVM_LINK_LLVM_DYLIB' lib/SPIRV/CMakeLists.txt
-    sed -i '/add_llvm_tool(/a DISABLE_LLVM_LINK_LLVM_DYLIB' tools/llvm-spirv/CMakeLists.txt
-
-    SPIRV_CMAKE_FLAGS=()
-    SPIRV_CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
-    SPIRV_CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
-    if [[ "${target}" == *mingw* ]]; then
-        # on Windows, we run into "multiple definition" errors when linking with gcc
-        SPIRV_CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake)
-        SPIRV_CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread")
-    else
-        SPIRV_CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
-    fi
-    SPIRV_CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
-    # the static lib is linked into the shared libpocl, so it must be PIC
-    SPIRV_CMAKE_FLAGS+=(-DCMAKE_POSITION_INDEPENDENT_CODE=ON)
-    SPIRV_CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
-    SPIRV_CMAKE_FLAGS+=(-DBASE_LLVM_VERSION=20.1)
-    SPIRV_CMAKE_FLAGS+=(-DLLVM_SPIRV_INCLUDE_TESTS=OFF)
-    if [[ "${target}" == *-apple-darwin* ]]; then
-        cmake -B build -S . -GNinja ${SPIRV_CMAKE_FLAGS[@]} \
-            -DCMAKE_CXX_FLAGS="-Wno-error=enum-constexpr-conversion -include vector"
-    else
-        cmake -B build -S . -GNinja ${SPIRV_CMAKE_FLAGS[@]}
-    fi
-    ninja -C build -j ${nproc} install
-    popd
-
-    spirv_inc=${prefix}/include/LLVMSPIRVLib
-    spirv_lib=${prefix}/lib/libLLVMSPIRVLib.a
-    echo "Vendored SPIR-V translator: lib=${spirv_lib} include=${spirv_inc}"
-    if [[ ! -f "${spirv_lib}" || ! -f "${spirv_inc}/LLVMSPIRVLib.h" ]]; then
-        echo "ERROR: vendored translator library/headers not found" >&2
-        exit 1
-    fi
-
-    ##########################################################################
-    # 2. Build PoCL.
-    ##########################################################################
-    cd $WORKSPACE/srcdir/pocl/
-    install_license LICENSE
-
-    # POCL wants a target sysroot for compiling the host kernellib (for `math.h` etc)
-    sysroot=/opt/${target}/${target}/sys-root
-    if [[ "${target}" == x86_64-apple-darwin* ]]; then
-        # use the combined sysroot assembled above
-        sysroot=$apple_sysroot
-    fi
-    if [[ "${target}" == *-mingw* ]]; then
-        sysroot_include=$sysroot/include
-    else
-        sysroot_include=$sysroot/usr/include
-    fi
-    if [[ "${target}" == *apple* ]]; then
-        # XXX: including the sysroot like this doesn't work on Apple, missing definitions like
-        #      TARGET_OS_IPHONE. it seems like these headers should be included using -isysroot,
-        #      but (a) that doesn't seem to work, and (b) isn't that already done by the cmake
-        #      toolchain file? work around the issue by inserting an include for the missing
-        #      definitions at the top of the headers included from POCL's kernel library.
-        sed -i '1s/^/#include <TargetConditionals.h>\n/' $sysroot_include/stdio.h
-    fi
-    sed -i "s|COMMENT \\"Building C to LLVM bitcode \${BC_FILE}\\"|\\"-I$sysroot_include\\"|" \
-        cmake/bitcode_rules.cmake
-
-    # our version of MinGW is ancient (?) and lacks `_aligned_malloc`
-    sed -i 's/_aligned_malloc/__mingw_aligned_malloc/g' include/vccompat.hpp
-
-    CMAKE_FLAGS=()
-
-    # Release build for best performance
-    CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
-
-    # Disable build mode
-    CMAKE_FLAGS+=(-DENABLE_POCL_BUILDING:Bool=OFF)
-
-    # Don't build tests
-    CMAKE_FLAGS+=(-DENABLE_TESTS:Bool=OFF)
-
-    # Enable optional debug messages for debuggability
-    CMAKE_FLAGS+=(-DPOCL_DEBUG_MESSAGES:Bool=ON)
-
-    # Install things into $prefix
-    CMAKE_FLAGS+=(-DCMAKE_INSTALL_PREFIX=${prefix})
-
-    # Explicitly use our cmake toolchain file and tell CMake we're cross-compiling.
-    if [[ "${target}" == *mingw* ]]; then
-        # Build PoCL with the Clang/lld toolchain on Windows; GNU ld is pathologically slow
-        # at producing a PE/COFF DLL from the large static LLVM/Clang archives (see the
-        # export-model notes above). Mirrors what the SPIR-V translator already uses.
-        CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN%.*}_clang.cmake)
-    else
-        CMAKE_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
-    fi
-    CMAKE_FLAGS+=(-DCMAKE_CROSSCOMPILING:BOOL=ON)
-
-    # PoCL 7.2 looks for the *host* LLVM tools (clang, opt, llc, ...) in the directory
-    # of the llvm-config we pass (LLVM_CONFIG_LOCATION), whereas 7.1 used LLVM_BINDIR.
-    # Our llvm-config is a wrapper script living alone in srcdir, so assemble a bin dir
-    # that holds it alongside symlinks to the native host LLVM tools, and point
-    # WITH_LLVM_CONFIG there.
-    llvm_host_bin=$WORKSPACE/srcdir/llvm-host-bin
-    mkdir -p $llvm_host_bin
-    cp $WORKSPACE/srcdir/llvm-config $llvm_host_bin/llvm-config
-    chmod +x $llvm_host_bin/llvm-config
-    for tool in clang clang++ opt llc llvm-as llvm-dis llvm-link; do
-        ln -sf /opt/$MACHTYPE/bin/$tool $llvm_host_bin/$tool
-        # on mingw targets CMake appends .exe when searching, so provide that name too
-        # (the host tools are ELF binaries; the suffix is just what find_program looks for)
-        ln -sf /opt/$MACHTYPE/bin/$tool $llvm_host_bin/$tool.exe
-    done
-
-    # Point to relevant LLVM tools (see above). The target-side dependencies live
-    # under ${prefix} (which is a symlink to the per-target destdir).
-    ## Target-side LLVM CMake package. PoCL 7.2 requires LLVM_DIR (the target
-    ## LLVMConfig.cmake) *in addition* to the spoofed llvm-config when cross-compiling
-    ## (cmake/LLVM.cmake); their major.minor versions must agree (both LLVM 20).
-    CMAKE_FLAGS+=(-DLLVM_DIR=${prefix}/lib/cmake/llvm)
-    ## HostDependency: llvm-config, but spoofed to return Dependency's paths
-    CMAKE_FLAGS+=(-DWITH_LLVM_CONFIG=$llvm_host_bin/llvm-config)
-    ## Native toolchain: for LLVM tools to ensure they can target the right architecture
-    CMAKE_FLAGS+=(-DLLVM_BINDIR=/opt/$MACHTYPE/bin)
-    if [[ "${target}" == *mingw* ]]; then
-        # XXX: fake .exe binaries so CMake finds them (PoCL isn't good at cross-compilation)
-        for tool in clang clang++ llvm-as llvm-dis llvm-link opt llc lli; do
-            ln -s /opt/$MACHTYPE/bin/$tool /opt/$MACHTYPE/bin/$tool.exe
-        done
-    fi
-
-    # Override the target and triple, which POCL takes from `llvm-config --host-target`
-    triple=$(clang -print-target-triple)
-    CMAKE_FLAGS+=(-DLLVM_HOST_TARGET=$triple)
-    CMAKE_FLAGS+=(-DLLC_TRIPLE=$triple)
-
-    # Override the auto-detected target CPU (which POCL takes from `llc --version`)
-    CPU=$(clang --print-supported-cpus 2>&1 | grep -P '\t' | head -n 1 | sed 's/\s//g')
-    CMAKE_FLAGS+=(-DLLC_HOST_CPU_AUTO=$CPU)
-
-    # Generate a portable build
-    CMAKE_FLAGS+=(-DKERNELLIB_HOST_CPU_VARIANTS=distro)
-
-    # Each work-item's private memory is laid out on the worker thread's stack
-    # and replicated across the work-group, so a private-heavy kernel at a large
-    # work-group size can overflow the default thread stack (only 512 KB on
-    # macOS, 1 MB on Windows) and crash. Enabling this makes PoCL estimate the
-    # per-work-item stack usage and clamp the kernel's reported
-    # CL_KERNEL_WORK_GROUP_SIZE accordingly, so launches fit (and over-large ones
-    # are rejected with CL_INVALID_WORK_GROUP_SIZE) instead of segfaulting.
-    CMAKE_FLAGS+=(-DHOST_CPU_ENABLE_STACK_SIZE_CHECK:Bool=ON)
-
-    # Build PoCL as a dynamic library loaded by the OpenCL runtime
-    CMAKE_FLAGS+=(-DENABLE_ICD:BOOL=ON)
-
-    # Link the CPU device drivers (basic, pthread) straight into libpocl on every platform
-    # rather than building them as separately-dlopen'd modules. We ship a fixed CPU-only set,
-    # so loadable modules add no capability; inlining keeps one self-contained library (no
-    # runtime driver-DLL discovery), consistent across platforms. It is also *required* on
-    # Windows, where libpocl is linked with lld and exports only its dllexport'd public API
-    # (--exclude-all-symbols): loadable modules can't import libpocl's internal pocl_driver_*
-    # ABI across that boundary.
-    CMAKE_FLAGS+=(-DENABLE_LOADABLE_DRIVERS:BOOL=OFF)
-
-    # Load CPU host kernels in-process via ORC/JITLink instead of Clang+dlopen.
-    # This is the whole point of pocl_next: it removes the external link step
-    # (no lld, no startup files, no clang driver invocation at run time).
-    CMAKE_FLAGS+=(-DHOST_CPU_ENABLE_JIT:BOOL=ON)
-
-    # Build without the (experimental) Level Zero driver. It is the only consumer
-    # of spirv-link, so disabling it lets us drop SPIRV_Tools_jll entirely.
-    CMAKE_FLAGS+=(-DENABLE_LEVEL0:BOOL=OFF)
-
-    # XXX: work around pocl#1776, disabling FP16 support for FreeBSD
-    if [[ ${target} == *-freebsd* ]]; then
-        CMAKE_FLAGS+=(-DHOST_COMPILER_SUPPORTS_FLOAT16:BOOL=OFF)
-    fi
-
-    # Link LLVM statically so that we don't have to worry about versioning the JLL against it
-    CMAKE_FLAGS+=(-DSTATIC_LLVM:Bool=ON)
-    # XXX: we add -pthread to the flags used to link libLLVM, so need that here too
-    #      (as that is not reflected by llvm-config)
-    if [[ "${target}" == *mingw* ]]; then
-        # PoCL is built with the Clang/lld toolchain on Windows (see above). Add -pthread to
-        # every link mode (not just executables): it pulls in libwinpthread, which Clang's
-        # windows-gnu driver -- unlike GCC's -- does not link implicitly, and it matches the
-        # -pthread we use when linking libLLVM (not reflected by llvm-config). Keep
-        # --allow-multiple-definition as a guard against duplicate COMDAT/weak template
-        # instantiations across the statically-linked LLVM/Clang/translator archives.
-        CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
-        CMAKE_FLAGS+=(-DCMAKE_SHARED_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
-        CMAKE_FLAGS+=(-DCMAKE_MODULE_LINKER_FLAGS="-pthread -Wl,--allow-multiple-definition")
-    else
-        CMAKE_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-pthread")
-    fi
-
-    # Our sysroot ships an old glibc whose <inttypes.h> only defines the PRI* format
-    # macros for C++ when __STDC_FORMAT_MACROS is set. PoCL's C++ sources include LLVM
-    # headers (which pull <inttypes.h>) before pocl_debug.h, so pocl_debug.h's own
-    # late `#define __STDC_FORMAT_MACROS` is too late (the include guard is already set)
-    # and PRId64/PRIu64 end up undefined (e.g. pocl_llvm_utils.cc's "Created context %"
-    # PRId64). Define it on the command line so it's set before the first include.
-    CMAKE_FLAGS+=(-DCMAKE_CXX_FLAGS="-D__STDC_FORMAT_MACROS")
-
-    # Enable SPIR-V support via the vendored translator *library* (built above), linked
-    # statically into libpocl. Pre-seed the cache vars SetupLLVMSPIRV.cmake would otherwise
-    # search for, so it uses our copy and enables HAVE_LLVM_SPIRV_LIB. We do NOT set any
-    # llvm-spirv binary path, so the binary code path stays off and no wrapper is needed.
-    CMAKE_FLAGS+=(-DLLVM_SPIRV_INCLUDEDIR=${spirv_inc})
-    CMAKE_FLAGS+=(-DLLVM_SPIRV_LIB=${spirv_lib})
-
-    # PoCL's CPU autodetection doesn't work on RISC-V
-    if [[ ${target} == riscv64-* ]]; then
-        CMAKE_FLAGS+=(-DLLC_HOST_CPU=rv64gc)
-        # forcing a CPU disables distro kernellib mode, so only provide a native build
-        CMAKE_FLAGS+=(-DKERNELLIB_HOST_CPU_VARIANTS=native)
-    fi
-
-    # XXX: PoCL defaults to not using shared libraries on MinGW -- this seems to work fine?
-    CMAKE_FLAGS+=(-DBUILD_SHARED_LIBS=ON)
-
-    cmake -B build -S . -GNinja ${CMAKE_FLAGS[@]}
-    ninja -C build -j ${nproc} install
-
-    # The vendored translator is now statically linked into libpocl; remove its build
-    # artifacts (static lib, generated headers, pkg-config, the unused llvm-spirv binary)
-    # from the prefix so they don't ship in the JLL.
-    rm -rf ${prefix}/include/LLVMSPIRVLib
-    rm -f ${prefix}/lib/libLLVMSPIRVLib.a \
-          ${prefix}/lib/pkgconfig/LLVMSPIRVLib.pc \
-          ${prefix}/bin/llvm-spirv ${prefix}/bin/llvm-spirv.exe
-    """
-end
-
-function init_block()
-    # No wrappers, no environment hacks: the JIT build links everything it needs
-    # (LLVM, clang, the SPIR-V translator) statically into libpocl, so there are no
-    # external tools to locate at run time. We only register the driver with the loader.
-    raw"""
-    # Register this driver with OpenCL_jll
-    if OpenCL_jll.is_available()
-        push!(OpenCL_jll.drivers, libpocl)
-    end
-    """
-end
-
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
@@ -379,11 +54,13 @@ filter!(p -> !(arch(p) == "i686" && libc(p) == "musl"), platforms)
 ## PoCL doesn't support 32-bit Windows
 filter!(p -> !(arch(p) == "i686" && os(p) == "windows"), platforms)
 
+include("../common.jl")
+
 # LLVM 20 was built against the macOS 10.14 SDK, so ship it. We only use the
 # helper for the (centralized) SDK source; the install itself is done
-# non-destructively in the build script, which extracts the SDK to a scratch dir
-# and redirects the toolchain at it, rather than overwriting the read-only
-# sys-root (whose `System` tree can no longer be `rm`'d on the current rootfs).
+# non-destructively in common.jl, which extracts the SDK to a scratch dir and
+# redirects the toolchain at it, rather than overwriting the read-only sys-root
+# (whose `System` tree can no longer be `rm`'d on the current rootfs).
 sources = vcat(sources, get_macos_sdk_sources("10.14"))
 
 # The products that we will ensure are always built
@@ -458,5 +135,3 @@ for (i,build) in enumerate(builds)
                    build.preferred_gcc_version, preferred_llvm_version=v"20",
                    julia_compat="1.6", init_block=init_block())
 end
-
-# bump

--- a/P/pocl/pocl_standalone/build_tarballs.jl
+++ b/P/pocl/pocl_standalone/build_tarballs.jl
@@ -7,23 +7,25 @@ const YGGDRASIL_DIR = "../../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
-name = "pocl_standalone"
-version = v"7.1.3"
+# This is the standalone (OpenCL-less) variant of the PoCL 7.2 track: instead of an ICD
+# driver loaded by an OpenCL ICD loader, it builds a directly-linkable library
+# (`libpocl_standalone`) whose OpenCL entrypoints are renamed to `PO<cl_function>`
+# (RENAME_POCL). That lets it be used as a CPU back-end (e.g. by KernelAbstractions.jl's
+# nanoOpenCL) without an OpenCL.jl/ICD dependency, while still coexisting in-process with a
+# real OpenCL ICD targeting other GPUs. The actual build lives in ../common.jl, shared with
+# the `pocl_next` (ICD) variant and selected via its `standalone` argument (true here).
+# Like `pocl_next` this is a JIT build, so it needs no run-time clang/lld/llvm-spirv tooling.
 
-# This is the standalone (OpenCL-less) variant of PoCL: instead of an ICD driver loaded by
-# an OpenCL ICD loader, it builds a directly-linkable library (`libpocl_standalone`) whose
-# OpenCL entrypoints are renamed to `PO<cl_function>` (RENAME_POCL). That lets it be used as
-# a CPU back-end (e.g. by KernelAbstractions.jl's nanoOpenCL) without an OpenCL.jl/ICD
-# dependency, while still coexisting in-process with a real OpenCL ICD targeting other GPUs.
-# The actual build differences live in ../common.jl, gated on the `standalone` argument.
+name = "pocl_standalone"
+version = v"7.2.0"
 
 # Build
 
 # Collection of sources required to complete build
 sources = [
     DirectorySource("./bundled"),
-    GitSource("https://github.com/juliagpu/pocl",
-              "21d408ea0adbfd59934d5720132c0e7f412af98e"),
+    GitSource("https://github.com/JuliaGPU/pocl",
+              "88a7a839b58ff7f0e3720f58ed858eaf1480111b"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).
@@ -72,21 +74,19 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built.
-# Unlike the regular `pocl` build, the standalone variant does not use an OpenCL ICD loader
-# (ENABLE_ICD=OFF) and uses PoCL's vendored OpenCL headers, so OpenCL_jll and
-# OpenCL_Headers_jll are not needed.
+#
+# Unlike the `pocl_next` (ICD) variant, the standalone build does not use an OpenCL ICD
+# loader (ENABLE_ICD=OFF) and uses PoCL's vendored OpenCL headers, so OpenCL_jll and
+# OpenCL_Headers_jll are not needed. As with `pocl_next`, the JIT build no longer shells
+# out to an external linker or clang at run time (no LLD_unified_jll/Clang_unified_jll);
+# with Level Zero disabled there is no spirv-link consumer (no SPIRV_Tools_jll); and the
+# SPIR-V translator is vendored and statically linked (no SPIRV_LLVM_Translator_jll).
+# LLVM_full_jll is only a build dependency because it is linked statically into libpocl.
 dependencies = [
     HostBuildDependency(PackageSpec(name="LLVM_full_jll", version="20.1.2")),
     BuildDependency(PackageSpec(name="LLVM_full_jll", version="20.1.2")),
     Dependency("Hwloc_jll"),
     Dependency("Zstd_jll"), # our LLVM 20 build has LLVM_ENABLE_ZSTD=ON
-    # the SPIR-V translator is vendored and statically linked (see common.jl), so
-    # SPIRV_LLVM_Translator_jll is no longer needed at run time.
-    # only used at run time, but also detected by the build
-    Dependency("SPIRV_Tools_jll"),
-    # only used at run time
-    RuntimeDependency("Clang_unified_jll"),
-    RuntimeDependency("LLD_unified_jll")
 ]
 
 builds = []
@@ -138,5 +138,3 @@ for (i,build) in enumerate(builds)
                    build.preferred_gcc_version, preferred_llvm_version=v"20",
                    julia_compat="1.6", init_block=init_block(true))
 end
-
-# bump


### PR DESCRIPTION
Flip the recipe layout so the 7.2 track is the shared one and the legacy 7.1 build is the odd one out:

- common.jl now holds the 7.2 JIT build (in-process ORC/JITLink, vendored static SPIR-V translator, no run-time clang/lld/llvm-spirv tooling), parametrized via `standalone` for the ICD vs directly-linkable variants.
- pocl_next becomes a thin recipe including common.jl (standalone=false), and is repinned to the current release_7_2 tip (88a7a839b58ff7f0e3720f58ed858eaf1480111b), which carries the upstreamed release_next bugfixes. Its previous pin was the pre-rebase release_7_2 tip. pocl_next_jll needs no run-time wrappers.
- pocl_standalone is bumped 7.1.3 -> 7.2.0 and now builds from the same 7.2 source via common.jl (standalone=true): a directly-linkable, RENAME_POCL library that, thanks to the JIT, needs no run-time wrappers (Clang_unified_jll, LLD_unified_jll, SPIRV_Tools_jll dependencies dropped).
- pocl (the stable 7.1.3 ICD build) keeps its 7.1 build system and external- link machinery (clang + lld wrappers are still required: 7.1 has no in-process JIT), now inlined into its own build_tarballs.jl so it no longer shares common.jl. It does drop SPIRV_Tools_jll and its spirv-link wrapper, though: spirv-link is only consumed by the Level Zero driver, which this CPU-only build does not enable (ENABLE_LEVEL0=OFF).

cc @vchuravy 