### PR TITLE
[aws_c_s3] Update to version 0.13.7

### DIFF
--- a/A/aws_c_s3/build_tarballs.jl
+++ b/A/aws_c_s3/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_s3"
-version = v"0.12.8"
+version = v"0.13.7"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-s3.git", "448ec5e49eb181687f9af39b0d3b83a563b15039"),
+    GitSource("https://github.com/awslabs/aws-c-s3.git", "2e74399ae4393f426d462fe56beed8b4a6c90f51"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_c_s3 to version 0.13.7.

All runtime deps pinned at latest known.
- `aws_c_auth_jll`: 1.0.0
- `aws_c_common_jll`: 1.0.0
- `aws_c_http_jll`: 1.0.0
- `aws_checksums_jll`: 1.0.0
- `s2n_tls_jll`: 1.7.8

cc: @Octogonapus