### PR TITLE
CUDA: Add 13.4 EA SDK JLLs from packages.nvidia.com.

### DIFF
--- a/C/CUDA/CUDA_SDK@13.4/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK@13.4/build_tarballs.jl
@@ -1,0 +1,16 @@
+using BinaryBuilder, Pkg
+
+include("../common.jl")
+
+const YGGDRASIL_DIR = "../../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
+
+name = "CUDA_SDK"
+version = CUDA.full_version(v"13.4")
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("aarch64", "linux"),
+             Platform("x86_64", "windows")]
+
+build_sdk(name, version, platforms; static=false)

--- a/C/CUDA/CUDA_SDK_static@13.4/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK_static@13.4/build_tarballs.jl
@@ -1,0 +1,16 @@
+using BinaryBuilder, Pkg
+
+include("../common.jl")
+
+const YGGDRASIL_DIR = "../../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
+
+name = "CUDA_SDK_static"
+version = CUDA.full_version(v"13.4")
+
+platforms = [Platform("x86_64", "linux"),
+             Platform("aarch64", "linux"),
+             Platform("x86_64", "windows")]
+
+build_sdk(name, version, platforms; static=true)

--- a/C/CUDA/common.jl
+++ b/C/CUDA/common.jl
@@ -2,21 +2,38 @@ using JSON3, Downloads
 using BinaryBuilder
 using Base: thisminor
 
+# GA releases have historically been published to developer.download.nvidia.com, while
+# EA/preview releases (and possibly everything, going forward) only appear on
+# packages.nvidia.com's bin-archive service. The latter serves the very same JSON manifest
+# format from a different root, the only difference being that the relative paths point
+# into a content-addressed pool instead of sitting next to the manifest.
+redist_roots(product::String) = [
+    "https://developer.download.nvidia.com/compute/$product/redist",
+    "https://packages.nvidia.com/bin-archive/release/$product/redist",
+]
+
 function get_sources(product::String, components::Vector{String};
                      version::Union{VersionNumber,String}, platform::Platform,
                      variant::Union{Nothing,String}=nothing)
-    root = "https://developer.download.nvidia.com/compute/$product/redist"
-
-    url = "$root/redistrib_$(version).json"
-    json = sprint(io->Downloads.download(url, io))
-    parse_sources(json, product, components; version, platform, variant)
+    errors = []
+    for root in redist_roots(product)
+        url = "$root/redistrib_$(version).json"
+        json = try
+            sprint(io->Downloads.download(url, io))
+        catch err
+            push!(errors, url => err)
+            continue
+        end
+        return parse_sources(json, product, components; version, platform, variant, root)
+    end
+    error("Could not download a redistributable manifest for $product $version:\n" *
+          join(("  $url: $(sprint(showerror, err))" for (url, err) in errors), "\n"))
 end
 # XXX: split, for now, so that we can use this with manual JSON
 function parse_sources(json::String, product::String, components::Vector{String};
                        version::Union{VersionNumber,String}, platform::Platform,
-                       variant::Union{Nothing,String}=nothing)
-    root = "https://developer.download.nvidia.com/compute/$product/redist"
-
+                       variant::Union{Nothing,String}=nothing,
+                       root::String=first(redist_roots(product)))
     redist = JSON3.read(json)
     if !haskey(platform, "cuda")
         error("Please provide a platform that has the 'cuda' tag set, indicating which CUDA toolkit version this product is to be used with.")
