### PR TITLE
[aws_c_iot] Update to version 0.2.2

### DIFF
--- a/A/aws_c_iot/build_tarballs.jl
+++ b/A/aws_c_iot/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_iot"
-version = v"0.2.1"
+version = v"0.2.2"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-iot.git", "9f0c152ed76af1a45d99fb98286707aa23c728af"),
+    GitSource("https://github.com/awslabs/aws-c-iot.git", "b593da73dcb1641d99a96777b6d134cfc3d7357f"),
 ]
 
 # Bash recipe for building across all platforms
@@ -36,7 +36,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency("aws_c_mqtt_jll"; compat="0.12.2"),
+    Dependency("aws_c_mqtt_jll"; compat="1.0.0"),
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_iot to version 0.2.2.

All runtime deps pinned at latest known.
- `aws_c_mqtt_jll`: 1.0.0

cc: @Octogonapus