### PR TITLE
[CI Manifest] Revert BBB bump

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -49,11 +49,11 @@ version = "0.6.6"
 
 [[deps.BinaryBuilderBase]]
 deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "430632cc4defc5131a83e04e4e3aa6994c5f9312"
+git-tree-sha1 = "0db728b70b61273f4d1c0bd447b544484045ba48"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "1.46.0"
+version = "1.44.0"
 
 [[deps.Binutils_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll", "Zstd_jll"]


### PR DESCRIPTION
I today tried to rebuild a recipe that was merged 4 days ago, but it failed on all apple and freebsd platforms today (see https://github.com/JuliaPackaging/Yggdrasil/pull/14131 for the concrete error logs). After talking to @giordano on slack (https://julialang.slack.com/archives/C674ELDNX/p1783161072137219), I did a bisect. On yggdrasil, this bisect pointed to https://github.com/JuliaPackaging/Yggdrasil/commit/f67801ac7efca9abdca5e0d8a6fa2328bbeeb494, which (besides other things) contains a BBB bump. Another bisect in BBB pointed to https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/422, the "fix" https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/483 right after unfortunately did not fix anything.

I thus propose to revert the BBB bump for the time being, so that we have working CI on the yggy master.