### PR TITLE
[CompilerSupportLibraries] Include the synchronization import library

### DIFF
--- a/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.5/build_tarballs.jl
+++ b/C/CompilerSupportLibraries/CompilerSupportLibraries@v1.5/build_tarballs.jl
@@ -1,5 +1,5 @@
 include("../common.jl")
 
-build_csl(ARGS, v"1.5.6"; preferred_gcc_version=v"15", unix_staticlibs=true, windows_staticlibs=true, julia_compat="1.12")
+build_csl(ARGS, v"1.5.7"; preferred_gcc_version=v"15", unix_staticlibs=true, windows_staticlibs=true, julia_compat="1.12")
 
 # Build trigger: 2

--- a/C/CompilerSupportLibraries/common.jl
+++ b/C/CompilerSupportLibraries/common.jl
@@ -96,7 +96,7 @@ if [[ ${target} == *mingw* ]]; then
         # and for direct ld links of Windows executables and DLLs.
         for lib in libadvapi32.a libdbghelp.a libgcc.a libgcc_s.a libiphlpapi.a libkernel32.a libmingwex.a \
                    libmingw32.a libmsvcrt.a libmsvcrt-os.a libmoldname.a libntdll.a libole32.a libpsapi.a libsecur32.a \
-                   libshell32.a libssp.a libuser32.a libuserenv.a libuuid.a libwinmm.a libws2_32.a \
+                   libshell32.a libssp.a libsynchronization.a libuser32.a libuserenv.a libuuid.a libwinmm.a libws2_32.a \
                    libpthread.dll.a libssp.dll.a dllcrt2.o crt2.o crt2u.o crtbegin.o crtend.o; do
             qfind "/opt/${target}" -name "${lib}" -exec install -Dvm 0644 '{}' "${destdir}/${lib}" \;
         done
@@ -204,6 +204,7 @@ install_license /usr/share/licenses/GPL-3.0+
                                  FileProduct("$(destdir)/libsecur32.a", :libsecur32_a),
                                  FileProduct("$(destdir)/libshell32.a", :libshell32_a),
                                  FileProduct("$(destdir)/libssp.a", :libssp_a),
+                                 FileProduct("$(destdir)/libsynchronization.a", :libsynchronization_a),
                                  FileProduct("$(destdir)/libuser32.a", :libuser32_a),
                                  FileProduct("$(destdir)/libuserenv.a", :libuserenv_a),
                                  FileProduct("$(destdir)/libuuid.a", :libuuid_a),


### PR DESCRIPTION
CSL ships the MinGW import libraries that Julia's build uses for direct ld links of Windows executables and DLLs, but libsynchronization.a (WaitOnAddress/WakeByAddressSingle) was not among them. Julia's libuv now uses those APIs (as of https://github.com/JuliaLang/libuv/pull/46), so add the import library alongside the others.