### PR TITLE
[ROCm_Libs] repackage therock artifacts as a jll

### DIFF
--- a/R/ROCm_Libs/build_tarballs.jl
+++ b/R/ROCm_Libs/build_tarballs.jl
@@ -16,7 +16,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 # encoding the major.minor version of the distribution they were taken from.
 
 name = "ROCm_Libs"
-version = v"0.1.0"
+version = v"7.14.0"
 
 const rocm_versions = [v"7.14.0"]
 

--- a/R/ROCm_Libs/build_tarballs.jl
+++ b/R/ROCm_Libs/build_tarballs.jl
@@ -1,0 +1,172 @@
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms
+
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+
+# ROCm_Libs repackages the GPU vendor libraries (rocBLAS, rocSPARSE, rocSOLVER, rocRAND,
+# rocFFT and MIOpen, together with their private in-bundle dependencies hipBLASLt,
+# rocRoller and rocm_kpack) from AMD's TheRock distribution tarballs. The ROCm runtime
+# itself (HIP, hiprtc, comgr, roctracer, HSA) is *not* included: the vendor libraries
+# resolve those from whatever ROCm distribution the loading package (e.g. AMDGPU.jl)
+# has set up.
+#
+# TheRock publishes one bundle per GPU architecture family, so artifacts are additionally
+# tagged with (and selected by) the "rocm_arch" platform tag, as well as a "rocm" tag
+# encoding the major.minor version of the distribution they were taken from.
+
+name = "ROCm_Libs"
+version = v"0.1.0"
+
+const rocm_versions = [v"7.14.0"]
+
+# sha256 hashes per (rocm version, rocm_arch tag, os) of the bundles published by
+# TheRock; not every bundle is available for every OS
+const bundle_hashes = Dict(
+    v"7.14.0" => Dict(
+        ("gfx908", "linux")         => "1686270efa2e523889168ec6a4343f2e53f173d6026fdb9c6b308d99f99d99fa",
+        ("gfx90a", "linux")         => "b1caebb79f542951114ef6478ea587a691d005cc13c2efadfec577bd82b6fc78",
+        ("gfx94x_dcgpu", "linux")   => "32e16dca7f8440a08a8d636a6a7db0034c61518f32ea915347b98d9f55199b0c",
+        ("gfx950_dcgpu", "linux")   => "12afeccd06e6caf0699d86d688f16083aafa35474d0ec1d8063477fb5c119d49",
+        ("gfx101x_dgpu", "linux")   => "fdb302ee45e9e3a6dcb6bab295fdf2e6a4c0f8b2c7a4937698b18178715822d9",
+        ("gfx101x_dgpu", "windows") => "58b33f43d67dae68087cff37494c13267a7613eda6202e1ee904097643e5958d",
+        ("gfx103x_all", "linux")    => "ce9a5be2b43ee1bdd85de3fa9ea3c3d5dcb6875445acf7281c3763a4ee783f19",
+        ("gfx103x_all", "windows")  => "93f5244854cd1bec2ea29bb977e448a2b79c7ee77609d253ab075ea24404462c",
+        ("gfx110x_all", "linux")    => "e78a4445c52d879fbd0765f24e7fa9df1e262a8baf681b118a13e75340120127",
+        ("gfx110x_all", "windows")  => "3ce5d7fcd56f7b169ba9f95916553b7cd6bb0370d98b1c0ce572eb34874630d6",
+        ("gfx1150", "linux")        => "d73f8e29a21d031051466dad88d5dba273582819521f5930d9f100a7e7dd0905",
+        ("gfx1150", "windows")      => "5f990ab9a3ca55b39fe771c92877fc950ba7a1702004d27395b2b7bf8a7ec56d",
+        ("gfx1151", "linux")        => "2567d5e34e470db104a62a02c36aa770cb0430175e48c1c46df0eefc05e1d77c",
+        ("gfx1151", "windows")      => "6d962c8868388e3d81a504c3b58caada49d40fd7a67b52da73319159f1479fe7",
+        ("gfx1152", "linux")        => "390c87f4bcacf026578fbfb36267a23912524f023f77f7f9322ecaaf61d88b60",
+        ("gfx1152", "windows")      => "2966c84fcb14865e5700603d68267cf037b18cf65b862e642553f3a882ab4bee",
+        ("gfx1153", "linux")        => "56dc233ace740364dca06ca12c22749a85e5f5f54ae3812ca24426d3c5eb787d",
+        ("gfx1153", "windows")      => "465070a1004cbd6c6762f5e43ba96a5ce8c1a83a7c0fa6c4aad2d8563d82fc28",
+        ("gfx120x_all", "linux")    => "2a304d07b925c7e46e51fa8f719b195a9bfe2df2cc920d706f10a29d2d2471af",
+        ("gfx120x_all", "windows")  => "87091e92ff9fcc0a590193b9d42bd48cf8e9ce9df258efeb52de7d3c3e44d395",
+    ),
+)
+
+augment_platform_block = """
+    const ROCm_Libs_jll_uuid = Base.UUID("07d9647d-253f-508d-88af-3defef7976bb")
+    const rocm_toolkits = $(repr(rocm_versions))
+    $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))"""
+
+script = raw"""
+cd ${WORKSPACE}/srcdir
+
+# Windows bundles wrap everything in a top-level directory; Linux ones extract flat
+if compgen -G "therock-dist-*" > /dev/null; then
+    cd therock-dist-*
+fi
+
+# licenses (renamed, so components don't clobber each other)
+mkdir -p ${WORKSPACE}/licenses
+for doc in rocblas hipblaslt rocroller rocsparse rocsolver rocrand rocfft miopen-hip; do
+    if [[ -f share/doc/${doc}/LICENSE.md ]]; then
+        cp share/doc/${doc}/LICENSE.md ${WORKSPACE}/licenses/LICENSE.${doc}.md
+    fi
+done
+install_license ${WORKSPACE}/licenses/*
+
+if [[ ${target} == *-linux-gnu ]]; then
+    mkdir -p ${libdir}
+
+    # the vendor libraries themselves (preserving SONAME symlinks)
+    mv lib/librocblas.so* lib/librocsparse.so* lib/librocsolver.so* \
+       lib/librocrand.so* lib/librocfft.so* lib/libMIOpen.so* ${libdir}
+
+    # private in-bundle dependencies: rocblas links hipblaslt, which links rocroller;
+    # rocm_kpack is used to load the kernel packs below
+    mv lib/libhipblaslt.so* ${libdir}
+    mv lib/librocroller.so* ${libdir} || true
+    mv lib/librocm_kpack.so* ${libdir} || true
+
+    # MIOpen's composable-kernel plugin(s), dlopened at runtime
+    mv lib/libMIOpenCKGroupedConv_*.so ${libdir} || true
+
+    # the small rocm_sysdeps libraries the above link against, resolved through their
+    # `$ORIGIN/rocm_sysdeps/lib` RUNPATH entry. everything else (HIP, hiprtc, comgr,
+    # roctracer) is deliberately left to the ROCm runtime used at load time.
+    mkdir -p ${libdir}/rocm_sysdeps/lib
+    for dep in zstd bz2 sqlite3 z; do
+        mv lib/rocm_sysdeps/lib/librocm_sysdeps_${dep}.so* ${libdir}/rocm_sysdeps/lib || true
+    done
+
+    # device code and auxiliary data, located relative to the libraries
+    mkdir -p ${libdir}/rocblas ${libdir}/hipblaslt
+    mv lib/rocblas/library ${libdir}/rocblas/
+    mv lib/hipblaslt/library ${libdir}/hipblaslt/ || true
+    mv lib/rocfft ${libdir}/  # also contains the rocfft_rtc_helper executable
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    mkdir -p ${bindir}
+
+    mv bin/rocblas.dll bin/rocsparse.dll bin/rocsolver.dll \
+       bin/rocrand.dll bin/rocfft.dll bin/MIOpen.dll ${bindir}
+
+    mv bin/libhipblaslt.dll ${bindir}
+    mv bin/rocm_kpack.dll ${bindir} || true
+    mv bin/MIOpenCKGroupedConv_*.dll ${bindir} || true
+    mv bin/rocfft_rtc_helper.exe ${bindir} || true
+
+    mkdir -p ${bindir}/rocblas ${bindir}/hipblaslt
+    mv bin/rocblas/library ${bindir}/rocblas/
+    mv bin/hipblaslt/library ${bindir}/hipblaslt/ || true
+
+    find ${bindir} -maxdepth 1 \( -name '*.dll' -o -name '*.exe' \) -exec chmod +x {} +
+fi
+
+# kernel packs for the shipped libraries, loaded through rocm_kpack
+mkdir -p ${prefix}/.kpack
+mv .kpack/blas_lib_*.kpack .kpack/fft_lib_*.kpack .kpack/rand_lib_*.kpack ${prefix}/.kpack/ || true
+"""
+
+products = [
+    LibraryProduct(["librocblas", "rocblas"], :librocblas),
+    LibraryProduct(["librocsparse", "rocsparse"], :librocsparse),
+    LibraryProduct(["librocsolver", "rocsolver"], :librocsolver),
+    LibraryProduct(["librocrand", "rocrand"], :librocrand),
+    LibraryProduct(["librocfft", "rocfft"], :librocfft),
+    LibraryProduct(["libMIOpen", "MIOpen"], :libMIOpen),
+    LibraryProduct("libhipblaslt", :libhipblaslt),
+]
+
+dependencies = []
+
+# determine exactly which tarballs we should build
+builds = []
+for rocm_version in rocm_versions
+    for ((arch_tag, os), sha256) in sort!(collect(bundle_hashes[rocm_version]))
+        # TheRock spells the architecture family with a capital X and dashes in URLs
+        url_arch = replace(arch_tag, "x_" => "X-", "_" => "-")
+        source = ArchiveSource("https://repo.amd.com/rocm/tarball-multi-arch/therock-dist-$(os)-$(url_arch)-$(rocm_version).tar.gz",
+                               sha256)
+
+        platform = if os == "linux"
+            Platform("x86_64", "linux"; libc="glibc")
+        else
+            Platform("x86_64", "windows")
+        end
+        platform["rocm_arch"] = arch_tag
+        platform["rocm"] = "$(rocm_version.major).$(rocm_version.minor)"
+
+        should_build_platform(triplet(platform)) || continue
+
+        push!(builds, (; platforms=[platform], sources=[source]))
+    end
+end
+
+# don't allow `build_tarballs` to override platform selection based on ARGS.
+# we handle that ourselves by calling `should_build_platform`
+non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
+
+# `--register` should only be passed to the latest `build_tarballs` invocation
+non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
+
+for (i, build) in enumerate(builds)
+    build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
+                   name, version, build.sources, script,
+                   build.platforms, products, dependencies;
+                   julia_compat="1.6", augment_platform_block,
+                   lazy_artifacts=true, skip_audit=true, dont_dlopen=true)
+end

