### PR TITLE
PoCL 7.2: vectorize OpenCL math builtins via SLEEF_jll (libsleefgnuabi)

### DIFF
--- a/P/pocl/common.jl
+++ b/P/pocl/common.jl
@@ -289,6 +289,29 @@ function build_script(standalone=false)
         CMAKE_FLAGS+=(-DHOST_COMPILER_SUPPORTS_FLOAT16:BOOL=OFF)
     fi
 
+    # Vectorize OpenCL math builtins (sin/exp/log/...) via a vector-math library. This is
+    # gated to exactly where it can work: LLVM's TargetLibraryInfo only maps a veclib for
+    # x86_64 (libmvec ABI, _ZGVdN*) and aarch64 (SLEEF ABI, _ZGVnN*), and SLEEF_jll only ships
+    # the symbol-providing libsleefgnuabi on ELF targets -- Linux and FreeBSD (NOT macOS, which
+    # has no GNUABI variant on Mach-O, and NOT Windows, where SLEEF_jll isn't built). The
+    # in-process JIT dlopens it by SONAME at run time, so nothing is redistributed beyond the
+    # SLEEF_jll dependency (added per-platform in build_tarballs.jl). Elsewhere there's no
+    # veclib -> the kernel body still vectorizes, transcendentals stay scalar. NB: on AVX-512
+    # hosts the work-item loop tends to pick width 16, which LLVM's x86 veclib tables don't
+    # cover (they stop at width 8), so the math scalarizes there; AVX2 (width 8) and aarch64
+    # NEON (width 4) get packed _ZGV* calls. (Separate from the always-on SLEEF kernel library,
+    # ENABLE_SLEEF.)
+    sleef_gnuabi="${prefix}/lib/libsleefgnuabi.so"
+    if [[ "${target}" == x86_64-linux-* || "${target}" == x86_64-*freebsd* ]]; then
+        CMAKE_FLAGS+=(-DENABLE_HOST_CPU_VECTORIZE_LIBMVEC:BOOL=ON)
+        CMAKE_FLAGS+=(-DLIBMVEC="${sleef_gnuabi}")
+        # libsleefgnuabi exports the required _ZGV* symbols; skip the (cross-unfriendly) probe.
+        CMAKE_FLAGS+=(-DLIBMVEC_HAS_REQUIRED_SYMBOLS:BOOL=ON)
+    elif [[ "${target}" == aarch64-linux-* || "${target}" == aarch64-*freebsd* ]]; then
+        CMAKE_FLAGS+=(-DENABLE_HOST_CPU_VECTORIZE_SLEEF:BOOL=ON)
+        CMAKE_FLAGS+=(-DLIBSLEEF="${sleef_gnuabi}")
+    fi
+
     # Link LLVM statically so that we don't have to worry about versioning the JLL against it
     CMAKE_FLAGS+=(-DSTATIC_LLVM:Bool=ON)
     # XXX: we add -pthread to the flags used to link libLLVM, so need that here too

--- a/P/pocl/pocl_next/build_tarballs.jl
+++ b/P/pocl/pocl_next/build_tarballs.jl
@@ -21,7 +21,7 @@ version = v"7.2.0"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/JuliaGPU/pocl",
-              "88a7a839b58ff7f0e3720f58ed858eaf1480111b"),
+              "e344b0f02c2c9f3680aa9ebc2fe13846783e8af1"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).
@@ -93,14 +93,15 @@ for platform in platforms
     platform_sources = deepcopy(sources)
     platform_dependencies = deepcopy(dependencies)
 
-    # for fp16, we need a vectorization library
-    if arch(platform) in ["armv6l", "aarch64"]
-        #push!(platform_dependencies, Dependency("SLEEF_jll"))
-        # XXX: PoCL hard-codes the path to libsleef
-        # `no such file or directory: '/opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/local/lib/libsleef.so'`
+    # Vectorize OpenCL math builtins via SLEEF's libmvec-ABI / SLEEF compat library
+    # (libsleefgnuabi), which the in-process JIT dlopens at run time (see common.jl for the
+    # matching CMake flags). Gated to x86_64/aarch64 on the ELF OSes where LLVM maps a veclib
+    # *and* SLEEF_jll ships libsleefgnuabi: Linux and FreeBSD (not macOS -- no GNUABI on
+    # Mach-O -- and not Windows -- no SLEEF_jll). Static linking isn't used: the JIT resolves
+    # _ZGV* symbols by dlopen, so a dynamic dependency is the natural fit.
+    if (Sys.islinux(platform) || Sys.isfreebsd(platform)) && arch(platform) in ["x86_64", "aarch64"]
+        push!(platform_dependencies, Dependency("SLEEF_jll"))
     end
