### PR TITLE
[LibSSH2] backport two more patches

### DIFF
--- a/L/LibSSH2/LibSSH2@1.11/build_tarballs.jl
+++ b/L/LibSSH2/LibSSH2@1.11/build_tarballs.jl
@@ -3,7 +3,7 @@ using Pkg
 using BinaryBuilderBase: sanitize
 
 name = "LibSSH2"
-version = v"1.11.102"
+version = v"1.11.103"
 upstream = VersionNumber(version.major, version.minor, version.patch÷100)
 # Collection of sources required to build LibSSH2
 sources = [

--- a/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-58050-3449752.patch
+++ b/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-58050-3449752.patch
@@ -23,7 +23,7 @@ index a0d31000..3a6dd116 100644
  
                  if(list[keys].num_attrs) {
 +                    if(list[keys].num_attrs > 1024) {
-+                        ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
++                        _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
 +                                 "Too many publickey attributes");
 +                        goto err_exit;
 +                    }

--- a/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-58050-3449752.patch
+++ b/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-58050-3449752.patch
@@ -1,0 +1,32 @@
+commit 34497525929b9a47f03dfb81887ac896202b7e12
+Author: Viktor Szakats <commit@vsz.me>
+Date:   Sun Jun 28 02:12:52 2026 +0200
+
+    publickey: fix potential multiplication overflow in 32-bit `libssh2_publickey_list_fetch()`
+    
+    Cap list size at 1024 elements.
+    
+    Reported-and-initial-patch-by: Mateusz Gierblinski
+    Reported-and-initial-patch-by: Behzod Abdullayev
+    Reported-by: Sharique Raza
+    
+    Follow-up to e15f5d97a04cc676ce117dd324fef85b046207a9
+    
+    Closes #2128
+
+diff --git a/src/publickey.c b/src/publickey.c
+index a0d31000..3a6dd116 100644
+--- a/src/publickey.c
++++ b/src/publickey.c
+@@ -1048,6 +1048,11 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
+                 }
+ 
+                 if(list[keys].num_attrs) {
++                    if(list[keys].num_attrs > 1024) {
++                        ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
++                                 "Too many publickey attributes");
++                        goto err_exit;
++                    }
+                     list[keys].attrs =
+                         SSH2_ALLOC(session,
+                                    list[keys].num_attrs *

--- a/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-58051-a9758da.patch
+++ b/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-58051-a9758da.patch
@@ -1,0 +1,25 @@
+commit a9758da45a52bc8c630ec9493804d0c6ea30b24a
+Author: Viktor Szakats <vszakats@users.noreply.github.com>
+Date:   Mon Jun 29 19:12:21 2026 +0200
+
+    publickey: fix potential arbitrary free in `libssh2_publickey_list_fetch()` (#2127)
+    
+    Due to uninitialized list entry.
+    
+    Reported-and-patch-by: Behzod Abdullayev
+    Reported-by: Sharique Raza
+    
+    Follow-up to e15f5d97a04cc676ce117dd324fef85b046207a9
+
+diff --git a/src/publickey.c b/src/publickey.c
+index b7f38431..a0d31000 100644
+--- a/src/publickey.c
++++ b/src/publickey.c
+@@ -905,6 +905,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
+                     goto err_exit;
+                 }
+                 list = newlist;
++                memset(&list[keys], 0, sizeof(list[keys]));
+             }
+             if(pkey->version == 1) {
+                 unsigned long comment_len;


### PR DESCRIPTION
Cf https://github.com/JuliaLang/SecurityAdvisories.jl/pull/562. Note that these have not been picked up by Debian (which was our source for the other backports).