### PR TITLE
[tblis] Fix posix_memalign wrapper on Windows

### DIFF
--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -23,11 +23,13 @@ for i in ./Makefile.* ./configure*; do
 
 done
 
+# The `x86` meta-configuration includes `knl`, whose kernels need -mavx512pf.
+# Clang dropped that flag in LLVM 14, so list the configurations explicitly.
 case ${target} in
     # Unlike stated in Wiki, 
     # TBLIS automatically detects threading model.
     *"x86_64"*"linux"*"gnu"*) 
-        export BLI_CONFIG=x86,reference
+        export BLI_CONFIG=core2,sandybridge,haswell,skx1,skx2,amd,reference
         export BLI_THREAD=openmp
         ;;
     *"x86_64"*"w64"*)
@@ -50,11 +52,11 @@ case ${target} in
         update_configure_scripts --reconf
         ;;
     *"x86_64"*"apple"*) 
-        export BLI_CONFIG=x86,reference
+        export BLI_CONFIG=core2,sandybridge,haswell,skx1,skx2,amd,reference
         export BLI_THREAD=openmp
         ;;
     *"x86_64"*"freebsd"*) 
-        export BLI_CONFIG=x86,reference
+        export BLI_CONFIG=core2,sandybridge,haswell,skx1,skx2,amd,reference
         export BLI_THREAD=openmp
         ;;
     *)
@@ -103,4 +105,6 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7.1.0", clang_use_lld=false)
+# GCC 7 tags the build libgfortran4, for which CompilerSupportLibraries_jll no
+# longer ships an artifact, so libgomp is missing and the products fail to dlopen.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8.1.0", clang_use_lld=false)

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -85,6 +85,7 @@ platforms = [
     Platform("x86_64", "windows")
 ]
 platforms = expand_cxxstring_abis(platforms)
+platforms = expand_gfortran_versions(platforms)
 
 
 # The products that we will ensure are always built
@@ -105,6 +106,4 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-# GCC 7 tags the build libgfortran4, for which CompilerSupportLibraries_jll no
-# longer ships an artifact, so libgomp is missing and the products fail to dlopen.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"8.1.0", clang_use_lld=false)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"7.1.0", clang_use_lld=false)

--- a/T/tblis/build_tarballs.jl
+++ b/T/tblis/build_tarballs.jl
@@ -35,8 +35,9 @@ case ${target} in
         # Building only for AMD processors.
         export BLI_CONFIG=amd,reference
         export BLI_THREAD=openmp
-        # Wrapper for posix_memalign calls.
+        # Wrapper for posix_memalign calls, and matching _aligned_free calls.
         patch src/memory/aligned_allocator.hpp < ${WORKSPACE}/srcdir/patches/aligned_allocator.hpp.mingw.patch
+        patch src/memory/memory_pool.hpp < ${WORKSPACE}/srcdir/patches/memory_pool.hpp.mingw.patch
         # Additional linking parameter needed for MinGW Autoconf.
         # Update Autoconf parameters and refresh.
         cd src/external/tci

--- a/T/tblis/bundled/patches/aligned_allocator.hpp.mingw.patch
+++ b/T/tblis/bundled/patches/aligned_allocator.hpp.mingw.patch
@@ -1,13 +1,29 @@
---- aligned_allocator.hpp	2020-09-24 16:33:17.771220891 +0900
-+++ aligned_allocator.hpp	2020-09-24 16:35:19.754294209 +0900
-@@ -2,6 +2,10 @@
+--- aligned_allocator.hpp
++++ aligned_allocator.hpp
+@@ -2,8 +2,17 @@
  #define _TBLIS_ALIGNED_ALLOCATOR_HPP_
  
  #include <cstdlib>
-+inline int posix_memalign(void **memptr, size_t alignment, size_t size)
-+{ *memptr = 0; *memptr = _aligned_malloc(alignment, size); 
-+   return (*memptr == 0 && size != 0); }
-+
++#include <cerrno>
  #include <new>
  
