### PR TITLE
[CUDA_Compiler] Don't select an artifact when CUDA is not available.

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Compiler"
-version = v"0.5.2"
+version = v"0.6.0"
 
 const toolkit_versions = [CUDA.cuda_full_versions; CUDA.cuda_prerelease_versions]
 const compiler_versions = filter(v -> v >= v"11.4", toolkit_versions)
@@ -22,7 +22,6 @@ augment_platform_block = """
     $(read(joinpath(@__DIR__, "..", "CUDA_Runtime", "toolkit_selection.jl"), String))
     const cuda_toolkits = $(compiler_versions)
     const cuda_prerelease_toolkits = $(CUDA.cuda_prerelease_versions)
-    const cuda_default_toolkit = $(repr(Base.thisminor(last(CUDA.cuda_full_versions))))
     $(read(joinpath(@__DIR__, "platform_augmentation.jl"), String))"""
 
 script = raw"""
@@ -148,29 +147,26 @@ function get_products(version::VersionNumber)
                                    "nvrtc64_112_0"
     nvrtc_builtins_dll = "nvrtc-builtins64_$(version.major)$(version.minor)"
 
-    # The libraries are not dlopen'ed at init time. Nothing in this artifact needs them
-    # pre-loaded (ptxas, nvlink, nvdisasm and tileiras only link against libc), and the
-    # artifact is lazy: on systems without CUDA the platform augmentation still selects an
-    # artifact (see `cuda_default_toolkit`), so an eager `dlopen` in `__init__` turns any
-    # missing or incomplete artifact into an InitError that breaks precompilation of every
-    # dependent package (JuliaGPU/CUDA.jl#3242). Consumers can still `ccall` into these
-    # libraries through their path variables, which are set regardless.
+    # NOTE: the libraries must be dlopen'ed eagerly (the default), even though nothing here
+    # calls into them. Other CUDA libraries pick them up by soname at run time: libcusolver,
+    # libcusparse and libcufft link against or dlopen `libnvJitLink.so.$major`, and cuBLASLt,
+    # cuFFT, cuDNN and cuTENSOR dlopen `libnvrtc.so.$major`, which in turn dlopens
+    # `libnvrtc-builtins.so.$major.$minor`. None of them have a RUNPATH, so those lookups
+    # only succeed because this JLL has already loaded the libraries.
     products = [
         FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
         FileProduct("nvvm/libdevice/libdevice.10.bc", :libdevice),
         LibraryProduct(["libnvvm", "nvvm64_40_0"], :libnvvm,
-                       ["nvvm/lib64", "nvvm/bin/x64", "nvvm/bin"]; dont_dlopen=true),
-        LibraryProduct(["libnvrtc", nvrtc_dll], :libnvrtc; dont_dlopen=true),
-        LibraryProduct(["libnvrtc-builtins", nvrtc_builtins_dll], :libnvrtc_builtins;
-                       dont_dlopen=true),
+                       ["nvvm/lib64", "nvvm/bin/x64", "nvvm/bin"]),
+        LibraryProduct(["libnvrtc", nvrtc_dll], :libnvrtc),
+        LibraryProduct(["libnvrtc-builtins", nvrtc_builtins_dll], :libnvrtc_builtins),
         ExecutableProduct("ptxas", :ptxas),
         ExecutableProduct("nvdisasm", :nvdisasm),
         ExecutableProduct("nvlink", :nvlink),
     ]
     if version >= v"12"
         nvjitlink_dll = version >= v"13" ? "nvJitLink_130_0" : "nvJitLink_120_0"
-        push!(products, LibraryProduct(["libnvJitLink", nvjitlink_dll], :libnvJitLink;
-                                       dont_dlopen=true))
+        push!(products, LibraryProduct(["libnvJitLink", nvjitlink_dll], :libnvJitLink))
     end
     if version >= v"13.1"
         push!(products, ExecutableProduct("tileiras", :tileiras))

--- a/C/CUDA/CUDA_Compiler/platform_augmentation.jl
+++ b/C/CUDA/CUDA_Compiler/platform_augmentation.jl
@@ -2,8 +2,13 @@
 
 function augment_platform!(platform::Platform)
     if !haskey(platform, "cuda")
-        default_tag = "$(cuda_default_toolkit.major).$(cuda_default_toolkit.minor)"
-        platform["cuda"] = something(cuda_toolkit_tag(), default_tag)
+        # use "none" when no CUDA toolkit could be selected (no driver, no preference), just
+        # like CUDA_Runtime_jll does. This makes `is_available()` false, instead of selecting
+        # a (lazy) artifact whose libraries would then be eagerly dlopen'ed at load time on
+        # a system that cannot use them (JuliaGPU/CUDA.jl#3242). Systems without a GPU that
+        # want to precompile or cross-compile should set the version preference explicitly.
+        # We can't just leave off the platform tag or Pkg would select *any* artifact.
+        platform["cuda"] = something(cuda_toolkit_tag(), "none")
     end
     BinaryPlatforms.set_compare_strategy!(platform, "cuda", cuda_comparison_strategy)
 


### PR DESCRIPTION
Since #12895 the platform augmentation defaulted to the most recent toolkit when no CUDA driver or version preference was found, so that the JLL would be usable on systems without a GPU. In practice that means selecting a lazy artifact on every such system and eagerly dlopen'ing its libraries at load time: if the artifact cannot be downloaded or is incomplete, __init__ throws and precompilation of CUDA.jl and everything depending on it fails (JuliaGPU/CUDA.jl#3242).

Fall back to "none" instead, like CUDA_Runtime_jll does, so that `is_available()` is false on systems without CUDA. Systems that want to precompile or cross-compile without a GPU can still set the version preference explicitly, which selects both the runtime and the compiler.

The eager dlopen of the libraries is kept (0.5.2, which disabled it, has been yanked): other CUDA libraries resolve libnvJitLink, libnvrtc and libnvrtc-builtins by soname at run time and have no RUNPATH, so they only find them because this JLL already loaded them. Document that.

This is a breaking change for consumers that relied on the default selection: CUDA.jl needs to guard its precompilation workload on `is_available()`, hence the bump to 0.6.