### PR TITLE
[GSL] Apply Debian patch requiring positive n_tries in siman

### DIFF
--- a/G/GSL/GSL@2/build_tarballs.jl
+++ b/G/GSL/GSL@2/build_tarballs.jl
@@ -5,8 +5,7 @@ using BinaryBuilder
 name = "GSL"
 version_string = "2.8"
 version = VersionNumber(version_string)
-# We bumped the version because we built for new architectures
-ygg_version = v"2.8.1"
+ygg_version = v"2.8.2"
 
 # Collection of sources required to build GSL
 sources = [
@@ -27,6 +26,7 @@ fi
 
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/0001-remove-unknown-ld-option.patch
 atomic_patch -p1 ${WORKSPACE}/srcdir/patches/ieee_interface.patch
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/n_tries_positive_in_siman.patch
 update_configure_scripts
 ./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target} --disable-static
 make -j${nproc}

--- a/G/GSL/GSL@2/bundled/patches/n_tries_positive_in_siman.patch
+++ b/G/GSL/GSL@2/bundled/patches/n_tries_positive_in_siman.patch
@@ -1,0 +1,18 @@
+Description: The n_tries parameter has to be positive
+Author: Dirk Eddelbuettel <edd@debian.org>
+Bug-Debian: https://bugs.debian.org/1086206
+Bug: https://lists.gnu.org/archive/html/bug-gsl/2024-09/msg00000.html
+Last-Update: 2024-10-28
+
+--- gsl-2.8+dfsg.orig/siman/siman.c
++++ gsl-2.8+dfsg/siman/siman.c
+@@ -197,6 +197,9 @@ gsl_siman_solve_many (const gsl_rng * r,
+   double u;                     /* throw the die to choose a new "x" */
+   int n_iter;
+ 
++  /* this function requires that n_tries be positive */
++  assert(params.n_tries > 0);
++
+   if (print_position) {
+     printf ("#-iter    temperature       position");
+     printf ("         delta_pos        energy\n");


### PR DESCRIPTION
File from https://sources.debian.org/src/gsl/2.8%2Bdfsg-6/debian/patches/n_tries_positive_in_siman

bumping JLL version to 2.8.2