### PR TITLE
[PipeWireAO] Add v1.7.0

### DIFF
--- a/P/PipeWireAO/build_tarballs.jl
+++ b/P/PipeWireAO/build_tarballs.jl
@@ -10,7 +10,7 @@ version = v"1.7.0"
 sources = [
     GitSource(
         "https://github.com/DarrylGamroth/PipeWireAO.git",
-        "6ba6627b3489b9e5c6bceb19c485cd0b27b2651e",
+        "d48418553fd372fc69cb7042a8370c099750a0ee",
     ),
     DirectorySource("./bundled"),
 ]

--- a/P/PipeWireAO/build_tarballs.jl
+++ b/P/PipeWireAO/build_tarballs.jl
@@ -10,7 +10,7 @@ version = v"1.7.0"
 sources = [
     GitSource(
         "https://github.com/DarrylGamroth/PipeWireAO.git",
-        "75e98a1596aeb3027117da096c6b0efac70134c4",
+        "b19cb64b9ee874d501737a476c5c0f494a52660a",
     ),
     DirectorySource("./bundled"),
 ]

--- a/P/PipeWireAO/build_tarballs.jl
+++ b/P/PipeWireAO/build_tarballs.jl
@@ -1,0 +1,110 @@
+using BinaryBuilder, Pkg
+using BinaryBuilderBase
+
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "microarchitectures.jl"))
+
+name = "PipeWireAO"
+version = v"1.7.0"
+
+sources = [
+    GitSource(
+        "https://github.com/DarrylGamroth/PipeWireAO.git",
+        "d35a02c73ab8386d0df09f70a91714fbf531a188",
+    ),
+    DirectorySource("./bundled"),
+]
+
+# Package the AO client/core infrastructure without external desktop audio
+# bridges or a session manager. Built-in SPA processing remains available to
+# the core modules. Runtime module loading happens during setup, before an AO
+# worker enters its allocation-free execution path.
+script = raw"""
+cd ${WORKSPACE}/srcdir/PipeWireAO
+atomic_patch -p1 ${WORKSPACE}/srcdir/patches/binarybuilder-compat.patch
+
+meson setup builddir \
+    --buildtype=release \
+    --cross-file=${MESON_TARGET_TOOLCHAIN} \
+    --prefix=${prefix} \
+    -Dauto_features=disabled \
+    -Dexamples=disabled \
+    -Dtests=disabled \
+    -Dinstalled_tests=disabled \
+    -Dpipewire-jack=disabled \
+    -Dpipewire-v4l2=disabled \
+    -Dpipewire-alsa=disabled \
+    -Dalsa=disabled \
+    -Dbluez5=disabled \
+    -Djack=disabled \
+    -Dv4l2=disabled \
+    -Dlibcamera=disabled \
+    -Daudiomixer=disabled \
+    -Daudioconvert=enabled \
+    -Dcontrol=disabled \
+    -Daudiotestsrc=disabled \
+    -Dvideoconvert=disabled \
+    -Dvideotestsrc=disabled \
+    -Ddbus=disabled \
+    -Dflatpak=disabled \
+    -Dsession-managers=[] \
+    -Dlegacy-rtkit=false \
+    -Drlimits-install=false
+
+meson compile -C builddir -j${nproc}
+meson install -C builddir
+install_license LICENSE
+"""
+
+# PipeWireAO is Linux-native. Add AVX2 beside the portable x86-64 baseline;
+# other supported Linux architectures retain their generic builds.
+platforms = filter(p -> Sys.islinux(p) && libc(p) == "glibc", supported_platforms())
+platforms = expand_microarchitectures(
+    platforms,
+    ["x86_64", "avx2"];
+    filter=p -> arch(p) == "x86_64",
+)
+
+augment_platform_block = """
+    $(MicroArchitectures.augment)
+    function augment_platform!(platform::Platform)
+        @static if Sys.ARCH === :x86_64
+            augment_microarchitecture!(platform)
+        else
+            platform
+        end
+    end
+    """
+
+products = [
+    LibraryProduct("libpipewire-ao-0.3", :libpipewire_ao),
+    LibraryProduct(
+        "libspa-support",
+        :libspa_support,
+        "lib/spa-ao-0.2/support";
+        dont_dlopen=true,
+    ),
+]
+
+dependencies = []
+
+init_block = raw"""
+ENV["PIPEWIREAO_SPA_PLUGIN_DIR"] = get(ENV, "PIPEWIREAO_SPA_PLUGIN_DIR", joinpath(artifact_dir, "lib", "spa-ao-0.2"))
+ENV["PIPEWIREAO_MODULE_DIR"] = get(ENV, "PIPEWIREAO_MODULE_DIR", joinpath(artifact_dir, "lib", "pipewire-ao-0.3"))
+ENV["PIPEWIREAO_CONFIG_DIR"] = get(ENV, "PIPEWIREAO_CONFIG_DIR", joinpath(artifact_dir, "share", "pipewire-ao"))
+"""
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    init_block,
+    augment_platform_block,
+    julia_compat="1.10",
+    preferred_gcc_version=v"11",
+)

