### PR TITLE
[Algencan] Add new recipe for v3.1.1

### DIFF
--- a/A/Algencan/build_tarballs.jl
+++ b/A/Algencan/build_tarballs.jl
@@ -1,0 +1,108 @@
+# Yggdrasil recipe for Algencan (TANGO project) — an augmented-Lagrangian
+# nonlinear programming solver by E. G. Birgin and J. M. Martínez.
+#
+# This builds the stand-alone Fortran library WITHOUT HSL. The HSL linear
+# solvers (MA57/MA86/MA97) are proprietary and cannot be redistributed, so this
+# JLL matches the default "easy way" build of NLPModelsAlgencan.jl (dummy HSL).
+# It removes the local build-time dependencies (gfortran + a working linker),
+# but does NOT change Algencan's numerics — for HSL-backed performance, users
+# still need a source build with their own HSL.
+#
+# To deploy: copy the `A/Algencan/` directory into a clone of
+# https://github.com/JuliaPackaging/Yggdrasil and open a PR.
+#
+# Build & test locally for a single platform (needs Docker/BinaryBuilder):
+#   julia --project build_tarballs.jl --verbose --debug aarch64-apple-darwin
+#   julia --project build_tarballs.jl --verbose --debug x86_64-linux-gnu
+
+using BinaryBuilder, Pkg
+
+name = "Algencan"
+version = v"3.1.1"
+
+# Mirror of the upstream tarball from
+# https://www.ime.usp.br/~egbirgin/tango/sources/algencan-3.1.1.tgz, republished
+# on a GitHub release for long-term reproducibility (the upstream location is a
+# personal academic URL). The file is byte-identical — same SHA256 — and
+# redistribution is permitted by Algencan's GPL-2.0-or-later license.
+sources = [
+    ArchiveSource(
+        "https://github.com/pjssilva/NLPModelsAlgencan.jl/releases/download/algencan-3.1.1/algencan-3.1.1.tgz",
+        "ab2a5496e9da49c508f68809cc339f9a604407329be24e3299bd7c21f14d6188",
+    ),
+]
+
+# Compile the static libalgencan.a (Fortran, no HSL), then wrap it in a shared
+# library that exports `c_algencan` — the C entry point that NLPModelsAlgencan.jl
+# `ccall`s via `dlsym(..., :c_algencan)`.
+script = raw"""
+cd ${WORKSPACE}/srcdir/algencan-3.1.1
+
+# The bundled top-level Makefile hardcodes CC := gcc-4.9, but only the Fortran
+# compiler and the archiver are used by the `algencan` (library) target. Name the
+# BinaryBuilder toolchain wrappers explicitly and build position-independent
+# objects. NOTE: use literal `gfortran`/`cc`/`ar` (the wrappers on PATH), NOT
+# `${AR}` etc. — BinaryBuilder does not export ${AR} in this environment, so
+# `AR="${AR}"` would set it empty and break `$(AR) rcs` in the Makefile.
+make FC=gfortran CC=cc AR=ar \
+     FFLAGS="-O3 -ffree-form -fPIC" CFLAGS="-O3 -fPIC"
+
+mkdir -p "${libdir}"
+
+# Turn the static archive into a shared library, forcing every object (and thus
+# the c_algencan symbol) to be included, and link the Fortran runtime.
+# ${libdir} already resolves to bin/ on Windows, so the DLL lands in the right
+# place with no special-casing of the output path.
+if [[ "${target}" == *-apple-* ]]; then
+    # macOS: -all_load pulls every object (and thus c_algencan) from the archive.
+    ${FC} -shared -o "${libdir}/libalgencan.${dlext}" \
+        -Wl,-all_load lib/libalgencan.a -lgfortran
+elif [[ "${target}" == *-mingw* ]]; then
+    # Windows: emit a DLL, pull in every object, and export all symbols so
+    # c_algencan is visible to dlopen/dlsym (mingw auto-exports, but be explicit).
+    ${FC} -shared -o "${libdir}/libalgencan.${dlext}" \
+        -Wl,--whole-archive lib/libalgencan.a -Wl,--no-whole-archive \
+        -Wl,--export-all-symbols -lgfortran
+else
+    # Linux/BSD: --whole-archive is the GNU-ld equivalent of macOS -all_load.
+    ${FC} -shared -o "${libdir}/libalgencan.${dlext}" \
+        -Wl,--whole-archive lib/libalgencan.a -Wl,--no-whole-archive -lgfortran
+fi
+
+install_license license.txt
+"""
+
+# Pure Fortran (GPL-2.0-or-later), no external deps beyond libgfortran, so build
+# for every platform Julia supports, Windows included (see the mingw branch in
+# the script for how the DLL exports c_algencan).
+platforms = supported_platforms()
+
+# libalgencan links libgfortran, whose ABI breaks across GCC major versions, so
+# each tarball must be tagged with the libgfortran version it binds to —
+# otherwise Pkg hands Julia a mismatched build and the library fails to dlopen.
+# Today this expands to libgfortran5 only, which is what every Julia >= 1.6
+# (our julia_compat) ships; older ABIs no longer have CompilerSupportLibraries
+# artifacts to bind against.
+platforms = expand_gfortran_versions(platforms)
+
+# libalgencan.${dlext} exporting the c_algencan entry point.
+#
+# `dont_dlopen=true` is deliberate and load-bearing for the consumer: Algencan is
+# Fortran code with unsafe common blocks, so NLPModelsAlgencan.jl dlopen's the
+# library and dlclose's it around every solve to guarantee a clean global state.
+# A JLL that dlopen's at __init__ would pin the library in memory and defeat
+# that, so this one only hands out the path.
+products = [
+    LibraryProduct("libalgencan", :libalgencan; dont_dlopen=true),
+]
+
+dependencies = [
+    # Provides the shared libgfortran that libalgencan links against at runtime.
+    Dependency("CompilerSupportLibraries_jll"),
+]
+
+# If a very old default gfortran mis-handles the legacy FORMAT strings in
+# fparam.f90, pin a newer toolchain by adding e.g. `preferred_gcc_version = v"8"`
+# to the build_tarballs call below.
+build_tarballs(ARGS, name, version, sources, script, platforms, products,
+               dependencies; julia_compat = "1.6")

