### PR TITLE
PoCL: switch to upstream sources with bundled patches; backport UTR fix

### DIFF
--- a/P/pocl/common.jl
+++ b/P/pocl/common.jl
@@ -123,6 +123,17 @@ function build_script(standalone=false)
     cd $WORKSPACE/srcdir/pocl/
     install_license LICENSE
 
+    # Apply our patch series on top of upstream release_7_2 (`git format-patch` exports; the
+    # binary SPIR-V test inputs are excluded since we don't build the tests):
+    # - 0001: MinGW Clang/lld toolchain support (JuliaGPU-only, not upstreamed)
+    # - 0002: FP16 host math overloads (upstream PR #2224, in `main`)
+    # - 0003: in-process JIT via ORC/JITLink (upstream PR #2190, in `main`)
+    # - 0004: CanonicalizeBarriers fix for reconverging barrier successors (upstream PR #2281)
+    # - 0005, 0006: UnreachablesToReturns fix for issue #1958 (upstream PR #2280)
+    for patch in $WORKSPACE/srcdir/patches/pocl/*.patch; do
+        atomic_patch -p1 $patch
+    done
+
     # POCL wants a target sysroot for compiling the host kernellib (for `math.h` etc)
     sysroot=/opt/${target}/${target}/sys-root
     if [[ "${target}" == *apple* ]]; then

--- a/P/pocl/pocl/build_tarballs.jl
+++ b/P/pocl/pocl/build_tarballs.jl
@@ -16,8 +16,8 @@ llvm_version = v"20.1.2"
 # Collection of sources required to complete build
 sources = [
     DirectorySource("./bundled"),
-    GitSource("https://github.com/juliagpu/pocl",
-              "763e259ff4bb3003280b991bbe99d4a9b712e051"),
+    GitSource("https://github.com/pocl/pocl",
+              "a6f7e5cc223cdf6254ff62ea1f37a9aa8a52d778"), # tag v7.1
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # the build script below); this commit is the LLVM-20.1-compatible revision (matches
     # LLVM_full_jll 20.1.2).
@@ -165,6 +165,16 @@ function build_script(standalone=false)
     ##########################################################################
     cd $WORKSPACE/srcdir/pocl/
     install_license LICENSE
+
+    # Apply our patch series on top of upstream v7.1 (`git format-patch` exports; the
+    # binary SPIR-V test inputs are excluded since we don't build the tests):
+    # - 0010: MinGW Clang/lld toolchain support (JuliaGPU-only, not upstreamed)
+    # - 0014: CanonicalizeBarriers fix for reconverging barrier successors (upstream PR #2281)
+    # - 0015, 0016: UnreachablesToReturns fix for issue #1958 (upstream PR #2280)
+    # - all others: backports of fixes that landed in upstream `main`
+    for patch in $WORKSPACE/srcdir/patches/pocl/*.patch; do
+        atomic_patch -p1 $patch
+    done
 
     # POCL wants a target sysroot for compiling the host kernellib (for `math.h` etc)
     sysroot=/opt/${target}/${target}/sys-root

--- a/P/pocl/pocl/bundled/patches/pocl/0001-Fix-pocld-when-not-linux.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0001-Fix-pocld-when-not-linux.patch
@@ -1,0 +1,92 @@
+From 88d13768ec58869a416021c7356c43f3e53a872f Mon Sep 17 00:00:00 2001
+From: Matthias Diener <mdiener@illinois.edu>
+Date: Fri, 23 May 2025 15:22:23 -0500
+Subject: [PATCH 01/16] Fix pocld when not linux
+
+Co-authored-by: Isuru Fernando <isuruf@gmail.com>
+---
+ lib/CL/pocl_networking.c   | 3 ++-
+ pocld/connection.cc        | 2 ++
+ pocld/daemon.cc            | 7 +++++++
+ pocld/shared_cl_context.cc | 2 +-
+ 4 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/lib/CL/pocl_networking.c b/lib/CL/pocl_networking.c
+index ca35f04f7..987e7b001 100644
+--- a/lib/CL/pocl_networking.c
++++ b/lib/CL/pocl_networking.c
+@@ -164,13 +164,14 @@ pocl_freeaddrinfo (struct addrinfo *ai)
+ {
+   if (ai)
+     {
++#ifdef HAVE_LINUX_VSOCK_H
+       if (ai->ai_family == AF_VSOCK)
+         {
+           free (ai->ai_canonname);
+           free (ai);
+           return;
+         }
+-
++#endif
+       freeaddrinfo (ai);
+     }
+ }
+diff --git a/pocld/connection.cc b/pocld/connection.cc
+index 503a1521b..eb88ce31a 100644
+--- a/pocld/connection.cc
++++ b/pocld/connection.cc
+@@ -47,9 +47,11 @@ void Connection::configure(bool LowLatency) {
+     // function only actually checks whether ai_family is AF_VSOCK
+     pocl_remote_client_set_socket_options(Fd, BufSize, LowLatency, AF_UNSPEC);
+     break;
++#ifdef HAVE_LINUX_VSOCK_H
+   case TransportDomain_Vsock:
+     pocl_remote_client_set_socket_options(Fd, BufSize, LowLatency, AF_VSOCK);
+     break;
++#endif
+   default:
+     break;
+   }
+diff --git a/pocld/daemon.cc b/pocld/daemon.cc
+index c924059e8..e97be8c7f 100644
+--- a/pocld/daemon.cc
++++ b/pocld/daemon.cc
+@@ -580,18 +580,25 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
+   addrinfo *ai = ResolvedAddress;
+   NumListenFds = 0;
+   for (addrinfo *ai = ResolvedAddress; ai; ai = ai->ai_next) {
++#ifdef HAVE_LINUX_VSOCK_H
+     if (ai->ai_family != AF_INET && ai->ai_family != AF_INET6 &&
+         ai->ai_family != AF_VSOCK)
+       continue;
++#else
++    if (ai->ai_family != AF_INET && ai->ai_family != AF_INET6)
++      continue;
++#endif
+     struct sockaddr *base_addr = ai->ai_addr;
+     int base_addrlen = ai->ai_addrlen;
+     std::string addr_string = describe_sockaddr(base_addr, base_addrlen);
++#ifdef HAVE_LINUX_VSOCK_H
+     if (UseVsock && ai->ai_family != AF_VSOCK) {
+       POCL_MSG_ERR("Using vsock requires using the correct address "
+                    "vsock:<cid>, instead of %s\n",
+                    addr_string.c_str());
+       break;
+     }
++#endif
+     int FdCommand = -1;
+     int FdStream = -1;
+     transport_domain_t Domain =
+diff --git a/pocld/shared_cl_context.cc b/pocld/shared_cl_context.cc
+index 7b410c534..02acec9e4 100644
+--- a/pocld/shared_cl_context.cc
++++ b/pocld/shared_cl_context.cc
+@@ -699,7 +699,7 @@ SharedCLContext::SharedCLContext(cl::Platform *p, unsigned pid,
+     if (MaxMemAllocSize < MaxSVMAllocSize)
+       MaxSVMAllocSize = MaxMemAllocSize;
+ 
+-    MaxTotalAllocatableSVM = std::min(MaxTotalAllocatableSVM,
++    MaxTotalAllocatableSVM = std::min(MaxTotalAllocatableSVM, (size_t)
+                                       Dev.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>());
+   }
+ 

--- a/P/pocl/pocl/bundled/patches/pocl/0002-use-CLANG_MARCH_FLAG-for-RISC-V-build.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0002-use-CLANG_MARCH_FLAG-for-RISC-V-build.patch
@@ -1,0 +1,22 @@
+From 6831fe8c5f45777918f74a4d39bf1bbd5072729b Mon Sep 17 00:00:00 2001
+From: Simeon David Schaub <simeon@schaub.rocks>
+Date: Wed, 15 Oct 2025 11:00:08 +0200
+Subject: [PATCH 02/16] use `CLANG_MARCH_FLAG` for RISC-V build
+
+---
+ lib/kernel/host/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/kernel/host/CMakeLists.txt b/lib/kernel/host/CMakeLists.txt
+index 217e6001f..6a4ed2d1a 100644
+--- a/lib/kernel/host/CMakeLists.txt
++++ b/lib/kernel/host/CMakeLists.txt
+@@ -657,7 +657,7 @@ endif()
+ if(X86)
+   x86_distro_variant_to_flags("${VARIANT}" LLC_CPUFLAGS CLANG_CPUFLAGS)
+ elseif(RISCV)
+-  set(CLANG_CPUFLAGS "-mcpu=${VARIANT} -mabi=${HOST_CPU_TARGET_ABI}")
++  set(CLANG_CPUFLAGS "${CLANG_MARCH_FLAG}${VARIANT} -mabi=${HOST_CPU_TARGET_ABI}")
+ 
+   if(LLVM_MARCH)
+     set(CLANG_CPUFLAGS "${CLANG_CPUFLAGS} -march=${LLVM_MARCH}")

--- a/P/pocl/pocl/bundled/patches/pocl/0003-WorkitemLoops-fix-stale-global-id-in-the-peeled-work.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0003-WorkitemLoops-fix-stale-global-id-in-the-peeled-work.patch
@@ -1,0 +1,215 @@
+From be4f9bb9c30d4807b94e1d4eae5a688e515d3111 Mon Sep 17 00:00:00 2001
+From: Michal Babej <90404+franz@users.noreply.github.com>
+Date: Sat, 30 May 2026 10:34:35 +0300
+Subject: [PATCH 03/16] WorkitemLoops: fix stale global id in the peeled
+ work-item
+
+---
+ lib/llvmopencl/WorkitemLoops.cc             |   4 +
+ tests/regression/CMakeLists.txt             |   3 +
+ tests/regression/test_peeled_wi_global_id.c | 160 ++++++++++++++++++++
+ 3 files changed, 167 insertions(+)
+ create mode 100644 tests/regression/test_peeled_wi_global_id.c
+
+diff --git a/lib/llvmopencl/WorkitemLoops.cc b/lib/llvmopencl/WorkitemLoops.cc
+index 4589cd6f2..7386dda73 100644
+--- a/lib/llvmopencl/WorkitemLoops.cc
++++ b/lib/llvmopencl/WorkitemLoops.cc
+@@ -672,6 +672,10 @@ bool WorkitemLoopsImpl::processFunction(Function &F) {
+     PR->insertPrologue(0, 0, 0);
+     builder.SetInsertPoint(&*(PR->entryBB()->getFirstInsertionPt()));
+     builder.CreateStore(ConstantInt::get(ST, 1), LocalIdXFirstVar);
++    // insertPrologue() reset the local ids to 0; re-base the global ids too,
++    // else the peeled WI reads a stale (loop-updated) global id.
++    for (int Dim = 0; Dim < 3; ++Dim)
++      builder.CreateStore(getGlobalIdOrigin(Dim), GlobalIdIterators[Dim]);
+   }
+ 
+   if (!WGDynamicLocalSize)
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index c8b8e6ea3..44fd7ea07 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -30,6 +30,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
+      test_llvm_segfault_issue_889
+      test_issue_1711 test_issue_1794 test_issue_1747
+      test_rematerialized_alloca_load_with_outside_pr_users
++     test_peeled_wi_global_id
+ )
+ foreach(PROG ${C_PROGRAMS_TO_BUILD})
+   add_executable("${PROG}" "${PROG}.c")
+@@ -139,6 +140,8 @@ add_test_pocl(NAME "regression/test_issue_1794b" COMMAND "test_issue_1794" "0" "
+ 
+ add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "${CMAKE_CURRENT_SOURCE_DIR}/test_issue_1747.spv" LABELS ${SPIRV_LABELS})
+ 
++add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
++
+ add_test_pocl(NAME "regression/test_issue_893" COMMAND "test_issue_893")
+ 
+ add_test_pocl(NAME "regression/test_flatten_barrier_subs" COMMAND "test_flatten_barrier_subs" EXPECTED_OUTPUT "test_flatten_barrier_subs.output")
+diff --git a/tests/regression/test_peeled_wi_global_id.c b/tests/regression/test_peeled_wi_global_id.c
+new file mode 100644
+index 000000000..733972b44
+--- /dev/null
++++ b/tests/regression/test_peeled_wi_global_id.c
+@@ -0,0 +1,160 @@
++// Copyright (c) 2026 PoCL developers
++//
++// Permission is hereby granted, free of charge, to any person obtaining a copy
++// of this software and associated documentation files (the "Software"), to deal
++// in the Software without restriction, including without limitation the rights
++// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++// copies of the Software, and to permit persons to whom the Software is
++// furnished to do so, subject to the following conditions:
++//
++// The above copyright notice and this permission notice shall be included in
++// all copies or substantial portions of the Software.
++//
++// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++// THE SOFTWARE.
++
++/*
++  Reduced from a Julia KernelAbstractions kernel (get_global_id reduced via
++  llvm-reduce). The kernel is, per work-item:
++
++      if (get_local_id(0) > 7) return;   // work-item-varying, dead for localsize 8
++      barrier();
++      A[get_global_id(0)] = get_global_id(0) + 1;
++
++  The varying early-return before the barrier makes WorkitemLoops peel work-item
++  (0,0,0). The peeled copy used to read a stale global id (the loop-updated value),
++  so get_global_id(0) returned the work-group size instead of 0: element 0 was
++  left untouched. Launched as global=local=8, the correct result is {1,..,8}.
++*/
++
++#include "pocl_opencl.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++
++// Mirrors the Julia argument layout the SPIR-V kernel expects.
++typedef struct { cl_long ndrange; cl_long numblocks; } Ctx;
++typedef struct { cl_long *ptr; size_t maxsize; size_t dim1; size_t len; } DeviceArray;
++
++#define CHECK_ERROR(err)                                                       \
++  if (err != CL_SUCCESS) {                                                     \
++    printf("OpenCL Error %d at %s:%d\n", err, __FILE__, __LINE__);             \
++    return 1;                                                                  \
++  }
++
++static const char *KERNEL_NAME =
++    "_Z7gpu_mwe16CompilerMetadataI11DynamicSize12DynamicCheckv16CartesianIndices"
++    "ILi1E5TupleI5OneToI5Int64EEE7NDRangeILi1ES0_10StaticSizeI4_8__ES8_vEE13CL"
++    "DeviceArrayIS5_Li1ELi1EE";
++
++int main(int argc, char **argv) {
++  cl_uint platform_index = argc > 1 ? (cl_uint)atoi(argv[1]) : 0;
++  cl_int err;
++
++  cl_uint num_platforms;
++  CHECK_ERROR(clGetPlatformIDs(0, NULL, &num_platforms));
++  if (platform_index >= num_platforms) {
++    printf("Platform index %u out of range\n", platform_index);
++    return 1;
++  }
++  cl_platform_id *platforms = malloc(sizeof(cl_platform_id) * num_platforms);
++  CHECK_ERROR(clGetPlatformIDs(num_platforms, platforms, NULL));
++  cl_platform_id platform = platforms[platform_index];
++  free(platforms);
++
++  cl_device_id device;
++  CHECK_ERROR(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL));
++
++  if (!poclu_device_supports_il(device, "SPIR-V_1.0")) {
++    printf("SKIP: The test requires support for SPIR-V 1.0\n");
++    return 77;
++  }
++
++  // The reduced kernel's barrier lowers to a sub_group_barrier, so the program
++  // only links on devices whose builtin library has the subgroup builtins.
++  if (!poclu_supports_extension(device, "cl_khr_subgroups")) {
++    printf("SKIP: The test requires cl_khr_subgroups\n");
++    return 77;
++  }
++
++  cl_context context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
++  CHECK_ERROR(err);
++  cl_queue_properties props[] = {0};
++  cl_command_queue queue =
++      clCreateCommandQueueWithProperties(context, device, props, &err);
++  CHECK_ERROR(err);
++
++  const size_t N = 8;
++  DeviceArray A = {NULL, sizeof(cl_long) * N, N, N};
++  A.ptr = clSVMAlloc(context, CL_MEM_READ_WRITE, sizeof(cl_long) * N, 0);
++  if (A.ptr == NULL) {
++    printf("SVM allocation failed\n");
++    return 1;
++  }
++  for (size_t i = 0; i < N; i++)
++    A.ptr[i] = -1;
++
++  FILE *f = fopen(SRCDIR "/test_peeled_wi_global_id.spv", "rb");
++  if (!f) {
++    printf("Failed to open test_peeled_wi_global_id.spv\n");
++    return 1;
++  }
++  fseek(f, 0, SEEK_END);
++  size_t size = ftell(f);
++  fseek(f, 0, SEEK_SET);
++  unsigned char *binary = malloc(size);
++  fread(binary, 1, size, f);
++  fclose(f);
++
++  cl_program program = clCreateProgramWithIL(context, binary, size, &err);
++  CHECK_ERROR(err);
++  err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
++  if (err != CL_SUCCESS) {
++    size_t log_size;
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
++                          &log_size);
++    char *log = malloc(log_size);
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size, log,
++                          NULL);
++    printf("Build error:\n%s\n", log);
++    return 1;
++  }
++  cl_kernel kernel = clCreateKernel(program, KERNEL_NAME, &err);
++  CHECK_ERROR(err);
++
++  Ctx ctx = {(cl_long)N, 1};
++  void *svm_ptrs[] = {A.ptr};
++  CHECK_ERROR(clSetKernelExecInfo(kernel, CL_KERNEL_EXEC_INFO_SVM_PTRS,
++                                  sizeof(void *), svm_ptrs));
++  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(Ctx), &ctx));
++  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(DeviceArray), &A));
++
++  size_t global_size = N, local_size = N;
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size,
++                                     &local_size, 0, NULL, NULL));
++  CHECK_ERROR(clFinish(queue));
++
++  int failed = 0;
++  for (size_t i = 0; i < N; i++)
++    if (A.ptr[i] != (cl_long)(i + 1)) {
++      printf("A[%zu] = %lld, expected %zu\n", i, (long long)A.ptr[i], i + 1);
++      failed = 1;
++    }
++
++  clSVMFree(context, A.ptr);
++  clReleaseKernel(kernel);
++  clReleaseProgram(program);
++  clReleaseCommandQueue(queue);
++  clReleaseContext(context);
++  free(binary);
++
++  if (failed)
++    return 1;
++  printf("OK\n");
++  return 0;
++}

--- a/P/pocl/pocl/bundled/patches/pocl/0004-clSetKernelExecInfo-fix-out-of-bounds-read-of-the-US.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0004-clSetKernelExecInfo-fix-out-of-bounds-read-of-the-US.patch
@@ -1,0 +1,166 @@
+From 333b161e41f08b9cfe90787e65b7de29715b2c35 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Thu, 4 Jun 2026 15:58:51 +0200
+Subject: [PATCH 04/16] clSetKernelExecInfo: fix out-of-bounds read of the USM
+ indirect pointer list.
+
+---
+ lib/CL/clSetKernelExecInfo.c              |   2 +-
+ tests/regression/CMakeLists.txt           |   3 +
+ tests/regression/test_usm_indirect_ptrs.c | 113 ++++++++++++++++++++++
+ 3 files changed, 117 insertions(+), 1 deletion(-)
+ create mode 100644 tests/regression/test_usm_indirect_ptrs.c
+
+diff --git a/lib/CL/clSetKernelExecInfo.c b/lib/CL/clSetKernelExecInfo.c
+index 9be7c81a2..321ead47f 100644
+--- a/lib/CL/clSetKernelExecInfo.c
++++ b/lib/CL/clSetKernelExecInfo.c
+@@ -105,7 +105,7 @@ POname(clSetKernelExecInfo)(cl_kernel kernel,
+         if (param_name == CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL
+             && ret_val == CL_SUCCESS)
+           pocl_reset_indirect_ptrs (kernel, (void **)param_value,
+-                                    param_value_size);
++                                    param_value_size / sizeof (void *));
+         return ret_val;
+       }
+ 
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index 44fd7ea07..0458e6583 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -31,6 +31,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
+      test_issue_1711 test_issue_1794 test_issue_1747
+      test_rematerialized_alloca_load_with_outside_pr_users
+      test_peeled_wi_global_id
++     test_usm_indirect_ptrs
+ )
+ foreach(PROG ${C_PROGRAMS_TO_BUILD})
+   add_executable("${PROG}" "${PROG}.c")
+@@ -142,6 +143,8 @@ add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "$
+ 
+ add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+ 
++add_test_pocl(NAME "regression/test_usm_indirect_ptrs" COMMAND "test_usm_indirect_ptrs")
++
+ add_test_pocl(NAME "regression/test_issue_893" COMMAND "test_issue_893")
+ 
+ add_test_pocl(NAME "regression/test_flatten_barrier_subs" COMMAND "test_flatten_barrier_subs" EXPECTED_OUTPUT "test_flatten_barrier_subs.output")
+diff --git a/tests/regression/test_usm_indirect_ptrs.c b/tests/regression/test_usm_indirect_ptrs.c
+new file mode 100644
+index 000000000..88c159eb8
+--- /dev/null
++++ b/tests/regression/test_usm_indirect_ptrs.c
+@@ -0,0 +1,113 @@
++/* Regression test for the clSetKernelExecInfo(CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL)
++   out-of-bounds read (reported downstream as JuliaGPU/OpenCL.jl#317).
++
++   clSetKernelExecInfo passed the parameter's *byte size* to pocl_reset_indirect_ptrs(),
++   which expects an *element count*, so it read 8x past the caller's pointer array. With a
++   large indirect-USM-pointer list the over-read runs off the mapping and segfaults; with a
++   small one it merely reads uninitialized memory. This test passes a large list and simply
++   checks that the call returns without crashing.
++
++   Copyright (c) 2026 Tim Besard
++
++   Permission is hereby granted, free of charge, to any person obtaining a copy
++   of this software and associated documentation files (the "Software"), to
++   deal in the Software without restriction, including without limitation the
++   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++   sell copies of the Software, and to permit persons to whom the Software is
++   furnished to do so, subject to the following conditions:
++
++   The above copyright notice and this permission notice shall be included in
++   all copies or substantial portions of the Software.
++
++   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
++   IN THE SOFTWARE.
++*/
++
++#include "pocl_opencl.h"
++
++#include <CL/cl_ext.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#define CHECK_ERROR(err)                                                      \
++  if (err != CL_SUCCESS)                                                      \
++    {                                                                         \
++      printf ("OpenCL error %d at %s:%d\n", err, __FILE__, __LINE__);         \
++      return EXIT_FAILURE;                                                    \
++    }
++
++static const char *kernel_source = "__kernel void foo (void) { }";
++
++int
++main (void)
++{
++  cl_context context;
++  cl_device_id device;
++  cl_command_queue queue;
++  cl_platform_id platform;
++
++  cl_int err = poclu_get_any_device2 (&context, &device, &queue, &platform);
++  CHECK_ERROR (err);
++
++  /* Requires the USM extension. */
++  char exts[4096] = { 0 };
++  clGetDeviceInfo (device, CL_DEVICE_EXTENSIONS, sizeof (exts), exts, NULL);
++  if (strstr (exts, "cl_intel_unified_shared_memory") == NULL)
++    {
++      printf ("SKIP: device does not support cl_intel_unified_shared_memory\n");
++      return 77;
++    }
++
++  void *(*clDeviceMemAllocINTEL) (cl_context, cl_device_id,
++                                  const cl_mem_properties_intel *, size_t,
++                                  cl_uint, cl_int *)
++    = clGetExtensionFunctionAddressForPlatform (platform,
++                                                "clDeviceMemAllocINTEL");
++  cl_int (*clMemFreeINTEL) (cl_context, void *)
++    = clGetExtensionFunctionAddressForPlatform (platform, "clMemFreeINTEL");
++  if (clDeviceMemAllocINTEL == NULL || clMemFreeINTEL == NULL)
++    {
++      printf ("SKIP: USM allocation entry points not found\n");
++      return 77;
++    }
++
++  cl_program program
++    = clCreateProgramWithSource (context, 1, &kernel_source, NULL, &err);
++  CHECK_ERROR (err);
++  err = clBuildProgram (program, 1, &device, NULL, NULL, NULL);
++  CHECK_ERROR (err);
++  cl_kernel kernel = clCreateKernel (program, "foo", &err);
++  CHECK_ERROR (err);
++
++  void *usm = clDeviceMemAllocINTEL (context, device, NULL, 64, 0, &err);
++  CHECK_ERROR (err);
++
++  /* A large indirect-pointer list: an 8x over-read (8 MiB -> 64 MiB) is sure to
++     run off the array's mapping. The pointers are all valid USM pointers; only
++     the length of the read decides whether the call faults. */
++  const size_t n = 1 << 20;
++  void **ptrs = (void **)malloc (n * sizeof (void *));
++  for (size_t i = 0; i < n; ++i)
++    ptrs[i] = usm;
++
++  err = clSetKernelExecInfo (kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL,
++                             n * sizeof (void *), ptrs);
++  CHECK_ERROR (err);
++
++  free (ptrs);
++  err = clMemFreeINTEL (context, usm);
++  CHECK_ERROR (err);
++  clReleaseKernel (kernel);
++  clReleaseProgram (program);
++  clReleaseCommandQueue (queue);
++  clReleaseContext (context);
++
++  printf ("OK\n");
++  return EXIT_SUCCESS;
++}

--- a/P/pocl/pocl/bundled/patches/pocl/0005-Support-RENAME_POCL-on-macOS.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0005-Support-RENAME_POCL-on-macOS.patch
@@ -1,0 +1,46 @@
+From b26ca6e72179c06ae7d25948b3d504300eb68ac7 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Mon, 8 Jun 2026 17:37:54 +0200
+Subject: [PATCH 05/16] Support RENAME_POCL on macOS
+
+On Apple, pocl_cl.h hardcoded `POname(name) name`, so building with
+-DENABLE_ICD=OFF -DRENAME_POCL=ON had no effect there: the library still
+exported the unprefixed cl* entrypoints instead of the PO-prefixed ones.
+
+Gate the Apple symbol macros on `RENAME_POCL && !BUILD_ICD`, mirroring the
+ELF path: rename to PO<name>, forward-declare the PO-prefixed entrypoints via
+POdeclsym (so internal callers see a prototype), and export them through
+POCL_EXPORT's default visibility. The ICD build (BUILD_ICD defined) is
+unaffected. Apple has no ELF-style aliases, so the unprefixed cl* names are
+not provided in this mode (as is already the case on ELF with RENAME_POCL).
+---
+ lib/CL/pocl_cl.h | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/lib/CL/pocl_cl.h b/lib/CL/pocl_cl.h
+index 2da055797..4d8bc1e9f 100644
+--- a/lib/CL/pocl_cl.h
++++ b/lib/CL/pocl_cl.h
+@@ -262,9 +262,22 @@ extern pocl_obj_id_t last_object_id;
+ #ifdef __APPLE__
+ /* Note: OSX doesn't support aliases because it doesn't use ELF */
+ 
++#if defined(RENAME_POCL) && !defined(BUILD_ICD)
++/* Rename the OpenCL API entrypoints to PO<name>, so the (directly linkable)
++ * library can coexist with another OpenCL implementation in the same process.
++ * Apple has no ELF-style symbol aliases, so unlike the ELF path we cannot also
++ * export the unprefixed cl* names; only the PO-prefixed ones are provided.
++ * As on the ELF path, POdeclsym forward-declares the PO-prefixed entrypoints
++ * (so internal callers see a prototype) and POCL_EXPORT gives them default
++ * visibility so they are exported from the library. */
++#  define POname(name) PO##name
++#  define POdeclsym(name) POCL_EXPORT __typeof__ (name) PO##name;
++#  define POdeclsymExport(name) POdeclsym(name)
++#else
+ #  define POname(name) name
+ #  define POdeclsym(name)
+ #  define POdeclsymExport(name)
++#endif
+ #  define POsym(name)
+ #  define POsymAlways(name)
+ 

--- a/P/pocl/pocl/bundled/patches/pocl/0006-kernel-fix-sub-group-queries-for-non-divisible-work-.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0006-kernel-fix-sub-group-queries-for-non-divisible-work-.patch
@@ -1,0 +1,113 @@
+From 7601a14db32d3ec48900dcb71dfcee8fb80a7037 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Wed, 10 Jun 2026 17:31:21 +0200
+Subject: [PATCH 06/16] kernel: fix sub-group queries for non-divisible
+ work-group sizes
+
+When the work-group size is not evenly divisible by the sub-group size
+(e.g. with intel_reqd_sub_group_size set to a value larger than, or not
+dividing, the work-group size), the last sub-group of a work-group is
+smaller than the maximum sub-group size. The generic CPU implementation
+did not account for this:
+
+- get_num_sub_groups() used truncating division, returning 0 for
+  work-groups smaller than the sub-group size, and undercounting
+  whenever there is a partial trailing sub-group;
+- get_sub_group_size() always returned the maximum sub-group size,
+  even for the (smaller) last sub-group, causing the sub-group
+  reductions/scans/ballot to access work-items beyond the work-group;
+- get_enqueued_num_sub_groups() hardcoded 1.
+
+Also fix the CUDA implementation of get_num_sub_groups(), which
+counted the sub-groups of the entire NDRange instead of those of a
+single work-group.
+
+Fixes part of #2181.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ lib/kernel/subgroups.cl | 54 ++++++++++++++++++++++++++---------------
+ 1 file changed, 34 insertions(+), 20 deletions(-)
+
+diff --git a/lib/kernel/subgroups.cl b/lib/kernel/subgroups.cl
+index 283747747..ca12f3498 100644
+--- a/lib/kernel/subgroups.cl
++++ b/lib/kernel/subgroups.cl
+@@ -36,6 +36,7 @@ extern uint _pocl_sub_group_size;
+ size_t _CL_OVERLOADABLE get_local_id (unsigned int dimindx);
+ size_t _CL_OVERLOADABLE get_local_linear_id (void);
+ size_t _CL_OVERLOADABLE get_local_size (unsigned int dimindx);
++size_t _CL_OVERLOADABLE get_enqueued_local_size (unsigned int dimindx);
+ 
+ void _CL_OVERLOADABLE _CL_CONVERGENT work_group_barrier(cl_mem_fence_flags);
+ void _CL_OVERLOADABLE
+@@ -68,29 +69,10 @@ sub_group_all (int predicate)
+   return sub_group_reduce_min ((unsigned)predicate);
+ }
+ 
+-uint _CL_OVERLOADABLE
+-get_sub_group_size (void)
+-{
+-  return _pocl_sub_group_size;
+-}
+-
+ uint _CL_OVERLOADABLE
+ get_max_sub_group_size (void)
+ {
+-  return get_sub_group_size ();
+-}
+-
+-uint _CL_OVERLOADABLE
+-get_num_sub_groups (void)
+-{
+-  return (uint)get_local_size (0) * get_local_size (1) * get_local_size (2)
+-         / get_max_sub_group_size ();
+-}
+-
+-uint _CL_OVERLOADABLE
+-get_enqueued_num_sub_groups (void)
+-{
+-  return 1;
++  return _pocl_sub_group_size;
+ }
+ 
+ uint _CL_OVERLOADABLE
+@@ -99,6 +81,38 @@ get_sub_group_id (void)
+   return (uint)get_local_linear_id () / get_max_sub_group_size ();
+ }
+ 
++uint _CL_OVERLOADABLE
++get_sub_group_size (void)
++{
++  /* The last sub-group of the work-group can have fewer work-items than
++     the maximum sub-group size when the work-group size is not evenly
++     divisible by it. */
++  uint wg_size
++    = (uint)get_local_size (0) * get_local_size (1) * get_local_size (2);
++  uint remaining = wg_size - get_sub_group_id () * get_max_sub_group_size ();
++  return remaining < get_max_sub_group_size () ? remaining
++                                               : get_max_sub_group_size ();
++}
++
++uint _CL_OVERLOADABLE
++get_num_sub_groups (void)
++{
++  /* Round up to account for a possibly smaller last sub-group. */
++  uint wg_size
++    = (uint)get_local_size (0) * get_local_size (1) * get_local_size (2);
++  return (wg_size + get_max_sub_group_size () - 1)
++         / get_max_sub_group_size ();
++}
++
++uint _CL_OVERLOADABLE
++get_enqueued_num_sub_groups (void)
++{
++  uint wg_size = (uint)get_enqueued_local_size (0)
++                 * get_enqueued_local_size (1) * get_enqueued_local_size (2);
++  return (wg_size + get_max_sub_group_size () - 1)
++         / get_max_sub_group_size ();
++}
++
+ uint _CL_OVERLOADABLE
+ get_sub_group_local_id (void)
+ {

--- a/P/pocl/pocl/bundled/patches/pocl/0007-Honor-intel_reqd_sub_group_size-in-clGetKernelSubGro.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0007-Honor-intel_reqd_sub_group_size-in-clGetKernelSubGro.patch
@@ -1,0 +1,473 @@
+From 10149732dc89dbef75592d4aacde730cb53c7c20 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Wed, 10 Jun 2026 17:31:35 +0200
+Subject: [PATCH 07/16] Honor intel_reqd_sub_group_size in
+ clGetKernelSubGroupInfo
+
+The host-side sub-group queries assumed the sub-group size always
+equals the local X dimension, ignoring a sub-group size required with
+the intel_reqd_sub_group_size kernel attribute. This made
+CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE and
+CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE disagree with the device-side
+get_max_sub_group_size() and get_num_sub_groups() builtins, breaking
+applications that size per-sub-group state using the host queries and
+index it on the device (e.g. the OpenCL.jl device RNG).
+
+Extract the attribute into the kernel metadata, store it in pocl
+binaries (format version 12; flag-gated so version 11 binaries still
+deserialize), and use it in the CPU drivers' sub-group queries, with
+the sub-group count rounded up to account for a smaller trailing
+sub-group, matching the device-side builtins. Also implement the
+CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL query from
+cl_intel_required_subgroup_size.
+
+Add a regression test verifying that the host- and device-side
+sub-group queries agree, with and without the attribute, including
+work-group sizes that are not evenly divisible by the sub-group size.
+
+Fixes #2181.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ lib/CL/clGetKernelSubGroupInfo.c      |   7 +-
+ lib/CL/devices/basic/basic.c          |  31 +++--
+ lib/CL/pocl_binary.c                  |  25 +++-
+ lib/CL/pocl_cl.h                      |   3 +
+ lib/CL/pocl_llvm_metadata.cc          |  17 +++
+ tests/runtime/CMakeLists.txt          |   5 +-
+ tests/runtime/test_subgroup_queries.c | 193 ++++++++++++++++++++++++++
+ 7 files changed, 265 insertions(+), 16 deletions(-)
+ create mode 100644 tests/runtime/test_subgroup_queries.c
+
+diff --git a/lib/CL/clGetKernelSubGroupInfo.c b/lib/CL/clGetKernelSubGroupInfo.c
+index a44706429..e2cbe6c84 100644
+--- a/lib/CL/clGetKernelSubGroupInfo.c
++++ b/lib/CL/clGetKernelSubGroupInfo.c
+@@ -70,7 +70,8 @@ CL_API_ENTRY cl_int CL_API_ENTRY POname (clGetKernelSubGroupInfo) (
+   POCL_RETURN_ERROR_ON ((dev_i == CL_UINT_MAX), CL_INVALID_KERNEL,
+                         "the kernel was not built for this device\n");
+ 
+-  if (param_name == CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE)
++  if (param_name == CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE
++      || param_name == CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE)
+     {
+       POCL_RETURN_ERROR_ON ((input_value == NULL
+                              || input_value_size < sizeof (size_t)
+@@ -95,6 +96,10 @@ CL_API_ENTRY cl_int CL_API_ENTRY POname (clGetKernelSubGroupInfo) (
+       else
+         POCL_RETURN_GETINFO (size_t, 0);
+ 
++    case CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL:
++      /* Returns 0 if the intel_reqd_sub_group_size attribute is not set. */
++      POCL_RETURN_GETINFO (size_t, kernel->meta->reqd_sub_group_size);
++
+     default:
+       POCL_RETURN_ERROR_ON ((realdev->ops->get_subgroup_info_ext == NULL),
+                             CL_INVALID_VALUE,
+diff --git a/lib/CL/devices/basic/basic.c b/lib/CL/devices/basic/basic.c
+index 008f1fad5..f5ca05ba8 100644
+--- a/lib/CL/devices/basic/basic.c
++++ b/lib/CL/devices/basic/basic.c
+@@ -919,25 +919,32 @@ pocl_basic_get_subgroup_info_ext (cl_device_id device,
+                                   void *param_value,
+                                   size_t *param_value_size_ret)
+ {
++  /* The SG size is the size required with the intel_reqd_sub_group_size
++     kernel attribute, otherwise WG_x. This must be kept in sync with the
++     device-side implementation in lib/kernel/subgroups.cl. */
++  size_t sg_size = kernel->meta->reqd_sub_group_size;
++  if (sg_size == 0 && input_value != NULL && input_value_size >= sizeof (size_t))
++    sg_size = ((size_t *)input_value)[0];
++
+   switch (param_name)
+     {
+     case CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE:
+       {
+-        /* For now assume SG == WG_x. */
+-        POCL_RETURN_GETINFO (size_t, ((size_t *)input_value)[0]);
++        POCL_RETURN_GETINFO (size_t, sg_size);
+       }
+     case CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE:
+       {
+-        /* For now assume SG == WG_x and thus we have WG_size_y*WG_size_z of
+-           them per WG. */
+-        POCL_RETURN_GETINFO (
+-          size_t,
+-          min (device->max_num_sub_groups,
+-               (input_value_size > sizeof (size_t) ? ((size_t *)input_value)[1]
+-                                                   : 1)
+-                 * (input_value_size > sizeof (size_t) * 2
+-                      ? ((size_t *)input_value)[2]
+-                      : 1)));
++        size_t wg_size = ((size_t *)input_value)[0]
++                         * (input_value_size > sizeof (size_t)
++                              ? ((size_t *)input_value)[1]
++                              : 1)
++                         * (input_value_size > sizeof (size_t) * 2
++                              ? ((size_t *)input_value)[2]
++                              : 1);
++        /* Round up to account for a possibly smaller last SG. */
++        size_t sg_count = sg_size ? (wg_size + sg_size - 1) / sg_size : 0;
++        POCL_RETURN_GETINFO (size_t,
++                             min (device->max_num_sub_groups, sg_count));
+       }
+     case CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT:
+       {
+diff --git a/lib/CL/pocl_binary.c b/lib/CL/pocl_binary.c
+index bf2389a21..bf5b0c0c1 100644
+--- a/lib/CL/pocl_binary.c
++++ b/lib/CL/pocl_binary.c
+@@ -52,10 +52,11 @@
+ /* changes for version 8: compilation parameters are stored in module metadata
+  * changes for version 9: support other than "program.bc" files in root dir
+  * changes for version 10: support program scope variables
+- * changes for version 11: support extra subgroup & workgroup metadata */
++ * changes for version 11: support extra subgroup & workgroup metadata
++ * changes for version 12: store the required sub-group size */
+ 
+ #define FIRST_SUPPORTED_POCLCC_VERSION 9
+-#define POCLCC_VERSION 11
++#define POCLCC_VERSION 12
+ 
+ /* pocl binary structures */
+ 
+@@ -68,6 +69,7 @@
+ 
+ #define POCL_KERNEL_HAS_WORKG_META (1 << 1)
+ #define POCL_KERNEL_HAS_SUBG_META (1 << 2)
++#define POCL_KERNEL_HAS_REQD_SUBG_SIZE (1 << 3)
+ 
+ typedef struct pocl_binary_kernel_s
+ {
+@@ -108,6 +110,9 @@ typedef struct pocl_binary_kernel_s
+   /* required work-group size */
+   uint64_t reqd_wg_size[OPENCL_MAX_DIMENSION];
+ 
++  /* required sub-group size */
++  uint32_t reqd_sub_group_size;
++
+   /* Stores: cl_bitfield kernel->meta->has_arg_metadata */
+   uint32_t has_arg_metadata;
+   /* Stores: extra flags (POCL_KERNEL_HAS) */
+@@ -438,6 +443,8 @@ pocl_binary_serialize_kernel_to_buffer(cl_program program,
+       || (meta->preferred_wg_multiple
+           && meta->preferred_wg_multiple[device_i]))
+     flags |= POCL_KERNEL_HAS_WORKG_META;
++  if (meta->reqd_sub_group_size)
++    flags |= POCL_KERNEL_HAS_REQD_SUBG_SIZE;
+   BUFFER_STORE (flags, uint32_t);
+ 
+   if (flags & POCL_KERNEL_HAS_SUBG_META)
+@@ -477,6 +484,12 @@ pocl_binary_serialize_kernel_to_buffer(cl_program program,
+       BUFFER_STORE (tmp, uint32_t);
+     }
+ 
++  if (flags & POCL_KERNEL_HAS_REQD_SUBG_SIZE)
++    {
++      uint32_t tmp = meta->reqd_sub_group_size;
++      BUFFER_STORE (tmp, uint32_t);
++    }
++
+   /***********************************************************************/
+   unsigned char *start = buffer;
+   for (i = 0; i < meta->num_args; i++)
+@@ -644,6 +657,11 @@ pocl_binary_deserialize_kernel_from_buffer (pocl_binary *b,
+           BUFFER_READ (kernel->spill_mem_size, uint32_t);
+         }
+ 
++      if (kernel->flags & POCL_KERNEL_HAS_REQD_SUBG_SIZE)
++        {
++          BUFFER_READ (kernel->reqd_sub_group_size, uint32_t);
++        }
++
+       meta->arg_info = calloc (kernel->num_args, sizeof (struct pocl_argument_info));
+       POCL_RETURN_ERROR_COND ((!meta->arg_info), CL_OUT_OF_HOST_MEMORY);
+ 
+@@ -948,6 +966,9 @@ pocl_binary_get_kernels_metadata (cl_program program, unsigned device_i)
+           km->spill_mem_size[device_i] = k.spill_mem_size;
+         }
+ 
++      if (k.flags & POCL_KERNEL_HAS_REQD_SUBG_SIZE)
++        km->reqd_sub_group_size = k.reqd_sub_group_size;
++
+       unsigned l;
+       for (l = 0; l < OPENCL_MAX_DIMENSION; l++)
+         {
+diff --git a/lib/CL/pocl_cl.h b/lib/CL/pocl_cl.h
+index 4d8bc1e9f..8ad2f9ad0 100644
+--- a/lib/CL/pocl_cl.h
++++ b/lib/CL/pocl_cl.h
+@@ -1882,6 +1882,9 @@ typedef struct pocl_kernel_metadata_s
+   size_t reqd_wg_size[OPENCL_MAX_DIMENSION];
+   size_t wg_size_hint[OPENCL_MAX_DIMENSION];
+   char vectypehint[16];
++  /* required sub-group size set with the intel_reqd_sub_group_size kernel
++     attribute; 0 if not set */
++  size_t reqd_sub_group_size;
+ 
+   /* if we know the size of _every_ kernel argument, we store
+    * the total size here. see struct _cl_kernel on why */
+diff --git a/lib/CL/pocl_llvm_metadata.cc b/lib/CL/pocl_llvm_metadata.cc
+index 19b1263ed..59fccc7c8 100644
+--- a/lib/CL/pocl_llvm_metadata.cc
++++ b/lib/CL/pocl_llvm_metadata.cc
+@@ -569,6 +569,16 @@ int pocl_llvm_get_kernels_metadata(cl_program program, unsigned device_i) {
+                    ReqdWGSize->getOperand(2))->getValue()))->getLimitedValue();
+     }
+ 
++    llvm::MDNode *ReqdSGSize =
++        KernelFunction->getMetadata("intel_reqd_sub_group_size");
++    if (ReqdSGSize != nullptr) {
++      meta->reqd_sub_group_size =
++          (llvm::cast<ConstantInt>(
++               llvm::dyn_cast<ConstantAsMetadata>(ReqdSGSize->getOperand(0))
++                   ->getValue()))
++              ->getLimitedValue();
++    }
++
+     llvm::MDNode *WGSizeHint =
+         KernelFunction->getMetadata("work_group_size_hint");
+     if (WGSizeHint != nullptr) {
+@@ -673,6 +683,13 @@ int pocl_llvm_get_kernels_metadata(cl_program program, unsigned device_i) {
+               << ", " << reqdz << " )))";
+     }
+ 
++    if (meta->reqd_sub_group_size) {
++      if (attrstr.tellp() > 0)
++        attrstr << " ";
++      attrstr << "__attribute__((intel_reqd_sub_group_size("
++              << meta->reqd_sub_group_size << ")))";
++    }
++
+     if (wghintx || wghinty || wghintz) {
+       meta->wg_size_hint[0] = wghintx;
+       meta->wg_size_hint[1] = wghinty;
+diff --git a/tests/runtime/CMakeLists.txt b/tests/runtime/CMakeLists.txt
+index 1154f36a7..5b2f4b929 100644
+--- a/tests/runtime/CMakeLists.txt
++++ b/tests/runtime/CMakeLists.txt
+@@ -47,7 +47,7 @@ set(C_PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
+   test_cl_pocl_content_size test_cl_pocl_content_size_migration
+   test_deviceside_enqueue test_command_buffer test_command_buffer_images
+   test_command_buffer_multi_device test_queue_creation_with_hints
+-  test_remote_discovery test_dbk_color_convert)
++  test_remote_discovery test_dbk_color_convert test_subgroup_queries)
+ 
+ if(HAVE_ONNXRT)
+   list(APPEND C_PROGRAMS_TO_BUILD test_dbk_onnx_inference)
+@@ -112,6 +112,8 @@ add_test_pocl(NAME "runtime/clCreateKernel" COMMAND "test_clCreateKernel" WORKIT
+ 
+ add_test_pocl(NAME "runtime/clGetKernelArgInfo" COMMAND "test_clGetKernelArgInfo" WORKITEM_HANDLER "loopvec")
+ 
++add_test_pocl(NAME "runtime/test_subgroup_queries" COMMAND "test_subgroup_queries" WORKITEM_HANDLER "loopvec")
++
+ add_test_pocl(NAME "runtime/clSetEventCallback"
+               COMMAND "test_clSetEventCallback"
+               EXPECTED_OUTPUT "test_clSetEventCallback_expout.txt"
+@@ -242,6 +244,7 @@ set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
+   "runtime/test_queue_creation_with_hints"
+   "runtime/clGetKernelArgInfo"
+   "runtime/clCreateSubDevices"
++  "runtime/test_subgroup_queries"
+   PROPERTIES
+     COST 2.0
+     PROCESSORS 1
+diff --git a/tests/runtime/test_subgroup_queries.c b/tests/runtime/test_subgroup_queries.c
+new file mode 100644
+index 000000000..6c51e0196
+--- /dev/null
++++ b/tests/runtime/test_subgroup_queries.c
+@@ -0,0 +1,193 @@
++/* Test that the host-side (clGetKernelSubGroupInfo) and device-side
++   (get_num_sub_groups etc.) sub-group queries agree, also when a sub-group
++   size is required with the intel_reqd_sub_group_size kernel attribute
++   (issue #2181).
++
++   Copyright (c) 2026 Tim Besard
++
++   Permission is hereby granted, free of charge, to any person obtaining a
++   copy of this software and associated documentation files (the "Software"),
++   to deal in the Software without restriction, including without limitation
++   the rights to use, copy, modify, merge, publish, distribute, sublicense,
++   and/or sell copies of the Software, and to permit persons to whom the
++   Software is furnished to do so, subject to the following conditions:
++
++   The above copyright notice and this permission notice shall be included in
++   all copies or substantial portions of the Software.
++
++   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++   DEALINGS IN THE SOFTWARE.
++*/
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#include "poclu.h"
++
++#define REQD_SG_SIZE 32
++
++static const char *SRC_TEMPLATE =
++  "%s\n"
++  "__kernel void\n"
++  "probe (__global uint *num, __global uint *max_size, __global uint *size,\n"
++  "       __global uint *id)\n"
++  "{\n"
++  "  size_t i = get_local_linear_id ();\n"
++  "  num[i] = get_num_sub_groups ();\n"
++  "  max_size[i] = get_max_sub_group_size ();\n"
++  "  size[i] = get_sub_group_size ();\n"
++  "  id[i] = get_sub_group_id ();\n"
++  "}\n";
++
++static const size_t LOCAL_SIZES[][3] = {
++  { 1, 1, 1 }, { 3, 1, 1 }, { 1, 3, 1 },
++  { 32, 1, 1 }, { 33, 1, 1 }, { 64, 1, 1 },
++};
++#define NUM_LOCAL_SIZES (sizeof (LOCAL_SIZES) / sizeof (LOCAL_SIZES[0]))
++#define MAX_LOCAL_SIZE 64
++
++static int
++check_variant (cl_context ctx, cl_device_id dev, cl_command_queue queue,
++               int with_attr)
++{
++  cl_int err;
++  char src[2048];
++  char attr[128] = "";
++  if (with_attr)
++    snprintf (attr, sizeof (attr),
++              "__attribute__ ((intel_reqd_sub_group_size (%d)))",
++              REQD_SG_SIZE);
++  snprintf (src, sizeof (src), SRC_TEMPLATE, attr);
++
++  const char *src_ptr = src;
++  cl_program program = clCreateProgramWithSource (ctx, 1, &src_ptr, NULL,
++                                                  &err);
++  CHECK_OPENCL_ERROR_IN ("clCreateProgramWithSource");
++  err = clBuildProgram (program, 1, &dev, NULL, NULL, NULL);
++  if (err != CL_SUCCESS)
++    poclu_show_program_build_log (program);
++  CHECK_OPENCL_ERROR_IN ("clBuildProgram");
++  cl_kernel kernel = clCreateKernel (program, "probe", &err);
++  CHECK_OPENCL_ERROR_IN ("clCreateKernel");
++
++#ifdef CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL
++  size_t compile_sg_size = 0;
++  err = clGetKernelSubGroupInfo (kernel, dev,
++                                 CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL, 0,
++                                 NULL, sizeof (compile_sg_size),
++                                 &compile_sg_size, NULL);
++  if (err == CL_SUCCESS)
++    TEST_ASSERT (compile_sg_size == (with_attr ? REQD_SG_SIZE : 0));
++#endif
++
++  cl_mem bufs[4];
++  for (unsigned i = 0; i < 4; ++i)
++    {
++      bufs[i] = clCreateBuffer (ctx, CL_MEM_READ_WRITE,
++                                sizeof (cl_uint) * MAX_LOCAL_SIZE, NULL,
++                                &err);
++      CHECK_OPENCL_ERROR_IN ("clCreateBuffer");
++      CHECK_CL_ERROR (clSetKernelArg (kernel, i, sizeof (cl_mem), &bufs[i]));
++    }
++
++  size_t max_wg_size = 0;
++  CHECK_CL_ERROR (clGetDeviceInfo (dev, CL_DEVICE_MAX_WORK_GROUP_SIZE,
++                                   sizeof (max_wg_size), &max_wg_size, NULL));
++
++  for (size_t l = 0; l < NUM_LOCAL_SIZES; ++l)
++    {
++      const size_t *ls = LOCAL_SIZES[l];
++      const size_t wg_size = ls[0] * ls[1] * ls[2];
++      if (wg_size > max_wg_size)
++        continue;
++
++      size_t host_max = 0, host_count = 0;
++      CHECK_CL_ERROR (clGetKernelSubGroupInfo (
++        kernel, dev, CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE,
++        sizeof (size_t) * 3, ls, sizeof (host_max), &host_max, NULL));
++      CHECK_CL_ERROR (clGetKernelSubGroupInfo (
++        kernel, dev, CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE,
++        sizeof (size_t) * 3, ls, sizeof (host_count), &host_count, NULL));
++
++      TEST_ASSERT (host_max > 0);
++      if (with_attr)
++        TEST_ASSERT (host_max == REQD_SG_SIZE);
++      /* the count must include a possibly smaller trailing sub-group */
++      TEST_ASSERT (host_count == (wg_size + host_max - 1) / host_max);
++
++      CHECK_CL_ERROR (clEnqueueNDRangeKernel (queue, kernel, 3, NULL, ls, ls,
++                                              0, NULL, NULL));
++
++      cl_uint dev_num[MAX_LOCAL_SIZE], dev_max[MAX_LOCAL_SIZE],
++        dev_size[MAX_LOCAL_SIZE], dev_id[MAX_LOCAL_SIZE];
++      cl_uint *results[4] = { dev_num, dev_max, dev_size, dev_id };
++      for (unsigned i = 0; i < 4; ++i)
++        CHECK_CL_ERROR (clEnqueueReadBuffer (queue, bufs[i], CL_TRUE, 0,
++                                             sizeof (cl_uint) * wg_size,
++                                             results[i], 0, NULL, NULL));
++
++      for (size_t i = 0; i < wg_size; ++i)
++        {
++          /* the device-side queries must agree with the host */
++          TEST_ASSERT (dev_num[i] == host_count);
++          TEST_ASSERT (dev_max[i] == host_max);
++
++          /* every work-item must see the actual size of its sub-group,
++             where the last sub-group may be smaller than the maximum */
++          size_t sg = i / host_max;
++          size_t expected_size = wg_size - sg * host_max;
++          if (expected_size > host_max)
++            expected_size = host_max;
++          TEST_ASSERT (dev_id[i] == sg);
++          TEST_ASSERT (dev_size[i] == expected_size);
++        }
++    }
++
++  for (unsigned i = 0; i < 4; ++i)
++    CHECK_CL_ERROR (clReleaseMemObject (bufs[i]));
++  CHECK_CL_ERROR (clReleaseKernel (kernel));
++  CHECK_CL_ERROR (clReleaseProgram (program));
++  return CL_SUCCESS;
++}
++
++int
++main (int argc, char **argv)
++{
++  cl_context ctx;
++  cl_device_id dev;
++  cl_command_queue queue;
++  cl_platform_id platform;
++
++  CHECK_CL_ERROR (poclu_get_any_device2 (&ctx, &dev, &queue, &platform));
++
++  cl_uint max_num_sub_groups = 0;
++  clGetDeviceInfo (dev, CL_DEVICE_MAX_NUM_SUB_GROUPS,
++                   sizeof (max_num_sub_groups), &max_num_sub_groups, NULL);
++  if (max_num_sub_groups == 0)
++    {
++      printf ("SKIP: device does not support sub-groups\n");
++      return 77;
++    }
++
++  CHECK_CL_ERROR (check_variant (ctx, dev, queue, 0));
++
++  /* only test intel_reqd_sub_group_size where supported */
++  char extensions[4096];
++  CHECK_CL_ERROR (clGetDeviceInfo (dev, CL_DEVICE_EXTENSIONS,
++                                   sizeof (extensions), extensions, NULL));
++  if (strstr (extensions, "cl_intel_required_subgroup_size") != NULL)
++    CHECK_CL_ERROR (check_variant (ctx, dev, queue, 1));
++
++  CHECK_CL_ERROR (clReleaseCommandQueue (queue));
++  CHECK_CL_ERROR (clReleaseContext (ctx));
++  CHECK_CL_ERROR (clUnloadPlatformCompiler (platform));
++
++  printf ("OK\n");
++  return EXIT_SUCCESS;
++}

--- a/P/pocl/pocl/bundled/patches/pocl/0008-Hide-statically-linked-LLVM-symbols-on-macOS-in-the-.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0008-Hide-statically-linked-LLVM-symbols-on-macOS-in-the-.patch
@@ -1,0 +1,68 @@
+From cd0d3970227e09382f57a5c715d42ed62e1baf00 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Wed, 10 Jun 2026 10:43:49 +0200
+Subject: [PATCH 08/16] Hide statically-linked LLVM symbols on macOS in the
+ CMake-package setup
+
+When LLVM is found through LLVMConfig.cmake (SetupLLVMviaCMake.cmake,
+mandatory when cross-compiling since LLVM_DIR is required), the LLVM and
+Clang static archives were linked into libpocl as plain imported
+targets, re-exporting every LLVM symbol. On ELF this is harmless
+because libpocl links with --exclude-libs,ALL, but Mach-O's ld64 has no
+such flag: the ~19k exported LLVM symbols include thousands of weak
+definitions (cl::opt vtables, template instantiations) that dyld
+coalesces across images. Any host application that carries its own,
+different LLVM then resolves libpocl's weak references against the
+host's copy, crashing on the first virtual call with a wild jump.
+Observed with Julia, which loads its own libLLVM (18) and whose
+libraries carry weak instantiations of the same LLVM header templates:
+loading a libpocl statically linked against LLVM 20 crashed with a bus
+error inside InitializeLLVM during plain clCreateContext, libpocl's
+cl::opt registration having been coalesced onto the LLVM-18 host code.
+
+SetupLLVMviaBinary.cmake already solves this for the llvm-config path
+by loading the archives with ld64's -hidden-l, which marks every symbol
+they contribute private-extern. Do the same in the CMake-package path:
+on APPLE with STATIC_LLVM and VISIBILITY_HIDDEN, convert the component
+targets to -Wl,-hidden-l<name> flags (component target names equal the
+archive base names), walking each target's INTERFACE_LINK_LIBRARIES
+transitively -- unwrapping $<LINK_ONLY:...> entries so those components
+are hidden rather than relinked plainly -- and keeping the non-LLVM
+dependencies (m, ZLIB::ZLIB, zstd::libzstd_*, ...) on the regular link
+list. Also load a static libLLVMSPIRVLib through -hidden-l, since its
+objects carry the same weak LLVM template instantiations.
+
+With this, a macOS libpocl built via the CMake package path exports the
+same minimal symbol set as the llvm-config path (417 vs. 54539 before,
+none of them LLVM, no weak externals), and coexists with a second LLVM
+in the process.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ lib/CL/CMakeLists.txt | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/lib/CL/CMakeLists.txt b/lib/CL/CMakeLists.txt
+index 471b80aab..6028f059b 100644
+--- a/lib/CL/CMakeLists.txt
++++ b/lib/CL/CMakeLists.txt
+@@ -357,7 +357,18 @@ if(ENABLE_LLVM)
+   list(APPEND POCL_PRIVATE_LINK_LIBRARIES ${LLVM_SYSLIBS})
+ 
+   if (HAVE_LLVM_SPIRV_LIB)
+-    list(PREPEND POCL_PRIVATE_LINK_LIBRARIES ${LLVM_SPIRV_LIB})
++    if(APPLE AND VISIBILITY_HIDDEN AND LLVM_SPIRV_LIB MATCHES "\\.a$")
++      # like the LLVM/Clang archives (see LLVM.cmake), keep the
++      # translator's symbols (including weak LLVM template instantiations from
++      # its objects) out of libpocl's exports; ld64 has no --exclude-libs, so
++      # load the archive with -hidden-l instead.
++      get_filename_component(LLVM_SPIRV_LIB_DIR "${LLVM_SPIRV_LIB}" DIRECTORY)
++      get_filename_component(LLVM_SPIRV_LIB_NAME "${LLVM_SPIRV_LIB}" NAME_WE)
++      string(REGEX REPLACE "^lib" "" LLVM_SPIRV_LIB_NAME "${LLVM_SPIRV_LIB_NAME}")
++      list(PREPEND POCL_PRIVATE_LINK_LIBRARIES "-L${LLVM_SPIRV_LIB_DIR}" "-Wl,-hidden-l${LLVM_SPIRV_LIB_NAME}")
++    else()
++      list(PREPEND POCL_PRIVATE_LINK_LIBRARIES ${LLVM_SPIRV_LIB})
++    endif()
+   endif()
+ endif()
+ 

--- a/P/pocl/pocl/bundled/patches/pocl/0009-cmake-gate-the-SIGFPE-handler-on-x86-64-not-all-x86.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0009-cmake-gate-the-SIGFPE-handler-on-x86-64-not-all-x86.patch
@@ -1,0 +1,37 @@
+From 9d52d6600b5717f2c20a42d3862754014937f849 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Tue, 16 Jun 2026 18:53:47 +0200
+Subject: [PATCH 09/16] cmake: gate the SIGFPE handler on x86-64, not all x86
+
+The SIGFPE handler (lib/CL/devices/signal_handlers.c) skips the faulting
+floating-point instruction from within the handler, which is implemented only
+for x86-64: the relevant code, including pocl_ignore_sigfpe_for_thread(), is
+guarded by `#ifdef __x86_64__`. The CMake default was gated on X86, which also
+matches 32-bit x86 (i686). There the option defaulted on, so the pthread
+scheduler compiled its `#ifdef ENABLE_SIGFPE_HANDLER` call to
+pocl_ignore_sigfpe_for_thread(), which has no definition on i686.
+
+This stays latent while the CPU driver is a separate dlopen()ed module (shared
+objects tolerate undefined symbols), but breaks linking once the driver is
+linked into libpocl (ENABLE_LOADABLE_DRIVERS=OFF): the poclcc and example
+executables then fail with
+`undefined reference to pocl_ignore_sigfpe_for_thread`.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8c3fbe7a2..a9dfacbbc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -786,7 +786,7 @@ endif()
+ # SIGFPE and SIGUSR2
+ if(UNIX AND (CMAKE_SYSTEM_NAME MATCHES "Linux"))
+   # this is now handled by a LLVM pass
+-  if(ENABLE_HOST_CPU_DEVICES AND X86 AND
++  if(ENABLE_HOST_CPU_DEVICES AND X86_64 AND
+      (NOT ENABLE_HOST_CPU_DEVICES_OPENMP) AND
+      (NOT ENABLE_TBB_DEVICE))
+     set(DEFAULT_SIGFPE ON)

--- a/P/pocl/pocl/bundled/patches/pocl/0010-MinGW-support-building-with-the-Clang-lld-toolchain.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0010-MinGW-support-building-with-the-Clang-lld-toolchain.patch
@@ -1,0 +1,118 @@
+From 21d408ea0adbfd59934d5720132c0e7f412af98e Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Fri, 26 Jun 2026 13:08:50 +0200
+Subject: [PATCH 10/16] MinGW: support building with the Clang/lld toolchain
+
+GNU ld is pathologically slow at linking the static LLVM/Clang archives
+into a PE/COFF DLL (tens of minutes for libpocl). ld.lld is far faster,
+but its COFF driver doesn't implement GNU ld's --exclude-libs, which
+libpocl used to keep the static-lib symbols out of its auto-generated
+export table. Without that, auto-exporting the whole static LLVM blob
+overflows the 64K PE export-ordinal limit.
+
+Switch MinGW to the MSVC-style export model, which works with both GNU ld
+and lld:
+
+- stamp __declspec(dllexport) on the OpenCL API for any Windows toolchain
+  (defined(_WIN32)), not just _MSC_VER;
+- define EXPORT_POCL_LIB / IMPORT_POCL_LIB for any WIN32 shared build, not
+  just MSVC;
+- export only the dllexport'd symbols (--exclude-all-symbols) instead of
+  auto-export-minus-static-libs (--exclude-libs).
+
+Because libpocl now exports only its public API, its internal symbols are
+no longer visible to separately-dlopen'd driver modules, so consumers must
+build with ENABLE_LOADABLE_DRIVERS=OFF (drivers linked into libpocl).
+
+Also make the spirv_fix_atomic_compare_exchange helper compile its own copy
+of spirv_parser.cc in the non-ICD case, mirroring the ICD branch, so it no
+longer relies on SPIRVParser being exported from libpocl.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ bin/CMakeLists.txt    |  3 ++-
+ include/pocl.h        |  2 +-
+ lib/CL/CMakeLists.txt | 12 ++++++------
+ 3 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/bin/CMakeLists.txt b/bin/CMakeLists.txt
+index 4038586e0..e0d53f582 100644
+--- a/bin/CMakeLists.txt
++++ b/bin/CMakeLists.txt
+@@ -34,7 +34,8 @@ if(ENABLE_SPIRV)
+     # Avoid POCL_EXPORT here
+     target_compile_definitions(spirv_fix_atomic_compare_exchange PRIVATE SPIRV_PARSER_LIB)
+   else()
+-    add_executable(spirv_fix_atomic_compare_exchange spirv_fix_atomic_compare_exchange.cc)
++    add_executable(spirv_fix_atomic_compare_exchange spirv_fix_atomic_compare_exchange.cc "${SPVSRC}/spirv_parser.hh" "${SPVSRC}/spirv_parser.cc")
++    target_compile_definitions(spirv_fix_atomic_compare_exchange PRIVATE SPIRV_PARSER_LIB)
+   endif()
+   harden(spirv_fix_atomic_compare_exchange)
+   target_link_libraries(spirv_fix_atomic_compare_exchange poclu ${OPENCL_LIBS})
+diff --git a/include/pocl.h b/include/pocl.h
+index 3269f931b..76dd71333 100644
+--- a/include/pocl.h
++++ b/include/pocl.h
+@@ -40,7 +40,7 @@
+    0 marks an invalid/undefined object. */
+ typedef uint64_t pocl_obj_id_t;
+ 
+-#if defined(EXPORT_POCL_LIB) && defined(_MSC_VER)
++#if defined(EXPORT_POCL_LIB) && defined(_WIN32)
+ /* To successfully export OpenCL API, the dllexport must be placed on
+  * both the declaration and the definition as MSVC requires that both
+  * of them have the same attributes.
+diff --git a/lib/CL/CMakeLists.txt b/lib/CL/CMakeLists.txt
+index 6028f059b..f8395e500 100644
+--- a/lib/CL/CMakeLists.txt
++++ b/lib/CL/CMakeLists.txt
+@@ -258,7 +258,7 @@ else()
+ endif()
+ 
+ add_library("pocl_cache" OBJECT "pocl_cache.c")
+-if(BUILD_SHARED_LIBS AND MSVC)
++if(BUILD_SHARED_LIBS AND WIN32)
+   # Inject __declspec(dllexport).
+   target_compile_definitions("pocl_cache" PRIVATE EXPORT_POCL_LIB)
+   target_compile_definitions("pocl_cache" INTERFACE IMPORT_POCL_LIB)
+@@ -282,7 +282,7 @@ if (ENABLE_LLVM)
+   add_library("lib_cl_llvm" OBJECT ${LLVM_API_SOURCES})
+   target_include_directories(lib_cl_llvm PRIVATE ${LLVM_INCLUDE_DIRS})
+   harden("lib_cl_llvm")
+-  if(BUILD_SHARED_LIBS AND MSVC)
++  if(BUILD_SHARED_LIBS AND WIN32)
+     # Inject __declspec(dllexport).
+     target_compile_definitions(lib_cl_llvm PRIVATE EXPORT_POCL_LIB)
+     target_compile_definitions(lib_cl_llvm INTERFACE IMPORT_POCL_LIB)
+@@ -328,7 +328,7 @@ add_library("libpocl_unlinked_objs" OBJECT ${POCL_LIB_SOURCES})
+ target_include_directories(libpocl_unlinked_objs
+   PRIVATE ${CMAKE_SOURCE_DIR}/thirdparty/STC/include)
+ 
+-if(BUILD_SHARED_LIBS AND MSVC)
++if(BUILD_SHARED_LIBS AND WIN32)
+   # Inject __declspec(dllexport).
+   target_compile_definitions(libpocl_unlinked_objs PRIVATE EXPORT_POCL_LIB)
+   target_compile_definitions(libpocl_unlinked_objs INTERFACE IMPORT_POCL_LIB)
+@@ -398,7 +398,7 @@ set(POCL_TRANSITIVE_LIBS ${POCL_PRIVATE_LINK_LIBRARIES} PARENT_SCOPE)
+ #################################################################
+ 
+ add_library("${POCL_LIBRARY_NAME}" ${LIBPOCL_OBJS})
+-if(BUILD_SHARED_LIBS AND MSVC)
++if(BUILD_SHARED_LIBS AND WIN32)
+   # Inject __declspec(dllexport).
+   target_compile_definitions("${POCL_LIBRARY_NAME}" PRIVATE EXPORT_POCL_LIB)
+   target_compile_definitions("${POCL_LIBRARY_NAME}" INTERFACE IMPORT_POCL_LIB)
+@@ -406,11 +406,11 @@ endif()
+ 
+ harden("${POCL_LIBRARY_NAME}")
+ 
+-if((UNIX OR MINGW) AND (NOT APPLE))
++if(UNIX AND (NOT APPLE))
+   target_link_options("${POCL_LIBRARY_NAME}" PRIVATE "LINKER:--exclude-libs,ALL")
+ endif()
+ if(MINGW)
+-  target_link_options("${POCL_LIBRARY_NAME}" PRIVATE "LINKER:--enable-auto-import,--enable-runtime-pseudo-reloc")
++  target_link_options("${POCL_LIBRARY_NAME}" PRIVATE "LINKER:--exclude-all-symbols,--enable-auto-import,--enable-runtime-pseudo-reloc")
+ endif()
+ 
+ set_target_properties("${POCL_LIBRARY_NAME}" PROPERTIES SOVERSION "${LIB_API_VERSION}"

--- a/P/pocl/pocl/bundled/patches/pocl/0011-llvmopencl-guard-implicit-barriers-by-source-dominan.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0011-llvmopencl-guard-implicit-barriers-by-source-dominan.patch
@@ -1,0 +1,392 @@
+From 0fc39852bcb9f1f89bba371be00fd2e906d503d8 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Tue, 14 Jul 2026 18:37:46 +0200
+Subject: [PATCH 11/16] llvmopencl: guard implicit barriers by source dominance
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+ImplicitConditionalBarriers can select an insertion block nested below a divergent guard. If another path bypasses that block and still reaches the source barrier, work-item-loop lowering can execute the guarded path for non-participating work-items.
+
+Require the insertion block to dominate the source barrier. This reuses the source barrier’s all-or-none execution guarantee while preserving dynamically uniform lane-indexed bounds checks before inlined subgroup shuffles. Add regressions for both the bypassing and dynamically uniform cases.
+---
+ lib/llvmopencl/ImplicitConditionalBarriers.cc |  10 +-
+ tests/regression/CMakeLists.txt               |   6 +
+ .../test_divergent_implicit_barrier_entry.c   | 148 +++++++++++++++++
+ .../test_uniform_implicit_barrier_entry.c     | 153 ++++++++++++++++++
+ 4 files changed, 313 insertions(+), 4 deletions(-)
+ create mode 100644 tests/regression/test_divergent_implicit_barrier_entry.c
+ create mode 100644 tests/regression/test_uniform_implicit_barrier_entry.c
+
+diff --git a/lib/llvmopencl/ImplicitConditionalBarriers.cc b/lib/llvmopencl/ImplicitConditionalBarriers.cc
+index f8b4635b4..c4519e255 100644
+--- a/lib/llvmopencl/ImplicitConditionalBarriers.cc
++++ b/lib/llvmopencl/ImplicitConditionalBarriers.cc
+@@ -34,8 +34,6 @@ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
+ #include "DebugHelpers.h"
+ #include "ImplicitConditionalBarriers.h"
+ #include "LLVMUtils.h"
+-#include "VariableUniformityAnalysis.h"
+-#include "VariableUniformityAnalysisResult.hh"
+ #include "Workgroup.h"
+ #include "WorkitemHandlerChooser.h"
+ POP_COMPILER_DIAGS
+@@ -95,7 +93,6 @@ ImplicitConditionalBarriers::run(llvm::Function &F,
+   llvm::LoopInfo &LI = FAM.getResult<LoopAnalysis>(F);
+ 
+   PreservedAnalyses PAChanged = PreservedAnalyses::none();
+-  PAChanged.preserve<VariableUniformityAnalysis>();
+   PAChanged.preserve<WorkitemHandlerChooser>();
+   PAChanged.preserve<LoopAnalysis>();
+ 
+@@ -155,7 +152,12 @@ ImplicitConditionalBarriers::run(llvm::Function &F,
+       if (Pred == BB) break; // Traced across a loop edge, skip this case.
+     }
+ 
+-    if (Barrier::hasOnlyBarrier(Pos)) continue;
++    if (Barrier::hasOnlyBarrier(Pos) || !DT.dominates(Pos, BB))
++      continue;
++
++    // Let the source barrier's all-or-none execution guarantee apply to the
++    // implicit barrier only when every path to the source crosses Pos.
++
+     // Inject a barrier at the beginning of the BB and let the
+     // CanonicalizeBarrier to clean it up (split to a separate BB).
+ 
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index 0458e6583..81755d624 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -31,6 +31,8 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
+      test_issue_1711 test_issue_1794 test_issue_1747
+      test_rematerialized_alloca_load_with_outside_pr_users
+      test_peeled_wi_global_id
++     test_divergent_implicit_barrier_entry
++     test_uniform_implicit_barrier_entry
+      test_usm_indirect_ptrs
+ )
+ foreach(PROG ${C_PROGRAMS_TO_BUILD})
+@@ -143,6 +145,10 @@ add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "$
+ 
+ add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+ 
++add_test_pocl(NAME "regression/divergent_implicit_barrier_entry" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_divergent_implicit_barrier_entry")
++
++add_test_pocl(NAME "regression/uniform_implicit_barrier_entry" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_uniform_implicit_barrier_entry")
++
+ add_test_pocl(NAME "regression/test_usm_indirect_ptrs" COMMAND "test_usm_indirect_ptrs")
+ 
+ add_test_pocl(NAME "regression/test_issue_893" COMMAND "test_issue_893")
+diff --git a/tests/regression/test_divergent_implicit_barrier_entry.c b/tests/regression/test_divergent_implicit_barrier_entry.c
+new file mode 100644
+index 000000000..3025ca65c
+--- /dev/null
++++ b/tests/regression/test_divergent_implicit_barrier_entry.c
+@@ -0,0 +1,148 @@
++// Copyright (c) 2026 PoCL developers
++//
++// Permission is hereby granted, free of charge, to any person obtaining a copy
++// of this software and associated documentation files (the "Software"), to deal
++// in the Software without restriction, including without limitation the rights
++// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++// copies of the Software, and to permit persons to whom the Software is
++// furnished to do so, subject to the following conditions:
++//
++// The above copyright notice and this permission notice shall be included in
++// all copies or substantial portions of the Software.
++//
++// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++// THE SOFTWARE.
++
++#include "pocl_opencl.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++
++#define CHECK_ERROR(err)                                                       \
++  do {                                                                         \
++    if ((err) != CL_SUCCESS) {                                                 \
++      fprintf(stderr, "OpenCL error %d at %s:%d\\n", (err), __FILE__,          \
++              __LINE__);                                                       \
++      goto error;                                                              \
++    }                                                                          \
++  } while (0)
++
++static const char KernelSource[] =
++    "__kernel void test_kernel(__global int *out,\n"
++    "                          __global const int *input,\n"
++    "                          uint active_n, uint logical_len) {\n"
++    "  __local int temp;\n"
++    "  size_t i = get_local_id(0);\n"
++    "  if (i == 0) temp = 0;\n"
++    "  barrier(CLK_LOCAL_MEM_FENCE);\n"
++    "  if (i < active_n) {\n"
++    "    if (i >= logical_len) return;\n"
++    "    if (input[i] < 0) temp = 1;\n"
++    "  }\n"
++    "  barrier(CLK_LOCAL_MEM_FENCE);\n"
++    "  if (i == 0) out[0] = temp;\n"
++    "}\n";
++
++int main(void) {
++  const cl_int input[] = {0, 0, -1, 0, 0, 0, 0, 0};
++  const cl_uint active_n = 2;
++  const cl_uint logical_len = 2;
++  cl_int output = -1;
++  const size_t work_size = 8;
++  cl_int err;
++  cl_uint num_platforms;
++  cl_platform_id *platforms = NULL;
++  cl_context context = NULL;
++  cl_command_queue queue = NULL;
++  cl_program program = NULL;
++  cl_kernel kernel = NULL;
++  cl_mem output_buffer = NULL;
++  cl_mem input_buffer = NULL;
++  int result = 1;
++
++  err = clGetPlatformIDs(0, NULL, &num_platforms);
++  CHECK_ERROR(err);
++  if (num_platforms == 0) {
++    puts("SKIP: no OpenCL platforms");
++    return 77;
++  }
++  platforms = malloc(num_platforms * sizeof(*platforms));
++  if (platforms == NULL)
++    goto error;
++  err = clGetPlatformIDs(num_platforms, platforms, NULL);
++  CHECK_ERROR(err);
++
++  cl_device_id device;
++  err = clGetDeviceIDs(platforms[0], CL_DEVICE_TYPE_ALL, 1, &device, NULL);
++  CHECK_ERROR(err);
++  context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
++  CHECK_ERROR(err);
++  const cl_queue_properties properties[] = {0};
++  queue = clCreateCommandQueueWithProperties(context, device, properties, &err);
++  CHECK_ERROR(err);
++
++  const char *sources[] = {KernelSource};
++  program = clCreateProgramWithSource(context, 1, sources, NULL, &err);
++  CHECK_ERROR(err);
++  err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
++  if (err != CL_SUCCESS) {
++    size_t log_size = 0;
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
++                          &log_size);
++    char *log = malloc(log_size);
++    if (log != NULL) {
++      clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size,
++                            log, NULL);
++      fprintf(stderr, "Build error:\\n%s\\n", log);
++      free(log);
++    }
++    goto error;
++  }
++  kernel = clCreateKernel(program, "test_kernel", &err);
++  CHECK_ERROR(err);
++  output_buffer =
++      clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
++                     sizeof(output), &output, &err);
++  CHECK_ERROR(err);
++  input_buffer =
++      clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
++                     sizeof(input), (void *)input, &err);
++  CHECK_ERROR(err);
++
++  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(output_buffer), &output_buffer));
++  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(input_buffer), &input_buffer));
++  CHECK_ERROR(clSetKernelArg(kernel, 2, sizeof(active_n), &active_n));
++  CHECK_ERROR(clSetKernelArg(kernel, 3, sizeof(logical_len), &logical_len));
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &work_size,
++                                     &work_size, 0, NULL, NULL));
++  CHECK_ERROR(clEnqueueReadBuffer(queue, output_buffer, CL_TRUE, 0,
++                                  sizeof(output), &output, 0, NULL, NULL));
++
++  if (output != 0) {
++    fprintf(stderr, "output = %d, expected 0\\n", output);
++    goto error;
++  }
++  puts("OK");
++  result = 0;
++
++error:
++  free(platforms);
++  if (input_buffer != NULL)
++    clReleaseMemObject(input_buffer);
++  if (output_buffer != NULL)
++    clReleaseMemObject(output_buffer);
++  if (kernel != NULL)
++    clReleaseKernel(kernel);
++  if (program != NULL)
++    clReleaseProgram(program);
++  if (queue != NULL)
++    clReleaseCommandQueue(queue);
++  if (context != NULL)
++    clReleaseContext(context);
++  return result;
++}
+diff --git a/tests/regression/test_uniform_implicit_barrier_entry.c b/tests/regression/test_uniform_implicit_barrier_entry.c
+new file mode 100644
+index 000000000..454ddb632
+--- /dev/null
++++ b/tests/regression/test_uniform_implicit_barrier_entry.c
+@@ -0,0 +1,153 @@
++// Copyright (c) 2026 PoCL developers
++//
++// Permission is hereby granted, free of charge, to any person obtaining a copy
++// of this software and associated documentation files (the "Software"), to deal
++// in the Software without restriction, including without limitation the rights
++// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++// copies of the Software, and to permit persons to whom the Software is
++// furnished to do so, subject to the following conditions:
++//
++// The above copyright notice and this permission notice shall be included in
++// all copies or substantial portions of the Software.
++//
++// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++// THE SOFTWARE.
++
++/*
++  The bounds check depends on the work-item id, but logical_len equals the
++  work-group size at launch, so every work-item reaches sub_group_shuffle.
++  The builtin is flattened before ImplicitConditionalBarriers and contains a
++  barrier. Its normal path dominates that barrier, so an implicit barrier is
++  legal even though VariableUniformityAnalysis cannot prove the condition
++  uniform.
++*/
++
++#include "pocl_opencl.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++
++#define CHECK_ERROR(err)                                                       \
++  do {                                                                         \
++    if ((err) != CL_SUCCESS) {                                                 \
++      fprintf(stderr, "OpenCL error %d at %s:%d\n", (err), __FILE__,           \
++              __LINE__);                                                       \
++      goto error;                                                              \
++    }                                                                          \
++  } while (0)
++
++static const char KernelSource[] =
++    "#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n"
++    "__kernel void test_kernel(__global int *out,\n"
++    "                          __global const int *input,\n"
++    "                          uint logical_len) {\n"
++    "  uint i = get_sub_group_local_id();\n"
++    "  if (i >= logical_len) return;\n"
++    "  uint j = get_sub_group_size() - i - 1;\n"
++    "  out[i] = sub_group_shuffle(input[i], j);\n"
++    "}\n";
++
++int main(void) {
++  const cl_int input[] = {0, 1, 2, 3, 4, 5, 6, 7};
++  cl_int output[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
++  const cl_uint logical_len = 8;
++  const size_t work_size = 8;
++  cl_int err;
++  cl_uint num_platforms;
++  cl_platform_id *platforms = NULL;
++  cl_context context = NULL;
++  cl_command_queue queue = NULL;
++  cl_program program = NULL;
++  cl_kernel kernel = NULL;
++  cl_mem output_buffer = NULL;
++  cl_mem input_buffer = NULL;
++  int result = 1;
++
++  err = clGetPlatformIDs(0, NULL, &num_platforms);
++  CHECK_ERROR(err);
++  if (num_platforms == 0) {
++    puts("SKIP: no OpenCL platforms");
++    return 77;
++  }
++  platforms = malloc(num_platforms * sizeof(*platforms));
++  if (platforms == NULL)
++    goto error;
++  err = clGetPlatformIDs(num_platforms, platforms, NULL);
++  CHECK_ERROR(err);
++
++  cl_device_id device;
++  err = clGetDeviceIDs(platforms[0], CL_DEVICE_TYPE_ALL, 1, &device, NULL);
++  CHECK_ERROR(err);
++  context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
++  CHECK_ERROR(err);
++  const cl_queue_properties properties[] = {0};
++  queue = clCreateCommandQueueWithProperties(context, device, properties, &err);
++  CHECK_ERROR(err);
++
++  const char *sources[] = {KernelSource};
++  program = clCreateProgramWithSource(context, 1, sources, NULL, &err);
++  CHECK_ERROR(err);
++  err = clBuildProgram(program, 1, &device, "-cl-std=CL3.0", NULL, NULL);
++  if (err != CL_SUCCESS) {
++    size_t log_size = 0;
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
++                          &log_size);
++    char *log = malloc(log_size);
++    if (log != NULL) {
++      clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size,
++                            log, NULL);
++      fprintf(stderr, "Build error:\n%s\n", log);
++      free(log);
++    }
++    goto error;
++  }
++  kernel = clCreateKernel(program, "test_kernel", &err);
++  CHECK_ERROR(err);
++  output_buffer =
++      clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
++                     sizeof(output), output, &err);
++  CHECK_ERROR(err);
++  input_buffer =
++      clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
++                     sizeof(input), (void *)input, &err);
++  CHECK_ERROR(err);
++
++  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(output_buffer), &output_buffer));
++  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(input_buffer), &input_buffer));
++  CHECK_ERROR(clSetKernelArg(kernel, 2, sizeof(logical_len), &logical_len));
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &work_size,
++                                     &work_size, 0, NULL, NULL));
++  CHECK_ERROR(clEnqueueReadBuffer(queue, output_buffer, CL_TRUE, 0,
++                                  sizeof(output), output, 0, NULL, NULL));
++
++  for (size_t i = 0; i < work_size; ++i) {
++    if (output[i] != input[work_size - i - 1]) {
++      fprintf(stderr, "output[%zu] = %d, expected %d\n", i, output[i],
++              input[work_size - i - 1]);
++      goto error;
++    }
++  }
++  puts("OK");
++  result = 0;
++
++error:
++  free(platforms);
++  if (input_buffer != NULL)
++    clReleaseMemObject(input_buffer);
++  if (output_buffer != NULL)
++    clReleaseMemObject(output_buffer);
++  if (kernel != NULL)
++    clReleaseKernel(kernel);
++  if (program != NULL)
++    clReleaseProgram(program);
++  if (queue != NULL)
++    clReleaseCommandQueue(queue);
++  if (context != NULL)
++    clReleaseContext(context);
++  return result;
++}

--- a/P/pocl/pocl/bundled/patches/pocl/0012-BarrierTailReplication-share-tails-within-a-region.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0012-BarrierTailReplication-share-tails-within-a-region.patch
@@ -1,0 +1,89 @@
+From c13c738b2e1eb2d33dd5eb26819464a98d233e0a Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Wed, 29 Jul 2026 18:22:22 +0200
+Subject: [PATCH 12/16] BarrierTailReplication: share tails within a region
+
+ReplicateJoinedSubgraphs creates a tail copy for each incoming edge. Multiple edges from one parallel region to the same join therefore become separate region exits, and WorkitemLoops may purge paths selected by divergent branches.
+
+Cache replicas by region-entry barrier and join block. Edges from one region share an exit, while different regions retain separate tails.
+---
+ lib/llvmopencl/BarrierTailReplication.cc | 33 +++++++++++++++++++-----
+ 1 file changed, 26 insertions(+), 7 deletions(-)
+
+diff --git a/lib/llvmopencl/BarrierTailReplication.cc b/lib/llvmopencl/BarrierTailReplication.cc
+index 61b36bf61..5031d8f36 100644
+--- a/lib/llvmopencl/BarrierTailReplication.cc
++++ b/lib/llvmopencl/BarrierTailReplication.cc
+@@ -69,6 +69,10 @@ private:
+   typedef std::set<llvm::BasicBlock *> BasicBlockSet;
+   typedef std::vector<llvm::BasicBlock *> BasicBlockVector;
+   typedef std::map<llvm::Value *, llvm::Value *> ValueValueMap;
++  // Share a tail among edges from the same parallel region.
++  typedef std::map<std::pair<llvm::BasicBlock *, llvm::BasicBlock *>,
++                   llvm::BasicBlock *>
++      ReplicaMap;
+ 
+   llvm::DominatorTree &DT;
+   llvm::LoopInfo &LI;
+@@ -77,7 +81,9 @@ private:
+   bool FindBarriersDFS(llvm::BasicBlock *BB, BasicBlockSet &ProcessedBBs);
+   bool ReplicateJoinedSubgraphs(llvm::BasicBlock *Dominator,
+                                 llvm::BasicBlock *SubgraphEntry,
+-                                BasicBlockSet &ProcessedBBs);
++                                llvm::BasicBlock *RegionEntryBarrier,
++                                BasicBlockSet &ProcessedBBs,
++                                ReplicaMap &Replicas);
+ 
+   llvm::BasicBlock *ReplicateSubgraph(llvm::BasicBlock *Entry,
+                                       llvm::Function *F);
+@@ -157,7 +163,8 @@ bool BarrierTailReplicationImpl::FindBarriersDFS(BasicBlock *BB,
+     std::cerr << "### block " << BB->getName().str() << " has a barrier, RJS" << std::endl;
+ #endif
+     BasicBlockSet processed_bbs_rjs;
+-    changed = ReplicateJoinedSubgraphs(BB, BB, processed_bbs_rjs);
++    ReplicaMap Replicas;
++    changed = ReplicateJoinedSubgraphs(BB, BB, BB, processed_bbs_rjs, Replicas);
+   }
+ 
+   auto t = BB->getTerminator();
+@@ -172,8 +179,13 @@ bool BarrierTailReplicationImpl::FindBarriersDFS(BasicBlock *BB,
+ // Only replicate those parts of the subgraph that are not
+ // dominated by a (barrier) basic block, to avoid excesive
+ // (and confusing) code replication.
+-bool BarrierTailReplicationImpl::ReplicateJoinedSubgraphs(BasicBlock *Dominator, BasicBlock *SubgraphEntry,
+-    BasicBlockSet &ProcessedBBs) {
++// Edges from the same parallel region to the same join point must share a
++// replica. Otherwise they become separate region exits and WorkitemLoops may
++// purge paths selected by work-item-varying branches.
++bool BarrierTailReplicationImpl::ReplicateJoinedSubgraphs(
++    BasicBlock *Dominator, BasicBlock *SubgraphEntry,
++    BasicBlock *RegionEntryBarrier, BasicBlockSet &ProcessedBBs,
++    ReplicaMap &Replicas) {
+   bool changed = false;
+ 
+   assert(DT.dominates(Dominator, SubgraphEntry));
+@@ -211,14 +223,21 @@ bool BarrierTailReplicationImpl::ReplicateJoinedSubgraphs(BasicBlock *Dominator,
+         std::cerr << "### " << Dominator->getName().str() << " dominates "
+                   << b->getName().str() << std::endl;
+ #endif
+-        changed |= ReplicateJoinedSubgraphs(Dominator, b, ProcessedBBs);
++        // Crossing a barrier starts a new parallel region; the tails joined
++        // from beyond it must not be shared with the ones joined from here.
++        BasicBlock *SuccRegion =
++            blockHasBarrier(b) ? b : RegionEntryBarrier;
++        changed |= ReplicateJoinedSubgraphs(Dominator, b, SuccRegion,
++                                            ProcessedBBs, Replicas);
+     } else {
+ #ifdef DEBUG_BARRIER_REPL
+         std::cerr << "### " << Dominator->getName().str() << " does not dominate "
+                   << b->getName().str() << " replicating " << std::endl;
+ #endif
+-        BasicBlock *replicated_subgraph_entry =
+-          ReplicateSubgraph(b, f);
++        BasicBlock *&replicated_subgraph_entry =
++            Replicas[std::make_pair(RegionEntryBarrier, b)];
++        if (replicated_subgraph_entry == nullptr)
++          replicated_subgraph_entry = ReplicateSubgraph(b, f);
+         t->setSuccessor(i, replicated_subgraph_entry);
+         changed = true;
+     }

--- a/P/pocl/pocl/bundled/patches/pocl/0013-WorkitemLoops-do-not-rematerialize-mutable-loads.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0013-WorkitemLoops-do-not-rematerialize-mutable-loads.patch
@@ -1,0 +1,96 @@
+From 8e177839e8d6d8850d7e919fbe24044bb5b87952 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Wed, 29 Jul 2026 18:33:45 +0200
+Subject: [PATCH 13/16] WorkitemLoops: do not rematerialize mutable loads
+
+A load cloned into a later parallel region can observe writes made after its original definition. This breaks local-memory read-barrier-write idioms; readonly arguments are also unsafe when a writable argument can alias them.
+
+Only clone simple loads from noalias readonly arguments, constant globals, or PoCL work-item geometry variables. Keep other values in per-work-item context storage.
+---
+ lib/llvmopencl/WorkitemLoops.cc      | 37 ++++++++++++++++++++++++++++
+ tests/regression/test_issue_1525.cpp |  3 ++-
+ 2 files changed, 39 insertions(+), 1 deletion(-)
+
+diff --git a/lib/llvmopencl/WorkitemLoops.cc b/lib/llvmopencl/WorkitemLoops.cc
+index 7386dda73..b07df6154 100644
+--- a/lib/llvmopencl/WorkitemLoops.cc
++++ b/lib/llvmopencl/WorkitemLoops.cc
+@@ -30,6 +30,7 @@ IGNORE_COMPILER_WARNING("-Wunused-parameter")
+ #include <llvm/ADT/Statistic.h>
+ #include <llvm/Analysis/LoopInfo.h>
+ #include <llvm/Analysis/PostDominators.h>
++#include <llvm/Analysis/ValueTracking.h>
+ #include <llvm/IR/DataLayout.h>
+ #include <llvm/IR/DebugInfoMetadata.h>
+ #include <llvm/IR/IRBuilder.h>
+@@ -56,6 +57,9 @@ IGNORE_COMPILER_WARNING("-Wunused-parameter")
+ 
+ POP_COMPILER_DIAGS
+ 
++#include "pocl_llvm_api.h"
++
++#include <algorithm>
+ #include <array>
+ #include <iostream>
+ #include <map>
+@@ -909,6 +913,31 @@ llvm::AllocaInst *WorkitemLoopsImpl::getContextArray(llvm::Instruction *Inst,
+              Inst, &*(Entry.getFirstInsertionPt()), CArrayName, PaddingAdded);
+ }
+ 
++static bool isRematerializableLoad(const LoadInst *Load) {
++  if (!Load->isSimple())
++    return false;
++
++  const llvm::Value *Obj = getUnderlyingObject(Load->getPointerOperand());
++
++  // readonly alone does not exclude writes through an alias.
++  if (const auto *Arg = dyn_cast<Argument>(Obj))
++    return Arg->onlyReadsMemory() && Arg->hasNoAliasAttr();
++
++  if (const auto *GV = dyn_cast<GlobalVariable>(Obj)) {
++    if (GV->isConstant())
++      return true;
++    // These are updated by the work-item loops and must be read in the target
++    // region. The program-scope variable buffer is ordinary writable memory.
++    llvm::StringRef Name = GV->getName();
++    return Name != PoclGVarBufferName &&
++           std::find(WorkgroupVariablesVector.begin(),
++                     WorkgroupVariablesVector.end(),
++                     Name.str()) != WorkgroupVariablesVector.end();
++  }
++
++  return false;
++}
++
+ /// Tries to rematerialize the given value-defining instruction.
+ ///
+ /// Rematerialization in this context means recomputing the value produced
+@@ -1002,6 +1031,14 @@ llvm::Value *WorkitemLoopsImpl::tryToRematerialize(
+   if (Inst->getParent() == &K->getEntryBlock())
+     return Inst;
+ 
++  // A rematerialized load may observe writes between the original definition
++  // and its use in a later parallel region.
++  if (Inst->mayReadFromMemory()) {
++    const auto *Load = dyn_cast<LoadInst>(Inst);
++    if (Load == nullptr || !isRematerializableLoad(Load))
++      UNABLE_TO_REMAT("reads mutable memory");
++  }
++
+   llvm::Instruction *Copy = CanDoIt == nullptr ? Inst->clone() : nullptr;
+   if (Copy != nullptr) {
+     Copy->setName(NamePrefix + ".remat");
+diff --git a/tests/regression/test_issue_1525.cpp b/tests/regression/test_issue_1525.cpp
+index 211b17218..9cf616873 100644
+--- a/tests/regression/test_issue_1525.cpp
++++ b/tests/regression/test_issue_1525.cpp
+@@ -15,7 +15,8 @@ using namespace std;
+ 
+ const char *SOURCE = R"RAW(
+ 
+-__kernel void test(__global long *output, __global long *input)
++__kernel void test(__global long *restrict output,
++                   __global long *restrict input)
+ {
+     size_t i = get_global_id(0) * 16;
+ 

--- a/P/pocl/pocl/bundled/patches/pocl/0014-CanonicalizeBarriers-split-reconverging-barrier-succ.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0014-CanonicalizeBarriers-split-reconverging-barrier-succ.patch
@@ -1,0 +1,284 @@
+From 763e259ff4bb3003280b991bbe99d4a9b712e051 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Mon, 17 Aug 2026 15:57:39 +0200
+Subject: [PATCH 14/16] CanonicalizeBarriers: split reconverging barrier
+ successors
+
+Parallel-region formation treats successors of a barrier block as entries of
+disjoint regions. Bounds-checked Julia kernels can instead branch around a
+variable-trip loop and reconverge at the next barrier, producing a malformed
+region and aborting work-group function generation.
+
+Detect successors that reach a common block before crossing another barrier
+and move their branch to a common post-barrier block. Successors ending at
+distinct barriers retain the existing conditional-barrier handling.
+
+Add a reduced SPIR-V regression that builds and executes with the loops,
+loopvec, and CBS handlers.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ lib/llvmopencl/CanonicalizeBarriers.cc        |  38 +++-
+ tests/regression/CMakeLists.txt               |   3 +
+ .../regression/test_barrier_divergent_skip.c  | 166 ++++++++++++++++++
+ 3 files changed, 204 insertions(+), 3 deletions(-)
+ create mode 100644 tests/regression/test_barrier_divergent_skip.c
+
+diff --git a/lib/llvmopencl/CanonicalizeBarriers.cc b/lib/llvmopencl/CanonicalizeBarriers.cc
+index 9dc1dad19..d30b23a88 100644
+--- a/lib/llvmopencl/CanonicalizeBarriers.cc
++++ b/lib/llvmopencl/CanonicalizeBarriers.cc
+@@ -29,6 +29,9 @@ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
+ #include <llvm/ADT/Twine.h>
+ POP_COMPILER_DIAGS
+ IGNORE_COMPILER_WARNING("-Wunused-parameter")
++#include <llvm/ADT/SmallPtrSet.h>
++#include <llvm/ADT/SmallVector.h>
++#include <llvm/IR/CFG.h>
+ #include <llvm/IR/Dominators.h>
+ #include <llvm/IR/Instructions.h>
+ #include <llvm/IR/Module.h>
+@@ -60,6 +63,31 @@ static bool processFunction(Function &F, WorkitemHandlerType Handler);
+ 
+ using InstructionSet = std::set<llvm::Instruction *>;
+ 
++// Parallel region formation treats successors of a barrier block as entries
++// of disjoint regions. If the successors reconverge before another barrier,
++// the branch instead belongs to a single region and needs a common entry.
++static bool successorsReconverge(llvm::Instruction *T) {
++  llvm::SmallPtrSet<llvm::BasicBlock *, 16> Reached;
++  for (unsigned Succ = 0, Num = T->getNumSuccessors(); Succ < Num; ++Succ) {
++    llvm::SmallPtrSet<llvm::BasicBlock *, 16> Visited;
++    llvm::SmallVector<llvm::BasicBlock *, 16> WorkList{T->getSuccessor(Succ)};
++    while (!WorkList.empty()) {
++      llvm::BasicBlock *BB = WorkList.pop_back_val();
++      if (!Visited.insert(BB).second)
++        continue;
++      // Include barrier blocks in the search, but do not cross them.
++      if (Reached.count(BB))
++        return true;
++      if (Barrier::hasBarrier(BB))
++        continue;
++      for (llvm::BasicBlock *SuccBB : successors(BB))
++        WorkList.push_back(SuccBB);
++    }
++    Reached.insert(Visited.begin(), Visited.end());
++  }
++  return false;
++}
++
+ static bool canonicalizeBarriers(Function &F, WorkitemHandlerType Handler) {
+   bool changed = false;
+ 
+@@ -149,11 +177,15 @@ static bool processFunction(Function &F, WorkitemHandlerType Handler) {
+     //     (t->getPrevNode() != *i)) {
+     // Change: barriers with several successors are all right
+     // they just start several parallel regions. Simplifies
+-    // loop handling.
++    // loop handling. Reconverging successors, however, belong to a single
++    // region and need a common post-barrier entry.
++
++    const bool MustSplitSuccessors =
++        t->getNumSuccessors() > 1 &&
++        (Handler == WorkitemHandlerType::CBS || successorsReconverge(t));
+ 
+     const bool HasNonBranchInstructionsAfterBarrier =
+-        t->getPrevNode() != *i ||
+-        (Handler == WorkitemHandlerType::CBS && t->getNumSuccessors() > 1);
++        t->getPrevNode() != *i || MustSplitSuccessors;
+ 
+     if (HasNonBranchInstructionsAfterBarrier) {
+       BasicBlock *new_b = SplitBlock(b, (*i)->getNextNode());
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index 81755d624..8c309f4a3 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -31,6 +31,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
+      test_issue_1711 test_issue_1794 test_issue_1747
+      test_rematerialized_alloca_load_with_outside_pr_users
+      test_peeled_wi_global_id
++     test_barrier_divergent_skip
+      test_divergent_implicit_barrier_entry
+      test_uniform_implicit_barrier_entry
+      test_usm_indirect_ptrs
+@@ -145,6 +146,8 @@ add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "$
+ 
+ add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+ 
++add_test_pocl(NAME "regression/barrier_divergent_skip" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_barrier_divergent_skip" LABELS ${SPIRV_LABELS})
++
+ add_test_pocl(NAME "regression/divergent_implicit_barrier_entry" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_divergent_implicit_barrier_entry")
+ 
+ add_test_pocl(NAME "regression/uniform_implicit_barrier_entry" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_uniform_implicit_barrier_entry")
+diff --git a/tests/regression/test_barrier_divergent_skip.c b/tests/regression/test_barrier_divergent_skip.c
+new file mode 100644
+index 000000000..69b1b29fd
+--- /dev/null
++++ b/tests/regression/test_barrier_divergent_skip.c
+@@ -0,0 +1,166 @@
++// Copyright (c) 2026 PoCL developers
++//
++// Permission is hereby granted, free of charge, to any person obtaining a copy
++// of this software and associated documentation files (the "Software"), to deal
++// in the Software without restriction, including without limitation the rights
++// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++// copies of the Software, and to permit persons to whom the Software is
++// furnished to do so, subject to the following conditions:
++//
++// The above copyright notice and this permission notice shall be included in
++// all copies or substantial portions of the Software.
++//
++// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++// THE SOFTWARE.
++
++/*
++  Reduced from a bounds-checked KernelAbstractions.jl radix-sort kernel. One
++  arm of a branch after a barrier skips a variable-trip loop, then reconverges
++  with the other arm at the next barrier:
++
++      barrier();
++      br i1 %skip, label %join, label %loop
++      ...
++      join:                  ; reconvergence point
++      barrier();
++
++  Treating the successors as disjoint region entries produced a malformed
++  region ending at the loop latch. Building the work-group function then
++  aborted in ParallelRegion::chainAfter.
++
++  The crash happened when building the work-group function; completing the
++  build and a launch with correct results is the test. The launch takes the
++  skip path in all work-items so the barrier behavior is defined.
++*/
++
++#include "pocl_opencl.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++#ifndef _WIN32
++#include <unistd.h>
++#endif
++
++#define CHECK_ERROR(err)                                                       \
++  if (err != CL_SUCCESS) {                                                     \
++    printf("OpenCL Error %d at %s:%d\n", err, __FILE__, __LINE__);             \
++    return 1;                                                                  \
++  }
++
++int main(int argc, char **argv) {
++  cl_uint platform_index = argc > 1 ? (cl_uint)atoi(argv[1]) : 0;
++  cl_int err;
++
++#ifndef _WIN32
++  // Fail quickly instead of tripping the much larger ctest timeout in case
++  // a regressed build hangs.
++  alarm(300);
++#endif
++
++  cl_uint num_platforms;
++  CHECK_ERROR(clGetPlatformIDs(0, NULL, &num_platforms));
++  if (platform_index >= num_platforms) {
++    printf("Platform index %u out of range\n", platform_index);
++    return 1;
++  }
++  cl_platform_id *platforms = malloc(sizeof(cl_platform_id) * num_platforms);
++  CHECK_ERROR(clGetPlatformIDs(num_platforms, platforms, NULL));
++  cl_platform_id platform = platforms[platform_index];
++  free(platforms);
++
++  cl_device_id device;
++  CHECK_ERROR(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL));
++
++  if (!poclu_device_supports_il(device, "SPIR-V_1.0")) {
++    printf("SKIP: The test requires support for SPIR-V 1.0\n");
++    return 77;
++  }
++
++  cl_context context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
++  CHECK_ERROR(err);
++  cl_queue_properties props[] = {0};
++  cl_command_queue queue =
++      clCreateCommandQueueWithProperties(context, device, props, &err);
++  CHECK_ERROR(err);
++
++  FILE *f = fopen(SRCDIR "/test_barrier_divergent_skip.spv", "rb");
++  if (!f) {
++    printf("Failed to open test_barrier_divergent_skip.spv\n");
++    return 1;
++  }
++  fseek(f, 0, SEEK_END);
++  size_t size = ftell(f);
++  fseek(f, 0, SEEK_SET);
++  unsigned char *binary = malloc(size);
++  if (fread(binary, 1, size, f) != size) {
++    printf("Failed to read SPIR-V\n");
++    free(binary);
++    fclose(f);
++    return 1;
++  }
++  fclose(f);
++
++  cl_program program = clCreateProgramWithIL(context, binary, size, &err);
++  CHECK_ERROR(err);
++  err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
++  if (err != CL_SUCCESS) {
++    size_t log_size;
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
++                          &log_size);
++    char *log = malloc(log_size);
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size, log,
++                          NULL);
++    printf("Build error:\n%s\n", log);
++    return 1;
++  }
++
++  // Building the work-group function is what used to crash; force it even
++  // when the driver would otherwise defer compilation to launch time.
++  size_t binary_size;
++  CHECK_ERROR(clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES,
++                               sizeof(binary_size), &binary_size, NULL));
++
++  cl_kernel kernel = clCreateKernel(program, "vartrip", &err);
++  CHECK_ERROR(err);
++
++  // All work-items enter the barrier and take the loop-skipping arm, so the
++  // barrier behavior is defined and every work-item stores 42.
++  const size_t local_size = 64, global_size = 128;
++  const cl_long opaque = 0;
++  const cl_uchar enter = 1, skip = 1, exitl = 1;
++  cl_int result[128];
++  cl_mem out =
++      clCreateBuffer(context, CL_MEM_WRITE_ONLY, sizeof(result), NULL, &err);
++  CHECK_ERROR(err);
++  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(out), &out));
++  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(opaque), &opaque));
++  CHECK_ERROR(clSetKernelArg(kernel, 2, sizeof(enter), &enter));
++  CHECK_ERROR(clSetKernelArg(kernel, 3, sizeof(skip), &skip));
++  CHECK_ERROR(clSetKernelArg(kernel, 4, sizeof(exitl), &exitl));
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size,
++                                     &local_size, 0, NULL, NULL));
++  CHECK_ERROR(clEnqueueReadBuffer(queue, out, CL_TRUE, 0, sizeof(result),
++                                  result, 0, NULL, NULL));
++
++  for (size_t i = 0; i < global_size; ++i) {
++    if (result[i] != 42) {
++      printf("FAIL at %zu: got %d, expected 42\n", i, result[i]);
++      return 1;
++    }
++  }
++
++  clReleaseMemObject(out);
++  clReleaseKernel(kernel);
++  clReleaseProgram(program);
++  clReleaseCommandQueue(queue);
++  clReleaseContext(context);
++  free(binary);
++
++  printf("OK\n");
++  return 0;
++}

--- a/P/pocl/pocl/bundled/patches/pocl/0015-UnreachablesToReturns-remove-regions-leading-only-to.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0015-UnreachablesToReturns-remove-regions-leading-only-to.patch
@@ -1,0 +1,530 @@
+From 799b5dd8d75e34add9a6d3c14aec4a0fb1d40dc0 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Mon, 17 Aug 2026 14:11:19 +0200
+Subject: [PATCH 15/16] UnreachablesToReturns: remove regions leading only to
+ unreachable
+
+For the loop handlers, this pass used to detach only blocks ending in
+unreachable. If such a block is the sole exit of a loop, as in the
+string-length loop of an inlined printf-then-abort path, detaching it leaves
+an infinite loop. WorkitemLoops then fails because the parallel region no
+longer reaches its exit (issue #1958).
+
+The loop handlers cannot represent a divergent work-item exit: a return would
+bypass the region exit and terminate the whole work-group function. Keep the
+deletion policy introduced by 89bc42187 to restore the behavior observed with
+PoCL 6.0, but apply it to the complete region that can reach an unreachable
+and cannot reach a return. Retarget incoming branches and switches, then let
+EliminateUnreachableBlocks remove the region. The CBS path remains unchanged.
+
+Add the issue SPIR-V as a regression test, adjusted to valid SPIR-V 1.0.
+Querying CL_PROGRAM_BINARY_SIZES forces construction of the work-group
+function; a non-aborting launch also checks the resulting kernel.
+GPUCompiler.jl#812 now lowers this control flow to returns, but equivalent
+SPIR-V from other producers still needs to compile.
+
+Fixes #1958.
+
+(cherry picked from commit a1b5abfe68fa4afb26b260789808896472a0e6cb)
+---
+ lib/llvmopencl/UnreachablesToReturns.cc | 254 ++++++++++--------------
+ tests/regression/CMakeLists.txt         |   4 +-
+ tests/regression/test_issue_1958.c      | 168 ++++++++++++++++
+ 3 files changed, 280 insertions(+), 146 deletions(-)
+ create mode 100644 tests/regression/test_issue_1958.c
+
+diff --git a/lib/llvmopencl/UnreachablesToReturns.cc b/lib/llvmopencl/UnreachablesToReturns.cc
+index 96ad3757e..a63157e43 100644
+--- a/lib/llvmopencl/UnreachablesToReturns.cc
++++ b/lib/llvmopencl/UnreachablesToReturns.cc
+@@ -9,12 +9,11 @@
+ // to create illegal code (barriers are only partially taken), however the CBS
+ // is able to handle these.
+ //
+-// for LOOPVEC handler, we find all basicblocks which have an unreachable inst,
+-// and "disconnect" them from their predecessor basicblocks. If the predecessor
+-// has an unconditional jump, it is also deleted. If it has a conditional jump,
+-// it's made unconditional (to the other branch). This matches the behavior
+-// of prior versions of PoCL (6.0) where the optimization similarly deleted
+-// these blocks.
++// for LOOPVEC handler, we delete regions which can reach an unreachable inst
++// but cannot reach the function's return. Branches from live blocks into the
++// deleted region are made unconditional (to the live branch), and switch cases
++// leading to it are removed. This preserves the PoCL 6.0 behavior that commit
++// 89bc42187 sought to restore.
+ //
+ // Note that neither handling is recursive. Therefore all non-kernel functions
+ // that have an unreachable inst, must be inlined before this Pass is run.
+@@ -120,7 +119,7 @@ static bool convertUnreachablesToReturns(Function &F) {
+   for (Function::iterator I = F.begin(), E = F.end(); I != E; ++I) {
+     BasicBlock &BB = *I;
+     assert(BB.getTerminator());
+-    if ((BB.sizeWithoutDebug() == 1) && isa<ReturnInst>(BB.getTerminator())) {
++    if ((BB.size() == 1) && isa<ReturnInst>(BB.getTerminator())) {
+       RetBB = &BB;
+       break;
+     }
+@@ -150,164 +149,129 @@ static bool convertUnreachablesToReturns(Function &F) {
+   return true;
+ }
+ 
+-// Fix predecessor BBs of BB which has an unreachable terminator inst
+-// to ignore the BB.
++// Delete regions which lead only to an unreachable instruction.
+ //
+-// If the predecessor has an unconditional branch, replaces the branch with
+-// UnreachableInst and adds the BB to \p NewUnreachableBBs. If the predecessor
+-// has a conditional branch, makes it unconditional. The function should
+-// be called until NewUnreachableBBs is empty.
+-static void detachBBFromPredecessor(BasicBlock &BB,
+-                                    SmallBBSet &NewUnreachableBBs) {
+-  if (BB.hasNPredecessors(0))
+-    return; // Already handled.
+-
+-  LLVM_DEBUG(
+-      dbgs() << "Detaching a BB that has an unreachable or leads to one:\n");
+-  LLVM_DEBUG(BB.dump());
+-
+-  // To avoid invalidating the predecessors iterator,
+-  // store replacement instructions and replace after the loop
+-  SmallMapVector<Instruction *, Instruction *, 8> Replacements;
+-
+-  // If the BB is in a switch case, these are the switch instructions to fix.
+-  std::vector<SwitchInst *> PredSwitches;
+-
+-  for (BasicBlock *Pred : predecessors(&BB)) {
+-    assert(Pred != nullptr);
+-    Instruction *I = Pred->getTerminator();
+-    assert(I != nullptr);
+-    if (BranchInst *BI = dyn_cast<BranchInst>(I)) {
+-      if (BI->isUnconditional()) {
+-        LLVM_DEBUG(dbgs() << "The predecessor " << Pred->getName().str()
+-                          << " is unconditionally branching to it\n");
+-        LLVM_DEBUG(Pred->dump());
+-        // The predecessor has an unconditional branch to the unreachable BB,
+-        // remove that in a next call.
+-        NewUnreachableBBs.insert(Pred);
+-      } else {
+-        LLVM_DEBUG(
+-            dbgs() << "The predecessor is conditionally branching to it\n");
+-        LLVM_DEBUG(Pred->dump());
+-
+-        BasicBlock *Other = nullptr;
+-        if (BI->getSuccessor(0) == &BB)
+-          Other = BI->getSuccessor(1);
+-        else
+-          Other = BI->getSuccessor(0);
+-        BranchInst *NewBI = BranchInst::Create(Other);
+-        Replacements.insert(std::make_pair(BI, NewBI));
+-      }
+-    } else if (SwitchInst *PredSwitch = dyn_cast<SwitchInst>(I)) {
+-      LLVM_DEBUG(dbgs() << "The predecessor is a switch case in "
+-                        << Pred->getName().str() << "\n");
+-      PredSwitches.push_back(PredSwitch);
+-    } else {
+-      LLVM_DEBUG(dbgs() << "Unhandled BB Terminator: \n");
+-      LLVM_DEBUG(I->dump());
+-      assert(0 && "Error: unexpected BB terminator\n");
+-    }
+-  }
+-
+-  for (auto [OldI, NewI] : Replacements) {
+-    ReplaceInstWithInst(OldI, NewI);
+-  }
+-
+-  for (SwitchInst *PredSwitch : PredSwitches) {
+-    // New default BB in case the unreachable block is a default BB.
+-    BasicBlock *NewDefaultBB = nullptr;
+-
+-    // The case value we could convert to a new default if that's the case.
+-    ConstantInt *RobbedCaseValue = nullptr;
+-    for (SwitchInst::CaseIt C = PredSwitch->cases().begin();
+-         C != PredSwitch->cases().end();) {
+-      if (C->getCaseSuccessor() == &BB) {
+-        PredSwitch->removeCase(C++);
+-        // RemoveCase invalidates all iterators and might reorder the cases,
+-        // let's just restart.
+-        C = PredSwitch->cases().begin();
+-        continue;
+-      }
+-      NewDefaultBB = C->getCaseSuccessor();
+-      RobbedCaseValue = C->getCaseValue();
+-      C++;
+-    }
+-    SwitchInst::CaseIt Default = PredSwitch->case_default();
+-    if (Default->getCaseSuccessor() == &BB) {
+-      if (NewDefaultBB != nullptr) {
+-        PredSwitch->setDefaultDest(NewDefaultBB);
+-        // Now we can remove the original case which also branched to this one
+-        // since it will be covered by the default. This will by coincidence
+-        // fix the Phi in a block where the switch...case has multiple branches
+-        // to. If we didn't do this, there would be one too few phi conditions.
+-        PredSwitch->removeCase(PredSwitch->findCaseValue(RobbedCaseValue));
+-      }
+-      if (NewDefaultBB == nullptr || PredSwitch->getNumCases() == 0) {
+-        LLVM_DEBUG(
+-            dbgs()
+-            << "A switch case with only a default which goes to unreachable\n");
+-        NewUnreachableBBs.insert(PredSwitch->getParent());
+-      }
+-    }
+-    LLVM_DEBUG(dbgs() << "switch case modified:\n");
+-    LLVM_DEBUG(PredSwitch->getParent()->dump());
+-  }
+-}
+-
++// These "doomed" blocks either end in an unreachable inst, or can only make
++// progress towards one -- possibly iterating forever in a loop whose sole
++// exit leads to an unreachable, e.g. the string-length loop of an inlined
++// printf-then-abort sequence. Merely detaching the unreachable-terminated
++// blocks would sever such a loop's exit edge and leave behind an infinite
++// loop that never reaches the parallel region exit, breaking WorkitemLoops
++// (issue #1958), so delete the doomed blocks wholesale.
+ static bool deleteBlocksWithUnreachable(Function &F) {
+ 
+   SmallBBSet UnreachableBBs;
+-
+-  for (Function::iterator I = F.begin(), E = F.end(); I != E; ++I) {
+-    BasicBlock &BB = *I;
++  for (BasicBlock &BB : F) {
+     assert(BB.getTerminator());
+-    if (isa<UnreachableInst>(BB.getTerminator())) {
+-      LLVM_DEBUG(dbgs() << "UNREACHABLE found, deleting BB\n");
+-      LLVM_DEBUG(BB.dump());
++    if (isa<UnreachableInst>(BB.getTerminator()))
+       UnreachableBBs.insert(&BB);
+-    }
+   }
+ 
+   if (UnreachableBBs.empty())
+     return false;
+ 
+-  // Check BB predecessors recursively, and disconnect them
+-  // from blocks which contain an unreachable.
+-  SmallBBSet HandledUnreachableBBs;
+-  while (!UnreachableBBs.empty()) {
+-    BasicBlock *BB = *UnreachableBBs.begin();
+-    detachBBFromPredecessor(*BB, UnreachableBBs);
+-    UnreachableBBs.erase(BB);
+-    HandledUnreachableBBs.insert(BB);
++  // Collect the live blocks, i.e. those that can reach a return.
++  SmallBBSet LiveBBs;
++  SmallVector<BasicBlock *, 16> WorkList;
++  for (BasicBlock &BB : F) {
++    if (isa<ReturnInst>(BB.getTerminator())) {
++      LiveBBs.insert(&BB);
++      WorkList.push_back(&BB);
++    }
++  }
++  while (!WorkList.empty()) {
++    BasicBlock *BB = WorkList.pop_back_val();
++    for (BasicBlock *Pred : predecessors(BB))
++      if (LiveBBs.insert(Pred).second)
++        WorkList.push_back(Pred);
+   }
+ 
+-  while (!HandledUnreachableBBs.empty()) {
++  // A non-returning region is not necessarily doomed: an intentional infinite
++  // loop need not lead to an unreachable instruction. Walk backwards from the
++  // unreachables and restrict deletion to the intersection of both sets.
++  SmallBBSet DoomedBBs = UnreachableBBs;
++  WorkList.assign(UnreachableBBs.begin(), UnreachableBBs.end());
++  while (!WorkList.empty()) {
++    BasicBlock *BB = WorkList.pop_back_val();
++    for (BasicBlock *Pred : predecessors(BB))
++      if (!LiveBBs.count(Pred) && DoomedBBs.insert(Pred).second)
++        WorkList.push_back(Pred);
++  }
+ 
+-    auto CandidateBB = HandledUnreachableBBs.begin();
++  // If not even the entry block can reach a return, deleting the doomed
++  // blocks would delete the whole function body. Convert the unreachables
++  // to returns instead.
++  if (DoomedBBs.count(&F.getEntryBlock()))
++    return convertUnreachablesToReturns(F);
+ 
+-    // We have to delete the "chains" bottom up to avoid having basic blocks
+-    // that refer to the values produced by the predecessors in the stem.
+-    while (!isa<UnreachableInst>((*CandidateBB)->getTerminator()))
+-      ++CandidateBB;
+-    assert(CandidateBB != HandledUnreachableBBs.end());
+-    BasicBlock *BB = *CandidateBB;
++  // Retarget terminators of live blocks to only branch to live blocks. Note
++  // that an edge from a doomed block to a live block cannot exist, and that
++  // a live block always has at least one live successor.
++  for (BasicBlock &BB : F) {
++    if (!LiveBBs.count(&BB))
++      continue;
+ 
+-    LLVM_DEBUG(dbgs() << "Deleting BB: \n");
+-    LLVM_DEBUG(BB->dump());
++    Instruction *TI = BB.getTerminator();
++    bool HasDoomedSuccessor = false;
++    for (BasicBlock *Succ : successors(&BB))
++      HasDoomedSuccessor |= DoomedBBs.count(Succ);
++    if (!HasDoomedSuccessor)
++      continue;
+ 
+-    // The deleted BB can have multiple predecessors.
+-    SmallMapVector<Instruction *, Instruction *, 8> Replacements;
+-    for (BasicBlock *Pred : predecessors(BB))
+-      Replacements.insert(std::make_pair(
+-          Pred->getTerminator(), new UnreachableInst(Pred->getContext())));
++    LLVM_DEBUG(dbgs() << "Detaching doomed successors of:\n");
++    LLVM_DEBUG(BB.dump());
+ 
+-    for (auto [OldI, NewI] : Replacements) {
+-      ReplaceInstWithInst(OldI, NewI);
++#if LLVM_MAJOR >= 23
++    if (auto *CBI = dyn_cast<CondBrInst>(TI)) {
++      BasicBlock *Live = !DoomedBBs.count(CBI->getSuccessor(0))
++                             ? CBI->getSuccessor(0)
++                             : CBI->getSuccessor(1);
++      assert(!DoomedBBs.count(Live));
++      ReplaceInstWithInst(TI, UncondBrInst::Create(Live));
++    }
++#else
++    if (BranchInst *BI = dyn_cast<BranchInst>(TI)) {
++      assert(BI->isConditional());
++      BasicBlock *Live = !DoomedBBs.count(BI->getSuccessor(0))
++                             ? BI->getSuccessor(0)
++                             : BI->getSuccessor(1);
++      assert(!DoomedBBs.count(Live));
++      ReplaceInstWithInst(TI, BranchInst::Create(Live));
++    }
++#endif
++    else if (SwitchInst *SI = dyn_cast<SwitchInst>(TI)) {
++      // Remove the cases leading to doomed blocks. RemoveCase invalidates
++      // all iterators and might reorder the cases, so restart after each
++      // removal.
++      bool Removed = true;
++      while (Removed) {
++        Removed = false;
++        for (SwitchInst::CaseIt C = SI->case_begin(); C != SI->case_end();
++             ++C) {
++          if (DoomedBBs.count(C->getCaseSuccessor())) {
++            SI->removeCase(C);
++            Removed = true;
++            break;
++          }
++        }
++      }
++      if (DoomedBBs.count(SI->getDefaultDest())) {
++        // Make one of the remaining cases the new default. Removing the
++        // repurposed case keeps the number of edges to its successor, and
++        // thus the successor's phi incoming counts, unchanged.
++        assert(SI->getNumCases() > 0);
++        SI->setDefaultDest(SI->case_begin()->getCaseSuccessor());
++        SI->removeCase(SI->case_begin());
++      }
++    } else {
++      LLVM_DEBUG(dbgs() << "Unhandled BB Terminator: \n");
++      LLVM_DEBUG(TI->dump());
++      assert(0 && "Error: unexpected BB terminator\n");
+     }
+-
+-    BB->eraseFromParent();
+-    HandledUnreachableBBs.erase(BB);
+   }
++
++  // The doomed blocks are now unreachable from the entry.
++  EliminateUnreachableBlocks(F);
+   return true;
+ }
+ 
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index 8c309f4a3..1bb244970 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -28,7 +28,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
+      test_program_from_binary_with_local_1_1_1
+      test_assign_loop_variable_to_privvar_makes_it_local_2
+      test_llvm_segfault_issue_889
+-     test_issue_1711 test_issue_1794 test_issue_1747
++     test_issue_1711 test_issue_1794 test_issue_1747 test_issue_1958
+      test_rematerialized_alloca_load_with_outside_pr_users
+      test_peeled_wi_global_id
+      test_barrier_divergent_skip
+@@ -144,6 +144,8 @@ add_test_pocl(NAME "regression/test_issue_1794b" COMMAND "test_issue_1794" "0" "
+ 
+ add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "${CMAKE_CURRENT_SOURCE_DIR}/test_issue_1747.spv" LABELS ${SPIRV_LABELS})
+ 
++add_test_pocl(NAME "regression/test_issue_1958" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_issue_1958" LABELS ${SPIRV_LABELS})
++
+ add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+ 
+ add_test_pocl(NAME "regression/barrier_divergent_skip" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_barrier_divergent_skip" LABELS ${SPIRV_LABELS})
+diff --git a/tests/regression/test_issue_1958.c b/tests/regression/test_issue_1958.c
+new file mode 100644
+index 000000000..06646a271
+--- /dev/null
++++ b/tests/regression/test_issue_1958.c
+@@ -0,0 +1,168 @@
++// Copyright (c) 2026 PoCL developers
++//
++// Permission is hereby granted, free of charge, to any person obtaining a copy
++// of this software and associated documentation files (the "Software"), to deal
++// in the Software without restriction, including without limitation the rights
++// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++// copies of the Software, and to permit persons to whom the Software is
++// furnished to do so, subject to the following conditions:
++//
++// The above copyright notice and this permission notice shall be included in
++// all copies or substantial portions of the Software.
++//
++// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++// THE SOFTWARE.
++
++/*
++  Reduced from a Julia (OpenCL.jl) kernel with a printf-then-abort exception
++  path (https://github.com/pocl/pocl/issues/1958). After a barrier, a
++  work-item-varying bounds check conditionally calls a noreturn helper that
++  printfs a diagnostic before ending in OpUnreachable:
++
++      barrier();
++      if (in_bounds(idx)) {         // work-item-varying!
++        if (out_of_bounds(gid)) {
++          printf("...");            // expands to a string-length loop
++          __builtin_unreachable();
++        }
++      }
++      // return
++
++  For the work-item loop handlers, ConvertUnreachablesToReturns removes the
++  blocks leading to the unreachable. Detaching only the unreachable-terminated
++  blocks severed the exit edge of the printf expansion's string-length loop,
++  leaving an infinite loop that never reaches the parallel region exit, which
++  WorkitemLoops cannot handle (it asserted in createLoopAround). Blocks that
++  cannot reach the kernel exit must be deleted wholesale.
++
++  The crash happened when building the work-group function, so completing the
++  build and a (non-aborting) launch is the test.
++*/
++
++#include "pocl_opencl.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++#ifndef _WIN32
++#include <unistd.h>
++#endif
++
++#define CHECK_ERROR(err)                                                       \
++  if (err != CL_SUCCESS) {                                                     \
++    printf("OpenCL Error %d at %s:%d\n", err, __FILE__, __LINE__);             \
++    return 1;                                                                  \
++  }
++
++int main(int argc, char **argv) {
++  cl_uint platform_index = argc > 1 ? (cl_uint)atoi(argv[1]) : 0;
++  cl_int err;
++
++#ifndef _WIN32
++  // Fail quickly instead of tripping the much larger ctest timeout in case
++  // a regressed build hangs.
++  alarm(300);
++#endif
++
++  cl_uint num_platforms;
++  CHECK_ERROR(clGetPlatformIDs(0, NULL, &num_platforms));
++  if (platform_index >= num_platforms) {
++    printf("Platform index %u out of range\n", platform_index);
++    return 1;
++  }
++  cl_platform_id *platforms = malloc(sizeof(cl_platform_id) * num_platforms);
++  CHECK_ERROR(clGetPlatformIDs(num_platforms, platforms, NULL));
++  cl_platform_id platform = platforms[platform_index];
++  free(platforms);
++
++  cl_device_id device;
++  CHECK_ERROR(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL));
++
++  if (!poclu_device_supports_il(device, "SPIR-V_1.0")) {
++    printf("SKIP: The test requires support for SPIR-V 1.0\n");
++    return 77;
++  }
++
++  cl_context context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
++  CHECK_ERROR(err);
++  cl_queue_properties props[] = {0};
++  cl_command_queue queue =
++      clCreateCommandQueueWithProperties(context, device, props, &err);
++  CHECK_ERROR(err);
++
++  FILE *f = fopen(SRCDIR "/test_issue_1958.spv", "rb");
++  if (!f) {
++    printf("Failed to open test_issue_1958.spv\n");
++    return 1;
++  }
++  fseek(f, 0, SEEK_END);
++  size_t size = ftell(f);
++  fseek(f, 0, SEEK_SET);
++  unsigned char *binary = malloc(size);
++  if (fread(binary, 1, size, f) != size) {
++    printf("Failed to read SPIR-V\n");
++    free(binary);
++    fclose(f);
++    return 1;
++  }
++  fclose(f);
++
++  cl_program program = clCreateProgramWithIL(context, binary, size, &err);
++  CHECK_ERROR(err);
++  err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
++  if (err != CL_SUCCESS) {
++    size_t log_size;
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
++                          &log_size);
++    char *log = malloc(log_size);
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size, log,
++                          NULL);
++    printf("Build error:\n%s\n", log);
++    return 1;
++  }
++
++  // Building the work-group function is what used to crash; force it even
++  // when the driver would otherwise defer compilation to launch time.
++  size_t binary_size;
++  CHECK_ERROR(clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES,
++                               sizeof(binary_size), &binary_size, NULL));
++
++  char kernel_name[1024];
++  CHECK_ERROR(clGetProgramInfo(program, CL_PROGRAM_KERNEL_NAMES,
++                               sizeof(kernel_name), kernel_name, NULL));
++  cl_kernel kernel = clCreateKernel(program, kernel_name, &err);
++  CHECK_ERROR(err);
++
++  // The kernel arguments are pointers to structs whose first word is a
++  // bounds value the work-item indices are checked against; a large bound
++  // steers all work-items away from the printf-then-abort path. The loaded
++  // values are only compared, never dereferenced.
++  cl_ulong bound[4] = {(cl_ulong)1 << 40, 0, 0, 0};
++  cl_mem buf = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
++                              sizeof(bound), bound, &err);
++  CHECK_ERROR(err);
++  cl_uint num_args;
++  CHECK_ERROR(clGetKernelInfo(kernel, CL_KERNEL_NUM_ARGS, sizeof(num_args),
++                              &num_args, NULL));
++  for (cl_uint i = 0; i < num_args; i++)
++    CHECK_ERROR(clSetKernelArg(kernel, i, sizeof(buf), &buf));
++
++  size_t global_size = 64, local_size = 16;
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size,
++                                     &local_size, 0, NULL, NULL));
++  CHECK_ERROR(clFinish(queue));
++
++  clReleaseMemObject(buf);
++  clReleaseKernel(kernel);
++  clReleaseProgram(program);
++  clReleaseCommandQueue(queue);
++  clReleaseContext(context);
++  free(binary);
++
++  printf("OK\n");
++  return 0;
++}

--- a/P/pocl/pocl/bundled/patches/pocl/0016-UnreachablesToReturns-keep-loops-with-side-effects.patch
+++ b/P/pocl/pocl/bundled/patches/pocl/0016-UnreachablesToReturns-keep-loops-with-side-effects.patch
@@ -1,0 +1,302 @@
+From 6f3e8027391c82648aafa42857002664edbc3917 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Wed, 26 Aug 2026 16:01:47 +0200
+Subject: [PATCH 16/16] UnreachablesToReturns: keep loops with side effects
+
+Deleting every block that can reach an unreachable but not a return also
+removed intentional infinite loops that merely contain a guarded abort path,
+e.g. `while (1) { if (c) { printf(...); unreachable; } out[0] = 1; }`, along
+with their observable side effects. Treat blocks of a cycle containing
+side-effecting instructions as live, so only the unreachable-bound exit is
+removed from such loops. Side-effect-free loops like the printf string-length
+loop from issue #1958 remain deletable.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+(cherry picked from commit e0e27c765520cf761756155db944c51af9a294fe)
+---
+ lib/llvmopencl/UnreachablesToReturns.cc       |  44 ++++-
+ tests/regression/CMakeLists.txt               |   6 +
+ .../test_unreachable_in_infinite_loop.c       | 153 ++++++++++++++++++
+ 3 files changed, 197 insertions(+), 6 deletions(-)
+ create mode 100644 tests/regression/test_unreachable_in_infinite_loop.c
+
+diff --git a/lib/llvmopencl/UnreachablesToReturns.cc b/lib/llvmopencl/UnreachablesToReturns.cc
+index a63157e43..f7420788c 100644
+--- a/lib/llvmopencl/UnreachablesToReturns.cc
++++ b/lib/llvmopencl/UnreachablesToReturns.cc
+@@ -10,10 +10,10 @@
+ // is able to handle these.
+ //
+ // for LOOPVEC handler, we delete regions which can reach an unreachable inst
+-// but cannot reach the function's return. Branches from live blocks into the
+-// deleted region are made unconditional (to the live branch), and switch cases
+-// leading to it are removed. This preserves the PoCL 6.0 behavior that commit
+-// 89bc42187 sought to restore.
++// but can reach neither the function's return nor a loop with side effects.
++// Branches from live blocks into the deleted region are made unconditional (to
++// the live branch), and switch cases leading to it are removed. This preserves
++// the PoCL 6.0 behavior that commit 89bc42187 sought to restore.
+ //
+ // Note that neither handling is recursive. Therefore all non-kernel functions
+ // that have an unreachable inst, must be inlined before this Pass is run.
+@@ -44,6 +44,7 @@ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
+ #include <llvm/ADT/Twine.h>
+ POP_COMPILER_DIAGS
+ IGNORE_COMPILER_WARNING("-Wunused-parameter")
++#include <llvm/ADT/SCCIterator.h>
+ #include <llvm/ADT/SmallPtrSet.h>
+ #include <llvm/IR/CFG.h>
+ #include <llvm/IR/Constants.h>
+@@ -158,6 +159,11 @@ static bool convertUnreachablesToReturns(Function &F) {
+ // blocks would sever such a loop's exit edge and leave behind an infinite
+ // loop that never reaches the parallel region exit, breaking WorkitemLoops
+ // (issue #1958), so delete the doomed blocks wholesale.
++//
++// Loops with side effects are exempt: an intentional infinite loop such as
++// `while (1) { if (c) abort(); write_pipe(...); }` never reaches a return
++// either, but deleting it would discard observable behavior. Only the
++// unreachable-bound path out of such a loop is removed, as before.
+ static bool deleteBlocksWithUnreachable(Function &F) {
+ 
+   SmallBBSet UnreachableBBs;
+@@ -170,7 +176,9 @@ static bool deleteBlocksWithUnreachable(Function &F) {
+   if (UnreachableBBs.empty())
+     return false;
+ 
+-  // Collect the live blocks, i.e. those that can reach a return.
++  // Collect the live blocks, i.e. those that can reach a return or a loop
++  // with side effects. A loop without side effects (like the string-length
++  // loop mentioned above) is not observable and remains deletable.
+   SmallBBSet LiveBBs;
+   SmallVector<BasicBlock *, 16> WorkList;
+   for (BasicBlock &BB : F) {
+@@ -179,6 +187,29 @@ static bool deleteBlocksWithUnreachable(Function &F) {
+       WorkList.push_back(&BB);
+     }
+   }
++  for (scc_iterator<Function *> I = scc_begin(&F), E = scc_end(&F); I != E;
++       ++I) {
++    if (!I.hasCycle())
++      continue;
++    bool HasSideEffects = false;
++    for (BasicBlock *BB : *I) {
++      for (Instruction &Inst : *BB) {
++        if (!Inst.isTerminator() && Inst.mayHaveSideEffects()) {
++          HasSideEffects = true;
++          break;
++        }
++      }
++      if (HasSideEffects)
++        break;
++    }
++    if (!HasSideEffects)
++      continue;
++    LLVM_DEBUG(dbgs() << "Keeping loop with side effects, header: "
++                      << (*I).front()->getName().str() << "\n");
++    for (BasicBlock *BB : *I)
++      if (LiveBBs.insert(BB).second)
++        WorkList.push_back(BB);
++  }
+   while (!WorkList.empty()) {
+     BasicBlock *BB = WorkList.pop_back_val();
+     for (BasicBlock *Pred : predecessors(BB))
+@@ -206,7 +237,8 @@ static bool deleteBlocksWithUnreachable(Function &F) {
+ 
+   // Retarget terminators of live blocks to only branch to live blocks. Note
+   // that an edge from a doomed block to a live block cannot exist, and that
+-  // a live block always has at least one live successor.
++  // a live block always has at least one live successor (blocks of a kept
++  // loop have a successor within that loop).
+   for (BasicBlock &BB : F) {
+     if (!LiveBBs.count(&BB))
+       continue;
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index 1bb244970..fa5f4f24a 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -29,6 +29,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
+      test_assign_loop_variable_to_privvar_makes_it_local_2
+      test_llvm_segfault_issue_889
+      test_issue_1711 test_issue_1794 test_issue_1747 test_issue_1958
++     test_unreachable_in_infinite_loop
+      test_rematerialized_alloca_load_with_outside_pr_users
+      test_peeled_wi_global_id
+      test_barrier_divergent_skip
+@@ -146,6 +147,8 @@ add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "$
+ 
+ add_test_pocl(NAME "regression/test_issue_1958" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_issue_1958" LABELS ${SPIRV_LABELS})
+ 
++add_test_pocl(NAME "regression/unreachable_in_infinite_loop" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_unreachable_in_infinite_loop")
++
+ add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+ 
+ add_test_pocl(NAME "regression/barrier_divergent_skip" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_barrier_divergent_skip" LABELS ${SPIRV_LABELS})
+@@ -334,6 +337,9 @@ set_property(TEST
+   "regression/test_flatten_barrier_subs_cbs"
+   "regression/infinite_loop_loopvec"
+   "regression/infinite_loop_cbs"
++  "regression/unreachable_in_infinite_loop_loops"
++  "regression/unreachable_in_infinite_loop_loopvec"
++  "regression/unreachable_in_infinite_loop_cbs"
+   APPEND PROPERTY LABELS "mingw_fail")
+ 
+ # Label tests that work with CUDA backend
+diff --git a/tests/regression/test_unreachable_in_infinite_loop.c b/tests/regression/test_unreachable_in_infinite_loop.c
+new file mode 100644
+index 000000000..7e488f9ac
+--- /dev/null
++++ b/tests/regression/test_unreachable_in_infinite_loop.c
+@@ -0,0 +1,153 @@
++// Copyright (c) 2026 PoCL developers
++//
++// Permission is hereby granted, free of charge, to any person obtaining a copy
++// of this software and associated documentation files (the "Software"), to deal
++// in the Software without restriction, including without limitation the rights
++// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++// copies of the Software, and to permit persons to whom the Software is
++// furnished to do so, subject to the following conditions:
++//
++// The above copyright notice and this permission notice shall be included in
++// all copies or substantial portions of the Software.
++//
++// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++// THE SOFTWARE.
++
++/*
++  An intentional infinite loop with observable side effects that also contains
++  a path to an unreachable instruction (here: printf followed by
++  __builtin_unreachable(), which clang does not fold into an assumption).
++
++  For the work-item loop handlers, ConvertUnreachablesToReturns deletes the
++  region that can only lead to the unreachable. The loop can reach the
++  unreachable and cannot reach the kernel's return, so an overly eager
++  deletion removed the whole loop, including its store, and the kernel
++  returned immediately. Only the unreachable path may be removed; the loop
++  itself must remain, so a launch that never takes the unreachable path must
++  never complete.
++
++  The check mirrors test_infinite_loop.cpp: give the kernel some time, verify
++  it is still running, then replace the process to get rid of the spinning
++  kernel thread.
++*/
++
++#include "pocl_opencl.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++#ifdef _WIN32
++#include <windows.h>
++#define sleep_ms(MS) Sleep(MS)
++#else
++#include <unistd.h>
++#define sleep_ms(MS) usleep((MS) * 1000)
++#endif
++
++#define CHECK_ERROR(err)                                                       \
++  if (err != CL_SUCCESS) {                                                     \
++    printf("OpenCL Error %d at %s:%d\n", err, __FILE__, __LINE__);             \
++    return 1;                                                                  \
++  }
++
++static const char KernelSource[] =
++    "kernel void test_kernel(global volatile int *out, int early_exit,\n"
++    "                        global const int *abort_flags) {\n"
++    "  if (early_exit)\n"
++    "    return;\n"
++    "  while (1) {\n"
++    "    if (abort_flags[get_global_id(0)]) {\n"
++    "      printf(\"aborting\\n\");\n"
++    "      __builtin_unreachable();\n"
++    "    }\n"
++    "    out[0] = 1;\n"
++    "  }\n"
++    "}\n";
++
++int main(int argc, char **argv) {
++  cl_int err;
++
++  cl_platform_id platform;
++  CHECK_ERROR(clGetPlatformIDs(1, &platform, NULL));
++  cl_device_id device;
++  CHECK_ERROR(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL));
++
++  cl_context context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
++  CHECK_ERROR(err);
++  cl_queue_properties props[] = {0};
++  cl_command_queue queue =
++      clCreateCommandQueueWithProperties(context, device, props, &err);
++  CHECK_ERROR(err);
++
++  const char *sources[] = {KernelSource};
++  cl_program program =
++      clCreateProgramWithSource(context, 1, sources, NULL, &err);
++  CHECK_ERROR(err);
++  err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
++  if (err != CL_SUCCESS) {
++    size_t log_size;
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
++                          &log_size);
++    char *log = malloc(log_size);
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size, log,
++                          NULL);
++    printf("Build error:\n%s\n", log);
++    return 1;
++  }
++  cl_kernel kernel = clCreateKernel(program, "test_kernel", &err);
++  CHECK_ERROR(err);
++
++  const size_t global_size = 4;
++  cl_int out = 0;
++  cl_int abort_flags[4] = {0, 0, 0, 0};
++  cl_mem out_buf =
++      clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
++                     sizeof(out), &out, &err);
++  CHECK_ERROR(err);
++  cl_mem flags_buf =
++      clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
++                     sizeof(abort_flags), abort_flags, &err);
++  CHECK_ERROR(err);
++  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(out_buf), &out_buf));
++  CHECK_ERROR(clSetKernelArg(kernel, 2, sizeof(flags_buf), &flags_buf));
++
++  // The early exit must still work.
++  cl_int early_exit = 1;
++  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(early_exit), &early_exit));
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size,
++                                     &global_size, 0, NULL, NULL));
++  CHECK_ERROR(clFinish(queue));
++
++  // Without the early exit, the kernel must spin forever.
++  early_exit = 0;
++  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(early_exit), &early_exit));
++  cl_event event;
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size,
++                                     &global_size, 0, NULL, &event));
++  CHECK_ERROR(clFlush(queue));
++
++  sleep_ms(1500);
++
++  cl_int status;
++  CHECK_ERROR(clGetEventInfo(event, CL_EVENT_COMMAND_EXECUTION_STATUS,
++                             sizeof(status), &status, NULL));
++  if (status == CL_COMPLETE) {
++    printf("FAIL: the infinite loop was compiled away\n");
++    return 1;
++  }
++
++  printf("OK\n");
++  fflush(stdout);
++  // Force exit of the process regardless of the running kernel thread by
++  // replacing the process with a dummy process.
++#ifdef _WIN32
++  ExitProcess(EXIT_SUCCESS);
++#else
++  execlp("true", "true", NULL);
++#endif
++  return 0;
++}

--- a/P/pocl/pocl_next/build_tarballs.jl
+++ b/P/pocl/pocl_next/build_tarballs.jl
@@ -22,8 +22,8 @@ macos_sdk_version = "11.0"
 # Collection of sources required to complete build
 sources = [
     DirectorySource("./bundled"),
-    GitSource("https://github.com/JuliaGPU/pocl",
-              "5b85d6b8daaafad59beae8e2ab26c95f19ae4a59"),
+    GitSource("https://github.com/pocl/pocl",
+              "73ae321bde8025287c0ba57b5fb8907ab7b4ae78"), # release_7_2
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this is the latest LLVM-22.1 maintenance revision.
     GitSource("https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",

--- a/P/pocl/pocl_next/bundled/patches/pocl/0001-MinGW-support-building-with-the-Clang-lld-toolchain.patch
+++ b/P/pocl/pocl_next/bundled/patches/pocl/0001-MinGW-support-building-with-the-Clang-lld-toolchain.patch
@@ -1,0 +1,118 @@
+From b0d12a8768dadb66f4ea1bb771e8d1006642dae9 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Fri, 26 Jun 2026 13:09:13 +0200
+Subject: [PATCH 1/6] MinGW: support building with the Clang/lld toolchain
+
+GNU ld is pathologically slow at linking the static LLVM/Clang archives
+into a PE/COFF DLL (tens of minutes for libpocl). ld.lld is far faster,
+but its COFF driver doesn't implement GNU ld's --exclude-libs, which
+libpocl used to keep the static-lib symbols out of its auto-generated
+export table. Without that, auto-exporting the whole static LLVM blob
+overflows the 64K PE export-ordinal limit.
+
+Switch MinGW to the MSVC-style export model, which works with both GNU ld
+and lld:
+
+- stamp __declspec(dllexport) on the OpenCL API for any Windows toolchain
+  (defined(_WIN32)), not just _MSC_VER;
+- define EXPORT_POCL_LIB / IMPORT_POCL_LIB for any WIN32 shared build, not
+  just MSVC;
+- export only the dllexport'd symbols (--exclude-all-symbols) instead of
+  auto-export-minus-static-libs (--exclude-libs).
+
+Because libpocl now exports only its public API, its internal symbols are
+no longer visible to separately-dlopen'd driver modules, so consumers must
+build with ENABLE_LOADABLE_DRIVERS=OFF (drivers linked into libpocl).
+
+Also make the spirv_fix_atomic_compare_exchange helper compile its own copy
+of spirv_parser.cc in the non-ICD case, mirroring the ICD branch, so it no
+longer relies on SPIRVParser being exported from libpocl.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ bin/CMakeLists.txt    |  3 ++-
+ include/pocl.h        |  2 +-
+ lib/CL/CMakeLists.txt | 12 ++++++------
+ 3 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/bin/CMakeLists.txt b/bin/CMakeLists.txt
+index 6f2c8b3f0..6f7286c0e 100644
+--- a/bin/CMakeLists.txt
++++ b/bin/CMakeLists.txt
+@@ -34,7 +34,8 @@ if(ENABLE_SPIRV)
+     # Avoid POCL_EXPORT here
+     target_compile_definitions(spirv_fix_atomic_compare_exchange PRIVATE SPIRV_PARSER_LIB)
+   else()
+-    add_executable(spirv_fix_atomic_compare_exchange spirv_fix_atomic_compare_exchange.cc)
++    add_executable(spirv_fix_atomic_compare_exchange spirv_fix_atomic_compare_exchange.cc "${SPVSRC}/spirv_parser.hh" "${SPVSRC}/spirv_parser.cc")
++    target_compile_definitions(spirv_fix_atomic_compare_exchange PRIVATE SPIRV_PARSER_LIB)
+   endif()
+   harden(spirv_fix_atomic_compare_exchange)
+   target_link_libraries(spirv_fix_atomic_compare_exchange poclu ${OPENCL_LIBS})
+diff --git a/include/pocl.h b/include/pocl.h
+index 3269f931b..76dd71333 100644
+--- a/include/pocl.h
++++ b/include/pocl.h
+@@ -40,7 +40,7 @@
+    0 marks an invalid/undefined object. */
+ typedef uint64_t pocl_obj_id_t;
+ 
+-#if defined(EXPORT_POCL_LIB) && defined(_MSC_VER)
++#if defined(EXPORT_POCL_LIB) && defined(_WIN32)
+ /* To successfully export OpenCL API, the dllexport must be placed on
+  * both the declaration and the definition as MSVC requires that both
+  * of them have the same attributes.
+diff --git a/lib/CL/CMakeLists.txt b/lib/CL/CMakeLists.txt
+index e18427ccb..6e553121b 100644
+--- a/lib/CL/CMakeLists.txt
++++ b/lib/CL/CMakeLists.txt
+@@ -260,7 +260,7 @@ else()
+ endif()
+ 
+ add_library("pocl_cache" OBJECT "pocl_cache.c")
+-if(BUILD_SHARED_LIBS AND MSVC)
++if(BUILD_SHARED_LIBS AND WIN32)
+   # Inject __declspec(dllexport).
+   target_compile_definitions("pocl_cache" PRIVATE EXPORT_POCL_LIB)
+   target_compile_definitions("pocl_cache" INTERFACE IMPORT_POCL_LIB)
+@@ -319,7 +319,7 @@ if (ENABLE_LLVM)
+     endif()
+   endif()
+ 
+-  if(BUILD_SHARED_LIBS AND MSVC)
++  if(BUILD_SHARED_LIBS AND WIN32)
+     # Inject __declspec(dllexport).
+     target_compile_definitions(lib_cl_llvm PRIVATE EXPORT_POCL_LIB)
+     target_compile_definitions(lib_cl_llvm INTERFACE IMPORT_POCL_LIB)
+@@ -359,7 +359,7 @@ add_library("libpocl_unlinked_objs" OBJECT ${POCL_LIB_SOURCES})
+ target_include_directories(libpocl_unlinked_objs
+   PRIVATE ${CMAKE_SOURCE_DIR}/thirdparty/STC/include)
+ 
+-if(BUILD_SHARED_LIBS AND MSVC)
++if(BUILD_SHARED_LIBS AND WIN32)
+   # Inject __declspec(dllexport).
+   target_compile_definitions(libpocl_unlinked_objs PRIVATE EXPORT_POCL_LIB)
+   target_compile_definitions(libpocl_unlinked_objs INTERFACE IMPORT_POCL_LIB)
+@@ -439,7 +439,7 @@ set(POCL_TRANSITIVE_LIBS ${POCL_PRIVATE_LINK_LIST} PARENT_SCOPE)
+ #################################################################
+ 
+ add_library("${POCL_LIBRARY_NAME}" ${LIBPOCL_OBJS})
+-if(BUILD_SHARED_LIBS AND MSVC)
++if(BUILD_SHARED_LIBS AND WIN32)
+   # Inject __declspec(dllexport).
+   target_compile_definitions("${POCL_LIBRARY_NAME}" PRIVATE EXPORT_POCL_LIB)
+   target_compile_definitions("${POCL_LIBRARY_NAME}" INTERFACE IMPORT_POCL_LIB)
+@@ -447,11 +447,11 @@ endif()
+ 
+ harden("${POCL_LIBRARY_NAME}")
+ 
+-if((UNIX OR MINGW) AND (NOT APPLE))
++if(UNIX AND (NOT APPLE))
+   target_link_options("${POCL_LIBRARY_NAME}" PRIVATE "LINKER:--exclude-libs,ALL")
+ endif()
+ if(MINGW)
+-  target_link_options("${POCL_LIBRARY_NAME}" PRIVATE "LINKER:--enable-auto-import,--enable-runtime-pseudo-reloc")
++  target_link_options("${POCL_LIBRARY_NAME}" PRIVATE "LINKER:--exclude-all-symbols,--enable-auto-import,--enable-runtime-pseudo-reloc")
+ endif()
+ 
+ set_target_properties("${POCL_LIBRARY_NAME}" PROPERTIES SOVERSION "${LIB_API_VERSION}"

--- a/P/pocl/pocl_next/bundled/patches/pocl/0002-core-math-provide-missing-FP16-host-math-overloads.patch
+++ b/P/pocl/pocl_next/bundled/patches/pocl/0002-core-math-provide-missing-FP16-host-math-overloads.patch
@@ -1,0 +1,533 @@
+From e5e9c91c707c904f885e7443b86e6325276da52a Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Tue, 30 Jun 2026 10:17:24 +0200
+Subject: [PATCH 2/6] core-math: provide missing FP16 host math overloads
+
+With cl_khr_fp16 enabled, the host CPU kernel library must provide half
+overloads for the OpenCL math builtins exposed through the FP16 wrappers. Some
+of those builtins have Clang/LLVM FP16 lowerings, but others have no native
+FP16 lowering and no SLEEF FP16 implementation. In vectorized host builds those
+promoted-only overloads were still missing, so half kernels could fail at build
+time with unresolved _cl_<fn>(half) symbols or unresolved host libm calls.
+
+Split the implementations by lowering path. additionalf16.cl now contains only
+the overloads backed directly by Clang/LLVM FP16 intrinsics, and remains limited
+to the non-vectorized build where those definitions do not collide with the
+generic vectorized sources. promotedf16.cl contains the overloads that have to
+be built in both configurations: logb, ilogb, ldexp, rootn, pown, remainder,
+nextafter, powr, modf, and remquo.
+
+The promoted overloads call pocl's renamed float OpenCL builtins and round back
+to half, or compute nextafter directly on the half bit pattern. This keeps the
+kernel library self-contained instead of lowering to unresolved host libm
+symbols such as logbf, modff, or remquof. pown and powr move out of powf16.cl
+for the same reason: powf16.cl is non-vectorized-only, while pown and powr have
+no native FP16 provider in the vectorized configuration.
+
+Define scalar, vector, and address-space pointer forms for modf and remquo by
+doing the pointer work through private temporaries before storing to the
+requested output address space. Add the small FP16 binary and ternary template
+helpers used by the intrinsic-backed definitions.
+
+Add an OpenCL C regression test that keeps the scalar and vector half builtin
+calls live and catches the unresolved-symbol failure in the vectorized host
+configuration.
+---
+ lib/kernel/core-math/additionalf16.cl   |  66 ++++++++-
+ lib/kernel/core-math/powf16.cl          |  42 +-----
+ lib/kernel/core-math/promotedf16.cl     | 180 ++++++++++++++++++++++++
+ lib/kernel/host/CMakeLists.txt          |   7 +-
+ lib/kernel/templates.h                  |  16 +++
+ tests/kernel/CMakeLists.txt             |   7 +-
+ tests/kernel/test_fp16_math_builtins.cl |  80 +++++++++++
+ 7 files changed, 355 insertions(+), 43 deletions(-)
+ create mode 100644 lib/kernel/core-math/promotedf16.cl
+ create mode 100644 tests/kernel/test_fp16_math_builtins.cl
+
+diff --git a/lib/kernel/core-math/additionalf16.cl b/lib/kernel/core-math/additionalf16.cl
+index 11025b908..5b8e6be38 100644
+--- a/lib/kernel/core-math/additionalf16.cl
++++ b/lib/kernel/core-math/additionalf16.cl
+@@ -1,16 +1,76 @@
+ #include "common_types.h"
+ 
++/* FP16 overloads for math builtins with a Clang/LLVM FP16 lowering: the
++   __builtin_elementwise_* intrinsics (scalar + @llvm.<op>.vNf16, so they
++   vectorize without SLEEF) plus fmod and frexp, which map to single LLVM
++   intrinsics.
++ *
++ * These supplement the kernel library only in the non-vectorized configuration
++ * (ENABLE_HOST_CPU_VECTORIZE_BUILTINS=OFF). When vectorization is ON the generic
++ * <fn>.cl files provide these same FP16 overloads via __builtin_<fn>f16, so this
++ * file is excluded then (see lib/kernel/host/CMakeLists.txt) to avoid multiple
++ * definitions.
++ *
++ * Functions without a native FP16 builtin (logb, ilogb, ldexp, rootn, pown,
++ * remainder, nextafter, powr, modf, remquo) are in promotedf16.cl. That file is
++ * compiled in both configurations because the vectorized generic path does not
++ * cover those overloads either. (sincos and lgamma_r half are provided by
++ * core-math/sincosf16.cl and lgammaf16.cl.) */
++
+ #undef isfinite
+ #undef isnormal
+ #undef isinf
+ #undef isnan
+ 
+ DEFINE_FP16_BUILTIN_FPCLASS (isfinite, 504)
+-
+ DEFINE_FP16_BUILTIN_FPCLASS (isnormal, 264)
+-
+ DEFINE_FP16_BUILTIN_FPCLASS (isinf, 516)
+-
+ DEFINE_FP16_BUILTIN_FPCLASS (isnan, 3)
+ 
+ DEFINE_FP16_BUILTIN_V_V (sqrt, __builtin_elementwise_sqrt)
++DEFINE_FP16_BUILTIN_V_V (ceil, __builtin_elementwise_ceil)
++DEFINE_FP16_BUILTIN_V_V (floor, __builtin_elementwise_floor)
++DEFINE_FP16_BUILTIN_V_V (trunc, __builtin_elementwise_trunc)
++DEFINE_FP16_BUILTIN_V_V (rint, __builtin_elementwise_rint)
++DEFINE_FP16_BUILTIN_V_V (round, __builtin_elementwise_round)
++DEFINE_FP16_BUILTIN_V_V (fabs, __builtin_elementwise_abs)
++
++/* __builtin_elementwise_max/min lower to @llvm.maxnum/minnum, matching the
++   OpenCL fmax/fmin NaN-quieting semantics. */
++DEFINE_FP16_BUILTIN_V_VV (fmax, __builtin_elementwise_max)
++DEFINE_FP16_BUILTIN_V_VV (fmin, __builtin_elementwise_min)
++DEFINE_FP16_BUILTIN_V_VVV (fma, __builtin_elementwise_fma)
++
++/* fdim(x, y) = (x > y) ? x - y : +0, returning NaN if either input is NaN.
++   No single builtin exists; build it from fmax (defined above), keeping the
++   isnan guards because fmax quiets NaNs. This file undefines isnan above so it
++   can define _cl_isnan, so call the prefixed overload directly. (maxmag/minmag
++   then resolve.) */
++#define IMPLEMENT_FP16_FDIM(TYPE)                                             \
++  TYPE _CL_OVERLOADABLE fdim (TYPE a, TYPE b)                                 \
++  {                                                                           \
++    return _cl_isnan (a) ? a : (_cl_isnan (b) ? b : fmax (a - b, (TYPE)0));   \
++  }
++
++IMPLEMENT_FP16_FDIM (half)
++IMPLEMENT_FP16_FDIM (half2)
++IMPLEMENT_FP16_FDIM (half3)
++IMPLEMENT_FP16_FDIM (half4)
++IMPLEMENT_FP16_FDIM (half8)
++IMPLEMENT_FP16_FDIM (half16)
++
++/* fmod -> @llvm.frem and frexp -> @llvm.frexp are single LLVM intrinsics (no
++   libm libcall), so they belong with the Clang-builtin-backed overloads. */
++half _CL_OVERLOADABLE fmod (half a, half b) { return (half)__builtin_fmodf ((float)a, (float)b); }
++DEFINE_FP16_EXPR_V_VV (fmod)
++
++half _CL_OVERLOADABLE
++frexp (half x, private int *e) { return (half)__builtin_frexpf ((float)x, e); }
++#define IMPLEMENT_FP16_FREXP_AS(AS)                                          \
++  half _CL_OVERLOADABLE frexp (half x, AS int *e)                            \
++  { int t; half r = frexp (x, &t); *e = t; return r; }
++IMPLEMENT_FP16_FREXP_AS (local)
++IMPLEMENT_FP16_FREXP_AS (global)
++#ifdef __opencl_c_generic_address_space
++IMPLEMENT_FP16_FREXP_AS (generic)
++#endif
+diff --git a/lib/kernel/core-math/powf16.cl b/lib/kernel/core-math/powf16.cl
+index 4a74d2974..06fad690b 100644
+--- a/lib/kernel/core-math/powf16.cl
++++ b/lib/kernel/core-math/powf16.cl
+@@ -308,40 +308,8 @@ Expected: -inf (half 0xfc00)
+ Actual: inf (half 0x7c00) at index: 9
+ */
+ 
+-_CL_OVERLOADABLE half pown(half x, int y) {
+-    float ret = pow(convert_float(x), y);
+-    return convert_half(ret);
+-}
+-
+-DEFINE_FP16_EXPR_V_VI(pown)
+-/*
+-
+-ERROR: powr: nan ulp error at {-0x1.be8p-12 (0x8efa), 0x1.becp+12 (0x6efb)}
+-Expected: nan  (half 0x7e00)
+-Actual: 0x0p+0 (half 0x0000) at index: 0
+-
+-ERROR: powr: nan ulp error at {-0x1.728p+9 (0xe1ca), -0x1.4ap+14 (0xf528)}
+-Expected: nan  (half 0x7e00)
+-Actual: 0x0p+0 (half 0x0000) at index: 14
+-
+-ERROR: powr: nan ulp error at {-0x1.5dcp-10 (0x9577), -0x1.c84p+12 (0xef21)}
+-Expected: nan  (half 0x7e00)
+-Actual: inf (half 0x7c00) at index: 9
+-
+-ERROR: powr: nan ulp error at {-0x1.f24p+13 (0xf3c9), -0x1.e84p+10 (0xe7a1)}
+-Expected: nan  (half 0x7e00)
+-Actual: -0x0p+0 (half 0x8000) at index: 7
+-
+-*/
+-
+-_CL_OVERLOADABLE half powr(half x, half y) {
+-    b16u16_u xx = { .f = x };
+-    x = (xx.u == 0x8000) ? 0 : x;
+-    half retval = pow(x, y);
+-    retval = (xx.u > 0x8000) ? NAN : retval;
+-    retval = isnan(x) ? NAN : retval;
+-    retval = isnan(y) ? NAN : retval;
+-    return retval;
+-}
+-
+-DEFINE_FP16_EXPR_V_VV(powr)
++/* NOTE: pown(half) and powr(half) live in promotedf16.cl, not here. They have no
++   native FP16 builtin and are not provided by the vectorized generic pow.cl, so
++   they must be compiled in BOTH configurations -- whereas pow(half) above clashes
++   with the generic vectorized pow.cl when ENABLE_HOST_CPU_VECTORIZE_BUILTINS=ON,
++   so this file stays in the non-vectorized build only. */
+diff --git a/lib/kernel/core-math/promotedf16.cl b/lib/kernel/core-math/promotedf16.cl
+new file mode 100644
+index 000000000..9a1e6216e
+--- /dev/null
++++ b/lib/kernel/core-math/promotedf16.cl
+@@ -0,0 +1,180 @@
++#include "common_types.h"
++
++float _CL_OVERLOADABLE _cl_modf (float, private float *);
++float _CL_OVERLOADABLE _cl_remquo (float, float, private int *);
++
++/* FP16 overloads for math builtins without a native FP16 path -- neither a
++   Clang/LLVM FP16 builtin nor a SLEEF FP16 routine. Unlike additionalf16.cl
++   (the __builtin_elementwise_* overloads, which the vectorized generic <fn>.cl
++   files already provide via __builtin_<fn>f16 when
++   ENABLE_HOST_CPU_VECTORIZE_BUILTINS=ON), nothing else in the kernel library
++   supplies these in either configuration, so this file is compiled in both the
++   vectorized and non-vectorized builds.
++ *
++ * These overloads either promote to float and compute with pocl's own float
++ * builtin before rounding back to half, or, for nextafter, compute directly on
++ * the half bit pattern. This keeps the calls inside the kernel library instead
++ * of lowering to unresolved host libm symbols.
++ *
++ * The float computation calls the OpenCL builtin (e.g. `logb`), which the
++ * kernel-library rename (_builtin_renames.h) maps to pocl's own `_cl_logb`. It
++ * must not use `__builtin_logbf`: that has no LLVM intrinsic, so at the kernel
++ * library's -O0 it lowers to a call to the libm symbol `logbf`, which the
++ * kernel library does not provide -- producing
++ * "Cannot find symbol logbf in kernel library" when a half kernel is built.
++ * (The half overload below renames to `_cl_logb(half)`; the `logb((float)a)`
++ * call resolves by overload to `_cl_logb(float)`, so there is no recursion.) */
++
++/* logb : half -> half */
++half _CL_OVERLOADABLE logb (half a) { return (half)logb ((float)a); }
++DEFINE_FP16_EXPR_V_V (logb)
++
++/* ilogb : half -> int (scalar), halfN -> intN (vector) */
++int _CL_OVERLOADABLE ilogb (half a) { return ilogb ((float)a); }
++#define IMPLEMENT_FP16_ILOGB(ITYPE, HTYPE, NAMEN)                            \
++  ITYPE _CL_OVERLOADABLE ilogb (HTYPE a) { return (ITYPE)NAMEN (ilogb); }
++IMPLEMENT_FP16_ILOGB (int2, half2, NAME1_2)
++IMPLEMENT_FP16_ILOGB (int3, half3, NAME1_3)
++IMPLEMENT_FP16_ILOGB (int4, half4, NAME1_4)
++IMPLEMENT_FP16_ILOGB (int8, half8, NAME1_8)
++IMPLEMENT_FP16_ILOGB (int16, half16, NAME1_16)
++
++/* ldexp : (half, int) -> half */
++half _CL_OVERLOADABLE ldexp (half a, int b) { return (half)ldexp ((float)a, b); }
++DEFINE_FP16_EXPR_V_VI (ldexp)
++
++/* rootn : (half, int) -> half */
++half _CL_OVERLOADABLE rootn (half a, int b) { return (half)rootn ((float)a, b); }
++DEFINE_FP16_EXPR_V_VI (rootn)
++
++/* pown : (half, int) -> half. (Relocated from powf16.cl, which is compiled only
++   in the non-vectorized build; pown has no native FP16 builtin so it is needed
++   in both.) */
++half _CL_OVERLOADABLE pown (half a, int b) { return (half)pown ((float)a, b); }
++DEFINE_FP16_EXPR_V_VI (pown)
++
++/* remainder : (half, half) -> half */
++half _CL_OVERLOADABLE remainder (half a, half b) { return (half)remainder ((float)a, (float)b); }
++DEFINE_FP16_EXPR_V_VV (remainder)
++
++/* modf : (halfN, address-space halfN*) -> halfN */
++half _CL_OVERLOADABLE
++modf (half x, private half *iptr)
++{
++  float fip;
++  half r = (half)modf ((float)x, &fip);
++  *iptr = (half)fip;
++  return r;
++}
++
++#define IMPLEMENT_FP16_MODF_AS(TYPE, AS)                                     \
++  TYPE _CL_OVERLOADABLE modf (TYPE x, AS TYPE *iptr)                         \
++  { TYPE t; TYPE r = modf (x, &t); *iptr = t; return r; }
++
++#define IMPLEMENT_FP16_MODF_VECTOR(TYPE, LTYPE, HTYPE, LO, HI)               \
++  TYPE _CL_OVERLOADABLE modf (TYPE x, private TYPE *iptr)                    \
++  {                                                                          \
++    LTYPE l;                                                                 \
++    HTYPE h;                                                                 \
++    TYPE r = (TYPE)(modf (x.LO, &l), modf (x.HI, &h));                       \
++    iptr->LO = l;                                                            \
++    iptr->HI = h;                                                            \
++    return r;                                                                \
++  }                                                                          \
++  IMPLEMENT_FP16_MODF_AS (TYPE, local)                                       \
++  IMPLEMENT_FP16_MODF_AS (TYPE, global)                                      \
++  IF_GEN_AS (IMPLEMENT_FP16_MODF_AS (TYPE, generic))
++
++IMPLEMENT_FP16_MODF_AS (half, local)
++IMPLEMENT_FP16_MODF_AS (half, global)
++IF_GEN_AS (IMPLEMENT_FP16_MODF_AS (half, generic))
++IMPLEMENT_FP16_MODF_VECTOR (half2, half, half, lo, hi)
++IMPLEMENT_FP16_MODF_VECTOR (half3, half2, half, lo, s2)
++IMPLEMENT_FP16_MODF_VECTOR (half4, half2, half2, lo, hi)
++IMPLEMENT_FP16_MODF_VECTOR (half8, half4, half4, lo, hi)
++IMPLEMENT_FP16_MODF_VECTOR (half16, half8, half8, lo, hi)
++
++/* remquo : (halfN, halfN, address-space intN*) -> halfN */
++half _CL_OVERLOADABLE
++remquo (half x, half y, private int *quo)
++{
++  return (half)remquo ((float)x, (float)y, quo);
++}
++
++#define IMPLEMENT_FP16_REMQUO_AS(TYPE, ITYPE, AS)                            \
++  TYPE _CL_OVERLOADABLE remquo (TYPE x, TYPE y, AS ITYPE *quo)               \
++  { ITYPE t; TYPE r = remquo (x, y, &t); *quo = t; return r; }
++
++#define IMPLEMENT_FP16_REMQUO_VECTOR(TYPE, ITYPE, LITYPE, HITYPE, LO, HI)    \
++  TYPE _CL_OVERLOADABLE remquo (TYPE x, TYPE y, private ITYPE *quo)          \
++  {                                                                          \
++    LITYPE l;                                                                \
++    HITYPE h;                                                                \
++    TYPE r = (TYPE)(remquo (x.LO, y.LO, &l), remquo (x.HI, y.HI, &h));       \
++    quo->LO = l;                                                             \
++    quo->HI = h;                                                             \
++    return r;                                                                \
++  }                                                                          \
++  IMPLEMENT_FP16_REMQUO_AS (TYPE, ITYPE, local)                              \
++  IMPLEMENT_FP16_REMQUO_AS (TYPE, ITYPE, global)                             \
++  IF_GEN_AS (IMPLEMENT_FP16_REMQUO_AS (TYPE, ITYPE, generic))
++
++IMPLEMENT_FP16_REMQUO_AS (half, int, local)
++IMPLEMENT_FP16_REMQUO_AS (half, int, global)
++IF_GEN_AS (IMPLEMENT_FP16_REMQUO_AS (half, int, generic))
++IMPLEMENT_FP16_REMQUO_VECTOR (half2, int2, int, int, lo, hi)
++IMPLEMENT_FP16_REMQUO_VECTOR (half3, int3, int2, int, lo, s2)
++IMPLEMENT_FP16_REMQUO_VECTOR (half4, int4, int2, int2, lo, hi)
++IMPLEMENT_FP16_REMQUO_VECTOR (half8, int8, int4, int4, lo, hi)
++IMPLEMENT_FP16_REMQUO_VECTOR (half16, int16, int8, int8, lo, hi)
++
++/* powr : (half, half) -> half. powr(x,y) = pow(x,y) for x >= 0, NaN for x < 0.
++   Built on the half `pow` builtin -- which is available in both configurations
++   (CORE-Math powf16.cl when vectorization is off, the generic vectorized pow.cl
++   when it is on) -- so this works in both. (Relocated from powf16.cl, which is
++   compiled only in the non-vectorized build.) */
++half _CL_OVERLOADABLE
++powr (half x, half y)
++{
++  ushort xu = as_ushort (x);
++  x = (xu == (ushort)0x8000) ? (half)0 : x;       /* -0 -> +0 */
++  half r = pow (x, y);
++  r = (xu > (ushort)0x8000) ? (half)NAN : r;       /* x < 0 -> NaN */
++  r = isnan (x) ? (half)NAN : r;
++  r = isnan (y) ? (half)NAN : r;
++  return r;
++}
++DEFINE_FP16_EXPR_V_VV (powr)
++
++/* nextafter : (half, half) -> half. Computed directly on the half bit pattern;
++   float promotion is wrong here (it would step to the next float, not the next
++   half). Mirrors sleef-pocl/nextafter.cl (pocl#2210). */
++half _CL_OVERLOADABLE
++nextafter (half x, half y)
++{
++  const short sign_bit = as_short ((ushort)0x8000);
++  const short sign_bit_mask = 0x7fff;
++
++  short ix = as_short (x);
++  short ax = ix & sign_bit_mask;
++  short mx = sign_bit - ix;
++  mx = ix < (short)0 ? mx : ix;
++
++  short iy = as_short (y);
++  short ay = iy & sign_bit_mask;
++  short my = sign_bit - iy;
++  my = iy < (short)0 ? my : iy;
++
++  short t = mx + (mx < my ? 1 : -1);
++  short r = sign_bit - t;
++  r = t < (short)0 ? r : t;
++
++  if (t == 0 && ix < 0)
++    r = sign_bit;
++
++  r = isnan (x) ? ix : r;
++  r = isnan (y) ? iy : r;
++  r = (((ax | ay) == (short)0) | (ix == iy)) ? iy : r;
++  return as_half (r);
++}
++DEFINE_FP16_EXPR_V_VV (nextafter)
+diff --git a/lib/kernel/host/CMakeLists.txt b/lib/kernel/host/CMakeLists.txt
+index 1df20f85a..e925f1f15 100644
+--- a/lib/kernel/host/CMakeLists.txt
++++ b/lib/kernel/host/CMakeLists.txt
+@@ -356,7 +356,10 @@ if(HOST_CPU_ENABLE_CL_KHR_FP16)
+         acoshf16.cl   atan2pif16.cl  exp10m1f16.cl   lgammaf16.cl    sinpif16.cl
+         atanhf16.cl   cospif16.cl    exp2m1f16.cl    log10p1f16.cl   asinhf16.cl
+         atanpif16.cl  erfcf16.cl     log1pf16.cl     sincosf16.cl    asinpif16.cl
+-        cbrtf16.cl    erff16.cl      expm1f16.cl     tanpif16.cl)
++        cbrtf16.cl    erff16.cl      expm1f16.cl     tanpif16.cl
++        # FP16 ops with no native FP16 builtin and no SLEEF FP16 path: not
++        # covered by the vectorized generic builtins above, so needed here too.
++        promotedf16.cl)
+       list(APPEND SOURCES_WITH_SLEEF "core-math/${FILE}")
+     endforeach()
+   else()
+@@ -368,7 +371,7 @@ if(HOST_CPU_ENABLE_CL_KHR_FP16)
+         asinf16.cl    atanhf16.cl    cospif16.cl     exp2m1f16.cl   log10p1f16.cl  tanf16.cl
+         asinhf16.cl   atanpif16.cl   erfcf16.cl      expf16.cl      log1pf16.cl    sincosf16.cl  tanhf16.cl
+         asinpif16.cl  cbrtf16.cl     erff16.cl       expm1f16.cl    log2f16.cl     sinf16.cl     tanpif16.cl
+-        additionalf16.cl)
++        additionalf16.cl  promotedf16.cl)
+       list(APPEND SOURCES_WITH_SLEEF "core-math/${FILE}")
+     endforeach()
+   endif()
+diff --git a/lib/kernel/templates.h b/lib/kernel/templates.h
+index e78cd0c2c..6ae3f794f 100644
+--- a/lib/kernel/templates.h
++++ b/lib/kernel/templates.h
+@@ -2228,3 +2228,19 @@
+   IMPLEMENT_FP16_EXPR_V_V (NAME, half4, BUILTIN (a))                          \
+   IMPLEMENT_FP16_EXPR_V_V (NAME, half8, BUILTIN (a))                          \
+   IMPLEMENT_FP16_EXPR_V_V (NAME, half16, BUILTIN (a))
++
++#define DEFINE_FP16_BUILTIN_V_VV(NAME, BUILTIN)                               \
++  IMPLEMENT_FP16_EXPR_V_VV (NAME, half, BUILTIN (a, b))                       \
++  IMPLEMENT_FP16_EXPR_V_VV (NAME, half2, BUILTIN (a, b))                      \
++  IMPLEMENT_FP16_EXPR_V_VV (NAME, half3, BUILTIN (a, b))                      \
++  IMPLEMENT_FP16_EXPR_V_VV (NAME, half4, BUILTIN (a, b))                      \
++  IMPLEMENT_FP16_EXPR_V_VV (NAME, half8, BUILTIN (a, b))                      \
++  IMPLEMENT_FP16_EXPR_V_VV (NAME, half16, BUILTIN (a, b))
++
++#define DEFINE_FP16_BUILTIN_V_VVV(NAME, BUILTIN)                              \
++  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half, BUILTIN (a, b, c))                   \
++  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half2, BUILTIN (a, b, c))                  \
++  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half3, BUILTIN (a, b, c))                  \
++  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half4, BUILTIN (a, b, c))                  \
++  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half8, BUILTIN (a, b, c))                  \
++  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half16, BUILTIN (a, b, c))
+diff --git a/tests/kernel/CMakeLists.txt b/tests/kernel/CMakeLists.txt
+index 85543dc32..749bfb322 100644
+--- a/tests/kernel/CMakeLists.txt
++++ b/tests/kernel/CMakeLists.txt
+@@ -97,6 +97,9 @@ add_test_pocl(NAME "kernel/test_short16"
+ add_test_pocl(NAME "kernel/test_frexp_modf"
+               COMMAND "kernel" "test_frexp_modf")
+ 
++add_test_pocl(NAME "kernel/test_fp16_math_builtins"
++              COMMAND "kernel" "test_fp16_math_builtins")
++
+ if(HOST_CPU_ENABLE_CL_KHR_KERNEL_CLOCK)
+   add_test_pocl(NAME "kernel/test_kernel_clock"
+                 COMMAND "kernel" "test_kernel_clock")
+@@ -140,7 +143,8 @@ foreach(VARIANT ${VARIANTS})
+     "kernel/test_convert_sat_regression_${VARIANT}"   "kernel/test_fabs_${VARIANT}"
+     "kernel/test_rotate_${VARIANT}" "kernel/test_copy_signbit_${VARIANT}" "kernel/test_ilogb_${VARIANT}"
+     "kernel/test_ldexp_${VARIANT}" "kernel/test_isnan_${VARIANT}" "kernel/test_short16_${VARIANT}"
+-    "kernel/test_frexp_modf_${VARIANT}" ${ENABLE_CPU_TESTS}
++    "kernel/test_frexp_modf_${VARIANT}" "kernel/test_fp16_math_builtins_${VARIANT}"
++    ${ENABLE_CPU_TESTS}
+     PROPERTIES
+       COST 4.0
+       PROCESSORS 1
+@@ -249,6 +253,7 @@ if(NOT HOST_CPU_ENABLE_CL_KHR_FP16)
+   foreach(VARIANT ${VARIANTS})
+   set_tests_properties("kernel/test_printf_vectors_halfn_${VARIANT}"
+     "kernel/test_shuffle_half_${VARIANT}" "kernel/test_halfs_${VARIANT}"
++    "kernel/test_fp16_math_builtins_${VARIANT}"
+     PROPERTIES
+       PROCESSORS 1
+       COST 120
+diff --git a/tests/kernel/test_fp16_math_builtins.cl b/tests/kernel/test_fp16_math_builtins.cl
+new file mode 100644
+index 000000000..32df4f14d
+--- /dev/null
++++ b/tests/kernel/test_fp16_math_builtins.cl
+@@ -0,0 +1,80 @@
++#pragma OPENCL EXTENSION cl_khr_fp16 : enable
++
++volatile global half x = 1.5h;
++volatile global half y = 2.0h;
++volatile global int n = 3;
++volatile global half8 vx = (half8)(1.5h);
++volatile global half8 vy = (half8)(2.0h);
++volatile global int8 vn = (int8)(3);
++
++volatile global half hsink;
++volatile global int isink;
++volatile global half8 vsink;
++volatile global int8 visink;
++
++kernel void test_fp16_math_builtins ()
++{
++  half hx = x;
++  half hy = y;
++  int hn = n;
++  half hip;
++  int iexp;
++  int quo;
++
++  hsink = ceil (hx);
++  hsink = floor (hx);
++  hsink = trunc (hx);
++  hsink = rint (hx);
++  hsink = round (hx);
++  hsink = fabs (hx);
++  hsink = fmax (hx, hy);
++  hsink = fmin (hx, hy);
++  hsink = fma (hx, hy, hx);
++  hsink = fdim (hy, hx);
++  hsink = maxmag (hx, hy);
++  hsink = minmag (hx, hy);
++  hsink = fmod (hy, hx);
++  hsink = frexp (hx, &iexp);
++  hsink = logb (hx);
++  isink = ilogb (hx);
++  hsink = ldexp (hx, hn);
++  hsink = rootn (hy, hn);
++  hsink = pown (hx, hn);
++  hsink = remainder (hy, hx);
++  hsink = modf (hx, &hip);
++  hsink = remquo (hy, hx, &quo);
++  isink = iexp + quo;
++  hsink = powr (hy, hx);
++  hsink = nextafter (hx, hy);
++
++  half8 hvx = vx;
++  half8 hvy = vy;
++  int8 hvn = vn;
++  half8 vip;
++  int8 vquo;
++
++  vsink = ceil (hvx);
++  vsink = floor (hvx);
++  vsink = trunc (hvx);
++  vsink = rint (hvx);
++  vsink = round (hvx);
++  vsink = fabs (hvx);
++  vsink = fmax (hvx, hvy);
++  vsink = fmin (hvx, hvy);
++  vsink = fma (hvx, hvy, hvx);
++  vsink = fdim (hvy, hvx);
++  vsink = maxmag (hvx, hvy);
++  vsink = minmag (hvx, hvy);
++  vsink = fmod (hvy, hvx);
++  vsink = logb (hvx);
++  visink = ilogb (hvx);
++  vsink = ldexp (hvx, hvn);
++  vsink = rootn (hvy, hvn);
++  vsink = pown (hvx, hvn);
++  vsink = remainder (hvy, hvx);
++  vsink = modf (hvx, &vip);
++  vsink = remquo (hvy, hvx, &vquo);
++  visink = vquo;
++  vsink = powr (hvy, hvx);
++  vsink = nextafter (hvx, hvy);
++}

--- a/P/pocl/pocl_next/bundled/patches/pocl/0003-Load-CPU-host-kernels-in-process-via-ORC-JITLink.patch
+++ b/P/pocl/pocl_next/bundled/patches/pocl/0003-Load-CPU-host-kernels-in-process-via-ORC-JITLink.patch
@@ -1,0 +1,2897 @@
+From e0de78db03448f841c98ad2ff4a906a17f97b928 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Thu, 9 Jul 2026 11:10:30 +0200
+Subject: [PATCH 3/6] Load CPU host kernels in-process via ORC/JITLink
+
+Add an ORC LLJIT loader for CPU work-group objects so supported hosts can link and load kernel objects in-process without writing a shared library, calling dlopen(), or executing an external linker.
+
+Keep the linker path available through POCL_CPU_JIT=0 or unsupported JITLink targets, and use in-process lld where available. Exported program binaries link JIT objects into shared libraries when possible, while the ordinary cache keeps distinct object and shared-library variants.
+
+Teach the JIT symbol model about libpocl, configured vector math libraries, compiler-rt/libgcc helpers, kernel-library builtins, printf flush, and MinGW helper symbols. Add focused CPU JIT smoke coverage.
+---
+ CMakeLists.txt                              | 124 ++++
+ cmake/SetupLLD.cmake                        |   3 +-
+ cmake/SetupLLVMviaCMake.cmake               |  10 +
+ cmake/test_jit_svml_failure.cmake           |  18 +
+ cmake/test_jit_svml_success.cmake           |  23 +
+ config.h.in.cmake                           |  16 +
+ doc/sphinx/source/cpu.rst                   |  53 +-
+ doc/sphinx/source/notes_7_2.rst             |   9 +
+ doc/sphinx/source/using.rst                 |  10 +
+ examples/vecadd/CMakeLists.txt              |   7 +
+ examples/vecbuiltin/CMakeLists.txt          |  19 +
+ include/pocl_cache.h                        |  10 +
+ lib/CL/CMakeLists.txt                       |   3 +
+ lib/CL/devices/common.c                     | 404 ++++++++---
+ lib/CL/devices/common.h                     |   8 +-
+ lib/CL/devices/common_driver.c              |  48 ++
+ lib/CL/devices/common_utils.c               |  15 +
+ lib/CL/pocl_binary.c                        |  14 +-
+ lib/CL/pocl_cache.c                         |  71 +-
+ lib/CL/pocl_cl.h                            |  19 +
+ lib/CL/pocl_llvm.h                          |   5 +-
+ lib/CL/pocl_llvm_api.h                      |   6 +
+ lib/CL/pocl_llvm_build.cc                   |  17 +-
+ lib/CL/pocl_llvm_orc.cc                     | 719 ++++++++++++++++++++
+ lib/CL/pocl_llvm_orc.h                      |  75 ++
+ lib/CL/pocl_llvm_spirv.cc                   |   2 +-
+ lib/CL/pocl_llvm_wg.cc                      | 144 +++-
+ lib/llvmopencl/linker.cpp                   |  69 +-
+ lib/llvmopencl/linker.h                     |   8 +-
+ tests/CMakeLists.txt                        |  28 +
+ tests/kernel/CMakeLists.txt                 |   9 +
+ tests/regression/CMakeLists.txt             |   5 +-
+ tests/regression/test_large_stack_frame.cpp |  69 ++
+ 33 files changed, 1849 insertions(+), 191 deletions(-)
+ create mode 100644 cmake/test_jit_svml_failure.cmake
+ create mode 100644 cmake/test_jit_svml_success.cmake
+ create mode 100644 lib/CL/pocl_llvm_orc.cc
+ create mode 100644 lib/CL/pocl_llvm_orc.h
+ create mode 100644 tests/regression/test_large_stack_frame.cpp
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0e2546862..96f04accc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1120,6 +1120,100 @@ if(ENABLE_LLVM AND ENABLE_HOST_CPU_DEVICES AND (NOT ENABLE_CONFORMANCE) AND (LLV
+   endif()
+ endif()
+ 
++# Record the compiler runtime archive for the JIT. The Clang-driver final link
++# used to add libgcc/compiler-rt implicitly; the in-process JIT needs the same
++# helper symbols (e.g. __truncdfhf2 for FP16 conversions) available through ORC.
++set(HOST_CPU_COMPILER_RT_LIBRARY "")
++set(HOST_CPU_COMPILER_RT_LIBRARY_SOURCE "" CACHE FILEPATH "Compiler runtime archive to install for CPU JIT kernels")
++if(HOST_CPU_ENABLE_JIT)
++  set(POCL_COMPILER_RT_LIBRARY "${HOST_CPU_COMPILER_RT_LIBRARY_SOURCE}")
++  if(NOT POCL_COMPILER_RT_LIBRARY)
++    # `-print-libgcc-file-name` is a GCC option; clang's answer may name a nonexistent archive
++    # (cross MinGW/clang). Fall back to `-print-file-name=libgcc.a` and require it to exist.
++    execute_process(
++      COMMAND "${CMAKE_C_COMPILER}" -print-libgcc-file-name
++      OUTPUT_VARIABLE POCL_COMPILER_RT_LIBRARY
++      OUTPUT_STRIP_TRAILING_WHITESPACE
++      ERROR_QUIET)
++    if(NOT (POCL_COMPILER_RT_LIBRARY AND EXISTS "${POCL_COMPILER_RT_LIBRARY}"))
++      execute_process(
++        COMMAND "${CMAKE_C_COMPILER}" -print-file-name=libgcc.a
++        OUTPUT_VARIABLE POCL_COMPILER_RT_LIBRARY
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++        ERROR_QUIET)
++    endif()
++  endif()
++  if(POCL_COMPILER_RT_LIBRARY AND EXISTS "${POCL_COMPILER_RT_LIBRARY}")
++    get_filename_component(POCL_COMPILER_RT_LIBRARY_NAME
++      "${POCL_COMPILER_RT_LIBRARY}" NAME)
++    install(FILES "${POCL_COMPILER_RT_LIBRARY}"
++      DESTINATION "${POCL_INSTALL_PRIVATE_DATADIR_REL}" COMPONENT "lib")
++    set(HOST_CPU_COMPILER_RT_LIBRARY "${POCL_COMPILER_RT_LIBRARY_NAME}")
++  elseif(HOST_COMPILER_SUPPORTS_FLOAT16)
++    # Warn rather than silently ship a driver whose FP16 kernels can't JIT (__truncdfhf2).
++    message(WARNING
++      "Could not locate a compiler runtime archive (libgcc/compiler-rt) for the CPU JIT. "
++      "FP16 kernels that emit soft-float helpers such as __truncdfhf2 will fail to resolve "
++      "at run time. Point PoCL at one with -DHOST_CPU_COMPILER_RT_LIBRARY_SOURCE=<libgcc.a>.")
++  endif()
++endif()
++
++# Record the SONAME of the SLEEF library for the JIT to link against
++set(HOST_CPU_SLEEF_LIBRARY "")
++set(HOST_CPU_SLEEF_LIBRARY_FALLBACK "")
++if(ENABLE_HOST_CPU_VECTORIZE_SLEEF AND LIBSLEEF)
++  set(HOST_CPU_SLEEF_LIBRARY "${LIBSLEEF}")
++  if(CMAKE_OBJDUMP)
++    execute_process(
++      COMMAND "${CMAKE_OBJDUMP}" -p "${LIBSLEEF}"
++      OUTPUT_VARIABLE POCL_SLEEF_OBJDUMP_OUTPUT
++      ERROR_QUIET
++      RESULT_VARIABLE POCL_SLEEF_OBJDUMP_RESULT)
++    if(POCL_SLEEF_OBJDUMP_RESULT STREQUAL "0")
++      string(REGEX MATCH "SONAME[ \t]+([^ \r\n]+)"
++             POCL_SLEEF_SONAME_MATCH "${POCL_SLEEF_OBJDUMP_OUTPUT}")
++      if(POCL_SLEEF_SONAME_MATCH)
++        set(HOST_CPU_SLEEF_LIBRARY "${CMAKE_MATCH_1}")
++        set(HOST_CPU_SLEEF_LIBRARY_FALLBACK "${LIBSLEEF}")
++      endif()
++    endif()
++  endif()
++endif()
++
++# Record the SONAME of the libmvec library for the JIT to dlopen at run time. LIBMVEC may be
++# the system libmvec (SONAME libmvec.so.1) or a libmvec-ABI-compatible replacement pointed at
++# via -DLIBMVEC=... (e.g. SLEEF's libsleefgnuabi.so); recording the SONAME lets the JIT resolve
++# the vectorized _ZGV* math symbols without relying on a system libmvec (absent on musl / old
++# glibc). Mirrors the SLEEF recording above.
++set(HOST_CPU_LIBMVEC_LIBRARY "")
++set(HOST_CPU_LIBMVEC_LIBRARY_FALLBACK "")
++if(ENABLE_HOST_CPU_VECTORIZE_LIBMVEC AND LIBMVEC)
++  set(HOST_CPU_LIBMVEC_LIBRARY "${LIBMVEC}")
++  if(CMAKE_OBJDUMP)
++    execute_process(
++      COMMAND "${CMAKE_OBJDUMP}" -p "${LIBMVEC}"
++      OUTPUT_VARIABLE POCL_LIBMVEC_OBJDUMP_OUTPUT
++      ERROR_QUIET
++      RESULT_VARIABLE POCL_LIBMVEC_OBJDUMP_RESULT)
++    if(POCL_LIBMVEC_OBJDUMP_RESULT STREQUAL "0")
++      string(REGEX MATCH "SONAME[ \t]+([^ \r\n]+)"
++             POCL_LIBMVEC_SONAME_MATCH "${POCL_LIBMVEC_OBJDUMP_OUTPUT}")
++      if(POCL_LIBMVEC_SONAME_MATCH)
++        set(HOST_CPU_LIBMVEC_LIBRARY "${CMAKE_MATCH_1}")
++        set(HOST_CPU_LIBMVEC_LIBRARY_FALLBACK "${LIBMVEC}")
++      endif()
++    endif()
++  endif()
++endif()
++
++# Record the paths to the SVML static libraries for the JIT to link against.
++set(HOST_CPU_SVML_LIBRARY "")
++set(HOST_CPU_IRC_LIBRARY "")
++if(ENABLE_HOST_CPU_VECTORIZE_SVML AND LIBSVML AND LIBIRC)
++  set(HOST_CPU_SVML_LIBRARY "${LIBSVML}")
++  set(HOST_CPU_IRC_LIBRARY "${LIBIRC}")
++endif()
++
+ ######################################################################################
+ ######################################################################################
+ 
+@@ -1236,6 +1330,35 @@ if(ENABLE_HOST_CPU_DEVICES AND ENABLE_SPIRV AND (NOT MSVC) AND (HOST_DEVICE_ADDR
+   set(HOST_CPU_ENABLE_SPIRV ON)
+ endif()
+ 
++# The JIT for CPU devices is supported on
++#   - non-Windows platforms whose architecture has a JITLink ELF/Mach-O
++#     backend (x86(-64), AArch64, ARM32, RISC-V, PPC64, LoongArch); s390x,
++#     MIPS and SPARC have none, so they keep the Clang+dlopen path;
++#   - Windows x86_64 (MinGW) via JITLink's COFF_x86_64 backend. Windows arm64
++#     has no COFF_aarch64 backend, and MSVC keeps its existing link paths
++#     (in-process lld-link, or the Clang driver).
++set(HOST_CPU_JIT_SUPPORTED OFF)
++if(ENABLE_HOST_CPU_DEVICES AND ENABLE_LLVM)
++  if((NOT WIN32) AND (CMAKE_SYSTEM_PROCESSOR MATCHES
++     "^(x86_64|amd64|AMD64|i[3-6]86|aarch64|arm64|arm.*|riscv32|riscv64|ppc64|ppc64le|powerpc64|powerpc64le|loongarch64)$"))
++    set(HOST_CPU_JIT_SUPPORTED ON)
++  elseif(MINGW
++         AND (CMAKE_SIZEOF_VOID_P EQUAL 8)
++         AND (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64|amd64|x64)"))
++    # Windows x86_64 (MinGW): JITLink's COFF_x86_64 backend; no COFF_aarch64.
++    set(HOST_CPU_JIT_SUPPORTED ON)
++  endif()
++endif()
++
++option(HOST_CPU_ENABLE_JIT
++       "JIT CPU kernels via ORC/JITLink instead of Clang+dlopen."
++       ${HOST_CPU_JIT_SUPPORTED})
++if(HOST_CPU_ENABLE_JIT AND NOT HOST_CPU_JIT_SUPPORTED)
++  message(FATAL_ERROR "HOST_CPU_ENABLE_JIT was requested, but JITLink has no "
++          "backend for this platform "
++          "(${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR}).")
++endif()
++
+ ######################################################################################
+ 
+ set(HAVE_DLFCN_H OFF CACHE BOOL "dlopen" FORCE)
+@@ -2848,6 +2971,7 @@ if (ENABLE_LLVM)
+   MESSAGE(STATUS "ENABLE_HOST_CPU_VECTORIZE_LIBMVEC: ${ENABLE_HOST_CPU_VECTORIZE_LIBMVEC}")
+   MESSAGE(STATUS "ENABLE_HOST_CPU_VECTORIZE_SVML: ${ENABLE_HOST_CPU_VECTORIZE_SVML}")
+   MESSAGE(STATUS "ENABLE_HOST_CPU_VECTORIZE_BUILTINS: ${ENABLE_HOST_CPU_VECTORIZE_BUILTINS}")
++  MESSAGE(STATUS "HOST_CPU_ENABLE_JIT: ${HOST_CPU_ENABLE_JIT}")
+   endif()
+ endif()
+ MESSAGE(STATUS "")
+diff --git a/cmake/SetupLLD.cmake b/cmake/SetupLLD.cmake
+index a24a9acc6..237a0d9ca 100644
+--- a/cmake/SetupLLD.cmake
++++ b/cmake/SetupLLD.cmake
+@@ -2,7 +2,8 @@
+ # through lld's library API instead of invoking the Clang driver, which needs
+ # no external toolchain (no linker to exec, no startup files). This keeps
+ # kernel linking -- and with it poclbinary export -- working in deployments
+-# that ship no host toolchain at all. On Windows (MSVC) the kernel
++# that ship no host toolchain at all (see also the JIT, which loads the
++# kernel objects without linking them). On Windows (MSVC) the kernel
+ # binaries are additionally linked without the C runtime, against bundled
+ # helper objects, so they need no VS Build Tools at run time either.
+ #
+diff --git a/cmake/SetupLLVMviaCMake.cmake b/cmake/SetupLLVMviaCMake.cmake
+index 1d1047cd6..afc3219e6 100644
+--- a/cmake/SetupLLVMviaCMake.cmake
++++ b/cmake/SetupLLVMviaCMake.cmake
+@@ -152,6 +152,16 @@ set(POCL_LLVM_COMPONENTS
+   LLVMWindowsDriver
+ )
+ 
++# CPU devices use ORC LLJIT + JITLink for the JIT
++if(ENABLE_HOST_CPU_DEVICES)
++  list(APPEND POCL_LLVM_COMPONENTS
++    LLVMOrcJIT
++    LLVMJITLink
++    LLVMOrcTargetProcess
++    LLVMOrcShared
++    LLVMRuntimeDyld)
++endif()
++
+ if("X86" IN_LIST LLVM_TARGETS_TO_BUILD)
+   list(APPEND POCL_LLVM_COMPONENTS
+     LLVMX86CodeGen
+diff --git a/cmake/test_jit_svml_failure.cmake b/cmake/test_jit_svml_failure.cmake
+new file mode 100644
+index 000000000..e32f4ebaf
+--- /dev/null
++++ b/cmake/test_jit_svml_failure.cmake
+@@ -0,0 +1,18 @@
++if(NOT DEFINED test_cmd)
++  message(FATAL_ERROR "test_cmd is required")
++endif()
++
++execute_process(
++  COMMAND "${test_cmd}"
++  RESULT_VARIABLE result
++  OUTPUT_VARIABLE stdout
++  ERROR_VARIABLE stderr)
++
++if(result EQUAL 0)
++  message(FATAL_ERROR "SVML fault-injection test unexpectedly succeeded")
++endif()
++
++set(output "${stdout}\n${stderr}")
++if(NOT output MATCHES "injected SVML provider failure \\(POCL_FAULT_INJECT_JIT_SVML\\)")
++  message(FATAL_ERROR "SVML fault-injection error was not reported:\n${output}")
++endif()
+diff --git a/cmake/test_jit_svml_success.cmake b/cmake/test_jit_svml_success.cmake
+new file mode 100644
+index 000000000..1a052a371
+--- /dev/null
++++ b/cmake/test_jit_svml_success.cmake
+@@ -0,0 +1,23 @@
++if(NOT DEFINED test_cmd OR NOT DEFINED cache_dir)
++  message(FATAL_ERROR "test_cmd and cache_dir are required")
++endif()
++
++file(REMOVE_RECURSE "${cache_dir}")
++file(MAKE_DIRECTORY "${cache_dir}")
++
++foreach(phase cold warm)
++  execute_process(
++    COMMAND "${CMAKE_COMMAND}" -E env "POCL_CACHE_DIR=${cache_dir}" "${test_cmd}"
++    RESULT_VARIABLE result
++    OUTPUT_VARIABLE stdout
++    ERROR_VARIABLE stderr)
++  if(result OR NOT "${stdout}${stderr}" MATCHES "OK")
++    message(FATAL_ERROR "SVML ${phase}-cache run failed:\n${stdout}\n${stderr}")
++  endif()
++  string(REGEX MATCHALL "activating lazy SVML archive provider" activations
++         "${stdout}\n${stderr}")
++  list(LENGTH activations activation_count)
++  if(NOT activation_count EQUAL 1)
++    message(FATAL_ERROR "SVML ${phase}-cache run activated ${activation_count} times")
++  endif()
++endforeach()
+diff --git a/config.h.in.cmake b/config.h.in.cmake
+index 7783db2bd..a221a9b8d 100644
+--- a/config.h.in.cmake
++++ b/config.h.in.cmake
+@@ -180,14 +180,30 @@
+ 
+ #cmakedefine HOST_CPU_ENABLE_SPIRV
+ 
++#cmakedefine HOST_CPU_ENABLE_JIT
++
++#cmakedefine HOST_CPU_COMPILER_RT_LIBRARY "@HOST_CPU_COMPILER_RT_LIBRARY@"
++
+ #cmakedefine ENABLE_HOST_CPU_VECTORIZE_BUILTINS
+ 
+ #cmakedefine ENABLE_HOST_CPU_VECTORIZE_LIBMVEC
+ 
++#cmakedefine HOST_CPU_LIBMVEC_LIBRARY "@HOST_CPU_LIBMVEC_LIBRARY@"
++
++#cmakedefine HOST_CPU_LIBMVEC_LIBRARY_FALLBACK "@HOST_CPU_LIBMVEC_LIBRARY_FALLBACK@"
++
+ #cmakedefine ENABLE_HOST_CPU_VECTORIZE_SLEEF
+ 
++#cmakedefine HOST_CPU_SLEEF_LIBRARY "@HOST_CPU_SLEEF_LIBRARY@"
++
++#cmakedefine HOST_CPU_SLEEF_LIBRARY_FALLBACK "@HOST_CPU_SLEEF_LIBRARY_FALLBACK@"
++
+ #cmakedefine ENABLE_HOST_CPU_VECTORIZE_SVML
+ 
++#cmakedefine HOST_CPU_SVML_LIBRARY "@HOST_CPU_SVML_LIBRARY@"
++
++#cmakedefine HOST_CPU_IRC_LIBRARY "@HOST_CPU_IRC_LIBRARY@"
++
+ #define HOST_LD_FLAGS  "@HOST_LD_FLAGS@"
+ 
+ #define HOST_LLC_FLAGS  "@HOST_LLC_FLAGS@"
+diff --git a/doc/sphinx/source/cpu.rst b/doc/sphinx/source/cpu.rst
+index ab3502b0a..a3bdedecd 100644
+--- a/doc/sphinx/source/cpu.rst
++++ b/doc/sphinx/source/cpu.rst
+@@ -59,23 +59,46 @@ always uses all cores and has no subdevice support.
+ 
+ The TBB driver can be tuned with at runtime with environment variables, see :ref:`pocl-env-variables`.
+ 
+-.. _cpu-linking:
++.. _cpu-jit:
+ 
+ ========================
+-Kernel linking
++In-process kernel JIT
+ ========================
+ 
+-A CPU driver turns each kernel into native code by generating a relocatable
+-object, which it then links into a shared library that PoCL loads with
+-``dlopen()``. Where lld is available at build time (``CPU_USE_LLD_LINK``),
+-that link happens in-process through lld's library API: nothing is exec'd and
+-no startup files are needed, since the kernel binary's undefined symbols
+-resolve at ``dlopen()`` time. This keeps kernel compilation -- and with it
+-poclbinary export -- working in deployments that ship no host toolchain at
+-all. Should the in-process link fail, or when PoCL was built without lld, the
+-object is handed to the Clang driver, which needs a toolchain present at run
+-time: a linker to exec, plus the C startup files and default libraries.
++A CPU driver compiles each kernel to a relocatable object, then links and loads
++it. By default PoCL uses LLVM ORC LLJIT with the JITLink object-linking layer:
++the cached final artifact is the object variant (``OBJ_EXT``, ``.so.o`` on
++Unix), with no shared library written and no OS loader involved.
+ 
+-On Windows (MSVC) the in-process link also avoids the C runtime, linking
+-against bundled helper objects instead, so kernel compilation needs no VS
+-Build Tools at run time either.
++With ``POCL_CPU_JIT=0`` or when the JIT is unavailable, PoCL links the object
++into a shared library and loads it with ``dlopen()``. If ``CPU_USE_LLD_LINK``
++was enabled, this link also runs in-process through lld. Otherwise PoCL invokes
++the Clang driver and needs a host linker, startup files, and default libraries.
++The link path is useful where runtime code generation is forbidden but shared
++libraries are allowed.
++
++JIT symbol resolution is deliberately fixed: process-visible C/libm symbols,
++libpocl and its private dependencies, configured vector-math libraries,
++compiler-rt/libgcc helpers, selected kernel-library bitcode for late PoCL
++builtins, and explicit host ABI callbacks such as printf flush and the MinGW
++stack probe. New unresolved symbols should be assigned to one of those classes,
++or explained before adding a special-case binding.
++
++The JIT is the default on supported hosts: ELF, Mach-O, and Windows x86-64
++(MinGW). Windows arm64 and MSVC builds use the link path. Disable the JIT with
++``-DHOST_CPU_ENABLE_JIT=OFF`` at build time or ``POCL_CPU_JIT=0`` for one run.
++
++Exported program binaries remain mode-independent when export-time linking
++succeeds: ``clGetProgramInfo(CL_PROGRAM_BINARIES)`` serializes linked shared
++libraries, so consumers without JIT or LLVM can load them. For JIT-produced
++cache entries, export first links the cached ``OBJ_EXT`` artifacts into shared
++libraries and skips those object files. If that link fails, PoCL serializes the
++objects as a fallback; those binaries require a JIT-enabled consumer or an
++LLVM-enabled non-JIT consumer that can link the objects on import.
++
++The ordinary kernel cache is mode-specific. A JIT device looks for the JIT
++object and does not fall back to a sibling shared library. ORC can only use that
++file through OS dynamic loading, which is the non-JIT path. On a bad object PoCL
++regenerates the object from program IR when possible. A non-JIT device looks for
++the shared library, and if only a JIT object is present and LLVM is available,
++links it into the shared-library variant before loading.
+diff --git a/doc/sphinx/source/notes_7_2.rst b/doc/sphinx/source/notes_7_2.rst
+index dc6f3b106..6931c383e 100644
+--- a/doc/sphinx/source/notes_7_2.rst
++++ b/doc/sphinx/source/notes_7_2.rst
+@@ -142,6 +142,15 @@ CPU driver
+   fallback when the in-process link fails, and is still used when PoCL was
+   built without lld.
+ 
++* The CPU drivers can now load kernels in-process with LLVM's ORC JIT and the
++  JITLink object-linking layer, instead of linking each kernel into a shared
++  library and loading it with ``dlopen()``. This also drops the dependency on
++  the OS loader, so it works with the kernel cache on a ``noexec`` filesystem
++  and in statically linked deployments. It is controlled by the new
++  ``-DHOST_CPU_ENABLE_JIT`` CMake option, on by default on ELF and Mach-O
++  hosts and on Windows x86-64 (MinGW). Set ``POCL_CPU_JIT=0`` to fall back to
++  the link-and-``dlopen()`` path at run time. See :ref:`cpu-jit`.
++
+ ===================================
+ Deprecation/feature removal notices
+ ===================================
+diff --git a/doc/sphinx/source/using.rst b/doc/sphinx/source/using.rst
+index 9e169b588..87e2ce479 100644
+--- a/doc/sphinx/source/using.rst
++++ b/doc/sphinx/source/using.rst
+@@ -137,6 +137,16 @@ pocl.
+  default cache directory will be used, which is ``$XDG_CACHE_HOME/pocl/kcache``
+  (if set) or ``$HOME/.cache/pocl/kcache/`` on Unix-like systems.
+ 
++- **POCL_CPU_JIT**
++
++ Specific to the CPU drivers, and only effective when PoCL was built with
++ ``-DHOST_CPU_ENABLE_JIT=ON``. Set to 0 to link kernels into shared libraries
++ and ``dlopen()`` them (in-process through lld where compiled in, through the
++ Clang driver otherwise) rather than loading them with the in-process
++ ORC/JITLink loader. Read once at device initialization; defaults to 1. Use it
++ to work around a JIT-specific problem without rebuilding PoCL. See
++ :ref:`cpu-jit`.
++
+ - **POCL_CPU_LOCAL_MEM_SIZE**
+ 
+  Set the local memory size of the CPU devices (cpu, cpu-minimal, cpu-tbb) to the
+diff --git a/examples/vecadd/CMakeLists.txt b/examples/vecadd/CMakeLists.txt
+index 7d5459bfd..13f00d35d 100644
+--- a/examples/vecadd/CMakeLists.txt
++++ b/examples/vecadd/CMakeLists.txt
+@@ -33,6 +33,13 @@ add_test(NAME "examples/vecadd" COMMAND "vecadd")
+ 
+ add_test(NAME "examples/vecadd_large_grid" COMMAND "vecadd" "128000" "128" "10000" "100" "1" "1")
+ 
++if(ENABLE_HOST_CPU_VECTORIZE_SVML)
++  # The SVML provider must remain dormant for an unrelated JIT kernel.
++  add_cpu_jit_test("vecadd_no_svml" vecadd)
++  set_tests_properties("cpu_jit/vecadd_no_svml" PROPERTIES
++    ENVIRONMENT "POCL_DEVICES=cpu;POCL_CPU_JIT=1;POCL_WORK_GROUP_METHOD=loopvec;POCL_KERNEL_CACHE=0;POCL_FAULT_INJECT_JIT_SVML=1")
++endif()
++
+ set(PROPS)
+ if(NOT ENABLE_ANYSAN)
+   set(PROPS
+diff --git a/examples/vecbuiltin/CMakeLists.txt b/examples/vecbuiltin/CMakeLists.txt
+index 665d2d228..a12678efa 100644
+--- a/examples/vecbuiltin/CMakeLists.txt
++++ b/examples/vecbuiltin/CMakeLists.txt
+@@ -41,6 +41,25 @@ add_symlink_to_built_opencl_dynlib("vecbuiltin")
+ 
+ add_test_pocl(NAME "examples/vecbuiltin" COMMAND "vecbuiltin" LLVM_FILECHECK "vecbuiltin.fc" WORKITEM_HANDLER "loopvec")
+ 
++if(ENABLE_HOST_CPU_VECTORIZE_SVML)
++  add_test(NAME "cpu_jit/vecbuiltin_svml"
++    COMMAND "${CMAKE_COMMAND}" "-Dtest_cmd=$<TARGET_FILE:vecbuiltin>"
++            "-Dcache_dir=${CMAKE_CURRENT_BINARY_DIR}/jit-svml-cache"
++            "-P" "${CMAKE_SOURCE_DIR}/cmake/test_jit_svml_success.cmake")
++  set_tests_properties("cpu_jit/vecbuiltin_svml" PROPERTIES
++    ENVIRONMENT "POCL_DEVICES=cpu;POCL_CPU_JIT=1;POCL_WORK_GROUP_METHOD=loopvec;POCL_KERNEL_CACHE=1;POCL_DEBUG=llvm"
++    LABELS "cpu_jit"
++    DEPENDS "pocl_version_check")
++
++  add_test(NAME "cpu_jit/vecbuiltin_svml_fault"
++    COMMAND "${CMAKE_COMMAND}" "-Dtest_cmd=$<TARGET_FILE:vecbuiltin>"
++            "-P" "${CMAKE_SOURCE_DIR}/cmake/test_jit_svml_failure.cmake")
++  set_tests_properties("cpu_jit/vecbuiltin_svml_fault" PROPERTIES
++    ENVIRONMENT "POCL_DEVICES=cpu;POCL_CPU_JIT=1;POCL_WORK_GROUP_METHOD=loopvec;POCL_KERNEL_CACHE=0;POCL_FAULT_INJECT_JIT_SVML=1"
++    LABELS "cpu_jit"
++    DEPENDS "pocl_version_check")
++endif()
++
+ set_tests_properties(
+   "examples/vecbuiltin"
+   PROPERTIES
+diff --git a/include/pocl_cache.h b/include/pocl_cache.h
+index 303e4b792..bdc5030cb 100644
+--- a/include/pocl_cache.h
++++ b/include/pocl_cache.h
+@@ -160,6 +160,16 @@ void pocl_cache_final_binary_path (char *final_binary_path, cl_program program,
+                                    unsigned device_i, cl_kernel kernel,
+                                    _cl_command_node *command, int specialize);
+ 
++POCL_EXPORT
++void pocl_cache_final_binary_variant_path (char *final_binary_path,
++                                           cl_program program,
++                                           unsigned device_i, cl_kernel kernel,
++                                           _cl_command_node *command,
++                                           int specialize, int jit_object);
++
++POCL_EXPORT
++int pocl_cache_object_shlib_variant (char *so_path, const char *path);
++
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/lib/CL/CMakeLists.txt b/lib/CL/CMakeLists.txt
+index 6e553121b..fc92ca82c 100644
+--- a/lib/CL/CMakeLists.txt
++++ b/lib/CL/CMakeLists.txt
+@@ -277,6 +277,9 @@ if (ENABLE_LLVM)
+   if(ENABLE_SPIRV)
+     list(APPEND EXTRA_LLVM_SOURCES "pocl_llvm_spirv.cc")
+   endif()
++  if(HOST_CPU_ENABLE_JIT)
++    list(APPEND EXTRA_LLVM_SOURCES "pocl_llvm_orc.cc")
++  endif()
+   set(LLVM_API_SOURCES "pocl_llvm_build.cc" "pocl_llvm_metadata.cc" "pocl_llvm_utils.cc" "pocl_llvm_wg.cc" ${EXTRA_LLVM_SOURCES})
+ 
+   pocl_build_clang_llvm_object(lib_cl_llvm ${LLVM_API_SOURCES})
+diff --git a/lib/CL/devices/common.c b/lib/CL/devices/common.c
+index f41bf4937..75fc5b2d3 100644
+--- a/lib/CL/devices/common.c
++++ b/lib/CL/devices/common.c
+@@ -51,6 +51,9 @@
+ #include "pocl_cache.h"
+ #include "pocl_debug.h"
+ #include "pocl_dynlib.h"
++#ifdef HOST_CPU_ENABLE_JIT
++#include "pocl_llvm_orc.h"
++#endif
+ #include "pocl_file_util.h"
+ #include "pocl_image_util.h"
+ #include "pocl_mem_management.h"
+@@ -120,10 +123,9 @@ link_with_clang_driver (cl_device_id device, const char *objfile,
+   cmd_line[last_arg_idx++] = "-noimplib";
+ #endif
+ 
+-  /* ENABLE_PRINTF_IMMEDIATE_FLUSH results in "pocl_flush_printf_buffer"
+-   * symbol referenced in the built kernel.so; however that function exists
+-   * only on the host side, therefore link to libpocl.so which provides it
+-   */
++  /* ENABLE_PRINTF_IMMEDIATE_FLUSH references the host-side
++   * "pocl_flush_printf_buffer" symbol from the kernel shared library, so link
++   * to libpocl.so which provides it. */
+ #ifdef ENABLE_PRINTF_IMMEDIATE_FLUSH
+ #ifdef HAVE_DLFCN_H
+   const char *fname = pocl_dynlib_pathname ((void *)pocl_cache_tempname);
+@@ -142,23 +144,22 @@ link_with_clang_driver (cl_device_id device, const char *objfile,
+   return pocl_invoke_clang (device->llvm_target_triplet, cmd_line);
+ }
+ 
+-/* Links a compiled kernel object into the final shared library the dynamic
+-   loader can pick up, through the device's custom finalization step if it
+-   has one, in-process lld where compiled in, and the Clang driver otherwise.
+-   The object file is left in place. */
+-static int
++/* Links a kernel object into the shared library used by the dynamic loader.
++   ORC/JITLink is the separate object-loader path; lld and Clang are final
++   linkers for the shared-library path. The object file is left in place. */
++int
+ pocl_link_final_binary (cl_device_id device, const char *objfile,
+                         const char *final_binary_path)
+ {
+   int error;
+ 
+-  /* Temporary filename for kernel.so. Create it next to the final binary
++  /* Create the temporary shared library next to the final binary
+      to enable a potential customized finalization step to create multiple
+      files next to it. */
+   char tmp_module[POCL_MAX_PATHNAME_LENGTH];
+   if (pocl_mk_tempname (tmp_module, final_binary_path, SHARED_LIB_EXT, NULL))
+     {
+-      POCL_MSG_PRINT_LLVM ("Creating temporary kernel.so file"
++      POCL_MSG_PRINT_LLVM ("Creating temporary shared-library file"
+                            " for %s FAILED\n",
+                            final_binary_path);
+       return -1;
+@@ -196,16 +197,16 @@ pocl_link_final_binary (cl_device_id device, const char *objfile,
+     }
+   if (error)
+     {
+-      POCL_MSG_PRINT_LLVM ("Linking kernel.so.o -> kernel.so has failed\n");
++      POCL_MSG_PRINT_LLVM ("Linking kernel object to shared library failed\n");
+       return error;
+     }
+ 
+-  /* rename temporary kernel.so */
++  /* rename temporary shared library */
+   error = pocl_rename (tmp_module, final_binary_path);
+ 
+   if (error)
+     POCL_MSG_PRINT_LLVM (
+-        "Renaming temporary kernel.so to final ('%s') has failed.\n",
++        "Renaming temporary shared library to final ('%s') failed.\n",
+         final_binary_path);
+ 
+   return error;
+@@ -233,7 +234,7 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
+   pocl_cache_work_group_function_path (parallel_bc_path, program, device_i,
+                                        kernel, command, specialize);
+ 
+-  /* $/kernel.so */
++  /* Cached final artifact: OBJ_EXT under JIT, SHARED_LIB_EXT otherwise. */
+   char final_binary_path[POCL_MAX_PATHNAME_LENGTH];
+   pocl_cache_final_binary_path (final_binary_path, program, device_i, kernel,
+                                 command, specialize);
+@@ -317,7 +318,7 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
+   if (pocl_exists (final_binary_path))
+     goto FINISH;
+ 
+-  /* Write temporary kernel.so.o, required for the final linking step */
++  /* Write temporary kernel object, required for the final linking step. */
+   error = pocl_cache_write_kernel_objfile (tmp_objfile, objfile, objfile_size);
+   if (error)
+     {
+@@ -331,11 +332,24 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
+                           tmp_objfile, (size_t)objfile_size);
+     }
+ 
++  /* JIT devices load the kernel object in-process, so it is itself the final
++     artifact: no shared library, no external linker. Publish it under its
++     cached name and return. */
++  if (pocl_cpu_device_uses_jit (device))
++    {
++      error = pocl_rename (tmp_objfile, final_binary_path);
++      if (error)
++        POCL_MSG_PRINT_LLVM (
++          "Renaming temporary kernel object to final ('%s') failed.\n",
++          final_binary_path);
++      goto FINISH;
++    }
++
+   error = pocl_link_final_binary (device, tmp_objfile, final_binary_path);
+   if (error)
+     goto FINISH;
+ 
+-  /* if LEAVE_COMPILER_FILES, rename temporary kernel.so.o, else delete it */
++  /* If requested, keep the temporary kernel object next to the shared library. */
+   if (pocl_get_bool_option ("POCL_LEAVE_KERNEL_COMPILER_TEMP_FILES", 0))
+     {
+       char objfile_path[POCL_MAX_PATHNAME_LENGTH];
+@@ -344,14 +358,14 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
+       error = pocl_rename (tmp_objfile, objfile_path);
+       if (error)
+         POCL_MSG_PRINT_LLVM (
+-            "Renaming temporary kernel.so.o to final %s has failed.\n",
++            "Renaming temporary kernel object to final %s failed.\n",
+             objfile_path);
+     }
+   else
+     {
+       error = pocl_remove (tmp_objfile);
+       if (error)
+-        POCL_MSG_PRINT_LLVM ("Removing temporary kernel.so.o has failed.\n");
++        POCL_MSG_PRINT_LLVM ("Removing temporary kernel object failed.\n");
+     }
+ 
+ FINISH:
+@@ -978,8 +992,8 @@ pocl_cmd_max_grid_dim_width (_cl_command_run *cmd)
+ 
+ /* CPU driver stuff */
+ 
+-typedef struct pocl_dlhandle_cache_item pocl_dlhandle_cache_item;
+-struct pocl_dlhandle_cache_item
++typedef struct pocl_module_cache_item pocl_module_cache_item;
++struct pocl_module_cache_item
+ {
+   pocl_kernel_hash_t hash;
+ 
+@@ -993,70 +1007,86 @@ struct pocl_dlhandle_cache_item
+   size_t max_grid_dim_width;
+ 
+   void *wg;
+-  void *dlhandle;
+-  pocl_dlhandle_cache_item *next;
+-  pocl_dlhandle_cache_item *prev;
++  void *module_handle;
++  /* If nonzero, module_handle is an ORC/JITLink handle. Otherwise it is a
++     native shared-library handle. */
++  int is_jit;
++  pocl_module_cache_item *next;
++  pocl_module_cache_item *prev;
+   unsigned ref_count;
+ };
+ 
+-static pocl_dlhandle_cache_item *pocl_dlhandle_cache;
++static pocl_module_cache_item *pocl_module_cache;
+ static pocl_lock_t pocl_llvm_codegen_lock;
+-static pocl_lock_t pocl_dlhandle_lock;
+-static int pocl_dlhandle_cache_initialized;
++static pocl_lock_t pocl_module_cache_lock;
++static int pocl_module_cache_initialized;
+ 
+ /* only to be called in basic/pthread/<other cpu driver> init */
+ void
+ pocl_init_dlhandle_cache ()
+ {
+-  if (!pocl_dlhandle_cache_initialized)
++  if (!pocl_module_cache_initialized)
+     {
+       POCL_INIT_LOCK (pocl_llvm_codegen_lock);
+-      POCL_INIT_LOCK (pocl_dlhandle_lock);
+-      pocl_dlhandle_cache_initialized = 1;
+-   }
++      POCL_INIT_LOCK (pocl_module_cache_lock);
++      pocl_module_cache_initialized = 1;
++    }
+ }
+ 
+ static unsigned handle_count = 0;
+ #define MAX_CACHE_ITEMS 128
+ 
+-/* must be called with pocl_dlhandle_lock LOCKED */
+-static pocl_dlhandle_cache_item *
+-get_new_dlhandle_cache_item ()
++/* Unloads a cache item's kernel module with the loader that loaded it. */
++static void
++release_module_handle (pocl_module_cache_item *ci)
+ {
+-  pocl_dlhandle_cache_item *ci = NULL;
+-  const char *dl_error = NULL;
++#ifdef HOST_CPU_ENABLE_JIT
++  if (ci->is_jit)
++    {
++      pocl_jit_unload (ci->module_handle);
++      return;
++    }
++#endif
++  pocl_dynlib_close (ci->module_handle);
++}
++
++/* must be called with pocl_module_cache_lock LOCKED */
++static pocl_module_cache_item *
++get_new_module_cache_item ()
++{
++  pocl_module_cache_item *ci = NULL;
+ 
+-  if (pocl_dlhandle_cache)
++  if (pocl_module_cache)
+     {
+-      ci = pocl_dlhandle_cache->prev;
+-      while (ci->ref_count > 0 && ci != pocl_dlhandle_cache)
++      ci = pocl_module_cache->prev;
++      while (ci->ref_count > 0 && ci != pocl_module_cache)
+         ci = ci->prev;
+     }
+ 
+-  if ((handle_count >= MAX_CACHE_ITEMS) && ci && (ci != pocl_dlhandle_cache))
++  if ((handle_count >= MAX_CACHE_ITEMS) && ci && (ci != pocl_module_cache))
+     {
+-      DL_DELETE (pocl_dlhandle_cache, ci);
+-      pocl_dynlib_close (ci->dlhandle);
+-      memset (ci, 0, sizeof (pocl_dlhandle_cache_item));
++      DL_DELETE (pocl_module_cache, ci);
++      release_module_handle (ci);
++      memset (ci, 0, sizeof (pocl_module_cache_item));
+     }
+   else
+     {
+       ++handle_count;
+-      ci = (pocl_dlhandle_cache_item *)calloc (
+-          1, sizeof (pocl_dlhandle_cache_item));
++      ci = (pocl_module_cache_item *)calloc (
++          1, sizeof (pocl_module_cache_item));
+     }
+ 
+   return ci;
+ }
+ 
+ void
+-pocl_release_dlhandle_cache (void *dlhandle_cache_item)
++pocl_release_dlhandle_cache (void *module_cache_item)
+ {
+-  pocl_dlhandle_cache_item *tmp = NULL, *ci = dlhandle_cache_item;
++  pocl_module_cache_item *tmp = NULL, *ci = module_cache_item;
+ 
+-  POCL_LOCK (pocl_dlhandle_lock);
++  POCL_LOCK (pocl_module_cache_lock);
+   int found = CL_FALSE;
+-  DL_FOREACH (pocl_dlhandle_cache, tmp)
++  DL_FOREACH (pocl_module_cache, tmp)
+   {
+     if (tmp == ci)
+       {
+@@ -1068,19 +1098,130 @@ pocl_release_dlhandle_cache (void *dlhandle_cache_item)
+   assert (found == CL_TRUE);
+   assert (ci->ref_count > 0);
+   --ci->ref_count;
+-  POCL_UNLOCK (pocl_dlhandle_lock);
++  POCL_UNLOCK (pocl_module_cache_lock);
+ }
+ 
++/**
++ * Whether a final-binary path names a JIT-loadable kernel object rather than
++ * a shared library, going by the distinct artifact-variant extensions (see
++ * pocl_cache_final_binary_variant_path()).
++ */
++static int
++final_binary_is_jit_object (const char *path)
++{
++  size_t len = strlen (path);
++  size_t ext_len = strlen (OBJ_EXT);
++  return len > ext_len && strcmp (path + len - ext_len, OBJ_EXT) == 0;
++}
++
++static int
++probe_jit_object (char *module_fn, _cl_command_node *command, int specialized)
++{
++  cl_kernel k = command->command.run.kernel;
++  cl_program p = k->program;
++  unsigned dev_i = command->program_device_i;
++  pocl_cache_final_binary_variant_path (module_fn, p, dev_i, k, command,
++                                        specialized, 1);
++  return pocl_exists (module_fn);
++}
++
++static int
++probe_shared_library (char *module_fn, _cl_command_node *command,
++                      int specialized)
++{
++  cl_kernel k = command->command.run.kernel;
++  cl_program p = k->program;
++  unsigned dev_i = command->program_device_i;
++  pocl_cache_final_binary_variant_path (module_fn, p, dev_i, k, command,
++                                        specialized, 0);
++  if (pocl_exists (module_fn))
++    return 1;
++
++#ifdef ENABLE_LLVM
++  char obj_path[POCL_MAX_PATHNAME_LENGTH];
++  pocl_cache_final_binary_variant_path (obj_path, p, dev_i, k, command,
++                                        specialized, 1);
++  if (!pocl_exists (obj_path))
++    return 0;
++
++  POCL_LOCK (pocl_llvm_codegen_lock);
++  int error = pocl_link_final_binary (command->device, obj_path, module_fn);
++  POCL_UNLOCK (pocl_llvm_codegen_lock);
++  if (error == 0)
++    return 1;
++  POCL_MSG_WARN ("Linking the cached kernel object %s failed.\n", obj_path);
++#endif
++  return 0;
++}
++
++/* JIT mode only consumes OBJ_EXT. Shared-library mode consumes SHARED_LIB_EXT,
++   or links an OBJ_EXT fallback into SHARED_LIB_EXT when LLVM is available. */
++static int
++probe_final_binary (char *module_fn, _cl_command_node *command,
++                    int specialized)
++{
++  if (pocl_cpu_device_uses_jit (command->device))
++    return probe_jit_object (module_fn, command, specialized);
++  return probe_shared_library (module_fn, command, specialized);
++}
++
++#ifdef HOST_CPU_ENABLE_JIT
++/* A JIT cache hit is only a fast path. If loading or linking the object fails,
++   remove that object, regenerate it from IR, and retry the JIT load once. */
++static int
++regenerate_cached_jit_object (pocl_module_cache_item *ci, char *module_fn,
++                              _cl_command_node *command, int specialize)
++{
++#ifdef ENABLE_LLVM
++  _cl_command_run *run_cmd = &command->command.run;
++
++#ifndef ENABLE_MLIR
++  if (run_cmd->kernel->program->binaries[command->program_device_i] == NULL)
++    return -1;
++#endif
++
++  if (ci->module_handle != NULL)
++    {
++      release_module_handle (ci);
++      ci->module_handle = NULL;
++      ci->wg = NULL;
++    }
++
++  if (pocl_exists (module_fn) && pocl_remove (module_fn))
++    {
++      POCL_MSG_WARN ("Removing stale JIT kernel object \"%s\" failed.\n",
++                     module_fn);
++      return -1;
++    }
++
++  POCL_LOCK (pocl_llvm_codegen_lock);
++  int err = llvm_codegen (module_fn, command->program_device_i,
++                          run_cmd->kernel, command->device, command,
++                          specialize);
++  POCL_UNLOCK (pocl_llvm_codegen_lock);
++  if (err)
++    return err;
++
++  ci->is_jit = 1;
++  ci->module_handle = pocl_jit_load_object (module_fn, run_cmd->kernel->name);
++  return ci->module_handle == NULL ? -1 : 0;
++#else
++  return -1;
++#endif
++}
++#endif
++
+ /**
+  * Checks if a built binary is found in the disk for the given kernel command,
+  * if not, builds the kernel, caches it, and returns the file name of the
+  * end result.
+  *
+- * \param module_fn [out] The file name of the final binary.
++ * \param module_fn [out] The file name of the final binary; its extension
++ * tells the load method (see final_binary_is_jit_object()).
+  * \param command The kernel run command.
+  * \param specialized 1 if should check the per-command specialized one instead
+  * of the generic one.
+- * \returns The filename of the built binary in the disk.
++ * \returns CL_SUCCESS if module_fn names a loadable binary.
+  */
+ int
+ pocl_check_kernel_disk_cache (char *module_fn,
+@@ -1095,9 +1236,7 @@ pocl_check_kernel_disk_cache (char *module_fn,
+   /* First try to find a static WG binary for the local size as they
+      are always more efficient than the dynamic ones.  Also, in case
+      of reqd_wg_size, there might not be a dynamic sized one at all.  */
+-  pocl_cache_final_binary_path (module_fn, p, dev_i, k, command, specialized);
+-
+-  if (pocl_exists (module_fn))
++  if (probe_final_binary (module_fn, command, specialized))
+     {
+       POCL_MSG_PRINT_INFO ("Using a cached WG function: %s\n", module_fn);
+       return CL_SUCCESS;
+@@ -1139,14 +1278,11 @@ pocl_check_kernel_disk_cache (char *module_fn,
+     {
+       /* First try to find a specialized WG binary, if allowed by the
+          command. */
+-      if (!run_cmd->force_generic_wg_func)
+-        pocl_cache_final_binary_path (module_fn, p, dev_i, k, command, 1);
+-
+-      if (run_cmd->force_generic_wg_func || !pocl_exists (module_fn))
++      if (run_cmd->force_generic_wg_func
++          || !probe_final_binary (module_fn, command, 1))
+         {
+           /* Then check for a dynamic (non-specialized) kernel. */
+-          pocl_cache_final_binary_path (module_fn, p, dev_i, k, command, 0);
+-          if (!pocl_exists (module_fn))
++          if (!probe_final_binary (module_fn, command, 0))
+             {
+               POCL_MSG_ERR ("Generic WG function binary does not exist.\n");
+               return -1;
+@@ -1162,16 +1298,13 @@ pocl_check_kernel_disk_cache (char *module_fn,
+ }
+ 
+ 
+-/* Look for a dlhandle in the dlhandle cache for the given kernel command.
+-   If found, push the handle up in the cache to improve cache hit speed,
+-   and return it. Otherwise return NULL. The caller should hold
+-   pocl_dlhandle_lock. */
+-static pocl_dlhandle_cache_item *
+-fetch_dlhandle_cache_item (_cl_command_run *run_cmd, int specialize)
++/* Look for a loaded kernel module for the given kernel command. */
++static pocl_module_cache_item *
++fetch_module_cache_item (_cl_command_run *run_cmd, int specialize)
+ {
+-  pocl_dlhandle_cache_item *ci = NULL, *tmp = NULL;
++  pocl_module_cache_item *ci = NULL, *tmp = NULL;
+   size_t max_grid_width = pocl_cmd_max_grid_dim_width (run_cmd);
+-  DL_FOREACH_SAFE (pocl_dlhandle_cache, ci, tmp)
++  DL_FOREACH_SAFE (pocl_module_cache, ci, tmp)
+   {
+     if ((memcmp (ci->hash, run_cmd->hash, sizeof (pocl_kernel_hash_t)) == 0)
+         && (ci->local_wgs[0] == run_cmd->pc.local_size[0])
+@@ -1184,8 +1317,8 @@ fetch_dlhandle_cache_item (_cl_command_run *run_cmd, int specialize)
+                 && run_cmd->pc.global_offset[2] == 0)))
+       {
+         /* move to the front of the line */
+-        DL_DELETE (pocl_dlhandle_cache, ci);
+-        DL_PREPEND (pocl_dlhandle_cache, ci);
++        DL_DELETE (pocl_module_cache, ci);
++        DL_PREPEND (pocl_module_cache, ci);
+         run_cmd->wg = ci->wg;
+         return ci;
+       }
+@@ -1206,7 +1339,7 @@ fetch_dlhandle_cache_item (_cl_command_run *run_cmd, int specialize)
+  * This can be useful in case we're just pre-compiling kernels
+  * (or compiling them for binaries), and not actually need them immediately.
+  *
+- * Returns: a dynlib handle cache item as void*; this needs to be given
++ * Returns: a module cache item as void*; this needs to be given
+  * to pocl_release_dlhandle_cache(), if it was retained */
+ void *
+ pocl_check_kernel_dlhandle_cache (_cl_command_node *command,
+@@ -1214,7 +1347,7 @@ pocl_check_kernel_dlhandle_cache (_cl_command_node *command,
+                                   int specialize)
+ {
+   char *workgroup_string = NULL;
+-  pocl_dlhandle_cache_item *ci = NULL;
++  pocl_module_cache_item *ci = NULL;
+   _cl_command_run *run_cmd = &command->command.run;
+ 
+   /* Brute force mechanism to test relying on generic work-group functions
+@@ -1222,17 +1355,17 @@ pocl_check_kernel_dlhandle_cache (_cl_command_node *command,
+   if (!pocl_get_bool_option("POCL_WORK_GROUP_SPECIALIZATION", 1))
+     specialize = 0;
+ 
+-  POCL_LOCK (pocl_dlhandle_lock);
+-  ci = fetch_dlhandle_cache_item (run_cmd, specialize);
++  POCL_LOCK (pocl_module_cache_lock);
++  ci = fetch_module_cache_item (run_cmd, specialize);
+   if (ci != NULL)
+     {
+       if (retain) ++ci->ref_count;
+-      POCL_UNLOCK (pocl_dlhandle_lock);
++      POCL_UNLOCK (pocl_module_cache_lock);
+       return ci;
+     }
+ 
+-  /* Not found, build a new kernel and cache its dlhandle. */
+-  ci = get_new_dlhandle_cache_item ();
++  /* Not found, build and cache a new kernel module. */
++  ci = get_new_module_cache_item ();
+   memcpy (ci->hash, run_cmd->hash, sizeof (pocl_kernel_hash_t));
+   ci->local_wgs[0] = run_cmd->pc.local_size[0];
+   ci->local_wgs[1] = run_cmd->pc.local_size[1];
+@@ -1247,22 +1380,47 @@ pocl_check_kernel_dlhandle_cache (_cl_command_node *command,
+   ci->max_grid_dim_width = max_grid_width;
+ 
+   char module_fn[POCL_MAX_PATHNAME_LENGTH];
++
+   int err = pocl_check_kernel_disk_cache (module_fn, command, specialize);
+   if (err)
+     {
+       free (ci);
+-      POCL_UNLOCK (pocl_dlhandle_lock);
++      POCL_UNLOCK (pocl_module_cache_lock);
+       return NULL;
+     }
+ 
+-  ci->dlhandle = pocl_dynlib_open (module_fn, 0, 1);
+-  if (ci->dlhandle == NULL)
++  /* The load method follows the found artifact: a JIT kernel object is loaded
++     in-process via ORC/JITLink, a shared library is dlopen()ed (see
++     probe_final_binary()). */
++  ci->is_jit = final_binary_is_jit_object (module_fn);
++#ifdef HOST_CPU_ENABLE_JIT
++  /* A JIT object is only produced or accepted when the device's JIT came up
++     at init (see pocl_cpu_device_uses_jit()). */
++  if (ci->is_jit)
++    ci->module_handle = pocl_jit_load_object (module_fn, run_cmd->kernel->name);
++  else
++#endif
++    ci->module_handle = pocl_dynlib_open (module_fn, 0, 1);
++
++#ifdef HOST_CPU_ENABLE_JIT
++  if (ci->module_handle == NULL && ci->is_jit)
+     {
+-      POCL_MSG_ERR ("pocl_dynlib_open(\"%s\") failed.\n"
+-                    "note: this may be caused by missing symbols "
+-                    " in the kernel binary\n.",
+-                    module_fn);
+-      POCL_UNLOCK (pocl_dlhandle_lock);
++      POCL_MSG_WARN ("loading cached JIT kernel object \"%s\" failed;"
++                     " regenerating it\n",
++                     module_fn);
++      regenerate_cached_jit_object (ci, module_fn, command, specialize);
++    }
++#endif
++
++  if (ci->module_handle == NULL)
++    {
++      POCL_MSG_ERR ("loading kernel binary \"%s\" failed.%s\n",
++                    module_fn,
++                    ci->is_jit
++                        ? ""
++                        : "\nnote: this may be caused by missing symbols"
++                          " in the kernel binary.");
++      POCL_UNLOCK (pocl_module_cache_lock);
+       free (ci);
+       return NULL;
+     }
+@@ -1272,32 +1430,74 @@ pocl_check_kernel_dlhandle_cache (_cl_command_node *command,
+   snprintf (workgroup_string, workgroup_len, "_pocl_kernel_%s_workgroup",
+             run_cmd->kernel->name);
+ 
+-  ci->wg = pocl_dynlib_symbol_address (ci->dlhandle, workgroup_string);
+-
+-  if (ci->wg == NULL)
++#ifdef HOST_CPU_ENABLE_JIT
++  /* ORC mangles the unmangled name for the target (e.g. adds the leading
++     underscore on Mach-O), so the JIT path needs no separate fallback. */
++  if (ci->is_jit)
++    ci->wg = pocl_jit_lookup (ci->module_handle, workgroup_string);
++  else
++#endif
+     {
+-      // Older OSX dyld APIs need the name without the underscore.
+-      snprintf (workgroup_string, workgroup_len, "pocl_kernel_%s_workgroup",
+-                run_cmd->kernel->name);
+-      ci->wg = pocl_dynlib_symbol_address (ci->dlhandle, workgroup_string);
+-
++      ci->wg = pocl_dynlib_symbol_address (ci->module_handle, workgroup_string);
+       if (ci->wg == NULL)
+         {
+-          POCL_MSG_ERR ("pocl_dynlib_symbol_address(\"%s\", \"%s\") failed.\n"
++          // Older OSX dyld APIs need the name without the underscore.
++          snprintf (workgroup_string, workgroup_len,
++                    "pocl_kernel_%s_workgroup", run_cmd->kernel->name);
++          ci->wg
++            = pocl_dynlib_symbol_address (ci->module_handle, workgroup_string);
++        }
++    }
++
++  if (ci->wg == NULL)
++    {
++      int recovered = 0;
++#ifdef HOST_CPU_ENABLE_JIT
++      if (ci->is_jit)
++        {
++          /* The JIT links the object on first lookup, so its lookup error
++             carries the real diagnostic (unresolved symbols, relocation
++             problems). */
++          const char *jit_error = pocl_jit_last_error ();
++          POCL_MSG_WARN ("looking up \"%s\" in cached JIT kernel object"
++                         " \"%s\" failed: %s; regenerating it\n",
++                         workgroup_string, module_fn,
++                         jit_error != NULL ? jit_error : "unknown error");
++          if (regenerate_cached_jit_object (ci, module_fn, command,
++                                            specialize) == 0)
++            ci->wg = pocl_jit_lookup (ci->module_handle, workgroup_string);
++          recovered = ci->wg != NULL;
++          if (!recovered)
++            {
++              jit_error = pocl_jit_last_error ();
++              POCL_MSG_ERR ("regenerated JIT kernel object \"%s\" failed"
++                            " to load or resolve \"%s\": %s\n",
++                            module_fn, workgroup_string,
++                            jit_error != NULL ? jit_error : "unknown error");
++            }
++        }
++      else
++#endif
++        {
++          POCL_MSG_ERR ("looking up \"%s\" in kernel binary \"%s\" failed.\n"
+                         "note: missing symbols in the kernel binary might be"
+                         " reported as 'file not found' errors.\n",
+-                        module_fn, workgroup_string);
+-          POCL_UNLOCK (pocl_dlhandle_lock);
+-          free (ci);
+-          free (workgroup_string);
+-          return NULL;
++                        workgroup_string, module_fn);
+         }
++      if (recovered)
++        goto FOUND_WORKGROUP;
++      release_module_handle (ci);
++      POCL_UNLOCK (pocl_module_cache_lock);
++      free (ci);
++      free (workgroup_string);
++      return NULL;
+     }
+ 
++FOUND_WORKGROUP:
+   run_cmd->wg = ci->wg;
+-  DL_PREPEND (pocl_dlhandle_cache, ci);
++  DL_PREPEND (pocl_module_cache, ci);
+ 
+-  POCL_UNLOCK (pocl_dlhandle_lock);
++  POCL_UNLOCK (pocl_module_cache_lock);
+   free (workgroup_string);
+   return ci;
+ }
+diff --git a/lib/CL/devices/common.h b/lib/CL/devices/common.h
+index f784cae79..210fcd33e 100644
+--- a/lib/CL/devices/common.h
++++ b/lib/CL/devices/common.h
+@@ -94,6 +94,12 @@ int pocl_check_kernel_disk_cache (char *module_fn,
+                                   _cl_command_node *cmd,
+                                   int specialized);
+ 
++#ifdef ENABLE_LLVM
++POCL_EXPORT
++int pocl_link_final_binary (cl_device_id device, const char *objfile,
++                            const char *final_binary_path);
++#endif
++
+ POCL_EXPORT
+ size_t pocl_cmd_max_grid_dim_width (_cl_command_run *cmd);
+ 
+@@ -103,7 +109,7 @@ void *pocl_check_kernel_dlhandle_cache (_cl_command_node *command,
+                                         int specialize);
+ 
+ POCL_EXPORT
+-void pocl_release_dlhandle_cache (void *dlhandle_cache_item);
++void pocl_release_dlhandle_cache (void *module_cache_item);
+ 
+ POCL_EXPORT
+ void pocl_setup_device_for_system_memory(cl_device_id device);
+diff --git a/lib/CL/devices/common_driver.c b/lib/CL/devices/common_driver.c
+index 3d662076a..0a3e605d9 100644
+--- a/lib/CL/devices/common_driver.c
++++ b/lib/CL/devices/common_driver.c
+@@ -48,6 +48,7 @@
+ #include "pocl_mlir.h"
+ #endif
+ 
++#include "common.h"
+ #include "common_driver.h"
+ 
+ #define APPEND_TO_BUILD_LOG_RET(err, ...)                                     \
+@@ -919,6 +920,45 @@ pocl_driver_supports_binary (cl_device_id device, size_t length,
+ #endif
+ }
+ 
++#ifdef ENABLE_LLVM
++/* Recursively links every JIT kernel object in 'path' whose shared library
++   variant is missing. An exported binary must carry the shared libraries: a
++   JIT device caches only the kernel objects, which an LLVM-less consumer --
++   the primary deployment target of poclbinaries -- cannot load or link.
++   Objects whose shared library exists are then skipped at serialization
++   (see pocl_binary.c). */
++static void
++link_jit_objects (cl_device_id device, const char *path)
++{
++  switch (pocl_get_file_type (path))
++    {
++    default:
++      return;
++    case POCL_FS_REGULAR:
++      {
++        char so_path[POCL_MAX_PATHNAME_LENGTH];
++        if (!pocl_cache_object_shlib_variant (so_path, path)
++            || pocl_exists (so_path))
++          return;
++        if (pocl_link_final_binary (device, path, so_path))
++          POCL_MSG_WARN ("Linking %s for the exported binary failed.\n",
++                         path);
++        return;
++      }
++    case POCL_FS_DIRECTORY:
++      {
++        pocl_dir_iter d;
++        if (pocl_dir_iterator (path, &d))
++          return;
++        while (pocl_dir_next_entry (d))
++          link_jit_objects (device, pocl_dir_iter_get_path (d));
++        pocl_release_dir_iterator (&d);
++        return;
++      }
++    }
++}
++#endif
++
+ /* Build the dynamic WG sized parallel.bc and device specific code,
+    for each kernel. This must be called *after* metadata has been setup  */
+ int
+@@ -1056,6 +1096,14 @@ pocl_driver_build_poclbinary (cl_program program, cl_uint device_i)
+       return CL_INVALID_OPERATION;
+     }
+ 
++#ifdef ENABLE_LLVM
++  {
++    char program_dir[POCL_MAX_PATHNAME_LENGTH];
++    pocl_cache_program_path (program_dir, program, device_i);
++    link_jit_objects (device, program_dir);
++  }
++#endif
++
+   POCL_UNLOCK_OBJ (program);
+   return CL_SUCCESS;
+ }
+diff --git a/lib/CL/devices/common_utils.c b/lib/CL/devices/common_utils.c
+index c5ec6a281..450c4e6da 100644
+--- a/lib/CL/devices/common_utils.c
++++ b/lib/CL/devices/common_utils.c
+@@ -36,6 +36,9 @@
+ #ifdef ENABLE_LLVM
+ #include "pocl_llvm.h"
+ #endif
++#ifdef HOST_CPU_ENABLE_JIT
++#include "pocl_llvm_orc.h"
++#endif
+ #include "pocl_mem_management.h"
+ #include "pocl_runtime_config.h"
+ #include "pocl_tensor_util.h"
+@@ -315,6 +318,18 @@ pocl_cpu_init_common (cl_device_id device, unsigned dev_i)
+ 
+   pocl_init_default_device_infos (device, HOST_DEVICE_EXTENSIONS);
+ 
++#ifdef HOST_CPU_ENABLE_JIT
++  /* Bring up the process-global JIT and latch the device's load mode for its
++     lifetime (see pocl_cpu_device_uses_jit()). A bring-up failure
++     (unsupported triple, executor setup) is not transient, so the device
++     permanently keeps the linker path. */
++  if (device->ops->finalize_binary == NULL
++      && pocl_get_bool_option ("POCL_CPU_JIT", 1)
++      && pocl_jit_initialize (device->llvm_target_triplet, device->llvm_cpu)
++           == 0)
++    device->uses_cpu_jit = CL_TRUE;
++#endif
++
+ #ifdef HOST_CPU_ENABLE_SPIRV
+   device->supported_spirv_extensions = HOST_DEVICE_SPV_EXTENSIONS;
+ 
+diff --git a/lib/CL/pocl_binary.c b/lib/CL/pocl_binary.c
+index bf5b0c0c1..2643dd0b8 100644
+--- a/lib/CL/pocl_binary.c
++++ b/lib/CL/pocl_binary.c
+@@ -346,13 +346,25 @@ static unsigned char *
+ recursively_serialize_path (const char *path, size_t basedir_offset,
+                             unsigned char *buffer)
+ {
+-
+   switch (pocl_get_file_type (path))
+     {
+     default:
+       POCL_MSG_WARN ("Skipping non-file/-directory: '%s'\n", path);
+       return buffer;
+     case POCL_FS_REGULAR:
++      /* A kernel object (OBJ_EXT) whose shared library variant exists is a
++         private cache artifact: consumers dlopen the shared library, or JIT
++         an equivalent object from the program IR, so don't ship it (see
++         pocl_driver_build_poclbinary()). Without the shared library (the
++         export-time link failed, e.g. for lack of a toolchain) ship the
++         object as a fallback only JIT-enabled or linker-equipped consumers
++         can load. */
++      {
++        char so_path[POCL_MAX_PATHNAME_LENGTH];
++        if (pocl_cache_object_shlib_variant (so_path, path)
++            && pocl_exists (so_path))
++          return buffer;
++      }
+       return serialize_file (path, basedir_offset, buffer);
+     case POCL_FS_DIRECTORY:
+       {
+diff --git a/lib/CL/pocl_cache.c b/lib/CL/pocl_cache.c
+index 9b9b225ba..1c6f02e0e 100644
+--- a/lib/CL/pocl_cache.c
++++ b/lib/CL/pocl_cache.c
+@@ -245,13 +245,18 @@ pocl_cache_work_group_function_path (char *parallel_bc_path,
+                                    specialize);
+ }
+ 
+-/* Return the final binary path for the given work-group function.
+-   If specialized is 1, find the WG function specialized for the
+-   given command's properties, if 0, return the path to a generic version. */
++/* Return the final binary path for the given work-group function, naming
++   either the JIT-loadable relocatable object (OBJ_EXT) or the linked shared
++   library variant of the artifact; the distinct extensions keep the two from
++   colliding in the cache dir. If specialized is 1, find the WG function
++   specialized for the given command's properties, if 0, return the path to a
++   generic version. */
+ void
+-pocl_cache_final_binary_path (char *final_binary_path, cl_program program,
+-                              unsigned device_i, cl_kernel kernel,
+-                              _cl_command_node *command, int specialized)
++pocl_cache_final_binary_variant_path (char *final_binary_path,
++                                      cl_program program, unsigned device_i,
++                                      cl_kernel kernel,
++                                      _cl_command_node *command,
++                                      int specialized, int jit_object)
+ {
+   assert (kernel->name);
+ 
+@@ -270,13 +275,12 @@ pocl_cache_final_binary_path (char *final_binary_path, cl_program program,
+     {
+       char file_name[POCL_MAX_FILENAME_LENGTH + 1];
+       pocl_hash_clipped_name (kernel->name, &file_name[0]);
+-      bytes_written = snprintf (final_binary_name, POCL_MAX_PATHNAME_LENGTH,
+-#ifdef _WIN32
+-                                "/%s.dll",
+-#else
+-                                "/%s.so",
+-#endif
+-                                file_name);
++      if (jit_object)
++        bytes_written = snprintf (final_binary_name, POCL_MAX_PATHNAME_LENGTH,
++                                  "/%s" OBJ_EXT, file_name);
++      else
++        bytes_written = snprintf (final_binary_name, POCL_MAX_PATHNAME_LENGTH,
++                                  "/%s" SHARED_LIB_EXT, file_name);
+     }
+ 
+   assert (bytes_written > 0 && bytes_written < POCL_MAX_PATHNAME_LENGTH);
+@@ -286,6 +290,47 @@ pocl_cache_final_binary_path (char *final_binary_path, cl_program program,
+                                    specialized);
+ }
+ 
++/* If 'path' names a cached kernel object (the OBJ_EXT artifact variant of a
++   final binary; see pocl_cache_final_binary_variant_path()), write the path
++   of its shared-library sibling variant into 'so_path' and return 1. Returns
++   0 for other files, including leftover temporary objects of already-linked
++   libraries ("<kernel>.dll.o", kept by POCL_LEAVE_KERNEL_COMPILER_TEMP_FILES
++   on platforms where OBJ_EXT doesn't embed SHARED_LIB_EXT). */
++int
++pocl_cache_object_shlib_variant (char *so_path, const char *path)
++{
++  size_t len = strlen (path);
++  size_t obj_ext_len = strlen (OBJ_EXT);
++  size_t so_ext_len = strlen (SHARED_LIB_EXT);
++  if (len <= obj_ext_len || strcmp (path + len - obj_ext_len, OBJ_EXT) != 0)
++    return 0;
++  size_t stem_len = len - obj_ext_len;
++  if (stem_len >= so_ext_len
++      && strcmp (path + stem_len - so_ext_len, SHARED_LIB_EXT) == 0)
++    return 0;
++  if (stem_len + so_ext_len >= POCL_MAX_PATHNAME_LENGTH)
++    return 0;
++  memcpy (so_path, path, stem_len);
++  strcpy (so_path + stem_len, SHARED_LIB_EXT);
++  return 1;
++}
++
++/* Return the path of the final binary a device generates for the given
++   work-group function: a JIT device produces the kernel object to load
++   in-process, the others a linked shared library (see
++   pocl_cpu_device_uses_jit()). */
++void
++pocl_cache_final_binary_path (char *final_binary_path, cl_program program,
++                              unsigned device_i, cl_kernel kernel,
++                              _cl_command_node *command, int specialized)
++{
++  int jit_object
++    = pocl_cpu_device_uses_jit (kernel->program->devices[device_i]);
++  pocl_cache_final_binary_variant_path (final_binary_path, program, device_i,
++                                        kernel, command, specialized,
++                                        jit_object);
++}
++
+ /******************************************************************************/
+ /******************************************************************************/
+ 
+diff --git a/lib/CL/pocl_cl.h b/lib/CL/pocl_cl.h
+index 21dabd67c..82929136b 100644
+--- a/lib/CL/pocl_cl.h
++++ b/lib/CL/pocl_cl.h
+@@ -1198,6 +1198,10 @@ struct _cl_device_id {
+    * This pass adds checks of input operands to div/rem so that UB is
+    * never triggered. */
+   cl_bool run_sanitize_divrem_pass;
++  /* CL_TRUE for CPU host devices that load kernel objects in-process via the
++   * ORC/JITLink JIT; latched in pocl_cpu_init_common() (see
++   * pocl_cpu_device_uses_jit()). */
++  cl_bool uses_cpu_jit;
+ 
+   /* If CL_TRUE, pocl_llvm_build_program will ignore pocl's OpenCL headers
+    * that perform built-in renames during OpenCL C build and relies on
+@@ -1441,6 +1445,21 @@ struct _cl_device_id {
+   struct _cl_device_id *next;
+ };
+ 
++/* Whether a CPU host device loads kernel objects in-process via the ORC/JITLink
++   JIT (HOST_CPU_ENABLE_JIT) instead of linking them into a shared library and
++   dlopen()ing it. Latched for the device's lifetime in pocl_cpu_init_common():
++   a device qualifies when it has no custom binary finalizer (custom back-ends
++   set finalize_binary and keep the link path), POCL_CPU_JIT is left on, and the
++   process-global JIT came up. This single gate decides codegen's code model and
++   the cached artifact variant. JIT devices use OBJ_EXT; non-JIT devices use
++   SHARED_LIB_EXT, linking a cached OBJ_EXT fallback only when LLVM is available
++   (see pocl_check_kernel_disk_cache()). */
++static inline int
++pocl_cpu_device_uses_jit (cl_device_id device)
++{
++  return device->uses_cpu_jit;
++}
++
+ #define DEVICE_SVM_FINEGR(dev) (dev->svm_caps & (CL_DEVICE_SVM_FINE_GRAIN_BUFFER \
+                                               | CL_DEVICE_SVM_FINE_GRAIN_SYSTEM))
+ #define DEVICE_SVM_ATOM(dev) (dev->svm_caps & CL_DEVICE_SVM_ATOMICS)
+diff --git a/lib/CL/pocl_llvm.h b/lib/CL/pocl_llvm.h
+index e5343a445..702a5c5cf 100644
+--- a/lib/CL/pocl_llvm.h
++++ b/lib/CL/pocl_llvm.h
+@@ -212,6 +212,7 @@ extern "C" {
+                          const char* MCPU,
+                          const char *Features,
+                          cl_device_type DevType,
++                         int ForJIT,
+                          pocl_lock_t *Lock,
+                          void *Modp, int EmitAsm,
+                          int EmitObj, char **Output, uint64_t *OutputSize);
+@@ -231,8 +232,8 @@ extern "C" {
+    * Link a kernel object into a shared library in-process through lld's
+    * library API. This bundles the linker into libpocl, dropping the
+    * dependency on an external toolchain: nothing is exec'd and no startup
+-   * files are needed: symbols the kernel binary leaves undefined resolve
+-   * when it is dlopen()ed.
++   * files are needed. Symbols the kernel binary leaves undefined resolve
++   * when it is dlopen()ed, the same way the JIT resolves them.
+    *
+    * @param Device the device whose target to link for
+    * @param InFile the input object file
+diff --git a/lib/CL/pocl_llvm_api.h b/lib/CL/pocl_llvm_api.h
+index 87c294eb2..afceac2f5 100644
+--- a/lib/CL/pocl_llvm_api.h
++++ b/lib/CL/pocl_llvm_api.h
+@@ -133,6 +133,12 @@ struct PoclLLVMContextData
+ #endif
+ };
+ 
++/* Return the device's OpenCL C built-in function library bitcode, parsed into
++ * the context's LLVMContext and cached in its kernelLibraryMap. Returns NULL if
++ * the library cannot be found. */
++llvm::Module *getKernelLibrary(cl_device_id device,
++                               PoclLLVMContextData *llvm_ctx);
++
+ #ifdef __GNUC__
+ #pragma GCC visibility pop
+ #endif
+diff --git a/lib/CL/pocl_llvm_build.cc b/lib/CL/pocl_llvm_build.cc
+index 97b4889d6..80e3e8ef7 100644
+--- a/lib/CL/pocl_llvm_build.cc
++++ b/lib/CL/pocl_llvm_build.cc
+@@ -166,9 +166,6 @@ static void get_build_log(cl_program program,
+   appendToProgramBuildLog(program, device_i, log);
+ }
+ 
+-static llvm::Module *getKernelLibrary(cl_device_id device,
+-                                      PoclLLVMContextData *llvm_ctx);
+-
+ /**
+  * Runs various LLVM "passes" on the program.bc LLVM module;
+  * the passes are not real LLVM passes, but perhaps it will make sense
+@@ -204,7 +201,8 @@ static bool generateProgramBC(PoclLLVMContextData *Context, llvm::Module *Mod,
+   if (Program->compiler_options)
+     Opts.assign(Program->compiler_options);
+   bool DebugRequested = (Opts.find("-g") != std::string::npos);
+-  if (link(Mod, BuiltinLib, Log, Device, !DebugRequested))
++  if (link(Mod, BuiltinLib, Log, Device, !DebugRequested,
++           /*ErrorOnUnresolved=*/true))
+     return true;
+ 
+   raw_string_ostream OS(Log);
+@@ -1046,8 +1044,8 @@ int pocl_llvm_link_program(cl_program program, unsigned device_i,
+  * Return the OpenCL C built-in function library bitcode
+  * for the given device.
+  */
+-static llvm::Module *getKernelLibrary(cl_device_id device,
+-                                      PoclLLVMContextData *llvm_ctx) {
++llvm::Module *getKernelLibrary(cl_device_id device,
++                               PoclLLVMContextData *llvm_ctx) {
+   Triple triple(device->llvm_target_triplet);
+   llvm::LLVMContext *llvmContext = llvm_ctx->Context;
+   kernelLibraryMapTy *kernelLibraryMap = llvm_ctx->kernelLibraryMap;
+@@ -1229,7 +1227,8 @@ int pocl_invoke_lld_link(cl_device_id Device, const char *InFile,
+   // The flags the Clang driver would pass to the linker are HOST_LD_FLAGS
+   // (-shared -nostartfiles and friends), expressed here in ld terms.
+   // Symbols the kernel binary leaves undefined resolve when it is
+-  // dlopen()ed, so no C runtime or startup files are needed at link time.
++  // dlopen()ed, the same way the JIT resolves them, so no C runtime or
++  // startup files are needed at link time.
+ #ifdef __APPLE__
+   ArgStorage.push_back(
+       llvm::Triple(Device->llvm_target_triplet).getArchName().str());
+@@ -1261,8 +1260,8 @@ int pocl_invoke_lld_link(cl_device_id Device, const char *InFile,
+ #endif
+ #endif
+ 
+-  // lld is not re-entrant; serialize links here instead of relying on the
+-  // callers' locking.
++  // lld is not re-entrant; the codegen lock does not cover all callers
++  // (poclbinary export links outside of it), so serialize here.
+   static std::mutex LLDMutex;
+   std::lock_guard<std::mutex> Guard(LLDMutex);
+ 
+diff --git a/lib/CL/pocl_llvm_orc.cc b/lib/CL/pocl_llvm_orc.cc
+new file mode 100644
+index 000000000..ad7f3f05f
+--- /dev/null
++++ b/lib/CL/pocl_llvm_orc.cc
+@@ -0,0 +1,719 @@
++/* OpenCL runtime library: in-process JIT linking and loading of kernel object
++   files via LLVM ORC + JITLink.
++
++   Copyright (c) 2026 PoCL developers
++
++   Permission is hereby granted, free of charge, to any person obtaining a copy
++   of this software and associated documentation files (the "Software"), to
++   deal in the Software without restriction, including without limitation the
++   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++   sell copies of the Software, and to permit persons to whom the Software is
++   furnished to do so, subject to the following conditions:
++
++   The above copyright notice and this permission notice shall be included in
++   all copies or substantial portions of the Software.
++
++   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
++   IN THE SOFTWARE.
++*/
++
++#include "config.h"
++
++#include "pocl_debug.h"
++#include "pocl_dynlib.h"
++#include "pocl_file_util.h"
++#include "pocl_llvm.h"
++#include "pocl_llvm_orc.h"
++#include "pocl_util.h"
++
++#include <llvm/ADT/StringSet.h>
++#include <llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h>
++#include <llvm/ExecutionEngine/JITSymbol.h>
++#include <llvm/ExecutionEngine/Orc/Core.h>
++#include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
++#include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
++#include <llvm/ExecutionEngine/Orc/LLJIT.h>
++#include <llvm/ExecutionEngine/Orc/ObjectFileInterface.h>
++#include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
++#include <llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h>
++#include <llvm/Object/Archive.h>
++#include <llvm/Support/Error.h>
++#include <llvm/Support/MemoryBuffer.h>
++#include <llvm/TargetParser/Triple.h>
++
++/* absoluteSymbols() moved from Core.h to its own header around LLVM 20. */
++#if __has_include(<llvm/ExecutionEngine/Orc/AbsoluteSymbols.h>)
++#include <llvm/ExecutionEngine/Orc/AbsoluteSymbols.h>
++#endif
++
++#include <cstdint>
++#include <cstdlib>
++#include <memory>
++#include <mutex>
++#include <set>
++#include <string>
++#include <vector>
++
++using namespace llvm;
++using namespace llvm::orc;
++
++#ifdef ENABLE_PRINTF_IMMEDIATE_FLUSH
++/* Host-side printf flush callback referenced by kernels built with immediate
++   flush; defined in libpocl (lib/CL/devices/printf_buffer.c). */
++extern "C" void pocl_flush_printf_buffer(char *buffer, uint32_t buffer_size);
++#endif
++
++#ifdef __MINGW32__
++/* MinGW kernel objects reference the libgcc/compiler-rt stack probe
++   ___chkstk_ms (emitted for frames > 4KB), which no Windows system DLL
++   exports. libpocl links against a libgcc/compiler-rt that provides it, so
++   defineHostSymbols() hands that copy to kernels as an absolute symbol. The
++   COFF JIT's large code model keeps it reachable; see GetTargetMachine() in
++   pocl_llvm_wg.cc. */
++extern "C" void ___chkstk_ms(void);
++
++/* Same story for the FP16 soft-float conversion helpers codegen emits for
++   double/float <-> _Float16: defined in libgcc, exported by no DLL. Loading
++   libgcc.a into the JIT to supply them does NOT work here -- their COFF members
++   carry .pdata/.xdata SEH unwind whose IMAGE_REL_AMD64_ADDR32NB fixups JITLink
++   cannot relocate into the high-mapped kernel image ("out of range of Pointer32
++   fixup"). Hand kernels libpocl's own statically-linked copies instead.
++
++   But mingw's libgcc uses the legacy soft-float ABI for these: the half is
++   carried in a GPR as an unsigned short, whereas LLVM's codegen calls them with
++   the _Float16 ABI, passing/returning the half in the low 16 bits of an XMM
++   register. Handing kernels libgcc's symbols directly therefore moves the half
++   through the wrong register -- e.g. `fptrunc double to half` (emitted for the
++   FP16 pow/atan2 builtins, which round a double result) reads a stale XMM0 and
++   returns garbage. Wrap libgcc's routines in the _Float16 ABI and inject the
++   wrappers. On f16c CPUs the half<->float pair is done in hardware, so only the
++   double conversions strictly need this, but wrap all four for CPUs without
++   f16c. (The Windows JIT build uses the Clang toolchain, which supports
++   _Float16.) */
++/* libgcc's routines, reached under private names via asm labels so we can give
++   them their real (integer-GPR) prototypes without clashing with the compiler's
++   builtin declarations. */
++extern "C" {
++unsigned short poclLibgccTruncSFHF2(float) __asm__("__truncsfhf2");
++unsigned short poclLibgccTruncDFHF2(double) __asm__("__truncdfhf2");
++float poclLibgccExtendHFSF2(unsigned short) __asm__("__extendhfsf2");
++double poclLibgccExtendHFDF2(unsigned short) __asm__("__extendhfdf2");
++}
++
++static _Float16 poclTruncSFHF2(float A) {
++  unsigned short H = poclLibgccTruncSFHF2(A);
++  _Float16 R;
++  __builtin_memcpy(&R, &H, sizeof R);
++  return R;
++}
++static _Float16 poclTruncDFHF2(double A) {
++  unsigned short H = poclLibgccTruncDFHF2(A);
++  _Float16 R;
++  __builtin_memcpy(&R, &H, sizeof R);
++  return R;
++}
++static float poclExtendHFSF2(_Float16 A) {
++  unsigned short H;
++  __builtin_memcpy(&H, &A, sizeof H);
++  return poclLibgccExtendHFSF2(H);
++}
++static double poclExtendHFDF2(_Float16 A) {
++  unsigned short H;
++  __builtin_memcpy(&H, &A, sizeof H);
++  return poclLibgccExtendHFDF2(H);
++}
++#endif
++
++namespace {
++
++/* Process-global JIT shared by all CPU host devices, created on the first
++   pocl_jit_initialize() call. JITMutex serializes access. Intentionally never
++   deleted: a destructor would unmap the JIT'd code at exit, but scheduler
++   threads (joined only under POCL_ENABLE_UNINIT) may still be running it. The
++   linker path leaks its kernel .so handles for the same reason. */
++LLJIT *TheJIT = nullptr;
++std::mutex JITMutex;
++
++/* Set when LLJIT creation fails, after which pocl_jit_initialize() fails fast.
++   Never reset, since the failure (unsupported triple, executor setup) is not
++   transient. */
++bool JITFailed = false;
++
++/* Keeps each JITDylib name unique within the ExecutionSession; touched only
++   under JITMutex. */
++uint64_t JDCounter = 0;
++
++/* Most recent pocl_jit_lookup() failure text, returned by
++   pocl_jit_last_error() (a dlerror() analogue). Guarded by JITMutex. */
++std::string LastLookupError;
++
++/* ORC symbol source model.
++
++   Kernel objects can only refer to symbols introduced by codegen, the linked
++   kernel library, or PoCL's host ABI. Keep each source class mapped to one
++   ORC mechanism, mirroring what the shared-library link path provided:
++
++   - Process/global scope: LLJIT's default process-symbol generator. This is
++     the JIT analogue of loader-visible process symbols.
++   - libpocl and its private dependency closure: DynamicLibrarySearchGenerator
++     on libpocl's own handle. This mirrors a kernel shared library's DT_NEEDED
++     edge to libpocl and, on POSIX, libpocl's dependencies such as libgcc_s or
++     libm when the ICD loader used RTLD_LOCAL.
++   - Configure-time vector math library: DynamicLibrarySearchGenerator for
++     shared veclibs (libmvec, SLEEF), or a request-driven archive generator for
++     static SVML/libirc. These are the same absolute link inputs the non-JIT
++     final link receives.
++   - Compiler runtime helpers: StaticLibraryDefinitionGenerator for the
++     installed compiler-rt/libgcc archive. This replaces the Clang driver's
++     implicit runtime library link.
++   - Host ABI callbacks and platform helper symbols: absoluteSymbols in the
++     process-symbols JITDylib. This covers deliberately hidden libpocl entry
++     points such as the printf flush callback and MinGW's stack probe.
++
++   PoCL kernel-library builtins are not a runtime source: they are linked into
++   the kernel object at IR time before codegen (see linkKernelLibraryForJIT in
++   pocl_llvm_wg.cc), so the object is self-contained for them.
++
++   A new unresolved CPU-kernel symbol should fit one of these buckets; if it
++   does not, first identify which codegen or ABI rule introduced it and then
++   add the corresponding generator here rather than treating it as a one-off. */
++
++/* Make a dynamic library's symbols (e.g. libmvec's _ZGVdN8v_expf, or
++   libpocl's own dependency chain) resolvable by JIT'd kernels. Attaches a
++   DynamicLibrarySearchGenerator for the library to the process-symbols
++   JITDylib, which every kernel JITDylib links against (LLJIT links each
++   JITDylib it creates against the process-symbols JITDylib by default).
++   Lookups are then served from the library's own handle through the JIT's
++   generator chain; on POSIX that dlsym scope includes the library's
++   dependencies. Returns false (and leaves the JIT usable) if the library
++   cannot be loaded. */
++static bool addLibrarySearchGenerator(const char *Library) {
++  if (!Library || !Library[0])
++    return false;
++  JITDylibSP PSJD = TheJIT->getProcessSymbolsJITDylib();
++  if (!PSJD)
++    return false;
++  Expected<std::unique_ptr<DynamicLibrarySearchGenerator>> Gen =
++      DynamicLibrarySearchGenerator::Load(
++          Library, TheJIT->getDataLayout().getGlobalPrefix());
++  if (!Gen) {
++    consumeError(Gen.takeError());
++    return false;
++  }
++  PSJD->addGenerator(std::move(*Gen));
++  return true;
++}
++
++/* Make a static archive's members resolvable by JIT'd kernels. JITLink pulls
++   members in lazily, materializing only those that satisfy a referenced symbol,
++   like a static link. Used for SVML, whose __svml_* symbols ship only in
++   Intel's libsvml.a (helpers in libirc.a). Attaches a
++   StaticLibraryDefinitionGenerator to the process-symbols JITDylib that every
++   kernel JITDylib links against. Returns false if the archive cannot be loaded,
++   leaving the JIT usable. */
++static bool loadStaticArchive(const char *Path) {
++  if (!Path || !Path[0])
++    return false;
++  JITDylibSP PSJD = TheJIT->getProcessSymbolsJITDylib();
++  if (!PSJD)
++    return false;
++  Expected<std::unique_ptr<StaticLibraryDefinitionGenerator>> Gen =
++      StaticLibraryDefinitionGenerator::Load(TheJIT->getObjLinkingLayer(),
++                                             Path);
++  if (!Gen) {
++    consumeError(Gen.takeError());
++    return false;
++  }
++  PSJD->addGenerator(std::move(*Gen));
++  return true;
++}
++
++/* Load an archive by absolute path, or by filename from PoCL's private data dir. */
++static bool loadPrivateStaticArchive(const char *Path) {
++  if (!Path || !Path[0])
++    return false;
++  if (pocl_exists(Path))
++    return loadStaticArchive(Path);
++
++  char PrivateDir[POCL_MAX_PATHNAME_LENGTH];
++  pocl_get_private_datadir(PrivateDir);
++  std::string FullPath = std::string(PrivateDir) + "/" + Path;
++  if (pocl_exists(FullPath.c_str()))
++    return loadStaticArchive(FullPath.c_str());
++
++  return loadStaticArchive(Path);
++}
++
++/* Unlike StaticLibraryDefinitionGenerator, this does not build an archive-wide
++   symbol map at JIT initialization. SVML is only needed after vectorized
++   builtins introduce a __svml_* reference, so keep the archive paths until
++   that first lookup and then consult only the requested archive-index names. */
++class LazySVMLDefinitionGenerator : public DefinitionGenerator {
++  struct IndexedArchive {
++    std::string Path;
++    std::unique_ptr<MemoryBuffer> Buffer;
++    std::unique_ptr<object::Archive> Archive;
++    std::set<uint64_t> LoadedOffsets;
++  };
++
++  struct SelectedMember {
++    IndexedArchive *Source;
++    uint64_t Offset;
++    MemoryBufferRef Buffer;
++  };
++
++public:
++  LazySVMLDefinitionGenerator(ObjectLayer &Layer, StringRef IRCPath,
++                              StringRef SVMLPath, char GlobalPrefix)
++      : Layer(Layer), IRCPath(IRCPath), SVMLPath(SVMLPath),
++        GlobalPrefix(GlobalPrefix) {}
++
++  Error tryToGenerate(LookupState &, LookupKind K, JITDylib &JD,
++                      JITDylibLookupFlags,
++                      const SymbolLookupSet &Symbols) override {
++    if (K != LookupKind::Static)
++      return Error::success();
++
++    if (!Active) {
++      bool NeedsSVML = false;
++      for (const auto &[Name, _] : Symbols)
++        if (isSVMLName(*Name)) {
++          NeedsSVML = true;
++          break;
++        }
++      if (!NeedsSVML)
++        return Error::success();
++
++      /* Keep this before opening either archive: it is the deterministic test
++         that unrelated JIT lookups leave the provider untouched. */
++      if (getenv("POCL_FAULT_INJECT_JIT_SVML"))
++        return createStringError(
++            inconvertibleErrorCode(),
++            "injected SVML provider failure (POCL_FAULT_INJECT_JIT_SVML)");
++
++      if (Error Err = activate())
++        return Err;
++    }
++
++    StringSet<> Requested;
++    for (const auto &[Name, _] : Symbols)
++      Requested.insert(*Name);
++
++    std::vector<SelectedMember> Members;
++    if (Error Err = selectMembers(*IRC, Requested, Members))
++      return Err;
++    if (!Requested.empty())
++      if (Error Err = selectMembers(*SVML, Requested, Members))
++        return Err;
++
++    for (const SelectedMember &Member : Members)
++      if (Error Err = addMember(JD, Member))
++        return Err;
++
++    return Error::success();
++  }
++
++private:
++  bool isSVMLName(StringRef Name) const {
++    if (GlobalPrefix != '\0') {
++      if (Name.empty() || Name.front() != GlobalPrefix)
++        return false;
++      Name = Name.drop_front();
++    }
++    return Name.starts_with("__svml_");
++  }
++
++  static Error openArchive(std::unique_ptr<IndexedArchive> &Out,
++                           StringRef Path) {
++    ErrorOr<std::unique_ptr<MemoryBuffer>> Buffer = MemoryBuffer::getFile(
++        Path, /*IsText=*/false, /*RequiresNullTerminator=*/false);
++    if (!Buffer)
++      return createStringError(inconvertibleErrorCode(),
++                               "pocl_jit: could not open SVML archive '%s': %s",
++                               Path.str().c_str(),
++                               Buffer.getError().message().c_str());
++
++    Expected<std::unique_ptr<object::Archive>> Archive =
++        object::Archive::create((*Buffer)->getMemBufferRef());
++    if (!Archive)
++      return createStringError(
++          inconvertibleErrorCode(),
++          "pocl_jit: could not parse SVML archive '%s': %s", Path.str().c_str(),
++          toString(Archive.takeError()).c_str());
++    if (!(*Archive)->hasSymbolTable())
++      return createStringError(
++          inconvertibleErrorCode(),
++          "pocl_jit: SVML archive '%s' has no symbol table",
++          Path.str().c_str());
++
++    auto Indexed = std::make_unique<IndexedArchive>();
++    Indexed->Path = Path.str();
++    Indexed->Buffer = std::move(*Buffer);
++    Indexed->Archive = std::move(*Archive);
++    Out = std::move(Indexed);
++    return Error::success();
++  }
++
++  Error activate() {
++    if (Error Err = openArchive(IRC, IRCPath))
++      return Err;
++    if (Error Err = openArchive(SVML, SVMLPath))
++      return Err;
++    Active = true;
++    POCL_MSG_PRINT_LLVM("pocl_jit: activating lazy SVML archive provider\n");
++    return Error::success();
++  }
++
++  static Error selectMembers(IndexedArchive &Source, StringSet<> &Requested,
++                             std::vector<SelectedMember> &Members) {
++    std::set<uint64_t> SelectedOffsets;
++    for (const object::Archive::Symbol &Symbol : Source.Archive->symbols()) {
++      StringRef Name = Symbol.getName();
++      if (Requested.find(Name) == Requested.end())
++        continue;
++
++      Expected<object::Archive::Child> Child = Symbol.getMember();
++      if (!Child)
++        return Child.takeError();
++      uint64_t Offset = Child->getDataOffset();
++      Requested.erase(Name);
++      if (Source.LoadedOffsets.count(Offset) ||
++          !SelectedOffsets.insert(Offset).second)
++        continue;
++
++      Expected<MemoryBufferRef> Buffer = Child->getMemoryBufferRef();
++      if (!Buffer)
++        return Buffer.takeError();
++      Members.push_back({&Source, Offset, *Buffer});
++    }
++    return Error::success();
++  }
++
++  Error addMember(JITDylib &JD, const SelectedMember &Member) {
++    std::string Identifier =
++        (Member.Source->Path + "[" + std::to_string(Member.Offset) + "](" +
++         Member.Buffer.getBufferIdentifier().str() + ")");
++    std::unique_ptr<MemoryBuffer> Buffer =
++        MemoryBuffer::getMemBuffer(Member.Buffer.getBuffer(), Identifier,
++                                   /*RequiresNullTerminator=*/false);
++    auto Interface = getObjectFileInterface(Layer.getExecutionSession(),
++                                            Buffer->getMemBufferRef());
++    if (!Interface)
++      return Interface.takeError();
++    if (Error Err = Layer.add(JD, std::move(Buffer), std::move(*Interface)))
++      return Err;
++
++    Member.Source->LoadedOffsets.insert(Member.Offset);
++    POCL_MSG_PRINT_LLVM("pocl_jit: materializing SVML archive member %s\n",
++                        Identifier.c_str());
++    return Error::success();
++  }
++
++  ObjectLayer &Layer;
++  std::string IRCPath;
++  std::string SVMLPath;
++  char GlobalPrefix;
++  bool Active = false;
++  std::unique_ptr<IndexedArchive> IRC;
++  std::unique_ptr<IndexedArchive> SVML;
++};
++
++static bool addLazySVMLGenerator(const char *IRCPath, const char *SVMLPath) {
++  if (!IRCPath || !IRCPath[0] || !SVMLPath || !SVMLPath[0])
++    return false;
++  JITDylibSP PSJD = TheJIT->getProcessSymbolsJITDylib();
++  if (!PSJD)
++    return false;
++  PSJD->addGenerator(std::make_unique<LazySVMLDefinitionGenerator>(
++      TheJIT->getObjLinkingLayer(), IRCPath, SVMLPath,
++      TheJIT->getDataLayout().getGlobalPrefix()));
++  return true;
++}
++
++/* Inject symbols that kernel objects reference but that are linked into libpocl
++   rather than exported by a process library: PoCL's own host callbacks and, on
++   Windows, the libgcc/compiler-rt stack probe. Defining them as absolute
++   symbols makes resolution independent of libpocl's (deliberately hidden)
++   dynamic-symbol visibility. They are constant for the process, so this is done
++   once at init into the process-symbols JITDylib that every kernel JITDylib
++   links against. Everything else (libc/libm/compiler-rt and msvcrt's mem*
++   helpers) resolves via the JIT's default process-symbol search, backed up on
++   POSIX by a search of libpocl's own handle (see pocl_jit_initialize). */
++void defineHostSymbols(JITDylib &JD) {
++  SymbolMap Syms;
++#ifdef ENABLE_PRINTF_IMMEDIATE_FLUSH
++  Syms[TheJIT->mangleAndIntern("pocl_flush_printf_buffer")] = {
++      ExecutorAddr::fromPtr(&pocl_flush_printf_buffer),
++      JITSymbolFlags::Exported | JITSymbolFlags::Callable};
++#endif
++#ifdef __MINGW32__
++  Syms[TheJIT->mangleAndIntern("___chkstk_ms")] = {
++      ExecutorAddr::fromPtr(&___chkstk_ms),
++      JITSymbolFlags::Exported | JITSymbolFlags::Callable};
++  Syms[TheJIT->mangleAndIntern("__truncsfhf2")] = {
++      ExecutorAddr::fromPtr(&poclTruncSFHF2),
++      JITSymbolFlags::Exported | JITSymbolFlags::Callable};
++  Syms[TheJIT->mangleAndIntern("__truncdfhf2")] = {
++      ExecutorAddr::fromPtr(&poclTruncDFHF2),
++      JITSymbolFlags::Exported | JITSymbolFlags::Callable};
++  Syms[TheJIT->mangleAndIntern("__extendhfsf2")] = {
++      ExecutorAddr::fromPtr(&poclExtendHFSF2),
++      JITSymbolFlags::Exported | JITSymbolFlags::Callable};
++  Syms[TheJIT->mangleAndIntern("__extendhfdf2")] = {
++      ExecutorAddr::fromPtr(&poclExtendHFDF2),
++      JITSymbolFlags::Exported | JITSymbolFlags::Callable};
++#endif
++  if (Syms.empty())
++    return;
++  if (Error Err = JD.define(absoluteSymbols(std::move(Syms))))
++    POCL_MSG_ERR("pocl_jit: failed to define host symbols: %s\n",
++                 toString(std::move(Err)).c_str());
++}
++
++} // namespace
++
++int pocl_jit_initialize(const char *TripleStr, const char *CPU) {
++  std::lock_guard<std::mutex> Lock(JITMutex);
++  if (TheJIT)
++    return 0;
++  if (JITFailed)
++    return -1;
++
++  /* Called from device init, which runs before clCreateContext's
++     InitializeLLVM() call, so register the native target (and the rest of
++     the one-time LLVM setup) here. InitializeLLVM() is idempotent. */
++  InitializeLLVM();
++
++  LLJITBuilder Builder;
++
++  /* Force the JITLink object-linking layer (LLJIT defaults to RuntimeDyld).
++     JITLink resolves relocations, maps code into executable memory, and
++     registers EH frames in-process, so no external linker is needed. The
++     creator callback signature varies by LLVM release:
++        LLVM <= 20 : (ExecutionSession&, const Triple&)
++        LLVM 21, 22: (ExecutionSession&)
++        LLVM >= 23 : (ExecutionSession&, jitlink::JITLinkMemoryManager&)
++     In each case we build an ObjectLinkingLayer, which uses the
++     ExecutorProcessControl's in-process memory manager by default. */
++  Builder.setObjectLinkingLayerCreator(
++#if LLVM_MAJOR >= 23
++      [](ExecutionSession &ES, jitlink::JITLinkMemoryManager &MM)
++          -> Expected<std::unique_ptr<ObjectLayer>> {
++        return std::make_unique<ObjectLinkingLayer>(ES, MM);
++      }
++#elif LLVM_MAJOR >= 21
++      [](ExecutionSession &ES) -> Expected<std::unique_ptr<ObjectLayer>> {
++        return std::make_unique<ObjectLinkingLayer>(ES);
++      }
++#else
++      [](ExecutionSession &ES,
++         const llvm::Triple &) -> Expected<std::unique_ptr<ObjectLayer>> {
++        return std::make_unique<ObjectLinkingLayer>(ES);
++      }
++#endif
++  );
++
++  /* Normalize the triple (e.g. "x86_64-w64-mingw32" -> "...-windows-gnu") so the
++     JIT's target machine and data layout use the COFF/Win64 form that matches the
++     kernel objects codegen emits; see GetTargetMachine() in pocl_llvm_wg.cc. */
++  JITTargetMachineBuilder JTMB{
++      llvm::Triple(llvm::Triple::normalize(TripleStr ? TripleStr : ""))};
++  if (CPU && CPU[0])
++    JTMB.setCPU(CPU);
++  Builder.setJITTargetMachineBuilder(std::move(JTMB));
++
++  Expected<std::unique_ptr<LLJIT>> JIT = Builder.create();
++  /* Test hook: simulate an environment where the JIT cannot be brought up
++     (unsupported triple, executor setup failure) to exercise the linker
++     fallback; see test_jit_fallback.jl. */
++  if (JIT && getenv("POCL_FAULT_INJECT_JIT"))
++    JIT = createStringError(inconvertibleErrorCode(),
++                            "injected failure (POCL_FAULT_INJECT_JIT)");
++  if (!JIT) {
++    POCL_MSG_WARN("pocl_jit: LLJIT creation failed: %s;"
++                  " falling back to linking kernel binaries\n",
++                  toString(JIT.takeError()).c_str());
++    JITFailed = true;
++    return -1;
++  }
++  TheJIT = JIT->release();
++
++  /* Define PoCL's host callbacks (and the Windows stack probe) once, into the
++     process-symbols JITDylib that every kernel JITDylib links against. */
++  if (JITDylibSP PSJD = TheJIT->getProcessSymbolsJITDylib())
++    defineHostSymbols(*PSJD);
++
++#ifdef HOST_CPU_COMPILER_RT_LIBRARY
++  if (!loadPrivateStaticArchive(HOST_CPU_COMPILER_RT_LIBRARY))
++    POCL_MSG_WARN(
++        "pocl_jit: could not load the compiler runtime archive '%s'; kernels "
++        "needing compiler-rt/libgcc helpers may fail to resolve symbols\n",
++        HOST_CPU_COMPILER_RT_LIBRARY);
++#endif
++
++#ifdef HAVE_DLFCN_H
++  /* The JIT's default process-symbol search uses the global dlsym scope, which
++     misses libpocl's private dependencies (libgcc_s for builtins like
++     __aeabi_uldivmod or __extendhfsf2, libm before glibc 2.34) when an ICD
++     loader dlopen'd libpocl RTLD_LOCAL. Also search libpocl's own handle, whose
++     dlsym scope covers its dependency chain, the way each kernel .so's implicit
++     -lgcc and DT_NEEDED entries do on the link path. This pins libpocl in
++     memory, which the process-lifetime JIT does anyway. On failure (e.g.
++     libpocl linked statically) kernels fall back to the process-global
++     lookup. */
++  const char *SelfPath =
++      pocl_dynlib_pathname(reinterpret_cast<void *>(&pocl_jit_initialize));
++  if (!addLibrarySearchGenerator(SelfPath))
++    POCL_MSG_PRINT_LLVM(
++        "pocl_jit: could not add libpocl's own libraries ('%s') to the symbol "
++        "search; kernels needing libpocl's private dependencies (libgcc_s, "
++        "libm) may fail to resolve symbols if those are not process-global\n",
++        SelfPath ? SelfPath : "<unknown>");
++#endif
++
++  /* CPU codegen vectorizes libm calls (expf, sinf, ...) into a vector-math
++     library's symbols (e.g. _ZGVdN8v_expf, __svml_expf8). The library is chosen
++     at configure time, matching codegen's veclib selection in pocl_llvm_wg.cc;
++     expose that same one to the JIT so the symbols resolve. */
++#if defined(ENABLE_HOST_CPU_VECTORIZE_LIBMVEC)
++  /* The configured SONAME first (e.g. SLEEF's libsleefgnuabi.so.3 when LIBMVEC was pointed
++     at it, so we don't depend on a system libmvec), then the configure-time path, then the
++     plain glibc SONAME as a last resort. */
++  const char *Candidates[] = {
++#ifdef HOST_CPU_LIBMVEC_LIBRARY
++      HOST_CPU_LIBMVEC_LIBRARY,
++#endif
++#ifdef HOST_CPU_LIBMVEC_LIBRARY_FALLBACK
++      HOST_CPU_LIBMVEC_LIBRARY_FALLBACK,
++#endif
++      "libmvec.so.1",
++  };
++  bool VecMathLoaded = false;
++  for (const char *VecMathLib : Candidates)
++    if ((VecMathLoaded = addLibrarySearchGenerator(VecMathLib)))
++      break;
++  if (!VecMathLoaded)
++    POCL_MSG_WARN(
++        "pocl_jit: could not load the libmvec vector-math library; vectorized "
++        "math kernels may fail to resolve their symbols\n");
++#elif defined(ENABLE_HOST_CPU_VECTORIZE_SLEEF)
++  /* The configured SONAME first, then the configure-time path, then the
++     plain library name as a last resort. */
++  const char *Candidates[] = {
++#ifdef HOST_CPU_SLEEF_LIBRARY
++      HOST_CPU_SLEEF_LIBRARY,
++#endif
++#ifdef HOST_CPU_SLEEF_LIBRARY_FALLBACK
++      HOST_CPU_SLEEF_LIBRARY_FALLBACK,
++#endif
++      "libsleef.so",
++  };
++  bool VecMathLoaded = false;
++  for (const char *VecMathLib : Candidates)
++    if ((VecMathLoaded = addLibrarySearchGenerator(VecMathLib)))
++      break;
++  if (!VecMathLoaded)
++    POCL_MSG_WARN(
++        "pocl_jit: could not load the SLEEF vector-math library; vectorized "
++        "math kernels may fail to resolve their symbols\n");
++#elif defined(ENABLE_HOST_CPU_VECTORIZE_SVML)
++  /* Do not index either archive here. Most cached kernels do not need SVML,
++     and the local generator opens both archives only after a __svml_* lookup.
++     Once active it also handles the non-SVML libirc helpers introduced by a
++     materialized libsvml member. */
++  bool VecMathLoaded = false;
++#if defined(HOST_CPU_IRC_LIBRARY) && defined(HOST_CPU_SVML_LIBRARY)
++  VecMathLoaded =
++      addLazySVMLGenerator(HOST_CPU_IRC_LIBRARY, HOST_CPU_SVML_LIBRARY);
++#endif
++  if (!VecMathLoaded)
++    POCL_MSG_WARN(
++        "pocl_jit: could not configure the lazy SVML archive provider; "
++        "vectorized math kernels may fail to resolve their symbols\n");
++#endif
++
++  return 0;
++}
++
++void *pocl_jit_load_object(const char *Path, const char *UniqName) {
++  std::lock_guard<std::mutex> Lock(JITMutex);
++  if (!TheJIT) {
++    POCL_MSG_ERR("pocl_jit: load_object called before initialize\n");
++    return nullptr;
++  }
++
++  ErrorOr<std::unique_ptr<MemoryBuffer>> Buf = MemoryBuffer::getFile(
++      Path, /*IsText=*/false, /*RequiresNullTerminator=*/false);
++  if (!Buf) {
++    POCL_MSG_ERR("pocl_jit: cannot read object '%s': %s\n", Path,
++                 Buf.getError().message().c_str());
++    return nullptr;
++  }
++
++  /* Give each loaded object its own JITDylib so symbol names never collide
++     across kernels/specializations and can be unloaded independently. The
++     JITDylib pointer doubles as the opaque module handle. */
++  std::string Name = std::string(UniqName ? UniqName : "kernel") + "#" +
++                     std::to_string(JDCounter++);
++  Expected<JITDylib &> JD = TheJIT->createJITDylib(std::move(Name));
++  if (!JD) {
++    POCL_MSG_ERR("pocl_jit: createJITDylib failed: %s\n",
++                 toString(JD.takeError()).c_str());
++    return nullptr;
++  }
++
++  if (Error Err = TheJIT->addObjectFile(*JD, std::move(*Buf))) {
++    POCL_MSG_ERR("pocl_jit: addObjectFile('%s') failed: %s\n", Path,
++                 toString(std::move(Err)).c_str());
++    if (Error RmErr = TheJIT->getExecutionSession().removeJITDylib(*JD))
++      consumeError(std::move(RmErr));
++    return nullptr;
++  }
++
++  return &*JD;
++}
++
++void *pocl_jit_lookup(void *Handle, const char *SymbolName) {
++  std::lock_guard<std::mutex> Lock(JITMutex);
++  JITDylib *JD = static_cast<JITDylib *>(Handle);
++  if (!TheJIT || JD == nullptr)
++    return nullptr;
++
++  /* ORC mangles the unmangled name for the target (e.g. adds the leading
++     underscore on Mach-O), so we pass the plain C symbol name. Linking and
++     relocation of the object happen here, on first lookup. */
++  Expected<ExecutorAddr> Addr = TheJIT->lookup(*JD, SymbolName);
++  if (!Addr) {
++    /* Leave reporting to the caller, which retrieves the diagnostic through
++       pocl_jit_last_error() (the dlerror() pattern), so only record it
++       instead of printing an error here. */
++    LastLookupError = toString(Addr.takeError());
++    POCL_MSG_PRINT_LLVM("pocl_jit: lookup('%s') failed: %s\n", SymbolName,
++                        LastLookupError.c_str());
++    return nullptr;
++  }
++  return reinterpret_cast<void *>(Addr->getValue());
++}
++
++const char *pocl_jit_last_error(void) {
++  std::lock_guard<std::mutex> Lock(JITMutex);
++  return LastLookupError.empty() ? nullptr : LastLookupError.c_str();
++}
++
++int pocl_jit_unload(void *Handle) {
++  std::lock_guard<std::mutex> Lock(JITMutex);
++  JITDylib *JD = static_cast<JITDylib *>(Handle);
++  if (JD == nullptr)
++    return 0;
++  if (TheJIT) {
++    if (Error Err = TheJIT->getExecutionSession().removeJITDylib(*JD))
++      POCL_MSG_ERR("pocl_jit: removeJITDylib failed: %s\n",
++                   toString(std::move(Err)).c_str());
++  }
++  return 1;
++}
+diff --git a/lib/CL/pocl_llvm_orc.h b/lib/CL/pocl_llvm_orc.h
+new file mode 100644
+index 000000000..687aac476
+--- /dev/null
++++ b/lib/CL/pocl_llvm_orc.h
+@@ -0,0 +1,75 @@
++/* OpenCL runtime library: in-process JIT linking and loading of kernel object
++   files via LLVM ORC + JITLink.
++
++   Copyright (c) 2026 PoCL developers
++
++   Permission is hereby granted, free of charge, to any person obtaining a copy
++   of this software and associated documentation files (the "Software"), to
++   deal in the Software without restriction, including without limitation the
++   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++   sell copies of the Software, and to permit persons to whom the Software is
++   furnished to do so, subject to the following conditions:
++
++   The above copyright notice and this permission notice shall be included in
++   all copies or substantial portions of the Software.
++
++   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
++   IN THE SOFTWARE.
++*/
++
++/* In-process JIT linking and loading of CPU host-device kernel objects via an
++   ORC LLJIT whose object-linking layer is JITLink. JITLink is both the linker
++   and the loader: it resolves relocations, maps the kernel code into
++   executable memory, and registers EH frames, without spawning an external
++   linker and without producing an on-disk shared object. */
++
++#ifndef POCL_LLVM_ORC_H
++#define POCL_LLVM_ORC_H
++
++#ifdef __cplusplus
++extern "C"
++{
++#endif
++
++/* Create the process-global LLJIT that loads kernel objects. Called from
++   CPU device init; idempotent and thread-safe. The triple determines the
++   JIT's data layout (and thus symbol mangling). Returns 0 on success. A
++   failure to create the JIT is latched internally and every later call
++   fails fast; device init uses the result to permanently route the device
++   through the linker path (see pocl_cpu_device_uses_jit()). */
++int pocl_jit_initialize (const char *triple,
++                         const char *cpu);
++
++/* Read a relocatable kernel object file from 'path' and stage it for
++   in-process JIT-linking in a fresh isolated JITDylib, returning an opaque
++   handle (NULL on failure). Relocation and linking are deferred until the
++   first pocl_jit_lookup() on the handle. 'uniq_name' is used only for
++   diagnostics and need not be unique. */
++void *pocl_jit_load_object (const char *path, const char *uniq_name);
++
++/* Look up an (unmangled) symbol in a previously loaded object. Returns the
++   executable address, or NULL on failure; the failure text is then available
++   from pocl_jit_last_error(). */
++void *pocl_jit_lookup (void *handle, const char *symbol_name);
++
++/* Text of the most recent pocl_jit_lookup() failure (a dlerror() analogue),
++   or NULL if no lookup has failed yet. With JITLink the first lookup is where
++   linking happens, so this is the diagnostic that names unresolved symbols or
++   relocation problems. The returned pointer is valid until the next failing
++   lookup; use (or copy) it immediately. */
++const char *pocl_jit_last_error (void);
++
++/* Unload a previously loaded object, reclaiming its code and memory.
++   Returns nonzero on success. */
++int pocl_jit_unload (void *handle);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif
+diff --git a/lib/CL/pocl_llvm_spirv.cc b/lib/CL/pocl_llvm_spirv.cc
+index eb2cbaf1c..d157a1996 100644
+--- a/lib/CL/pocl_llvm_spirv.cc
++++ b/lib/CL/pocl_llvm_spirv.cc
+@@ -811,7 +811,7 @@ static int convertBCorSPV(char *InputPath,
+   }
+   pocl_lock_t Lock;
+   POCL_INIT_LOCK(Lock);
+-  if (pocl_llvm_codegen2(Triple, "", "", CL_DEVICE_TYPE_GPU, &Lock,
++  if (pocl_llvm_codegen2(Triple, "", "", CL_DEVICE_TYPE_GPU, /*ForJIT=*/0, &Lock,
+                          Mod, CL_FALSE, CL_TRUE, &Content, &ContentSize) != CL_SUCCESS) {
+     BuildLog->append("failed to convert LLVM IR to SPIR-V "
+                      "using LLVM SPIRV backend\n");
+diff --git a/lib/CL/pocl_llvm_wg.cc b/lib/CL/pocl_llvm_wg.cc
+index 85e5ca59a..baed8c4a1 100644
+--- a/lib/CL/pocl_llvm_wg.cc
++++ b/lib/CL/pocl_llvm_wg.cc
+@@ -29,7 +29,10 @@
+ #include "CompilerWarnings.h"
+ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
+ #include <llvm/ADT/StringRef.h>
++#include <llvm/ADT/StringSet.h>
+ #include <llvm/ADT/Twine.h>
++#include <llvm/IR/InstIterator.h>
++#include <llvm/IR/InstrTypes.h>
+ #include <llvm/TargetParser/Triple.h>
+ POP_COMPILER_DIAGS
+ IGNORE_COMPILER_WARNING("-Wunused-parameter")
+@@ -49,6 +52,7 @@ IGNORE_COMPILER_WARNING("-Wunused-parameter")
+ #include <llvm/Support/CodeGen.h>
+ #include <llvm/Target/TargetMachine.h>
+ #include <llvm/Target/TargetOptions.h>
++#include <llvm/Transforms/IPO/Internalize.h>
+ #include <llvm/Transforms/Utils/Cloning.h>
+ // legacy PassManager is needed for CodeGen, even if new PM is used for IR
+ #include <llvm/IR/LegacyPassManager.h>
+@@ -114,17 +118,32 @@ static bool enableDebugLogs() {
+ }
+ 
+ // Returns the TargetMachine instance or zero if no triple is provided.
++// ForJIT selects a code model suitable for the in-process ORC/JITLink JIT (see
++// pocl_llvm_orc.cc); it only changes codegen on COFF targets.
+ static TargetMachine *GetTargetMachine(const char* TripleStr,
+                                        const char* MCPU = "",
+-                                       const char* Features = "") {
++                                       const char* Features = "",
++                                       bool ForJIT = false) {
+ 
+   std::string Error;
+ 
++  // Normalize the triple before handing it to codegen. A configure-time triple
++  // like "x86_64-w64-mingw32" (LLVM's own default target triple on MinGW, so
++  // what LLC_TRIPLE picks up from a cmake LLVM package) has an OS component
++  // ("mingw32") that llvm::Triple does not recognize, so it falls back to the
++  // ELF object format and the System V ABI -- yielding kernels the COFF/Win64
++  // host then calls with the wrong calling convention (a crash). clang and llc
++  // normalize the triple to "x86_64-w64-windows-gnu" (OS=Win32 => COFF) before
++  // codegen; do the same here so both the object format and the code-model
++  // decision below match the host ABI. A no-op for already-canonical triples.
++  std::string TripleNorm = llvm::Triple::normalize(TripleStr);
++  llvm::Triple TheTriple(TripleNorm);
++
+ #if LLVM_MAJOR < 22
+-  const Target *TheTarget = TargetRegistry::lookupTarget(TripleStr,
++  const Target *TheTarget = TargetRegistry::lookupTarget(TripleNorm,
+                                                          Error);
+ #else
+-  const Target *TheTarget = TargetRegistry::lookupTarget(Triple(TripleStr),
++  const Target *TheTarget = TargetRegistry::lookupTarget(TheTriple,
+                                                          Error);
+ #endif
+ 
+@@ -133,14 +152,26 @@ static TargetMachine *GetTargetMachine(const char* TripleStr,
+     return nullptr;
+   }
+ 
++  // JITLink's COFF/x86-64 backend does not synthesize far-call stubs (its ELF
++  // and Mach-O backends do). Under the small code model a kernel's +-2GB
++  // PC-relative call to a runtime helper mapped far from the JIT-allocated code
++  // overflows: the libgcc stack probe (___chkstk_ms) and msvcrt's mem* helpers
++  // both live in libraries outside that range. The large code model emits
++  // 64-bit indirect calls instead, so they resolve wherever they are. Hence the
++  // COFF JIT only; ELF/Mach-O and the linker-based paths are fine with small +
++  // PIC.
++  CodeModel::Model CM = CodeModel::Small;
++  if (ForJIT && TheTriple.isOSBinFormatCOFF())
++    CM = CodeModel::Large;
++
+   TargetMachine *TM = TheTarget->createTargetMachine(
+ #if LLVM_MAJOR < 22
+-      TripleStr,
++      TripleNorm,
+ #else
+-      Triple(TripleStr),
++      TheTriple,
+ #endif
+       MCPU, Features, TargetOptions(),
+-      Reloc::PIC_, CodeModel::Small,
++      Reloc::PIC_, CM,
+       CodeGenOptLevel::Aggressive);
+ 
+   assert(TM != NULL && "llvm target has no targetMachine constructor");
+@@ -945,6 +976,91 @@ pocl_llvm_run_pocl_passes(llvm::Module *Bitcode,
+   return 0;
+ }
+ 
++#ifdef HOST_CPU_ENABLE_JIT
++/* Make an in-process JIT work-group object self-contained.
++
++   The JIT links each kernel object in isolation, so every builtin the kernel
++   references must be defined in the object. Two things leave them unresolved:
++
++   - A pocl pass can leave a call whose callee Function still belongs to the
++     program / kernel-library module (they share the LLVMContext). Such a
++     cross-module reference is absent from this module's symbol table.
++   - clBuildProgram's callgraph-selective link only copied the builtins the
++     program IR referenced at that point; e.g. FP16 vector math helpers
++     (_cl_sinDv4_Dh, ...) can still be referenced but undefined here.
++
++   The shared-library path resolves both at the final .so link. Do the
++   equivalent at IR time: localize the cross-module references, copy the
++   referenced builtin bodies from the device kernel library, then internalize
++   everything but the launcher(s) and run GlobalDCE so the object neither
++   leaves builtins undefined nor exports them. Mirrors the CUDA linkLibDevice
++   flow. */
++static int linkKernelLibraryForJIT(llvm::Module *ParallelBC,
++                                   cl_device_id Device,
++                                   PoclLLVMContextData *PoCLLLVMContext) {
++  llvm::Module *KernelLib = getKernelLibrary(Device, PoCLLLVMContext);
++  if (KernelLib == nullptr) {
++    POCL_MSG_ERR("pocl_jit: cannot load the kernel library to finalize the "
++                 "work-group object\n");
++    return -1;
++  }
++
++  // Rewrite calls whose callee still lives in another module to a local
++  // declaration of the same name, so the selective linker below -- which finds
++  // undefined symbols by walking this module's function list -- resolves them
++  // like any other builtin. Restricted to builtins the kernel library actually
++  // defines; anything else (libc/libm/compiler-rt) is left for the JIT to
++  // resolve from process symbols. That also covers pocl host callbacks such as
++  // pocl_flush_printf_buffer when ENABLE_PRINTF_IMMEDIATE_FLUSH is enabled:
++  // defineHostSymbols() provides it as an absolute ORC symbol, and the
++  // program-stage link inserts the declaration only after its unresolved-symbol
++  // check has already run.
++  for (llvm::Function &F : *ParallelBC) {
++    for (llvm::Instruction &I : llvm::instructions(F)) {
++      auto *CB = llvm::dyn_cast<llvm::CallBase>(&I);
++      if (CB == nullptr)
++        continue;
++      llvm::Function *Callee = CB->getCalledFunction();
++      if (Callee == nullptr || Callee->getParent() == ParallelBC ||
++          Callee->isIntrinsic())
++        continue;
++      llvm::Function *LibFunc = KernelLib->getFunction(Callee->getName());
++      if (LibFunc == nullptr || LibFunc->isDeclaration())
++        continue;
++      llvm::FunctionCallee Local = ParallelBC->getOrInsertFunction(
++          Callee->getName(), Callee->getFunctionType());
++      if (auto *LF = llvm::dyn_cast<llvm::Function>(Local.getCallee()))
++        LF->copyAttributesFrom(Callee);
++      CB->setCalledFunction(Local);
++    }
++  }
++
++  // The Workgroup pass leaves only the launcher(s) with external linkage, and
++  // the builtins the link is about to copy in arrive external too. Remember the
++  // current entry points so we can internalize the copied builtins afterwards.
++  llvm::StringSet<> EntryPoints;
++  for (llvm::Function &F : *ParallelBC)
++    if (!F.isDeclaration() && !F.hasLocalLinkage())
++      EntryPoints.insert(F.getName());
++
++  std::string Log;
++  if (link(ParallelBC, KernelLib, Log, Device, /*StripAllDebugInfo=*/true,
++           /*ErrorOnUnresolved=*/false)) {
++    POCL_MSG_ERR("pocl_jit: linking the kernel library into the work-group "
++                 "object failed:\n%s\n",
++                 Log.c_str());
++    return -1;
++  }
++
++  auto PreserveEntryPoints = [&EntryPoints](const llvm::GlobalValue &GV) {
++    return EntryPoints.contains(GV.getName());
++  };
++  internalizeModule(*ParallelBC, PreserveEntryPoints);
++  populateModulePM(nullptr, ParallelBC, /*OptL=*/3);
++  return 0;
++}
++#endif
++
+ int pocl_llvm_generate_workgroup_function_nowrite(
+     unsigned DeviceI, cl_device_id Device, cl_kernel Kernel,
+     _cl_command_node *Command, void **Output, int Specialize) {
+@@ -980,6 +1096,14 @@ int pocl_llvm_generate_workgroup_function_nowrite(
+                                       PoCLLLVMContext, Program, Kernel, Device,
+                                       Specialize);
+ 
++#ifdef HOST_CPU_ENABLE_JIT
++  // The JIT links each kernel object in isolation, so it must carry every
++  // builtin it references (see linkKernelLibraryForJIT). The shared-library
++  // path resolves those at the final link and is left untouched.
++  if (res == 0 && pocl_cpu_device_uses_jit(Device))
++    res = linkKernelLibraryForJIT(ParallelBC, Device, PoCLLLVMContext);
++#endif
++
+   std::string FinalizerCommand =
+       pocl_get_string_option("POCL_BITCODE_FINALIZER", "");
+   if (!FinalizerCommand.empty()) {
+@@ -1226,7 +1350,7 @@ static TargetLibraryInfoImpl *initPassManagerForCodeGen(legacy::PassManager &PM,
+  * Output native object file (<kernel>.so.o). */
+ int pocl_llvm_codegen2(const char* TTriple, const char* MCPU,
+                        const char *Features, cl_device_type DevType,
+-                       pocl_lock_t *Lock, void *Modp, int EmitAsm,
++                       int ForJIT, pocl_lock_t *Lock, void *Modp, int EmitAsm,
+                        int EmitObj, char **Output, uint64_t *OutputSize) {
+ 
+   PoclCompilerMutexGuard LockHolder(Lock);
+@@ -1251,7 +1375,8 @@ int pocl_llvm_codegen2(const char* TTriple, const char* MCPU,
+     }
+   }
+ 
+-  std::unique_ptr<llvm::TargetMachine> TM(GetTargetMachine(TTriple, MCPU, Features));
++  std::unique_ptr<llvm::TargetMachine> TM(
++      GetTargetMachine(TTriple, MCPU, Features, ForJIT));
+   llvm::TargetMachine *Target = TM.get();
+ 
+   // First try direct object code generation from LLVM, if supported by the
+@@ -1380,7 +1505,8 @@ int pocl_llvm_codegen(cl_device_id Device, cl_program Program,
+   PoclLLVMContextData *LLVMCtx = (PoclLLVMContextData *)Ctx->llvm_context_data;
+ 
+   return pocl_llvm_codegen2 (Device->llvm_target_triplet, Device->llvm_cpu,
+-                            Features, Device->type, &LLVMCtx->Lock,
++                            Features, Device->type,
++                            pocl_cpu_device_uses_jit (Device), &LLVMCtx->Lock,
+                             Modp, EmitAsm, EmitObj, Output, OutputSize);
+ }
+ 
+diff --git a/lib/llvmopencl/linker.cpp b/lib/llvmopencl/linker.cpp
+index 69b395e79..9554e2225 100644
+--- a/lib/llvmopencl/linker.cpp
++++ b/lib/llvmopencl/linker.cpp
+@@ -889,7 +889,7 @@ static void replaceIntrinsics(llvm::Module *Program, const llvm::Module *Lib,
+ using namespace pocl;
+ 
+ int link(llvm::Module *Program, const llvm::Module *Lib, std::string &Log,
+-         cl_device_id ClDev, bool StripAllDebugInfo) {
++         cl_device_id ClDev, bool StripAllDebugInfo, bool ErrorOnUnresolved) {
+ 
+   assert(Program);
+   assert(Lib);
+@@ -985,45 +985,47 @@ int link(llvm::Module *Program, const llvm::Module *Lib, std::string &Log,
+   convertAddrSpaceOperator(Program->getFunction("__to_private"), Log);
+   convertAddrSpaceOperator(Program->getFunction("__to_global"), Log);
+ 
+-  // check all function declarations in the program
+-  // *after* we have linked functions from the library
+-  DeclaredFunctions.clear();
+-  for (auto &F : *Program) {
+-    if (F.isDeclaration()) {
+-      DB_PRINT("Post-link: %s is not defined\n", F.getName().data());
+-      DeclaredFunctions.insert(F.getName());
+-      continue;
++  if (ErrorOnUnresolved) {
++    // check all function declarations in the program
++    // *after* we have linked functions from the library
++    DeclaredFunctions.clear();
++    for (auto &F : *Program) {
++      if (F.isDeclaration()) {
++        DB_PRINT("Post-link: %s is not defined\n", F.getName().data());
++        DeclaredFunctions.insert(F.getName());
++        continue;
++      }
+     }
+-  }
+ 
+-  bool FoundAllUndefined = true;
+-  // this one is a handled with a special pocl LLVM pass
+-  StringRef pocl_sampler_handler("__translate_sampler_initializer");
++    bool FoundAllUndefined = true;
++    // this one is a handled with a special pocl LLVM pass
++    StringRef pocl_sampler_handler("__translate_sampler_initializer");
+ 
+-  if (!modIsNvptx(Program)) {
+-    for (auto &DeclIter : DeclaredFunctions) {
+-      llvm::StringRef FName = DeclIter.getKey();
+-      Function *F = Program->getFunction(FName);
++    if (!modIsNvptx(Program)) {
++      for (auto &DeclIter : DeclaredFunctions) {
++        llvm::StringRef FName = DeclIter.getKey();
++        Function *F = Program->getFunction(FName);
+ 
+-      if ((F == NULL) ||
+-          (F->isDeclaration() &&
+-           // A target might want to expose the C99 printf in
+-           // case not supporting the OpenCL 1.2 printf.
+-           F->getName() != "printf" && F->getName() != pocl_sampler_handler &&
+-           !F->getName().starts_with("llvm.") &&
+-           F->getName() != BARRIER_FUNCTION_NAME &&
+-           F->getName() != "__pocl_local_mem_alloca" &&
+-           F->getName() != "__pocl_work_group_alloca")) {
+-        Log.append("Cannot find symbol ");
+-        Log.append(FName.str());
+-        Log.append(" in kernel library\n");
+-        FoundAllUndefined = false;
++        if ((F == NULL) ||
++            (F->isDeclaration() &&
++             // A target might want to expose the C99 printf in
++             // case not supporting the OpenCL 1.2 printf.
++             F->getName() != "printf" && F->getName() != pocl_sampler_handler &&
++             !F->getName().starts_with("llvm.") &&
++             F->getName() != BARRIER_FUNCTION_NAME &&
++             F->getName() != "__pocl_local_mem_alloca" &&
++             F->getName() != "__pocl_work_group_alloca")) {
++          Log.append("Cannot find symbol ");
++          Log.append(FName.str());
++          Log.append(" in kernel library\n");
++          FoundAllUndefined = false;
++        }
+       }
+     }
+-  }
+ 
+-  if (!FoundAllUndefined)
+-    return -1;
++    if (!FoundAllUndefined)
++      return -1;
++  }
+ 
+   shared_copy(Program, Lib, Log, vvm);
+ 
+@@ -1279,4 +1281,3 @@ bool moveProgramScopeVarsOutOfProgramBc(llvm::LLVMContext *Context,
+ }
+ 
+ /* vim: set expandtab ts=2 : */
+-
+diff --git a/lib/llvmopencl/linker.h b/lib/llvmopencl/linker.h
+index afe9f6a7e..b42cf597f 100644
+--- a/lib/llvmopencl/linker.h
++++ b/lib/llvmopencl/linker.h
+@@ -39,10 +39,14 @@
+  * this is faster than calling llvm::Linker and then
+  * running DCE.
+  *
+- * log is used to report errors if we run into undefined symbols
++ * log is used to report errors if we run into undefined symbols.
++ *
++ * If ErrorOnUnresolved is false, declarations that lib does not define are
++ * left in place for a later resolution stage such as the dynamic linker or the
++ * ORC JIT process-symbol search.
+  */
+ int link(llvm::Module *Program, const llvm::Module *Lib, std::string &Log,
+-         cl_device_id ClDev, bool StripAllDebugInfo);
++         cl_device_id ClDev, bool StripAllDebugInfo, bool ErrorOnUnresolved);
+ 
+ int copyKernelFromBitcode(const char* Name, llvm::Module *ParallelBC,
+                           const llvm::Module *Program,
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index add73e049..7a1310afd 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -27,6 +27,34 @@ set_opencl_header_includes()
+ 
+ add_test(NAME pocl_version_check COMMAND test_version)
+ 
++function(add_cpu_jit_test TEST_NAME TEST_TARGET)
++  if(NOT (ENABLE_HOST_CPU_DEVICES AND HOST_CPU_ENABLE_JIT))
++    return()
++  endif()
++
++  set(FULL_TEST_NAME "cpu_jit/${TEST_NAME}")
++  set(RUN_CMD "$<TARGET_FILE:${TEST_TARGET}>")
++  foreach(TEST_ARG ${ARGN})
++    set(RUN_CMD "${RUN_CMD}####${TEST_ARG}")
++  endforeach()
++
++  add_test(NAME "${FULL_TEST_NAME}"
++    COMMAND "${CMAKE_COMMAND}" "-Dtest_cmd=${RUN_CMD}"
++            "-P" "${CMAKE_SOURCE_DIR}/cmake/run_test.cmake")
++  set_tests_properties("${FULL_TEST_NAME}"
++    PROPERTIES
++      ENVIRONMENT "POCL_DEVICES=cpu;POCL_CPU_JIT=1;POCL_WORK_GROUP_METHOD=loopvec"
++      LABELS "cpu_jit"
++      PASS_REGULAR_EXPRESSION "OK"
++      FAIL_REGULAR_EXPRESSION "FAIL"
++      SKIP_RETURN_CODE 77
++      DEPENDS "pocl_version_check")
++  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
++    set_tests_properties("${FULL_TEST_NAME}" PROPERTIES
++      SKIP_REGULAR_EXPRESSION "SKIP")
++  endif()
++endfunction()
++
+ if(ENABLE_HOST_CPU_DEVICES)
+     # If basic OpenCL device is not included, we assume the device is chosen using
+     # the POCL_DEVICES env. Otherwise, use the basic dev to check that we are using
+diff --git a/tests/kernel/CMakeLists.txt b/tests/kernel/CMakeLists.txt
+index 749bfb322..481203c77 100644
+--- a/tests/kernel/CMakeLists.txt
++++ b/tests/kernel/CMakeLists.txt
+@@ -63,6 +63,9 @@ add_test_pocl(NAME "kernel/test_min_max"
+ 
+ add_test_pocl(NAME "kernel/test_length_distance"
+               COMMAND "kernel" "test_length_distance")
++if(ENABLE_HOST_CPU_VECTORIZE_BUILTINS)
++  add_cpu_jit_test("vector_math" kernel "test_length_distance")
++endif()
+ 
+ add_test_pocl(NAME "kernel/test_fmin_fmax_fma"
+               COMMAND "kernel" "test_fmin_fmax_fma")
+@@ -107,6 +110,9 @@ endif()
+ 
+ add_test_pocl(NAME "kernel/test_halfs"
+               COMMAND "kernel" "test_halfs")
++if(HOST_CPU_ENABLE_CL_KHR_FP16)
++  add_cpu_jit_test("compiler_rt_fp16" kernel "test_halfs")
++endif()
+ 
+ # convert_type_{4,8,16} + hadd/as_type/bitselect produce very large kernels
+ # that can cause LLVM to spend extremely long time on optimization,
+@@ -236,6 +242,9 @@ add_test_pocl(NAME "kernel/test_ucharn"
+ add_test_pocl(NAME "kernel/test_printf"
+               EXPECTED_OUTPUT "test_printf_expout.txt"
+               COMMAND "kernel" "test_printf")
++if(ENABLE_PRINTF_IMMEDIATE_FLUSH)
++  add_cpu_jit_test("printf_flush" kernel "test_printf")
++endif()
+ 
+ add_test_pocl(NAME "kernel/test_printf_vectors"
+               EXPECTED_OUTPUT "test_printf_vectors_expout.txt"
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index 16bf3b378..57aa91cd8 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -58,7 +58,7 @@ set(PROGRAMS_TO_BUILD test_barrier_between_for_loops test_early_return
+   test_workitem_func_outside_kernel test_program_scope_vars test_issue_1548
+   test_issue_1525 test_issue_1608 test_issue_1826 test_builtin_regression
+   test_mem_host_ptr_issue test_issue_1962 test_issue_2005
+-  test_global_atomics
++  test_global_atomics test_large_stack_frame
+ )
+ if(UNIX)
+   list(APPEND PROGRAMS_TO_BUILD test_issue_2174)
+@@ -91,6 +91,8 @@ endif()
+ add_test_pocl(NAME "regression/test_issue_231" COMMAND "test_issue_231")
+ 
+ add_test_pocl(NAME "regression/test_global_atomics" COMMAND "test_global_atomics")
++add_cpu_jit_test("atomics" test_global_atomics)
++add_cpu_jit_test("stack_probe" test_large_stack_frame)
+ 
+ add_test_pocl(NAME "regression/test_issue_445" COMMAND "test_issue_445")
+ 
+@@ -114,6 +116,7 @@ add_test_pocl(NAME "regression/test_issue_1826" COMMAND "test_issue_1826")
+ 
+ add_test_pocl(NAME "regression/test_builtin_regression"
+   COMMAND "test_builtin_regression")
++add_cpu_jit_test("kernel_library" test_builtin_regression)
+ 
+ 
+ add_test_pocl(NAME "regression/test_mem_host_ptr_issue"
+diff --git a/tests/regression/test_large_stack_frame.cpp b/tests/regression/test_large_stack_frame.cpp
+new file mode 100644
+index 000000000..4d5de6dad
+--- /dev/null
++++ b/tests/regression/test_large_stack_frame.cpp
+@@ -0,0 +1,69 @@
++// Regression test for CPU kernels whose private stack frame is large enough to
++// require a target ABI stack-probe helper (___chkstk_ms on x86_64 MinGW).
++
++#define CL_HPP_TARGET_OPENCL_VERSION 300
++#define CL_HPP_ENABLE_EXCEPTIONS
++#include <CL/opencl.hpp>
++
++#include <cstdint>
++#include <iostream>
++#include <vector>
++
++static const char *Source = R"RAW(
++__kernel void large_stack_frame(__global uint *out) {
++  const uint gid = get_global_id(0);
++  volatile uint scratch[2048];
++
++  for (uint i = 0; i < 2048; ++i)
++    scratch[i] = (i * 33u) ^ (gid + 17u);
++
++  uint acc = 0;
++  for (uint i = 0; i < 2048; ++i)
++    acc += scratch[i];
++
++  out[gid] = acc;
++}
++)RAW";
++
++static uint32_t expected(uint32_t Gid) {
++  uint32_t Acc = 0;
++  for (uint32_t I = 0; I < 2048; ++I)
++    Acc += (I * 33u) ^ (Gid + 17u);
++  return Acc;
++}
++
++int main() try {
++  cl::Device Device = cl::Device::getDefault();
++  cl::Context Context = cl::Context::getDefault();
++  cl::CommandQueue Queue = cl::CommandQueue::getDefault();
++
++  cl::Program Program(Context, Source);
++  Program.build({Device});
++
++  constexpr size_t N = 16;
++  std::vector<cl_uint> Out(N, 0);
++  cl::Buffer OutBuf(Context, CL_MEM_WRITE_ONLY, Out.size() * sizeof(cl_uint));
++
++  cl::Kernel Kernel(Program, "large_stack_frame");
++  Kernel.setArg(0, OutBuf);
++  Queue.enqueueNDRangeKernel(Kernel, cl::NullRange, cl::NDRange(N),
++                             cl::NullRange);
++  Queue.enqueueReadBuffer(OutBuf, CL_TRUE, 0, Out.size() * sizeof(cl_uint),
++                          Out.data());
++
++  for (size_t I = 0; I < Out.size(); ++I) {
++    uint32_t Want = expected(static_cast<uint32_t>(I));
++    if (Out[I] != Want) {
++      std::cout << "FAIL at " << I << ": got " << Out[I] << ", expected "
++                << Want << "\n";
++      return EXIT_FAILURE;
++    }
++  }
++
++  std::cout << "OK\n";
++  return EXIT_SUCCESS;
++} catch (cl::Error &Err) {
++  std::cout << "FAIL with OpenCL error = " << Err.what() << " (" << Err.err()
++            << ")\n";
++  return EXIT_FAILURE;
++}
+\ No newline at end of file

--- a/P/pocl/pocl_next/bundled/patches/pocl/0004-CanonicalizeBarriers-split-reconverging-barrier-succ.patch
+++ b/P/pocl/pocl_next/bundled/patches/pocl/0004-CanonicalizeBarriers-split-reconverging-barrier-succ.patch
@@ -1,0 +1,284 @@
+From 33d0aeda4bd53e561d9c12f3b51f93d423cb56fc Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Mon, 17 Aug 2026 15:57:39 +0200
+Subject: [PATCH 4/6] CanonicalizeBarriers: split reconverging barrier
+ successors
+
+Parallel-region formation treats successors of a barrier block as entries of
+disjoint regions. Bounds-checked Julia kernels can instead branch around a
+variable-trip loop and reconverge at the next barrier, producing a malformed
+region and aborting work-group function generation.
+
+Detect successors that reach a common block before crossing another barrier
+and move their branch to a common post-barrier block. Successors ending at
+distinct barriers retain the existing conditional-barrier handling.
+
+Add a reduced SPIR-V regression that builds and executes with the loops,
+loopvec, and CBS handlers.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ lib/llvmopencl/CanonicalizeBarriers.cc        |  38 +++-
+ tests/regression/CMakeLists.txt               |   3 +
+ .../regression/test_barrier_divergent_skip.c  | 166 ++++++++++++++++++
+ 3 files changed, 204 insertions(+), 3 deletions(-)
+ create mode 100644 tests/regression/test_barrier_divergent_skip.c
+
+diff --git a/lib/llvmopencl/CanonicalizeBarriers.cc b/lib/llvmopencl/CanonicalizeBarriers.cc
+index 9dc1dad19..d30b23a88 100644
+--- a/lib/llvmopencl/CanonicalizeBarriers.cc
++++ b/lib/llvmopencl/CanonicalizeBarriers.cc
+@@ -29,6 +29,9 @@ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
+ #include <llvm/ADT/Twine.h>
+ POP_COMPILER_DIAGS
+ IGNORE_COMPILER_WARNING("-Wunused-parameter")
++#include <llvm/ADT/SmallPtrSet.h>
++#include <llvm/ADT/SmallVector.h>
++#include <llvm/IR/CFG.h>
+ #include <llvm/IR/Dominators.h>
+ #include <llvm/IR/Instructions.h>
+ #include <llvm/IR/Module.h>
+@@ -60,6 +63,31 @@ static bool processFunction(Function &F, WorkitemHandlerType Handler);
+ 
+ using InstructionSet = std::set<llvm::Instruction *>;
+ 
++// Parallel region formation treats successors of a barrier block as entries
++// of disjoint regions. If the successors reconverge before another barrier,
++// the branch instead belongs to a single region and needs a common entry.
++static bool successorsReconverge(llvm::Instruction *T) {
++  llvm::SmallPtrSet<llvm::BasicBlock *, 16> Reached;
++  for (unsigned Succ = 0, Num = T->getNumSuccessors(); Succ < Num; ++Succ) {
++    llvm::SmallPtrSet<llvm::BasicBlock *, 16> Visited;
++    llvm::SmallVector<llvm::BasicBlock *, 16> WorkList{T->getSuccessor(Succ)};
++    while (!WorkList.empty()) {
++      llvm::BasicBlock *BB = WorkList.pop_back_val();
++      if (!Visited.insert(BB).second)
++        continue;
++      // Include barrier blocks in the search, but do not cross them.
++      if (Reached.count(BB))
++        return true;
++      if (Barrier::hasBarrier(BB))
++        continue;
++      for (llvm::BasicBlock *SuccBB : successors(BB))
++        WorkList.push_back(SuccBB);
++    }
++    Reached.insert(Visited.begin(), Visited.end());
++  }
++  return false;
++}
++
+ static bool canonicalizeBarriers(Function &F, WorkitemHandlerType Handler) {
+   bool changed = false;
+ 
+@@ -149,11 +177,15 @@ static bool processFunction(Function &F, WorkitemHandlerType Handler) {
+     //     (t->getPrevNode() != *i)) {
+     // Change: barriers with several successors are all right
+     // they just start several parallel regions. Simplifies
+-    // loop handling.
++    // loop handling. Reconverging successors, however, belong to a single
++    // region and need a common post-barrier entry.
++
++    const bool MustSplitSuccessors =
++        t->getNumSuccessors() > 1 &&
++        (Handler == WorkitemHandlerType::CBS || successorsReconverge(t));
+ 
+     const bool HasNonBranchInstructionsAfterBarrier =
+-        t->getPrevNode() != *i ||
+-        (Handler == WorkitemHandlerType::CBS && t->getNumSuccessors() > 1);
++        t->getPrevNode() != *i || MustSplitSuccessors;
+ 
+     if (HasNonBranchInstructionsAfterBarrier) {
+       BasicBlock *new_b = SplitBlock(b, (*i)->getNextNode());
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index 57aa91cd8..a47eebf39 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -31,6 +31,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
+      test_issue_1711 test_issue_1794 test_issue_1747
+      test_rematerialized_alloca_load_with_outside_pr_users
+      test_peeled_wi_global_id
++     test_barrier_divergent_skip
+      test_divergent_implicit_barrier_entry
+      test_uniform_implicit_barrier_entry
+      test_localmem_load_across_barrier
+@@ -160,6 +161,8 @@ add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "$
+ 
+ add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+ 
++add_test_pocl(NAME "regression/barrier_divergent_skip" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_barrier_divergent_skip" LABELS ${SPIRV_LABELS})
++
+ add_test_pocl(NAME "regression/divergent_implicit_barrier_entry" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_divergent_implicit_barrier_entry")
+ 
+ add_test_pocl(NAME "regression/uniform_implicit_barrier_entry" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_uniform_implicit_barrier_entry")
+diff --git a/tests/regression/test_barrier_divergent_skip.c b/tests/regression/test_barrier_divergent_skip.c
+new file mode 100644
+index 000000000..69b1b29fd
+--- /dev/null
++++ b/tests/regression/test_barrier_divergent_skip.c
+@@ -0,0 +1,166 @@
++// Copyright (c) 2026 PoCL developers
++//
++// Permission is hereby granted, free of charge, to any person obtaining a copy
++// of this software and associated documentation files (the "Software"), to deal
++// in the Software without restriction, including without limitation the rights
++// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++// copies of the Software, and to permit persons to whom the Software is
++// furnished to do so, subject to the following conditions:
++//
++// The above copyright notice and this permission notice shall be included in
++// all copies or substantial portions of the Software.
++//
++// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++// THE SOFTWARE.
++
++/*
++  Reduced from a bounds-checked KernelAbstractions.jl radix-sort kernel. One
++  arm of a branch after a barrier skips a variable-trip loop, then reconverges
++  with the other arm at the next barrier:
++
++      barrier();
++      br i1 %skip, label %join, label %loop
++      ...
++      join:                  ; reconvergence point
++      barrier();
++
++  Treating the successors as disjoint region entries produced a malformed
++  region ending at the loop latch. Building the work-group function then
++  aborted in ParallelRegion::chainAfter.
++
++  The crash happened when building the work-group function; completing the
++  build and a launch with correct results is the test. The launch takes the
++  skip path in all work-items so the barrier behavior is defined.
++*/
++
++#include "pocl_opencl.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++#ifndef _WIN32
++#include <unistd.h>
++#endif
++
++#define CHECK_ERROR(err)                                                       \
++  if (err != CL_SUCCESS) {                                                     \
++    printf("OpenCL Error %d at %s:%d\n", err, __FILE__, __LINE__);             \
++    return 1;                                                                  \
++  }
++
++int main(int argc, char **argv) {
++  cl_uint platform_index = argc > 1 ? (cl_uint)atoi(argv[1]) : 0;
++  cl_int err;
++
++#ifndef _WIN32
++  // Fail quickly instead of tripping the much larger ctest timeout in case
++  // a regressed build hangs.
++  alarm(300);
++#endif
++
++  cl_uint num_platforms;
++  CHECK_ERROR(clGetPlatformIDs(0, NULL, &num_platforms));
++  if (platform_index >= num_platforms) {
++    printf("Platform index %u out of range\n", platform_index);
++    return 1;
++  }
++  cl_platform_id *platforms = malloc(sizeof(cl_platform_id) * num_platforms);
++  CHECK_ERROR(clGetPlatformIDs(num_platforms, platforms, NULL));
++  cl_platform_id platform = platforms[platform_index];
++  free(platforms);
++
++  cl_device_id device;
++  CHECK_ERROR(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL));
++
++  if (!poclu_device_supports_il(device, "SPIR-V_1.0")) {
++    printf("SKIP: The test requires support for SPIR-V 1.0\n");
++    return 77;
++  }
++
++  cl_context context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
++  CHECK_ERROR(err);
++  cl_queue_properties props[] = {0};
++  cl_command_queue queue =
++      clCreateCommandQueueWithProperties(context, device, props, &err);
++  CHECK_ERROR(err);
++
++  FILE *f = fopen(SRCDIR "/test_barrier_divergent_skip.spv", "rb");
++  if (!f) {
++    printf("Failed to open test_barrier_divergent_skip.spv\n");
++    return 1;
++  }
++  fseek(f, 0, SEEK_END);
++  size_t size = ftell(f);
++  fseek(f, 0, SEEK_SET);
++  unsigned char *binary = malloc(size);
++  if (fread(binary, 1, size, f) != size) {
++    printf("Failed to read SPIR-V\n");
++    free(binary);
++    fclose(f);
++    return 1;
++  }
++  fclose(f);
++
++  cl_program program = clCreateProgramWithIL(context, binary, size, &err);
++  CHECK_ERROR(err);
++  err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
++  if (err != CL_SUCCESS) {
++    size_t log_size;
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
++                          &log_size);
++    char *log = malloc(log_size);
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size, log,
++                          NULL);
++    printf("Build error:\n%s\n", log);
++    return 1;
++  }
++
++  // Building the work-group function is what used to crash; force it even
++  // when the driver would otherwise defer compilation to launch time.
++  size_t binary_size;
++  CHECK_ERROR(clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES,
++                               sizeof(binary_size), &binary_size, NULL));
++
++  cl_kernel kernel = clCreateKernel(program, "vartrip", &err);
++  CHECK_ERROR(err);
++
++  // All work-items enter the barrier and take the loop-skipping arm, so the
++  // barrier behavior is defined and every work-item stores 42.
++  const size_t local_size = 64, global_size = 128;
++  const cl_long opaque = 0;
++  const cl_uchar enter = 1, skip = 1, exitl = 1;
++  cl_int result[128];
++  cl_mem out =
++      clCreateBuffer(context, CL_MEM_WRITE_ONLY, sizeof(result), NULL, &err);
++  CHECK_ERROR(err);
++  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(out), &out));
++  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(opaque), &opaque));
++  CHECK_ERROR(clSetKernelArg(kernel, 2, sizeof(enter), &enter));
++  CHECK_ERROR(clSetKernelArg(kernel, 3, sizeof(skip), &skip));
++  CHECK_ERROR(clSetKernelArg(kernel, 4, sizeof(exitl), &exitl));
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size,
++                                     &local_size, 0, NULL, NULL));
++  CHECK_ERROR(clEnqueueReadBuffer(queue, out, CL_TRUE, 0, sizeof(result),
++                                  result, 0, NULL, NULL));
++
++  for (size_t i = 0; i < global_size; ++i) {
++    if (result[i] != 42) {
++      printf("FAIL at %zu: got %d, expected 42\n", i, result[i]);
++      return 1;
++    }
++  }
++
++  clReleaseMemObject(out);
++  clReleaseKernel(kernel);
++  clReleaseProgram(program);
++  clReleaseCommandQueue(queue);
++  clReleaseContext(context);
++  free(binary);
++
++  printf("OK\n");
++  return 0;
++}

--- a/P/pocl/pocl_next/bundled/patches/pocl/0005-UnreachablesToReturns-remove-regions-leading-only-to.patch
+++ b/P/pocl/pocl_next/bundled/patches/pocl/0005-UnreachablesToReturns-remove-regions-leading-only-to.patch
@@ -1,0 +1,521 @@
+From 58d4c982e445c5560dad3f6c30564462c1b55dc1 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Mon, 17 Aug 2026 14:11:19 +0200
+Subject: [PATCH 5/6] UnreachablesToReturns: remove regions leading only to
+ unreachable
+
+For the loop handlers, this pass used to detach only blocks ending in
+unreachable. If such a block is the sole exit of a loop, as in the
+string-length loop of an inlined printf-then-abort path, detaching it leaves
+an infinite loop. WorkitemLoops then fails because the parallel region no
+longer reaches its exit (issue #1958).
+
+The loop handlers cannot represent a divergent work-item exit: a return would
+bypass the region exit and terminate the whole work-group function. Keep the
+deletion policy introduced by 89bc42187 to restore the behavior observed with
+PoCL 6.0, but apply it to the complete region that can reach an unreachable
+and cannot reach a return. Retarget incoming branches and switches, then let
+EliminateUnreachableBlocks remove the region. The CBS path remains unchanged.
+
+Add the issue SPIR-V as a regression test, adjusted to valid SPIR-V 1.0.
+Querying CL_PROGRAM_BINARY_SIZES forces construction of the work-group
+function; a non-aborting launch also checks the resulting kernel.
+GPUCompiler.jl#812 now lowers this control flow to returns, but equivalent
+SPIR-V from other producers still needs to compile.
+
+Fixes #1958.
+
+(cherry picked from commit a1b5abfe68fa4afb26b260789808896472a0e6cb)
+---
+ lib/llvmopencl/UnreachablesToReturns.cc | 252 ++++++++++--------------
+ tests/regression/CMakeLists.txt         |   4 +-
+ tests/regression/test_issue_1958.c      | 168 ++++++++++++++++
+ 3 files changed, 279 insertions(+), 145 deletions(-)
+ create mode 100644 tests/regression/test_issue_1958.c
+
+diff --git a/lib/llvmopencl/UnreachablesToReturns.cc b/lib/llvmopencl/UnreachablesToReturns.cc
+index ba3cda03c..a63157e43 100644
+--- a/lib/llvmopencl/UnreachablesToReturns.cc
++++ b/lib/llvmopencl/UnreachablesToReturns.cc
+@@ -9,12 +9,11 @@
+ // to create illegal code (barriers are only partially taken), however the CBS
+ // is able to handle these.
+ //
+-// for LOOPVEC handler, we find all basicblocks which have an unreachable inst,
+-// and "disconnect" them from their predecessor basicblocks. If the predecessor
+-// has an unconditional jump, it is also deleted. If it has a conditional jump,
+-// it's made unconditional (to the other branch). This matches the behavior
+-// of prior versions of PoCL (6.0) where the optimization similarly deleted
+-// these blocks.
++// for LOOPVEC handler, we delete regions which can reach an unreachable inst
++// but cannot reach the function's return. Branches from live blocks into the
++// deleted region are made unconditional (to the live branch), and switch cases
++// leading to it are removed. This preserves the PoCL 6.0 behavior that commit
++// 89bc42187 sought to restore.
+ //
+ // Note that neither handling is recursive. Therefore all non-kernel functions
+ // that have an unreachable inst, must be inlined before this Pass is run.
+@@ -150,164 +149,129 @@ static bool convertUnreachablesToReturns(Function &F) {
+   return true;
+ }
+ 
+-// Fix predecessor BBs of BB which has an unreachable terminator inst
+-// to ignore the BB.
++// Delete regions which lead only to an unreachable instruction.
+ //
+-// If the predecessor has an unconditional branch, replaces the branch with
+-// UnreachableInst and adds the BB to \p NewUnreachableBBs. If the predecessor
+-// has a conditional branch, makes it unconditional. The function should
+-// be called until NewUnreachableBBs is empty.
+-static void detachBBFromPredecessor(BasicBlock &BB,
+-                                    SmallBBSet &NewUnreachableBBs) {
+-  if (BB.hasNPredecessors(0))
+-    return; // Already handled.
+-
+-  LLVM_DEBUG(
+-      dbgs() << "Detaching a BB that has an unreachable or leads to one:\n");
+-  LLVM_DEBUG(BB.dump());
+-
+-  // To avoid invalidating the predecessors iterator,
+-  // store replacement instructions and replace after the loop
+-  SmallMapVector<Instruction *, Instruction *, 8> Replacements;
+-
+-  // If the BB is in a switch case, these are the switch instructions to fix.
+-  std::vector<SwitchInst *> PredSwitches;
+-
+-  for (BasicBlock *Pred : predecessors(&BB)) {
+-    assert(Pred != nullptr);
+-    Instruction *I = Pred->getTerminator();
+-    assert(I != nullptr);
+-    if (BranchInst *BI = dyn_cast<BranchInst>(I)) {
+-      if (BI->isUnconditional()) {
+-        LLVM_DEBUG(dbgs() << "The predecessor " << Pred->getName().str()
+-                          << " is unconditionally branching to it\n");
+-        LLVM_DEBUG(Pred->dump());
+-        // The predecessor has an unconditional branch to the unreachable BB,
+-        // remove that in a next call.
+-        NewUnreachableBBs.insert(Pred);
+-      } else {
+-        LLVM_DEBUG(
+-            dbgs() << "The predecessor is conditionally branching to it\n");
+-        LLVM_DEBUG(Pred->dump());
+-
+-        BasicBlock *Other = nullptr;
+-        if (BI->getSuccessor(0) == &BB)
+-          Other = BI->getSuccessor(1);
+-        else
+-          Other = BI->getSuccessor(0);
+-        BranchInst *NewBI = BranchInst::Create(Other);
+-        Replacements.insert(std::make_pair(BI, NewBI));
+-      }
+-    } else if (SwitchInst *PredSwitch = dyn_cast<SwitchInst>(I)) {
+-      LLVM_DEBUG(dbgs() << "The predecessor is a switch case in "
+-                        << Pred->getName().str() << "\n");
+-      PredSwitches.push_back(PredSwitch);
+-    } else {
+-      LLVM_DEBUG(dbgs() << "Unhandled BB Terminator: \n");
+-      LLVM_DEBUG(I->dump());
+-      assert(0 && "Error: unexpected BB terminator\n");
+-    }
+-  }
+-
+-  for (auto [OldI, NewI] : Replacements) {
+-    ReplaceInstWithInst(OldI, NewI);
+-  }
+-
+-  for (SwitchInst *PredSwitch : PredSwitches) {
+-    // New default BB in case the unreachable block is a default BB.
+-    BasicBlock *NewDefaultBB = nullptr;
+-
+-    // The case value we could convert to a new default if that's the case.
+-    ConstantInt *RobbedCaseValue = nullptr;
+-    for (SwitchInst::CaseIt C = PredSwitch->cases().begin();
+-         C != PredSwitch->cases().end();) {
+-      if (C->getCaseSuccessor() == &BB) {
+-        PredSwitch->removeCase(C++);
+-        // RemoveCase invalidates all iterators and might reorder the cases,
+-        // let's just restart.
+-        C = PredSwitch->cases().begin();
+-        continue;
+-      }
+-      NewDefaultBB = C->getCaseSuccessor();
+-      RobbedCaseValue = C->getCaseValue();
+-      C++;
+-    }
+-    SwitchInst::CaseIt Default = PredSwitch->case_default();
+-    if (Default->getCaseSuccessor() == &BB) {
+-      if (NewDefaultBB != nullptr) {
+-        PredSwitch->setDefaultDest(NewDefaultBB);
+-        // Now we can remove the original case which also branched to this one
+-        // since it will be covered by the default. This will by coincidence
+-        // fix the Phi in a block where the switch...case has multiple branches
+-        // to. If we didn't do this, there would be one too few phi conditions.
+-        PredSwitch->removeCase(PredSwitch->findCaseValue(RobbedCaseValue));
+-      }
+-      if (NewDefaultBB == nullptr || PredSwitch->getNumCases() == 0) {
+-        LLVM_DEBUG(
+-            dbgs()
+-            << "A switch case with only a default which goes to unreachable\n");
+-        NewUnreachableBBs.insert(PredSwitch->getParent());
+-      }
+-    }
+-    LLVM_DEBUG(dbgs() << "switch case modified:\n");
+-    LLVM_DEBUG(PredSwitch->getParent()->dump());
+-  }
+-}
+-
++// These "doomed" blocks either end in an unreachable inst, or can only make
++// progress towards one -- possibly iterating forever in a loop whose sole
++// exit leads to an unreachable, e.g. the string-length loop of an inlined
++// printf-then-abort sequence. Merely detaching the unreachable-terminated
++// blocks would sever such a loop's exit edge and leave behind an infinite
++// loop that never reaches the parallel region exit, breaking WorkitemLoops
++// (issue #1958), so delete the doomed blocks wholesale.
+ static bool deleteBlocksWithUnreachable(Function &F) {
+ 
+   SmallBBSet UnreachableBBs;
+-
+-  for (Function::iterator I = F.begin(), E = F.end(); I != E; ++I) {
+-    BasicBlock &BB = *I;
++  for (BasicBlock &BB : F) {
+     assert(BB.getTerminator());
+-    if (isa<UnreachableInst>(BB.getTerminator())) {
+-      LLVM_DEBUG(dbgs() << "UNREACHABLE found, deleting BB\n");
+-      LLVM_DEBUG(BB.dump());
++    if (isa<UnreachableInst>(BB.getTerminator()))
+       UnreachableBBs.insert(&BB);
+-    }
+   }
+ 
+   if (UnreachableBBs.empty())
+     return false;
+ 
+-  // Check BB predecessors recursively, and disconnect them
+-  // from blocks which contain an unreachable.
+-  SmallBBSet HandledUnreachableBBs;
+-  while (!UnreachableBBs.empty()) {
+-    BasicBlock *BB = *UnreachableBBs.begin();
+-    detachBBFromPredecessor(*BB, UnreachableBBs);
+-    UnreachableBBs.erase(BB);
+-    HandledUnreachableBBs.insert(BB);
++  // Collect the live blocks, i.e. those that can reach a return.
++  SmallBBSet LiveBBs;
++  SmallVector<BasicBlock *, 16> WorkList;
++  for (BasicBlock &BB : F) {
++    if (isa<ReturnInst>(BB.getTerminator())) {
++      LiveBBs.insert(&BB);
++      WorkList.push_back(&BB);
++    }
++  }
++  while (!WorkList.empty()) {
++    BasicBlock *BB = WorkList.pop_back_val();
++    for (BasicBlock *Pred : predecessors(BB))
++      if (LiveBBs.insert(Pred).second)
++        WorkList.push_back(Pred);
+   }
+ 
+-  while (!HandledUnreachableBBs.empty()) {
++  // A non-returning region is not necessarily doomed: an intentional infinite
++  // loop need not lead to an unreachable instruction. Walk backwards from the
++  // unreachables and restrict deletion to the intersection of both sets.
++  SmallBBSet DoomedBBs = UnreachableBBs;
++  WorkList.assign(UnreachableBBs.begin(), UnreachableBBs.end());
++  while (!WorkList.empty()) {
++    BasicBlock *BB = WorkList.pop_back_val();
++    for (BasicBlock *Pred : predecessors(BB))
++      if (!LiveBBs.count(Pred) && DoomedBBs.insert(Pred).second)
++        WorkList.push_back(Pred);
++  }
+ 
+-    auto CandidateBB = HandledUnreachableBBs.begin();
++  // If not even the entry block can reach a return, deleting the doomed
++  // blocks would delete the whole function body. Convert the unreachables
++  // to returns instead.
++  if (DoomedBBs.count(&F.getEntryBlock()))
++    return convertUnreachablesToReturns(F);
+ 
+-    // We have to delete the "chains" bottom up to avoid having basic blocks
+-    // that refer to the values produced by the predecessors in the stem.
+-    while (!isa<UnreachableInst>((*CandidateBB)->getTerminator()))
+-      ++CandidateBB;
+-    assert(CandidateBB != HandledUnreachableBBs.end());
+-    BasicBlock *BB = *CandidateBB;
++  // Retarget terminators of live blocks to only branch to live blocks. Note
++  // that an edge from a doomed block to a live block cannot exist, and that
++  // a live block always has at least one live successor.
++  for (BasicBlock &BB : F) {
++    if (!LiveBBs.count(&BB))
++      continue;
+ 
+-    LLVM_DEBUG(dbgs() << "Deleting BB: \n");
+-    LLVM_DEBUG(BB->dump());
++    Instruction *TI = BB.getTerminator();
++    bool HasDoomedSuccessor = false;
++    for (BasicBlock *Succ : successors(&BB))
++      HasDoomedSuccessor |= DoomedBBs.count(Succ);
++    if (!HasDoomedSuccessor)
++      continue;
+ 
+-    // The deleted BB can have multiple predecessors.
+-    SmallMapVector<Instruction *, Instruction *, 8> Replacements;
+-    for (BasicBlock *Pred : predecessors(BB))
+-      Replacements.insert(std::make_pair(
+-          Pred->getTerminator(), new UnreachableInst(Pred->getContext())));
++    LLVM_DEBUG(dbgs() << "Detaching doomed successors of:\n");
++    LLVM_DEBUG(BB.dump());
+ 
+-    for (auto [OldI, NewI] : Replacements) {
+-      ReplaceInstWithInst(OldI, NewI);
++#if LLVM_MAJOR >= 23
++    if (auto *CBI = dyn_cast<CondBrInst>(TI)) {
++      BasicBlock *Live = !DoomedBBs.count(CBI->getSuccessor(0))
++                             ? CBI->getSuccessor(0)
++                             : CBI->getSuccessor(1);
++      assert(!DoomedBBs.count(Live));
++      ReplaceInstWithInst(TI, UncondBrInst::Create(Live));
++    }
++#else
++    if (BranchInst *BI = dyn_cast<BranchInst>(TI)) {
++      assert(BI->isConditional());
++      BasicBlock *Live = !DoomedBBs.count(BI->getSuccessor(0))
++                             ? BI->getSuccessor(0)
++                             : BI->getSuccessor(1);
++      assert(!DoomedBBs.count(Live));
++      ReplaceInstWithInst(TI, BranchInst::Create(Live));
++    }
++#endif
++    else if (SwitchInst *SI = dyn_cast<SwitchInst>(TI)) {
++      // Remove the cases leading to doomed blocks. RemoveCase invalidates
++      // all iterators and might reorder the cases, so restart after each
++      // removal.
++      bool Removed = true;
++      while (Removed) {
++        Removed = false;
++        for (SwitchInst::CaseIt C = SI->case_begin(); C != SI->case_end();
++             ++C) {
++          if (DoomedBBs.count(C->getCaseSuccessor())) {
++            SI->removeCase(C);
++            Removed = true;
++            break;
++          }
++        }
++      }
++      if (DoomedBBs.count(SI->getDefaultDest())) {
++        // Make one of the remaining cases the new default. Removing the
++        // repurposed case keeps the number of edges to its successor, and
++        // thus the successor's phi incoming counts, unchanged.
++        assert(SI->getNumCases() > 0);
++        SI->setDefaultDest(SI->case_begin()->getCaseSuccessor());
++        SI->removeCase(SI->case_begin());
++      }
++    } else {
++      LLVM_DEBUG(dbgs() << "Unhandled BB Terminator: \n");
++      LLVM_DEBUG(TI->dump());
++      assert(0 && "Error: unexpected BB terminator\n");
+     }
+-
+-    BB->eraseFromParent();
+-    HandledUnreachableBBs.erase(BB);
+   }
++
++  // The doomed blocks are now unreachable from the entry.
++  EliminateUnreachableBlocks(F);
+   return true;
+ }
+ 
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index a47eebf39..364a27029 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -28,7 +28,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
+      test_program_from_binary_with_local_1_1_1
+      test_assign_loop_variable_to_privvar_makes_it_local_2
+      test_llvm_segfault_issue_889
+-     test_issue_1711 test_issue_1794 test_issue_1747
++     test_issue_1711 test_issue_1794 test_issue_1747 test_issue_1958
+      test_rematerialized_alloca_load_with_outside_pr_users
+      test_peeled_wi_global_id
+      test_barrier_divergent_skip
+@@ -159,6 +159,8 @@ add_test_pocl(NAME "regression/test_issue_1794b" COMMAND "test_issue_1794" "0" "
+ 
+ add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "${CMAKE_CURRENT_SOURCE_DIR}/test_issue_1747.spv" LABELS ${SPIRV_LABELS})
+ 
++add_test_pocl(NAME "regression/test_issue_1958" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_issue_1958" LABELS ${SPIRV_LABELS})
++
+ add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+ 
+ add_test_pocl(NAME "regression/barrier_divergent_skip" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_barrier_divergent_skip" LABELS ${SPIRV_LABELS})
+diff --git a/tests/regression/test_issue_1958.c b/tests/regression/test_issue_1958.c
+new file mode 100644
+index 000000000..06646a271
+--- /dev/null
++++ b/tests/regression/test_issue_1958.c
+@@ -0,0 +1,168 @@
++// Copyright (c) 2026 PoCL developers
++//
++// Permission is hereby granted, free of charge, to any person obtaining a copy
++// of this software and associated documentation files (the "Software"), to deal
++// in the Software without restriction, including without limitation the rights
++// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++// copies of the Software, and to permit persons to whom the Software is
++// furnished to do so, subject to the following conditions:
++//
++// The above copyright notice and this permission notice shall be included in
++// all copies or substantial portions of the Software.
++//
++// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++// THE SOFTWARE.
++
++/*
++  Reduced from a Julia (OpenCL.jl) kernel with a printf-then-abort exception
++  path (https://github.com/pocl/pocl/issues/1958). After a barrier, a
++  work-item-varying bounds check conditionally calls a noreturn helper that
++  printfs a diagnostic before ending in OpUnreachable:
++
++      barrier();
++      if (in_bounds(idx)) {         // work-item-varying!
++        if (out_of_bounds(gid)) {
++          printf("...");            // expands to a string-length loop
++          __builtin_unreachable();
++        }
++      }
++      // return
++
++  For the work-item loop handlers, ConvertUnreachablesToReturns removes the
++  blocks leading to the unreachable. Detaching only the unreachable-terminated
++  blocks severed the exit edge of the printf expansion's string-length loop,
++  leaving an infinite loop that never reaches the parallel region exit, which
++  WorkitemLoops cannot handle (it asserted in createLoopAround). Blocks that
++  cannot reach the kernel exit must be deleted wholesale.
++
++  The crash happened when building the work-group function, so completing the
++  build and a (non-aborting) launch is the test.
++*/
++
++#include "pocl_opencl.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++#ifndef _WIN32
++#include <unistd.h>
++#endif
++
++#define CHECK_ERROR(err)                                                       \
++  if (err != CL_SUCCESS) {                                                     \
++    printf("OpenCL Error %d at %s:%d\n", err, __FILE__, __LINE__);             \
++    return 1;                                                                  \
++  }
++
++int main(int argc, char **argv) {
++  cl_uint platform_index = argc > 1 ? (cl_uint)atoi(argv[1]) : 0;
++  cl_int err;
++
++#ifndef _WIN32
++  // Fail quickly instead of tripping the much larger ctest timeout in case
++  // a regressed build hangs.
++  alarm(300);
++#endif
++
++  cl_uint num_platforms;
++  CHECK_ERROR(clGetPlatformIDs(0, NULL, &num_platforms));
++  if (platform_index >= num_platforms) {
++    printf("Platform index %u out of range\n", platform_index);
++    return 1;
++  }
++  cl_platform_id *platforms = malloc(sizeof(cl_platform_id) * num_platforms);
++  CHECK_ERROR(clGetPlatformIDs(num_platforms, platforms, NULL));
++  cl_platform_id platform = platforms[platform_index];
++  free(platforms);
++
++  cl_device_id device;
++  CHECK_ERROR(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL));
++
++  if (!poclu_device_supports_il(device, "SPIR-V_1.0")) {
++    printf("SKIP: The test requires support for SPIR-V 1.0\n");
++    return 77;
++  }
++
++  cl_context context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
++  CHECK_ERROR(err);
++  cl_queue_properties props[] = {0};
++  cl_command_queue queue =
++      clCreateCommandQueueWithProperties(context, device, props, &err);
++  CHECK_ERROR(err);
++
++  FILE *f = fopen(SRCDIR "/test_issue_1958.spv", "rb");
++  if (!f) {
++    printf("Failed to open test_issue_1958.spv\n");
++    return 1;
++  }
++  fseek(f, 0, SEEK_END);
++  size_t size = ftell(f);
++  fseek(f, 0, SEEK_SET);
++  unsigned char *binary = malloc(size);
++  if (fread(binary, 1, size, f) != size) {
++    printf("Failed to read SPIR-V\n");
++    free(binary);
++    fclose(f);
++    return 1;
++  }
++  fclose(f);
++
++  cl_program program = clCreateProgramWithIL(context, binary, size, &err);
++  CHECK_ERROR(err);
++  err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
++  if (err != CL_SUCCESS) {
++    size_t log_size;
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
++                          &log_size);
++    char *log = malloc(log_size);
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size, log,
++                          NULL);
++    printf("Build error:\n%s\n", log);
++    return 1;
++  }
++
++  // Building the work-group function is what used to crash; force it even
++  // when the driver would otherwise defer compilation to launch time.
++  size_t binary_size;
++  CHECK_ERROR(clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES,
++                               sizeof(binary_size), &binary_size, NULL));
++
++  char kernel_name[1024];
++  CHECK_ERROR(clGetProgramInfo(program, CL_PROGRAM_KERNEL_NAMES,
++                               sizeof(kernel_name), kernel_name, NULL));
++  cl_kernel kernel = clCreateKernel(program, kernel_name, &err);
++  CHECK_ERROR(err);
++
++  // The kernel arguments are pointers to structs whose first word is a
++  // bounds value the work-item indices are checked against; a large bound
++  // steers all work-items away from the printf-then-abort path. The loaded
++  // values are only compared, never dereferenced.
++  cl_ulong bound[4] = {(cl_ulong)1 << 40, 0, 0, 0};
++  cl_mem buf = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
++                              sizeof(bound), bound, &err);
++  CHECK_ERROR(err);
++  cl_uint num_args;
++  CHECK_ERROR(clGetKernelInfo(kernel, CL_KERNEL_NUM_ARGS, sizeof(num_args),
++                              &num_args, NULL));
++  for (cl_uint i = 0; i < num_args; i++)
++    CHECK_ERROR(clSetKernelArg(kernel, i, sizeof(buf), &buf));
++
++  size_t global_size = 64, local_size = 16;
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size,
++                                     &local_size, 0, NULL, NULL));
++  CHECK_ERROR(clFinish(queue));
++
++  clReleaseMemObject(buf);
++  clReleaseKernel(kernel);
++  clReleaseProgram(program);
++  clReleaseCommandQueue(queue);
++  clReleaseContext(context);
++  free(binary);
++
++  printf("OK\n");
++  return 0;
++}

--- a/P/pocl/pocl_next/bundled/patches/pocl/0006-UnreachablesToReturns-keep-loops-with-side-effects.patch
+++ b/P/pocl/pocl_next/bundled/patches/pocl/0006-UnreachablesToReturns-keep-loops-with-side-effects.patch
@@ -1,0 +1,302 @@
+From a0aaebfe1196ed6ae621c9d4da0223ad63da4e54 Mon Sep 17 00:00:00 2001
+From: Tim Besard <tim.besard@gmail.com>
+Date: Wed, 26 Aug 2026 16:01:47 +0200
+Subject: [PATCH 6/6] UnreachablesToReturns: keep loops with side effects
+
+Deleting every block that can reach an unreachable but not a return also
+removed intentional infinite loops that merely contain a guarded abort path,
+e.g. `while (1) { if (c) { printf(...); unreachable; } out[0] = 1; }`, along
+with their observable side effects. Treat blocks of a cycle containing
+side-effecting instructions as live, so only the unreachable-bound exit is
+removed from such loops. Side-effect-free loops like the printf string-length
+loop from issue #1958 remain deletable.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+(cherry picked from commit e0e27c765520cf761756155db944c51af9a294fe)
+---
+ lib/llvmopencl/UnreachablesToReturns.cc       |  44 ++++-
+ tests/regression/CMakeLists.txt               |   6 +
+ .../test_unreachable_in_infinite_loop.c       | 153 ++++++++++++++++++
+ 3 files changed, 197 insertions(+), 6 deletions(-)
+ create mode 100644 tests/regression/test_unreachable_in_infinite_loop.c
+
+diff --git a/lib/llvmopencl/UnreachablesToReturns.cc b/lib/llvmopencl/UnreachablesToReturns.cc
+index a63157e43..f7420788c 100644
+--- a/lib/llvmopencl/UnreachablesToReturns.cc
++++ b/lib/llvmopencl/UnreachablesToReturns.cc
+@@ -10,10 +10,10 @@
+ // is able to handle these.
+ //
+ // for LOOPVEC handler, we delete regions which can reach an unreachable inst
+-// but cannot reach the function's return. Branches from live blocks into the
+-// deleted region are made unconditional (to the live branch), and switch cases
+-// leading to it are removed. This preserves the PoCL 6.0 behavior that commit
+-// 89bc42187 sought to restore.
++// but can reach neither the function's return nor a loop with side effects.
++// Branches from live blocks into the deleted region are made unconditional (to
++// the live branch), and switch cases leading to it are removed. This preserves
++// the PoCL 6.0 behavior that commit 89bc42187 sought to restore.
+ //
+ // Note that neither handling is recursive. Therefore all non-kernel functions
+ // that have an unreachable inst, must be inlined before this Pass is run.
+@@ -44,6 +44,7 @@ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
+ #include <llvm/ADT/Twine.h>
+ POP_COMPILER_DIAGS
+ IGNORE_COMPILER_WARNING("-Wunused-parameter")
++#include <llvm/ADT/SCCIterator.h>
+ #include <llvm/ADT/SmallPtrSet.h>
+ #include <llvm/IR/CFG.h>
+ #include <llvm/IR/Constants.h>
+@@ -158,6 +159,11 @@ static bool convertUnreachablesToReturns(Function &F) {
+ // blocks would sever such a loop's exit edge and leave behind an infinite
+ // loop that never reaches the parallel region exit, breaking WorkitemLoops
+ // (issue #1958), so delete the doomed blocks wholesale.
++//
++// Loops with side effects are exempt: an intentional infinite loop such as
++// `while (1) { if (c) abort(); write_pipe(...); }` never reaches a return
++// either, but deleting it would discard observable behavior. Only the
++// unreachable-bound path out of such a loop is removed, as before.
+ static bool deleteBlocksWithUnreachable(Function &F) {
+ 
+   SmallBBSet UnreachableBBs;
+@@ -170,7 +176,9 @@ static bool deleteBlocksWithUnreachable(Function &F) {
+   if (UnreachableBBs.empty())
+     return false;
+ 
+-  // Collect the live blocks, i.e. those that can reach a return.
++  // Collect the live blocks, i.e. those that can reach a return or a loop
++  // with side effects. A loop without side effects (like the string-length
++  // loop mentioned above) is not observable and remains deletable.
+   SmallBBSet LiveBBs;
+   SmallVector<BasicBlock *, 16> WorkList;
+   for (BasicBlock &BB : F) {
+@@ -179,6 +187,29 @@ static bool deleteBlocksWithUnreachable(Function &F) {
+       WorkList.push_back(&BB);
+     }
+   }
++  for (scc_iterator<Function *> I = scc_begin(&F), E = scc_end(&F); I != E;
++       ++I) {
++    if (!I.hasCycle())
++      continue;
++    bool HasSideEffects = false;
++    for (BasicBlock *BB : *I) {
++      for (Instruction &Inst : *BB) {
++        if (!Inst.isTerminator() && Inst.mayHaveSideEffects()) {
++          HasSideEffects = true;
++          break;
++        }
++      }
++      if (HasSideEffects)
++        break;
++    }
++    if (!HasSideEffects)
++      continue;
++    LLVM_DEBUG(dbgs() << "Keeping loop with side effects, header: "
++                      << (*I).front()->getName().str() << "\n");
++    for (BasicBlock *BB : *I)
++      if (LiveBBs.insert(BB).second)
++        WorkList.push_back(BB);
++  }
+   while (!WorkList.empty()) {
+     BasicBlock *BB = WorkList.pop_back_val();
+     for (BasicBlock *Pred : predecessors(BB))
+@@ -206,7 +237,8 @@ static bool deleteBlocksWithUnreachable(Function &F) {
+ 
+   // Retarget terminators of live blocks to only branch to live blocks. Note
+   // that an edge from a doomed block to a live block cannot exist, and that
+-  // a live block always has at least one live successor.
++  // a live block always has at least one live successor (blocks of a kept
++  // loop have a successor within that loop).
+   for (BasicBlock &BB : F) {
+     if (!LiveBBs.count(&BB))
+       continue;
+diff --git a/tests/regression/CMakeLists.txt b/tests/regression/CMakeLists.txt
+index 364a27029..538e63ac7 100644
+--- a/tests/regression/CMakeLists.txt
++++ b/tests/regression/CMakeLists.txt
+@@ -29,6 +29,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
+      test_assign_loop_variable_to_privvar_makes_it_local_2
+      test_llvm_segfault_issue_889
+      test_issue_1711 test_issue_1794 test_issue_1747 test_issue_1958
++     test_unreachable_in_infinite_loop
+      test_rematerialized_alloca_load_with_outside_pr_users
+      test_peeled_wi_global_id
+      test_barrier_divergent_skip
+@@ -161,6 +162,8 @@ add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "$
+ 
+ add_test_pocl(NAME "regression/test_issue_1958" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_issue_1958" LABELS ${SPIRV_LABELS})
+ 
++add_test_pocl(NAME "regression/unreachable_in_infinite_loop" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_unreachable_in_infinite_loop")
++
+ add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+ 
+ add_test_pocl(NAME "regression/barrier_divergent_skip" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_barrier_divergent_skip" LABELS ${SPIRV_LABELS})
+@@ -356,6 +359,9 @@ set_property(TEST
+   "regression/infinite_loop_cbs"
+   "regression/infinite_loop_with_barrier_loopvec"
+   "regression/infinite_loop_with_barrier_cbs"
++  "regression/unreachable_in_infinite_loop_loops"
++  "regression/unreachable_in_infinite_loop_loopvec"
++  "regression/unreachable_in_infinite_loop_cbs"
+   APPEND PROPERTY LABELS "mingw_fail")
+ 
+ # Label tests that work with CUDA backend
+diff --git a/tests/regression/test_unreachable_in_infinite_loop.c b/tests/regression/test_unreachable_in_infinite_loop.c
+new file mode 100644
+index 000000000..7e488f9ac
+--- /dev/null
++++ b/tests/regression/test_unreachable_in_infinite_loop.c
+@@ -0,0 +1,153 @@
++// Copyright (c) 2026 PoCL developers
++//
++// Permission is hereby granted, free of charge, to any person obtaining a copy
++// of this software and associated documentation files (the "Software"), to deal
++// in the Software without restriction, including without limitation the rights
++// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++// copies of the Software, and to permit persons to whom the Software is
++// furnished to do so, subject to the following conditions:
++//
++// The above copyright notice and this permission notice shall be included in
++// all copies or substantial portions of the Software.
++//
++// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++// THE SOFTWARE.
++
++/*
++  An intentional infinite loop with observable side effects that also contains
++  a path to an unreachable instruction (here: printf followed by
++  __builtin_unreachable(), which clang does not fold into an assumption).
++
++  For the work-item loop handlers, ConvertUnreachablesToReturns deletes the
++  region that can only lead to the unreachable. The loop can reach the
++  unreachable and cannot reach the kernel's return, so an overly eager
++  deletion removed the whole loop, including its store, and the kernel
++  returned immediately. Only the unreachable path may be removed; the loop
++  itself must remain, so a launch that never takes the unreachable path must
++  never complete.
++
++  The check mirrors test_infinite_loop.cpp: give the kernel some time, verify
++  it is still running, then replace the process to get rid of the spinning
++  kernel thread.
++*/
++
++#include "pocl_opencl.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++#ifdef _WIN32
++#include <windows.h>
++#define sleep_ms(MS) Sleep(MS)
++#else
++#include <unistd.h>
++#define sleep_ms(MS) usleep((MS) * 1000)
++#endif
++
++#define CHECK_ERROR(err)                                                       \
++  if (err != CL_SUCCESS) {                                                     \
++    printf("OpenCL Error %d at %s:%d\n", err, __FILE__, __LINE__);             \
++    return 1;                                                                  \
++  }
++
++static const char KernelSource[] =
++    "kernel void test_kernel(global volatile int *out, int early_exit,\n"
++    "                        global const int *abort_flags) {\n"
++    "  if (early_exit)\n"
++    "    return;\n"
++    "  while (1) {\n"
++    "    if (abort_flags[get_global_id(0)]) {\n"
++    "      printf(\"aborting\\n\");\n"
++    "      __builtin_unreachable();\n"
++    "    }\n"
++    "    out[0] = 1;\n"
++    "  }\n"
++    "}\n";
++
++int main(int argc, char **argv) {
++  cl_int err;
++
++  cl_platform_id platform;
++  CHECK_ERROR(clGetPlatformIDs(1, &platform, NULL));
++  cl_device_id device;
++  CHECK_ERROR(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL));
++
++  cl_context context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
++  CHECK_ERROR(err);
++  cl_queue_properties props[] = {0};
++  cl_command_queue queue =
++      clCreateCommandQueueWithProperties(context, device, props, &err);
++  CHECK_ERROR(err);
++
++  const char *sources[] = {KernelSource};
++  cl_program program =
++      clCreateProgramWithSource(context, 1, sources, NULL, &err);
++  CHECK_ERROR(err);
++  err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
++  if (err != CL_SUCCESS) {
++    size_t log_size;
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
++                          &log_size);
++    char *log = malloc(log_size);
++    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size, log,
++                          NULL);
++    printf("Build error:\n%s\n", log);
++    return 1;
++  }
++  cl_kernel kernel = clCreateKernel(program, "test_kernel", &err);
++  CHECK_ERROR(err);
++
++  const size_t global_size = 4;
++  cl_int out = 0;
++  cl_int abort_flags[4] = {0, 0, 0, 0};
++  cl_mem out_buf =
++      clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
++                     sizeof(out), &out, &err);
++  CHECK_ERROR(err);
++  cl_mem flags_buf =
++      clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
++                     sizeof(abort_flags), abort_flags, &err);
++  CHECK_ERROR(err);
++  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(out_buf), &out_buf));
++  CHECK_ERROR(clSetKernelArg(kernel, 2, sizeof(flags_buf), &flags_buf));
++
++  // The early exit must still work.
++  cl_int early_exit = 1;
++  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(early_exit), &early_exit));
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size,
++                                     &global_size, 0, NULL, NULL));
++  CHECK_ERROR(clFinish(queue));
++
++  // Without the early exit, the kernel must spin forever.
++  early_exit = 0;
++  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(early_exit), &early_exit));
++  cl_event event;
++  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &global_size,
++                                     &global_size, 0, NULL, &event));
++  CHECK_ERROR(clFlush(queue));
++
++  sleep_ms(1500);
++
++  cl_int status;
++  CHECK_ERROR(clGetEventInfo(event, CL_EVENT_COMMAND_EXECUTION_STATUS,
++                             sizeof(status), &status, NULL));
++  if (status == CL_COMPLETE) {
++    printf("FAIL: the infinite loop was compiled away\n");
++    return 1;
++  }
++
++  printf("OK\n");
++  fflush(stdout);
++  // Force exit of the process regardless of the running kernel thread by
++  // replacing the process with a dummy process.
++#ifdef _WIN32
++  ExitProcess(EXIT_SUCCESS);
++#else
++  execlp("true", "true", NULL);
++#endif
++  return 0;
++}

--- a/P/pocl/pocl_standalone/build_tarballs.jl
+++ b/P/pocl/pocl_standalone/build_tarballs.jl
@@ -26,8 +26,8 @@ macos_sdk_version = "11.0"
 # Collection of sources required to complete build
 sources = [
     DirectorySource("./bundled"),
-    GitSource("https://github.com/JuliaGPU/pocl",
-              "5b85d6b8daaafad59beae8e2ab26c95f19ae4a59"),
+    GitSource("https://github.com/pocl/pocl",
+              "73ae321bde8025287c0ba57b5fb8907ab7b4ae78"), # release_7_2
     # vendored SPIR-V translator, built as a static library against our LLVM (see
     # common.jl); this is the latest LLVM-22.1 maintenance revision.
     GitSource("https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",

--- a/P/pocl/pocl_standalone/bundled
+++ b/P/pocl/pocl_standalone/bundled
@@ -1,1 +1,1 @@
-../pocl/bundled
+../pocl_next/bundled/


### PR DESCRIPTION
Points all three PoCL recipes at upstream `pocl/pocl` instead of the `JuliaGPU/pocl` fork, and carries our changes as `git format-patch` series under `bundled/patches/pocl`, so the JLLs' divergence from upstream is visible here rather than hidden behind a fork commit hash.

- **pocl** (7.1 track): tag `v7.1` + 16 patches (previously fork `release_7_1`).
- **pocl_next / pocl_standalone** (7.2 track): upstream `release_7_2` tip (`73ae321bd`) + 6 patches (previously fork `release_7_2`, whose base was 19 upstream commits behind; three of our backports have since landed on the upstream branch and are dropped).
- `pocl_standalone/bundled` now symlinks to `pocl_next/bundled` instead of `pocl/bundled`, since the two tracks carry different patch series (the rest of the directory was identical).

Patch provenance: everything is a backport of upstream `main` except the MinGW Clang/lld toolchain patch (JuliaGPU-only) and the CanonicalizeBarriers fix (upstream pocl/pocl#2281, open). Both series also add the merged form of pocl/pocl#2280 (UnreachablesToReturns: remove regions leading only to unreachable + the "keep loops with side effects" follow-up), fixing pocl/pocl#1958. Binary SPIR-V test inputs are excluded from the patches (`ENABLE_TESTS=OFF`).

Verified locally that both series apply with GNU `patch` at zero fuzz/offset onto their upstream bases and reproduce the (former) fork branch trees exactly, minus the `.spv` files.