### PR TITLE
Speed up JLL registration jobs

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -30,14 +30,14 @@ used to publish packages is never exposed to the (potentially untrusted)
 
 We moved off `cryptic-buildkite-plugin` to native [Buildkite
 secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets).
-Buildkite secrets are scoped per pipeline, so we use that scoping to keep the
-The tokens used to push `*_jll` packages, create releases, and register packages
+Buildkite secrets are scoped per pipeline, so the tokens used to push `*_jll`
+packages, create releases, and register packages
 are readable **only** from the trusted `yggdrasil-register` pipeline.
 
 The build steps run `build_tarballs.jl`, which is arbitrary code coming from
-PRs. Those steps must never have access to `GITHUB_TOKEN`. By performing the
+PRs. Those steps must never have access to publication tokens. By performing the
 registration in a separate pipeline that is *triggered* (rather than running
-the registration inline in the main pipeline), the token is only ever present
+the registration inline in the main pipeline), the tokens are only ever present
 in the trusted registration job.
 
 
@@ -66,14 +66,14 @@ in the trusted registration job.
 * **WebUI step:** see
   [`0_webui_yggdrasil_register.yml`](./0_webui_yggdrasil_register.yml). It runs
   `buildkite-agent pipeline upload .buildkite/register_pipeline.yml`.
-* [`register_pipeline.yml`](./register_pipeline.yml) defines a single step that
-  runs [`register.sh`](./register.sh) and declares
-  `secrets: [GITHUB_TOKEN]`.
+* [`register_pipeline.yml`](./register_pipeline.yml) runs
+  [`register.sh`](./register.sh) inside a concurrency gate and declares both
+  publication secrets.
 * The triggering build supplies `NAME`, `PROJECT`, `SKIP_BUILD`, `BUILD_ID`
   (and the registry / pkg-server env) through the trigger step's `build.env`.
 * `register.sh` regenerates the `meta.json` with both publication tokens cleared,
   starts Julia with multiple threads, and then runs
-  [`.ci/register_package.jl`](../.ci/register_package.jl) with the token
+  [`.ci/register_package.jl`](../.ci/register_package.jl) with the tokens
   available.
 * `register_package.jl` downloads the freshly-built tarballs and metadata from the
   triggering build with
@@ -81,10 +81,9 @@ in the trusted registration job.
   `*_jll` package, uploads the tarballs to GitHub releases, and registers the
   package to the General registry.
 
-The registration step keeps `concurrency: 1` in the
-`yggdrasil/register` concurrency group, so registrations remain serialized
-even though they now run in their own pipeline (concurrency groups are
-cluster-wide).
+The register pipeline uses a global concurrency gate to keep at most three
+registrations in flight. The registration step also has a per-package concurrency
+group, so two builds cannot register the same JLL concurrently.
 
 ## Required Buildkite configuration
 

--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -22,7 +22,7 @@ used to publish packages is never exposed to the (potentially untrusted)
                          │                                                │
                          │  register_pipeline.yml                         │
                          │    └─ register.sh ─► register_package.jl       │
