### PR TITLE
[IRL] drop armv6l-linux-musleabihf

### DIFF
--- a/I/IRL/build_tarballs.jl
+++ b/I/IRL/build_tarballs.jl
@@ -35,6 +35,7 @@ find ${includedir}/irl -type f ! -name '*.h' ! -name '*.tpp' -print -delete
 
 platforms = supported_platforms()
 platforms = filter(p -> arch(p) != "riscv64", platforms)
+platforms = filter(p -> !(arch(p) == "armv6l" && libc(p) == "musl"), platforms)
 platforms = expand_cxxstring_abis(platforms)
 
 products = [


### PR DESCRIPTION
Follow-up to #14154. The master build after that merge failed, so `IRL_jll` was never deployed : no tarballs, no `JuliaBinaryWrappers/IRL_jll.jl`, no General entry.

The only failing target was `armv6l-linux-musleabihf-cxx11` in [build 31520](https://buildkite.com/julialang/yggdrasil/builds/31520); the other 18 platforms were green. It is not a compile failure, the build finishes and the audit then hangs:

```
11:04:22Z  merge commit lands, build starts
11:07:08Z  Child Process exited, exit code 0
           [ Info: Beginning audit of .../armv6l-linux-musleabihf-cxx11/.../destdir
           (no further output)
16:07:04Z  Terminated with signal SIGTERM (because the job timed out)
```

So: audit hangs >5h under qemu-arm on armv6l-musl, passed on PR builds 31398 and the ce119cd build, compile itself succeeds in 3 min.
The same recipe (byte-identical `build_tarballs.jl` and patch) passed this target twice on the PR — but retrying costs five hours of a shared builder each time it loses, so dropping the target seems better than gambling on it.

`version` stays at `v"0.1.0"` since that version was never published.