### PR TITLE
[SQLite] Restore the libsqlite3.so.0 SONAME / libsqlite3.0.dylib id

### DIFF
--- a/S/SQLite/build_tarballs.jl
+++ b/S/SQLite/build_tarballs.jl
@@ -32,6 +32,18 @@ export CPPFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1 \
                  -DSQLITE_ENABLE_MATH_FUNCTIONS \
                  -DSQLITE_USE_URI"
 
+# SQLite 3.49 switched to autosetup, which links the shared library without an
+# SONAME unless `--soname` is given.  The auditor then fills the SONAME in from
+# the file name, so the ABI name became `libsqlite3.so.<version>` and changed on
+# every release, breaking dependents linked against `libsqlite3.so.0`.
+# `--soname` is ELF-only, so macOS is fixed up after `make install`, and Windows
+# keeps its historical `libsqlite3-0.dll` name.
+# See https://sqlite.org/src/forumpost/5a3b44f510df8ded
+SONAME_FLAGS=()
+if [[ ${target} == *-linux-* ]] || [[ ${target} == *-freebsd* ]]; then
+    SONAME_FLAGS=(--soname=legacy)
+fi
+
 ./configure --prefix=${prefix} \
     --build=${MACHTYPE} \
     --host=$target \
@@ -39,9 +51,18 @@ export CPPFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1 \
     --enable-fts3 \
     --enable-fts4 \
     --enable-fts5 \
-    --enable-rtree
+    --enable-rtree \
+    "${SONAME_FLAGS[@]}"
 make -j${nproc}
 make install
