### PR TITLE
[LAL] Package the core LALSuite libraries and headers (v7.7.1)

### DIFF
--- a/L/LAL/build_tarballs.jl
+++ b/L/LAL/build_tarballs.jl
@@ -91,10 +91,12 @@ platforms = filter(!Sys.iswindows, supported_platforms())
 # the ABI matrix supported by that HDF5 release; it predates MPIABI_jll.
 const hdf5_mpi_abis = (
     ("MPICH", PackageSpec(name="MPICH_jll"), "4.3.0 - 4", p -> !Sys.iswindows(p)),
-    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5.5.3 - 5", p -> !Sys.iswindows(p) && !(libc(p) == "musl")),
-    # Prefer OpenMPI 5: it is HDF5-compatible and carries artifacts for the
-    # legacy libgfortran platform selected by BinaryBuilder's GCC 6 shard.
-    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "5", p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc")),
+    # Newer MPItrampoline releases dropped libgfortran3 artifacts that
+    # HDF5_jll v1.14.6 still requires on several platforms.
+    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "=5.5.3", p -> !Sys.iswindows(p) && !(libc(p) == "musl")),
+    # OpenMPI v5 dropped artifacts needed by HDF5_jll v1.14.6 (notably
+    # 32-bit Linux, FreeBSD, and RISC-V); v4.1.8 retains that matrix.
+    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "=4.1.8", p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc")),
 )
 
 function augment_hdf5_mpi_platforms(platforms)

--- a/L/LAL/build_tarballs.jl
+++ b/L/LAL/build_tarballs.jl
@@ -30,7 +30,7 @@ sed \
     -e 's%@PACKAGE_VCS_INFO_HEADER@%lal/LALVCSInfo.h%g' \
     -e 's%@PACKAGE_CONFIG_HEADER@%lal/LALConfig.h%g' \
     -e 's%@ID@%fd81149d68cb3c9424fcfe229e697ee534ac02ab%g' \
-    -e 's%@DATE@%2026-02-01 22:19:30 +0000%g' \
+    -e 's%@DATE@%2026-02-01 16:49:30 +0000%g' \
     -e 's%@BRANCH@%None%g' \
     -e 's%@TAG@%lal-v7.7.1%g' \
     -e 's%@AUTHOR@%Karl Wette <karl.wette@ligo.org>%g' \
@@ -47,6 +47,9 @@ export LDFLAGS="${LDFLAGS} -L${libdir}"
 export PKG_CONFIG_PATH="${libdir}/pkgconfig:${PKG_CONFIG_PATH}"
 export GSL_LIBS="-L${libdir} -lgsl -lgslcblas -lm"
 export HDF5_LIBS="-L${libdir} -lhdf5 -lhdf5_hl"
+# LAL's HDF5 probe temporarily sets CC to h5cc's compiler, which is mpicc.
+# Pin MPItrampoline's backend now so its mpicc wrapper cannot invoke itself.
+export MPITRAMPOLINE_CC="${CC}"
 
 ../configure \
     --prefix=${prefix} \
@@ -62,6 +65,7 @@ export HDF5_LIBS="-L${libdir} -lhdf5 -lhdf5_hl"
     --disable-help2man \
     --disable-gcc-flags \
     --enable-pthread-lock \
+    --with-fallback-data-path=no \
     --with-hdf5=yes
 
 cp ../lib/LALVCSInfoHeader.h lib/LALVCSInfoHeader.h
@@ -70,6 +74,13 @@ make -j${nproc} V=1 -C include
 make -j${nproc} V=1 -C lib
 make -j${nproc} V=1 -C lib install
 make install-pkgconfigDATA
+
+# pkg-config expands Zlib_jll's prefix while configuring, so remove those
+# build-only paths from the installed metadata.
+sed -i \
+    -e "s|-L${libdir} ||g" \
+    -e "s|-I${includedir} ||g" \
+    ${libdir}/pkgconfig/lalsupport.pc
 
 rm -f ${prefix}/share/man/man7/LAL_DEBUG_LEVEL.7
 rmdir ${prefix}/share/man/man7 2>/dev/null || true
@@ -81,6 +92,9 @@ test -f ${includedir}/lal/LALDict.h
 test -f ${includedir}/lal/XLALError.h
 test -f ${libdir}/pkgconfig/lal.pc
 test -f ${libdir}/pkgconfig/lalsupport.pc