--- a/R/ROCm_Libs/build_tarballs.jl
+++ b/R/ROCm_Libs/build_tarballs.jl
@@ -4,16 +4,13 @@ using Base.BinaryPlatforms
 const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 
-# ROCm_Libs repackages the GPU vendor libraries (rocBLAS, rocSPARSE, rocSOLVER, rocRAND,
+# Repackage the ROCm vendor libraries (rocBLAS, rocSPARSE, rocSOLVER, rocRAND,
 # rocFFT and MIOpen, together with their private in-bundle dependencies hipBLASLt,
-# rocRoller and rocm_kpack) from AMD's TheRock distribution tarballs. The ROCm runtime
-# itself (HIP, hiprtc, comgr, roctracer, HSA) is *not* included: the vendor libraries
-# resolve those from whatever ROCm distribution the loading package (e.g. AMDGPU.jl)
-# has set up.
-#
-# TheRock publishes one bundle per GPU architecture family, so artifacts are additionally
-# tagged with (and selected by) the "rocm_arch" platform tag, as well as a "rocm" tag
-# encoding the major.minor version of the distribution they were taken from.
+# rocRoller and rocm_kpack) from AMD's TheRock tarballs. All the compiler/llvm stuff
+# we build ourselves, so we can ship much smaller tarballs by excluding these
+
+# This does platform augmentation with the ROCm arch as well as the ROCm version,
+# so we don't have to ship huge tarballs with code for every architecture possible
 
 name = "ROCm_Libs"
 version = v"7.14.0"
