### PR TITLE
[aws_lc] Update to version 4.0.0

### DIFF
--- a/A/aws_lc/build_tarballs.jl
+++ b/A/aws_lc/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_lc"
-version = v"1.73.0"
+version = v"4.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-lc.git", "44766fa7daa88e5afc7fc6de3311c48eeeb02f39"),
+    GitSource("https://github.com/awslabs/aws-lc.git", "9f04eaf85c794aedae4437b04409066862140077"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
This PR updates aws_lc to version 4.0.0.

No runtime JLL dependencies with compat pins.

cc: @Octogonapus