### PR TITLE
[LLVM_full] Re-register v22 as v22.1.8

### DIFF
--- a/L/LLVM/LLVM_full@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@22/build_tarballs.jl
@@ -1,4 +1,4 @@
-version = v"22.1.1"
+version = v"22.1.8"
 
 include("../common.jl")
 

--- a/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
@@ -1,4 +1,4 @@
-version = v"22.1.1"
+version = v"22.1.8"
 
 include("../common.jl")
 

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -29,7 +29,7 @@ const llvm_tags = Dict(
     v"19.1.7" => "ccda9ec62497d9de88ca7090a749e52a89f62132", # julia-19.1.7-2
     v"20.1.8" => "5b9f96366ce26dfc8ca91697ef0a57894791d95e", # julia-20.1.8-0
     v"21.1.8" => "7cd4442d4a6c949de43c1e2c0e20334ee59aa154", # julia-21.1.8-0
-    v"22.1.1" => "bb28dd22e7ad95ca869437f5e773603b6561fc9b", # julia-22.1.8-0
+    v"22.1.8" => "bb28dd22e7ad95ca869437f5e773603b6561fc9b", # julia-22.1.8-0
 )
 
 const buildscript = raw"""


### PR DESCRIPTION
The stage-1 recipe (#14053) registered LLVM_full_jll and LLVM_full_assert_jll as v22.1.1+0, but the source they package is actually LLVM 22.1.8 (fork tag julia-22.1.8-0, commit bb28dd22). Correct the version number to match the LLVM release actually shipped, so the downstream extraction JLLs (libLLVM, Clang, LLD, LLVM, MLIR) can register at the right version.

Same source commit as v22.1.1+0; only the version number changes.

This pull request was written with the assistance of generative AI.