@@ -55,12 +52,12 @@ augment_platform_block = """
 script = raw"""
 cd ${WORKSPACE}/srcdir
 
-# Windows bundles wrap everything in a top-level directory; Linux ones extract flat
+# Windows bundles wrap everything in a top-level directory, Linux doesn't
 if compgen -G "therock-dist-*" > /dev/null; then
     cd therock-dist-*
 fi
 
-# licenses (renamed, so components don't clobber each other)
+# rename licenses
 mkdir -p ${WORKSPACE}/licenses
 for doc in rocblas hipblaslt rocroller rocsparse rocsolver rocrand rocfft miopen-hip; do
     if [[ -f share/doc/${doc}/LICENSE.md ]]; then
@@ -86,8 +83,7 @@ if [[ ${target} == *-linux-gnu ]]; then
     mv lib/libMIOpenCKGroupedConv_*.so ${libdir} || true
 
     # the small rocm_sysdeps libraries the above link against, resolved through their
-    # `$ORIGIN/rocm_sysdeps/lib` RUNPATH entry. everything else (HIP, hiprtc, comgr,
-    # roctracer) is deliberately left to the ROCm runtime used at load time.
+    # `$ORIGIN/rocm_sysdeps/lib` RUNPATH entry
     mkdir -p ${libdir}/rocm_sysdeps/lib
     for dep in zstd bz2 sqlite3 z; do
         mv lib/rocm_sysdeps/lib/librocm_sysdeps_${dep}.so* ${libdir}/rocm_sysdeps/lib || true

