### PR TITLE
Fixes for new LLVM bootstrap shards

### DIFF
--- a/0_RootFS/LLVMBootstrap@19/bundled/patches/cpuidex-mingw.patch
+++ b/0_RootFS/LLVMBootstrap@19/bundled/patches/cpuidex-mingw.patch
@@ -1,0 +1,15 @@
+On Windows, mingw's <intrin.h> already declares __cpuidex (non-static), while
+clang's cpuid.h also defines it (static __inline, added in llvm-project#97785).
+Including both yields "static declaration of '__cpuidex' follows non-static
+declaration". The upstream guard only skips clang's definition when __cpuidex is
+a builtin (-fms-extensions / MSVC), not for mingw-gnu. Also skip it on _WIN32 so
+the platform header owns __cpuidex (matches clang<=18 behavior on Windows).
+
+--- a/clang/lib/Headers/cpuid.h
++++ b/clang/lib/Headers/cpuid.h
+@@ -343,4 +343,4 @@
+ // In some configurations, __cpuidex is defined as a builtin (primarily
+ // -fms-extensions) which will conflict with the __cpuidex definition below.
+-#if !(__has_builtin(__cpuidex))
++#if !(__has_builtin(__cpuidex)) && !defined(_WIN32)
+ static __inline void __cpuidex(int __cpu_info[4], int __leaf, int __subleaf) {

--- a/0_RootFS/LLVMBootstrap@20/bundled/patches/cpuidex-mingw.patch
+++ b/0_RootFS/LLVMBootstrap@20/bundled/patches/cpuidex-mingw.patch
@@ -1,0 +1,1 @@
+../../../LLVMBootstrap@19/bundled/patches/cpuidex-mingw.patch

--- a/0_RootFS/LLVMBootstrap@21/bundled/patches/cpuidex-mingw.patch
+++ b/0_RootFS/LLVMBootstrap@21/bundled/patches/cpuidex-mingw.patch
@@ -1,0 +1,1 @@
+../../../LLVMBootstrap@19/bundled/patches/cpuidex-mingw.patch

--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -65,21 +65,18 @@ function llvm_script(;version = v"8.0.1", llvm_build_type = "Release", kwargs...
     apk update
     apk add build-base python3 python3-dev linux-headers musl-dev zlib-dev
 
-    # We need the XML2, iconv, Zlib libraries in our LLVMBootstrap artifact,
-    # and we also need them in target-prefixed directories, so they stick
-    # around in `/opt/${target}/${target}/lib64` when mounted.
+    # We need the Zlib library in our LLVMBootstrap artifact, and we also need it
+    # in a target-prefixed directory, so it sticks around in
+    # `/opt/${target}/${target}/lib64` when mounted. (We deliberately do NOT bundle
+    # libxml2 here: it's built with LLVM_ENABLE_LIBXML2=OFF below, so libLLVM has no
+    # libxml2 dependency. Bundling libxml2 into the target sysroot also shadowed the
+    # target's own XML2_jll during cross-compilation -- and libxml2 2.14 dropped
+    # symbol versioning, breaking links against libs built on older libxml2.)
     mkdir -p ${prefix}/${target}/lib64
     # First, copy in the real files:
-    cp -a $(realpath ${libdir}/libxml2.so)  ${prefix}/${target}/lib64
-    cp -a $(realpath ${libdir}/libiconv.so) ${prefix}/${target}/lib64
     cp -a $(realpath ${libdir}/libz.so)     ${prefix}/${target}/lib64
 
     # Then create the symlinks
-    ln -s $(basename ${prefix}/${target}/lib64/libxml2.so.*) ${prefix}/${target}/lib64/libxml2.so
-    ln -s $(basename ${prefix}/${target}/lib64/libxml2.so.*) ${prefix}/${target}/lib64/libxml2.so.2
-    ln -s $(basename ${prefix}/${target}/lib64/libxml2.so.*) ${prefix}/${target}/lib64/libxml2.so.16
-    ln -s $(basename ${prefix}/${target}/lib64/libiconv.so.*) ${prefix}/${target}/lib64/libiconv.so
-    ln -s $(basename ${prefix}/${target}/lib64/libiconv.so.*) ${prefix}/${target}/lib64/libiconv.so.2
     ln -s $(basename ${prefix}/${target}/lib64/libz.so.*) ${prefix}/${target}/lib64/libz.so
     ln -s $(basename ${prefix}/${target}/lib64/libz.so.*) ${prefix}/${target}/lib64/libz.so.1
 
@@ -143,6 +140,12 @@ function llvm_script(;version = v"8.0.1", llvm_build_type = "Release", kwargs...
     # default flags, so building it just wasted time.)
     CMAKE_FLAGS+=(-DLLVM_ENABLE_PROJECTS='clang;lld')
 
+    # Don't link libxml2 (only used by the WindowsManifestMerger / llvm-mt, which a
+    # cross-toolchain doesn't need). This matches the shipped LLVM_full and, crucially,
+    # avoids bundling a libxml2.so into the target sysroot where it shadowed the target's
+    # own XML2_jll and broke downstream links (libxml2 2.14 dropped symbol versioning).
+    CMAKE_FLAGS+=(-DLLVM_ENABLE_LIBXML2=OFF)
+
     # Build runtimes
     CMAKE_FLAGS+=(-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind')
 
@@ -205,16 +208,12 @@ function llvm_products(;kwargs...)
 end
 
 # Dependencies that must be installed before this package can be built
-function llvm_dependencies(; version=v"8.0.1", kwargs...)
-    # XML2 had an ABI break between the 2.13 and 2.14 series: 2.14 bumped its SONAME from
-    # `libxml2.so.2` to `libxml2.so.16` (https://github.com/JuliaPackaging/Yggdrasil/pull/10965).
-    # LLVM >= 19 links against the new SONAME, older LLVM against the old one, so pin XML2 to
-    # the series matching the LLVM version we're building (older shards stay reproducible).
-    xml2_compat = version >= v"19" ? "~2.14.1" : "~2.13.6"
+function llvm_dependencies(; kwargs...)
+    # No XML2_jll: we build with LLVM_ENABLE_LIBXML2=OFF (see llvm_script), so libLLVM
+    # has no libxml2 dependency. (Older recipes pulled XML2_jll and bundled libxml2 into
+    # the target sysroot, which shadowed the target's own XML2_jll during cross builds.)
     return [
         Dependency("Zlib_jll"),
-        Dependency("XML2_jll"; compat=xml2_compat),
-	# transitive dependency libiconv
     ]
 end
 


### PR DESCRIPTION
https://github.com/JuliaPackaging/Yggdrasil/pull/14099 revealed some missues with #11007:
- the new breaking libxml2 got picked up because of being in the sysroot, breaking things
- a new `__cpuidex` definition in Clang's `cpuid.h` conflicts with mingw headers

Fix both by simply not linking against libxml2 (I don't think we need it, if it turns out we do we can always revert and link against the old version instead) and adding a patch for the `__cpuidex` definition.