-                         │         secrets: GITHUB_TOKEN                  │
+                         │         publication secrets                    │
                          └────────────────────────────────────────────────┘
 ```
 
@@ -31,8 +31,8 @@ used to publish packages is never exposed to the (potentially untrusted)
 We moved off `cryptic-buildkite-plugin` to native [Buildkite
 secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets).
 Buildkite secrets are scoped per pipeline, so we use that scoping to keep the
-`GITHUB_TOKEN` (used to push the `*_jll` packages and create GitHub releases)
-readable **only** from the trusted `yggdrasil-register` pipeline.
+The tokens used to push `*_jll` packages, create releases, and register packages
+are readable **only** from the trusted `yggdrasil-register` pipeline.
 
 The build steps run `build_tarballs.jl`, which is arbitrary code coming from
 PRs. Those steps must never have access to `GITHUB_TOKEN`. By performing the
@@ -56,8 +56,7 @@ in the trusted registration job.
   trigger the `yggdrasil-register` pipeline and never publish anything.
 * The `build_step` and `trigger_registration_step` helpers live in
   [`utils.jl`](./utils.jl).
-* Builds upload their tarballs as Buildkite artifacts
-  (`**/products/$NAME*.tar.*`).
+* Builds upload tarballs and their metadata sidecars as Buildkite artifacts.
 
 ## `yggdrasil-register` — the register pipeline
 
@@ -72,11 +71,11 @@ in the trusted registration job.
   `secrets: [GITHUB_TOKEN]`.
 * The triggering build supplies `NAME`, `PROJECT`, `SKIP_BUILD`, `BUILD_ID`
   (and the registry / pkg-server env) through the trigger step's `build.env`.
-* `register.sh` regenerates the `meta.json` (with `GITHUB_TOKEN` cleared, since
-  it runs project code) and then runs
+* `register.sh` regenerates the `meta.json` with both publication tokens cleared,
+  starts Julia with multiple threads, and then runs
   [`.ci/register_package.jl`](../.ci/register_package.jl) with the token
   available.
-* `register_package.jl` downloads the freshly-built tarballs from the
+* `register_package.jl` downloads the freshly-built tarballs and metadata from the
   triggering build with
   `buildkite-agent artifact download --build $BUILD_ID ...`, pushes the
   `*_jll` package, uploads the tarballs to GitHub releases, and registers the
@@ -93,5 +92,5 @@ cluster-wide).
    the `trigger_registration_step` targets this exact slug).
 2. Point its WebUI step at
    `buildkite-agent pipeline upload .buildkite/register_pipeline.yml`.
-3. Add the `GITHUB_TOKEN` Buildkite secret and scope it so it is readable
-   **only** by the `yggdrasil-register` pipeline.
+3. Add the `GITHUB_TOKEN` and `REGISTRY_GITHUB_TOKEN` Buildkite secrets and scope
+   them so they are readable **only** by the `yggdrasil-register` pipeline.

--- a/.buildkite/register.sh
+++ b/.buildkite/register.sh
@@ -5,16 +5,16 @@ set -e
 export JULIA_PROJECT="${BUILDKITE_BUILD_CHECKOUT_PATH}/.ci"
 
 echo "--- Setup Julia packages"
-GITHUB_TOKEN="" julia --color=yes -e 'import Pkg; Pkg.instantiate(); Pkg.precompile()'
+GITHUB_TOKEN="" REGISTRY_GITHUB_TOKEN="" julia --color=yes -e 'import Pkg; Pkg.instantiate(); Pkg.precompile()'
 
 cd "${PROJECT}"
 echo "--- Generating meta.json..."
-GITHUB_TOKEN="" julia --compile=min ./build_tarballs.jl --meta-json=${NAME}.meta.json
+GITHUB_TOKEN="" REGISTRY_GITHUB_TOKEN="" julia --compile=min ./build_tarballs.jl --meta-json="${NAME}.meta.json"
 
 echo "--- Setting up git"
 git config --global user.name "jlbuild"
 git config --global user.email "juliabuildbot@gmail.com"
 
 echo "--- Registering ${NAME}..."
-julia ${BUILDKITE_BUILD_CHECKOUT_PATH}/.ci/register_package.jl "${NAME}.meta.json" --verbose
-
+# BinaryBuilder bounds concurrent tarball inspection to avoid exhausting TMPDIR.
+julia --threads 8 "${BUILDKITE_BUILD_CHECKOUT_PATH}/.ci/register_package.jl" "${NAME}.meta.json" --verbose

--- a/.buildkite/register_pipeline.yml
+++ b/.buildkite/register_pipeline.yml
@@ -13,6 +13,19 @@
 # The `NAME`, `PROJECT`, `SKIP_BUILD`, `BUILD_ID` (and the registry/pkg-server)
 # environment variables are supplied by the triggering build.
 steps:
+  # Bound the number of registration builds in flight. The closing step is ordered
+  # ahead of later builds' opening steps, so this pair forms a Buildkite concurrency gate.
+  - label: ":pipeline: Enter registration gate"
+    command: "true"
+    concurrency: 3
+    concurrency_group: "yggdrasil/register"
+    agents:
+      queue: "yggdrasil"
+      arch: "x86_64"
+      os: "linux"
+
+  - wait
+
   - label: "register -- ${NAME}"
     priority: 10
     agents:
@@ -26,9 +39,23 @@ steps:
           version: "1.12.4"
       - JuliaCI/merge-commit: ~
     timeout_in_minutes: 90
+    # Do not let two builds choose a wrapper version for the same package concurrently.
     concurrency: 1
-    concurrency_group: "yggdrasil/register"
+    concurrency_group: "yggdrasil/register/${NAME}"
     command: .buildkite/register.sh
     secrets:
       - GITHUB_TOKEN
       - REGISTRY_GITHUB_TOKEN
+
+  # Always release the global gate, including after a failed registration.
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":pipeline: Leave registration gate"
+    command: "true"
+    concurrency: 3
+    concurrency_group: "yggdrasil/register"
+    agents:
+      queue: "yggdrasil"
+      arch: "x86_64"
+      os: "linux"

--- a/.buildkite/utils.jl
+++ b/.buildkite/utils.jl
@@ -81,7 +81,9 @@ function build_step(NAME, PLATFORM, PROJECT, IS_PR)
         :commands => [script],
         :env => build_env,
         :artifacts => [
-            "**/products/$NAME*.tar.*"
+            "**/products/$NAME*.tar.*",
+            # Reuse the hashes and product locations computed while packaging.
+            "**/products/$NAME*.meta.json",
         ],
     )
 end

--- a/.buildkite/utils.jl
+++ b/.buildkite/utils.jl
@@ -96,14 +96,13 @@ function trigger_registration_step(NAME, PROJECT, SKIP_BUILD, NUM_PLATFORMS)
     if SKIP_BUILD
         register_env["SKIP_BUILD"] = "true"
     end
-    # For packages with a large number of platforms, trying to upload several release
-    # artifacts at once with `ghr` results in exceeding GitHub's API secondary rate limits.
+    # Trying to upload too many release artifacts at once with `ghr` results in exceeding
+    # GitHub's API secondary rate limits.
     # Ref: <https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1334>.
-    if NUM_PLATFORMS > 80
-        concurrency = 4
-        @info "Reducing ghr concurrency" NAME NUM_PLATFORMS concurrency
-        register_env["BINARYBUILDER_GHR_CONCURRENCY"] = string(concurrency)
-    end
+    # The registration gate admits three jobs, so cap each upload at four requests.
+    concurrency = 4
+    @info "Setting ghr concurrency" NAME concurrency
+    register_env["BINARYBUILDER_GHR_CONCURRENCY"] = string(concurrency)
 
     # Registration needs the `GITHUB_TOKEN` Buildkite secret, which is only
     # readable from the dedicated `yggdrasil-register` pipeline.  Keeping it out

--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -35,7 +35,7 @@ version = "1.11.0"
 
 [[deps.BinaryBuilder]]
 deps = ["ArgParse", "BinaryBuilderBase", "Binutils_jll", "Dates", "Downloads", "GitHub", "HTTP", "JLD2", "JSON", "LibGit2", "Libdl", "Logging", "LoggingExtras", "ObjectFile", "Patchelf_jll", "Pkg", "PkgLicenses", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Scratch", "Sockets", "TOML", "UUIDs", "ghr_jll"]
-git-tree-sha1 = "a4969aeecbb7dea72df7e6c56827dc43f7da1042"
+git-tree-sha1 = "2134545fbec382fc17f55a87444577055194e261"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilder.jl.git"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
@@ -43,7 +43,7 @@ version = "0.6.6"
 
 [[deps.BinaryBuilderBase]]
 deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "38ac28858e80c575fc2ff3c7ac73982459c4482d"
+git-tree-sha1 = "5540ee6ca394a968ff7fa34ab3e565112ebc59f7"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"

--- a/.ci/register_package.jl
+++ b/.ci/register_package.jl
@@ -55,16 +55,28 @@ function mvdir(src, dest)
     end
 end
 
-function download_cached_binaries(download_dir)
+function download_cached_binaries(download_dir, build_meta_dir)
     NAME = ENV["NAME"]
     PROJECT = ENV["PROJECT"]
     BUILD_ID = ENV["BUILD_ID"]
+
     artifacts = "$(PROJECT)/products/$(NAME)*.tar.*"
     cmd = `buildkite-agent artifact download --build $BUILD_ID $artifacts $download_dir`
     if !success(pipeline(cmd; stderr))
         error("Download failed")
     end
     mvdir(joinpath(download_dir, PROJECT, "products"), download_dir)
+
+    # Keep build metadata out of `download_dir`, which is uploaded as release assets.
+    meta = "$(PROJECT)/products/$(NAME)*.meta.json"
+    cmd = `buildkite-agent artifact download --build $BUILD_ID $meta $build_meta_dir`
+    downloaded = joinpath(build_meta_dir, PROJECT, "products")
+    # Older builds have no sidecars; BinaryBuilder will inspect their tarballs instead.
+    if success(pipeline(cmd; stderr)) && isdir(downloaded)
+        mvdir(downloaded, build_meta_dir)
+    else
+        @info "No build metadata sidecars in this build; tarballs will be unpacked instead"
+    end
 end
 
 function download_binaries_from_release(download_dir)
@@ -98,16 +110,18 @@ for json_obj in [merged, objs_unmerged...]
     json_obj["dependencies"] = Dependency[dep for dep in json_obj["dependencies"] if BinaryBuilderBase.is_runtime_dependency(dep)]
 end
 skip_build = get(ENV, "SKIP_BUILD", "false") == "true"
+# This directory is separate because `download_dir` is uploaded to GitHub.
+build_meta_dir = mktempdir()
 mktempdir() do download_dir
     # Grab the binaries for our package
     if skip_build
         # We only want to update the wrappers, so download the tarballs from the
-        # latest build.
+        # latest build. Released tarballs do not include metadata sidecars.
         download_binaries_from_release(download_dir)
     else
         # We are going to publish the new binaries we've just baked, take them
         # out of the cache while they're hot.
-        download_cached_binaries(download_dir)
+        download_cached_binaries(download_dir, build_meta_dir)
     end
 
     # Push up the JLL package (pointing to as-of-yet missing tarballs)
@@ -119,7 +133,7 @@ mktempdir() do download_dir
     # This loop over the unmerged objects necessary in the event that we have multiple packages being built by a single build_tarballs.jl
     for (i,json_obj) in enumerate(objs_unmerged)
         from_scratch = (i == 1)
-        BinaryBuilder.rebuild_jll_package(json_obj; download_dir, upload_prefix, verbose, from_scratch)
+        BinaryBuilder.rebuild_jll_package(json_obj; download_dir, build_meta_dir, upload_prefix, verbose, from_scratch)
     end
 
     # Restore Artifacts.toml

--- a/H/HelloWorldC/build_tarballs.jl
+++ b/H/HelloWorldC/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "HelloWorldC"
-version = v"1.4.2"
+version = v"1.4.3"
 
 # No sources, we're just building the testsuite
 sources = [


### PR DESCRIPTION
Pass BinaryBuilder's per-tarball metadata from build jobs to the registration pipeline, allowing registration to reuse hashes and product locations computed while packaging.

Metadata sidecars are uploaded as Buildkite artifacts but downloaded into a directory separate from the tarballs, so they are not published as GitHub release assets. Builds without sidecars continue to use
BinaryBuilder's tarball-inspection fallback.

Registration now starts Julia with eight threads so the fallback can inspect multiple platforms concurrently.

The registration pipeline also uses a Buildkite concurrency gate:

- at most three registration builds may run at once;
- registrations of the same package remain serialized;
- each `ghr` process is capped at four concurrent uploads.

This reduces organization-wide queueing without allowing simultaneous wrapper-version selection for the same JLL or unbounded GitHub API traffic.

Requires https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/489 and https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1446