### PR TITLE
[CI] Reduce size limit for artifacts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled
           version: "1.12.6"
-          artifacts_size_limit: "214748364800" # 200GB
+          artifacts_size_limit: "187904819200" # 175GiB
       - JuliaCI/merge-commit: ~
       - JuliaCI/forerunner#v1:
           watch:


### PR DESCRIPTION
We don't do deduplication anymore, so we need to be more conservative with this threshold.