### PR TITLE
CUDA: Build the 13.4 EA runtime, opt-in only.

### DIFF
--- a/C/CUDA/CUDA_Runtime/build_13.4.jl
+++ b/C/CUDA/CUDA_Runtime/build_13.4.jl
@@ -1,0 +1,18 @@
+function get_products(platform)
+    [
+        LibraryProduct(["libcudart", "cudart64_13"], :libcudart),
+        LibraryProduct(["libcufft", "cufft64_12"], :libcufft),
+        LibraryProduct(["libcublas", "cublas64_13"], :libcublas),
+        LibraryProduct(["libcublasLt", "cublasLt64_13"], :libcublasLt),
+        LibraryProduct(["libcusparse", "cusparse64_12"], :libcusparse),
+        LibraryProduct(["libcusolver", "cusolver64_12"], :libcusolver),
+        LibraryProduct(["libcusolverMg", "cusolverMg64_12"], :libcusolverMg),
+        LibraryProduct(["libcurand", "curand64_10"], :libcurand),
+        LibraryProduct(["libcupti", "cupti64_2026.3.0"], :libcupti),
+        LibraryProduct(["libnvperf_host", "nvperf_host"], :libnvperf_host),
+        LibraryProduct(["libnvperf_target", "nvperf_target"], :libnvperf_target),
+        LibraryProduct(["libnvrtc", "nvrtc64_130_0"], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_134"], :libnvrtc_builtins),
+        LibraryProduct(["libnvJitLink", "nvJitLink_130_0"], :libnvJitLink),
+    ]
+end

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,11 +7,16 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.23.0"
+version = v"0.24.0"
+
+# we ship artifacts for both GA and EA/preview toolkits; the platform augmentation only
+# ever selects the latter when the user asks for it through the "version" preference.
+const toolkit_versions = [CUDA.cuda_full_versions; CUDA.cuda_prerelease_versions]
 
 augment_platform_block = """
     $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))
-    const cuda_toolkits = $(CUDA.cuda_full_versions)"""
+    const cuda_toolkits = $(toolkit_versions)
+    const cuda_prerelease_toolkits = $(CUDA.cuda_prerelease_versions)"""
 
 script = raw"""
 # rename directories, stripping the architecture and version suffix
@@ -100,7 +105,7 @@ fi
 
 # determine exactly which tarballs we should build
 builds = []
-for version in reverse(CUDA.cuda_full_versions)
+for version in reverse(toolkit_versions)
     include("build_$(version.major).$(version.minor).jl")
 
     # CUDA_Runtime contains all of the following components

--- a/C/CUDA/CUDA_Runtime/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Runtime/platform_augmentation.jl
@@ -265,6 +265,10 @@ function cuda_toolkit_tag()
             return thisminor(toolkit) == thisminor(cuda_version_override)
         end
 
+        # never auto-select an EA/preview toolkit; those have to be requested explicitly
+        # through the "version" preference (handled by the early return above).
+        toolkit in cuda_prerelease_toolkits && return false
+
         # enhanced compatibility
         #
         # "From CUDA 11 onwards, applications compiled with a CUDA Toolkit release


### PR DESCRIPTION
Follow-up to the 13.4 SDK JLLs: now that CUDA_SDK_jll 13.4.0 is registered, build CUDA_Runtime for the preview toolkit as well, so that it can actually be used from CUDA.jl.

The toolkit list the recipe iterates (and the one spliced into the platform augmentation) becomes `cuda_full_versions` plus `cuda_prerelease_versions`, and the augmentation grows a guard that skips prerelease toolkits when picking the newest one compatible with the driver. Without it every r580+ user would silently be switched to the EA toolkit, since the filter admits any toolkit whose major does not exceed the driver's and the newest one wins. Requesting 13.4 explicitly still works: the "version" preference is handled by an early return that runs before the guard, so e.g. CUDA.set_runtime_version!(v"13.4") selects it.

Only the two Windows library names changed with respect to 13.3, both verified against the redistributable archives: CUPTI's DLL is now cupti64_2026.3.0.dll (its own version, fully decoupled from the CUDA version) and the NVRTC builtins are nvrtc-builtins64_134.dll.

Built locally for x86_64-linux-gnu, aarch64-linux-gnu and x86_64-w64-mingw32.