### PR TITLE
[HiGHS] patch Highs_destory to fix thread-safety issue

### DIFF
--- a/H/HiGHS/build_tarballs.jl
+++ b/H/HiGHS/build_tarballs.jl
@@ -24,6 +24,7 @@ script = raw"""
 cd $WORKSPACE/srcdir/HiGHS
 
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/fix-cli11.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/fix-destroy.patch
 
 # Remove system CMake to use the jll version
 apk del cmake

--- a/H/HiGHS/bundled/patches/fix-destroy.patch
+++ b/H/HiGHS/bundled/patches/fix-destroy.patch
@@ -1,0 +1,11 @@
+diff --git a/highs/interfaces/highs_c_api.cpp b/highs/interfaces/highs_c_api.cpp
+index f7d52b84d2..89360cb4f8 100644
+--- a/highs/interfaces/highs_c_api.cpp
++++ b/highs/interfaces/highs_c_api.cpp
+@@ -174,7 +174,6 @@ HighsInt Highs_qpCall(
+ void* Highs_create(void) { return new Highs(); }
+
+ void Highs_destroy(void* highs) {
+-  Highs::resetGlobalScheduler(true);
+   delete (Highs*)highs;
+ }


### PR DESCRIPTION
This will overwrite the existing v1.15.1 because that version is not thread-safe and is causing segfaults. Patch is fixed upstream, but they're not making an official release for a while.