--- a/A/Algencan/build_tarballs.jl
+++ b/A/Algencan/build_tarballs.jl
@@ -1,108 +1,79 @@
-# Yggdrasil recipe for Algencan (TANGO project) — an augmented-Lagrangian
-# nonlinear programming solver by E. G. Birgin and J. M. Martínez.
-#
-# This builds the stand-alone Fortran library WITHOUT HSL. The HSL linear
-# solvers (MA57/MA86/MA97) are proprietary and cannot be redistributed, so this
-# JLL matches the default "easy way" build of NLPModelsAlgencan.jl (dummy HSL).
-# It removes the local build-time dependencies (gfortran + a working linker),
-# but does NOT change Algencan's numerics — for HSL-backed performance, users
-# still need a source build with their own HSL.
-#
-# To deploy: copy the `A/Algencan/` directory into a clone of
-# https://github.com/JuliaPackaging/Yggdrasil and open a PR.
-#
-# Build & test locally for a single platform (needs Docker/BinaryBuilder):
-#   julia --project build_tarballs.jl --verbose --debug aarch64-apple-darwin
-#   julia --project build_tarballs.jl --verbose --debug x86_64-linux-gnu
-
 using BinaryBuilder, Pkg
 
 name = "Algencan"
 version = v"3.1.1"
 
-# Mirror of the upstream tarball from
-# https://www.ime.usp.br/~egbirgin/tango/sources/algencan-3.1.1.tgz, republished
-# on a GitHub release for long-term reproducibility (the upstream location is a
-# personal academic URL). The file is byte-identical — same SHA256 — and
-# redistribution is permitted by Algencan's GPL-2.0-or-later license.
+# Collection of sources required to complete build
+# Mirror of the upstream tarball, which lives at a personal academic URL.
+# Byte identical, same SHA256. Algencan is GPL-2.0-or-later.
 sources = [
     ArchiveSource(
         "https://github.com/pjssilva/NLPModelsAlgencan.jl/releases/download/algencan-$(version)/algencan-$(version).tgz",
         "ab2a5496e9da49c508f68809cc339f9a604407329be24e3299bd7c21f14d6188",
     ),
+    DirectorySource("./bundled"),
 ]
 
