### PR TITLE
[CCCL_C] Mark CUDA artifacts lazy

### DIFF
--- a/C/CCCL_C/build_tarballs.jl
+++ b/C/CCCL_C/build_tarballs.jl
@@ -255,5 +255,7 @@ for (i, build) in enumerate(builds)
         julia_compat="1.10",
         # selection is keyed on the compiler, not the runtime (see above)
         augment_platform_block=CUDA.compiler_augment,
+        lazy_artifacts=true,
+        dont_dlopen=true,
         preferred_gcc_version=v"13")
 end


### PR DESCRIPTION
Pkg cannot load CUDA_Compiler_jll while running initial artifact selection, so no CUDA-tagged CCCL_C artifact is downloaded. Mark the artifacts lazy so installation is deferred until augmentation can select a toolkit at import time, and disable eager dlopen as required for CUDA consumers.