### PR TITLE
0_RootFS: Disable mingw TLS for GCC <= 15, enable native TLS for GCC 16+

### DIFF
--- a/0_RootFS/common.jl
+++ b/0_RootFS/common.jl
@@ -70,7 +70,9 @@ function get_next_shard_tag(cs)
     end
 
     last_version = VersionNumber(last_tag[length(cs.name)+2:end])
-    build_number = 0
+    # A tag without a `+N` suffix (the first deploy of a version) is build 0,
+    # so the next build number is 1 -- `+0` would alias the existing release.
+    build_number = 1
     if isa(last_version.build, Tuple{<:UInt})
         build_number = last_version.build[1] + 1
     end

--- a/0_RootFS/common.jl
+++ b/0_RootFS/common.jl
@@ -57,6 +57,17 @@ function publish_artifact(repo::AbstractString, tag::AbstractString, hash::Base.
     end
 end
 
+# HACK (2026-07, remove eventually): GCCBootstrap 14.3.0 tarballs are recorded in
+# BinaryBuilderBase's Artifacts.toml under the v14.2.0 artifact names, because
+# `available_gcc_builds` still identifies the GCC 14 toolchain as v14.2.0 (the
+# 14.3.0 content was slotted into the existing stanzas by hand, see
+# JuliaPackaging/BinaryBuilderBase.jl#486). Until BBB is bumped to know about
+# 14.3.0 (rename the stanzas + update `available_gcc_builds`), deploys of 14.3.0
+# must upload assets/tags under v14.3.0 but look up and bind the Artifacts.toml
+# entries under v14.2.0.
+shard_bind_version(name, version) =
+    (name == "GCCBootstrap" && version == v"14.3.0") ? v"14.2.0" : version
+
 function get_next_shard_tag(cs)
     artifacts_toml = joinpath(dirname(dirname(pathof(BinaryBuilderBase))), "Artifacts.toml")
     meta = artifact_meta(BinaryBuilderBase.artifact_name(cs), artifacts_toml; platform=cs.host)
@@ -89,7 +100,17 @@ end
 
 function upload_compiler_shard(repo, name, version, hash, archive_type; platform=host_platform, target=nothing)
     cs = CompilerShard(name, version, platform, archive_type; target=target)
-    tag = get_next_shard_tag(cs)
+    # The tag lookup must consult the entry the shard is *recorded* under in the
+    # BBB Artifacts.toml, which may differ from the upload name (see shard_bind_version).
+    bind_cs = CompilerShard(name, shard_bind_version(name, version), platform, archive_type; target=target)
+    tag = get_next_shard_tag(bind_cs)
+    # Releases are always tagged by the *upload* version. If the lookup produced
+    # something else (e.g. the bind-version fallback because the entry is missing),
+    # the active BBB Artifacts.toml is stale/inconsistent -- bail before uploading.
+    if !startswith(tag, "$(name)-v$(version)")
+        error("Computed release tag $(tag) does not match shard version $(version); " *
+              "is the active BinaryBuilderBase's Artifacts.toml up to date?")
+    end
     filename = BinaryBuilderBase.artifact_name(cs)
     tarball_hash = publish_artifact(repo, tag, hash, filename)
 
@@ -126,9 +147,10 @@ function upload_and_insert_shards(repo, name, version, unpacked_hash, squashfs_h
         squashfs_dl_info = upload_compiler_shard(repo, name, version, squashfs_hash, :squashfs; platform=platform, target=target)
     end
 
-    # Insert these final versions into BB
-    insert_compiler_shard(name, version, unpacked_hash, :unpacked; download_info=unpacked_dl_info, platform=platform, target=target)
-    insert_compiler_shard(name, version, squashfs_hash, :squashfs; download_info=squashfs_dl_info, platform=platform, target=target)
+    # Insert these final versions into BB, under the name BBB looks shards up by
+    # (see shard_bind_version).
+    insert_compiler_shard(name, shard_bind_version(name, version), unpacked_hash, :unpacked; download_info=unpacked_dl_info, platform=platform, target=target)
+    insert_compiler_shard(name, shard_bind_version(name, version), squashfs_hash, :squashfs; download_info=squashfs_dl_info, platform=platform, target=target)
 end
 
 function upload_and_insert_shards(repo, name, version, build_info; target=nothing)

--- a/0_RootFS/gcc_common.jl
+++ b/0_RootFS/gcc_common.jl
@@ -132,6 +132,27 @@ function gcc_script(gcc_version::VersionNumber, compiler_target::Platform)
         # On mingw, we need to explicitly set the windres code page to 1, otherwise windres segfaults
         export CPPFLAGS="${CPPFLAGS} -DCP_ACP=1"
 
+        # TLS on Windows:
+        # - GCC <= 15 has no native TLS codegen; TLS there only means libstdc++ uses
+        #   emutls-based __thread for the std::call_once internals. Keep it disabled:
+        #   the emutls libstdc++ ABI is transitional (msys2 moves to native TLS with
+        #   GCC 16 and will rebuild their world), and it breaks clang-compiled
+        #   downstreams, since clang defaults to native TLS on mingw
+        #   (https://github.com/EnzymeAD/ReactantBuilder/pull/195). See also
+        #   https://github.com/JuliaLang/julia/pull/45582#issuecomment-1295697412
+        # - GCC 16+ has native Windows TLS, opt-in via --enable-tls and requiring
+        #   binutils >= 2.44: https://gcc.gnu.org/gcc-16/changes.html
+        #   Enable it, following msys2's transition plan
+        #   (https://github.com/msys2/MINGW-packages/issues/29272). The bundled
+        #   libstdcpp-tls-abi patch keeps the non-TLS compatibility symbols in
+        #   libstdc++ so existing binaries built against the non-TLS ABI still load;
+        #   it will need to be carried to any future GCC 16 recipe.
+        if [[ "${GCC_VERSION_MAJOR}" -ge 16 ]]; then
+            GCC_CONF_ARGS="${GCC_CONF_ARGS} --enable-tls"
+        else
+            GCC_CONF_ARGS="${GCC_CONF_ARGS} --disable-tls"
+        fi
+
     elif [[ "${COMPILER_TARGET}" == *-darwin* ]]; then
         # Use llvm archive tools to dodge binutils bugs
         export LD_FOR_TARGET=${prefix}/bin/${COMPILER_TARGET}-ld


### PR DESCRIPTION
Ok, so the basic story here is there there's three different ABIs:
- No TLS
- EmuTLS
- Native TLS

Traditionally we've been using "No TLS", but we enabled Dual-ABI (with "EmuTLS" default) support in #11663, since msys2 switched on (Emu)TLS. However, this broke downstream builders that were using Clang, since Clang defaults to Native TLS (msys2 carried a clang patch to change this default). That said, msys2 *just* (two months ago), switched to Native TLS ABI, so there's really no point in shipping EmuTLS at all. Unfortunately, Native TLS is broken before GCC 16. Switch back to No TLS and at some point in the near future, we should build a GCC 16 (dual "No TLS","Native TLS") shard/CSL for Julia 1.14

I will rebuild all the toolchain images on top of this. C++ packages that were built since #11663 and use std::future may need rebuilding.

cc @wsmoses 