### PR TITLE
[aws_lc] Update to version 5.6.0

### DIFF
--- a/A/aws_lc/build_tarballs.jl
+++ b/A/aws_lc/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_lc"
-version = v"4.0.0"
+version = v"5.6.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-lc.git", "9f04eaf85c794aedae4437b04409066862140077"),
+    GitSource("https://github.com/awslabs/aws-lc.git", "51cbeccf8ea55db59a5e53f405e17a5468d9f62b"),
     DirectorySource("./bundled"),
 ]
 

--- a/A/aws_lc/bundled/patches/ppc64le_auxvec.patch
+++ b/A/aws_lc/bundled/patches/ppc64le_auxvec.patch
@@ -1,12 +1,10 @@
 diff --git a/crypto/fipsmodule/cpucap/cpu_ppc64le.c b/crypto/fipsmodule/cpucap/cpu_ppc64le.c
-index 6cad2c644..17286facd 100644
 --- a/crypto/fipsmodule/cpucap/cpu_ppc64le.c
 +++ b/crypto/fipsmodule/cpucap/cpu_ppc64le.c
-@@ -17,6 +17,7 @@
- #if defined(OPENSSL_PPC64LE)
- 
- #include <sys/auxv.h>
+@@ -12,6 +12,7 @@
+ #if defined(OPENSSL_LINUX)
+ #include "cpu_getauxval_linux.h"
 +#include <linux/auxvec.h>
- 
- #if !defined(PPC_FEATURE2_HAS_VCRYPTO)
- // PPC_FEATURE2_HAS_VCRYPTO was taken from section 4.1.2.3 of the “OpenPOWER
+ #elif defined(OPENSSL_FREEBSD)
+ #include <sys/auxv.h>
+ #endif


### PR DESCRIPTION
This PR updates aws_lc to version 5.6.0.

No runtime JLL dependencies with compat pins.

cc: @Octogonapus