### PR TITLE
[xrt_cxxwrap] rebuild for xrt@2.26

### DIFF
--- a/X/xrt_cxxwrap/common.jl
+++ b/X/xrt_cxxwrap/common.jl
@@ -52,5 +52,5 @@ VERBOSE=ON cmake --build build --config Release --target install -- -j${nproc}
     ]
 
     build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-                   preferred_gcc_version=v"9", julia_compat=libjulia_julia_compat(julia_versions))
+                   preferred_gcc_version=v"10", dont_dlopen=true, julia_compat=libjulia_julia_compat(julia_versions))
 end

--- a/X/xrt_cxxwrap/xrt_cxxwrap@2.26/build_tarballs.jl
+++ b/X/xrt_cxxwrap/xrt_cxxwrap@2.26/build_tarballs.jl
@@ -1,4 +1,4 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 include("../common.jl")
-build_xrt_cxxwrap(ARGS, v"2.23.0")
+build_xrt_cxxwrap(ARGS, v"2.26.0")


### PR DESCRIPTION
Also includes the gcc bump to avoid bad any_cast errors. I believe
the newer gcc version is the reason we have to specify `dont_dlopen`
