### PR TITLE
[GMP] Add Julia's interruption-safe mpz reallocation patch

### DIFF
--- a/G/GMP/GMP@6.3.0/build_tarballs.jl
+++ b/G/GMP/GMP@6.3.0/build_tarballs.jl
@@ -9,4 +9,4 @@ build_tarballs(ARGS, configure(version, llvm_version)...;
                clang_use_lld=false, julia_compat="1.6", preferred_gcc_version=v"6",
                preferred_llvm_version=llvm_version)
 
-# Build trigger: 2
+# Build trigger: 3

--- a/G/GMP/GMP@6.3.0/bundled/patches/README
+++ b/G/GMP/GMP@6.3.0/bundled/patches/README
@@ -8,3 +8,12 @@ overflow in favour of the old mechanism introduced via Julia's
 patches. The main reasons are: (a) this works for Julia right away (no
 changes to Base necessary), and (b) Julia's patches handle more cases,
 i.e. more places where an overflow can occur.
+
+gmp-mpz_realloc.patch (also carried in Julia's deps/patches) reorders
+the reallocation paths in _mpz_realloc and mpz_mul to
+allocate-install-free-last, so an mpz stays structurally valid at
+every interruptible point. Julia's task cancellation can unwind out
+of a GMP call from inside the allocation hooks; with the upstream
+order (free old, raise ALLOC, then allocate) such an unwind leaves
+the mpz pointing at freed memory with an overstated capacity, and a
+later mpz_clear double-frees it, corrupting the heap.

--- a/G/GMP/GMP@6.3.0/bundled/patches/gmp-mpz_realloc.patch
+++ b/G/GMP/GMP@6.3.0/bundled/patches/gmp-mpz_realloc.patch
@@ -1,0 +1,102 @@
+--- a/mpz/realloc.c
++++ b/mpz/realloc.c
+@@ -50,21 +50,40 @@
+ 	__GMP_ALLOC_OVERFLOW_FUNC ();
+     }
+ 
+-  if (ALLOC (m) == 0)
++  /* Allocate-copy-install-free-last (rather than realloc-in-place), so the
++     mpz is structurally valid at every interruptible point: an asynchronous
++     unwind (e.g. Julia task cancellation delivered inside GMP) between any
++     two statements leaves PTR/ALLOC/SIZ mutually consistent, at worst
++     leaking the block that was not yet freed.  The realloc-based version
++     has a window where PTR (m) dangles - the old block is freed inside the
++     allocation hook before the new pointer is stored - which a later
++     mpz_clear would double free.  ALLOC is stepped through MIN (old, new)
++     so that capacity is understated, never overstated, in every window.  */
++  mp = __GMP_ALLOCATE_FUNC_LIMBS (new_alloc);
++  if (ALLOC (m) != 0)
+     {
+-      mp = __GMP_ALLOCATE_FUNC_LIMBS (new_alloc);
+-    }
+-  else
+-    {
+-      mp = __GMP_REALLOCATE_FUNC_LIMBS (PTR (m), ALLOC (m), new_alloc);
++      mp_ptr old_mp = PTR (m);
++      mp_size_t old_alloc = ALLOC (m);
++      mp_size_t copy_size = ABSIZ (m);
++      if (copy_size > new_alloc)
++	copy_size = new_alloc;
++      MPN_COPY (mp, old_mp, copy_size);
+ 
+       /* Don't create an invalid number; if the current value doesn't fit after
+ 	 reallocation, clear it to 0.  */
+       if (UNLIKELY (ABSIZ (m) > new_alloc))
+ 	SIZ (m) = 0;
+-    }
+ 
+-  PTR (m) = mp;
+-  ALLOC(m) = new_alloc;
++      if (new_alloc < old_alloc)
++	ALLOC (m) = new_alloc;
++      PTR (m) = mp;
++      ALLOC (m) = new_alloc;
++      __GMP_FREE_FUNC_LIMBS (old_mp, old_alloc);
++    }
++  else
++    {
++      PTR (m) = mp;
++      ALLOC (m) = new_alloc;
++    }
+   return (void *) mp;
+ }
+diff --git a/mpz/mul.c b/mpz/mul.c
+--- a/mpz/mul.c
++++ b/mpz/mul.c
+@@ -103,20 +103,37 @@
+   wsize = usize + vsize;
+   if (ALLOC (w) < wsize)
+     {
+-      if (ALLOC (w) != 0)
++      /* Allocate-install-free-last (mirroring _mpz_realloc), so W stays
++	 structurally valid at every interruptible point: an asynchronous
++	 unwind (e.g. Julia task cancellation delivered inside the
++	 allocation hook) between any two statements leaves PTR/ALLOC/SIZ
++	 mutually consistent, at worst leaking the just-allocated block.
++	 The previous order freed the old limbs and raised ALLOC before the
++	 new block was installed, so an unwind there left W pointing at
++	 freed memory with an overstated capacity, which a later mpz_clear
++	 double-freed.  */
++      mp_ptr old_wp = wp;
++      mp_size_t old_alloc = ALLOC (w);
++      wp = __GMP_ALLOCATE_FUNC_LIMBS (wsize);
++      PTR (w) = wp;
++      /* The old value is not copied; don't let SIZ describe uninitialized
++	 limbs if the operation is unwound before the final SIZ store.
++	 (usize/vsize were captured above - clearing SIZ is safe even when
++	 W aliases an input.)  */
++      SIZ (w) = 0;
++      ALLOC (w) = wsize;
++      if (old_alloc != 0)
+ 	{
+-	  if (wp == up || wp == vp)
++	  if (old_wp == up || old_wp == vp)
+ 	    {
+-	      free_me = wp;
+-	      free_me_size = ALLOC (w);
++	      /* W is also an input: its old limbs are still read by the
++		 multiplication below - free them only afterwards.  */
++	      free_me = old_wp;
++	      free_me_size = old_alloc;
+ 	    }
+ 	  else
+-	    (*__gmp_free_func) (wp, (size_t) ALLOC (w) * GMP_LIMB_BYTES);
++	    (*__gmp_free_func) (old_wp, (size_t) old_alloc * GMP_LIMB_BYTES);
+ 	}
+-
+-      ALLOC (w) = wsize;
+-      wp = __GMP_ALLOCATE_FUNC_LIMBS (wsize);
+-      PTR (w) = wp;
+     }
+   else
+     {

--- a/G/GMP/common.jl
+++ b/G/GMP/common.jl
@@ -67,7 +67,7 @@ install_license COPYING*
 
     # Dependencies that must be installed before this package can be built
     dependencies = [
-        BuildDependency(PackageSpec(name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=llvm_version);
+        BuildDependency(PackageSpec(name="LLVMCompilerRT_jll", uuid="4e17d02c-6bf5-513e-be62-445f41c75a11", version=string(llvm_version));
                         platforms=filter(p -> sanitize(p)=="memory", platforms)),
     ]
 


### PR DESCRIPTION
Julia's task cancellation (JuliaLang/julia#60281) can unwind out of a GMP call from inside the allocation hooks. GMP's reallocation paths in _mpz_realloc and mpz_mul free the old limb block and raise ALLOC before allocating the new block, so an unwind in that window leaves the mpz pointing at freed memory with an overstated capacity; a later mpz_clear then double-frees it and corrupts the heap. The patch (carried in Julia's deps/patches and applied to Julia's source builds of GMP) reorders both paths to allocate-install-free-last, keeping the mpz structurally valid at every interruptible point at the cost of at most a leaked block on unwind.