### PR TITLE
PoCL 7.2: FP16 math builtins (LLVM_full clang for kernel lib + pocl bump).

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -49,11 +49,11 @@ version = "0.6.6"
 
 [[deps.BinaryBuilderBase]]
 deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "d5956b90032e994a22d9527f2d9250f6f9e13cdc"
+git-tree-sha1 = "430632cc4defc5131a83e04e4e3aa6994c5f9312"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "1.45.0"
+version = "1.46.0"
 
 [[deps.Binutils_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll", "Zstd_jll"]

--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -49,11 +49,11 @@ version = "0.6.6"
 
 [[deps.BinaryBuilderBase]]
 deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "0db728b70b61273f4d1c0bd447b544484045ba48"
+git-tree-sha1 = "d5956b90032e994a22d9527f2d9250f6f9e13cdc"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "1.44.0"
+version = "1.45.0"
 
 [[deps.Binutils_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll", "Zstd_jll"]

--- a/P/pocl/common.jl
+++ b/P/pocl/common.jl
@@ -206,11 +206,22 @@ function build_script(standalone=false)
     mkdir -p $llvm_host_bin
     cp $WORKSPACE/srcdir/llvm-config $llvm_host_bin/llvm-config
     chmod +x $llvm_host_bin/llvm-config
+    # Compile the kernel builtin library with LLVM_full_jll's own clang/opt/... (the
+    # HostBuildDependency under $host_prefix/tools), NOT BinaryBuilderBase's native
+    # toolchain clang in /opt/$MACHTYPE/bin. The latter is LLVMBootstrap, which BBB only
+    # ships up to 18.1.7, so preferred_llvm_version=20 silently clamps to it. Clang 18's
+    # frontend lacks several _Float16 math builtins (__builtin_ceilf16/floorf16/truncf16/
+    # roundf16/rintf16/fmaxf16/fminf16/fmaf16/...), so once cl_khr_fp16 is enabled the
+    # per-file `#if !__has_builtin(__builtin_*f16)` guards drop those half builtins from
+    # the bitcode kernel library while the --fp16 SPIR wrappers still reference them ->
+    # "Cannot find symbol _Z8_cl_ceilDh in kernel library" at clCreateProgramWithIL time.
+    # LLVM_full_jll's clang (20) has these builtins, and matching the build-time LLVM tools
+    # to the LLVM we link against also keeps the emitted bitcode version in sync.
     for tool in clang clang++ opt llc llvm-as llvm-dis llvm-link; do
-        ln -sf /opt/$MACHTYPE/bin/$tool $llvm_host_bin/$tool
+        ln -sf ${host_prefix}/tools/$tool $llvm_host_bin/$tool
         # on mingw targets CMake appends .exe when searching, so provide that name too
         # (the host tools are ELF binaries; the suffix is just what find_program looks for)
-        ln -sf /opt/$MACHTYPE/bin/$tool $llvm_host_bin/$tool.exe
+        ln -sf ${host_prefix}/tools/$tool $llvm_host_bin/$tool.exe
     done
 
     # Point to relevant LLVM tools (see above). The target-side dependencies live

--- a/P/pocl/common.jl
+++ b/P/pocl/common.jl
@@ -206,22 +206,11 @@ function build_script(standalone=false)
     mkdir -p $llvm_host_bin
     cp $WORKSPACE/srcdir/llvm-config $llvm_host_bin/llvm-config
     chmod +x $llvm_host_bin/llvm-config
-    # Compile the kernel builtin library with LLVM_full_jll's own clang/opt/... (the
-    # HostBuildDependency under $host_prefix/tools), NOT BinaryBuilderBase's native
-    # toolchain clang in /opt/$MACHTYPE/bin. The latter is LLVMBootstrap, which BBB only
-    # ships up to 18.1.7, so preferred_llvm_version=20 silently clamps to it. Clang 18's
-    # frontend lacks several _Float16 math builtins (__builtin_ceilf16/floorf16/truncf16/
-    # roundf16/rintf16/fmaxf16/fminf16/fmaf16/...), so once cl_khr_fp16 is enabled the
-    # per-file `#if !__has_builtin(__builtin_*f16)` guards drop those half builtins from
-    # the bitcode kernel library while the --fp16 SPIR wrappers still reference them ->
-    # "Cannot find symbol _Z8_cl_ceilDh in kernel library" at clCreateProgramWithIL time.
-    # LLVM_full_jll's clang (20) has these builtins, and matching the build-time LLVM tools
-    # to the LLVM we link against also keeps the emitted bitcode version in sync.
     for tool in clang clang++ opt llc llvm-as llvm-dis llvm-link; do
-        ln -sf ${host_prefix}/tools/$tool $llvm_host_bin/$tool
+        ln -sf /opt/$MACHTYPE/bin/$tool $llvm_host_bin/$tool
         # on mingw targets CMake appends .exe when searching, so provide that name too
         # (the host tools are ELF binaries; the suffix is just what find_program looks for)
-        ln -sf ${host_prefix}/tools/$tool $llvm_host_bin/$tool.exe
+        ln -sf /opt/$MACHTYPE/bin/$tool $llvm_host_bin/$tool.exe
     done
 
     # Point to relevant LLVM tools (see above). The target-side dependencies live

--- a/P/pocl/pocl/build_tarballs.jl
+++ b/P/pocl/pocl/build_tarballs.jl
@@ -9,6 +9,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "pocl"
 version = v"7.1.3"
+llvm_version = v"20.1.2"
 
 # Build
 
@@ -559,8 +560,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    HostBuildDependency(PackageSpec(name="LLVM_full_jll", version="20.1.2")),
-    BuildDependency(PackageSpec(name="LLVM_full_jll", version="20.1.2")),
+    HostBuildDependency(PackageSpec(name="LLVM_full_jll", version=string(llvm_version))),
+    BuildDependency(PackageSpec(name="LLVM_full_jll", version=string(llvm_version))),
     Dependency("OpenCL_jll"),
     Dependency("OpenCL_Headers_jll"),
     Dependency("Hwloc_jll"),
@@ -621,6 +622,7 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, build_script(),
                    [build.platform], products, build.dependencies;
-                   build.preferred_gcc_version, preferred_llvm_version=v"20",
+                   build.preferred_gcc_version,
+                   preferred_llvm_version=Base.thismajor(llvm_version),
                    julia_compat="1.6", init_block=init_block())
 end

--- a/P/pocl/pocl_next/build_tarballs.jl
+++ b/P/pocl/pocl_next/build_tarballs.jl
@@ -21,7 +21,7 @@ version = v"7.2.0"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/JuliaGPU/pocl",
-              "e344b0f02c2c9f3680aa9ebc2fe13846783e8af1"),
+              "a18752a7e51c1d08ff1b1f5b116512ae2bbc9ec0"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).

--- a/P/pocl/pocl_next/build_tarballs.jl
+++ b/P/pocl/pocl_next/build_tarballs.jl
@@ -14,6 +14,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "pocl_next"
 version = v"7.2.0"
+llvm_version = v"20.1.2"
 
 # Build
 
@@ -78,8 +79,8 @@ products = [
 # binary (SPIRV_LLVM_Translator_jll gone). LLVM_full_jll is only a build dependency
 # because it is linked statically into libpocl.
 dependencies = [
-    HostBuildDependency(PackageSpec(name="LLVM_full_jll", version="20.1.2")),
-    BuildDependency(PackageSpec(name="LLVM_full_jll", version="20.1.2")),
+    HostBuildDependency(PackageSpec(name="LLVM_full_jll", version=string(llvm_version))),
+    BuildDependency(PackageSpec(name="LLVM_full_jll", version=string(llvm_version))),
     Dependency("OpenCL_jll"),
     Dependency("OpenCL_Headers_jll"),
     Dependency("Hwloc_jll"),
@@ -136,6 +137,7 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, build_script(),
                    [build.platform], products, build.dependencies;
-                   build.preferred_gcc_version, preferred_llvm_version=v"20",
+                   build.preferred_gcc_version,
+                   preferred_llvm_version=Base.thismajor(llvm_version),
                    julia_compat="1.6", init_block=init_block())
 end

--- a/P/pocl/pocl_standalone/build_tarballs.jl
+++ b/P/pocl/pocl_standalone/build_tarballs.jl
@@ -18,6 +18,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "pocl_standalone"
 version = v"7.2.0"
+llvm_version = v"20.1.2"
 
 # Build
 
@@ -83,8 +84,8 @@ products = [
 # SPIR-V translator is vendored and statically linked (no SPIRV_LLVM_Translator_jll).
 # LLVM_full_jll is only a build dependency because it is linked statically into libpocl.
 dependencies = [
-    HostBuildDependency(PackageSpec(name="LLVM_full_jll", version="20.1.2")),
-    BuildDependency(PackageSpec(name="LLVM_full_jll", version="20.1.2")),
+    HostBuildDependency(PackageSpec(name="LLVM_full_jll", version=string(llvm_version))),
+    BuildDependency(PackageSpec(name="LLVM_full_jll", version=string(llvm_version))),
     Dependency("Hwloc_jll"),
     Dependency("Zstd_jll"), # our LLVM 20 build has LLVM_ENABLE_ZSTD=ON
 ]
@@ -140,6 +141,7 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, build_script(true),
                    [build.platform], products, build.dependencies;
-                   build.preferred_gcc_version, preferred_llvm_version=v"20",
+                   build.preferred_gcc_version,
+                   preferred_llvm_version=Base.thismajor(llvm_version),
                    julia_compat="1.6", init_block=init_block(true))
 end

--- a/P/pocl/pocl_standalone/build_tarballs.jl
+++ b/P/pocl/pocl_standalone/build_tarballs.jl
@@ -25,7 +25,7 @@ version = v"7.2.0"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/JuliaGPU/pocl",
-              "e344b0f02c2c9f3680aa9ebc2fe13846783e8af1"),
+              "a18752a7e51c1d08ff1b1f5b116512ae2bbc9ec0"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).


### PR DESCRIPTION
Build the kernel library with LLVM_full_jll's clang (host_prefix/tools, v20) instead of BinaryBuilderBase's bootstrap clang (capped at 18.1.7), whose frontend lacks the _Float16 math builtins. Bump the pocl GitSource to pick up the new FP16 overloads (ceil/floor/.../fma/fdim, logb/ilogb/ldexp/rootn/fmod/ remainder, nextafter).