### PR TITLE
[CasADi] v3.8.0: progressively enable more plugins (experimental)

### DIFF
--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -2,12 +2,12 @@ using BinaryBuilder, Pkg
 
 name = "CasADi"
 
-version = v"3.7.3" # upstream is 3.7.2; bump Yggdrasil version because we updated compat bounds
+version = v"3.8.0"
 
 sources = [
     GitSource(
         "https://github.com/casadi/casadi.git",
-        "f959d3175a444d763e4eda4aece48f4c5f4a6f90",
+        "83b3cec864e42c5b64a07e85d4adf91da71458b1",
     ),
     DirectorySource("./bundled"),
 ]

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -50,6 +50,13 @@ if [[ "${target}" == *mingw* ]]; then
     sed -i 's/-lasl//g' ${prefix}/lib/pkgconfig/*.pc
 fi
 
+# HiGHS_jll has no powerpc64le build, so the dependency (and this flag) are
+# scoped to the platforms where it exists.
+HIGHS_FLAG="-DWITH_HIGHS=OFF"
+if [[ "${target}" != powerpc64le-* ]]; then
+    HIGHS_FLAG="-DWITH_HIGHS=ON"
+fi
+
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_INSTALL_BINDIR=${bindir} \
     -DCMAKE_INSTALL_LIBDIR=${libdir} \
@@ -62,6 +69,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DBLAS_LIBRARIES="${LBT}" \
     -DWITH_IPOPT=ON \
     -DWITH_BONMIN=ON \
+    ${HIGHS_FLAG} \
     -DWITH_CLP=ON \
     -DWITH_CBC=ON \
     -DWITH_QPOASES=ON \
@@ -87,11 +95,16 @@ platforms = expand_cxxstring_abis(platforms)
 filter!(p -> arch(p) != "riscv64" && !Sys.isfreebsd(p),
     platforms)
 
+# HiGHS_jll filters out powerpc64le (see H/HiGHS/build_tarballs.jl), so the
+# highs plugin exists on every platform except that one.
+highs_platforms = filter(p -> arch(p) != "powerpc64le", platforms)
+
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
     Dependency("Ipopt_jll"; compat="300.1400.1901"),
     Dependency("Bonmin_jll"; compat="100.800.902"),
-    Dependency("libblastrampoline_jll"; compat="5.4.0")
+    Dependency("libblastrampoline_jll"; compat="5.4.0"),
+    Dependency("HiGHS_jll"; compat="1.15.1", platforms=highs_platforms)
 ]
 
 products = [
@@ -134,15 +147,23 @@ products = [
     LibraryProduct("libcasadi_xmlfile_tinyxml", :libcasadi_xmlfile_tinyxml),
 ]
 
-build_tarballs(
-    ARGS,
-    name,
-    version,
-    sources,
-    script,
-    platforms,
-    products,
-    dependencies;
-    preferred_gcc_version = v"8",
-    julia_compat = "1.6",
-)
+highs_product = LibraryProduct("libcasadi_conic_highs", :libcasadi_conic_highs)
+
+# One build_tarballs call per platform, so the products list can differ: the
+# highs plugin is absent on powerpc64le. This is the same idiom B/blasfeo uses.
+for platform in platforms
+    should_build_platform(triplet(platform)) || continue
+    platform_products = arch(platform) == "powerpc64le" ? products : [products; highs_product]
+    build_tarballs(
+        ARGS,
+        name,
+        version,
+        sources,
+        script,
+        [platform],
+        platform_products,
+        dependencies;
+        preferred_gcc_version = v"8",
+        julia_compat = "1.6",
+    )
+end

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -33,6 +33,9 @@ export CFLAGS="${CFLAGS} -fPIC"
 # Clp_jll and Cbc_jll already link against, so we do not pull a second BLAS
 # into the prefix. Pre-setting LAPACK_LIBRARIES makes CasADi skip its
 # find_package(LAPACK) (see the `if(NOT LAPACK_LIBRARIES)` in CMakeLists.txt).
+# BLAS_LIBRARIES must be set too: external_packages/qpOASES/CMakeLists.txt does
+# `target_link_libraries(casadi_qpoases lapack ${BLAS_LIBRARIES})`, and an unset
+# BLAS_LIBRARIES expands to FALSE, which reaches the linker as -lFALSE.
 if [[ "${target}" == *mingw* ]]; then
     LBT="${libdir}/libblastrampoline-5.${dlext}"
 else
@@ -48,6 +51,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} \
     -DWITH_LAPACK=ON \
     -DLAPACK_LIBRARIES="${LBT}" \
+    -DBLAS_LIBRARIES="${LBT}" \
     -DWITH_IPOPT=ON \
     -DWITH_BONMIN=ON \
     -DWITH_CLP=ON \

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -73,11 +73,6 @@ if [[ -n "${BLASFEO_LIBFILE}" ]]; then
     # resolve it; removed again after install so it never reaches the tarball.
     mkdir -p ${BLASFEO_ROOT}/lib/cmake/blasfeo
     cat > ${BLASFEO_ROOT}/lib/cmake/blasfeo/blasfeo-config.cmake <<EOCFG
-    # fatrop's own targets do not all pick up the include directory from the
-    # imported target, so put it on the compiler flags the ExternalProject
-    # inherits as well.
-    export CXXFLAGS="${CXXFLAGS} -I${BLASFEO_ROOT}/include"
-    export CFLAGS="${CFLAGS} -I${BLASFEO_ROOT}/include"
 if(NOT TARGET blasfeo::blasfeo)
   add_library(blasfeo::blasfeo UNKNOWN IMPORTED)
   set_target_properties(blasfeo::blasfeo PROPERTIES
@@ -85,6 +80,10 @@ if(NOT TARGET blasfeo::blasfeo)
     INTERFACE_INCLUDE_DIRECTORIES "${BLASFEO_ROOT}/include")
 endif()
 EOCFG
+    # fatrop's own targets do not all pick up the include directory from the
+    # imported target, so put it on the compiler flags the sub-build inherits.
+    export CXXFLAGS="${CXXFLAGS} -I${BLASFEO_ROOT}/include"
+    export CFLAGS="${CFLAGS} -I${BLASFEO_ROOT}/include"
     FATROP_FLAGS="-DWITH_BLASFEO=ON -DWITH_FATROP=ON -DWITH_BUILD_FATROP=ON"
     FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_REPO=${WORKSPACE}/srcdir/fatrop"
     FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_VERSION=2d8c5198a47890a55bb872ed4f895484c7769f74"

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -73,6 +73,12 @@ if [[ -n "${BLASFEO_LIBFILE}" ]]; then
     # resolve it; removed again after install so it never reaches the tarball.
     mkdir -p ${BLASFEO_ROOT}/lib/cmake/blasfeo
     cat > ${BLASFEO_ROOT}/lib/cmake/blasfeo/blasfeo-config.cmake <<EOCFG
+if(NOT TARGET blasfeo)
+  add_library(blasfeo UNKNOWN IMPORTED)
+  set_target_properties(blasfeo PROPERTIES
+    IMPORTED_LOCATION "${BLASFEO_LIBFILE}"
+    INTERFACE_INCLUDE_DIRECTORIES "${BLASFEO_ROOT}/include")
+endif()
 if(NOT TARGET blasfeo::blasfeo)
   add_library(blasfeo::blasfeo UNKNOWN IMPORTED)
   set_target_properties(blasfeo::blasfeo PROPERTIES
@@ -84,6 +90,7 @@ EOCFG
     # imported target, so put it on the compiler flags the sub-build inherits.
     export CXXFLAGS="${CXXFLAGS} -I${BLASFEO_ROOT}/include"
     export CFLAGS="${CFLAGS} -I${BLASFEO_ROOT}/include"
+    export LDFLAGS="${LDFLAGS} -L${BLASFEO_ROOT}/lib"
     FATROP_FLAGS="-DWITH_BLASFEO=ON -DWITH_FATROP=ON -DWITH_BUILD_FATROP=ON"
     FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_REPO=${WORKSPACE}/srcdir/fatrop"
     FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_VERSION=2d8c5198a47890a55bb872ed4f895484c7769f74"

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -58,6 +58,24 @@ else
     LBT="${libdir}/libblastrampoline.${dlext}"
 fi
 
+# fatrop, built from the vendored checkout against blasfeo_jll. Locate blasfeo
+# by finding the library rather than naming a directory: FindBLASFEO.cmake looks
+# under $BLASFEO, and the JLL's own layout is not something to assume.
+BLASFEO_LIBFILE=$(find ${prefix} -name 'libblasfeo.*' 2>/dev/null | head -1)
+FATROP_FLAGS="-DWITH_FATROP=OFF -DWITH_BLASFEO=OFF"
+if [[ -n "${BLASFEO_LIBFILE}" ]]; then
+    BLASFEO_ROOT=$(dirname "$(dirname "${BLASFEO_LIBFILE}")")
+    echo "Found blasfeo at ${BLASFEO_LIBFILE}, root ${BLASFEO_ROOT}"
+    export BLASFEO=${BLASFEO_ROOT}
+    FATROP_FLAGS="-DWITH_BLASFEO=ON -DWITH_FATROP=ON -DWITH_BUILD_FATROP=ON"
+    FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_REPO=${WORKSPACE}/srcdir/fatrop"
+    FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_VERSION=2d8c5198a47890a55bb872ed4f895484c7769f74"
+    FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_SHALLOW=OFF"
+else
+    echo "No blasfeo in ${prefix}; fatrop disabled. Prefix contents:"
+    ls -la ${prefix}
+fi
+
 # OSQP is parked. The plugin itself works, but OSQP_jll ships one header tree
 # for its single- and double-precision builds with `#define OSQP_USE_FLOAT` in
 # it, so OSQPFloat is float and CasADi's double-only interface will not compile.

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -84,17 +84,27 @@ fi
 # removed, and let the patched CMake pick libosqp_builtin_double via
 # find_library (CMAKE_DISABLE_FIND_PACKAGE_OSQP keeps the shipped, single-
 # precision CMake config from winning first).
+# Best effort: if the headers cannot be prepared, drop OSQP rather than fail the
+# whole build. Copy the headers file by file into a directory we created, so
+# there is no `cp -r` directory-semantics ambiguity, and report what we saw.
+OSQP_FLAGS="-DWITH_OSQP=OFF"
 OSQP_CFG=$(find -L ${prefix} -name osqp_configure.h 2>/dev/null | head -1)
-if [[ -z "${OSQP_CFG}" ]]; then
-    echo "osqp_configure.h not found under ${prefix}"
-    exit 1
+echo "OSQP: osqp_configure.h -> '${OSQP_CFG}'"
+if [[ -n "${OSQP_CFG}" ]]; then
+    OSQP_SRC=$(dirname "${OSQP_CFG}")
+    OSQP_INC=${WORKSPACE}/srcdir/osqp-double-include/osqp
+    rm -rf "${OSQP_INC}"
+    mkdir -p "${OSQP_INC}"
+    cp "${OSQP_SRC}"/*.h "${OSQP_INC}"/ || true
+    if [[ -f "${OSQP_INC}/osqp_configure.h" ]]; then
+        sed -i '/^#define OSQP_USE_FLOAT$/d' "${OSQP_INC}/osqp_configure.h"
+        OSQP_FLAGS="-DWITH_OSQP=ON -DCMAKE_DISABLE_FIND_PACKAGE_OSQP=ON -DOSQP_INCLUDE_DIR=${OSQP_INC}"
+        echo "OSQP: headers prepared from ${OSQP_SRC}"
+    else
+        echo "OSQP: copy from ${OSQP_SRC} produced nothing; disabling. Source holds:"
+        ls -la "${OSQP_SRC}" | head -20
+    fi
 fi
-OSQP_INC=${WORKSPACE}/srcdir/osqp-double-include
-rm -rf ${OSQP_INC}
-mkdir -p ${OSQP_INC}
-cp -r "$(dirname ${OSQP_CFG})" ${OSQP_INC}/osqp
-sed -i '/^#define OSQP_USE_FLOAT$/d' ${OSQP_INC}/osqp/osqp_configure.h
-echo "OSQP headers copied from $(dirname ${OSQP_CFG})"
 
 # cbc.pc carries `-lasl` on every platform, which links fine everywhere except
 # Windows: ASL_jll's recipe only ever does `cp libasl.${dlext} ${libdir}`, so on
@@ -125,9 +135,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DWITH_BONMIN=ON \
     ${HIGHS_FLAG} \
     ${FATROP_FLAGS} \
-    -DWITH_OSQP=ON \
-    -DCMAKE_DISABLE_FIND_PACKAGE_OSQP=ON \
-    -DOSQP_INCLUDE_DIR="${OSQP_INC}/osqp" \
+    ${OSQP_FLAGS} \
     -DWITH_CLP=ON \
     -DWITH_CBC=ON \
     -DWITH_QPOASES=ON \
@@ -180,7 +188,6 @@ products = [
     LibraryProduct("libcasadi_conic_clp", :libcasadi_conic_clp),
     LibraryProduct("libcasadi_conic_ipqp", :libcasadi_conic_ipqp),
     LibraryProduct("libcasadi_conic_nlpsol", :libcasadi_conic_nlpsol),
-    LibraryProduct("libcasadi_conic_osqp", :libcasadi_conic_osqp),
     LibraryProduct("libcasadi_conic_qpoases", :libcasadi_conic_qpoases),
     LibraryProduct("libcasadi_conic_qrqp", :libcasadi_conic_qrqp),
     LibraryProduct("libcasadi_importer_shell", :libcasadi_importer_shell),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -210,8 +210,13 @@ highs_platforms = filter(p -> arch(p) != "powerpc64le", platforms)
 # blasfeo_jll ships x86_64 (linux glibc+musl, windows, macOS) and aarch64 macOS
 # only; its artifacts carry a march tag but resolve fine for an untagged
 # platform, so CasADi does not need microarchitecture expansion of its own.
-fatrop_platforms = filter(p -> arch(p) == "x86_64" || (arch(p) == "aarch64" && Sys.isapple(p)),
-    platforms)
+# Linux x86_64 only. macOS has two separate blockers, both upstream of this
+# recipe: fatrop's ip_utils.cpp hits "call to 'abs' is ambiguous" under clang,
+# and CasADi's casadi_blas_blasfeo shim fails to link with undefined
+# blasfeo_blas_dgemm / daxpy / ddot because blasfeo_jll is built without
+# blasfeo's optional BLAS API. Linux only tolerates the latter because shared
+# libraries there may carry undefined symbols; that plugin would fail on use.
+fatrop_platforms = filter(p -> arch(p) == "x86_64" && Sys.islinux(p), platforms)
 
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -13,6 +13,13 @@ sources = [
         "https://github.com/casadi/casadi.git",
         "83b3cec864e42c5b64a07e85d4adf91da71458b1",
     ),
+    # Vendored so ExternalProject_Add can clone it from disk: Yggdrasil fetches
+    # sources outside the sandbox, and CasADi's BUILD_FATROP_GIT_REPO is a cache
+    # variable we can redirect at the local checkout.
+    GitSource(
+        "https://github.com/jgillis/fatrop.git",
+        "2d8c5198a47890a55bb872ed4f895484c7769f74",  # v1.1.8.mod
+    ),
     DirectorySource("./bundled"),
 ]
 
@@ -59,6 +66,18 @@ fi
 # removed, and let the patched CMake pick libosqp_builtin_double via
 # find_library (CMAKE_DISABLE_FIND_PACKAGE_OSQP keeps the shipped, single-
 # precision CMake config from winning first).
+# blasfeo_jll installs into <prefix>/blasfeo/{include,lib} rather than straight
+# into the prefix, and FindBLASFEO.cmake looks under $BLASFEO. Only x86_64 (all
+# OSes) and aarch64 macOS have blasfeo artifacts, so fatrop is limited to those.
+FATROP_FLAGS="-DWITH_FATROP=OFF -DWITH_BLASFEO=OFF"
+if [[ -d "${prefix}/blasfeo" ]]; then
+    export BLASFEO=${prefix}/blasfeo
+    FATROP_FLAGS="-DWITH_BLASFEO=ON -DWITH_FATROP=ON -DWITH_BUILD_FATROP=ON"
+    FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_REPO=${WORKSPACE}/srcdir/fatrop"
+    FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_VERSION=2d8c5198a47890a55bb872ed4f895484c7769f74"
+    FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_SHALLOW=OFF"
+fi
+
 OSQP_INC=${WORKSPACE}/srcdir/osqp-double-include
 mkdir -p ${OSQP_INC}
 cp -r ${includedir}/osqp ${OSQP_INC}/
@@ -92,6 +111,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DWITH_IPOPT=ON \
     -DWITH_BONMIN=ON \
     ${HIGHS_FLAG} \
+    ${FATROP_FLAGS} \
     -DWITH_OSQP=ON \
     -DCMAKE_DISABLE_FIND_PACKAGE_OSQP=ON \
     -DOSQP_INCLUDE_DIR="${OSQP_INC}/osqp" \
@@ -124,13 +144,20 @@ filter!(p -> arch(p) != "riscv64" && !Sys.isfreebsd(p),
 # highs plugin exists on every platform except that one.
 highs_platforms = filter(p -> arch(p) != "powerpc64le", platforms)
 
+# blasfeo_jll ships x86_64 (linux glibc+musl, windows, macOS) and aarch64 macOS
+# only; its artifacts carry a march tag but resolve fine for an untagged
+# platform, so CasADi does not need microarchitecture expansion of its own.
+fatrop_platforms = filter(p -> arch(p) == "x86_64" || (arch(p) == "aarch64" && Sys.isapple(p)),
+    platforms)
+
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
     Dependency("Ipopt_jll"; compat="300.1400.1901"),
     Dependency("Bonmin_jll"; compat="100.800.902"),
     Dependency("libblastrampoline_jll"; compat="5.4.0"),
     Dependency("HiGHS_jll"; compat="1.15.1", platforms=highs_platforms),
-    Dependency("OSQP_jll"; compat="100.0.0")
+    Dependency("OSQP_jll"; compat="100.0.0"),
+    Dependency("blasfeo_jll"; compat="0.1.4", platforms=fatrop_platforms)
 ]
 
 products = [
@@ -175,12 +202,16 @@ products = [
 ]
 
 highs_product = LibraryProduct("libcasadi_conic_highs", :libcasadi_conic_highs)
+fatrop_product = LibraryProduct("libcasadi_nlpsol_fatrop", :libcasadi_nlpsol_fatrop)
 
 # One build_tarballs call per platform, so the products list can differ: the
 # highs plugin is absent on powerpc64le. This is the same idiom B/blasfeo uses.
 for platform in platforms
     should_build_platform(triplet(platform)) || continue
     platform_products = arch(platform) == "powerpc64le" ? products : [products; highs_product]
+    if platform in fatrop_platforms
+        platform_products = [platform_products; fatrop_product]
+    end
     build_tarballs(
         ARGS,
         name,

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -84,6 +84,20 @@ fi
 # removed, and let the patched CMake pick libosqp_builtin_double via
 # find_library (CMAKE_DISABLE_FIND_PACKAGE_OSQP keeps the shipped, single-
 # precision CMake config from winning first).
+# OSQP stays off. CMAKE_DISABLE_FIND_PACKAGE_OSQP was meant to stop the config
+# OSQP_jll ships (which points osqp::osqp at the single-precision build) from
+# winning before the patched branch runs, but it turns "found the wrong thing"
+# into "not found", and CasADi hard-errors at CMakeLists.txt:1291:
+#
+#   OSQP not found on your system yet required. Set WITH_BUILD_OSQP or
+#   WITH_BUILD_REQUIRED ON to build this required package from source.
+#
+# The fix is to let find_package succeed and have the patch retarget the
+# existing imported target -- set_target_properties works on imported targets --
+# rather than trying to create a second one. Left for a follow-up so that fatrop
+# and libzip can be validated first. The header prep below is kept because it is
+# correct and will be needed then.
+#
 # Best effort: if the headers cannot be prepared, drop OSQP rather than fail the
 # whole build. Copy the headers file by file into a directory we created, so
 # there is no `cp -r` directory-semantics ambiguity, and report what we saw.
@@ -98,8 +112,7 @@ if [[ -n "${OSQP_CFG}" ]]; then
     cp "${OSQP_SRC}"/*.h "${OSQP_INC}"/ || true
     if [[ -f "${OSQP_INC}/osqp_configure.h" ]]; then
         sed -i '/^#define OSQP_USE_FLOAT$/d' "${OSQP_INC}/osqp_configure.h"
-        OSQP_FLAGS="-DWITH_OSQP=ON -DCMAKE_DISABLE_FIND_PACKAGE_OSQP=ON -DOSQP_INCLUDE_DIR=${OSQP_INC}"
-        echo "OSQP: headers prepared from ${OSQP_SRC}"
+        echo "OSQP: headers prepared from ${OSQP_SRC} (plugin still off, see below)"
     else
         echo "OSQP: copy from ${OSQP_SRC} produced nothing; disabling. Source holds:"
         ls -la "${OSQP_SRC}" | head -20

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -61,7 +61,7 @@ fi
 # fatrop, built from the vendored checkout against blasfeo_jll. Locate blasfeo
 # by finding the library rather than naming a directory: FindBLASFEO.cmake looks
 # under $BLASFEO, and the JLL's own layout is not something to assume.
-BLASFEO_LIBFILE=$(find ${prefix} -name 'libblasfeo.*' 2>/dev/null | head -1)
+BLASFEO_LIBFILE=$(find -L ${prefix} -name 'libblasfeo.*' 2>/dev/null | head -1)
 FATROP_FLAGS="-DWITH_FATROP=OFF -DWITH_BLASFEO=OFF"
 if [[ -n "${BLASFEO_LIBFILE}" ]]; then
     BLASFEO_ROOT=$(dirname "$(dirname "${BLASFEO_LIBFILE}")")
@@ -76,12 +76,25 @@ else
     ls -la ${prefix}
 fi
 
-# OSQP is parked. The plugin itself works, but OSQP_jll ships one header tree
-# for its single- and double-precision builds with `#define OSQP_USE_FLOAT` in
-# it, so OSQPFloat is float and CasADi's double-only interface will not compile.
-# Sanitising the headers from the shell needs the layout in the prefix, which is
-# not what the artifact looks like; that belongs in the CMake patch, where
-# find_path has already resolved the directory. Re-enable once that is written.
+# OSQP_jll installs a single- and a double-precision build into one prefix, and
+# the single one lands last: lib/cmake/osqp points osqp::osqp at
+# libosqp_builtin_single, and include/osqp/osqp_configure.h carries
+# `#define OSQP_USE_FLOAT`, so OSQPFloat is float for everyone. CasADi's
+# interface is double-only. Take a private copy of the headers with that define
+# removed, and let the patched CMake pick libosqp_builtin_double via
+# find_library (CMAKE_DISABLE_FIND_PACKAGE_OSQP keeps the shipped, single-
+# precision CMake config from winning first).
+OSQP_CFG=$(find -L ${prefix} -name osqp_configure.h 2>/dev/null | head -1)
+if [[ -z "${OSQP_CFG}" ]]; then
+    echo "osqp_configure.h not found under ${prefix}"
+    exit 1
+fi
+OSQP_INC=${WORKSPACE}/srcdir/osqp-double-include
+rm -rf ${OSQP_INC}
+mkdir -p ${OSQP_INC}
+cp -r "$(dirname ${OSQP_CFG})" ${OSQP_INC}/osqp
+sed -i '/^#define OSQP_USE_FLOAT$/d' ${OSQP_INC}/osqp/osqp_configure.h
+echo "OSQP headers copied from $(dirname ${OSQP_CFG})"
 
 # cbc.pc carries `-lasl` on every platform, which links fine everywhere except
 # Windows: ASL_jll's recipe only ever does `cp libasl.${dlext} ${libdir}`, so on
@@ -112,7 +125,9 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DWITH_BONMIN=ON \
     ${HIGHS_FLAG} \
     ${FATROP_FLAGS} \
-    -DWITH_OSQP=OFF \
+    -DWITH_OSQP=ON \
+    -DCMAKE_DISABLE_FIND_PACKAGE_OSQP=ON \
+    -DOSQP_INCLUDE_DIR="${OSQP_INC}/osqp" \
     -DWITH_CLP=ON \
     -DWITH_CBC=ON \
     -DWITH_QPOASES=ON \
@@ -154,6 +169,7 @@ dependencies = [
     Dependency("Bonmin_jll"; compat="100.800.902"),
     Dependency("libblastrampoline_jll"; compat="5.4.0"),
     Dependency("HiGHS_jll"; compat="1.15.1", platforms=highs_platforms),
+    Dependency("OSQP_jll"; compat="100.0.0"),
     Dependency("blasfeo_jll"; compat="0.1.4", platforms=fatrop_platforms)
 ]
 
@@ -164,6 +180,7 @@ products = [
     LibraryProduct("libcasadi_conic_clp", :libcasadi_conic_clp),
     LibraryProduct("libcasadi_conic_ipqp", :libcasadi_conic_ipqp),
     LibraryProduct("libcasadi_conic_nlpsol", :libcasadi_conic_nlpsol),
+    LibraryProduct("libcasadi_conic_osqp", :libcasadi_conic_osqp),
     LibraryProduct("libcasadi_conic_qpoases", :libcasadi_conic_qpoases),
     LibraryProduct("libcasadi_conic_qrqp", :libcasadi_conic_qrqp),
     LibraryProduct("libcasadi_importer_shell", :libcasadi_importer_shell),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -1,5 +1,9 @@
 using BinaryBuilder, Pkg
 
+const YGGDRASIL_DIR = "../.."
+# For should_build_platform
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+
 name = "CasADi"
 
 version = v"3.8.0"
@@ -15,6 +19,11 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir/casadi
 install_license LICENSE.txt
+
+for p in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 "${p}"
+done
+
 mkdir -p build
 cd build
 
@@ -70,6 +79,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DWITH_IPOPT=ON \
     -DWITH_BONMIN=ON \
     ${HIGHS_FLAG} \
+    -DWITH_OSQP=ON \
     -DWITH_CLP=ON \
     -DWITH_CBC=ON \
     -DWITH_QPOASES=ON \
@@ -104,7 +114,8 @@ dependencies = [
     Dependency("Ipopt_jll"; compat="300.1400.1901"),
     Dependency("Bonmin_jll"; compat="100.800.902"),
     Dependency("libblastrampoline_jll"; compat="5.4.0"),
-    Dependency("HiGHS_jll"; compat="1.15.1", platforms=highs_platforms)
+    Dependency("HiGHS_jll"; compat="1.15.1", platforms=highs_platforms),
+    Dependency("OSQP_jll"; compat="100.0.0")
 ]
 
 products = [
@@ -114,6 +125,7 @@ products = [
     LibraryProduct("libcasadi_conic_clp", :libcasadi_conic_clp),
     LibraryProduct("libcasadi_conic_ipqp", :libcasadi_conic_ipqp),
     LibraryProduct("libcasadi_conic_nlpsol", :libcasadi_conic_nlpsol),
+    LibraryProduct("libcasadi_conic_osqp", :libcasadi_conic_osqp),
     LibraryProduct("libcasadi_conic_qpoases", :libcasadi_conic_qpoases),
     LibraryProduct("libcasadi_conic_qrqp", :libcasadi_conic_qrqp),
     LibraryProduct("libcasadi_importer_shell", :libcasadi_importer_shell),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -38,6 +38,11 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} \
     -DWITH_IPOPT=ON \
     -DWITH_BONMIN=ON \
+    -DWITH_CLP=ON \
+    -DWITH_CBC=ON \
+    -DWITH_QPOASES=ON \
+    -DWITH_NO_QPOASES_BANNER=ON \
+    -DWITH_BLOCKSQP=ON \
     -DWITH_EXAMPLES=OFF \
     -DWITH_DEEPBIND=OFF \
     ..
@@ -67,8 +72,11 @@ dependencies = [
 products = [
     ExecutableProduct("amplexe", :amplexe),
     LibraryProduct("libcasadi", :libcasadi),
+    LibraryProduct("libcasadi_conic_cbc", :libcasadi_conic_cbc),
+    LibraryProduct("libcasadi_conic_clp", :libcasadi_conic_clp),
     LibraryProduct("libcasadi_conic_ipqp", :libcasadi_conic_ipqp),
     LibraryProduct("libcasadi_conic_nlpsol", :libcasadi_conic_nlpsol),
+    LibraryProduct("libcasadi_conic_qpoases", :libcasadi_conic_qpoases),
     LibraryProduct("libcasadi_conic_qrqp", :libcasadi_conic_qrqp),
     LibraryProduct("libcasadi_importer_shell", :libcasadi_importer_shell),
     LibraryProduct("libcasadi_integrator_collocation", :libcasadi_integrator_collocation),
@@ -84,6 +92,7 @@ products = [
     LibraryProduct("libcasadi_linsol_qr", :libcasadi_linsol_qr),
     LibraryProduct("libcasadi_linsol_symbolicqr", :libcasadi_linsol_symbolicqr),
     LibraryProduct("libcasadi_linsol_tridiag", :libcasadi_linsol_tridiag),
+    LibraryProduct("libcasadi_nlpsol_blocksqp", :libcasadi_nlpsol_blocksqp),
     LibraryProduct("libcasadi_nlpsol_feasiblesqpmethod", :libcasadi_nlpsol_feasiblesqpmethod),
     LibraryProduct("libcasadi_nlpsol_ipopt", :libcasadi_nlpsol_ipopt),
     LibraryProduct("libcasadi_nlpsol_qrsqp", :libcasadi_nlpsol_qrsqp),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -131,6 +131,8 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DWITH_LAPACK=ON \
     -DLAPACK_LIBRARIES="${LBT}" \
     -DBLAS_LIBRARIES="${LBT}" \
+    -DWITH_ZLIB=ON \
+    -DWITH_LIBZIP=ON \
     -DWITH_IPOPT=ON \
     -DWITH_BONMIN=ON \
     ${HIGHS_FLAG} \
@@ -176,6 +178,8 @@ dependencies = [
     Dependency("Ipopt_jll"; compat="300.1400.1901"),
     Dependency("Bonmin_jll"; compat="100.800.902"),
     Dependency("libblastrampoline_jll"; compat="5.4.0"),
+    Dependency("Zlib_jll"),
+    Dependency("libzip_jll"; compat="1.11.3"),
     Dependency("HiGHS_jll"; compat="1.15.1", platforms=highs_platforms),
     Dependency("OSQP_jll"; compat="100.0.0"),
     Dependency("blasfeo_jll"; compat="0.1.4", platforms=fatrop_platforms)

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -29,6 +29,16 @@ fi
 export CXXFLAGS="-fPIC ${CXX_STANDARD} -I${includedir}/coin-or"
 export CFLAGS="${CFLAGS} -fPIC"
 
+# LAPACK via libblastrampoline, the same BLAS/LAPACK shim that Ipopt_jll,
+# Clp_jll and Cbc_jll already link against, so we do not pull a second BLAS
+# into the prefix. Pre-setting LAPACK_LIBRARIES makes CasADi skip its
+# find_package(LAPACK) (see the `if(NOT LAPACK_LIBRARIES)` in CMakeLists.txt).
+if [[ "${target}" == *mingw* ]]; then
+    LBT="${libdir}/libblastrampoline-5.${dlext}"
+else
+    LBT="${libdir}/libblastrampoline.${dlext}"
+fi
+
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_INSTALL_BINDIR=${bindir} \
     -DCMAKE_INSTALL_LIBDIR=${libdir} \
@@ -36,6 +46,8 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} \
+    -DWITH_LAPACK=ON \
+    -DLAPACK_LIBRARIES="${LBT}" \
     -DWITH_IPOPT=ON \
     -DWITH_BONMIN=ON \
     -DWITH_CLP=ON \
@@ -66,7 +78,8 @@ filter!(p -> arch(p) != "riscv64" && !Sys.isfreebsd(p),
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
     Dependency("Ipopt_jll"; compat="300.1400.1901"),
-    Dependency("Bonmin_jll"; compat="100.800.902")
+    Dependency("Bonmin_jll"; compat="100.800.902"),
+    Dependency("libblastrampoline_jll"; compat="5.4.0")
 ]
 
 products = [
@@ -87,6 +100,8 @@ products = [
     LibraryProduct("libcasadi_interpolant_linear", :libcasadi_interpolant_linear),
     LibraryProduct("libcasadi_linsol_csparse", :libcasadi_linsol_csparse),
     LibraryProduct("libcasadi_linsol_csparsecholesky", :libcasadi_linsol_csparsecholesky),
+    LibraryProduct("libcasadi_linsol_lapacklu", :libcasadi_linsol_lapacklu),
+    LibraryProduct("libcasadi_linsol_lapackqr", :libcasadi_linsol_lapackqr),
     LibraryProduct("libcasadi_linsol_ldl", :libcasadi_linsol_ldl),
     LibraryProduct("libcasadi_linsol_lsqr", :libcasadi_linsol_lsqr),
     LibraryProduct("libcasadi_linsol_qr", :libcasadi_linsol_qr),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -67,6 +67,19 @@ if [[ -n "${BLASFEO_LIBFILE}" ]]; then
     BLASFEO_ROOT=$(dirname "$(dirname "${BLASFEO_LIBFILE}")")
     echo "Found blasfeo at ${BLASFEO_LIBFILE}, root ${BLASFEO_ROOT}"
     export BLASFEO=${BLASFEO_ROOT}
+    # fatrop does `find_package(blasfeo REQUIRED)` in config mode and links
+    # blasfeo::blasfeo, but blasfeo_jll ships only include/ and lib/ -- no CMake
+    # package files at all. Drop in a minimal config so the ExternalProject can
+    # resolve it; removed again after install so it never reaches the tarball.
+    mkdir -p ${BLASFEO_ROOT}/lib/cmake/blasfeo
+    cat > ${BLASFEO_ROOT}/lib/cmake/blasfeo/blasfeo-config.cmake <<EOCFG
+if(NOT TARGET blasfeo::blasfeo)
+  add_library(blasfeo::blasfeo UNKNOWN IMPORTED)
+  set_target_properties(blasfeo::blasfeo PROPERTIES
+    IMPORTED_LOCATION "${BLASFEO_LIBFILE}"
+    INTERFACE_INCLUDE_DIRECTORIES "${BLASFEO_ROOT}/include")
+endif()
+EOCFG
     FATROP_FLAGS="-DWITH_BLASFEO=ON -DWITH_FATROP=ON -DWITH_BUILD_FATROP=ON"
     FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_REPO=${WORKSPACE}/srcdir/fatrop"
     FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_VERSION=2d8c5198a47890a55bb872ed4f895484c7769f74"
@@ -162,6 +175,9 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
 
 make -j ${nproc}
 make install
+
+# The blasfeo CMake shim was only needed during the build.
+rm -rf ${prefix}/blasfeo/lib/cmake
 
 # Build amplexe
 cd $WORKSPACE/srcdir

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -51,6 +51,19 @@ else
     LBT="${libdir}/libblastrampoline.${dlext}"
 fi
 
+# OSQP_jll installs a single- and a double-precision build into one prefix, and
+# the single one lands last: lib/cmake/osqp points osqp::osqp at
+# libosqp_builtin_single, and include/osqp/osqp_configure.h carries
+# `#define OSQP_USE_FLOAT`, so OSQPFloat is float for everyone. CasADi's
+# interface is double-only. Take a private copy of the headers with that define
+# removed, and let the patched CMake pick libosqp_builtin_double via
+# find_library (CMAKE_DISABLE_FIND_PACKAGE_OSQP keeps the shipped, single-
+# precision CMake config from winning first).
+OSQP_INC=${WORKSPACE}/srcdir/osqp-double-include
+mkdir -p ${OSQP_INC}
+cp -r ${includedir}/osqp ${OSQP_INC}/
+sed -i '/^#define OSQP_USE_FLOAT$/d' ${OSQP_INC}/osqp/osqp_configure.h
+
 # cbc.pc carries `-lasl` on every platform, which links fine everywhere except
 # Windows: ASL_jll's recipe only ever does `cp libasl.${dlext} ${libdir}`, so on
 # mingw it ships libasl.dll with no import library and `-lasl` has nothing to
@@ -80,6 +93,8 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DWITH_BONMIN=ON \
     ${HIGHS_FLAG} \
     -DWITH_OSQP=ON \
+    -DCMAKE_DISABLE_FIND_PACKAGE_OSQP=ON \
+    -DOSQP_INCLUDE_DIR="${OSQP_INC}/osqp" \
     -DWITH_CLP=ON \
     -DWITH_CBC=ON \
     -DWITH_QPOASES=ON \

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -42,6 +42,14 @@ else
     LBT="${libdir}/libblastrampoline.${dlext}"
 fi
 
+# cbc.pc carries `-lasl` on every platform, which links fine everywhere except
+# Windows: ASL_jll's recipe only ever does `cp libasl.${dlext} ${libdir}`, so on
+# mingw it ships libasl.dll with no import library and `-lasl` has nothing to
+# resolve against. The ASL symbols are already inside libCbc.dll, so drop it.
+if [[ "${target}" == *mingw* ]]; then
+    sed -i 's/-lasl//g' ${prefix}/lib/pkgconfig/*.pc
+fi
+
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_INSTALL_BINDIR=${bindir} \
     -DCMAKE_INSTALL_LIBDIR=${libdir} \

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -73,6 +73,11 @@ if [[ -n "${BLASFEO_LIBFILE}" ]]; then
     # resolve it; removed again after install so it never reaches the tarball.
     mkdir -p ${BLASFEO_ROOT}/lib/cmake/blasfeo
     cat > ${BLASFEO_ROOT}/lib/cmake/blasfeo/blasfeo-config.cmake <<EOCFG
+    # fatrop's own targets do not all pick up the include directory from the
+    # imported target, so put it on the compiler flags the ExternalProject
+    # inherits as well.
+    export CXXFLAGS="${CXXFLAGS} -I${BLASFEO_ROOT}/include"
+    export CFLAGS="${CFLAGS} -I${BLASFEO_ROOT}/include"
 if(NOT TARGET blasfeo::blasfeo)
   add_library(blasfeo::blasfeo UNKNOWN IMPORTED)
   set_target_properties(blasfeo::blasfeo PROPERTIES

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -58,39 +58,12 @@ else
     LBT="${libdir}/libblastrampoline.${dlext}"
 fi
 
-# OSQP_jll installs a single- and a double-precision build into one prefix, and
-# the single one lands last: lib/cmake/osqp points osqp::osqp at
-# libosqp_builtin_single, and include/osqp/osqp_configure.h carries
-# `#define OSQP_USE_FLOAT`, so OSQPFloat is float for everyone. CasADi's
-# interface is double-only. Take a private copy of the headers with that define
-# removed, and let the patched CMake pick libosqp_builtin_double via
-# find_library (CMAKE_DISABLE_FIND_PACKAGE_OSQP keeps the shipped, single-
-# precision CMake config from winning first).
-# blasfeo_jll installs into <prefix>/blasfeo/{include,lib} rather than straight
-# into the prefix, and FindBLASFEO.cmake looks under $BLASFEO. Only x86_64 (all
-# OSes) and aarch64 macOS have blasfeo artifacts, so fatrop is limited to those.
-FATROP_FLAGS="-DWITH_FATROP=OFF -DWITH_BLASFEO=OFF"
-if [[ -d "${prefix}/blasfeo" ]]; then
-    export BLASFEO=${prefix}/blasfeo
-    FATROP_FLAGS="-DWITH_BLASFEO=ON -DWITH_FATROP=ON -DWITH_BUILD_FATROP=ON"
-    FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_REPO=${WORKSPACE}/srcdir/fatrop"
-    FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_VERSION=2d8c5198a47890a55bb872ed4f895484c7769f74"
-    FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_SHALLOW=OFF"
-fi
-
-OSQP_CFG=$(find ${prefix} -name osqp_configure.h | head -1)
-if [[ -z "${OSQP_CFG}" ]]; then
-    echo "osqp_configure.h not found under ${prefix}; osqp files present:"
-    find ${prefix} -iname '*osqp*' | head -40
-    exit 1
-fi
-OSQP_INC=${WORKSPACE}/srcdir/osqp-double-include
-rm -rf ${OSQP_INC}
-mkdir -p ${OSQP_INC}
-cp -r "$(dirname ${OSQP_CFG})" ${OSQP_INC}/osqp
-sed -i '/^#define OSQP_USE_FLOAT$/d' ${OSQP_INC}/osqp/osqp_configure.h
-echo "OSQP headers copied from $(dirname ${OSQP_CFG})"
-grep -c OSQP_USE_FLOAT ${OSQP_INC}/osqp/osqp_configure.h || echo "OSQP_USE_FLOAT define removed"
+# OSQP is parked. The plugin itself works, but OSQP_jll ships one header tree
+# for its single- and double-precision builds with `#define OSQP_USE_FLOAT` in
+# it, so OSQPFloat is float and CasADi's double-only interface will not compile.
+# Sanitising the headers from the shell needs the layout in the prefix, which is
+# not what the artifact looks like; that belongs in the CMake patch, where
+# find_path has already resolved the directory. Re-enable once that is written.
 
 # cbc.pc carries `-lasl` on every platform, which links fine everywhere except
 # Windows: ASL_jll's recipe only ever does `cp libasl.${dlext} ${libdir}`, so on
@@ -121,9 +94,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DWITH_BONMIN=ON \
     ${HIGHS_FLAG} \
     ${FATROP_FLAGS} \
-    -DWITH_OSQP=ON \
-    -DCMAKE_DISABLE_FIND_PACKAGE_OSQP=ON \
-    -DOSQP_INCLUDE_DIR="${OSQP_INC}/osqp" \
+    -DWITH_OSQP=OFF \
     -DWITH_CLP=ON \
     -DWITH_CBC=ON \
     -DWITH_QPOASES=ON \
@@ -165,7 +136,6 @@ dependencies = [
     Dependency("Bonmin_jll"; compat="100.800.902"),
     Dependency("libblastrampoline_jll"; compat="5.4.0"),
     Dependency("HiGHS_jll"; compat="1.15.1", platforms=highs_platforms),
-    Dependency("OSQP_jll"; compat="100.0.0"),
     Dependency("blasfeo_jll"; compat="0.1.4", platforms=fatrop_platforms)
 ]
 
@@ -176,7 +146,6 @@ products = [
     LibraryProduct("libcasadi_conic_clp", :libcasadi_conic_clp),
     LibraryProduct("libcasadi_conic_ipqp", :libcasadi_conic_ipqp),
     LibraryProduct("libcasadi_conic_nlpsol", :libcasadi_conic_nlpsol),
-    LibraryProduct("libcasadi_conic_osqp", :libcasadi_conic_osqp),
     LibraryProduct("libcasadi_conic_qpoases", :libcasadi_conic_qpoases),
     LibraryProduct("libcasadi_conic_qrqp", :libcasadi_conic_qrqp),
     LibraryProduct("libcasadi_importer_shell", :libcasadi_importer_shell),

--- a/C/CasADi/build_tarballs.jl
+++ b/C/CasADi/build_tarballs.jl
@@ -78,10 +78,19 @@ if [[ -d "${prefix}/blasfeo" ]]; then
     FATROP_FLAGS="${FATROP_FLAGS} -DBUILD_FATROP_GIT_SHALLOW=OFF"
 fi
 
+OSQP_CFG=$(find ${prefix} -name osqp_configure.h | head -1)
+if [[ -z "${OSQP_CFG}" ]]; then
+    echo "osqp_configure.h not found under ${prefix}; osqp files present:"
+    find ${prefix} -iname '*osqp*' | head -40
+    exit 1
+fi
 OSQP_INC=${WORKSPACE}/srcdir/osqp-double-include
+rm -rf ${OSQP_INC}
 mkdir -p ${OSQP_INC}
-cp -r ${includedir}/osqp ${OSQP_INC}/
+cp -r "$(dirname ${OSQP_CFG})" ${OSQP_INC}/osqp
 sed -i '/^#define OSQP_USE_FLOAT$/d' ${OSQP_INC}/osqp/osqp_configure.h
+echo "OSQP headers copied from $(dirname ${OSQP_CFG})"
+grep -c OSQP_USE_FLOAT ${OSQP_INC}/osqp/osqp_configure.h || echo "OSQP_USE_FLOAT define removed"
 
 # cbc.pc carries `-lasl` on every platform, which links fine everywhere except
 # Windows: ASL_jll's recipe only ever does `cp libasl.${dlext} ${libdir}`, so on

--- a/C/CasADi/bundled/patches/0001-osqp-find-installed.patch
+++ b/C/CasADi/bundled/patches/0001-osqp-find-installed.patch
@@ -1,0 +1,33 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2538,6 +2538,30 @@
+       DESTINATION "${INCLUDE_PREFIX}")
+       create_import_library(osqp osqp)
+     set(WITH_OSQP_V1 ON CACHE BOOL "Use v1 ABI of OSQP")
++  elseif(NOT TARGET osqp::osqp)
++    # Use an OSQP that is already installed on the system instead of cloning
++    # one at build time. OSQP_LIBRARY and OSQP_INCLUDE_DIR may be supplied by
++    # the caller; otherwise look in the usual places. The suffixed name comes
++    # from OSQP's own OSQP_LIB_SUFFIX option, which distributors use to ship
++    # several precision/algebra variants side by side.
++    if(NOT OSQP_LIBRARY)
++      find_library(OSQP_LIBRARY NAMES osqp osqp_builtin_double)
++    endif()
++    if(NOT OSQP_INCLUDE_DIR)
++      find_path(OSQP_INCLUDE_DIR osqp_api_functions.h PATH_SUFFIXES osqp)
++    endif()
++    if(NOT OSQP_LIBRARY OR NOT OSQP_INCLUDE_DIR)
++      message(FATAL_ERROR "WITH_OSQP is on but OSQP was not found. Set "
++        "OSQP_LIBRARY and OSQP_INCLUDE_DIR, or enable WITH_BUILD_OSQP.")
++    endif()
++    message(STATUS "OSQP library: ${OSQP_LIBRARY}")
++    message(STATUS "OSQP headers: ${OSQP_INCLUDE_DIR}")
++    add_library(osqp UNKNOWN IMPORTED)
++    set_target_properties(osqp PROPERTIES
++      IMPORTED_LOCATION "${OSQP_LIBRARY}"
++      INTERFACE_INCLUDE_DIRECTORIES "${OSQP_INCLUDE_DIR}")
++    add_library(osqp::osqp INTERFACE IMPORTED)
++    set_target_properties(osqp::osqp PROPERTIES INTERFACE_LINK_LIBRARIES osqp)
+   endif()
+ endif()
+ add_feature_info(osqp-interface WITH_OSQP "Interface to QP solver OSQP.")

--- a/C/CasADi/bundled/patches/0002-blasfeo-find-installed.patch
+++ b/C/CasADi/bundled/patches/0002-blasfeo-find-installed.patch
@@ -1,0 +1,28 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1579,8 +1579,23 @@
+         PATTERN "blasfeo*.h"
+         PATTERN "hpipm*.h")
+   else()
+-    #add_library(lapack INTERFACE)
+-    #target_link_libraries(lapack INTERFACE ${LAPACK_LIBRARIES})
++    # Use a BLASFEO that is already installed (FindBLASFEO honours the BLASFEO
++    # environment variable) rather than building one. Both the imported target
++    # and BLASFEO_PATH are needed downstream: fatrop and hpipm link the former
++    # and pass the latter into their own CMake.
++    if(NOT BLASFEO_FOUND)
++      message(FATAL_ERROR "WITH_BLASFEO is on but BLASFEO was not found. Set the "
++        "BLASFEO environment variable, or enable WITH_BUILD_BLASFEO.")
++    endif()
++    if(NOT TARGET blasfeo)
++      add_library(blasfeo UNKNOWN IMPORTED)
++      set_target_properties(blasfeo PROPERTIES
++        IMPORTED_LOCATION "${BLASFEO_LIB}"
++        INTERFACE_INCLUDE_DIRECTORIES "${BLASFEO_INCLUDE_DIR}")
++    endif()
++    get_filename_component(BLASFEO_PATH "${BLASFEO_INCLUDE_DIR}" DIRECTORY)
++    message(STATUS "BLASFEO library: ${BLASFEO_LIB}")
++    message(STATUS "BLASFEO prefix:  ${BLASFEO_PATH}")
+   endif()
+ endif()
+ 


### PR DESCRIPTION
Draft / experimental. Companion to #14555 (`[CasADi] Update to v3.8.0`); this PR worked out which additional CasADi capabilities can be turned on in the JLL, one batch at a time. **Not for merge as-is** — the confirmed set should fold into #14555.

## Result

Latest build: **13 of 15 platforms green, 0 failures.** The two stragglers (`i686-linux-gnu`, `i686-w64-mingw32`) are stuck in the intermittent audit hang described below; both passed in earlier rounds.

| capability | option(s) | platforms | source |
|---|---|---|---|
| `conic_qpoases` | `WITH_QPOASES` | all | bundled in `external_packages/qpOASES` |
| `nlpsol_blocksqp` | `WITH_BLOCKSQP` | all | bundled in `casadi/interfaces/blocksqp` |
| `conic_clp` | `WITH_CLP` | all | `Clp_jll`, already present via `Bonmin_jll` |
| `conic_cbc` | `WITH_CBC` | all | `Cbc_jll`, already present via `Bonmin_jll` |
| `linsol_lapacklu` / `lapackqr` | `WITH_LAPACK` | all | `libblastrampoline_jll` |
| `conic_highs` | `WITH_HIGHS` | all but ppc64le | `HiGHS_jll` |
| **`.fmu` loading** | `WITH_ZLIB`, `WITH_LIBZIP` | all | `libzip_jll`, `Zlib_jll` |
| `nlpsol_fatrop` | `WITH_FATROP` + `WITH_BUILD_FATROP` | x86_64 Linux | vendored `GitSource` + `blasfeo_jll` |

Two techniques did most of the work and are worth noting for other recipes:

- **Platform-scoped dependencies and products.** `Dependency(...; platforms=...)` plus one `build_tarballs` call per platform (the `B/blasfeo` idiom) means a JLL that covers only part of the matrix does not force the whole build down to its subset.
- **Vendored `ExternalProject_Add`.** Yggdrasil fetches `sources` outside the sandbox, so adding fatrop as a `GitSource` and pointing `BUILD_FATROP_GIT_REPO` at `${WORKSPACE}/srcdir/fatrop` lets CasADi's own ExternalProject clone from disk with no network. `E/ESBMC` and `D/databento_julia` do the `FetchContent` equivalent.

## FMU

`WITH_FMI2` / `WITH_FMI3` were never at risk — they default ON and use bundled headers. But `.fmu` files are zip archives, and without libzip `resource_internal.cpp` raises *"Unzipping '<path>' requires libzip. Compile CasADi with WITH_LIBZIP=ON"*, so every FMU had to be unzipped by hand first. `libzip_jll` covers the full platform set and pulls `Zlib_jll` itself.

## Still open

**OSQP.** Off. `OSQP_jll` installs its single- and double-precision builds into one prefix and the single one lands last, so `lib/cmake/osqp` points `osqp::osqp` at `libosqp_builtin_single` *and* `include/osqp/osqp_configure.h` carries `#define OSQP_USE_FLOAT`. CasADi's interface is double-only. `bundled/patches/0001-osqp-find-installed.patch` adds the missing discovery branch and is kept; the remaining work is to have it *retarget* the imported target `find_package` already created rather than trying to suppress that call, which trips CasADi's own "OSQP not found yet required" check at `CMakeLists.txt:1291`.

**fatrop on macOS.** Two upstream blockers: fatrop's `src/ip_algorithm/ip_utils.cpp:11` hits *"call to 'abs' is ambiguous"* under clang, and `casadi_blas_blasfeo` fails to link with undefined `blasfeo_blas_dgemm` / `daxpy` / `ddot` because `blasfeo_jll` is built without blasfeo's optional BLAS API. Linux only tolerates the latter because shared libraries there may carry undefined symbols — that plugin would still fail when used, so it is worth fixing regardless of platform.

## The audit hang (relevant to #14555)

The `aarch64-apple-darwin` failure blocking #14555 is not a build failure. In [build 32120](https://buildkite.com/julialang/yggdrasil/builds/32120) that job compiled, installed and linked cleanly, exiting 0 three minutes in, then hung after `Beginning audit of ...` until the five-hour timeout. It is intermittent and not platform-specific — it has since hit `armv6l-linux-gnueabihf` and `i686-linux-gnu`, and `aarch64-apple-darwin` has passed repeatedly. Every platform has now built and audited green at least once. **#14555 most likely just needs a re-trigger.**

## Upstream issues found

- `blasfeo_jll` ships no CMake config (this PR writes a shim), and is built without blasfeo's BLAS API.
- `OSQP_jll` — single-precision install clobbers the shared headers, giving any double-precision consumer a silent ABI mismatch.
- `ASL_jll` — installs `libasl.dll` with no import library on mingw, so the `-lasl` in `cbc.pc` cannot resolve.
- fatrop — `abs` ambiguity under clang.
- CasADi — `external_packages/qpOASES/CMakeLists.txt:22` passes a bare `${BLAS_LIBRARIES}`, which reaches the linker as `-lFALSE` when unset; `WITH_SYSTEM_SUNDIALS` is defined by the build system but read nowhere, so `WITH_BUILD_SUNDIALS=OFF` cannot work.