### PR TITLE
[Rmath] Update to v0.5.2

### DIFF
--- a/R/Rmath/build_tarballs.jl
+++ b/R/Rmath/build_tarballs.jl
@@ -1,11 +1,11 @@
 using BinaryBuilder
 
 name = "Rmath"
-version = v"0.5.1"
+version = v"0.5.2"
 
 sources = [
     GitSource("https://github.com/JuliaStats/Rmath-julia.git",
-              "6f2d37ff112914d65559bc3e0035b325c11cf361"),
+              "982eb93bca6b655d8b433af23ee847561694e2b2"),
 ]
 
 script = raw"""


### PR DESCRIPTION
Draft, please do not merge yet: the `v0.5.2` tag does not exist yet, it will point at `982eb93` (the commit pinned here). Draft so that CI checks all platforms before I tag. Will mark ready once tagged.

Picks up JuliaStats/Rmath-julia#58, which shrinks the TLS segment from 856 to 16 bytes and fixes JuliaStats/Rmath-julia#56. `include/` is unchanged, so no ABI change.