+! grep -F "${prefix}" ${libdir}/pkgconfig/lal.pc
+! grep -F "${prefix}" ${libdir}/pkgconfig/lalsupport.pc
+! grep -a -F "${prefix}/share/lal" ${libdir}/liblalsupport*
 """
 
 # LALSuite's upstream package explicitly excludes Windows.

--- a/L/LAL/build_tarballs.jl
+++ b/L/LAL/build_tarballs.jl
@@ -85,6 +85,11 @@ test -f ${libdir}/pkgconfig/lalsupport.pc
 
 # LALSuite's upstream package explicitly excludes Windows.
 platforms = filter(!Sys.iswindows, supported_platforms())
+# HDF5_jll v1.14.6 and MPItrampoline need a Fortran runtime despite LAL itself
+# being C-only.  libgfortran3 artifacts are no longer available from the
+# current CompilerSupportLibraries_jll, so select the supported v5 ABI.
+platforms = expand_gfortran_versions(platforms)
+filter!(p -> libgfortran_version(p) >= v"5", platforms)
 
 # HDF5_jll v1.14.6 is MPI-augmented, so LAL must expose matching artifacts and
 # runtime dependencies even though its public API is not MPI-based.  This is

--- a/L/LAL/build_tarballs.jl
+++ b/L/LAL/build_tarballs.jl
@@ -1,6 +1,7 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
 
 name = "LAL"
 version = v"7.7.1"
@@ -85,6 +86,64 @@ test -f ${libdir}/pkgconfig/lalsupport.pc
 # LALSuite's upstream package explicitly excludes Windows.
 platforms = filter(!Sys.iswindows, supported_platforms())
 
+# HDF5_jll v1.14.6 is MPI-augmented, so LAL must expose matching artifacts and
+# runtime dependencies even though its public API is not MPI-based.  This is
+# the ABI matrix supported by that HDF5 release; it predates MPIABI_jll.
+const hdf5_mpi_abis = (
+    ("MPICH", PackageSpec(name="MPICH_jll"), "4.3.0 - 4", p -> !Sys.iswindows(p)),
+    ("MPItrampoline", PackageSpec(name="MPItrampoline_jll"), "5.5.3 - 5", p -> !Sys.iswindows(p) && !(libc(p) == "musl")),
+    # Prefer OpenMPI 5: it is HDF5-compatible and carries artifacts for the
+    # legacy libgfortran platform selected by BinaryBuilder's GCC 6 shard.
+    ("OpenMPI", PackageSpec(name="OpenMPI_jll"), "5", p -> !Sys.iswindows(p) && !(arch(p) == "armv6l" && libc(p) == "glibc")),
+)
+
+function augment_hdf5_mpi_platforms(platforms)
+    augmented_platforms = AbstractPlatform[]
+    dependencies = []
+    for (abi, package, compat, supports) in hdf5_mpi_abis
+        abi_platforms = deepcopy(filter(supports, platforms))
+        foreach(abi_platforms) do platform
+            platform["mpi"] = abi
+        end
+        append!(augmented_platforms, abi_platforms)
+        push!(dependencies, Dependency(package; compat, platforms=abi_platforms))
+    end
+    push!(dependencies, RuntimeDependency(
+        PackageSpec(name="MPIPreferences", uuid="3da0fdf6-3ccc-4f1b-acd9-58baa6c99267");
+        compat="0.1",
+        top_level=true,
+    ))
+    return augmented_platforms, dependencies
+end
+
+augment_platform_block = raw"""
+    using Base.BinaryPlatforms
+    MPIPreferences_UUID = Base.UUID("3da0fdf6-3ccc-4f1b-acd9-58baa6c99267")
+    const preferences = Base.get_preferences(MPIPreferences_UUID)
+
+    const binary_to_abi = Dict(
+        "MPICH_jll" => "MPICH",
+        "MPItrampoline_jll" => "MPItrampoline",
+        "OpenMPI_jll" => "OpenMPI",
+    )
+
+    function augment_mpi!(platform)
+        binary = get(preferences, "binary", "MPICH_jll")
+        if binary == "system"
+            abi = get(preferences, "abi", nothing)
+            abi === nothing && error("MPIPreferences: binary is system but abi is unset")
+        else
+            abi = get(binary_to_abi, binary, nothing)
+            abi === nothing && error("Unsupported MPI binary: $binary")
+        end
+        !haskey(platform, "mpi") && (platform["mpi"] = abi)
+        return platform
+    end
+
+    augment_platform!(platform::Platform) = augment_mpi!(platform)
+"""
+platforms, platform_dependencies = augment_hdf5_mpi_platforms(platforms)
+
 products = [
     LibraryProduct("liblal", :liblal),
     LibraryProduct("liblalsupport", :liblalsupport),
@@ -97,6 +156,11 @@ dependencies = [
     Dependency("HDF5_jll"; compat="~1.14.6"),
     Dependency("Zlib_jll"; compat="1.2.12"),
 ]
+append!(dependencies, platform_dependencies)
+
+# Prevent MPItrampoline from resolving a system MPI implementation while the
+# BinaryBuilder auditor validates each produced shared library.
+ENV["MPITRAMPOLINE_DELAY_INIT"] = "1"
 
 build_tarballs(
     ARGS,
@@ -107,6 +171,7 @@ build_tarballs(
     platforms,
     products,
     dependencies;
+    augment_platform_block,
     julia_compat="1.6",
     preferred_gcc_version=v"6",
 )

--- a/L/LAL/build_tarballs.jl
+++ b/L/LAL/build_tarballs.jl
@@ -1,0 +1,112 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+name = "LAL"
+version = v"7.7.1"
+
+# LALSuite tag: lal-v7.7.1
+sources = [
+    GitSource(
+        "https://github.com/lscsoft/lalsuite.git",
+        "fd81149d68cb3c9424fcfe229e697ee534ac02ab",
+    ),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/lalsuite/lal
+
+./00boot
+update_configure_scripts
+
+# GitSource checkouts do not retain .git metadata.  LAL's release archives
+# contain this generated header, so recreate the release-tagged form here.
+sed \
+    -e 's%@PACKAGE_NAME@%LAL%g' \
+    -e 's%@PACKAGE_NAME_UCASE@%LAL%g' \
+    -e 's%@PACKAGE_NAME_LCASE@%lal%g' \
+    -e 's%@PACKAGE_NAME_NOLAL@%%g' \
+    -e 's%@PACKAGE_VCS_INFO_HEADER@%lal/LALVCSInfo.h%g' \
+    -e 's%@PACKAGE_CONFIG_HEADER@%lal/LALConfig.h%g' \
+    -e 's%@ID@%fd81149d68cb3c9424fcfe229e697ee534ac02ab%g' \
+    -e 's%@DATE@%2026-02-01 22:19:30 +0000%g' \
+    -e 's%@BRANCH@%None%g' \
+    -e 's%@TAG@%lal-v7.7.1%g' \
+    -e 's%@AUTHOR@%Karl Wette <karl.wette@ligo.org>%g' \
+    -e 's%@COMMITTER@%Karl Wette <karl.wette@ligo.org>%g' \
+    -e 's%@CLEAN@%CLEAN%g' \
+    -e 's%@STATUS@%CLEAN: All modifications committed%g' \
+    lib/LALVCSInfoHeader.h.git > lib/LALVCSInfoHeader.h
+
+mkdir build
+cd build
+
+export CPPFLAGS="${CPPFLAGS} -I${includedir}"
+export LDFLAGS="${LDFLAGS} -L${libdir}"
+export PKG_CONFIG_PATH="${libdir}/pkgconfig:${PKG_CONFIG_PATH}"
+export GSL_LIBS="-L${libdir} -lgsl -lgslcblas -lm"
+export HDF5_LIBS="-L${libdir} -lhdf5 -lhdf5_hl"
+
+../configure \
+    --prefix=${prefix} \
+    --build=${MACHTYPE} \
+    --host=${target} \
+    --disable-static \
+    --enable-shared \
+    --disable-python \
+    --disable-swig \
+    --disable-swig-python \
+    --disable-swig-octave \
+    --disable-doxygen \
+    --disable-help2man \
+    --disable-gcc-flags \
+    --enable-pthread-lock \
+    --with-hdf5=yes
+
+cp ../lib/LALVCSInfoHeader.h lib/LALVCSInfoHeader.h
+
+make -j${nproc} V=1 -C include
+make -j${nproc} V=1 -C lib
+make -j${nproc} V=1 -C lib install
+make install-pkgconfigDATA
+
+rm -f ${prefix}/share/man/man7/LAL_DEBUG_LEVEL.7
+rmdir ${prefix}/share/man/man7 2>/dev/null || true
+
+install_license ../COPYING
+
+test -f ${includedir}/lal/LALDatatypes.h
+test -f ${includedir}/lal/LALDict.h
+test -f ${includedir}/lal/XLALError.h
+test -f ${libdir}/pkgconfig/lal.pc
+test -f ${libdir}/pkgconfig/lalsupport.pc
+"""
+
+# LALSuite's upstream package explicitly excludes Windows.
+platforms = filter(!Sys.iswindows, supported_platforms())
+
+products = [
+    LibraryProduct("liblal", :liblal),
+    LibraryProduct("liblalsupport", :liblalsupport),
+    FileProduct("include/lal", :lal_headers),
+]
+
+dependencies = [
+    Dependency("FFTW_jll"; compat="3.3.11"),
+    Dependency("GSL_jll"; compat="2.8.1"),
+    Dependency("HDF5_jll"; compat="~1.14.6"),
+    Dependency("Zlib_jll"; compat="1.2.12"),
+]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    julia_compat="1.6",
+    preferred_gcc_version=v"6",
+)


### PR DESCRIPTION
This PR adds a BinaryBuilder recipe for the core [`LAL`](https://lscsoft.docs.ligo.org/lalsuite/lal/) component of [`LALSuite`](https://lscsoft.docs.ligo.org/lalsuite/lalsuite/). The broader goal is to make [`LALSimulation`](https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/)—including gravitational-wave generation and neutron-star simulation functionality—available through native Julia packages. Because LALSimulation builds on the fundamental data structures, error handling, numerical utilities, and memory-management interfaces provided by LAL, packaging LAL is the required first step.

The recipe builds the pinned [`lal-v7.7.1` source](https://github.com/lscsoft/lalsuite/commit/fd81149d68cb3c9424fcfe229e697ee534ac02ab) and produces `LAL_jll`, containing `liblal`, `liblalsupport`, public C headers, and pkg-config metadata for supported non-Windows platforms. This provides the reproducible native dependency needed for a follow-up `LALSimulation_jll` recipe and, subsequently, a native `LALSimulation.jl` interface without requiring Python or SWIG at runtime.