### PR TITLE
[aws_c_common] Update to version 1.0.0

### DIFF
--- a/A/aws_c_common/build_tarballs.jl
+++ b/A/aws_c_common/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_common"
-version = v"0.14.5"
+version = v"1.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-common.git", "991b041cd9933bb663be72b691ed9e44bd61b90a"),
+    GitSource("https://github.com/awslabs/aws-c-common.git", "3d274e1af954592b344a33fdf042af37b936f3d5"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_c_common to version 1.0.0.

No runtime JLL dependencies with compat pins.

cc: @Octogonapus