### PR TITLE
[CasADi] Update to v3.8.0

### DIFF
--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -2,12 +2,12 @@ using BinaryBuilder, Pkg
 
 name = "CasADi"
 
-version = v"3.7.3" # upstream is 3.7.2; bump Yggdrasil version because we updated compat bounds
+version = v"3.8.0"
 
 sources = [
     GitSource(
         "https://github.com/casadi/casadi.git",
-        "f959d3175a444d763e4eda4aece48f4c5f4a6f90",
+        "83b3cec864e42c5b64a07e85d4adf91da71458b1",
     ),
     DirectorySource("./bundled"),
 ]


### PR DESCRIPTION
## Summary

- update `CasADi_jll` to upstream CasADi 3.8.0
- pin the immutable commit referenced by the `3.8.0` tag
- preserve the existing products, dependencies, platform matrix, and Julia compatibility

## Validation

- local BinaryBuilder build, product audit, and packaging passed for `x86_64-linux-gnu` using the Docker runner