### PR TITLE
[S2Geometry] Update to v0.13.1

### DIFF
--- a/S/S2Geometry/build_tarballs.jl
+++ b/S/S2Geometry/build_tarballs.jl
@@ -6,11 +6,11 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "S2Geometry"
-version = v"0.13.0"
+version = v"0.13.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/google/s2geometry.git", "ed62eeeaa92f19c70aeaa91e8acbd3b5c1171a57"),
+    GitSource("https://github.com/google/s2geometry.git", "a37aba69f14af676e9605cd9515c8aca6cef8342"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
Patch release: version and source commit only, no other recipe changes.

Built locally for x86_64/aarch64 linux-gnu, x86_64 linux-musl, x86_64 mingw32, and both macOS.

Rebased now that #14330 has merged, so this is a single commit on `master`. Merge before #14332.