--- a/P/PipeWireAO/build_tarballs.jl
+++ b/P/PipeWireAO/build_tarballs.jl
@@ -10,7 +10,7 @@ version = v"1.7.0"
 sources = [
     GitSource(
         "https://github.com/DarrylGamroth/PipeWireAO.git",
-        "f74e304c824f72ecad049e919868de0412cd97f9",
+        "6ba6627b3489b9e5c6bceb19c485cd0b27b2651e",
     ),
     DirectorySource("./bundled"),
 ]

--- a/P/PipeWireAO/build_tarballs.jl
+++ b/P/PipeWireAO/build_tarballs.jl
@@ -10,7 +10,7 @@ version = v"1.7.0"
 sources = [
     GitSource(
         "https://github.com/DarrylGamroth/PipeWireAO.git",
-        "b19cb64b9ee874d501737a476c5c0f494a52660a",
+        "f74e304c824f72ecad049e919868de0412cd97f9",
     ),
     DirectorySource("./bundled"),
 ]

--- a/P/PipeWireAO/build_tarballs.jl
+++ b/P/PipeWireAO/build_tarballs.jl
@@ -10,7 +10,7 @@ version = v"1.7.0"
 sources = [
     GitSource(
         "https://github.com/DarrylGamroth/PipeWireAO.git",
-        "d48418553fd372fc69cb7042a8370c099750a0ee",
+        "4e2ad0198e09f8e741bfd5383e9716527333d3ab",
     ),
     DirectorySource("./bundled"),
 ]

--- a/P/PipeWireAO/build_tarballs.jl
+++ b/P/PipeWireAO/build_tarballs.jl
@@ -10,7 +10,7 @@ version = v"1.7.0"
 sources = [
     GitSource(
         "https://github.com/DarrylGamroth/PipeWireAO.git",
-        "3eed4fe5f45d19f71413736b00f2eb02af93f0dd",
+        "75e98a1596aeb3027117da096c6b0efac70134c4",
     ),
     DirectorySource("./bundled"),
 ]
@@ -78,6 +78,7 @@ augment_platform_block = """
 
 products = [
     LibraryProduct("libpipewire-ao-0.3", :libpipewire_ao),
+    LibraryProduct("libspa-ao", :libspa_ao, "lib/spa-ao-0.2"),
     LibraryProduct(
         "libspa-support",
         :libspa_support,

--- a/P/PipeWireAO/build_tarballs.jl
+++ b/P/PipeWireAO/build_tarballs.jl
@@ -56,12 +56,15 @@ meson install -C builddir
 install_license LICENSE
 """
 
-# PipeWireAO is Linux-native. Add AVX2 beside the portable x86-64 baseline;
-# other supported Linux architectures retain their generic builds.
-platforms = filter(p -> Sys.islinux(p) && libc(p) == "glibc", supported_platforms())
+# PipeWireAO is Linux-native. Publish only the AO deployment architectures:
+# an aarch64 baseline plus baseline, AVX2, and AVX-512 x86-64 artifacts.
+platforms = filter(
+    p -> Sys.islinux(p) && libc(p) == "glibc" && arch(p) in ("aarch64", "x86_64"),
+    supported_platforms(),
+)
 platforms = expand_microarchitectures(
     platforms,
-    ["x86_64", "avx2"];
+    ["x86_64", "avx2", "avx512"];
     filter=p -> arch(p) == "x86_64",
 )
 

--- a/P/PipeWireAO/build_tarballs.jl
+++ b/P/PipeWireAO/build_tarballs.jl
@@ -10,7 +10,7 @@ version = v"1.7.0"
 sources = [
     GitSource(
         "https://github.com/DarrylGamroth/PipeWireAO.git",
-        "d35a02c73ab8386d0df09f70a91714fbf531a188",
+        "3eed4fe5f45d19f71413736b00f2eb02af93f0dd",
     ),
     DirectorySource("./bundled"),
 ]

