### PR TITLE
Recompile MUMPS 5.9.1

### DIFF
--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -65,7 +65,7 @@ fi
 # Keep images in the low 2 GB.
 EXTRA_LDFLAGS=()
 if [[ "${target}" == *mingw* ]]; then
-    EXTRA_LDFLAGS+=("-Wl,--disable-high-entropy-va")
+    EXTRA_LDFLAGS+=("-Wl,--disable-dynamicbase")
 fi
 
 # Override MPItrampoline's built-in compiler paths

--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -59,12 +59,14 @@ elif [[ ${bb_full_target} == *openmpi* ]]; then
     MPILIBS=(-lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh -lmpi)
 fi
 
-# Avoid "32 bit pseudo relocation out of range" aborts on Windows:
-# mingw's 32-bit runtime pseudo-relocs (used for cross-DLL Fortran COMMON data)
-# overflow when High-Entropy ASLR places DLLs >2 GB apart.
-# Keep images in the low 2 GB.
 EXTRA_LDFLAGS=()
-if [[ "${target}" == *mingw* ]]; then
+if [[ "${target}" == *w64-mingw* ]]; then
+    # On mingw/x86_64, cross-DLL references to un-`dllimport`ed data symbols are
+    # resolved via mingw's 32-bit runtime pseudo-relocations. Under high-entropy
+    # ASLR two DLLs can map >2 GB apart, overflowing the 32-bit fixup and aborting
+    # at load: "32 bit pseudo relocation ... out of range". Disabling the runtime
+    # pseudo-relocs fixes the crash and keeps ASLR fully enabled. (The link would
+    # fail here if any such data import genuinely needed a runtime fixup.)
     EXTRA_LDFLAGS+=("-Wl,--disable-runtime-pseudo-reloc")
 fi
 

--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -65,7 +65,7 @@ fi
 # Keep images in the low 2 GB.
 EXTRA_LDFLAGS=()
 if [[ "${target}" == *mingw* ]]; then
-    EXTRA_LDFLAGS+=("-Wl,--disable-dynamicbase")
+    EXTRA_LDFLAGS+=("-Wl,--disable-runtime-pseudo-reloc")
 fi
 
 # Override MPItrampoline's built-in compiler paths

--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -60,7 +60,7 @@ elif [[ ${bb_full_target} == *openmpi* ]]; then
 fi
 
 EXTRA_LDFLAGS=()
-if [[ "${target}" == *w64-mingw* ]]; then
+if [[ "${target}" == *x86_64-w64-mingw* ]]; then
     # On mingw/x86_64, cross-DLL references to un-`dllimport`ed data symbols are
     # resolved via mingw's 32-bit runtime pseudo-relocations. Under high-entropy
     # ASLR two DLLs can map >2 GB apart, overflowing the 32-bit fixup and aborting

--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -59,6 +59,15 @@ elif [[ ${bb_full_target} == *openmpi* ]]; then
     MPILIBS=(-lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh -lmpi)
 fi
 
+# Avoid "32 bit pseudo relocation out of range" aborts on Windows:
+# mingw's 32-bit runtime pseudo-relocs (used for cross-DLL Fortran COMMON data)
+# overflow when High-Entropy ASLR places DLLs >2 GB apart.
+# Keep images in the low 2 GB.
+EXTRA_LDFLAGS=()
+if [[ "${target}" == *mingw* ]]; then
+    EXTRA_LDFLAGS+=("-Wl,--disable-high-entropy-va")
+fi
+
 # Override MPItrampoline's built-in compiler paths
 export MPITRAMPOLINE_CC=cc
 export MPITRAMPOLINE_CXX=c++
@@ -83,7 +92,7 @@ FSCOTCH="-Dscotch"
 
 make_args+=(PLAT="par" \
             OPTF="-O3 -fopenmp" \
-            OPTL="-O3 -l${OMP}" \
+            OPTL="-O3 -l${OMP} ${EXTRA_LDFLAGS[*]}" \
             OPTC="-O3 -fopenmp" \
             CDEFS=-DAdd_ \
             LMETISDIR="${libdir}" \


### PR DESCRIPTION
I need to recompile MUMPS v5.9.1 on Windows.
It should help with this [error](https://github.com/JuliaSmoothOptimizers/MUMPS.jl/actions/runs/31299423242/job/93209694907?pr=194).