### PR TITLE
[libpicosat] Fix pointer-rebase truncation on Windows x64 (965.0.2)

### DIFF
--- a/L/libpicosat/build_tarballs.jl
+++ b/L/libpicosat/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "libpicosat"
-version = v"965.0.1"
+version = v"965.0.2"
 
 # Collection of sources required to complete build
 sources = [
@@ -15,6 +15,9 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/picosat*
 cp ../{Makefile,config.h} .
+for f in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 ${f}
+done
 if [[ ${target} == *musl* ]]; then
     sed -i 's!sys/unistd.h!unistd.h!g' picosat.c
 fi

--- a/L/libpicosat/bundled/patches/0001-use-ptrdiff_t-for-pointer-rebase-deltas.patch
+++ b/L/libpicosat/bundled/patches/0001-use-ptrdiff_t-for-pointer-rebase-deltas.patch
@@ -1,0 +1,123 @@
+Use ptrdiff_t, not long, for pointer-rebase deltas (fixes crashes on Windows x64)
+
+enlarge() reallocates the solver's literal and rank arrays, then rebases every
+stored Lit*/Rnk* by the byte distance the arrays moved. It held that distance in
+a `long`.
+
+On LLP64 -- which is Windows x64 -- `long` is 32 bits while pointers are 64, so
+whenever realloc moves an array more than 2GB the delta is truncated and every
+rebased pointer is left pointing at garbage. `sizeof(Lit) == 1`, so the delta is
+a raw byte distance and 2GB is reachable on ordinary problems. The next solve
+then dereferences wild pointers inside bcp()/prop2() and segfaults.
+
+ptrdiff_t is the natural type of the expression (`ps->lits - old_lits` is
+pointer difference), so this is a no-op on LP64 (Linux, macOS) and on 32-bit
+targets, where long is already wide enough.
+
+Observed as an EXCEPTION_ACCESS_VIOLATION in bcp on Windows x64 with a
+truncating delta of 3187172336 logged three lines before the crash (it becomes
+-1107794960 as a 32-bit long, a rebase error of exactly 2^32 bytes).
+
+Upstream picosat has had no release since 965 (2014) and has no public VCS or
+issue tracker, so there is nowhere to send this.
+
+--- a/picosat.c
++++ b/picosat.c
+@@ -28,6 +28,7 @@
+ #include <ctype.h>
+ #include <stdarg.h>
+ #include <stdint.h>
++#include <stddef.h>
+ 
+ #include "picosat.h"
+ 
+@@ -2802,7 +2803,7 @@
+ }
+ 
+ static void
+-fix_trail_lits (PS * ps, long delta)
++fix_trail_lits (PS * ps, ptrdiff_t delta)
+ {
+   Lit **p;
+   for (p = ps->trail; p < ps->thead; p++)
+@@ -2811,7 +2812,7 @@
+ 
+ #ifdef NO_BINARY_CLAUSES
+ static void
+-fix_impl_lits (PS * ps, long delta)
++fix_impl_lits (PS * ps, ptrdiff_t delta)
+ {
+   Ltk * s;
+   Lit ** p;
+@@ -2823,7 +2824,7 @@
+ #endif
+ 
+ static void
+-fix_clause_lits (PS * ps, long delta)
++fix_clause_lits (PS * ps, ptrdiff_t delta)
+ {
+   Cls **p, *clause;
+   Lit **q, *lit, **eol;
+@@ -2847,7 +2848,7 @@
+ }
+ 
+ static void
+-fix_added_lits (PS * ps, long delta)
++fix_added_lits (PS * ps, ptrdiff_t delta)
+ {
+   Lit **p;
+   for (p = ps->added; p < ps->ahead; p++)
+@@ -2855,7 +2856,7 @@
+ }
+ 
+ static void
+-fix_assumed_lits (PS * ps, long delta)
++fix_assumed_lits (PS * ps, ptrdiff_t delta)
+ {
+   Lit **p;
+   for (p = ps->als; p < ps->alshead; p++)
+@@ -2863,7 +2864,7 @@
+ }
+ 
+ static void
+-fix_cls_lits (PS * ps, long delta)
++fix_cls_lits (PS * ps, ptrdiff_t delta)
+ {
+   Lit **p;
+   for (p = ps->CLS; p < ps->clshead; p++)
+@@ -2871,7 +2872,7 @@
+ }
+ 
+ static void
+-fix_heap_rnks (PS * ps, long delta)
++fix_heap_rnks (PS * ps, ptrdiff_t delta)
+ {
+   Rnk **p;
+ 
+@@ -2882,7 +2883,7 @@
+ #ifndef NADC
+ 
+ static void
+-fix_ado (long delta, Lit ** ado)
++fix_ado (ptrdiff_t delta, Lit ** ado)
+ {
+   Lit ** p;
+   for (p = ado; *p; p++)
+@@ -2890,7 +2891,7 @@
+ }
+ 
+ static void
+-fix_ados (PS * ps, long delta)
++fix_ados (PS * ps, ptrdiff_t delta)
+ {
+   Lit *** p;
+ 
+@@ -2903,7 +2904,7 @@
+ static void
+ enlarge (PS * ps, unsigned new_size_vars)
+ {
+-  long rnks_delta, lits_delta;
++  ptrdiff_t rnks_delta, lits_delta;
+   Lit *old_lits = ps->lits;
+   Rnk *old_rnks = ps->rnks;
+ 


### PR DESCRIPTION
## The bug

`enlarge()` in `picosat.c` reallocates the solver's literal and rank arrays and
then rebases every stored `Lit*`/`Rnk*` by the byte distance the arrays moved.
It holds that distance in a `long`:

```c
long rnks_delta, lits_delta;                /* picosat.c:2906 */
...
if ((lits_delta = ps->lits - old_lits))     /* truncates on LLP64 */
  {
    fix_trail_lits (ps, lits_delta);
    fix_clause_lits (ps, lits_delta);
    ...
```

On LLP64 — which is Windows x64 — `long` is 32 bits while pointers are 64. And
`sizeof (Lit) == 1`, so this delta is a *raw byte distance*, not an element
count. Whenever `realloc` moves an array more than 2GB, the delta is truncated,
every rebased pointer is left wild, and the next solve segfaults in `bcp()`.

Two things follow from the mechanism, both of which we observed:

- **It is platform-specific in exactly the way you'd predict.** LLP64 is the
  only ABI where `long` is narrower than a pointer, so Linux/macOS x64 (LP64)
  and 32-bit Windows are all fine. We see failures *only* on Windows x64.
- **It is intermittent**, because whether `realloc` moves a block more than 2GB
  is up to the allocator.

## The fix

`long` → `ptrdiff_t` at the two delta declarations and the nine `fix_*`
signatures. `ptrdiff_t` is the natural type of the expression — `ps->lits -
old_lits` *is* a pointer difference — so this is a strict correctness fix and a
no-op on LP64 and on 32-bit targets, where `long` is already wide enough.

## Evidence

The bug does not reproduce on Linux for two *independent* reasons, and removing
both makes it deterministic:

1. LP64's `long` is wide enough. Simulated LLP64 by making only the delta
   variables `int32_t`, leaving pointers 64-bit. This is faithful: on LLP64 both
   the delta variable and the `fix_*` parameters are 32-bit, so truncating once
   at the assignment and sign-extending into the parameters is the same
   arithmetic.
2. glibc's `realloc` keeps blocks close together, so the >2GB move never
   happens. Forced it by routing picosat's three allocation primitives
   (`new`/`delete`/`resize`, all of which carry explicit sizes) through an
   `mmap` allocator placing each block 4GB past the previous.

With both removed — same allocator, same workload, same compiler, delta type the
only variable:

| delta type | outcome |
|---|---|
| `int32_t` (LLP64 simulation) | **segfault, 6/6 runs** |
| `ptrdiff_t` (this patch) | **survives, 6/6 runs**, solve returns SAT |

```
int32_t   delta: PICOTRUNC max_var=0     real=38654705664    as32=0
                 PICOTRUNC max_var=11164 real=24133421236224 as32=0
                 Segmentation fault (signal 11)

ptrdiff_t delta: same two truncations detected
                 solve result = 10 (SAT), SURVIVED
```

The `max_var=0` truncation is harmless — it happens during `picosat_adjust` on
an empty solver, where the fix-up loops iterate over nothing. The fatal one is
on a populated solver.

Full reproducer (instrumented diff + C driver + instructions):
https://gist.github.com/StefanKarpinski/039eea8ae42cee78b13217688bbc1dfb

This also matches what we see in the wild. The failure was found from a
`Resolver.jl` CI job that segfaults only on `Julia nightly - windows-latest -
x64`, with an instrumented build on the actual runner logging a truncating delta
of `3187172336` (`-1107794960` as a 32-bit `long`, a rebase error of exactly
2^32 bytes) three log lines before `EXCEPTION_ACCESS_VIOLATION ... in bcp`.

`Resolver.jl`'s full test suite passes against a locally-built patched
`libpicosat` loaded via an artifact override.

## Upstream

There is nowhere to send this. picosat's last release is 965 (2014), its home
(http://fmv.jku.at/picosat/) is a tarball page with no VCS or issue tracker, and
there is no picosat repository under the author's GitHub. `conda/pycosat`, the
most widely distributed vendored copy, carries the identical unpatched line.

## License

picosat is MIT, which explicitly grants `modify` and `distribute`; the recipe
already ships the notice via `install_license LICENSE`.