@@ -70,10 +87,26 @@ function parse_sources(json::String, product::String, components::Vector{String}
         end
 
         push!(sources, ArchiveSource(
-            "$root/$(data["relative_path"])", data["sha256"]
+            resolve_redist_url(root, data["relative_path"]), data["sha256"]
         ))
     end
     sources
+end
+
+# resolve a manifest-relative path against the directory the manifest lives in, folding
+# away any ".." segments (bin-archive manifests use e.g. ../../../pool/<platform>/<uuid>/).
+# libcurl would normalize these anyway, but the URL also ends up in build metadata.
+function resolve_redist_url(root::String, relative_path::AbstractString)
+    resolved = String[]
+    for part in split("$root/$relative_path", '/')
+        if part == ".."
+            isempty(resolved) && error("Invalid relative path $relative_path")
+            pop!(resolved)
+        elseif part != "."
+            push!(resolved, part)
+        end
+    end
+    join(resolved, '/')
 end
 
 function build_sdk(name::String, version::VersionNumber, platforms::Vector{Platform};

--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -134,9 +134,17 @@ const cuda_full_versions = [
     v"13.3.1"
 ]
 
+# EA/preview toolkits. We do build JLLs for these, so that they can be used explicitly,
+# but they are never selected automatically: they are left out of `supported_platforms`
+# unless asked for, and CUDA_Runtime_jll's platform augmentation only ever picks one when
+# the user requests it through the "version" preference.
+const cuda_prerelease_versions = [
+    v"13.4.0"
+]
+
 function full_version(ver::VersionNumber)
     ver == Base.thisminor(ver) || error("Cannot specify a patch version")
-    for full_ver in cuda_full_versions
+    for full_ver in [cuda_full_versions; cuda_prerelease_versions]
         if ver == Base.thisminor(full_ver)
             return full_ver
         end
@@ -152,8 +160,10 @@ Return a list of supported platforms to build CUDA artifacts for.
 # Arguments
 - `min_version=v"11"`: Min. CUDA version to target.
 - `max_version=nothing`: Max. CUDA version to target.
+- `prereleases=false`: Also target EA/preview toolkits (`cuda_prerelease_versions`).
 """
-function supported_platforms(; min_version=v"11", max_version=nothing)
+function supported_platforms(; min_version=v"11", max_version=nothing,
+                               prereleases::Bool=false)
     base_platforms = [
         Platform("x86_64", "linux"; libc = "glibc"),
         Platform("aarch64", "linux"; libc = "glibc", cuda_platform = "jetson"),
@@ -164,9 +174,11 @@ function supported_platforms(; min_version=v"11", max_version=nothing)
         #Platform("x86_64", "windows"),
     ]
 
+    candidate_versions = prereleases ? [cuda_full_versions; cuda_prerelease_versions] :
+                                       cuda_full_versions
     cuda_versions = filter(v -> (isnothing(min_version) || v >= min_version) &&
                                 (isnothing(max_version) || v <= max_version),
-                           cuda_full_versions)
+                           candidate_versions)
 
     # augment with CUDA versions
     platforms = Platform[]
@@ -308,6 +320,10 @@ function cuda_nvcc_redist_source(cuda_ver, arch)
             # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.2.0.json
             ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-13.2.51-archive.tar.xz",
                           "706b996fefc59dc8d64d317fdf48d0aa84c4ae004eff43009dd918f40c5cc66a")
+        elseif cuda_ver == "13.4"
+            # See https://packages.nvidia.com/bin-archive/release/cuda/redist/redistrib_13.4.0.json
+            ArchiveSource("https://packages.nvidia.com/bin-archive/pool/linux-x86_64/5B515474-7E78-11F1-8656-C51E4F4B317F/cuda_nvcc-linux-x86_64-13.4.46-archive.tar.xz",
+                          "52e355da195b4a7ee910429680a69cdeea31834041cb65df738e0c561d5c4d69")
         else
             error("No CUDA redist available for CUDA version $cuda_ver on arch $arch")
         end


### PR DESCRIPTION
CUDA 13.4 is an Early Access/Developer Preview release, and NVIDIA does not publish it to developer.download.nvidia.com anymore. It is available from packages.nvidia.com's bin-archive service, which serves the exact same redistrib JSON manifest at a classic-shaped URL:

    https://packages.nvidia.com/bin-archive/release/cuda/redist/redistrib_13.4.0.json

so there's no need to hand-write a manifest. `get_sources` now tries the classic root first and falls back to the bin-archive one, which keeps every existing recipe (and the non-CUDA products, whose redists still live on the old server) byte-for-byte on its current URLs, while picking up new-host-only releases automatically. The only semantic difference between the two is that bin-archive manifests point into a content-addressed pool with relative paths like `../../../pool/<platform>/<uuid>/`, so the joined URL is normalized before it ends up in an ArchiveSource.

Since 13.4 is a preview, it goes into a separate `cuda_prerelease_versions` list instead of `cuda_full_versions`: `full_version` resolves it (so recipes can ask for CUDA_SDK_jll@13.4.0 explicitly), but `supported_platforms` only returns it when passed `prereleases=true`, so consumer recipes don't silently grow an EA platform on their next rebuild.

CUDA_Driver needs no changes: the preview ships no `cuda_compat` and introduces no new driver floor, as existing CUDA 13.x applications keep running on r580+ under minor version compatibility.

The CUDA_Runtime side (and with it the platform augmentation that has to avoid auto-selecting a preview toolkit) follows separately.