--- a/R/ROCm_Libs/platform_augmentation.jl
+++ b/R/ROCm_Libs/platform_augmentation.jl
@@ -1,0 +1,254 @@
+# Platform augmentation for ROCm_Libs_jll.
+#
+# Artifacts are selected based on two platform tags:
+#  - "rocm_arch": the GPU architecture family of the bundle (e.g. "gfx110x_all"),
+#    matched against the devices detected on the host;
+#  - "rocm": the major.minor version of the ROCm distribution the libraries were
+#    taken from, selectable through the "version" preference.
+#
+# NOTE: the device detection logic is derived from AMDGPU.jl's
+#       `.pkg/platform_augmentation.jl` (with a simplified Windows path); the goal
+#       is for this JLL to become the canonical implementation, with AMDGPU.jl
+#       delegating to `ROCm_Libs_jll.augment_platform!` the way CUDA.jl delegates
+#       to CUDA_Runtime_jll.
+
+using Base.BinaryPlatforms
+using Base: thismajor, thisminor
+using Libdl
+
+const preferences = Base.get_preferences(ROCm_Libs_jll_uuid)
+foreach(pref -> Base.record_compiletime_preference(ROCm_Libs_jll_uuid, pref),
+        ("version", "local", "arch"))
+
+function load_preference(name, expected, parse)
+    haskey(preferences, name) || return missing
+    parsed = parse(preferences[name])
+    parsed === nothing || return parsed
+    @error "ROCm $name preference is not valid; expected $expected, but got '$(preferences[name])'"
+    return missing
+end
+const local_preference = load_preference("local", "a boolean",
+    v -> v isa Bool ? v : v isa String ? tryparse(Bool, v) : nothing)
+const version_preference = load_preference("version", "a version number",
+    v -> v isa String ? tryparse(VersionNumber, v) : nothing)
+const arch_preference = load_preference("arch", "a string (e.g. 'gfx1100')",
+    v -> v isa String ? v : nothing)
+
+
+## device detection
+
+function rocm_arch_string(target::Integer)
+    patch = string(target % 100, base = 16)
+    return "gfx$(div(target, 10000))$(div(target, 100) % 100)$(patch)"
+end
+
+# marketing-name substrings => gfx architecture family, for hosts where we cannot
+# query the driver for the real architecture (i.e. Windows)
+const device_name_archs = [
+    # STX Halo iGPUs: Radeon 8050S / 8060S Graphics
+    ["8050s", "8060s", "device 1586"] => "gfx1151",
+    # STX Point iGPUs: Radeon 880M / 890M Graphics
+    ["880m", "890m"] => "gfx1150",
+    # RDNA4: Radeon AI PRO R9700, RX 9070 XT/GRE, RX 9070, RX 9060 XT
+    ["r9700", "9060", "9070"] => "gfx120X",
+    # RDNA3: Radeon PRO V710/W7900/W7800/W7700, RX 7900 XTX/XT/GRE, RX 7800 XT, RX 7700 XT
+    ["7700", "7800", "7900", "v710"] => "gfx110X",
+    # RDNA2: RX 6800 XT/6800, RX 6700 XT/6700, RX 6600 XT/6600, RX 6500 XT/6500
+    ["6800", "6700", "6600", "6500"] => "gfx103X",
+]
+
+function rocm_arch_from_device_name(device_name::AbstractString)
+    name = lowercase(device_name)
+    occursin("radeon", name) || occursin("amd", name) || return ""
+    for (substrings, arch) in device_name_archs
+        any(s -> occursin(s, name), substrings) && return arch
+    end
+    return ""
+end
+
+function rocm_arch_linux()
+    topology_root = "/sys/class/kfd/kfd/topology/nodes/"
+    isdir(topology_root) || return String[]
+
+    arch = String[]
+    for dir in readdir(topology_root; join = true)
+        props = joinpath(dir, "properties")
+        isfile(props) || continue
+
+        for s in eachline(props)
+            m = match(r"^gfx_target_version (\d+)$", s)
+            m === nothing && continue
+
+            target = parse(Int, m[1])
+            target == 0 && continue
+
+            push!(arch, rocm_arch_string(target))
+        end
+    end
+    return arch
+end
+
+function windows_video_device_names()
+    # DISPLAY_DEVICEW layout: DWORD cb; WCHAR DeviceName[32]; WCHAR DeviceString[128];
+    #                         DWORD StateFlags; WCHAR DeviceID[128]; WCHAR DeviceKey[128]
+    sz = 4 + 2*32 + 2*128 + 4 + 2*128 + 2*128
+    dd = Vector{UInt8}(undef, sz)
+    names = String[]
+    dev = 0
+    while true
+        fill!(dd, 0)
+        dd[1:4] .= reinterpret(UInt8, UInt32[sz])  # cb = sizeof(DISPLAY_DEVICEW)
+        ok = ccall((:EnumDisplayDevicesW, "user32"), stdcall, Cint,
+                   (Ptr{Cvoid}, Culong, Ptr{UInt8}, Culong), C_NULL, dev, dd, 0)
+        ok == 0 && break
+        state_flags = reinterpret(UInt32, dd[325:328])[1]
+        if state_flags & 0x00000008 == 0  # skip DISPLAY_DEVICE_MIRRORING_DRIVER pseudo-devices
+            device_string = reinterpret(UInt16, dd[69:324])
+            len = something(findfirst(iszero, device_string), length(device_string) + 1) - 1
+            push!(names, transcode(String, device_string[1:len]))
+        end
+        dev += 1
+    end
+    return names
+end
+
+function rocm_arch()
+    arch_preference !== missing && return split(arch_preference, ',')
+
+    arch = if Sys.islinux()
+        rocm_arch_linux()
+    elseif Sys.iswindows()
+        map(rocm_arch_from_device_name, windows_video_device_names())
+    else
+        String[]
+    end
+    filter!(!isempty, arch)
+    unique!(arch)
+    sort!(arch; rev = true)
+    return arch
+end
+
+
+## "rocm_arch" tag comparison
+
+function rocm_arch_comparison_strategy(a::String, b::String, a_requested::Bool, b_requested::Bool)
+    a == "none" && return false
+    b == "none" && return false
+
+    a_arches = split(a, ',')
+    b_arches = split(b, ',')
+    for a_arch in a_arches
+        for b_arch in b_arches
+            rocm_arch_matches(a_arch, b_arch) && return true
+            rocm_arch_matches(b_arch, a_arch) && return true
+        end
+    end
+    return false
+end
+
+function rocm_arch_core(arch::AbstractString)
+    return match(r"gfx(.*)", first(split(arch, r"[_-]", limit = 2)))[1]
+end
+
+function rocm_arch_matches(pattern::AbstractString, arch::AbstractString)
+    pattern = rocm_arch_core(pattern)
+    arch = rocm_arch_core(arch)
+
+    length(pattern) == length(arch) || return false
+    for (pattern_char, arch_char) in zip(pattern, arch)
+        if lowercase(pattern_char) == 'x'
+            isxdigit(arch_char) || lowercase(arch_char) == 'x' || return false
+        elseif pattern_char != arch_char
+            return false
+        end
+    end
+    return true
+end
+
+
+## "rocm" version tag
+
+# get the version of a local ROCm installation by querying the HIP runtime, if present
+function get_hip_runtime_version()
+    libhip = Libdl.find_library(Sys.iswindows() ? ["amdhip64_7", "amdhip64_6", "amdhip64"] :
+                                                  ["libamdhip64.so.7", "libamdhip64.so.6", "libamdhip64.so"])
+    if libhip == ""
+        @debug "No system HIP runtime library found"
+        return nothing
+    end
+    @debug "Found HIP runtime library at '$libhip'"
+
+    handle = Libdl.dlopen(libhip; throw_error=false)
+    handle === nothing && return nothing
+    hipRuntimeGetVersion = Libdl.dlsym(handle, "hipRuntimeGetVersion"; throw_error=false)
+    hipRuntimeGetVersion === nothing && return nothing
+
+    version_ref = Ref{Cint}()
+    status = ccall(hipRuntimeGetVersion, Cint, (Ptr{Cint},), version_ref)
+    if status != 0
+        @debug "Call to 'hipRuntimeGetVersion' failed with status $status"
+        return nothing
+    end
+    v = version_ref[]
+    major = v ÷ 10_000_000
+    minor = (v ÷ 100_000) % 100
+    patch = v % 100_000
+    return VersionNumber(major, minor, patch)
+end
+
+# returns the value for the "rocm" tag we should use in the platform ("$MAJOR.$MINOR"),
+# or nothing if no compatible ROCm distribution is available.
+function rocm_version_tag()
+    override = version_preference
+
+    if local_preference === true
+        # the artifact selection below never matches when using a local ROCm
+        # (see `rocm_comparison_strategy`), so the tag value doesn't matter much;
+        # still try to reflect the local version for informational purposes.
+        if override === missing
+            version = get_hip_runtime_version()
+            version === nothing && return nothing
+            override = version
+        end
+        return "$(override.major).$(override.minor)"
+    end
+
+    compatible_toolkits = override === missing ? rocm_toolkits :
+        filter(toolkit -> thisminor(toolkit) == thisminor(override), rocm_toolkits)
+    if isempty(compatible_toolkits)
+        @error "Requested ROCm version $override does not match any supported ROCm distribution ($(join(rocm_toolkits, ", ", " or ")))"
+        return nothing
+    end
+
+    rocm_toolkit = thisminor(last(compatible_toolkits))
+    @debug "Selected ROCm distribution: $rocm_toolkit"
+    return "$(rocm_toolkit.major).$(rocm_toolkit.minor)"
+end
+
+function rocm_comparison_strategy(a::String, b::String, a_requested::Bool, b_requested::Bool)
+    # bail out from downloading artifacts if the user requested a local ROCm installation
+    local_preference === true && return false
+
+    # the tag is known to exactly match one of the available distributions
+    return a == b
+end
+
+
+## entry point
+
+function augment_platform!(platform::Platform)
+    if !haskey(platform, "rocm_arch")
+        arch = rocm_arch()
+        platform["rocm_arch"] = isempty(arch) ? "none" : join(arch, ',')
+    end
+    BinaryPlatforms.set_compare_strategy!(platform, "rocm_arch", rocm_arch_comparison_strategy)
+
+    if !haskey(platform, "rocm")
+        # XXX: use "none" when we couldn't select a distribution.
+        #      we can't just leave off the platform tag or Pkg would select *any* artifact.
+        platform["rocm"] = something(rocm_version_tag(), "none")
+    end
+    BinaryPlatforms.set_compare_strategy!(platform, "rocm", rocm_comparison_strategy)
+
+    return platform
+end

