### PR TITLE
Voiage: new package at 2.1.0

### DIFF
--- a/V/voiage_ffi/build_tarballs.jl
+++ b/V/voiage_ffi/build_tarballs.jl
@@ -41,6 +41,7 @@ install_license ../LICENSE
 platforms = supported_platforms()
 filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms) # Rust toolchain is not available on aarch64-unknown-freebsd
 filter!(p -> arch(p) != "riscv64", platforms) # Rust toolchain is not available on riscv64
+filter!(p -> !(Sys.iswindows(p) && arch(p) == "i686"), platforms) # Rust toolchain cannot link i686-w64-mingw32 unwinding symbols
 
 products = [
     LibraryProduct("libvoiage_ffi", :libvoiage_ffi),

--- a/V/voiage_ffi/build_tarballs.jl
+++ b/V/voiage_ffi/build_tarballs.jl
@@ -1,0 +1,63 @@
+using BinaryBuilder
+using Pkg
+
+name = "voiage_ffi"
+version = v"2.0.0"
+
+sources = [
+    GitSource(
+        "https://github.com/edithatogo/voiage.git",
+        "e849e89152c306e79c96d0a8a9815ee5faca0529",
+    ),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/voiage/rust
+
+cargo build \
+    --release \
+    --locked \
+    --package voiage-ffi \
+    --target "${rust_target}"
+
+if [[ "${rust_target}" == *-windows-* ]]; then
+    source_library="target/${rust_target}/release/voiage_ffi.dll"
+else
+    source_library="target/${rust_target}/release/libvoiage_ffi.${dlext}"
+fi
+
+install -Dvm 755 \
+    "${source_library}" \
+    "${libdir}/libvoiage_ffi.${dlext}"
+install_license ../LICENSE
+"""
+
+platforms = [
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "musl"),
+    Platform("aarch64", "linux"; libc = "musl"),
+    Platform("x86_64", "macos"),
+    Platform("aarch64", "macos"),
+    Platform("x86_64", "windows"),
+]
+
+products = [
+    LibraryProduct("libvoiage_ffi", :libvoiage_ffi),
+]
+
+dependencies = Dependency[]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    julia_compat = "1.10",
+    preferred_gcc_version = v"10",
+    compilers = [:c, :rust],
+)

--- a/V/voiage_ffi/build_tarballs.jl
+++ b/V/voiage_ffi/build_tarballs.jl
@@ -38,15 +38,9 @@ install -Dvm 755 \
 install_license ../LICENSE
 """
 
-platforms = [
-    Platform("x86_64", "linux"; libc = "glibc"),
-    Platform("aarch64", "linux"; libc = "glibc"),
-    Platform("x86_64", "linux"; libc = "musl"),
-    Platform("aarch64", "linux"; libc = "musl"),
-    Platform("x86_64", "macos"),
-    Platform("aarch64", "macos"),
-    Platform("x86_64", "windows"),
-]
+platforms = supported_platforms()
+filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms) # Rust toolchain is not available on aarch64-unknown-freebsd
+filter!(p -> arch(p) != "riscv64", platforms) # Rust toolchain is not available on riscv64
 
 products = [
     LibraryProduct("libvoiage_ffi", :libvoiage_ffi),

--- a/V/voiage_ffi/build_tarballs.jl
+++ b/V/voiage_ffi/build_tarballs.jl
@@ -14,6 +14,12 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/voiage/rust
 
+# Rust's musl targets default to a static C runtime, which cannot produce the
+# shared-library product consumed by a JLL package.
+if [[ "${target}" == *-musl* ]]; then
+    export RUSTFLAGS="-C target-feature=-crt-static"
+fi
+
 cargo build \
     --release \
     --locked \

--- a/V/voiage_ffi/build_tarballs.jl
+++ b/V/voiage_ffi/build_tarballs.jl
@@ -2,12 +2,12 @@ using BinaryBuilder
 using Pkg
 
 name = "voiage_ffi"
-version = v"2.1.0"
+version = v"2.2.0"
 
 sources = [
     GitSource(
         "https://github.com/edithatogo/voiage.git",
-        "964a0fc334ece9509387cd07d43776adf38be240",
+        "7af563c8cb373057d30662650b3f332f39e05b83",
     ),
 ]
 

--- a/V/voiage_ffi/build_tarballs.jl
+++ b/V/voiage_ffi/build_tarballs.jl
@@ -2,12 +2,12 @@ using BinaryBuilder
 using Pkg
 
 name = "voiage_ffi"
-version = v"2.0.0"
+version = v"2.1.0"
 
 sources = [
     GitSource(
         "https://github.com/edithatogo/voiage.git",
-        "e849e89152c306e79c96d0a8a9815ee5faca0529",
+        "964a0fc334ece9509387cd07d43776adf38be240",
     ),
 ]
 


### PR DESCRIPTION
Builds the stable Rust C ABI from the signed voiage v2.0.0 source revision and publishes `libvoiage_ffi` for 64-bit glibc/musl Linux, macOS, and Windows targets.

The generated `voiage_ffi_jll` will remove the Julia package’s current requirement for an independently installed Rust toolchain or locally built shared library.

Validation:
- the recipe parses and reaches BinaryBuilder runner creation locally;
- Yggdrasil Buildkite passes all seven requested targets: x86_64/aarch64 glibc Linux, x86_64/aarch64 musl Linux, x86_64/aarch64 macOS, and x86_64 Windows;
- the consuming Voiage Julia package passes Aqua and its numerical reference tests across Julia 1.10, 1.11, and 1.12 on Linux, macOS, and Windows.