### PR TITLE
[SLEEF] Auto-load libsleefgnuabi (drop dont_dlopen)

### DIFF
--- a/S/SLEEF/build_tarballs.jl
+++ b/S/SLEEF/build_tarballs.jl
@@ -135,11 +135,9 @@ products = [
 
 # libsleefgnuabi -- the GNU vector-ABI / drop-in libmvec compat library, exporting the plain
 # `_ZGV*` symbols LLVM emits for `-fveclib` -- is only built *and installed* by SLEEF on
-# x86/AArch64/RISC-V (PPC64LE builds it but doesn't install it; macOS has no GNUABI variant).
-# Declare it as a product only there, and `dont_dlopen` it: it's only loaded by specialized
-# consumers (e.g. pocl's CPU veclib), so a plain existence check suffices. Dynamic consumers
-# resolve `libsleefgnuabi.so` by SONAME; static ones link the `libsleefgnuabi.a` from above.
-gnuabi_product = LibraryProduct("libsleefgnuabi", :libsleefgnuabi; dont_dlopen=true)
+# x86/AArch64/RISC-V (PPC64LE builds it but doesn't install it; macOS has no GNUABI variant),
+# so declare the product only there.
+gnuabi_product = LibraryProduct("libsleefgnuabi", :libsleefgnuabi)
 has_gnuabi(p) = !Sys.isapple(p) && arch(p) in ("x86_64", "aarch64", "riscv64")
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
The libsleefgnuabi product was marked dont_dlopen, so SLEEF_jll declares the path accessor but never loads the library. That breaks dynamic consumers that resolve it by SONAME at run time -- notably pocl's CPU JIT, whose dlopen("libsleefgnuabi.so.3") only succeeds once the library is already in the process; with dont_dlopen it isn't, so pocl would fall back to a system libmvec (absent on musl). dont_dlopen was also unnecessary: the product is already gated to the platforms that build+install it (x86/AArch64/RISC-V Linux/FreeBSD), where it dlopen-probes fine. Make it a normal product so the JLL auto-loads it.