--- a/P/PipeWireAO/bundled/patches/binarybuilder-compat.patch
+++ b/P/PipeWireAO/bundled/patches/binarybuilder-compat.patch
@@ -1,0 +1,62 @@
+diff --git a/spa/tests/meson.build b/spa/tests/meson.build
+index 01e7eea70..4065ba33c 100644
+--- a/spa/tests/meson.build
++++ b/spa/tests/meson.build
+@@ -4,7 +4,7 @@
+ # Do it for C++ if possible (picks up C++-specific errors), otherwise for C.
+ find = find_program('find', required: false)
+ summary({'find (for header testing)': find.found()}, bool_yn: true, section: 'Optional programs')
+-if find.found()
++if get_option('tests').allowed() and find.found()
+   spa_headers = run_command(find,
+                             meson.project_source_root() / 'spa' / 'include',
+                             '-name', '*.h',
+diff --git a/spa/plugins/audioconvert/meson.build b/spa/plugins/audioconvert/meson.build
+index f1db583a9..93df242c3 100644
+--- a/spa/plugins/audioconvert/meson.build
++++ b/spa/plugins/audioconvert/meson.build
+@@ -7,11 +7,7 @@ simd_cargs = []
+ simd_dependencies = []
+ 
+ opt_flags = []
+-if host_machine.cpu_family() != 'alpha'
+-  opt_flags += '-Ofast'
+-else
+-  opt_flags += '-O3'
+-endif
++opt_flags += '-O3'
+ 
+ audioconvert_c = static_library('audioconvert_c',
+   [ 'channelmix-ops-c.c',
+diff --git a/spa/plugins/support/logger.c b/spa/plugins/support/logger.c
+--- a/spa/plugins/support/logger.c
++++ b/spa/plugins/support/logger.c
+@@ -11,7 +11,6 @@
+ #include <errno.h>
+ #include <stdio.h>
+ #include <time.h>
+-#include <threads.h>
+ #include <fnmatch.h>
+ 
+ #include <spa/support/log.h>
+@@ -97,7 +96,7 @@ impl_log_logtv(void *object,
+ 	spa_strbuf_append(&msg, "%s[%s]", prefix, levels[level]);
+ 
+ #ifdef HAVE_GETTID
+-	static thread_local pid_t tid;
++	static _Thread_local pid_t tid;
+ 	if (SPA_UNLIKELY(tid == 0))
+ 		tid = gettid();
+ 
+diff --git a/spa/plugins/filter-graph/meson.build b/spa/plugins/filter-graph/meson.build
+--- a/spa/plugins/filter-graph/meson.build
++++ b/spa/plugins/filter-graph/meson.build
+@@ -72,7 +72,7 @@ spa_filter_graph_plugin_builtin = shared_library('spa-filter-graph-plugin-builti
+   include_directories : [configinc],
+   install : true,
+   install_dir : spa_plugindir / 'filter-graph',
+-  dependencies : [ filter_graph_dependencies ],
++  dependencies : [ filter_graph_dependencies, pthread_lib ],
+   objects : audioconvert_c.extract_objects('biquad.c')
+ )
+ 


### PR DESCRIPTION
## Summary

Register the collision-free PipeWireAO client/core libraries as `PipeWireAO_jll` at version 1.7.0.

The recipe:
- builds the namespaced `libpipewire-ao-0.3`, `libspa-ao`, and SPA support plugin;
- disables desktop audio/video bridges and session managers while retaining the core AO infrastructure;
- publishes only aarch64 baseline and x86-64 baseline, AVX2, and AVX-512 Linux glibc artifacts;
- installs PipeWireAO-specific runtime environment defaults; and
- pins PipeWireAO commit `b19cb64b9ee874d501737a476c5c0f494a52660a`, including the first-class ndarray, progressive, acquisition-metadata, huge-page-hint, and callable helper ABIs.

## Local verification

- Clean `x86_64-linux-gnu` BinaryBuilder build completed.
- Declared library products were present and loadable.
- The artifact exported the callable SPA progressive and acquisition helpers.
- The full PipeWireAO.jl test suite passed against the locally generated artifact, including C/Julia acquisition layout parity and zero warmed capture-path allocations.

The additional aarch64, AVX2, and AVX-512 variants are qualified by this PR platform builds.

The earlier fork branch also contained an unrelated `P/PipeWire` commit. This PR uses a fresh current-upstream branch and contains only `P/PipeWireAO`.