### PR TITLE
[Epsteinlib] Update to v0.6.1

### DIFF
--- a/E/Epsteinlib/build_tarballs.jl
+++ b/E/Epsteinlib/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"0.6.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/epsteinlib/epsteinlib.git", "fb16dbc45412cdf00792bab1d8a0df4da288ea01")
+    GitSource("https://github.com/epsteinlib/epsteinlib.git", "4283b41209c6eab32ed5340a37e6e2d1708e15a3")
 ]
 
 # Bash recipe for building across all platforms

--- a/E/Epsteinlib/build_tarballs.jl
+++ b/E/Epsteinlib/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "Epsteinlib"
-version = v"0.5.1"
+version = v"0.6.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/epsteinlib/epsteinlib.git", "0ce7c02717da95d4def7a14ff1ec0300b22df805")
+    GitSource("https://github.com/epsteinlib/epsteinlib.git", "a1f130459762603e4c4a507fda2b38f354de3090")
 ]
 
 # Bash recipe for building across all platforms

--- a/E/Epsteinlib/build_tarballs.jl
+++ b/E/Epsteinlib/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"0.6.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/epsteinlib/epsteinlib.git", "a1f130459762603e4c4a507fda2b38f354de3090")
+    GitSource("https://github.com/epsteinlib/epsteinlib.git", "fb16dbc45412cdf00792bab1d8a0df4da288ea01")
 ]
 
 # Bash recipe for building across all platforms

--- a/E/Epsteinlib/build_tarballs.jl
+++ b/E/Epsteinlib/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "Epsteinlib"
-version = v"0.6.0"
+version = v"0.6.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/epsteinlib/epsteinlib.git", "4283b41209c6eab32ed5340a37e6e2d1708e15a3")
+    GitSource("https://github.com/epsteinlib/epsteinlib.git", "2760ec25ad0e3c7559e8f066dfe41814f3df55bc")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Matches latest EpsteinLib release [v0.6.1](https://github.com/epsteinlib/epsteinlib/tree/v0.6.1)

Note, that `v0.6.1` is a fix of the prior major release [v0.6.0](https://github.com/epsteinlib/epsteinlib/tree/v0.6.0) that failed, as the aarch46 darwin plattform could not link complex-by-complex division on the Yggdrasil toolchain.