### PR TITLE
[Serd] Update to v0.32.10, switch waf → meson

### DIFF
--- a/S/Serd/build_tarballs.jl
+++ b/S/Serd/build_tarballs.jl
@@ -1,40 +1,44 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder, Pkg
+using BinaryBuilder
 
+# Serd: a lightweight C library for RDF syntax (Turtle, NTriples, NQuads,
+# TriG) (https://gitlab.com/drobilla/serd), ISC. The base of sord, sratom
+# and lilv.
 name = "Serd"
-# <-- this is a lie, we're building v0.30.10, but we need to bump version to build for julia v1.6
-version_fake = v"0.30.11"
-version = v"0.30.10"
+version = v"0.32.10"
 
-# Collection of sources required to complete build
 sources = [
-    ArchiveSource("http://download.drobilla.net/serd-$(version).tar.bz2", "affa80deec78921f86335e6fc3f18b80aefecf424f6a5755e9f2fa0eb0710edf")
+    ArchiveSource("https://download.drobilla.net/serd-$(version).tar.xz",
+                  "b0e93b49e52f01a049475b7886ef140407115a32d3b1e5dc5f95141c88275d1c"),
 ]
 
-# Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/serd*/
-
+cd ${WORKSPACE}/srcdir/serd-*
 install_license COPYING
-./waf configure --prefix=$prefix
-./waf
-./waf install
-exit
+if [[ "${target}" == *-apple-* ]]; then
+    # The cross file names the cctools ld64 as the linker, which meson cannot
+    # identify (it rejects --version and prints its banner to stdout), while
+    # the clang wrapper links with lld, which meson detects fine. Let meson use
+    # the compiler's linker.
+    sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"
+fi
+meson setup build --cross-file="${MESON_TARGET_TOOLCHAIN}" --buildtype=release \
+    -Ddefault_library=shared \
+    -Ddocs=disabled -Dman=disabled -Dtests=disabled -Dtools=enabled
+meson compile -C build -j${nproc}
+meson install -C build
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
-# The products that we will ensure are always built
 products = [
-    LibraryProduct(["libserd-0", "serd"], :libserd)
+    LibraryProduct(["libserd-0", "libserd", "serd-0"], :libserd),   # on Windows BB parses libfoo-0.dll as "libfoo"
+    ExecutableProduct("serdi", :serdi),
 ]
 
-# Dependencies that must be installed before this package can be built
 dependencies = Dependency[
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version_fake, sources, script, platforms, products, dependencies, julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")


### PR DESCRIPTION
Update `Serd_jll` 0.30.10 → 0.32.10 (ISC): upstream moved from waf to meson, so the fake 0.30.11 version is no longer needed. Adds `serdi` and the `serd-0`/`libserd` names; `libserd` unchanged. Step 1 of the chain Zix/lv2/Serd → Sord → Sratom → Lilv (lilv-based LV2 discovery for SciML/AudioPlugins.jl).
Tested: aarch64-linux-gnu locally; CI green on all platforms.