### PR TITLE
[iceberg_rust_ffi] Bump to 0.9.1

### DIFF
--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -52,11 +52,18 @@ dependencies = Dependency[
 # BinaryBuilder's default (the single newest Rust version known across all
 # toolchain shards), which isn't necessarily published for every platform yet.
 #
+# preferred_gcc_version=v"12.1.0": aws-lc-sys's generated aarch64-linux-gnu
+# assembly (aesv8-gcm-armv8-unroll8.S) declares `.arch armv8.2-a+crypto`,
+# which the assembler bundled with BinaryBuilder's default/older GCC
+# shards (e.g. GCC 5) doesn't recognize ("unknown architecture"). Matches
+# rcodesign's recipe, which hits the same aws-lc/aws-lc-sys requirement on
+# aarch64-linux-gnu and already pins the same GCC version for this reason.
+#
 # lock_microarchitecture=false: the compiler wrappers otherwise reject the
 # -march flag aarch64-apple-darwin needs above (see rcodesign's recipe,
 # which hits the same aws-lc-sys requirement).
 build_tarballs(
     ARGS, name, version, sources, script, platforms, products, dependencies;
-    compilers=[:c, :rust], julia_compat="1.10", preferred_gcc_version=v"5", dont_dlopen=true,
+    compilers=[:c, :rust], julia_compat="1.10", preferred_gcc_version=v"12.1.0", dont_dlopen=true,
     preferred_rust_version=v"1.94", lock_microarchitecture=false,
 )

--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -4,7 +4,7 @@ name = "iceberg_rust_ffi"
 version = v"0.9.2"
 
 sources = [
-    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "44bd93e2d559f358c3a4ce1acdfeaa9dfd448505"),
+    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "208160ac5b133b771d4520970165cc16bcae994b"),
 ]
 
 # Bash recipe for building across all platforms

--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -9,6 +9,14 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
+if [[ "${target}" == "aarch64-apple-darwin"* ]]; then
+    # aws-lc-sys (pulled in via rustls/hyper-rustls) requires the NEON and
+    # crypto extensions to be statically enabled on Apple aarch64 (every
+    # Apple Silicon CPU has them, but this clang does not enable them for
+    # bare arm64-apple-macosx). Same fix as the rcodesign recipe.
+    export CFLAGS="${CFLAGS} -march=armv8-a+crypto"
+fi
+
 cd ${WORKSPACE}/srcdir/RustyIceberg.jl/iceberg_rust_ffi/
 
 # Build the library with native compilation
@@ -40,8 +48,12 @@ dependencies = Dependency[
 # iceberg-rust's MSRV is 1.94; pin explicitly rather than relying on
 # BinaryBuilder's default (the single newest Rust version known across all
 # toolchain shards), which isn't necessarily published for every platform yet.
+#
+# lock_microarchitecture=false: the compiler wrappers otherwise reject the
+# -march flag aarch64-apple-darwin needs above (see rcodesign's recipe,
+# which hits the same aws-lc-sys requirement).
 build_tarballs(
     ARGS, name, version, sources, script, platforms, products, dependencies;
     compilers=[:c, :rust], julia_compat="1.10", preferred_gcc_version=v"5", dont_dlopen=true,
-    preferred_rust_version=v"1.94",
+    preferred_rust_version=v"1.94", lock_microarchitecture=false,
 )

--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -37,8 +37,11 @@ dependencies = Dependency[
     Dependency("OpenSSL_jll"; compat="3.0.14")
 ]
 
-# Build the tarballs
+# iceberg-rust's MSRV is 1.94; pin explicitly rather than relying on
+# BinaryBuilder's default (the single newest Rust version known across all
+# toolchain shards), which isn't necessarily published for every platform yet.
 build_tarballs(
     ARGS, name, version, sources, script, platforms, products, dependencies;
     compilers=[:c, :rust], julia_compat="1.10", preferred_gcc_version=v"5", dont_dlopen=true,
+    preferred_rust_version=v"1.94",
 )

--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -1,10 +1,10 @@
 using BinaryBuilder
 
 name = "iceberg_rust_ffi"
-version = v"0.9.1"
+version = v"0.9.2"
 
 sources = [
-    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "d9f3d12c6c7f8b1f946dba2b991fdb1af4de912e"),
+    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "44bd93e2d559f358c3a4ce1acdfeaa9dfd448505"),
 ]
 
 # Bash recipe for building across all platforms

--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -9,11 +9,14 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-if [[ "${target}" == "aarch64-apple-darwin"* ]]; then
+if [[ "${target}" == aarch64-* ]]; then
     # aws-lc-sys (pulled in via rustls/hyper-rustls) requires the NEON and
-    # crypto extensions to be statically enabled on Apple aarch64 (every
-    # Apple Silicon CPU has them, but this clang does not enable them for
-    # bare arm64-apple-macosx). Same fix as the rcodesign recipe.
+    # crypto extensions to be statically enabled on aarch64 (every real
+    # aarch64 CPU has them, but neither clang's bare arm64-apple-macosx
+    # target nor the aarch64-linux-gnu assembler enable them by default,
+    # so aws-lc-sys's hand-written crypto assembly fails to assemble:
+    # "selected processor does not support `aese ...'" etc). Same fix as
+    # the rcodesign recipe (for Apple) and needed for aarch64-linux-gnu too.
     export CFLAGS="${CFLAGS} -march=armv8-a+crypto"
 fi
 

--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -1,10 +1,10 @@
 using BinaryBuilder
 
 name = "iceberg_rust_ffi"
-version = v"0.9.0"
+version = v"0.9.1"
 
 sources = [
-    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "5493fe407bb6fd9d7c2ff607ad8447a64b32dfd4"),
+    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "d9f3d12c6c7f8b1f946dba2b991fdb1af4de912e"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bumps `iceberg_rust_ffi_jll` to 0.9.1, pointing at [RelationalAI/RustyIceberg.jl@d9f3d12](https://github.com/RelationalAI/RustyIceberg.jl/commit/d9f3d12c6c7f8b1f946dba2b991fdb1af4de912e), the merge commit for [RustyIceberg.jl#110](https://github.com/RelationalAI/RustyIceberg.jl/pull/110).

That PR bumps the fork's pinned `apache/iceberg-rust` dependency to fix a same-type column reorder mislabeling bug, plus two bugs found while validating the merge (a `DeleteFileIndex` bug that broke incremental scan's delete handling, and a credential-refresh-retry gap for reads). It also fixes a separate, FFI-local issue where Julia's `Arrow.jl` doesn't support the Run-End Encoded Arrow format iceberg-rust now uses for constant metadata columns.

No changes to the build recipe itself beyond the version and source commit bump.