### PR TITLE
[aws_c_mqtt] Update to version 0.16.2

### DIFF
--- a/A/aws_c_mqtt/build_tarballs.jl
+++ b/A/aws_c_mqtt/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_mqtt"
-version = v"0.15.2"
+version = v"0.16.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-mqtt.git", "3c2ceee52b66db42228053a4fb55210c8f8433a0"),
+    GitSource("https://github.com/awslabs/aws-c-mqtt.git", "7b420e769391cf91e56e70fdec5125735d698a33"),
 ]
 
 # Bash recipe for building across all platforms
@@ -36,8 +36,8 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("aws_c_http_jll"; compat="0.10.11"),
-    Dependency("aws_c_io_jll"; compat="0.26.3"),
+    Dependency("aws_c_http_jll"; compat="1.0.0"),
+    Dependency("aws_c_io_jll"; compat="1.0.0"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_mqtt to version 0.16.2.

All runtime deps pinned at latest known.
- `aws_c_http_jll`: 1.0.0
- `aws_c_io_jll`: 1.0.0

cc: @Octogonapus