### PR TITLE
[S2Geometry] Rebuild with GCC 10

### DIFF
--- a/S/S2Geometry/build_tarballs.jl
+++ b/S/S2Geometry/build_tarballs.jl
@@ -70,5 +70,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-# Abseil requires <filesystem>, provided in GCC 9 or later
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.6", preferred_gcc_version=v"9")
+# Match S2Geography's compiler to preserve the MinGW C++ ABI across the DLL boundary.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat = "1.6", preferred_gcc_version=v"10")


### PR DESCRIPTION
Rebuilds S2Geometry 0.14.0 as `+1` with GCC 10.

`S2Geometry_jll +0` uses GCC 9 while downstream `S2Geography_jll` uses GCC 10. On MinGW, the compilers pass by-value `S1Angle` arguments in different registers, so buffer radii arrive as zero (and other `S1Angle` calls can be corrupted).

Validated the Buildkite Windows artifact with the direct C++ reproducer and all 236 S2Geography.jl tests; buffer and tolerance-sensitive tessellation are fixed.
