### PR TITLE
0_RootFS: Add LLVM 22 bootstrap shard

### DIFF
--- a/0_RootFS/LLVMBootstrap@22/build_tarballs.jl
+++ b/0_RootFS/LLVMBootstrap@22/build_tarballs.jl
@@ -1,0 +1,16 @@
+# Include everything common between our LLVM versions (That's a lot)
+include("../llvm_common.jl")
+
+# Build the tarballs, then upload to Yggdrasil releases
+
+name = "LLVMBootstrap"
+version = v"22.1.7"
+sources, script, products, dependencies = llvm_build_args(;version=version)
+ndARGS, deploy_target = find_deploy_arg(ARGS)
+# Earlier versions of GCC can cause Clang to fail with `error: unknown target CPU 'x86-64'`
+# https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/112#issuecomment-776940748
+build_info = build_tarballs(ndARGS, name, version, sources, script, [host_platform], products, dependencies;
+                            skip_audit=true, preferred_gcc_version=v"8")
+if deploy_target !== nothing
+    upload_and_insert_shards(deploy_target, name, version, build_info)
+end

--- a/0_RootFS/LLVMBootstrap@22/bundled/patches/cpuidex-mingw.patch
+++ b/0_RootFS/LLVMBootstrap@22/bundled/patches/cpuidex-mingw.patch
@@ -1,0 +1,1 @@
+../../../LLVMBootstrap@19/bundled/patches/cpuidex-mingw.patch

--- a/0_RootFS/LLVMBootstrap@22/bundled/patches/install-prefix.patch
+++ b/0_RootFS/LLVMBootstrap@22/bundled/patches/install-prefix.patch
@@ -1,0 +1,1 @@
+../../../LLVMBootstrap@15/bundled/patches/install-prefix.patch

--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -45,6 +45,7 @@ llvm_tags = Dict(
     v"19.1.7" => "cd708029e0b2869e80abe31ddb175f7c35361f90",
     v"20.1.2" => "58df0ef89dd64126512e4ee27b4ac3fd8ddf6247",
     v"21.1.8" => "2078da43e25a4623cab2d0d60decddf709aaea28",
+    v"22.1.7" => "a255c1ed36a1d06f79bd2633ba9f8d900153007c",
 )
 
 function llvm_sources(;version = "v8.0.1", kwargs...)

--- a/L/LLVMOpenMP/build_tarballs.jl
+++ b/L/LLVMOpenMP/build_tarballs.jl
@@ -24,7 +24,7 @@ platform_config=()
 if [[ "${target}" == *-mingw* ]]; then
     # backport https://gitlab.kitware.com/cmake/cmake/-/commit/78f758a463516a78a9ec8d472080c6e61cb89c7f
     sed -i "s@/c  */Fo@-c -Fo@" /usr/share/cmake/Modules/CMakeASM_MASMInformation.cmake
-    sed -i "s@libomp_append(asmflags_local /@libomp_append(asmflags_local -@" runtime/cmake/LibompHandleFlags.cmake
+    sed -i "s@libomp_append(asmflags_local /@libomp_append(asmflags_local -@" cmake/modules/LibompHandleFlags.cmake
     if [[ "${target}" == *x86_64* ]]; then
         platform_config+=(-DLIBOMP_ASMFLAGS="-win64")
     fi

--- a/L/LLVMOpenMP/build_tarballs.jl
+++ b/L/LLVMOpenMP/build_tarballs.jl
@@ -3,29 +3,22 @@
 using BinaryBuilder, Pkg
 
 name = "LLVMOpenMP"
-version = v"21.1.8"
+version = v"22.1.7"
 ygg_version = version
 
 sources = [
     ArchiveSource(
-        "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/openmp-$(version).src.tar.xz",
-        "856b023748b41ac7b2c83fd8e9f765ff48a4df2fe6777d2811ef7c7ed8f2f977"
-    ),
-    # we need a bunch of additional cmake files to build the subproject separately
-    # see: https://github.com/llvm/llvm-project/issues/53281#issuecomment-1260187944
-    ArchiveSource(
-        "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/cmake-$(version).src.tar.xz",
-        "85735f20fd8c81ecb0a09abb0c267018475420e93b65050cc5b7634eab744de9"
+        "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/llvm-project-$(version).src.tar.xz",
+        "5cc4a3f12bba50b6bdfb4b61bdc852117a0ff2517807c3902fc13267fb93562e"
     ),
     DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/openmp-*/
-mv ../cmake-* ../cmake
+cd $WORKSPACE/srcdir/llvm-project-*/openmp
 # https://github.com/msys2/MINGW-packages/blob/d440dcb738/mingw-w64-clang/0901-cast-to-make-gcc-happy.patch
-atomic_patch -p1 ../patches/0901-cast-to-make-gcc-happy.patch
+atomic_patch -p1 $WORKSPACE/srcdir/patches/0901-cast-to-make-gcc-happy.patch
 
 platform_config=()
 if [[ "${target}" == *-mingw* ]]; then


### PR DESCRIPTION
Adds LLVM 22.1.7 bootstrap and OpenMP support.

- Adds the x86_64-linux-musl LLVMBootstrap 22.1.7 shard. The unpacked and squashfs archives, plus build logs, are uploaded to the LLVMBootstrap-v22.1.7 Yggdrasil release.
- Updates LLVMOpenMP to 22.1.7. LLVM 22 now uses one monorepo source archive, so the recipe builds its OpenMP subdirectory directly.
- Fixes MinGW after LLVM 22 moved LibompHandleFlags.cmake to cmake/modules.

Validated the LLVMBootstrap shard with a local x86_64-linux-musl build. Validated LLVMOpenMP on x86_64-linux-gnu, x86_64-w64-mingw32, and i686-w64-mingw32; each produced its libomp product.