-    # TODO: libsvml for x86 (part of mkl)
-    # TODO: libmvec as fallback (part of glibc 2.22+)
 
     # On Windows we now link PoCL with the Clang/lld toolchain, but still build against this
     # GCC's MinGW sysroot and libstdc++, so its version must stay compatible with the

--- a/P/pocl/pocl_standalone/build_tarballs.jl
+++ b/P/pocl/pocl_standalone/build_tarballs.jl
@@ -25,7 +25,7 @@ version = v"7.2.0"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/JuliaGPU/pocl",
-              "88a7a839b58ff7f0e3720f58ed858eaf1480111b"),
+              "e344b0f02c2c9f3680aa9ebc2fe13846783e8af1"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).
@@ -96,14 +96,16 @@ for platform in platforms
     platform_sources = deepcopy(sources)
     platform_dependencies = deepcopy(dependencies)
 
-    # for fp16, we need a vectorization library
-    if arch(platform) in ["armv6l", "aarch64"]
-        #push!(platform_dependencies, Dependency("SLEEF_jll"))
-        # XXX: PoCL hard-codes the path to libsleef
-        # `no such file or directory: '/opt/aarch64-linux-gnu/aarch64-linux-gnu/sys-root/usr/local/lib/libsleef.so'`
+    # Vectorize OpenCL math builtins via SLEEF's libmvec-ABI / SLEEF compat library
+    # (libsleefgnuabi), which the in-process JIT dlopens at run time (see common.jl for the
+    # matching CMake flags). Gated to x86_64/aarch64 on the ELF OSes where LLVM maps a veclib
+    # *and* SLEEF_jll ships libsleefgnuabi: Linux and FreeBSD (not macOS -- no GNUABI on
+    # Mach-O -- and not Windows -- no SLEEF_jll). Even though this is the "standalone"
+    # (JLL-dependency-free in spirit) build, a dynamic SLEEF_jll dep is the natural fit: the
+    # JIT resolves _ZGV* symbols by dlopen, not by static linking.
+    if (Sys.islinux(platform) || Sys.isfreebsd(platform)) && arch(platform) in ["x86_64", "aarch64"]
+        push!(platform_dependencies, Dependency("SLEEF_jll"))
     end
-    # TODO: libsvml for x86 (part of mkl)
-    # TODO: libmvec as fallback (part of glibc 2.22+)
 
     # On Windows we now link PoCL with the Clang/lld toolchain, but still build against this
     # GCC's MinGW sysroot and libstdc++, so its version must stay compatible with the


### PR DESCRIPTION
Wire a vector-math library into the CPU kernel compiler so transcendental builtins (sin/exp/log/...) vectorize to packed _ZGV* calls, resolved at run time by the in-process JIT (dynamic, no redistributed .so beyond the SLEEF_jll dependency).

- Bump pocl to e344b0f02c2c (adds a configurable libmvec SONAME for the JIT to dlopen, instead of the hardcoded libmvec.so.1, so it can use a shipped lib on musl/old-glibc).
- common.jl: on x86_64 use LLVM's libmvec veclib (_ZGVdN*); on aarch64 use the SLEEF veclib (_ZGVnN*); point both at SLEEF's libsleefgnuabi (a drop-in libmvec-ABI lib).
- Add a SLEEF_jll dependency on x86_64/aarch64 for Linux+FreeBSD -- the ELF targets where LLVM maps a veclib AND SLEEF_jll ships libsleefgnuabi (not macOS: no GNUABI on Mach-O; not Windows: no SLEEF_jll).

Validated locally via OpenCL.jl: a transcendental kernel compiles to <8 x float>
@llvm.sin.v8f32 and the object calls _ZGVdN8v_sinf, resolved against libsleefgnuabi, with correct results. NB: on AVX-512 hosts the work-item loop picks width 16, which LLVM's x86 veclib tables don't cover (max width 8), so math scalarizes there; AVX2 (8) and aarch64 NEON (4) get packed calls.

cc @vchuravy 