### PR TITLE
[LibUnwind] Don't re-export symbols from liblzma

### DIFF
--- a/L/LibUnwind/LibUnwind@1.8.3/build_tarballs.jl
+++ b/L/LibUnwind/LibUnwind@1.8.3/build_tarballs.jl
@@ -85,7 +85,7 @@ dependencies = [
                                 version="5.8.1")),
     BuildDependency(PackageSpec(name="LLVMCompilerRT_jll",
                                 uuid="4e17d02c-6bf5-513e-be62-445f41c75a11",
-                                version=llvm_version);
+                                version=string(llvm_version));
                     platforms=filter(p -> sanitize(p) == "memory", platforms)),
 ]
 

--- a/L/LibUnwind/LibUnwind@1.8.3/build_tarballs.jl
+++ b/L/LibUnwind/LibUnwind@1.8.3/build_tarballs.jl
@@ -36,6 +36,8 @@ if [[ ${bb_full_target} == *-sanitize+memory* ]]; then
 fi
 
 export CFLAGS="-DPI -fPIC"
+# liblzma is linked statically, don't re-export its symbols
+export LDFLAGS="-Wl,--exclude-libs=liblzma.a"
 if [[ "${target}" == aarch64-linux-* ]]; then
     # Define macro introduced in later Linux kernel than what we have in the RootFS.
     CFLAGS="${CFLAGS} -DNT_ARM_PAC_MASK=0x406"
@@ -80,7 +82,7 @@ dependencies = [
     Dependency("Zlib_jll"),
     BuildDependency(PackageSpec(name="XZ_jll",
                                 uuid="ffd25f8a-64ca-5728-b0f7-c24cf3aae800",
-                                version=v"5.8.1")),
+                                version=v"5.8.1+0")),
     BuildDependency(PackageSpec(name="LLVMCompilerRT_jll",
                                 uuid="4e17d02c-6bf5-513e-be62-445f41c75a11",
                                 version=llvm_version);

--- a/L/LibUnwind/LibUnwind@1.8.3/build_tarballs.jl
+++ b/L/LibUnwind/LibUnwind@1.8.3/build_tarballs.jl
@@ -82,7 +82,7 @@ dependencies = [
     Dependency("Zlib_jll"),
     BuildDependency(PackageSpec(name="XZ_jll",
                                 uuid="ffd25f8a-64ca-5728-b0f7-c24cf3aae800",
-                                version=v"5.8.1+0")),
+                                version="5.8.1")),
     BuildDependency(PackageSpec(name="LLVMCompilerRT_jll",
                                 uuid="4e17d02c-6bf5-513e-be62-445f41c75a11",
                                 version=llvm_version);


### PR DESCRIPTION
A fix for https://github.com/JuliaLang/julia/issues/62239 and hopefully https://github.com/JuliaPy/PythonCall.jl/issues/735