### PR TITLE
[aws_c_http] Update to version 0.11.1

### DIFF
--- a/A/aws_c_http/build_tarballs.jl
+++ b/A/aws_c_http/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_http"
-version = v"0.10.15"
+version = v"0.11.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-http.git", "2a22c94f71bfca8dd954ad4fdd96150a3d23efa8"),
+    GitSource("https://github.com/awslabs/aws-c-http.git", "99adf4876684224db5c28210e371bf5f052ee158"),
     DirectorySource("./bundled"),
 ]
 
@@ -63,8 +63,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("aws_c_compression_jll"; compat="0.3.2"),
-    Dependency("aws_c_io_jll"; compat="0.26.3"),
+    Dependency("aws_c_compression_jll"; compat="1.0.0"),
+    Dependency("aws_c_io_jll"; compat="1.0.0"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_http to version 0.11.1.

All runtime deps pinned at latest known.
- `aws_c_compression_jll`: 1.0.0
- `aws_c_io_jll`: 1.0.0

cc: @Octogonapus