### PR TITLE
[LLVM] New builds of LLVM 20, 21 and 22

### DIFF
--- a/L/LLVM/LLVM_full@20/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@20/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 1
+# Build trigger: 2

--- a/L/LLVM/LLVM_full@21/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@21/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 0
+# Build trigger: 1

--- a/L/LLVM/LLVM_full@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@22/build_tarballs.jl
@@ -13,4 +13,4 @@ include("../common.jl")
 # floor low and stays on the well-tested toolchain.
 build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"18", julia_compat="1.6")
-# Build trigger: 0
+# Build trigger: 1

--- a/L/LLVM/LLVM_full_assert@20/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@20/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 1
+# Build trigger: 2

--- a/L/LLVM/LLVM_full_assert@21/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@21/build_tarballs.jl
@@ -4,4 +4,4 @@ include("../common.jl")
 
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"16", julia_compat="1.6")
-# Build trigger: 0
+# Build trigger: 1

--- a/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@22/build_tarballs.jl
@@ -5,4 +5,4 @@ include("../common.jl")
 # Built with GCC 10; see LLVM_full@22 for rationale.
 build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
                preferred_gcc_version=v"10", preferred_llvm_version=v"18", julia_compat="1.6")
-# Build trigger: 0
+# Build trigger: 1

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -27,9 +27,9 @@ const llvm_tags = Dict(
     v"17.0.6" => "0007e48608221f440dce2ea0d3e4f561fc10d3c6", # julia-17.0.6-5
     v"18.1.7" => "32719222d3ea71ed0b19c2cb75fa6f76713fda20", # julia-18.1.7-4
     v"19.1.7" => "ccda9ec62497d9de88ca7090a749e52a89f62132", # julia-19.1.7-2
-    v"20.1.8" => "f391048978428f629edbcd9f372705eb91a44c55", # julia-20.1.8-1
-    v"21.1.8" => "7cd4442d4a6c949de43c1e2c0e20334ee59aa154", # julia-21.1.8-0
-    v"22.1.8" => "bb28dd22e7ad95ca869437f5e773603b6561fc9b", # julia-22.1.8-0
+    v"20.1.8" => "24bdfdd813f4117f0464fd0dac5b4bce43ed1388", # julia-20.1.8-2
+    v"21.1.8" => "151034ef71856c7406f58c150dba7d419dbd063d", # julia-21.1.8-1
+    v"22.1.8" => "4df0bb28e9e4d59f293433a1e325a46479da5174", # julia-22.1.8-1
 )
 
 const buildscript = raw"""


### PR DESCRIPTION
Rebuilds LLVM 20, 21 and 22 to pick up two backported upstream patches:

- **[SROA] Reject illegal vector memset promotion** — [llvm/llvm-project#216772](https://github.com/llvm/llvm-project/pull/216772) (not merged upstream yet).
  SROA can vector-promote an alloca partition that mixes a `memset` with vector accesses of non-integral pointers, rewriting the memset byte pattern into an integer splat and an `inttoptr`. That is illegal for Julia's GC-tracked address space 10; with assertions enabled LLVM 20/21 crash in `convertValue` (`Value not convertable to type`), and LLVM 22 silently introduces the `inttoptr`.
  Needed by JuliaLang/julia#62724 (coverage-instrumented system/package images), see [this comment](https://github.com/JuliaLang/julia/pull/62724#issuecomment-5318316038).

- **[X86] Invalid fp16 comparison fix** — [llvm/llvm-project@6d4bb20](https://github.com/llvm/llvm-project/commit/6d4bb2088818784c89eea8ecc799852ea48e086b) (llvm/llvm-project#160304, fixing llvm/llvm-project#159723).
  The masked `VCMPPH{Z,Z128,Z256}rrik` opcodes were missing from `commuteInstructionImpl`/`findCommutedOpIndices`, so operands got commuted without swapping the predicate immediate — producing inverted `Float16` comparison results on AVX512-FP16 hardware. Observed on Julia's Windows CI in JuliaLang/julia#62781, see [this comment](https://github.com/JuliaLang/julia/pull/62781#issuecomment-5319682000). Its baseline test (llvm/llvm-project#159786) is backported alongside it.

Strictly, the SROA fix is only needed for Julia master (LLVM 21, soon 22) and the fp16 fix only for Julia 1.13 (LLVM 20), but backporting both to every branch keeps them consistent. Doing all three versions in one PR avoids merge conflicts on the shared `common.jl`.

Per branch:

| LLVM | tag | commits added |
| --- | --- | --- |
| 20.1.8 | [`julia-20.1.8-2`](https://github.com/JuliaLang/llvm-project/compare/julia-20.1.8-1...julia-20.1.8-2) | SROA + fp16 (+ baseline test) |
| 21.1.8 | [`julia-21.1.8-1`](https://github.com/JuliaLang/llvm-project/compare/julia-21.1.8-0...julia-21.1.8-1) | SROA + fp16 (+ baseline test) |
| 22.1.8 | [`julia-22.1.8-1`](https://github.com/JuliaLang/llvm-project/compare/julia-22.1.8-0...julia-22.1.8-1) | SROA (fp16 fix is already in 22) |

Note that the LLVM 21 bump additionally picks up two commits that were already on `julia-release/21.x` but had not been built yet: `DILocation: Support 32-bit column number` and `[VectorCombine] Fix transitive Uses in foldShuffleToIdentity (#188989)`.

Verified locally on all three branches with a Release+assertions build: `llvm/test/Transforms/SROA` and `llvm/test/CodeGen/X86` show no new failures, and both new tests fail without the respective patch and pass with it.
