### PR TITLE
[tree_sitter_ptx/spirv/gcn/llvm] new GPU-assembly grammars

### DIFF
--- a/T/tree_sitter_gcn/build_tarballs.jl
+++ b/T/tree_sitter_gcn/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_gcn"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource(
+        "https://github.com/JuliaGPU/tree-sitter-gcn.git",
+        "4ce48aad94400ac1fba191170445abfaa477d69a"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+    cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_gcn", :libtreesitter_gcn),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.6")

--- a/T/tree_sitter_gcn/bundled/CMakeLists.txt
+++ b/T/tree_sitter_gcn/bundled/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_gcn)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+file(GLOB SOURCE_GCN tree-sitter/src/*.c)
+add_library(treesitter_gcn SHARED ${SOURCE_GCN})
+
+install(TARGETS treesitter_gcn DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_llvm/build_tarballs.jl
+++ b/T/tree_sitter_llvm/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_llvm"
+version = v"1.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource(
+        "https://github.com/benwilliamgraham/tree-sitter-llvm.git",
+        "2914786ae6774d4c4e25a230f4afe16aa68fe1c1"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+    cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_llvm", :libtreesitter_llvm),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.6")

--- a/T/tree_sitter_llvm/bundled/CMakeLists.txt
+++ b/T/tree_sitter_llvm/bundled/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_llvm)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+file(GLOB SOURCE_LLVM tree-sitter/src/*.c)
+add_library(treesitter_llvm SHARED ${SOURCE_LLVM})
+
+install(TARGETS treesitter_llvm DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_ptx/build_tarballs.jl
+++ b/T/tree_sitter_ptx/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_ptx"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource(
+        "https://github.com/JuliaGPU/tree-sitter-ptx.git",
+        "a993c54d2c60a943b8c6bcfe0972ea1d9633f314"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+    cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_ptx", :libtreesitter_ptx),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.6")

--- a/T/tree_sitter_ptx/bundled/CMakeLists.txt
+++ b/T/tree_sitter_ptx/bundled/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_ptx)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+file(GLOB SOURCE_PTX tree-sitter/src/*.c)
+add_library(treesitter_ptx SHARED ${SOURCE_PTX})
+
+install(TARGETS treesitter_ptx DESTINATION lib CONFIGURATIONS Release)

--- a/T/tree_sitter_spirv/build_tarballs.jl
+++ b/T/tree_sitter_spirv/build_tarballs.jl
@@ -1,0 +1,51 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tree_sitter_spirv"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource(
+        "https://github.com/JuliaGPU/tree-sitter-spirv.git",
+        "57032ecc3e8472593137910ecc154356420c26df"
+    ),
+    DirectorySource("./bundled")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir
+mv tree-sitter-* tree-sitter
+
+BUILD_FLAGS=(-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN})
+mkdir build && cd build
+cmake .. "${BUILD_FLAGS[@]}"
+make -j${nproc}
+make install
+
+cd ..
+if [ -d tree-sitter/queries ]; then
+    cp -r tree-sitter/queries $WORKSPACE/destdir/
+fi
+if [ -f tree-sitter/LICENSE ]; then
+    install_license tree-sitter/LICENSE
+fi
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libtreesitter_spirv", :libtreesitter_spirv),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.6")

--- a/T/tree_sitter_spirv/bundled/CMakeLists.txt
+++ b/T/tree_sitter_spirv/bundled/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+project(treesitter_spirv)
+set(CMAKE_C_STANDARD 99)
+
+include_directories(tree-sitter/src)
+file(GLOB SOURCE_SPIRV tree-sitter/src/*.c)
+add_library(treesitter_spirv SHARED ${SOURCE_SPIRV})
+
+install(TARGETS treesitter_spirv DESTINATION lib CONFIGURATIONS Release)


### PR DESCRIPTION
Add tree-sitter grammar JLLs for the assembly formats GPUCompiler.jl emits, so it can syntax-highlight code_native output via Highlights.jl instead of shelling out to pygmentize:

- tree_sitter_ptx: NVIDIA PTX (JuliaGPU/tree-sitter-ptx)
- tree_sitter_spirv: SPIR-V assembly / spvasm (JuliaGPU/tree-sitter-spirv)
- tree_sitter_gcn: AMD GCN/RDNA assembly (JuliaGPU/tree-sitter-gcn)
- tree_sitter_llvm: LLVM IR (benwilliamgraham/tree-sitter-llvm)

Each recipe mirrors T/tree_sitter_julia: a small bundled CMakeLists.txt compiles the committed src/parser.c into libtreesitter_<lang> and copies the grammar's queries/ into the artifact.