### PR TITLE
[oneAPI] oneAPI_Support_Headers 2025.3.1 Retry

### DIFF
--- a/O/oneAPI_Support_Headers/build_tarballs.jl
+++ b/O/oneAPI_Support_Headers/build_tarballs.jl
@@ -39,3 +39,4 @@ dependencies = Dependency[]
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
                julia_compat="1.6")
+# bump


### PR DESCRIPTION
Redo this PR since the registration trigger failed in the pipeline after the merge in https://github.com/JuliaPackaging/Yggdrasil/pull/14316 .