-# Compile the static libalgencan.a (Fortran, no HSL), then wrap it in a shared
-# library that exports `c_algencan` — the C entry point that NLPModelsAlgencan.jl
-# `ccall`s via `dlsym(..., :c_algencan)`.
 script = raw"""
 cd ${WORKSPACE}/srcdir/algencan-*
 
-# The bundled top-level Makefile hardcodes CC := gcc-4.9, but only the Fortran
-# compiler and the archiver are used by the `algencan` (library) target. Name the
-# BinaryBuilder toolchain wrappers explicitly and build position-independent
-# objects. NOTE: use literal `gfortran`/`cc`/`ar` (the wrappers on PATH), NOT
-# `${AR}` etc. — BinaryBuilder does not export ${AR} in this environment, so
-# `AR="${AR}"` would set it empty and break `$(AR) rcs` in the Makefile.
-make FC=gfortran CC=cc AR=ar \
-     FFLAGS="-O3 -ffree-form -fPIC" CFLAGS="-O3 -fPIC"
+# Makes Algencan query HSL's ma57_available at run time instead of deciding at
+# compile time, so one binary uses MA57 when a licensed HSL is installed and
+# falls back to truncated Newton otherwise. Also drops Algencan's use of
+# finfo%pivot, a field only a locally patched MA57 provides.
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/algencan-3.1.1-runtime-hsl.patch
+
+# sources/algencan/Makefile selects the real lssma57.o over the stub when
+# hsl_ma57_double.mod is found in HSLSRC. Only that module is linked in, so
+# MA86 and MA97 keep their stubs.
+mkdir -p hsldetect
+ln -s ${prefix}/modules/hsl_ma57_double.mod hsldetect/
+
+make -C sources/algencan lib \
+     FC=gfortran AR=ar \
+     FFLAGS="-O3 -ffree-form -fPIC -I${prefix}/modules" \
+     HSLSRC=${PWD}/hsldetect
 
 mkdir -p "${libdir}"
 
-# Turn the static archive into a shared library, forcing every object (and thus
-# the c_algencan symbol) to be included, and link the Fortran runtime.
-# ${libdir} already resolves to bin/ on Windows, so the DLL lands in the right
-# place with no special-casing of the output path.
+# Force every object in so that c_algencan survives.
 if [[ "${target}" == *-apple-* ]]; then
-    # macOS: -all_load pulls every object (and thus c_algencan) from the archive.
     ${FC} -shared -o "${libdir}/libalgencan.${dlext}" \
-        -Wl,-all_load lib/libalgencan.a -lgfortran
+        -Wl,-all_load sources/algencan/libalgencan.a \
+        -L${libdir} -L${prefix}/lib -lhsl_subset -lgfortran
 elif [[ "${target}" == *-mingw* ]]; then
-    # Windows: emit a DLL, pull in every object, and export all symbols so
-    # c_algencan is visible to dlopen/dlsym (mingw auto-exports, but be explicit).
     ${FC} -shared -o "${libdir}/libalgencan.${dlext}" \
-        -Wl,--whole-archive lib/libalgencan.a -Wl,--no-whole-archive \
-        -Wl,--export-all-symbols -lgfortran
+        -Wl,--whole-archive sources/algencan/libalgencan.a -Wl,--no-whole-archive \
+        -Wl,--export-all-symbols -L${libdir} -L${prefix}/lib -lhsl_subset -lgfortran
 else
-    # Linux/BSD: --whole-archive is the GNU-ld equivalent of macOS -all_load.
     ${FC} -shared -o "${libdir}/libalgencan.${dlext}" \
-        -Wl,--whole-archive lib/libalgencan.a -Wl,--no-whole-archive -lgfortran
+        -Wl,--whole-archive sources/algencan/libalgencan.a -Wl,--no-whole-archive \
+        -L${libdir} -L${prefix}/lib -lhsl_subset -lgfortran
 fi
 
 install_license license.txt
 """
 
-# Pure Fortran (GPL-2.0-or-later), no external deps beyond libgfortran, so build
-# for every platform Julia supports, Windows included (see the mingw branch in
-# the script for how the DLL exports c_algencan).
 platforms = supported_platforms()
