### PR TITLE
[S2Geometry] Update to v0.13.0

### DIFF
--- a/S/S2Geometry/build_tarballs.jl
+++ b/S/S2Geometry/build_tarballs.jl
@@ -2,12 +2,15 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
 name = "S2Geometry"
-version = v"0.11.1"
+version = v"0.13.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/google/s2geometry.git", "5b5eccd54a08ae03b4467e79ffbb076d0b5f221e"),
+    GitSource("https://github.com/google/s2geometry.git", "ed62eeeaa92f19c70aeaa91e8acbd3b5c1171a57"),
     DirectorySource("./bundled"),
 ]
 
@@ -22,10 +25,15 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_TESTS=OFF \
+    -DCMAKE_CXX_STANDARD=17 \
     ..
 make -j${nproc}
 make install
 """
+
+# Abseil is built as C++17, and the libc++ in the default Intel macOS sys-root
+# exports none of the std::bad_{variant,optional}_access symbols it needs.
+sources, script = require_macos_sdk("10.14", sources, script)
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
@@ -48,8 +56,9 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15"),
-    Dependency(PackageSpec(name="abseil_cpp_jll", uuid="43133aba-3931-5066-b004-a34c79b93f2e"); compat = "20240116.2.0"),
+    Dependency(PackageSpec(name="abseil_cpp_jll", uuid="43133aba-3931-5066-b004-a34c79b93f2e"); compat = "20250814.1"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.6", preferred_gcc_version=v"7")
+# Abseil requires <filesystem>, provided in GCC 9 or later
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.6", preferred_gcc_version=v"9")

--- a/S/S2Geometry/build_tarballs.jl
+++ b/S/S2Geometry/build_tarballs.jl
@@ -55,7 +55,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.15"),
+    Dependency(PackageSpec(name="OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95"); compat="3.0.16"),
     Dependency(PackageSpec(name="abseil_cpp_jll", uuid="43133aba-3931-5066-b004-a34c79b93f2e"); compat = "20250814.1"),
 ]
 

--- a/S/S2Geometry/bundled/patches/msvc_to_win32_target.patch
+++ b/S/S2Geometry/bundled/patches/msvc_to_win32_target.patch
@@ -1,12 +1,21 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -70,7 +70,7 @@ if (WITH_PYTHON)
-     find_package(Python3 COMPONENTS Interpreter Development)
+@@ -70,9 +70,14 @@ if (WITH_PYTHON)
+     find_package(Python3 COMPONENTS Interpreter Development.Module)
  endif()
  
 -if (MSVC)
+-    # Use unsigned characters
+-    add_definitions(-J)
 +if (WIN32)
-     # Use unsigned characters
-     add_definitions(-J)
++    # Use unsigned characters.  Note that GCC's `-J` takes an argument, so
++    # passing it there would silently swallow the next flag on the command line.
++    if (MSVC)
++        add_definitions(-J)
++    else()
++        add_definitions(-funsigned-char)
++    endif()
      # Make sure cmath header defines things like M_PI
+     add_definitions(-D_USE_MATH_DEFINES)
+     # Make sure Windows doesn't define min/max macros that interfere with STL


### PR DESCRIPTION
v0.13.0 replaces the `absl::Nonnull`/`absl::Nullable` template aliases with the `absl_nonnull`/`absl_nullable` macros that superseded them in Abseil LTS 20250127, so it needs `abseil_cpp_jll` 20250814.1 (#14310).

Knock-on changes:

- C++17: `std::optional` is used unconditionally in `s2closest_edge_query_base.h`.
- `preferred_gcc_version` 7 -> 9, since Abseil's headers include `<filesystem>` when built as C++17.
- Intel macOS needs a 10.14 SDK via `require_macos_sdk`; the default darwin14 sys-root's libc++ exports no `std::bad_variant_access`/`bad_optional_access` typeinfo.
- `msvc_to_win32_target.patch` previously rewrote `if (MSVC)` to `if (WIN32)` wholesale, feeding MSVC's `-J` to GCC on mingw. GCC's `-J` takes an argument, so it silently swallowed the following `-std=c++17` and the target built as gnu++14. Keep `-J` under MSVC, use `-funsigned-char` elsewhere.

Built locally for x86_64/aarch64 linux-gnu, x86_64 linux-musl, x86_64 mingw32, and both macOS.

First of three; merge in order: this -> #14331 -> #14332.
