### PR TITLE
[HiGHS] rebuild v1.15.0

### DIFF
--- a/H/HiGHS/build_tarballs.jl
+++ b/H/HiGHS/build_tarballs.jl
@@ -9,6 +9,7 @@ sources = [
         "https://github.com/ERGO-Code/HiGHS.git",
         "83960019015b0d5152df73110ff142f328edcfd2",
     ),
+    DirectorySource("./bundled"),
 ]
 
 # These are the platforms we will build for by default, unless further
@@ -21,6 +22,8 @@ platforms = filter!(p -> arch(p) != "powerpc64le", platforms)
 
 script = raw"""
 cd $WORKSPACE/srcdir/HiGHS
+
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/fix-cli11.patch
 
 # Remove system CMake to use the jll version
 apk del cmake
@@ -39,6 +42,7 @@ cmake -S . -B build \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_TESTING=OFF \
     -DHIPO=ON \
     -DBUILD_SHARED_EXTRAS_LIB=OFF \
     -DBLA_VENDOR=blastrampoline \

--- a/H/HiGHS/build_tarballs.jl
+++ b/H/HiGHS/build_tarballs.jl
@@ -25,8 +25,8 @@ cd $WORKSPACE/srcdir/HiGHS
 # Remove system CMake to use the jll version
 apk del cmake
 
-mkdir -p build
-cd build
+rm -rf build
+mkdir build
 
 if [[ "${target}" == *-mingw* ]]; then
     LBT=blastrampoline-5
@@ -34,28 +34,28 @@ else
     LBT=blastrampoline
 fi
 
-cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
+cmake -S . -B build \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
-    -DBUILD_TESTING=OFF \
     -DHIPO=ON \
+    -DBUILD_SHARED_EXTRAS_LIB=OFF \
     -DBLA_VENDOR=blastrampoline \
-    -DBLAS_LIBRARIES=\"${LBT}\" \
-    ..
+    -DBLAS_LIBRARIES=\"${LBT}\"
 
 if [[ "${target}" == *-linux-* ]]; then
-        make -j ${nproc}
+    make -C build -j ${nproc}
 else
     if [[ "${target}" == *-mingw* ]]; then
-        cmake --build . --config Release
+        cmake --build build --config Release
     else
-        cmake --build . --config Release --parallel
+        cmake --build build --config Release --parallel
     fi
 fi
-make install
+cmake --install build
 
-install_license ../LICENSE.txt
+install_license LICENSE.txt
 """
 
 products = [

--- a/H/HiGHS/bundled/patches/fix-cli11.patch
+++ b/H/HiGHS/bundled/patches/fix-cli11.patch
@@ -1,0 +1,13 @@
+diff --git a/extern/cli11/CLI11.hpp b/extern/cli11/CLI11.hpp
+index 2ed2fd7c8a..f61cbe6061 100644
+--- a/extern/cli11/CLI11.hpp
++++ b/extern/cli11/CLI11.hpp
+@@ -9315,7 +9315,7 @@ CLI11_INLINE void App::_process_callbacks() {
+     }
+
+     for(const Option_p &opt : options_) {
+-        if((*opt) && !opt->get_callback_run()) {
++        if(opt->count() > 0 && !opt->get_callback_run()) {
+             opt->run_callback();
+         }
+     }


### PR DESCRIPTION
Upstream changed their build script, so even though the compilation passed in #14077 , it didn't compile part of the library (the opt-in HiPO solver) like it used to.

This PR updates to the same script used by upstream, which hopefully fixes the issue. (Note the extra `BUILD_SHARED_EXTRAS_LIB=OFF`.)