### PR TITLE
[LibSSH2] Backport four more security patches from Debian 1.11.1-5

### DIFF
--- a/L/LibSSH2/LibSSH2@1.11/build_tarballs.jl
+++ b/L/LibSSH2/LibSSH2@1.11/build_tarballs.jl
@@ -3,7 +3,7 @@ using Pkg
 using BinaryBuilderBase: sanitize
 
 name = "LibSSH2"
-version = v"1.11.103"
+version = v"1.11.104"
 upstream = VersionNumber(version.major, version.minor, version.patch÷100)
 # Collection of sources required to build LibSSH2
 sources = [
@@ -16,7 +16,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/libssh2*
 
-# Security patches from https://udd.debian.org/patches.cgi?src=libssh2&version=1.11.1-4
+# Security patches from https://udd.debian.org/patches.cgi?src=libssh2&version=1.11.1-5
 for f in ${WORKSPACE}/srcdir/patches/*.patch; do
     atomic_patch -p1 "${f}"
 done

--- a/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-66032.patch
+++ b/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-66032.patch
@@ -1,0 +1,24 @@
+From 5e4776146552d898b9c0e1b313cd093fa8dc92d0 Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Thu, 2 Jul 2026 11:00:23 -0700
+Subject: [PATCH] Prevent dangling pointer by nullifying data (#2180)
+
+Set data to NULL after freeing it to avoid dangling pointer. fixes
+GHSA-px3w-7g75-hg7w.
+
+Credit: VladimirEliTokarev
+Forwarded: not-needed
+---
+ src/sftp.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/src/sftp.c
++++ b/src/sftp.c
+@@ -1279,6 +1279,7 @@
+                                "got HANDLE FXOK"));
+ 
+                 LIBSSH2_FREE(session, data);
++                data = NULL;
+ 
+                 /* silly situation, but check for a HANDLE */
+                 rc = sftp_packet_require(sftp, SSH_FXP_HANDLE,

--- a/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-66033.patch
+++ b/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-66033.patch
@@ -1,0 +1,40 @@
+From a2ed82d40964bbc0d64cd717aa0a5a892117d2e6 Mon Sep 17 00:00:00 2001
+From: Viktor Szakats <commit@vsz.me>
+Date: Thu, 23 Jul 2026 10:32:04 +0200
+Subject: [PATCH] openssl: fix potential OOB read/write with AES-GCM in
+ `ssh2_cipher_crypt()`
+
+By applying two bounds checks to non-debug builds.
+
+Reported-by: Vladimir Eli Tokarev
+Fixes GHSA-c4f7-cvfc-33j7
+Follow-up to 3c953c05d67eb1ebcfd3316f279f12c4b1d600b4 #797
+
+Closes #2401
+Forwarded: not-needed
+---
+ src/openssl.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+--- a/src/openssl.c
++++ b/src/openssl.c
+@@ -1042,13 +1042,15 @@
+     const int aadlen = (is_aesgcm && IS_FIRST(firstlast)) ? 4 : 0;
+     /* size of AT, if present */
+     const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
+-    /* length to encrypt */
+-    const int cryptlen = (unsigned int)blocksize - aadlen - authenticationtag;
++    unsigned int cryptlen; /* length to encrypt */
+ 
+     (void)algo;
+ 
+-    assert(blocksize <= sizeof(buf));
+-    assert(cryptlen >= 0);
++    if(blocksize > sizeof(buf) ||
++       blocksize < (size_t)(aadlen + authenticationtag))
++        return 1;
++
++    cryptlen = (unsigned int)blocksize - aadlen - authenticationtag;
+ 
+ #if LIBSSH2_AES_GCM
+     /* First block */

--- a/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-66034.patch
+++ b/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-66034.patch
@@ -1,0 +1,31 @@
+From a13bb6c773f0d55ad1628cede57e99803cd898d9 Mon Sep 17 00:00:00 2001
+From: Viktor Szakats <commit@vsz.me>
+Date: Sat, 4 Jul 2026 11:19:49 +0200
+Subject: [PATCH] publickey: fix potential OOB read in
+ `libssh2_publickey_list_fetch()`
+
+Reported-by: Vladimir Eli Tokarev
+Fixes GHSA-w6g9-cpfp-22gc
+
+Closes #2202
+Forwarded: not-needed
+---
+ src/publickey.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/src/publickey.c
++++ b/src/publickey.c
+@@ -988,6 +988,13 @@
+                 }
+ 
+                 if(comment_len) {
++                    if(pkey->listFetch_s + comment_len >
++                       pkey->listFetch_data + pkey->listFetch_data_len) {
++                        _libssh2_error(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
++                                 "ListFetch data too short");
++                        goto err_exit;
++                    }
++
+                     list[keys].num_attrs = 1;
+                     list[keys].attrs =
+                         LIBSSH2_ALLOC(session,

--- a/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-66035.patch
+++ b/L/LibSSH2/LibSSH2@1.11/bundled/patches/CVE-2026-66035.patch
@@ -1,0 +1,37 @@
+From 42e33d81577ed4b95d4b4f6f845e5ee8efe5eeb4 Mon Sep 17 00:00:00 2001
+From: Viktor Szakats <commit@vsz.me>
+Date: Fri, 3 Jul 2026 18:22:55 +0200
+Subject: [PATCH] transport: fix potential heap overflow on ETM decrypt
+
+Reported-by: Vladimir Eli Tokarev
+Fixes GHSA-6c79-444r-wx26
+
+Closes #2198
+Forwarded: not-needed
+---
+ src/transport.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+--- a/src/transport.c
++++ b/src/transport.c
+@@ -242,6 +242,12 @@
+                 unsigned char *decrypt_buffer;
+                 int blocksize = session->remote.crypt->blocksize;
+ 
++                if(p->total_num < mac_len + 4 + (size_t)blocksize) {
++                    LIBSSH2_FREE(session, p->payload);
++                    return LIBSSH2_ERROR_DECRYPT;
++                }
++                decrypt_size = (ssize_t)(p->total_num - mac_len - 4);
++
+                 rc = decrypt(session, p->payload + 4,
+                              first_block, blocksize, FIRST_BLOCK);
+                 if(rc) {
+@@ -249,7 +255,6 @@
+                 }
+ 
+                 /* we need buffer for decrypt */
+-                decrypt_size = p->total_num - mac_len - 4;
+                 decrypt_buffer = LIBSSH2_ALLOC(session, decrypt_size);
+                 if(!decrypt_buffer) {
+                     return LIBSSH2_ERROR_ALLOC;


### PR DESCRIPTION
Adds the patches new in Debian's libssh2 1.11.1-5 that are not yet bundled here:

* CVE-2026-66032: sftp.c: prevent dangling pointer by nullifying data after free (GHSA-px3w-7g75-hg7w)
* CVE-2026-66033: openssl: fix potential OOB read/write with AES-GCM in ssh2_cipher_crypt() (GHSA-c4f7-cvfc-33j7)
* CVE-2026-66034: publickey: fix potential OOB read in libssh2_publickey_list_fetch() (GHSA-w6g9-cpfp-22gc)
* CVE-2026-66035: transport: fix potential heap overflow on ETM decrypt (GHSA-6c79-444r-wx26)
