### PR TITLE
MAGEMin v2.0.0

### DIFF
--- a/M/MAGEMin/build_tarballs.jl
+++ b/M/MAGEMin/build_tarballs.jl
@@ -4,11 +4,11 @@ using BinaryBuilder, Pkg
 using Base.BinaryPlatforms
 
 name = "MAGEMin"
-version = v"1.9.11"
+version = v"2.0.0"
 
 # Collection of sources required to complete build
 sources = [GitSource("https://github.com/ComputationalThermodynamics/MAGEMin", 
-                    "2665963dea0f21ec02c13bde9ff96a95b35ca79b")                 ]
+                    "6fab7661b1930fd96960a5566cb4df1cb400b422")                 ]
 
 # Bash recipe for building across all platforms
 script = raw"""


### PR DESCRIPTION
- Added THERMOCALC “all” database that list all available solution models across ig, mb, mp, um and igad datasets
- Added DEW (Deep Earth Water) model to work with THERMOCALC new “all” dataset
- Further extended chemical space reduction for THERMOCALC databases ig, mb, mp, igad, mtl and um. The minimum chemical space is now SiO2 + Al2O3 + MgO + FeO