+
+if [[ ${target} == *-apple-darwin* ]]; then
+    # Same problem: the dylib id became `@rpath/libsqlite3.dylib` instead of the
+    # `@rpath/libsqlite3.0.dylib` that dependents are linked against.
+    install_name_tool -id @rpath/libsqlite3.0.dylib \
+        "$(readlink -f "${libdir}/libsqlite3.0.dylib")"
+fi
+
 install_license "${WORKSPACE}/srcdir/LICENSE"
 """
 


### PR DESCRIPTION
Since `SQLite_jll` 3.51.2, dependent JLLs no longer resolve SQLite from the JLL. On a machine with a system SQLite this is silent, because the system copy gets loaded instead. On a clean image (JuliaHub job containers, minimal Docker images) it is a hard failure:

```
could not load library ".../lib/libproj.so"
libsqlite3.so.0: cannot open shared object file: No such file or directory
```

Reported downstream against ArchGDAL / Proj / GDAL / GeoDataFrames / Rasters, all of which cascade from one `PROJ_jll` init error.

## Root cause

SQLite 3.49 replaced the autoconf/libtool build with autosetup. The new build system links the shared library without an SONAME unless `--soname` is passed. The default is `none`, because an SONAME breaks the `--dynlink-tools` feature that upstream cares about, and package maintainers are expected to opt in ([upstream discussion](https://sqlite.org/src/forumpost/5a3b44f510df8ded)):

```tcl
# autosetup/sqlite-config.tcl
} else {
    # Enabling soname breaks linking for the --dynlink-tools feature,
    # and this project has no direct use for soname, so default to
    # none. Package maintainers, on the other hand, like to have an
    # soname.
    set soname none
}
```

BinaryBuilder's auditor then fills the missing SONAME in from the file name (`ensure_soname` → `soname = basename(path)`), so what actually shipped was:

| | real file | SONAME / dylib id |
|---|---|---|
| 3.48.0 (libtool) | `libsqlite3.so.0.8.6` | `libsqlite3.so.0` |
| 3.51.2 / 3.53.2 (autosetup) | `libsqlite3.so.3.53.2` | `libsqlite3.so.3.53.2` |
| 3.48.0 macOS | `libsqlite3.0.dylib` | `@rpath/libsqlite3.0.dylib` |
| 3.51.2 / 3.53.2 macOS | `libsqlite3.3.53.2.dylib` | `@rpath/libsqlite3.dylib` |

Dependents are linked against the historical names. `PROJ_jll` v902.800.100 records `NEEDED libsqlite3.so.0` on Linux and `LOAD_DYLIB @rpath/libsqlite3.0.dylib` on macOS, because BinaryBuilder builds against the compat floor (its log shows `Found SQLite3: /workspace/destdir/include (found version "3.48.0")`) while Pkg resolves the latest SQLite_jll at runtime.

So Julia preloads `libsqlite3.so.3.53.2`, the loader registers it under that SONAME, `libproj`'s `libsqlite3.so.0` goes unsatisfied, and the loader searches system paths. `RUNPATH` is `$ORIGIN`, i.e. PROJ's own `lib`, which has no SQLite.

Because the SONAME is derived from the file name, the ABI name changes on every SQLite release. `util_linux`'s `liblastlog2.so.2.0.0` was built against 3.51.2 and requires `libsqlite3.so.3.51.2`, which the current 3.53.2 JLL does not ship, so that one is already broken today.

This is also the incompatibility that got 3.49.0 yanked from the registry. The note recording it was removed in #12946 without the underlying problem being fixed:

```
-# SQLite 3.49.0 uses a new build system (autosetup instead of
-# autoconf), and this leads to different names for all shared
-# libraries [...] We will either need to rename the shared libraries
-# (if possible) or increase the major version number of this package.
```

## Fix

Use the option upstream provides for this: `--soname=legacy` (→ `libsqlite3.so.0`) on ELF platforms, and reset the dylib id on macOS, where ld64 has no `-soname` and `proj-check-soname` would `proj-fatal` if `--soname` were passed. Windows already keeps its historical `libsqlite3-0.dll` and is untouched.

Every already-released dependent JLL works again with no rebuilds, and the ABI name stops drifting on future releases.

## Verification

Rebuilt with `sandbox` for each platform family. `x86_64-linux-gnu`, `aarch64-linux-musl` and `x86_64-unknown-freebsd` get SONAME `libsqlite3.so.0`; `x86_64-apple-darwin14` gets id `@rpath/libsqlite3.0.dylib`; `x86_64-w64-mingw32` is unchanged at `libsqlite3-0.dll`.

File layout is unchanged (`libsqlite3.so` and `libsqlite3.so.0` symlinks onto `libsqlite3.so.<version>`), and the exported feature symbols are identical to 3.48.0's.

End-to-end, dlopening the shipped `PROJ_jll` after the SQLite JLL, with the system SQLite removed from the library path to emulate a clean image:

```
######## BEFORE: shipped SQLite_jll 3.53.2 ########
[1] dlopen SQLite_jll library: .../libsqlite3.so.3.53.2
    ok
[2] dlopen PROJ_jll library: .../libproj.so.25
    FAILED: libsqlite3.so.0: cannot open shared object file: No such file or directory

######## AFTER: rebuilt with --soname=legacy ########
[1] dlopen SQLite_jll library: .../fixed-libsqlite3.so
    ok
[2] dlopen PROJ_jll library: .../libproj.so.25
    ok
[3] sqlite objects actually mapped into the process:
    loaded sqlite object: .../fixed-libsqlite3.so
```

With system SQLite present on the same machine, the "before" case loads two different SQLite libraries into one process, the JLL's and `/lib/x86_64-linux-gnu/libsqlite3.so.0`. That is how this stayed hidden on developer laptops.

## Follow-ups, not in this PR

- `util_linux` and `SQLCipher` have artifacts pinned to `libsqlite3.so.3.51.2` and need a rebuild after this lands.
- The macOS build also leaks a `/workspace/destdir/lib` `LC_RPATH` into the shipped dylib (autosetup enables rpath by default; the auditor rewrites this on Linux but not macOS). `--disable-rpath` would fix it, left out to keep this change to the one issue.
- Worth considering whether 3.51.2 and 3.53.2 should be yanked in the registry, as 3.49.0 was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
