### PR TITLE
Switch YASM consumers to NASM

### DIFF
--- a/J/JpegTurbo/build_tarballs.jl
+++ b/J/JpegTurbo/build_tarballs.jl
@@ -51,7 +51,7 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     # Avengers; ASSEMBLE!
-    HostBuildDependency("YASM_jll"),
+    HostBuildDependency("NASM_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/L/libaom/build_tarballs.jl
+++ b/L/libaom/build_tarballs.jl
@@ -53,12 +53,8 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-#
-# YASM is recommended in the build instructions, but errors on apple platforms.
-# Assembly only exists for x86 targets.
 dependencies = [
-    HostBuildDependency("YASM_jll"; platforms=filter(p->proc_family(p) == "intel" && !Sys.isapple(p), platforms)),
-    HostBuildDependency("NASM_jll"; platforms=filter(p->proc_family(p) == "intel" && Sys.isapple(p), platforms)),
+    HostBuildDependency("NASM_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/MPIR/build_tarballs.jl
+++ b/M/MPIR/build_tarballs.jl
@@ -18,7 +18,7 @@ cd $WORKSPACE/srcdir/mpir
 apk add texinfo
 
 # Symlink the nasm executable into yasm to make the build use it
-ln -s ${bindir}/nasm ${bindir}/yasm
+ln -s ${host_bindir}/nasm ${host_bindir}/yasm
 
 # Our C compilers are too new for the configure script in this
 # package. We need to disable errors (that used to be warnings) for
@@ -37,9 +37,6 @@ ln -s ${bindir}/nasm ${bindir}/yasm
     CFLAGS="-Wno-error=implicit-int -Wno-error=implicit-function-declaration"
 make -j${nproc}
 make install
-
-# Remove the symlink to prevent it from being in the final tarball
-rm -f ${bindir}/yasm
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/MPIR/build_tarballs.jl
+++ b/M/MPIR/build_tarballs.jl
@@ -17,6 +17,9 @@ cd $WORKSPACE/srcdir/mpir
 
 apk add texinfo
 
+# Symlink the nasm executable into yasm to make the build use it
+ln -s ${bindir}/nasm ${bindir}/yasm
+
 # Our C compilers are too new for the configure script in this
 # package. We need to disable errors (that used to be warnings) for
 # implicit function declarations.
@@ -34,6 +37,9 @@ apk add texinfo
     CFLAGS="-Wno-error=implicit-int -Wno-error=implicit-function-declaration"
 make -j${nproc}
 make install
+
+# Remove the symlink to prevent it from being in the final tarball
+rm -f ${bindir}/yasm
 """
 
 # These are the platforms we will build for by default, unless further

--- a/M/MPIR/build_tarballs.jl
+++ b/M/MPIR/build_tarballs.jl
@@ -17,9 +17,6 @@ cd $WORKSPACE/srcdir/mpir
 
 apk add texinfo
 
-# Symlink the nasm executable into yasm to make the build use it
-ln -s ${host_bindir}/nasm ${host_bindir}/yasm
-
 # Our C compilers are too new for the configure script in this
 # package. We need to disable errors (that used to be warnings) for
 # implicit function declarations.
@@ -54,7 +51,10 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    HostBuildDependency("NASM_jll"),
+    # YASM is basically unsupported, but MPIR doesn't seem to support building
+    # with NASM (an alternative assembler) based on this upstream discussion:
+    # https://groups.google.com/g/mpir-devel/c/JU0d9Bh2MAc
+    HostBuildDependency("YASM_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/M/MPIR/build_tarballs.jl
+++ b/M/MPIR/build_tarballs.jl
@@ -51,7 +51,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    HostBuildDependency("YASM_jll"),
+    HostBuildDependency("NASM_jll"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
YASM is unmaintained and has security advisories against it, so replace it with NASM.

:rocket: Let's see what breaks :boom:.

cc @mbauman 

Fixes https://github.com/JuliaPackaging/Yggdrasil/issues/14347