### PR TITLE
[ZoneDetect] Add builder

### DIFF
--- a/Z/ZoneDetect/build_tarballs.jl
+++ b/Z/ZoneDetect/build_tarballs.jl
@@ -1,0 +1,31 @@
+using BinaryBuilder
+
+name = "ZoneDetect"
+version = v"2024.9.13"  # there are no actual versions so this is the date of the commit used
+
+sources = [
+    GitSource("https://github.com/BertoldVdb/ZoneDetect",
+              "082fa6b14815340d0f0d9e23b1ded318ba77c82c"),
+    DirectorySource("./bundled"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/ZoneDetect
+
+for patch in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 ${patch}
+done
+
+make -C library install CC=${CC} prefix=${prefix} STRIP=
+"""
+
+platforms = supported_platforms()
+
+products = [
+    LibraryProduct("libzonedetect", :libzonedetect),
+]
+
+dependencies = []
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")

--- a/Z/ZoneDetect/build_tarballs.jl
+++ b/Z/ZoneDetect/build_tarballs.jl
@@ -16,7 +16,16 @@ for patch in ${WORKSPACE}/srcdir/patches/*.patch; do
     atomic_patch -p1 ${patch}
 done
 
-make -C library install CC=${CC} prefix=${prefix} STRIP=
+FLAGS=(
+    CC=${CC}
+    prefix=${prefix}
+    STRIP=
+)
+if [[ "${target}" == *mingw* ]]; then
+    FLAGS+=(OS=Windows_NT)
+fi
+
+make -C library install ${FLAGS[@]}
 """
 
 platforms = supported_platforms()

--- a/Z/ZoneDetect/bundled/patches/macos-dylib.patch
+++ b/Z/ZoneDetect/bundled/patches/macos-dylib.patch
@@ -1,9 +1,9 @@
 diff --git a/library/Makefile b/library/Makefile
-index 7c62c1f..bbf124e 100644
+index 7c62c1f..0c48ace 100644
 --- a/library/Makefile
 +++ b/library/Makefile
 @@ -34,6 +34,9 @@ LDFLAGS=-shared
-
+ 
  ifeq ($(OS),Windows_NT)
    EXT=dll
 +else ifeq ($(shell uname),Darwin)
@@ -12,11 +12,3 @@ index 7c62c1f..bbf124e 100644
  else
    EXT=so
    VER_MAJ = $(word 1,$(subst ., ,$(VERSION)))
-@@ -79,7 +82,6 @@ else
- endif
-        # Assuming DESTDIR is set for cross-installing only, we don't need
-        # (and probably do not have) ldconfig
--       $(if $(DESTDIR),,ldconfig)
-
- nice:
-        mkdir -p bak/

--- a/Z/ZoneDetect/bundled/patches/macos-dylib.patch
+++ b/Z/ZoneDetect/bundled/patches/macos-dylib.patch
@@ -1,14 +1,71 @@
 diff --git a/library/Makefile b/library/Makefile
-index 7c62c1f..0c48ace 100644
+index 7c62c1f..553f615 100644
 --- a/library/Makefile
 +++ b/library/Makefile
-@@ -34,6 +34,9 @@ LDFLAGS=-shared
+@@ -25,31 +25,46 @@
+ 
+ # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+ VERSION = 0.0.0
++VER_MAJ = $(word 1,$(subst ., ,$(VERSION)))
++VER_MIN = $(word 2,$(subst ., ,$(VERSION)))
+ 
+ CC?=$(CCARCH)gcc
+ STRIP?=$(CCARCH)strip
+ 
+ CFLAGS=$(if $(DEBUG),-O0 -g,-O3) -std=gnu99 -pedantic -Wall -Wextra -Wconversion -Werror -c -fmessage-length=0 -ffunction-sections -fdata-sections
+-LDFLAGS=-shared
  
  ifeq ($(OS),Windows_NT)
    EXT=dll
++  LDFLAGS=-shared
 +else ifeq ($(shell uname),Darwin)
 +  EXT=dylib
++  LDFLAGS=-dynamiclib -Wl,-install_name,@rpath/$(EXECUTABLE) -Wl,-current_version,$(VERSION) -Wl,-compatibility_version,$(VER_MAJ).$(VER_MIN)
 +  CFLAGS += -fPIC
  else
    EXT=so
-   VER_MAJ = $(word 1,$(subst ., ,$(VERSION)))
+-  VER_MAJ = $(word 1,$(subst ., ,$(VERSION)))
+-  VER_MIN = $(word 2,$(subst ., ,$(VERSION)))
+   CFLAGS += -fPIC
+-  LDFLAGS += -Wl,-soname=$(EXECUTABLE).$(VERSION) -Wl,--hash-style=gnu
++  LDFLAGS=-shared -Wl,-soname=$(EXECUTABLE).$(VERSION) -Wl,--hash-style=gnu
+ endif
+ 
+ prefix ?= /usr
+ libdir ?= $(prefix)/lib
+ includedir ?= $(prefix)/include
+ 
+-EXECUTABLE=libzonedetect.$(EXT)
++LIBNAME=libzonedetect
++EXECUTABLE=$(LIBNAME).$(EXT)
+ INCLUDES_SRC=zonedetect.h
+ SOURCES_SRC=zonedetect.c
+ 
++# macOS puts the version before the extension, non-Windows platforms put it after
++ifeq ($(shell uname),Darwin)
++  EXEC_VERSION=$(LIBNAME).$(VERSION).$(EXT)
++  EXEC_MAJ_MIN=$(LIBNAME).$(VER_MAJ).$(VER_MIN).$(EXT)
++  EXEC_MAJ=$(LIBNAME).$(VER_MAJ).$(EXT)
++else ifneq ($(OS),Windows_NT)
++  EXEC_VERSION=$(EXECUTABLE).$(VERSION)
++  EXEC_MAJ_MIN=$(EXECUTABLE).$(VER_MAJ).$(VER_MIN)
++  EXEC_MAJ=$(EXECUTABLE).$(VER_MAJ)
++endif
+ 
+ OBJECTS_OBJ=$(SOURCES_SRC:.c=.o)
+ 
+@@ -72,10 +87,10 @@ install: $(EXECUTABLE)
+ ifeq ($(OS),Windows_NT)
+ 	install -m 0644 $(EXECUTABLE) -t $(DESTDIR)$(libdir) $(if $(STRIP),--strip --strip-program=$(STRIP))
+ else
+-	install -m 0644 $(EXECUTABLE) -D $(DESTDIR)$(libdir)/$(EXECUTABLE).$(VERSION) $(if $(STRIP),--strip --strip-program=$(STRIP))
+-	ln -sf $(EXECUTABLE).$(VERSION) $(DESTDIR)$(libdir)/$(EXECUTABLE).$(VER_MAJ).$(VER_MIN)
+-	ln -sf $(EXECUTABLE).$(VER_MAJ).$(VER_MIN) $(DESTDIR)$(libdir)/$(EXECUTABLE).$(VER_MAJ)
+-	ln -sf $(EXECUTABLE).$(VER_MAJ) $(DESTDIR)$(libdir)/$(EXECUTABLE)
++	install -m 0644 $(EXECUTABLE) -D $(DESTDIR)$(libdir)/$(EXEC_VERSION) $(if $(STRIP),--strip --strip-program=$(STRIP))
++	ln -sf $(EXEC_VERSION) $(DESTDIR)$(libdir)/$(EXEC_MAJ_MIN)
++	ln -sf $(EXEC_MAJ_MIN) $(DESTDIR)$(libdir)/$(EXEC_MAJ)
++	ln -sf $(EXEC_MAJ) $(DESTDIR)$(libdir)/$(EXECUTABLE)
+ endif
+ 	# Assuming DESTDIR is set for cross-installing only, we don't need
+ 	# (and probably do not have) ldconfig

--- a/Z/ZoneDetect/bundled/patches/makefile.patch
+++ b/Z/ZoneDetect/bundled/patches/makefile.patch
@@ -1,0 +1,22 @@
+diff --git a/library/Makefile b/library/Makefile
+index 7c62c1f..bbf124e 100644
+--- a/library/Makefile
++++ b/library/Makefile
+@@ -34,6 +34,9 @@ LDFLAGS=-shared
+
+ ifeq ($(OS),Windows_NT)
+   EXT=dll
++else ifeq ($(shell uname),Darwin)
++  EXT=dylib
++  CFLAGS += -fPIC
+ else
+   EXT=so
+   VER_MAJ = $(word 1,$(subst ., ,$(VERSION)))
+@@ -79,7 +82,6 @@ else
+ endif
+        # Assuming DESTDIR is set for cross-installing only, we don't need
+        # (and probably do not have) ldconfig
+-       $(if $(DESTDIR),,ldconfig)
+
+ nice:
+        mkdir -p bak/

--- a/Z/ZoneDetect/bundled/patches/no-ldconfig.patch
+++ b/Z/ZoneDetect/bundled/patches/no-ldconfig.patch
@@ -1,0 +1,14 @@
+diff --git a/library/Makefile b/library/Makefile
+index 7c62c1f..69d682b 100644
+--- a/library/Makefile
++++ b/library/Makefile
+@@ -77,9 +77,6 @@ else
+ 	ln -sf $(EXECUTABLE).$(VER_MAJ).$(VER_MIN) $(DESTDIR)$(libdir)/$(EXECUTABLE).$(VER_MAJ)
+ 	ln -sf $(EXECUTABLE).$(VER_MAJ) $(DESTDIR)$(libdir)/$(EXECUTABLE)
+ endif
+-	# Assuming DESTDIR is set for cross-installing only, we don't need
+-	# (and probably do not have) ldconfig
+-	$(if $(DESTDIR),,ldconfig)
+ 
+ nice:
+ 	mkdir -p bak/

--- a/Z/ZoneDetect/bundled/patches/pr-48.patch
+++ b/Z/ZoneDetect/bundled/patches/pr-48.patch
@@ -1,0 +1,32 @@
+From 1dc78b572da39619d7ecad78a526dd2fabe0bfcd Mon Sep 17 00:00:00 2001
+From: Albert Kharisov <albkharisov@gmail.com>
+Date: Tue, 16 Dec 2025 18:52:30 +0400
+Subject: [PATCH] Fix memory leak in issue #46
+
+Fix memory leak found in
+https://github.com/BertoldVdb/ZoneDetect/issues/46.
+Free memory which is not used nor freed nor returned
+from a function.
+---
+ library/zonedetect.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/library/zonedetect.c b/library/zonedetect.c
+index 899c09b..5fcb076 100644
+--- a/library/zonedetect.c
++++ b/library/zonedetect.c
+@@ -618,6 +618,7 @@ float* ZDPolygonToList(const ZoneDetect *library, uint32_t polygonId, size_t* le
+         flData[i] = ZDFixedPointToFloat(lat, 90, library->precision);
+         flData[i+1] = ZDFixedPointToFloat(lon, 180, library->precision);
+     }
++    free(data);
+ 
+     if(lengthPtr) {
+         *lengthPtr = length;
+@@ -1257,4 +1258,4 @@ char* ZDHelperSimpleLookupString(const ZoneDetect* library, float lat, float lon
+ void ZDHelperSimpleLookupStringFree(char* str)
+ {
+     free(str);
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
Includes a patch from an open PR that fixes a memory leak and a local patch to use the .dylib extension on macOS.