### PR TITLE
PoCL: Bump for divergent-barrier fix.

### DIFF
--- a/P/pocl/pocl/build_tarballs.jl
+++ b/P/pocl/pocl/build_tarballs.jl
@@ -17,7 +17,7 @@ llvm_version = v"20.1.2"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/juliagpu/pocl",
-              "8e177839e8d6d8850d7e919fbe24044bb5b87952"),
+              "763e259ff4bb3003280b991bbe99d4a9b712e051"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # the build script below); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).

--- a/P/pocl/pocl_next/build_tarballs.jl
+++ b/P/pocl/pocl_next/build_tarballs.jl
@@ -23,7 +23,7 @@ macos_sdk_version = "11.0"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/JuliaGPU/pocl",
-              "63c20286812d392031bbc6ee3c8add9ea2d32744"),
+              "5b85d6b8daaafad59beae8e2ab26c95f19ae4a59"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this is the latest LLVM-22.1 maintenance revision.
     GitSource("https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",

--- a/P/pocl/pocl_standalone/build_tarballs.jl
+++ b/P/pocl/pocl_standalone/build_tarballs.jl
@@ -27,7 +27,7 @@ macos_sdk_version = "11.0"
 sources = [
     DirectorySource("./bundled"),
     GitSource("https://github.com/JuliaGPU/pocl",
-              "63c20286812d392031bbc6ee3c8add9ea2d32744"),
+              "5b85d6b8daaafad59beae8e2ab26c95f19ae4a59"),
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this is the latest LLVM-22.1 maintenance revision.
     GitSource("https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",


### PR DESCRIPTION
Backports pocl/pocl#2281 (CanonicalizeBarriers: split reconverging barrier successors) to the 7.1 and 7.2 release branches.