### PR TITLE
[aws_c_cal] Update to version 0.9.15

### DIFF
--- a/A/aws_c_cal/build_tarballs.jl
+++ b/A/aws_c_cal/build_tarballs.jl
@@ -6,11 +6,11 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "aws_c_cal"
-version = v"0.9.14"
+version = v"0.9.15"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-cal.git", "9edd8eac2b21ca6a04535b91d60d361c2f1bb60f"),
+    GitSource("https://github.com/awslabs/aws-c-cal.git", "8aa2a48a09f93c65d4cf06388e143a6584de6321"),
 ]
 
 # Bash recipe for building across all platforms
@@ -43,7 +43,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("aws_c_common_jll"; compat="0.13.0"),
+    Dependency("aws_c_common_jll"; compat="1.0.0"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_cal to version 0.9.15.

All runtime deps pinned at latest known.
- `aws_c_common_jll`: 1.0.0

cc: @Octogonapus