-
-# libalgencan links libgfortran, whose ABI breaks across GCC major versions, so
-# each tarball must be tagged with the libgfortran version it binds to —
-# otherwise Pkg hands Julia a mismatched build and the library fails to dlopen.
-# Today this expands to libgfortran5 only, which is what every Julia >= 1.6
-# (our julia_compat) ships; older ABIs no longer have CompilerSupportLibraries
-# artifacts to bind against.
 platforms = expand_gfortran_versions(platforms)
 
-# libalgencan.${dlext} exporting the c_algencan entry point.
-#
-# `dont_dlopen=true` is deliberate and load-bearing for the consumer: Algencan is
-# Fortran code with unsafe common blocks, so NLPModelsAlgencan.jl dlopen's the
-# library and dlclose's it around every solve to guarantee a clean global state.
-# A JLL that dlopen's at __init__ would pin the library in memory and defeat
-# that, so this one only hands out the path.
+# dont_dlopen: Algencan keeps state in Fortran common blocks, so consumers load
+# and unload the library around each solve.
 products = [
     LibraryProduct("libalgencan", :libalgencan; dont_dlopen=true),
 ]
 
+# libhsl_subset is linked for the hsl_ma57_double module symbols and for
+# ma57_available. The public artifact is a stub, so no licensed code enters the
+# build; users with a licence override the artifact.
+#
+# Note for consumers: libhsl_subset is LP64, and Julia registers only an ILP64
+# BLAS backend by default, so an LP64 one has to be forwarded to
+# libblastrampoline, as HSL.jl and Ipopt.jl do.
 dependencies = [
-    # Provides the shared libgfortran that libalgencan links against at runtime.
     Dependency("CompilerSupportLibraries_jll"),
+    Dependency("HSL_jll"),
 ]
 
-# If a very old default gfortran mis-handles the legacy FORMAT strings in
-# fparam.f90, pin a newer toolchain by adding e.g. `preferred_gcc_version = v"8"`
-# to the build_tarballs call below.
 build_tarballs(ARGS, name, version, sources, script, platforms, products,
                dependencies; julia_compat = "1.6")

