### PR TITLE
[Pango] Rebuild against HarfBuzz_jll 100.x (fix GLFW + HarfBuzz.jl conflict)

### DIFF
--- a/P/Pango/build_tarballs.jl
+++ b/P/Pango/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "Pango"
-version = v"1.58.0"
+version = v"1.58.0+1"
 
 # Collection of sources required to build Pango: https://download.gnome.org/sources/pango/
 sources = [
@@ -78,7 +78,7 @@ dependencies = [
     Dependency("FreeType2_jll"; compat="2.13.4"),
     Dependency("FriBidi_jll"; compat="1.0.17"),
     Dependency("Glib_jll"; compat="2.84.0"),
-    Dependency("HarfBuzz_jll"; compat="8.5.1"),
+    Dependency("HarfBuzz_jll"; compat="100.14002"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
## Summary

Bump `HarfBuzz_jll` compat from `8.5.1` to `100.14002` and the `Pango_jll` version from `1.58.0` to `1.58.0+1` (rebuild).

## Problem

`HarfBuzz.jl` now depends on `HarfBuzz_jll` 100.x (HarfBuzz 14.2/14.3, using Yggdrasil's `VersionNumber(100, 1000*major+minor, patch)` scheme). `Pango_jll` 1.58.0 was built against `HarfBuzz_jll` 8.5.1, so its compat excluded 100.x.

Because `GLFW_jll` -> `libdecor_jll` -> `Pango_jll`, any environment that wants both **GLFW** and the new **HarfBuzz.jl** is unsatisfiable:

```
Pango_jll: restricted by HarfBuzz_jll to versions satisfying 8.5.1
HarfBuzz_jll: restricted by HarfBuzz (HarfBuzz.jl) to 100.14002 - 100.14003
libdecor_jll: restricted by GLFW to Pango >= 1.52.2
=> no Pango version satisfies both libdecor (>=1.52.2) and HarfBuzz_jll 100.x
```

This blocks CImGui (which depends on GLFW) from coexisting with HarfBuzz.jl in the same environment.

## Fix

Pango 1.58.0 is source-compatible with HarfBuzz 14.x. Rebuilding against `HarfBuzz_jll` 100.14003 and widening the compat to `100.14002` lets the two coexist, unblocking CImGui (GLFW) + HarfBuzz.jl environments.

The `1.58.0+1` version bump is the rebuild marker. `libdecor_jll`'s Pango compat `1.52.2` (>=1.52.2) includes `1.58.0+1`, so the full chain resolves.

## Changes

- `P/Pango/build_tarballs.jl`:
  - `version = v"1.58.0"` -> `v"1.58.0+1"`
  - `Dependency("HarfBuzz_jll"; compat="8.5.1")` -> `compat="100.14002"`

No source patches needed (Pango 1.58.0 builds against HarfBuzz 14.x).

AI-assisted.