### PR TITLE
[CURL] version 8.21.0

### DIFF
--- a/L/LibCURL/CURL/build_tarballs.jl
+++ b/L/LibCURL/CURL/build_tarballs.jl
@@ -1,3 +1,3 @@
 include("../common.jl")
 
-build_libcurl(ARGS, "CURL", v"8.20.0")
+build_libcurl(ARGS, "CURL", v"8.21.0")


### PR DESCRIPTION
We were already building LibCURL at this version from https://github.com/JuliaPackaging/Yggdrasil/pull/14114.