### PR TITLE
[CUDA_Compiler] Keep dlopen'ing libnvJitLink at init time.

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Compiler"
-version = v"0.5.2"
+version = v"0.5.3"
 
 const toolkit_versions = [CUDA.cuda_full_versions; CUDA.cuda_prerelease_versions]
 const compiler_versions = filter(v -> v >= v"11.4", toolkit_versions)
@@ -148,13 +148,19 @@ function get_products(version::VersionNumber)
                                    "nvrtc64_112_0"
     nvrtc_builtins_dll = "nvrtc-builtins64_$(version.major)$(version.minor)"
 
-    # The libraries are not dlopen'ed at init time. Nothing in this artifact needs them
-    # pre-loaded (ptxas, nvlink, nvdisasm and tileiras only link against libc), and the
-    # artifact is lazy: on systems without CUDA the platform augmentation still selects an
-    # artifact (see `cuda_default_toolkit`), so an eager `dlopen` in `__init__` turns any
-    # missing or incomplete artifact into an InitError that breaks precompilation of every
-    # dependent package (JuliaGPU/CUDA.jl#3242). Consumers can still `ccall` into these
-    # libraries through their path variables, which are set regardless.
+    # libnvvm, libnvrtc and libnvrtc-builtins are not dlopen'ed at init time: nothing needs
+    # them pre-loaded (the executables here only link against libc, and no CUDA_Runtime_jll
+    # library links against them), and the artifact is lazy: on systems without CUDA the
+    # platform augmentation still selects an artifact (see `cuda_default_toolkit`), so an
+    # eager `dlopen` in `__init__` turns any missing or incomplete artifact into an
+    # InitError that breaks precompilation of every dependent package
+    # (JuliaGPU/CUDA.jl#3242). Consumers can still `ccall` into these libraries through
+    # their path variables, which are set regardless.
+    #
+    # libnvJitLink is different: CUDA_Runtime_jll's libcusolver, libcusolverMg and (on CUDA
+    # 12.0) libcusparse link against `libnvJitLink.so.$major`, which is only found because
+    # this JLL has already loaded it when the runtime's `__init__` dlopen's them. It must
+    # therefore remain eagerly loaded.
     products = [
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("nvvm/libdevice/libdevice.10.bc", :libdevice),
@@ -169,8 +175,7 @@ function get_products(version::VersionNumber)
     ]
     if version >= v"12"
         nvjitlink_dll = version >= v"13" ? "nvJitLink_130_0" : "nvJitLink_120_0"
-        push!(products, LibraryProduct(["libnvJitLink", nvjitlink_dll], :libnvJitLink;
-                                       dont_dlopen=true))
+        push!(products, LibraryProduct(["libnvJitLink", nvjitlink_dll], :libnvJitLink))
     end
     if version >= v"13.1"
         push!(products, ExecutableProduct("tileiras", :tileiras))


### PR DESCRIPTION
CUDA_Runtime_jll's libcusolver, libcusolverMg and (on CUDA 12.0) libcusparse link against libnvJitLink.so.$major, which is provided by this JLL and only resolved because our __init__ has already loaded it. Marking it dont_dlopen in 0.5.2 broke loading of CUDA_Runtime_jll:

    InitError: could not load library ".../lib/libcusolver.so"
    libnvJitLink.so.12: cannot open shared object file: No such file or directory

Restore the eager dlopen for libnvJitLink; libnvvm, libnvrtc and libnvrtc-builtins stay dont_dlopen since nothing links against them.