### PR TITLE
[MPFR@4.2.2] Set preferred LLVM version to 17

### DIFF
--- a/M/MPFR/MPFR@4.2.2/build_tarballs.jl
+++ b/M/MPFR/MPFR@4.2.2/build_tarballs.jl
@@ -15,7 +15,7 @@ products = mpfr_products()
 preferred_llvm_version = v"17"
 
 # Dependencies that must be installed before this package can be built
-dependencies = mpfr_dependencies(platforms; llvm_compilerrt_version=preferred_llvm_version)
+dependencies = mpfr_dependencies(platforms; llvm_compilerrt_version=v"13.0.1")
 
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;

--- a/M/MPFR/MPFR@4.2.2/build_tarballs.jl
+++ b/M/MPFR/MPFR@4.2.2/build_tarballs.jl
@@ -13,11 +13,30 @@ platforms = mpfr_platforms()
 products = mpfr_products()
 
 preferred_llvm_version = v"17"
+msan_preferred_llvm_version = v"13.0.1+0"
 
 # Dependencies that must be installed before this package can be built
-dependencies = mpfr_dependencies(platforms; llvm_compilerrt_version=v"13.0.1+0")
+dependencies = mpfr_dependencies(platforms; llvm_compilerrt_version=msan_preferred_llvm_version)
 
-# Build the tarballs
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
-               preferred_gcc_version=v"5", preferred_llvm_version=preferred_llvm_version,
-               julia_compat="1.6")
+# Everything below is necessary only because we need to build msan platforms with a different LLVM version
+
+# Do we build all platforms, or those specified as arguments?
+platform_args = filter(!startswith("--"), ARGS)
+if !isempty(platform_args)
+    platforms = parse_platform.(split(only(platform_args), ','))
+end
+
+# The regular options, excluding the list of platforms
+option_args = filter(startswith("--"), ARGS)
+non_register_option_args = filter(!=("--register"), option_args)
+
+for (n, platform) in enumerate(platforms)
+    # We register the build products only after the last build
+    args = n == length(platforms) ? option_args : non_register_option_args
+
+    pref_llvm = sanitize(platform) == "memory" ? msan_preferred_llvm_version : preferred_llvm_version
+
+    build_tarballs(args, name, version, sources, script, [platform], products, dependencies;
+                   preferred_gcc_version=v"5", preferred_llvm_version=pref_llvm,
+                   julia_compat="1.6")
+end

--- a/M/MPFR/MPFR@4.2.2/build_tarballs.jl
+++ b/M/MPFR/MPFR@4.2.2/build_tarballs.jl
@@ -15,7 +15,7 @@ products = mpfr_products()
 preferred_llvm_version = v"17"
 
 # Dependencies that must be installed before this package can be built
-dependencies = mpfr_dependencies(platforms; llvm_compilerrt_version=v"13.0.1")
+dependencies = mpfr_dependencies(platforms; llvm_compilerrt_version=v"13.0.1+0")
 
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;

--- a/M/MPFR/MPFR@4.2.2/build_tarballs.jl
+++ b/M/MPFR/MPFR@4.2.2/build_tarballs.jl
@@ -12,7 +12,7 @@ script = mpfr_script()
 platforms = mpfr_platforms()
 products = mpfr_products()
 
-preferred_llvm_version = v"13.0.1"
+preferred_llvm_version = v"17"
 
 # Dependencies that must be installed before this package can be built
 dependencies = mpfr_dependencies(platforms; llvm_compilerrt_version=preferred_llvm_version)

--- a/M/MPFR/MPFR@4.2.2/build_tarballs.jl
+++ b/M/MPFR/MPFR@4.2.2/build_tarballs.jl
@@ -1,6 +1,7 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
+using BinaryBuilderBase: parse_platform
 
 include("../common.jl")
 

--- a/M/MPFR/MPFR@4.2.2/build_tarballs.jl
+++ b/M/MPFR/MPFR@4.2.2/build_tarballs.jl
@@ -13,7 +13,7 @@ script = mpfr_script()
 platforms = mpfr_platforms()
 products = mpfr_products()
 
-preferred_llvm_version = v"17"
+# We only set a preferred LLVM version for msan, otherwise we just use the latest available
 msan_preferred_llvm_version = v"13.0.1+0"
 
 # Dependencies that must be installed before this package can be built
@@ -35,9 +35,9 @@ for (n, platform) in enumerate(platforms)
     # We register the build products only after the last build
     args = n == length(platforms) ? option_args : non_register_option_args
 
-    pref_llvm = sanitize(platform) == "memory" ? msan_preferred_llvm_version : preferred_llvm_version
+    # Don't pass the kwarg at all unless we're building for msan
+    kw = sanitize(platform) == "memory" ? (; preferred_llvm_version=msan_preferred_llvm_version) : NamedTuple()
 
     build_tarballs(args, name, version, sources, script, [platform], products, dependencies;
-                   preferred_gcc_version=v"5", preferred_llvm_version=pref_llvm,
-                   julia_compat="1.6")
+                   preferred_gcc_version=v"5", julia_compat="1.6", kw...)
 end


### PR DESCRIPTION
This fixes a miscompile with Clang on FreeBSD AArch64. Older Clang versions didn't model the AArch64 TLSDESC call as clobbering the NZCV condition flags, which for MPFR led to Julia issue 57121. This was fixed in LLVM 17, and I've confirmed locally that `libmpfr.so.6.2.2` built with `preferred_llvm_version=v"17"` resolves that Julia issue.