### PR TITLE
[aws_c_compression] Update to version 1.0.0

### DIFF
--- a/A/aws_c_compression/build_tarballs.jl
+++ b/A/aws_c_compression/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_compression"
-version = v"0.3.3"
+version = v"1.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-compression.git", "978bf83abfa5182eb9482577f6864e86e7dfdf43"),
+    GitSource("https://github.com/awslabs/aws-c-compression.git", "891312c058e69a4d55f569f79dde1ee221982532"),
 ]
 
 # Bash recipe for building across all platforms
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("aws_c_common_jll"; compat="0.13.0"),
+    Dependency("aws_c_common_jll"; compat="1.0.0"),
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This PR updates aws_c_compression to version 1.0.0.

All runtime deps pinned at latest known.
- `aws_c_common_jll`: 1.0.0

cc: @Octogonapus