### PR TITLE
[SuiteSparse] Update to 7.14.0 and update GraphBLAS (its bundled)

### DIFF
--- a/S/SuiteSparse/SSGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparse/SSGraphBLAS/build_tarballs.jl
@@ -26,7 +26,9 @@ CMAKE_OPTIONS+=(
         --debug-trycompile
     )
 if [[ "$target" == *-mingw* ]]; then
-    CMAKE_OPTIONS+="-DGBNCPUFEAT=1"
+    CMAKE_OPTIONS+=(
+        "-DGBNCPUFEAT=1"
+    )
 fi
 """ * build_script(; use_omp=true)
 

--- a/S/SuiteSparse/SSGraphBLAS/build_tarballs.jl
+++ b/S/SuiteSparse/SSGraphBLAS/build_tarballs.jl
@@ -1,13 +1,14 @@
 include("../common.jl")
 
 name = "SSGraphBLAS"
-version = v"10.3.1"
+version = v"10.5.0"
 
 function gb_to_ss_version(version::VersionNumber)
     # Version map started when GraphBLAS decoupled from SS dependency. Everything before here
     # has a dependency on SS in the registry and can't be rebuilt easily.
     ss_version = Dict(
         v"10.3.1" => v"7.12.2",
+        v"10.5.0" => v"7.14.0",
     )
     return ss_version[version]
 end
@@ -21,7 +22,6 @@ script = raw"""
 export GRAPHBLAS_CACHE_PATH=/workspace/srcdir
 PROJECTS_TO_BUILD="graphblas"
 CMAKE_OPTIONS+=(
-        -DSUITESPARSE_USE_SYSTEM_SUITESPARSE_CONFIG=ON
         -DGRAPHBLAS_CROSS_TOOLCHAIN_FLAGS_NATIVE="-DCMAKE_TOOLCHAIN_FILE=${CMAKE_HOST_TOOLCHAIN}"
         --debug-trycompile
     )
@@ -39,9 +39,7 @@ dependencies = append!(dependencies, [
     Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae"); platforms=filter(!Sys.isbsd, platforms)),
     Dependency(PackageSpec(name="LLVMOpenMP_jll", uuid="1d63c593-3942-5779-bab2-d838dc0a180e"); platforms=filter(Sys.isbsd, platforms)),
 
-    # SSGraphBLAS doesn't actually depend on SuiteSparse, it is just shipped inside of it and needs the basic infrastructure to be around
-    # in the build system, but not when running
-    BuildDependency("SuiteSparse_jll"),
+    # SSGraphBlas is actually independent from SuiteSparse, so there is no need to have any dependencies on it.
 ])
 
 # Build the tarballs, and possibly a `build.jl` as well.

--- a/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
@@ -2,7 +2,7 @@
 include("../common.jl")
 
 name = "SuiteSparse"
-version = v"7.12.1"
+version = v"7.14.0"
 
 sources = suitesparse_sources(version)
 

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -71,6 +71,10 @@ function suitesparse_sources(version::VersionNumber; kwargs...)
             GitSource("https://github.com/DrTimothyAldenDavis/SuiteSparse.git",
                       "42151688813c45846a597edcb601435a0e38f3dd")
         ],
+        v"7.14.0" => [
+            GitSource("https://github.com/DrTimothyAldenDavis/SuiteSparse.git",
+                      "4d40960f58fada6113b3bcf715ae504a43ec4f5f")
+        ]
     )
     return Any[
         suitesparse_version_sources[version]...,


### PR DESCRIPTION
Only bump the main package and GraphBLAS here. The rest need this version built ot be used as a build dependency.