### PR TITLE
[aws_c_event_stream] Update to version 1.0.0

### DIFF
--- a/A/aws_c_event_stream/build_tarballs.jl
+++ b/A/aws_c_event_stream/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_event_stream"
-version = v"0.7.2"
+version = v"1.0.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-event-stream.git", "f18e12078b3e53a3f2ac9c5853ddc3502b09938d"),
+    GitSource("https://github.com/awslabs/aws-c-event-stream.git", "d32600bfecc6616cab0c478f96ea5a779f03e05e"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates aws_c_event_stream to version 1.0.0.

All runtime deps pinned at latest known.
- `aws_c_common_jll`: 1.0.0
- `aws_c_io_jll`: 1.0.0
- `aws_checksums_jll`: 1.0.0

cc: @Octogonapus