### PR TITLE
[SPIRV_LLVM_Backend] Backport extracvalue_aggregate_chain

### DIFF
--- a/S/SPIRV_LLVM_Backend/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Backend/build_tarballs.jl
@@ -39,6 +39,8 @@ atomic_patch -p1 $WORKSPACE/srcdir/patches/nested_aggregate_insertvalue.patch
 # release/22.x backport for aggregate PHI value-id operands. Main already has a
 # broader aggregate PHI/select/freeze lowering path.
 atomic_patch -p1 $WORKSPACE/srcdir/patches/aggregate_phi_value_id.patch
+# Backport of llvm-project fd1f9225458a (https://github.com/llvm/llvm-project/pull/200065)
+atomic_patch -p1 $WORKSPACE/srcdir/patches/extractvalue_aggregate_chain.patch
 
 install_license LICENSE.TXT
 

--- a/S/SPIRV_LLVM_Backend/bundled/patches/extractvalue_aggregate_chain.patch
+++ b/S/SPIRV_LLVM_Backend/bundled/patches/extractvalue_aggregate_chain.patch
@@ -1,0 +1,69 @@
+From fd1f9225458aa5add79b1cc3039b98fd223d5dff Mon Sep 17 00:00:00 2001
+From: Arseniy Obolenskiy <arseniy.obolenskiy@amd.com>
+Date: Sun, 7 Jun 2026 22:21:12 +0200
+Subject: [PATCH] [SPIR-V] Rewrite extractvalue over aggregate spv_extractv
+ result (#200065)
+
+Chained extractvalue from an aggregate-returning call left raw IR over a
+multi-register spv_extractv, crashing later in foldImm. Mutate the
+producer to i32 and convert the user too
+---
+ lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp | 10 ++++++--
+ .../extractvalue-aggregate-chain.ll           | 23 +++++++++++++++++++
+ 2 files changed, 31 insertions(+), 2 deletions(-)
+ create mode 100644 test/CodeGen/SPIRV/instructions/extractvalue-aggregate-chain.ll
+
+diff --git a/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp b/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+index 42199ca11ee1..341eabe8a4f0 100644
+--- a/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
++++ b/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+@@ -2005,10 +2005,16 @@ Instruction *SPIRVEmitIntrinsics::visitInsertValueInst(InsertValueInst &I) {
+ }
+ 
+ Instruction *SPIRVEmitIntrinsics::visitExtractValueInst(ExtractValueInst &I) {
+-  if (I.getAggregateOperand()->getType()->isAggregateType())
+-    return &I;
+   IRBuilder<> B(I.getParent());
+   B.SetInsertPoint(&I);
++  if (I.getAggregateOperand()->getType()->isAggregateType()) {
++    // Mutate an aggregate-returning spv_extractv producer to i32 so
++    // IRTranslator does not see a multi-register value.
++    CallBase *CB = dyn_cast<CallBase>(I.getAggregateOperand());
++    if (!CB || CB->getIntrinsicID() != Intrinsic::spv_extractv)
++      return &I;
++    CB->mutateType(B.getInt32Ty());
++  }
+   SmallVector<Value *> Args(I.operands());
+   for (auto &Op : I.indices())
+     Args.push_back(B.getInt32(Op));
+diff --git a/test/CodeGen/SPIRV/instructions/extractvalue-aggregate-chain.ll b/test/CodeGen/SPIRV/instructions/extractvalue-aggregate-chain.ll
+new file mode 100644
+index 0000000000000..c7391a54db12f
+--- /dev/null
++++ b/test/CodeGen/SPIRV/instructions/extractvalue-aggregate-chain.ll
+@@ -0,0 +1,23 @@
++; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
++; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
++
++; Chained extractvalue from an aggregate-returning call used to crash in
++; foldImm because the outer extractvalue was left as raw IR over a
++; multi-register spv_extractv result.
++
++%ty = type { ptr addrspace(4), ptr addrspace(4), [8 x i8] }
++
++declare %ty @arr_ret()
++
++; CHECK: OpFunction
++; CHECK: %[[#AGG:]] = OpFunctionCall %[[#]] %[[#]]
++; CHECK: %[[#ARR:]] = OpCompositeExtract %[[#]] %[[#AGG]] 2
++; CHECK: %[[#ELT:]] = OpCompositeExtract %[[#]] %[[#ARR]] 0
++; CHECK: OpStore %[[#]] %[[#ELT]]
++define void @chain(ptr addrspace(4) %p) {
++  %1 = call %ty @arr_ret()
++  %2 = extractvalue %ty %1, 2
++  %3 = extractvalue [8 x i8] %2, 0
++  store i8 %3, ptr addrspace(4) %p, align 1
++  ret void
++}
+-- 
+2.47.3


### PR DESCRIPTION
Backports https://github.com/llvm/llvm-project/pull/200065 to the LLVM 22 series
