### PR TITLE
NetCDF: enable HDF5/NCZarr plugins

### DIFF
--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -47,11 +47,6 @@ if [[ ${target} == *-mingw* ]]; then
     CONFIGURE_OPTIONS="--disable-byterange"
 fi
 
-if [[ ${target} -ne x86_64-linux-gnu ]]; then
-    # utilities are necessary to run the tests
-    CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --disable-utilities"
-fi
-
 if [[ ${target} == x86_64-linux-musl ]]; then
     # see
     # https://github.com/JuliaPackaging/Yggdrasil/blob/48af117395188f48d361a46ea929ee7563d9c2e4/A/ADIOS2/build_tarballs.jl

--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -147,7 +147,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("Blosc_jll"; compat="1.21.6"),
+    Dependency("Blosc_jll"; compat="1.21.7"),
     Dependency("Bzip2_jll"; compat="1.0.9"),
     Dependency("HDF5_jll"; compat="2.1.2"),
     Dependency("LibCURL_jll"; compat="7.73.0,8"),

--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -99,6 +99,14 @@ fi
 
 make install
 
+# Plugins on apple-darwin have the .so extension when cross-compiling
+# See <https://github.com/Unidata/netcdf-c/issues/3418>
+if [[ ${target} == *-apple-darwin* ]]; then
+    for f in ${prefix}/hdf5/lib/plugin/*.so; do
+       mv "$f" "${f%.so}.dylib"
+    done
+fi
+
 nc-config --all
 """
 

--- a/N/NetCDF/build_tarballs.jl
+++ b/N/NetCDF/build_tarballs.jl
@@ -14,7 +14,7 @@ name = "NetCDF"
 upstream_version = v"4.10.1"
 
 # Offset to add to the version number.  Remember to always bump this.
-version_offset = v"1.0.0"
+version_offset = v"1.0.1"
 
 version = VersionNumber(upstream_version.major * 100 + version_offset.major,
                         upstream_version.minor * 100 + version_offset.minor,
@@ -87,13 +87,14 @@ export CFLAGS=-Wno-implicit-function-declaration
     --enable-shared \
     --disable-static \
     --disable-dap-remote-tests \
-    --disable-plugins \
     ${CONFIGURE_OPTIONS}
 
 make LDFLAGS="${LDFLAGS_MAKE}" -j${nproc}
 
 if [[ ${target} == x86_64-linux-gnu ]]; then
-    make check
+    # Test run_dfaltpluginpath.sh assumes HOME is set
+    # See <https://github.com/Unidata/netcdf-c/issues/3415>
+    HOME=/tmp make check
 fi
 
 make install
@@ -113,6 +114,19 @@ platforms = supported_platforms()
 
 platforms, platform_dependencies = MPI.augment_platforms(platforms)
 
+# HDF5/NCZarr plugins
+plugins = [
+    "lib__nch5blosc",
+    "lib__nch5bzip2",
+    "lib__nch5deflate",
+    "lib__nch5fletcher32",
+    "lib__nch5shuffle",
+    "lib__nch5szip",
+    "lib__nch5zstd",
+    "lib__nczhdf5filters",
+    "lib__nczstdfilters",
+]
+
 # The products that we will ensure are always built
 products = [
     # NetCDF tools
@@ -126,6 +140,9 @@ products = [
 
     # NetCDF library
     LibraryProduct("libnetcdf", :libnetcdf),
+
+    # NetCDF plugins
+    [LibraryProduct(plugin, Symbol(plugin),["hdf5/lib/plugin"]) for plugin in plugins]...,
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
This PR enables the HDF5/NCZarr plugins provided by NetCDF.
In the past these plugins have been disabled because there was no API that allowed to set the plugin search path at runtime. This is now possible (see [pluginpath](https://github.com/Unidata/netcdf-c/blob/932548c0bba4cd2dd509473e0721063a2a370f44/docs/pluginpath.md)).

For the tests, we temporarily set the HOME directory to work-around issue https://github.com/Unidata/netcdf-c/issues/3415

The PR also also remove the tests:

```bash
if [[ ${target} -ne x86_64-linux-gnu ]]; then
    # utilities are necessary to run the tests
    CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --disable-utilities"
fi
```

The option did not seem to have any effect and as the utilities (ncdump, ncgen...) are compiled anyway and we are now distributing them as `ExecutableProduct`.   

CC:
@mkitti @bjarthur @eschnett 

See also:
https://github.com/JuliaPackaging/Yggdrasil/pull/13316
https://github.com/JuliaGeo/NCDatasets.jl/pull/317