### PR TITLE
[tensorprimitives_tapp] Build v0.1.0

### DIFF
--- a/T/tensorprimitives_tapp/build_tarballs.jl
+++ b/T/tensorprimitives_tapp/build_tarballs.jl
@@ -13,15 +13,9 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/tensorprimitives-rs
-RFLAGS=()
 if [[ "${target}" == *-musl* ]]; then
-    RFLAGS+=(-C target-feature=-crt-static);
-elif [[ "${target}" == *-apple-* ]]; then
-    RFLAGS+=(-C link-arg=-Wl,-install_name,@rpath/libtensorprimitives_tapp.${dlext});
-elif [[ "${target}" != *-mingw* ]]; then
-    RFLAGS+=(-C link-arg=-Wl,-soname,libtensorprimitives_tapp.${dlext});
+    export RUSTFLAGS="-C target-feature=-crt-static"
 fi
-export RUSTFLAGS="${RFLAGS[@]}"
 export CARGO_PROFILE_RELEASE_DEBUG=0
 export CARGO_TARGET_DIR=${WORKSPACE}/target
 cargo build --release --locked -j${nproc} --target ${rust_target} -p tensorprimitives-tapp

--- a/T/tensorprimitives_tapp/build_tarballs.jl
+++ b/T/tensorprimitives_tapp/build_tarballs.jl
@@ -35,7 +35,6 @@ filter!(p -> !(triplet(p) in ("riscv64-linux-gnu", "aarch64-unknown-freebsd")), 
 
 # The products that we will ensure are always built
 products = [
-    # Two names: on mingw the DLL has no `lib` prefix.
     LibraryProduct(["libtensorprimitives_tapp", "tensorprimitives_tapp"], :libtensorprimitives_tapp),
     FileProduct("include/tapp.h", :tapp_h)
 ]

--- a/T/tensorprimitives_tapp/build_tarballs.jl
+++ b/T/tensorprimitives_tapp/build_tarballs.jl
@@ -24,11 +24,8 @@ crates/tensorprimitives-tapp/install.sh --prefix="${prefix}" --libdir="${libdir}
 install_license LICENSE-MIT LICENSE-APACHE
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = supported_platforms()
 # BinaryBuilder's Rust toolchain does not work for 32-bit Windows.
-filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
+platforms = supported_platforms(; exclude = p -> Sys.iswindows(p) && arch(p) == "i686")
 
 # The products that we will ensure are always built
 products = [

--- a/T/tensorprimitives_tapp/build_tarballs.jl
+++ b/T/tensorprimitives_tapp/build_tarballs.jl
@@ -1,0 +1,52 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+name = "tensorprimitives_tapp"
+version = v"0.1.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/lkdvos/tensorprimitives-rs.git", "ca916fae1947efa526cf7177bf06018c042fd8a6")
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd $WORKSPACE/srcdir/tensorprimitives-rs
+RFLAGS=()
+if [[ "${target}" == *-musl* ]]; then RFLAGS+=(-C target-feature=-crt-static); fi
+if [[ "${target}" == *-apple-* ]]; then RFLAGS+=(-C link-arg=-Wl,-install_name,@rpath/libtensorprimitives_tapp.${dlext}); elif [[ "${target}" != *-mingw* ]]; then RFLAGS+=(-C link-arg=-Wl,-soname,libtensorprimitives_tapp.${dlext}); fi
+export RUSTFLAGS="${RFLAGS[@]}"
+export CARGO_PROFILE_RELEASE_DEBUG=0
+export CARGO_TARGET_DIR=${WORKSPACE}/target
+cargo build --release --locked -j${nproc} --target ${rust_target} -p tensorprimitives-tapp
+crates/tensorprimitives-tapp/install.sh --prefix="${prefix}" --libdir="${libdir}" --includedir="${includedir}" --artifacts="${CARGO_TARGET_DIR}/${rust_target}/release" --no-licenses
+install_license LICENSE-MIT LICENSE-APACHE
+"""
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = supported_platforms()
+# BinaryBuilder's Rust toolchain does not work for 32-bit Windows.
+filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
+# No Rust toolchain shard exists for these two at any available version, so
+# `choose_shards` errors on them rather than falling back.
+filter!(p -> !(triplet(p) in ("riscv64-linux-gnu", "aarch64-unknown-freebsd")), platforms)
+
+# The products that we will ensure are always built
+products = [
+    # Two names: on mingw the DLL has no `lib` prefix.
+    LibraryProduct(["libtensorprimitives_tapp", "tensorprimitives_tapp"], :libtensorprimitives_tapp),
+    FileProduct("include/tapp.h", :tapp_h)
+]
+
+# Dependencies that must be installed before this package can be built.
+# There are none: this is native Rust. The two unresolved-library warnings the
+# audit emits are expected and have no JLL to point at -- libgcc_s.so.1, which
+# every Rust cdylib needs for its unwinder and which Julia ships, and
+# bcryptprimitives.dll on Windows, imported by Rust's standard library.
+dependencies = Dependency[
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", compilers = [:rust, :c])

--- a/T/tensorprimitives_tapp/build_tarballs.jl
+++ b/T/tensorprimitives_tapp/build_tarballs.jl
@@ -39,10 +39,6 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built.
-# There are none: this is native Rust. The two unresolved-library warnings the
-# audit emits are expected and have no JLL to point at -- libgcc_s.so.1, which
-# every Rust cdylib needs for its unwinder and which Julia ships, and
-# bcryptprimitives.dll on Windows, imported by Rust's standard library.
 dependencies = Dependency[
 ]
 

--- a/T/tensorprimitives_tapp/build_tarballs.jl
+++ b/T/tensorprimitives_tapp/build_tarballs.jl
@@ -14,8 +14,14 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/tensorprimitives-rs
 RFLAGS=()
-if [[ "${target}" == *-musl* ]]; then RFLAGS+=(-C target-feature=-crt-static); fi
-if [[ "${target}" == *-apple-* ]]; then RFLAGS+=(-C link-arg=-Wl,-install_name,@rpath/libtensorprimitives_tapp.${dlext}); elif [[ "${target}" != *-mingw* ]]; then RFLAGS+=(-C link-arg=-Wl,-soname,libtensorprimitives_tapp.${dlext}); fi
+if [[ "${target}" == *-musl* ]]; then
+    RFLAGS+=(-C target-feature=-crt-static);
+fi
+if [[ "${target}" == *-apple-* ]]; then
+    RFLAGS+=(-C link-arg=-Wl,-install_name,@rpath/libtensorprimitives_tapp.${dlext});
+elif [[ "${target}" != *-mingw* ]]; then
+    RFLAGS+=(-C link-arg=-Wl,-soname,libtensorprimitives_tapp.${dlext});
+fi
 export RUSTFLAGS="${RFLAGS[@]}"
 export CARGO_PROFILE_RELEASE_DEBUG=0
 export CARGO_TARGET_DIR=${WORKSPACE}/target

--- a/T/tensorprimitives_tapp/build_tarballs.jl
+++ b/T/tensorprimitives_tapp/build_tarballs.jl
@@ -29,9 +29,6 @@ install_license LICENSE-MIT LICENSE-APACHE
 platforms = supported_platforms()
 # BinaryBuilder's Rust toolchain does not work for 32-bit Windows.
 filter!(p -> !Sys.iswindows(p) || arch(p) != "i686", platforms)
-# No Rust toolchain shard exists for these two at any available version, so
-# `choose_shards` errors on them rather than falling back.
-filter!(p -> !(triplet(p) in ("riscv64-linux-gnu", "aarch64-unknown-freebsd")), platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/T/tensorprimitives_tapp/build_tarballs.jl
+++ b/T/tensorprimitives_tapp/build_tarballs.jl
@@ -16,8 +16,7 @@ cd $WORKSPACE/srcdir/tensorprimitives-rs
 RFLAGS=()
 if [[ "${target}" == *-musl* ]]; then
     RFLAGS+=(-C target-feature=-crt-static);
-fi
-if [[ "${target}" == *-apple-* ]]; then
+elif [[ "${target}" == *-apple-* ]]; then
     RFLAGS+=(-C link-arg=-Wl,-install_name,@rpath/libtensorprimitives_tapp.${dlext});
 elif [[ "${target}" != *-mingw* ]]; then
     RFLAGS+=(-C link-arg=-Wl,-soname,libtensorprimitives_tapp.${dlext});


### PR DESCRIPTION
New package. `tensorprimitives_tapp` is the TAPP (Tensor Algebra Processing
Primitives, arXiv:2601.07827) C ABI over `tensorcontract`, a native-Rust dense
tensor contraction engine. Both crates were published to crates.io as 0.1.0
today. MIT OR Apache-2.0.

Source is a `GitSource` pinned to a commit rather than an archive of the tag,
since BinaryBuilder rejects GitHub's auto-generated archives.

Rust 1.94.0, above the crate's 1.89 MSRV. No dependencies: the engine is pure
Rust over two pure-Rust crates with no build script, so there is no system
library to resolve.

Two platform filters, both checked against BinaryBuilderBase 1.44.0 rather than
copied from another recipe:

* `i686-w64-mingw32`: BinaryBuilder's Rust toolchain does not work there.
* `riscv64-linux-gnu` and `aarch64-unknown-freebsd`: no Rust shard at any
  version. `choose_shards` fails for exactly these two of the 18 supported
  platforms.

The audit emits one unresolved-library warning, `libgcc_s.so.1` on Linux and
`bcryptprimitives.dll` on Windows. Both are expected and the recipe says why in
a comment: every Rust cdylib carries the former for its unwinder and Julia ships
one, and the latter is a Windows 10+ system DLL that Rust's standard library
imports. `CompilerSupportLibraries_jll` was tried here and made things worse
rather than better. A third such warning would be a real finding.

Dry-run on `x86_64-linux-gnu` builds clean.
