### PR TITLE
[gawk] Add patch for layout bug in v5.4.1

### DIFF
--- a/G/gawk/build_tarballs.jl
+++ b/G/gawk/build_tarballs.jl
@@ -16,6 +16,10 @@ cd $WORKSPACE/srcdir/gawk*/
 # Add missing #include for `_NSGetExecutablePath`
 atomic_patch -p1 $WORKSPACE/srcdir/patches/gawk_nsgep.patch
 
+# Apply workaround for v5.4.1 layout bug
+# (see https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00020.html)
+atomic_patch -p1 $WORKSPACE/srcdir/patches/gawk_node_alignment.patch
+
 apk add texinfo
 
 CONFIGURE_ARGS=()

--- a/G/gawk/bundled/patches/gawk_node_alignment.patch
+++ b/G/gawk/bundled/patches/gawk_node_alignment.patch
@@ -1,0 +1,73 @@
+Fix NODE numeric-union layout in non-MPFR builds
+
+gawk 5.4.1 built without MPFR (as this recipe builds it) miscomputes values
+that pass through the NODE numeric union: the non-MPFR union is smaller than
+the MPFR one, shifting field offsets, so e.g. an array element auto-created
+by referencing it behaves as the number 0 instead of an uninitialized value:
+
+    $ gawk 'BEGIN { if (e["W"] == "") ; print "[" e["W"] "]" }'
+    5.4.0 / patched:  []        unpatched 5.4.1:  [0]
+
+Among other casualties this breaks GCC's option generation (optc-gen.awk),
+and therefore any recipe that builds GCC with this gawk.
+
+Upstream fix by Arnold D. Robbins on the gawk-5.4-stable branch (described
+there as a workaround pending a NODE-struct refactor in the next major
+release); this is that commit's awk.h change verbatim, with its ChangeLog
+hunk omitted:
+  commit bf85f8a3175af703597082d4c7e0abc2066a44d3
+  "Workaround fix for systems without MPFR and GMP." (2026-07-14)
+Patch announcement:
+  https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00020.html
+Report threads:
+  https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00011.html
+  https://lists.gnu.org/archive/html/bug-gawk/2026-08/msg00016.html
+
+diff --git a/awk.h b/awk.h
+index dbad0d81..f4a84300 100644
+--- a/awk.h
++++ b/awk.h
+@@ -406,17 +406,24 @@ typedef struct exp_node {
+ 		} nodep;
+ 
+ 		struct {
+-#ifdef HAVE_MPFR
+ 			union {
+ 				AWKNUM fltnum;
++#ifdef HAVE_MPFR
+ 				mpfr_t mpnum;
+ 				mpz_t mpi;
+-			} nm;
+-			int rndmode;
+ #else
+-			AWKNUM fltnum;
+-			int for_alignment_only;	// especially on 32-bit
+-#endif
++				// 7/2026:
++				// This is a workaround for systems that build
++				// gawk without MPFR and GMP.  The NODE struct
++				// desperately needs to be refactored.
++#if SIZEOF_VOID_P == 4
++				char alignment[28];
++#else	// SIZEOF_VOID_P != 4
++				char alignment[48];
++#endif	// SIZEOF_VOID_P != 4
++#endif	// HAVE_MPFR
++			} nm;
++			int rndmode;	// only used for MPFR.
+ 			char *sp;
+ 			size_t slen;
+ 			int idx;
+@@ -561,10 +568,8 @@ typedef struct exp_node {
+ #ifdef HAVE_MPFR
+ #define mpg_numbr	sub.val.nm.mpnum
+ #define mpg_i		sub.val.nm.mpi
+-#define numbr		sub.val.nm.fltnum
+-#else
+-#define numbr		sub.val.fltnum
+ #endif
++#define numbr		sub.val.nm.fltnum
+ #define typed_re	sub.val.typre
+ 
+ /*
+cgit v1.3


### PR DESCRIPTION
Gawk 5.4.1 introduced a regression to its struct layout:
  - https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00011.html
  - https://lists.gnu.org/archive/html/bug-gawk/2026-08/msg00016.html

A workaround / patch was provided in https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00020.html and should be available in the [upcoming 5.4.1a release](https://github.com/sailfishos-mirror/gawk/commit/3b73b226881621d2e16c707a8a43c1f34874ecda), but this should fix things for us for now.

This is required for the GCC / CRT recipes to build under BinaryBuilder2 (and probably BB1 too).