### PR TITLE
[UniversalNumbers] Build v0.1.2

### DIFF
--- a/U/UniversalNumbers/build_tarballs.jl
+++ b/U/UniversalNumbers/build_tarballs.jl
@@ -6,12 +6,12 @@ using BinaryBuilder, Pkg
 include(joinpath("..", "..", "platforms", "macos_sdks.jl"))
 
 name = "UniversalNumbers"
-version = v"0.1.1"
+version = v"0.1.2"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/jamesquinlan/UniversalNumbers.jl.git",
-              "cd4dd715498a43365fb489d1285b9fb997c4338a"),
+              "1c65497f0f4dff9b5f35dba9326ae6c48a79b167"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bump UniversalNumbers_jll to v0.1.2.

Rebuilds against UniversalNumbers.jl @ 1c65497, which re-vendors Stillwater Universal @ c34dc576. The quire no longer throws on a NaR operand in a  no-throw build (upstream #1226, PR #1228): it gained a sticky NaR state that  propagates through accumulation and resolves to the scalar's native NaR.  Because the wrapper builds with POSIT_THROW_ARITHMETIC_EXCEPTION 0, this fixes a SIGABRT that could kill the Julia process on a NaR operand.
  
Recipe change: version v0.1.1 -> v0.1.2, GitSource pin cd4dd715 -> 1c65497.