--- a/A/Algencan/build_tarballs.jl
+++ b/A/Algencan/build_tarballs.jl
@@ -36,7 +36,7 @@ sources = [
 # library that exports `c_algencan` — the C entry point that NLPModelsAlgencan.jl
 # `ccall`s via `dlsym(..., :c_algencan)`.
 script = raw"""
-cd ${WORKSPACE}/srcdir/algencan-3.1.1
+cd ${WORKSPACE}/srcdir/algencan-*
 
 # The bundled top-level Makefile hardcodes CC := gcc-4.9, but only the Fortran
 # compiler and the archiver are used by the `algencan` (library) target. Name the

--- a/A/Algencan/build_tarballs.jl
+++ b/A/Algencan/build_tarballs.jl
@@ -27,7 +27,7 @@ version = v"3.1.1"
 # redistribution is permitted by Algencan's GPL-2.0-or-later license.
 sources = [
     ArchiveSource(
-        "https://github.com/pjssilva/NLPModelsAlgencan.jl/releases/download/algencan-3.1.1/algencan-3.1.1.tgz",
+        "https://github.com/pjssilva/NLPModelsAlgencan.jl/releases/download/algencan-$(version)/algencan-$(version).tgz",
         "ab2a5496e9da49c508f68809cc339f9a604407329be24e3299bd7c21f14d6188",
     ),
 ]

--- a/A/Algencan/bundled/patches/algencan-3.1.1-runtime-hsl.patch
+++ b/A/Algencan/bundled/patches/algencan-3.1.1-runtime-hsl.patch
@@ -24,17 +24,29 @@ More-Sorensen safeguard in moresor.f90,
      ls = max( l + (d / ueucn2), ls )
 
 which raises the lower bound on the trust-region multiplier so that the
-iteration can leave the region where the matrix is indefinite.  With pval
-returned as zero that update cannot raise ls, lambda stops advancing, and
-the iteration would spin until the iteration limit is reached.  Detecting
-that ls did not increase and returning msinfo = 5 immediately gives the
-same outcome without the wasted factorizations: betra already reacts to
-msinfo = 5 by computing a dogleg direction instead.
+iteration can leave the region where the matrix is indefinite.  Rather than
+do without it, the value is reconstructed in scalcu, where the factorization
+just failed: with u(idx) = 1 and the leading block solved, the pivot the
+factorization rejected is the quadratic form u'(A + lI)u over the first idx
+unknowns, and alin and acol are still in the ordering u refers to.  Over a
+308 problem CUTEst sweep the reconstruction agrees with a patched MA57's
+real finfo%pivot to eight or more significant digits in the early
+iterations, degrading only when the true pivot falls to the level where
+summing the quadratic form cancels, at which point the value is small enough
+that the safeguard it feeds is inactive anyway.
 
-With a patched MA57 the pivot is nonzero, ls always increases, and the new
-test never fires, so a conventional build is unaffected.
---- a/sources/algencan/lssma57.f90
-+++ b/sources/algencan/lssma57.f90
+Nothing else in the algorithm is touched.  An earlier version of this patch
+also returned msinfo = 5 when ls failed to advance, to send betra to a
+dogleg direction rather than let the iteration run to the limit.  That was
+written when the pivot was left at zero and ls therefore could not advance
+at all; once the pivot is reconstructed it advances normally and the test is
+redundant.  Worse, it pre-empts the iteration limit that already bounds the
+loop: on CUTEst OPTPRLOC it fired seventy two million times without the
+limit ever being reached, turning a 2.8 second solve into a non-terminating
+one.  The safeguard has been removed and the loop left as ALGENCAN wrote it.
+diff --color -Naur a/sources/algencan/lssma57.f90 b/sources/algencan/lssma57.f90
+--- a/sources/algencan/lssma57.f90	2015-05-05 10:45:12.000000000 -0300
++++ b/sources/algencan/lssma57.f90	2026-08-05 13:41:32.591285690 -0300
 @@ -52,7 +52,16 @@
      ! FUNCTION TYPE
      logical :: lss_ma57
@@ -79,8 +91,9 @@ test never fires, so a conventional build is unaffected.
  
         lssinfo = 2
  
---- a/sources/algencan/moresor.f90
-+++ b/sources/algencan/moresor.f90
+diff --color -Naur a/sources/algencan/moresor.f90 b/sources/algencan/moresor.f90
+--- a/sources/algencan/moresor.f90	2015-05-05 10:45:12.000000000 -0300
++++ b/sources/algencan/moresor.f90	2026-08-05 13:41:32.601079332 -0300
 @@ -234,7 +234,7 @@
          l  = lu
       else
@@ -90,23 +103,7 @@ test never fires, so a conventional build is unaffected.
          chcnt = chcnt + 1
  
          if ( memfail ) then
-@@ -245,6 +245,15 @@
-         ls = max( l + (d / ueucn2), ls )
-         ll = max( ll, ls )
-         l  = ls
-+
-+        ! If ls did not advance, the iteration cannot leave the region
-+        ! where the matrix is indefinite, so stop rather than exhausting
-+        ! the iteration limit and let betra fall back to dogleg.
-+
-+        if ( ls .le. lsant ) then
-+           msinfo = 5
-+           go to 22
-+        end if
-      end if
- 
-      iter = iter + 1
-@@ -565,7 +574,7 @@
+@@ -565,7 +565,7 @@
  ! ******************************************************************
  
  subroutine scalcu(n,annz,alin,acol,aval,adiag,l,idx,u,ueucn2,wd, &
@@ -115,7 +112,7 @@ test never fires, so a conventional build is unaffected.
    
    use lsslvr
    use modalgparam, only: lsssubTR
-@@ -577,6 +586,7 @@
+@@ -577,6 +577,7 @@
    integer,      intent(in)    :: annz,idx,n
    real(kind=8), intent(in)    :: l
    real(kind=8), intent(inout) :: ueucn2
@@ -123,7 +120,7 @@ test never fires, so a conventional build is unaffected.
  
    ! ARRAY ARGUMENTS
    integer,      intent(inout) :: acol(annz),adiag(n),alin(annz)
-@@ -592,6 +602,9 @@
+@@ -592,6 +593,9 @@
    if ( idx .eq. 1 ) then
       u(idx) = 1.0d0
       ueucn2 = 1.0d0
@@ -133,7 +130,7 @@ test never fires, so a conventional build is unaffected.
       return
    end if
  
-@@ -675,6 +688,35 @@
+@@ -675,6 +679,35 @@
       end if
    end do
  

--- a/A/Algencan/bundled/patches/algencan-3.1.1-runtime-hsl.patch
+++ b/A/Algencan/bundled/patches/algencan-3.1.1-runtime-hsl.patch
@@ -1,0 +1,171 @@
+Make MA57 usage a run-time decision and compute the More-Sorensen pivot
+instead of reading it from a patched MA57.
+
+ALGENCAN decides whether MA57 is usable through lss_ma57(), which is a
+compile-time constant: the real sources/algencan/lssma57.f90 returns .true.
+and the stub sources/algencan/dummy_lssma57.f90 returns .false., and the
+build system picks one of them.  That makes it impossible to ship a single
+binary that uses MA57 when it is present and the truncated Newton inner
+solver when it is not, which is what a Julia JLL package needs: the HSL
+library is distributed to licensees only, so the binary must be built and
+shipped without it and pick it up later, if the user has it.
+
+Standard HSL distributions expose the public module variable ma57_available
+in hsl_ma57_double, which is .true. only when the loaded library really
+implements MA57.  Returning it from lss_ma57() is enough to turn the whole
+existing selection logic in algencan.f90 into a run-time decision, with no
+other change to the algorithm.
+
+Building against a standard HSL also means giving up finfo%pivot, which is
+not part of ma57_finfo and is added by a local patch to MA57.  It is read
+in lssfac_ma57 and returned as pval, and its only consumer is the
+More-Sorensen safeguard in moresor.f90,
+
+     ls = max( l + (d / ueucn2), ls )
+
+which raises the lower bound on the trust-region multiplier so that the
+iteration can leave the region where the matrix is indefinite.  With pval
+returned as zero that update cannot raise ls, lambda stops advancing, and
+the iteration would spin until the iteration limit is reached.  Detecting
+that ls did not increase and returning msinfo = 5 immediately gives the
+same outcome without the wasted factorizations: betra already reacts to
+msinfo = 5 by computing a dogleg direction instead.
+
+With a patched MA57 the pivot is nonzero, ls always increases, and the new
+test never fires, so a conventional build is unaffected.
+--- a/sources/algencan/lssma57.f90
++++ b/sources/algencan/lssma57.f90
+@@ -52,7 +52,16 @@
+     ! FUNCTION TYPE
+     logical :: lss_ma57
+ 
+-    lss_ma57 = .true.
++    ! ma57_available is a public module variable of hsl_ma57_double. It is
++    ! .true. when the HSL library that is actually loaded implements MA57,
++    ! and .false. when the library only provides the placeholder routines
++    ! distributed to users without an HSL licence. Returning it here turns
++    ! the MA57 availability test into a run-time query instead of a
++    ! compile-time constant, so that a single binary uses MA57 when a
++    ! licensed HSL is present and falls back to the truncated Newton inner
++    ! solver when it is not.
++
++    lss_ma57 = ma57_available
+ 
+   end function lss_ma57
+ 
+@@ -297,8 +306,15 @@
+     else if ( finfo%flag .eq. -6 ) then
+        ! MATRIX NOT POSITIVE DEFINITE
+ 
++       ! In the original code pval is abs( finfo%pivot ). The pivot field is
++       ! not part of ma57_finfo in a standard HSL distribution, it is added
++       ! by a local patch to MA57. Since pind and pval are consumed only by
++       ! the trust-region solver (moresor), which is disabled in this build,
++       ! the value is not needed and is set to zero here. The same applies to
++       ! the rank deficient case below.
++
+        pind    = finfo%more
+-       pval    = abs( finfo%pivot )
++       pval    = 0.0d0
+ 
+        lssinfo = 1
+ 
+@@ -306,7 +322,7 @@
+        ! RANK DEFICIENT MATRIX
+ 
+        pind    = finfo%more
+-       pval    = abs( finfo%pivot )
++       pval    = 0.0d0
+ 
+        lssinfo = 2
+ 
+--- a/sources/algencan/moresor.f90
++++ b/sources/algencan/moresor.f90
+@@ -234,7 +234,7 @@
+         l  = lu
+      else
+         call scalcu(n,bnnz,blin,bcol,bval,bdiag,l,idx,p,ueucn2,wd, &
+-             memfail)
++             d,memfail)
+         chcnt = chcnt + 1
+ 
+         if ( memfail ) then
+@@ -245,6 +245,15 @@
+         ls = max( l + (d / ueucn2), ls )
+         ll = max( ll, ls )
+         l  = ls
++
++        ! If ls did not advance, the iteration cannot leave the region
++        ! where the matrix is indefinite, so stop rather than exhausting
++        ! the iteration limit and let betra fall back to dogleg.
++
++        if ( ls .le. lsant ) then
++           msinfo = 5
++           go to 22
++        end if
+      end if
+ 
+      iter = iter + 1
+@@ -565,7 +574,7 @@
+ ! ******************************************************************
+ 
+ subroutine scalcu(n,annz,alin,acol,aval,adiag,l,idx,u,ueucn2,wd, &
+-     memfail)
++     pivot,memfail)
+   
+   use lsslvr
+   use modalgparam, only: lsssubTR
+@@ -577,6 +586,7 @@
+   integer,      intent(in)    :: annz,idx,n
+   real(kind=8), intent(in)    :: l
+   real(kind=8), intent(inout) :: ueucn2
++  real(kind=8), intent(out)   :: pivot
+ 
+   ! ARRAY ARGUMENTS
+   integer,      intent(inout) :: acol(annz),adiag(n),alin(annz)
+@@ -592,6 +602,9 @@
+   if ( idx .eq. 1 ) then
+      u(idx) = 1.0d0
+      ueucn2 = 1.0d0
++     ! The ordering is not established yet at this point, so the pivot
++     ! cannot be formed here. Zero makes the caller fall back to dogleg.
++     pivot = 0.0d0
+      return
+   end if
+ 
+@@ -675,6 +688,35 @@
+      end if
+   end do
+ 
++  ! Offending pivot. With u(idx) = 1 and the leading block solved above,
++  ! the value that the factorization rejected is the quadratic form
++  ! u'(A + lI)u over the first idx unknowns. A standard HSL distribution
++  ! does not report it, ma57_finfo has no pivot field, so it is computed
++  ! here, while alin and acol are still in the ordering that u refers to.
++  ! A is symmetric with each off-diagonal entry stored once, hence the
++  ! factor of two, and l enters through the diagonal shift.
++
++  u(idx) = 1.0d0
++
++  pivot = 0.0d0
++  do i = 1,annz
++     lin = alin(i)
++     col = acol(i)
++     if ( lin .le. idx .and. col .le. idx ) then
++        if ( lin .eq. col ) then
++           pivot = pivot + aval(i) * u(lin) * u(col)
++        else
++           pivot = pivot + 2.0d0 * aval(i) * u(lin) * u(col)
++        end if
++     end if
++  end do
++
++  do i = 1,idx
++     pivot = pivot + l * u(i)**2
++  end do
++
++  pivot = abs( pivot )
++
+   ! print *,'CALL LSSUNPERMIND'
+   call lssunpermind(n,annz,alin,acol)
+ 


### PR DESCRIPTION
Adds a recipe for Algencan 3.1.1, the augmented Lagrangian nonlinear solver from the TANGO project, to be consumed by NLPModelsAlgencan.jl, which today compiles it from source at install time.

One binary, HSL used only when the user has a licence. A patch makes Algencan's lss_ma57() return HSL's public ma57_available module variable instead of a compile-time constant, so the choice becomes a runtime one. Without a licence users get the truncated Newton inner solver; users who override the HSL_jll artifact get MA57. Only the public stub is linked, so no licensed code enters the build or the tarballs.

The patch is 2 files and removes no code. It also drops Algencan's use of finfo%pivot, which exists only in a locally patched MA57; the Moré-Sorensen safeguard that consumes it computes the value instead, from a vector scalcu already returns. Verified against a patched MA57 that reports the real pivot: agreement to 7–11 significant digits.

Notes:

- Links libhsl_subset, following GALAHAD, because Algencan needs the hsl_ma57_double Fortran module.
- dont_dlopen=true is deliberate: Algencan keeps state in Fortran common blocks, so the consumer loads and unloads the library around every solve.
- Consumers need an LP64 BLAS forwarded to libblastrampoline, as HSL.jl and Ipopt.jl do. Handled in NLPModelsAlgencan.jl.

Tested on x86_64-linux-gnu against a conventional Algencan built with a locally patched MA57, over 55 CUTEst problems: no regressions, one problem the JLL build solves that the source build does not. CI covers the build on all platforms; the HSL path itself is only exercised on Linux x86_64.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>