### PR TITLE
[lv2] New recipe: v1.18.10 (LV2 specification)

### DIFF
--- a/L/lv2/build_tarballs.jl
+++ b/L/lv2/build_tarballs.jl
@@ -1,0 +1,45 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+# The LV2 audio plugin specification (https://lv2plug.in): C headers plus the
+# Turtle bundles that define the core ontology, ISC. Needed to build sratom
+# and lilv, and at run time by lilv to describe plugin classes and ports.
+# Example plugins are not built.
+name = "lv2"
+version = v"1.18.10"
+
+sources = [
+    ArchiveSource("https://lv2plug.in/spec/lv2-$(version).tar.xz",
+                  "78c51bcf21b54e58bb6329accbb4dae03b2ed79b520f9a01e734bd9de530953f"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/lv2-*
+install_license COPYING
+if [[ "${target}" == *-apple-* ]]; then
+    # The cross file names the cctools ld64 as the linker, which meson cannot
+    # identify (it rejects --version and prints its banner to stdout), while
+    # the clang wrapper links with lld, which meson detects fine. Let meson use
+    # the compiler's linker.
+    sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"
+fi
+meson setup build --cross-file="${MESON_TARGET_TOOLCHAIN}" --buildtype=release \
+    -Ddocs=disabled -Dplugins=disabled -Dtests=disabled -Dold_headers=true \
+    -Dlv2dir="${prefix}/lib/lv2"
+meson compile -C build -j${nproc}
+meson install -C build
+"""
+
+platforms = supported_platforms()
+
+products = [
+    FileProduct("include/lv2/core/lv2.h", :lv2_h),
+    FileProduct("lib/lv2/core.lv2/manifest.ttl", :lv2_core_manifest),
+]
+
+dependencies = Dependency[
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")


### PR DESCRIPTION
New recipe: `lv2_jll` 1.18.10 (ISC, meson) — the LV2 specification headers and ontology bundles (file products; no library), for sratom/lilv and for lilv at run time. Step 1 of the chain Zix/lv2/Serd → Sord → Sratom → Lilv.
Tested: aarch64-linux-gnu locally; CI green on all platforms.