### PR TITLE
[Epsteinlib] Update to v0.6.2

### DIFF
--- a/E/Epsteinlib/build_tarballs.jl
+++ b/E/Epsteinlib/build_tarballs.jl
@@ -7,7 +7,7 @@ version = v"0.6.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/epsteinlib/epsteinlib.git", "5a991d27b7f4fff85bdfb1539fded71bdd9977ce")
+    GitSource("https://github.com/epsteinlib/epsteinlib.git", "a383fe88a4ed6a0fcfc74afd602e58796cfa8d73")
 ]
 
 # Bash recipe for building across all platforms

--- a/E/Epsteinlib/build_tarballs.jl
+++ b/E/Epsteinlib/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "Epsteinlib"
-version = v"0.6.1"
+version = v"0.6.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/epsteinlib/epsteinlib.git", "2760ec25ad0e3c7559e8f066dfe41814f3df55bc")
+    GitSource("https://github.com/epsteinlib/epsteinlib.git", "5a991d27b7f4fff85bdfb1539fded71bdd9977ce")
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Matches upcoming EpsteinLib [release](https://github.com/epsteinlib/epsteinlib/issues/106) `v0.6.2`, where some silently wrong return values of core functions are fixed.