### PR TITLE
[aws_c_s3] Update to version 0.12.4

### DIFF
--- a/A/aws_c_s3/build_tarballs.jl
+++ b/A/aws_c_s3/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_s3"
-version = v"0.12.3"
+version = v"0.12.4"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-s3.git", "a31a657840daffbfa7749b63cd0e2a178a6a5d9e"),
+    GitSource("https://github.com/awslabs/aws-c-s3.git", "f1a52b5e960c06bd9392cb5e982c6fe04f1ce253"),
 ]
 
 # Bash recipe for building across all platforms
@@ -37,10 +37,10 @@ products = [
 # Dependencies that must be installed before this package can be built
 dependencies = [
     Dependency("aws_checksums_jll"; compat="0.2.10"),
-    Dependency("aws_c_http_jll"; compat="0.10.13"),
-    Dependency("aws_c_auth_jll"; compat="0.10.1"),
+    Dependency("aws_c_http_jll"; compat="0.10.15"),
+    Dependency("aws_c_auth_jll"; compat="0.10.3"),
     Dependency("aws_c_common_jll"; compat="0.12.6"),
-    Dependency("s2n_tls_jll"; compat="1.7.2"),    
+    Dependency("s2n_tls_jll"; compat="1.7.3"),    
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_s3 to version 0.12.4.

### Held back from latest
- `aws_c_common_jll`: using **0.12.6** (latest known **0.13.0**)
- `aws_checksums_jll`: using **0.2.10** (latest known **0.2.11**)

### At latest
- `aws_c_auth_jll`: 0.10.3
- `aws_c_http_jll`: 0.10.15
- `s2n_tls_jll`: 1.7.3

cc: @Octogonapus