### PR TITLE
[msolve@0.9] Rebuild with FLINT v3.6.0

### DIFF
--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -3,16 +3,16 @@
 using BinaryBuilder, Pkg
 
 name = "msolve"
-upstream_version = v"0.10.0"
+upstream_version = v"0.9.5"
 
-version_offset = v"0.0.0"
+version_offset = v"0.0.3"
 version = VersionNumber(upstream_version.major*100+version_offset.major,
                         upstream_version.minor*100+version_offset.minor,
                         upstream_version.patch*100+version_offset.patch)
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/algebraic-solving/msolve.git", "0441849e0655a901dcbbae7aa78b714bd7cafbe6")
+    GitSource("https://github.com/algebraic-solving/msolve.git", "7c4fbe08cf4dcaf73fad2ae2d3902795d040f290")
 ]
 
 # Bash recipe for building across all platforms

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -5,7 +5,7 @@ using BinaryBuilder, Pkg
 name = "msolve"
 upstream_version = v"0.9.5"
 
-version_offset = v"0.0.3"
+version_offset = v"0.0.4"
 version = VersionNumber(upstream_version.major*100+version_offset.major,
                         upstream_version.minor*100+version_offset.minor,
                         upstream_version.patch*100+version_offset.patch)
@@ -41,7 +41,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GMP_jll", v"6.2.1"),
-    Dependency("FLINT_jll", compat = "~301.500.000"),
+    Dependency("FLINT_jll", compat = "~301.600.000"),
     Dependency("MPFR_jll", v"4.1.1"),
     Dependency("OpenBLAS32_jll", v"0.3.29"),
 

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -5,7 +5,7 @@ using BinaryBuilder, Pkg
 name = "msolve"
 upstream_version = v"0.10.0"
 
-version_offset = v"0.0.1"
+version_offset = v"0.0.0"
 version = VersionNumber(upstream_version.major*100+version_offset.major,
                         upstream_version.minor*100+version_offset.minor,
                         upstream_version.patch*100+version_offset.patch)
@@ -41,7 +41,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("GMP_jll", v"6.2.1"),
-    Dependency("FLINT_jll", compat = "~301.600.000"),
+    Dependency("FLINT_jll", compat = "~301.500.000"),
     Dependency("MPFR_jll", v"4.1.1"),
     Dependency("OpenBLAS32_jll", v"0.3.29"),
 

--- a/M/msolve/build_tarballs.jl
+++ b/M/msolve/build_tarballs.jl
@@ -53,4 +53,4 @@ dependencies = [
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-  julia_compat="1.6", preferred_gcc_version = v"8")
+  julia_compat="1.6", preferred_gcc_version = v"8", preferred_llvm_version=v"17")


### PR DESCRIPTION
Since Oscar.jl and AlgebraicSolving.jl still use msolve v0.9.x, we would like to rebuild this non-recent msolve version also with FLINT 3.6.0 support. This will then fix the resolver issues experienced in https://github.com/oscar-system/Oscar.jl/pull/6094.

Once this PR is merged and the release is through, I will immediately revert this PR with the appropriate CI skipping flags, so that the recipe on Yggy master again reflects msolve v0.10.x

cc @ederc @herearound