### PR TITLE
[CUDA] Ship tileirdisasm in CUDA_Compiler on CUDA 13.4+.

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -54,6 +54,9 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv cuda_nvdisasm/bin/nvdisasm ${bindir}
     if [[ -d cuda_tileiras ]]; then
         mv cuda_tileiras/bin/tileiras ${bindir}
+        if [[ -f cuda_tileiras/bin/tileirdisasm ]]; then
+            mv cuda_tileiras/bin/tileirdisasm ${bindir}
+        fi
     fi
 elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     # normalize the layout of the library components: starting with CUDA 13 there's an
@@ -90,6 +93,9 @@ elif [[ ${target} == x86_64-w64-mingw32 ]]; then
     mv cuda_nvdisasm/bin/nvdisasm.exe ${bindir}
     if [[ -d cuda_tileiras ]]; then
         mv cuda_tileiras/bin/tileiras.exe ${bindir}
+        if [[ -f cuda_tileiras/bin/tileirdisasm.exe ]]; then
+            mv cuda_tileiras/bin/tileirdisasm.exe ${bindir}
+        fi
     fi
 
     # Fix permissions
@@ -153,6 +159,10 @@ function get_products(version::VersionNumber)
     end
     if version >= v"13.1"
         push!(products, ExecutableProduct("tileiras", :tileiras))
+    end
+    if version >= v"13.4"
+        # NVIDIA started shipping the Tile IR disassembler with CUDA 13.4
+        push!(products, ExecutableProduct("tileirdisasm", :tileirdisasm))
     end
     return products
 end


### PR DESCRIPTION
NVIDIA started including the Tile IR disassembler in the cuda_tileiras redist archive with CUDA 13.4; move it into CUDA_Compiler alongside tileiras so consumers get a version-matched disassembler.