### PR TITLE
[aws_c_io] Update to version 0.27.7

### DIFF
--- a/A/aws_c_io/build_tarballs.jl
+++ b/A/aws_c_io/build_tarballs.jl
@@ -36,6 +36,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DBUILD_TESTING=OFF \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
+    -DUSE_S2N=OFF \
     ..
 cmake --build . -j${nproc} --target install
 """

--- a/A/aws_c_io/build_tarballs.jl
+++ b/A/aws_c_io/build_tarballs.jl
@@ -6,11 +6,11 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "aws_c_io"
-version = v"0.26.3"
+version = v"0.27.7"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-io.git", "1ec8081f208ef8d51381889eda3bda9756fd5bb5"),
+    GitSource("https://github.com/awslabs/aws-c-io.git", "94b6a898c80f859f30876ca3c7b305c510500301"),
 ]
 
 # Bash recipe for building across all platforms
@@ -54,9 +54,9 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("s2n_tls_jll"; compat="1.7.0", platforms=filter(p->Sys.islinux(p) || Sys.isfreebsd(p), platforms)),
-    Dependency("aws_c_cal_jll"; compat="0.9.13"),
-    Dependency("aws_c_common_jll"; compat="0.12.6"),
+    Dependency("s2n_tls_jll"; compat="1.7.8", platforms=filter(p->Sys.islinux(p) || Sys.isfreebsd(p), platforms)),
+    Dependency("aws_c_cal_jll"; compat="0.9.15"),
+    Dependency("aws_c_common_jll"; compat="1.0.0"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_io to version 0.27.7.

All runtime deps pinned at latest known.
- `aws_c_cal_jll`: 0.9.15
- `aws_c_common_jll`: 1.0.0
- `s2n_tls_jll`: 1.7.8

cc: @Octogonapus