### PR TITLE
[aws_c_event_stream] Update to version 0.7.2

### DIFF
--- a/A/aws_c_event_stream/build_tarballs.jl
+++ b/A/aws_c_event_stream/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_event_stream"
-version = v"0.7.0"
+version = v"0.7.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-event-stream.git", "66cafb1d8bb1bfeb62a7601ce03d1a6fcd4798ed"),
+    GitSource("https://github.com/awslabs/aws-c-event-stream.git", "f18e12078b3e53a3f2ac9c5853ddc3502b09938d"),
 ]
 
 # Bash recipe for building across all platforms
@@ -36,9 +36,9 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("aws_c_common_jll"; compat="0.12.6"),
-    Dependency("aws_c_io_jll"; compat="0.26.3"),
-    Dependency("aws_checksums_jll"; compat="0.2.10"),
+    Dependency("aws_c_common_jll"; compat="1.0.0"),
+    Dependency("aws_c_io_jll"; compat="1.0.0"),
+    Dependency("aws_checksums_jll"; compat="1.0.0"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_event_stream to version 0.7.2.

All runtime deps pinned at latest known.
- `aws_c_common_jll`: 1.0.0
- `aws_c_io_jll`: 1.0.0
- `aws_checksums_jll`: 1.0.0

cc: @Octogonapus