### PR TITLE
[libsparseir] Add x86_64 macOS build

### DIFF
--- a/L/libsparseir/build_tarballs.jl
+++ b/L/libsparseir/build_tarballs.jl
@@ -1,5 +1,8 @@
 using BinaryBuilder, Pkg
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
 name = "libsparseir"
 version = v"0.8.4"
 
@@ -17,10 +20,6 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/sparse-ir-rs/
 install_license LICENSE
 
-if [[ "${target}" == x86_64-apple-darwin* ]]; then
-    export MACOSX_DEPLOYMENT_TARGET=10.12
-fi
-
 if [[ "${target}" == *mingw* ]]; then
     export RUSTFLAGS="-C link-arg=-L${libdir} -C link-arg=-lblastrampoline-5"
     export CARGO_PROFILE_RELEASE_DEBUG=line-tables-only
@@ -37,6 +36,9 @@ fi
 
 cp sparse-ir-capi/include/sparseir/sparseir.h ${includedir}
 """
+
+# Install a newer SDK containing the libc++ atomic symbols required by spindle.
+sources, script = require_macos_sdk("11.0", sources, script)
 
 platforms = supported_platforms()
 # Build fails: warning: dropping unsupported crate type `cdylib` for target `aarch64-unknown-linux-musl`

--- a/L/libsparseir/build_tarballs.jl
+++ b/L/libsparseir/build_tarballs.jl
@@ -17,6 +17,10 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/sparse-ir-rs/
 install_license LICENSE
 
+if [[ "${target}" == x86_64-apple-darwin* ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=10.12
+fi
+
 if [[ "${target}" == *mingw* ]]; then
     export RUSTFLAGS="-C link-arg=-L${libdir} -C link-arg=-lblastrampoline-5"
     export CARGO_PROFILE_RELEASE_DEBUG=line-tables-only
@@ -35,8 +39,6 @@ cp sparse-ir-capi/include/sparseir/sparseir.h ${includedir}
 """
 
 platforms = supported_platforms()
-# Build fails: deployment target in MACOSX_DEPLOYMENT_TARGET was set to 10.10, but the minimum supported by `rustc` is 10.12
-filter!(p -> !(arch(p) == "x86_64" && os(p) == "macos"), platforms)
 # Build fails: warning: dropping unsupported crate type `cdylib` for target `aarch64-unknown-linux-musl`
 filter!(p -> !(arch(p) == "aarch64" && os(p) == "linux" && libc(p) == "musl"), platforms)
 # Build fails: Couldn't open /proc/mounts


### PR DESCRIPTION
Fixes SpM-lab/SparseIR.jl#138.

## Summary
- restore the `x86_64-apple-darwin` target
- set `MACOSX_DEPLOYMENT_TARGET=10.12`, the minimum supported by the Rust toolchain

## Verification
- confirmed recipe metadata omitted `x86_64-apple-darwin` before this change
- confirmed recipe metadata includes it after this change with the deployment-target override
- full local build requires accepting the Apple SDK license; Yggdrasil CI will perform the artifact build