--- a/R/ROCm_Libs/platform_augmentation.jl
+++ b/R/ROCm_Libs/platform_augmentation.jl
@@ -5,12 +5,6 @@
 #    matched against the devices detected on the host;
 #  - "rocm": the major.minor version of the ROCm distribution the libraries were
 #    taken from, selectable through the "version" preference.
-#
-# NOTE: the device detection logic is derived from AMDGPU.jl's
-#       `.pkg/platform_augmentation.jl` (with a simplified Windows path); the goal
-#       is for this JLL to become the canonical implementation, with AMDGPU.jl
-#       delegating to `ROCm_Libs_jll.augment_platform!` the way CUDA.jl delegates
-#       to CUDA_Runtime_jll.
 
 using Base.BinaryPlatforms
 using Base: thismajor, thisminor
@@ -88,6 +82,8 @@ function rocm_arch_linux()
     return arch
 end
 
+# XXX: Windows is vibe-coded and only tested at a surface level on wine
+# Testers wanted!
 function windows_video_device_names()
     # DISPLAY_DEVICEW layout: DWORD cb; WCHAR DeviceName[32]; WCHAR DeviceString[128];
     #                         DWORD StateFlags; WCHAR DeviceID[128]; WCHAR DeviceKey[128]

--- a/R/ROCm_Libs/platform_augmentation.jl
+++ b/R/ROCm_Libs/platform_augmentation.jl
@@ -199,8 +199,8 @@ function rocm_version_tag()
 
     if local_preference === true
         # the artifact selection below never matches when using a local ROCm
-        # (see `rocm_comparison_strategy`), so the tag value doesn't matter much;
-        # still try to reflect the local version for informational purposes.
+        # (see `rocm_comparison_strategy`), so the tag value doesn't matter much,
+        # but try to still reflect the local version
         if override === missing
             version = get_hip_runtime_version()
             version === nothing && return nothing


### PR DESCRIPTION
We don't want to ship the tarballs provided by upstream wholesale since it contains lots of LLVM stuff we don't need. Platform augmentation is quite ugly since we need to detect the ROCm arch, it's unfortunate this has to live in Yggdrasil and can't be part of AMDGPU.jl

ref https://github.com/JuliaGPU/AMDGPU.jl/pull/919#issuecomment-5278973837