### PR TITLE
[aws_c_auth] Update to version 1.0.0

### DIFF
--- a/A/aws_c_auth/build_tarballs.jl
+++ b/A/aws_c_auth/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_auth"
-version = v"0.10.5"
+version = v"1.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-auth.git", "eff3bb91d56fc0e245d378ebe2a62c3ea7380755"),
+    GitSource("https://github.com/awslabs/aws-c-auth.git", "055e822f021d1cab11d608b94ac34de250986134"),
 ]
 
 # Bash recipe for building
@@ -38,7 +38,7 @@ products = [
 dependencies = [
     Dependency("aws_c_cal_jll"; compat="1.0.0"),
     Dependency("aws_c_http_jll"; compat="1.0.0"),
-    Dependency("aws_c_sdkutils_jll"; compat="0.2.10"),
+    Dependency("aws_c_sdkutils_jll"; compat="1.0.0"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_auth to version 1.0.0.

All runtime deps pinned at latest known.
- `aws_c_cal_jll`: 1.0.0
- `aws_c_http_jll`: 1.0.0
- `aws_c_sdkutils_jll`: 1.0.0

cc: @Octogonapus