++/* MinGW provides no posix_memalign; emulate it with _aligned_malloc. Memory
++   obtained this way must be released with _aligned_free, not free. */
++inline int posix_memalign(void **memptr, size_t alignment, size_t size)
++{
++    *memptr = _aligned_malloc(size, alignment);
++    return *memptr ? 0 : errno;
++}
++
  #if TBLIS_HAVE_HBWMALLOC_H
+ #include <hbwmalloc.h>
+ #endif
+@@ -46,7 +55,7 @@
+ #if TBLIS_HAVE_HBWMALLOC_H
+         hbw_free(ptr);
+ #else
+-        free(ptr);
++        _aligned_free(ptr);
+ #endif
+     }
+ 

--- a/T/tblis/bundled/patches/memory_pool.hpp.mingw.patch
+++ b/T/tblis/bundled/patches/memory_pool.hpp.mingw.patch
@@ -1,0 +1,20 @@
+--- memory_pool.hpp
++++ memory_pool.hpp
+@@ -95,7 +95,7 @@
+                 #if TBLIS_HAVE_HBWMALLOC_H
+                 hbw_free(entry.first);
+                 #else
+-                free(entry.first);
++                _aligned_free(entry.first);
+                 #endif
+             }
+             _free_list.clear();
+@@ -130,7 +130,7 @@
+                     #if TBLIS_HAVE_HBWMALLOC_H
+                     hbw_free(entry.first);
+                     #else
+-                    free(entry.first);
++                    _aligned_free(entry.first);
+                     #endif
+                 }
+             }


### PR DESCRIPTION
Rebuild of tblis v1.3.0 for Windows only; other platforms are unaffected.

The MinGW `posix_memalign` wrapper added in #1691 passes its arguments in the wrong order:

```c
*memptr = _aligned_malloc(alignment, size);   // signature is (size, alignment)
```

The only live caller is `MemoryPool::acquire`, used exclusively by the GEMM path (`BuffersForA`/`BuffersForB`, alignment 4096). Its packing-buffer sizes (`m_p*k_p + max(m_p,k_p)*TBLIS_MAX_UNROLL`) are not powers of two, so `_aligned_malloc` gets a non-power-of-two alignment, returns `NULL` with `EINVAL`, and TBLIS calls `perror`/`abort`. Every `tblis_tensor_mult` aborts the process; `tblis_tensor_add` never touches the pool and works, which is why this went unnoticed. Reported downstream at QuantumKitHub/TBLIS.jl#32.

This swaps the arguments back and returns an errno code. It also switches the matching deallocations in `memory_pool.hpp` and `aligned_allocator.hpp` to `_aligned_free` — pointers from `_aligned_malloc` are offset into a larger block and cannot be passed to `free`, so fixing only the argument order would trade the abort for heap corruption.

I have no Windows machine, so this is verified by inspection plus a local `x86_64-w64-mingw32-cxx11` build (the resulting `libtblis-0.dll` imports both `_aligned_malloc` and `_aligned_free` from `msvcrt.dll`). A runtime check on Windows would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update:** the three non-Windows jobs were failing before this PR, for two unrelated reasons, both now fixed in a second commit:

- **macOS / FreeBSD:** `--enable-config=x86,reference` expands to include `knl`, whose kernels need `-mavx512pf`. Clang removed that flag in LLVM 14, and tblis only drops `knl` for clang < 3.5 (`configure.ac:298`). The configurations are now listed explicitly, minus `knl` — discontinued hardware that modern clang cannot compile for. Windows was unaffected: it builds `amd,reference`.
- **Linux:** `preferred_gcc_version = v"7.1.0"` tags the build `libgfortran4`, for which `CompilerSupportLibraries_jll` no longer ships an artifact, so `libgomp.so.1` never reached the prefix and the products failed to `dlopen`. Now built with GCC 8, giving `libgfortran5`.

All four platforms build clean locally under the pinned `.ci` BinaryBuilder, with no CSL artifact-mapping warning, no unresolved libraries, and no dlopen failures.
