### PR TITLE
[CUDA] Runtime/Compiler: use the Driver's toolkit selection library

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -7,13 +7,18 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Compiler"
-version = v"0.5.0"
+version = v"0.5.1"
 
 const toolkit_versions = [CUDA.cuda_full_versions; CUDA.cuda_prerelease_versions]
 const compiler_versions = filter(v -> v >= v"11.4", toolkit_versions)
 
+# preferences are read from our own namespace first, falling back to CUDA_Runtime_jll's:
+# LocalPreferences.toml files predating the runtime/compiler split only pin the runtime,
+# and silently combining such a pinned runtime with an auto-selected (newer) compiler
+# would break at load time through major-versioned sonames (e.g. libnvJitLink).
 augment_platform_block = """
-    const CUDA_jll_uuid = Base.UUID("d1e2174e-dfdc-576e-b43e-73b79eb1aca8")
+    const CUDA_jll_uuids = [Base.UUID("d1e2174e-dfdc-576e-b43e-73b79eb1aca8"),
+                            Base.UUID("76a88914-d11a-5bdc-97e0-2f5a05c973a2")]
     $(read(joinpath(@__DIR__, "..", "CUDA_Runtime", "toolkit_selection.jl"), String))
     const cuda_toolkits = $(compiler_versions)
     const cuda_prerelease_toolkits = $(CUDA.cuda_prerelease_versions)
@@ -104,7 +109,8 @@ fi
 """
 
 dependencies = [
-    Dependency("CUDA_Driver_jll"; compat="13"),
+    # 13.3.1: first version providing the toolkit selection library our hook calls into
+    Dependency("CUDA_Driver_jll", v"13.3.1"; compat="13.3.1 - 13"),
 ]
 
 function get_platforms(version::VersionNumber)

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,14 +7,14 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.24.0"
+version = v"0.24.1"
 
 # we ship artifacts for both GA and EA/preview toolkits; the platform augmentation only
 # ever selects the latter when the user asks for it through the "version" preference.
 const toolkit_versions = [CUDA.cuda_full_versions; CUDA.cuda_prerelease_versions]
 
 augment_platform_block = """
-    const CUDA_jll_uuid = Base.UUID("76a88914-d11a-5bdc-97e0-2f5a05c973a2")
+    const CUDA_jll_uuids = [Base.UUID("76a88914-d11a-5bdc-97e0-2f5a05c973a2")]
     $(read(joinpath(@__DIR__, "toolkit_selection.jl"), String))
     const cuda_toolkits = $(toolkit_versions)
     const cuda_prerelease_toolkits = $(CUDA.cuda_prerelease_versions)
@@ -133,17 +133,36 @@ for version in reverse(toolkit_versions)
 
         if Base.thisminor(version) == v"10.2"
             push!(builds,
-                (; dependencies=[Dependency("CUDA_Driver_jll", v"13.3"; compat="13"),
+                (; dependencies=[Dependency("CUDA_Driver_jll", v"13.3.1"; compat="13.3.1 - 13"),
                                  BuildDependency(PackageSpec(name="CUDA_SDK_jll", version="10.2.89"))],
                    script=get_script(), platforms=[augmented_platform], products=get_products(platform),
-                   sources=[]
+                   sources=[], init_block=""
             ))
         else
+            # the runtime libraries may link against libraries from CUDA_Compiler_jll with
+            # major-versioned sonames (e.g. libnvJitLink), so detect the mismatched pairs
+            # that can result from setting the version preference on only one of the JLLs
+            # (e.g. from a LocalPreferences.toml predating the runtime/compiler split).
+            init_block = """
+                if isdefined(CUDA_Compiler_jll, :cuda_version)
+                    let runtime = v"$(version.major).$(version.minor)",
+                        compiler = Base.thisminor(CUDA_Compiler_jll.cuda_version)
+                        if compiler.major != runtime.major
+                            @error \"\"\"CUDA_Runtime_jll provides CUDA \$runtime, but CUDA_Compiler_jll provides CUDA \$compiler.
+                                       These versions need to have the same major version; call `CUDA.set_runtime_version!` to
+                                       reconfigure both, or remove stale entries from your LocalPreferences.toml.\"\"\"
+                        elseif compiler < runtime
+                            @warn \"\"\"CUDA_Runtime_jll provides CUDA \$runtime, which is newer than CUDA_Compiler_jll's CUDA \$compiler.
+                                      This is an unsupported combination; call `CUDA.set_runtime_version!` to reconfigure both.\"\"\"
+                        end
+                    end
+                end"""
             push!(builds,
-                (; dependencies=[Dependency("CUDA_Driver_jll", v"13.3"; compat="13"),
+                (; dependencies=[Dependency("CUDA_Driver_jll", v"13.3.1"; compat="13.3.1 - 13"),
                                  Dependency("CUDA_Compiler_jll"; compat="0.5")],
                    script, platforms=[augmented_platform], products=get_products(platform),
-                   sources=get_sources("cuda", components; version, platform=augmented_platform)
+                   sources=get_sources("cuda", components; version, platform=augmented_platform),
+                   init_block
             ))
         end
     end
@@ -160,7 +179,7 @@ for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, build.script,
                    build.platforms, build.products, build.dependencies;
-                   julia_compat="1.6", augment_platform_block,
+                   julia_compat="1.6", augment_platform_block, init_block=build.init_block,
                    lazy_artifacts=true, skip_audit=true, dont_dlopen=true)
 end
 

--- a/C/CUDA/CUDA_Runtime/toolkit_selection.jl
+++ b/C/CUDA/CUDA_Runtime/toolkit_selection.jl
@@ -1,7 +1,15 @@
 # CUDA toolkit selection logic, shared between the platform augmentation blocks of
-# CUDA_Runtime_jll and CUDA_Compiler_jll. The including build recipe must define
-# `CUDA_jll_uuid`, append `cuda_toolkits` and `cuda_prerelease_toolkits`, and append an
+# CUDA_Runtime_jll and CUDA_Compiler_jll. The including build recipe must prepend a
+# `CUDA_jll_uuids` list (preference namespaces, in decreasing order of priority),
+# append `cuda_toolkits` and `cuda_prerelease_toolkits`, and append an
 # `augment_platform!` implementation.
+#
+# The driver-dependent parts of the selection -- inspecting the driver and its devices,
+# and the capability database -- live in CUDA_Driver_jll's toplevel block; see
+# `select_cuda_toolkit` there. Only what must keep working when that package cannot be
+# loaded (which can happen during initial installation, cf. JuliaLang/Pkg.jl#3225) is
+# inlined here: preference handling, and the version-override and local-toolkit paths,
+# so that precompiling with a fixed version works without CUDA_Driver_jll or a driver.
 
 using Base.BinaryPlatforms
 
@@ -9,9 +17,27 @@ using Base: thismajor, thisminor
 
 using Libdl
 
-const preferences = Base.get_preferences(CUDA_jll_uuid)
-Base.record_compiletime_preference(CUDA_jll_uuid, "version")
-Base.record_compiletime_preference(CUDA_jll_uuid, "local")
+# read the preferences from the first UUID that has any CUDA selection preference set;
+# namespaces are not merged, to avoid mixing related preferences from different sources.
+# all namespaces are recorded regardless, so the precompilation cache is invalidated
+# when a higher-priority namespace gains a preference later.
+#
+# we can't use Preferences.jl here, for the same manifest-related reasons we can't
+# rely on CUDA_Driver_jll (see above).
+const preferences = let
+    selected = nothing
+    for uuid in CUDA_jll_uuids
+        Base.record_compiletime_preference(uuid, "version")
+        Base.record_compiletime_preference(uuid, "local")
+        prefs = Base.get_preferences(uuid)
+        if selected === nothing &&
+           any(key -> haskey(prefs, key), ["version", "local", "actual_version"])
+            selected = prefs
+        end
+    end
+    something(selected, Dict{String,Any}())
+end
+
 const local_preference = if haskey(preferences, "local")
     if isa(preferences["local"], Bool)
         preferences["local"]
@@ -67,17 +93,15 @@ end
 # - CUDA_Driver_jll may not be available
 # - the wrong version of CUDA_Driver_jll may be available
 #
-# because of that, we need to be very careful about using that dependency.
-# currently, we support all existing versions of CUDA_Driver_jll, but if we
-# ever need to introduce a breaking change, we'll need some way to identify
-# the version of CUDA_Driver_jll from its module (e.g. a global constant).
+# because of that, we need to be very careful about using that dependency: guard the
+# import, and treat any error calling into it (including UndefVarError from versions
+# predating the selection library) as "no selection possible".
 #
 # ref: https://github.com/JuliaLang/Pkg.jl/issues/3225
-# can't use Preferences for the same reason
 try
     using CUDA_Driver_jll
 catch err
-    # we'll handle this below
+    # handled in cuda_toolkit_tag below
 end
 
 # get the version of the local CUDA toolkit by querying the system libcudart
@@ -121,97 +145,6 @@ function get_runtime_version()
     cudaRuntimeGetVersion(runtime_handle)
 end
 
-# get the CUDA driver version and the compute capability of each visible device
-# by invoking CUDA_Driver_jll's `inspect_driver` helper, which runs the inspection
-# in a subprocess so we don't have to load the driver into our own process.
-function get_driver_info()
-    if !@isdefined(CUDA_Driver_jll)
-        # driver JLL not available because we're in the middle of installing packages
-        @debug "CUDA_Driver_jll not available; not selecting an artifact"
-        return nothing
-    end
-
-    # inspect the system driver (rather than CUDA_Driver_jll.libcuda, which may
-    # be the forwards-compatible driver bundled in its artifact and which has
-    # private deps the inspection subprocess wouldn't preload). only the system
-    # driver actually changes when the user upgrades their NVIDIA driver, and
-    # it's the one we want to depend on for cache invalidation.
-    libcuda_system = Sys.iswindows() ? "nvcuda" : "libcuda.so.1"
-
-    # platform augmentation runs in a Pkg subprocess where the in-memory manifest
-    # may be inconsistent (JuliaLang/Pkg.jl#3225), so the CUDA_Driver_jll we just
-    # loaded may not actually be the one we'd resolve against. swallow any error
-    # accessing/calling `inspect_driver` and bail out.
-    info = try
-        CUDA_Driver_jll.inspect_driver(libcuda_system; inspect_devices=true)
-    catch err
-        @debug "CUDA_Driver_jll.inspect_driver failed: $err"
-        return nothing
-    end
-    info === nothing && return nothing
-
-    # register the resolved driver path as an include dependency so our
-    # precompile cache is invalidated when the user upgrades their driver.
-    @debug "Adding include dependency on $(info.path)"
-    Base.include_dependency(info.path)
-
-    return (info.version, info.capabilities)
-end
-
-# CUDA toolkit support for each GPU compute capability. Maps a compute
-# capability to a `(lo, hi)` tuple of inclusive toolkit version bounds:
-# `lo` is the toolkit that introduced support for the architecture, `hi` is
-# the last toolkit that still supports it (toolkits drop architecture support
-# over time). `v"99"` is used as an open-ended upper bound for capabilities
-# still supported by current toolkits.
-#
-# Sources:
-# - https://en.wikipedia.org/wiki/CUDA#GPUs_supported
-# - `ptxas |& grep -A 10 '\--gpu-name'`
-const cuda_cap_db = Dict{VersionNumber, NTuple{2, VersionNumber}}(
-    v"1.0"   => (v"0",     v"6.5"),
-    v"1.1"   => (v"0",     v"6.5"),
-    v"1.2"   => (v"0",     v"6.5"),
-    v"1.3"   => (v"0",     v"6.5"),
-    v"2.0"   => (v"0",     v"8.0"),
-    v"2.1"   => (v"0",     v"8.0"),
-    v"3.0"   => (v"4.2",   v"10.2"),
-    v"3.2"   => (v"6.0",   v"10.2"),
-    v"3.5"   => (v"5.0",   v"11.8"),
-    v"3.7"   => (v"6.5",   v"11.8"),
-    v"5.0"   => (v"6.0",   v"12.9"),
-    v"5.2"   => (v"7.0",   v"12.9"),
-    v"5.3"   => (v"7.5",   v"12.9"),
-    v"6.0"   => (v"8.0",   v"12.9"),
-    v"6.1"   => (v"8.0",   v"12.9"),
-    v"6.2"   => (v"8.0",   v"12.9"),
-    v"7.0"   => (v"9.0",   v"12.9"),
-    v"7.2"   => (v"9.2",   v"12.9"),
-    v"7.5"   => (v"10.0",  v"99"),
-    v"8.0"   => (v"11.0",  v"99"),
-    v"8.6"   => (v"11.1",  v"99"),
-    v"8.7"   => (v"11.4",  v"99"),
-    v"8.9"   => (v"11.8",  v"99"),
-    v"9.0"   => (v"11.8",  v"99"),
-    v"10.0"  => (v"12.8",  v"99"),
-    v"10.3"  => (v"12.8",  v"99"),
-    v"11.0"  => (v"12.8",  v"99"),
-    v"12.0"  => (v"12.8",  v"99"),
-    v"12.1"  => (v"12.9",  v"99"),
-)
-
-"""
-    supported_capabilities(toolkit::VersionNumber) -> Set{VersionNumber}
-
-Return the set of GPU compute capabilities supported by the given CUDA toolkit.
-Comparisons are at minor-version granularity, so e.g. `v"12.9.1"` and `v"12.9.0"`
-are treated identically.
-"""
-function supported_capabilities(toolkit::VersionNumber)
-    minor = thisminor(toolkit)
-    Set(cap for (cap, (lo, hi)) in cuda_cap_db if lo <= minor <= hi)
-end
-
 # returns the value for the "cuda" tag we should use in the platform ("$MAJOR.$MINOR")
 # or nothing if no compatible CUDA toolkit was found.
 function cuda_toolkit_tag()
@@ -243,85 +176,33 @@ function cuda_toolkit_tag()
         end
     end
 
-    # if not, we need to be able to inspect the driver to determine its version
-    # and the compute capability of each visible device. we only require this
-    # when there's no override, to support precompiling with a fixed version
-    # without having the driver available.
-    if !@isdefined(cuda_version_override)
-        driver_info = get_driver_info()
-        if driver_info === nothing
-            @debug "Failed to query the CUDA driver and its devices"
+    # with a version override, we don't need to (and shouldn't) inspect the driver:
+    # this supports precompiling with a fixed version without a driver available.
+    if @isdefined(cuda_version_override)
+        compatible_toolkits =
+            filter(toolkit -> thisminor(toolkit) == thisminor(cuda_version_override),
+                   cuda_toolkits)
+        if isempty(compatible_toolkits)
+            @error "Requested CUDA version $(cuda_version_override) does not match any supported CUDA toolkit ($(join(cuda_toolkits, ", ", " or ")))"
             return nothing
         end
-        cuda_driver_version, device_capabilities = driver_info
-        @debug "CUDA driver version: $cuda_driver_version"
-        if isempty(device_capabilities)
-            @debug "No CUDA devices visible"
-        else
-            @debug "CUDA device compute capabilities: $(join(device_capabilities, ", "))"
-        end
+        cuda_toolkit = thisminor(last(compatible_toolkits))
+        @debug "Selected CUDA toolkit: $cuda_toolkit"
+        return "$(cuda_toolkit.major).$(cuda_toolkit.minor)"
     end
 
-    # "[...] applications built against any of the older CUDA Toolkits always continued
-    #  to function on newer drivers due to binary backward compatibility"
-    compatible_toolkits = filter(cuda_toolkits) do toolkit
-        if @isdefined(cuda_version_override)
-            return thisminor(toolkit) == thisminor(cuda_version_override)
-        end
-
-        # never auto-select an EA/preview toolkit; those have to be requested explicitly
-        # through the "version" preference (handled by the early return above).
-        toolkit in cuda_prerelease_toolkits && return false
-
-        # enhanced compatibility
-        #
-        # "From CUDA 11 onwards, applications compiled with a CUDA Toolkit release
-        #  from within a CUDA major release family can run, with limited feature-set,
-        #  on systems having at least the minimum required driver version"
-        if cuda_driver_version >= v"11"
-            thismajor(toolkit) <= thismajor(cuda_driver_version)
-        else
-            thisminor(toolkit) <= thisminor(cuda_driver_version)
-        end
-    end
-    if isempty(compatible_toolkits)
-        if @isdefined(cuda_version_override)
-            @error "Requested CUDA version $(cuda_version_override) does not match any supported CUDA toolkit ($(join(cuda_toolkits, ", ", " or ")))"
-        else
-            @error "CUDA driver $(cuda_driver_version) is not compatible with any supported CUDA toolkit ($(join(cuda_toolkits, ", ", " or ")))"
-        end
+    # otherwise, delegate to CUDA_Driver_jll, which inspects the driver to determine its
+    # version and the compute capability of each visible device.
+    cuda_toolkit = try
+        CUDA_Driver_jll.select_cuda_toolkit(cuda_toolkits, cuda_prerelease_toolkits)
+    catch err
+        # CUDA_Driver_jll not loadable, a version predating the selection library,
+        # or driver inspection went wrong: don't select an artifact.
+        @debug "Could not select a CUDA toolkit through CUDA_Driver_jll" exception=err
         return nothing
     end
-
-    # narrow the candidate toolkits to those that support the user's hardware,
-    # giving priority to the newest devices: walk device capabilities from
-    # newest to oldest, intersecting the candidate set with toolkits supporting
-    # each. if an older device cannot be supported alongside newer ones, drop
-    # it rather than discard the whole selection, as the user almost certainly
-    # cares more about their newest hardware working than their oldest.
-    if !@isdefined(cuda_version_override) && !isempty(device_capabilities)
-        supports_capability(toolkit, cap) = let minor = thisminor(toolkit)
-            # capabilities absent from `cuda_cap_db` are presumed unsupported:
-            # they're either future architectures that need a newer toolkit
-            # than anything we know about, or fictional. either way no toolkit
-            # in our list is known to handle them.
-            haskey(cuda_cap_db, cap) || return false
-            lo, hi = cuda_cap_db[cap]
-            lo <= minor <= hi
-        end
-        for cap in sort(unique(device_capabilities); rev=true)
-            subset = filter(t -> supports_capability(t, cap), compatible_toolkits)
-            if isempty(subset)
-                @debug "No remaining toolkit supports device with compute capability $cap; dropping it from the selection"
-            else
-                compatible_toolkits = subset
-            end
-        end
-    end
-
-    cuda_toolkit = Base.thisminor(last(compatible_toolkits))
-    @debug "Selected CUDA toolkit: $cuda_toolkit"
-    "$(cuda_toolkit.major).$(cuda_toolkit.minor)"
+    cuda_toolkit === nothing && return nothing
+    return "$(cuda_toolkit.major).$(cuda_toolkit.minor)"
 end
 
 function cuda_comparison_strategy(a::String, b::String, a_requested::Bool, b_requested::Bool)


### PR DESCRIPTION
Slim down the platform augmentation hooks to call into the selection library now provided by CUDA_Driver_jll 13.3.1 (through a single try/catch envelope, so an unavailable or stale CUDA_Driver_jll -- which can happen mid-resolve, cf. JuliaLang/Pkg.jl#3225 -- degrades to the "none"/default fallback instead of erroring). Preference parsing and the version-override/local-toolkit paths stay inlined in the shared shim so that precompiling with a pinned version keeps working without CUDA_Driver_jll or a driver, e.g. during initial installation.

Also fold in two consistency fixes for the runtime/compiler split:

- CUDA_Compiler_jll now reads its preferences from its own namespace first, falling back to CUDA_Runtime_jll's: LocalPreferences.toml files predating the split only pin the runtime, and silently combining a pinned runtime with an auto-selected newer compiler breaks at load time through major-versioned sonames (e.g. libnvJitLink).
- CUDA_Runtime_jll's wrappers now cross-check the selected CUDA_Compiler_jll version at load time: error on a major-version mismatch, warn when the compiler is older than the runtime.

Both JLLs put a lower bound of 13.3.1 on CUDA_Driver_jll so the steady state always pairs the shims with a Driver that has the library.