### PR TITLE
[aws_c_common] Update to version 0.13.1

### DIFF
--- a/A/aws_c_common/build_tarballs.jl
+++ b/A/aws_c_common/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_common"
-version = v"0.13.0"
+version = v"0.13.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-common.git", "7f18168e834b2abf276c6f92ae3b27af494fcca1"),
+    GitSource("https://github.com/awslabs/aws-c-common.git", "d3b926fd87e6c37887ae12bb2253550334e7445a"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_c_common to version 0.13.1.

No runtime JLL dependencies with compat pins.

cc: @Octogonapus