### PR TITLE
[CUDA_Driver] Add Tegra compatibility drivers by L4T generation

### DIFF
--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -20,8 +20,22 @@ driver_version = "610.43.02"
 # wrapper code changes in ways consumers need to express compat bounds against (Julia
 # package resolution cannot distinguish build numbers). 13.3.1: introduction of the
 # toolkit selection library in the toplevel block. 13.3.2: detailed driver-inspection
-# failure diagnostics (dependency load vs. dlopen vs. cuInit failures).
+# failure diagnostics and the `tegra` platform tag with per-KMD-generation artifacts
+# shipping the L4T compatibility drivers.
 version = v"13.3.2"
+
+# the Tegra compat drivers to ship, per kernel-mode driver generation (the `tegra`
+# platform tag; see tegra_detection.jl). NVIDIA built L4T compat UMDs against the r35
+# KMD through CUDA 12.2 and against r36 through 12.9; only the newest UMD per KMD
+# generation is worth shipping (any older toolkit runs on a newer same-major UMD).
+# no compat driver exists for r32 (JetPack 4), and from r38 (JetPack 7) on the
+# driver ships with the L4T BSP itself, so those get helper-only artifacts.
+tegra_compat_drivers = [
+    # tegra tag => (cuda version of the redist manifest, compat driver version)
+    "35" => (v"12.2.2", v"12.2.34086590"),
+    "36" => (v"12.9.1", v"12.9.40580548"),
+]
+tegra_helper_only = ["32", "38"]
 
 script = raw"""
     # Build the driver inspection binary. On Linux/macOS we need -ldl for
@@ -36,12 +50,14 @@ script = raw"""
     fi
 
     # Install the forwards-compatible driver from the CUDA toolkit. NVIDIA only
-    # ships this on Linux.
-    if [[ ${target} == *-linux-gnu ]]; then
+    # ships this on Linux. Helper-only builds have no cuda_compat source.
+    if [[ ${target} == *-linux-gnu ]] && compgen -G "${WORKSPACE}/srcdir/cuda_compat*" >/dev/null; then
         mkdir -p ${libdir}
         cd ${WORKSPACE}/srcdir/cuda_compat*
         install_license LICENSE
         mv compat/* ${libdir}
+        # the L4T packages also contain MPS executables; keep those in bindir
+        mv ${libdir}/nvidia-cuda-mps-* ${bindir} 2>/dev/null || true
     fi
 """
 
@@ -61,6 +77,7 @@ init_block = map(eachline(IOBuffer(init_block))) do line
     end |> join
 
 helper_product = ExecutableProduct("cuda_inspect_driver", :cuda_inspect_driver)
+# the datacenter/sbsa compat driver, as shipped with the CUDA toolkit
 compat_products = [
     LibraryProduct("libcuda", :libcuda_compat;                            dont_dlopen=true),
     LibraryProduct("libcudadebugger", :libcuda_debugger;                  dont_dlopen=true),
@@ -70,21 +87,28 @@ compat_products = [
     LibraryProduct("libnvidia-tileiras", :libnvidia_tileiras;             dont_dlopen=true),
     helper_product,
 ]
+# the L4T compat drivers lack the newer desktop-only libraries; init.jl only
+# references products that are actually defined for the selected artifact
+l4t_compat_products = [
+    LibraryProduct("libcuda", :libcuda_compat;                            dont_dlopen=true),
+    LibraryProduct("libcudadebugger", :libcuda_debugger;                  dont_dlopen=true),
+    LibraryProduct("libnvidia-nvvm", :libnvidia_nvvm;                     dont_dlopen=true),
+    LibraryProduct("libnvidia-ptxjitcompiler", :libnvidia_ptxjitcompiler; dont_dlopen=true),
+    helper_product,
+]
 
 dependencies = []
 
-# Platforms that ship the forwards-compatible driver alongside the helper.
-compat_platforms = [Platform("x86_64", "linux"),
-                    Platform("aarch64", "linux")]
-
-# Platforms where we only build the cuda_inspect_driver helper, without a
-# forwards-compatible libcuda. CUDA_Runtime_jll's platform augmentation needs
-# the JLL to be `is_available()` on these platforms so it can pick a runtime
-# artifact based on the system driver.
-helper_only_platforms = [Platform("x86_64", "windows")]
+# Every artifact carries an explicit value for the `tegra` tag matching what
+# `augment_platform!` computes. This leaves no untagged artifact that could match
+# every Tegra generation; in particular, a Tegra host must never receive the
+# SBSA/datacenter compat driver, which cannot drive the Tegra iGPU.
 
 builds = []
-for platform in compat_platforms
+
+# platforms that ship the datacenter forwards-compatible driver alongside the helper
+for platform in [Platform("x86_64", "linux"; tegra="none"),
+                 Platform("aarch64", "linux"; tegra="none")]
     augmented_platform = deepcopy(platform)
     augmented_platform["cuda"] = CUDA.platform(cuda_version)
     should_build_platform(triplet(augmented_platform)) || continue
@@ -99,6 +123,32 @@ for platform in compat_platforms
 
     push!(builds, (; platforms=[platform], sources, products=compat_products))
 end
+
+# Tegra generations with an L4T compat driver
+for (tegra, (manifest_version, compat_version)) in tegra_compat_drivers
+    platform = Platform("aarch64", "linux"; tegra)
+    augmented_platform = deepcopy(platform)
+    augmented_platform["cuda"] = CUDA.platform(compat_version)
+    should_build_platform(triplet(augmented_platform)) || continue
+
+    # `get_sources` needs the cuda_platform tag to map pre-13 aarch64 onto the
+    # Tegra (`linux-aarch64`) entries of the redist manifest
+    source_platform = deepcopy(augmented_platform)
+    source_platform["cuda_platform"] = "jetson"
+    sources = get_sources("cuda", ["cuda_compat"]; version=manifest_version,
+                          platform=source_platform)
+    push!(sources, DirectorySource("./src"))
+
+    push!(builds, (; platforms=[platform], sources, products=l4t_compat_products))
+end
+
+# platforms where we only build the cuda_inspect_driver helper, without a
+# forwards-compatible libcuda: Windows (NVIDIA doesn't ship one), and Tegra
+# generations without an applicable compat driver. CUDA_Runtime_jll's platform
+# augmentation needs the JLL to be `is_available()` on these platforms so it
+# can pick a runtime artifact based on the system driver.
+helper_only_platforms = [Platform("x86_64", "windows"; tegra="none");
+                         [Platform("aarch64", "linux"; tegra) for tegra in tegra_helper_only]]
 for platform in helper_only_platforms
     augmented_platform = deepcopy(platform)
     augmented_platform["cuda"] = CUDA.platform(cuda_version)
@@ -115,13 +165,34 @@ non_platform_ARGS = filter(arg -> startswith(arg, "--"), ARGS)
 # `--register` should only be passed to the latest `build_tarballs` invocation
 non_reg_ARGS = filter(arg -> arg != "--register", non_platform_ARGS)
 
+# Private Tegra routing, spliced into the self-contained augmentation block.
+# Reusable detection helpers are exposed by the unconditional toplevel block.
+tegra_detection = read(joinpath(@__DIR__, "tegra_detection.jl"), String)
+
+# platform augmentation: set the `tegra` tag so that Tegra hosts select the
+# artifact with the compat driver matching their kernel-mode driver generation.
+# Re-adding this block makes Pkg spawn an artifact-selection subprocess for this
+# JLL during package operations (add/instantiate/etc), not during ordinary use.
+augment_platform_block = """
+    using Base.BinaryPlatforms
+
+    $(tegra_detection)
+
+    function augment_platform!(platform::Platform)
+        haskey(platform, "tegra") && return platform
+        platform["tegra"] = _tegra_artifact_generation()
+        return platform
+    end"""
+
 # driver inspection and toolkit selection functionality, shared with the platform
 # augmentation hooks of dependent JLLs (which access it with `using CUDA_Driver_jll`)
 # and with CUDA.jl. this goes into the module's `toplevel_block` so that it is defined
-# unconditionally, even on platforms without a matching artifact. we deliberately do
-# not use an `augment_platform_block` here: it would be included both in the module
-# and in Pkg's artifact-selection subprocess, and its mere presence makes every Pkg
-# resolve spawn such a subprocess for this JLL.
+# unconditionally, even on platforms without a matching artifact.
+#
+# The augmentation block is also included in the JLL module, so the toplevel block
+# can expose the private Tegra detection through public wrappers without repeating its
+# definitions (which would cause method-overwrite errors during precompilation). The
+# clamped artifact-generation function remains an implementation detail.
 toplevel_block = read(joinpath(@__DIR__, "toplevel.jl"), String)
 
 for (i,build) in enumerate(builds)
@@ -129,5 +200,5 @@ for (i,build) in enumerate(builds)
                    name, version, build.sources, script,
                    build.platforms, build.products, dependencies;
                    skip_audit=true, init_block, julia_compat="1.10",
-                   toplevel_block)
+                   augment_platform_block, toplevel_block)
 end

--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -19,8 +19,9 @@ driver_version = "610.43.02"
 # the JLL version tracks `cuda_version`, but can diverge in the patch digit when the
 # wrapper code changes in ways consumers need to express compat bounds against (Julia
 # package resolution cannot distinguish build numbers). 13.3.1: introduction of the
-# toolkit selection library in the toplevel block.
-version = v"13.3.1"
+# toolkit selection library in the toplevel block. 13.3.2: detailed driver-inspection
+# failure diagnostics (dependency load vs. dlopen vs. cuInit failures).
+version = v"13.3.2"
 
 script = raw"""
     # Build the driver inspection binary. On Linux/macOS we need -ldl for

--- a/C/CUDA/CUDA_Driver/init.jl
+++ b/C/CUDA/CUDA_Driver/init.jl
@@ -57,9 +57,15 @@ if Libdl.dlopen(libcuda_system, Libdl.RTLD_NOLOAD; throw_error=false) !== nothin
     return
 end
 
-# only reference the compat-driver dependency products now that we've
-# confirmed they exist (helper-only builds don't declare these symbols).
-libcuda_deps = [libcuda_debugger, libnvidia_nvvm, libnvidia_ptxjitcompiler, libnvidia_gpucomp, libnvidia_tileiras]
+# collect the compat driver's dependent libraries. not every artifact declares
+# every product (helper-only builds declare none, and the L4T compat drivers lack
+# the newer desktop-only libraries), so only reference those that exist.
+libcuda_deps = String[]
+for dep in [:libcuda_debugger, :libnvidia_nvvm, :libnvidia_ptxjitcompiler,
+            :libnvidia_gpucomp, :libnvidia_tileiras]
+    isdefined(@__MODULE__, dep) || continue
+    push!(libcuda_deps, getfield(@__MODULE__, dep))
+end
 
 # fetch driver details
 compat_driver_task = @static if VERSION >= v"1.12-"

--- a/C/CUDA/CUDA_Driver/init.jl
+++ b/C/CUDA/CUDA_Driver/init.jl
@@ -76,13 +76,13 @@ else
 end
 compat_driver_info = fetch(compat_driver_task)
 if compat_driver_info === nothing
-    @debug "Failed to load forwards-compatible driver."
+    @debug "Forwards-compatible driver is not usable (see above for details); using system driver."
     return
 end
 @debug "Forwards compatible driver version: $(compat_driver_info.version)"
 system_driver_info = fetch(system_driver_task)
 if system_driver_info === nothing
-    @debug "Failed to load system driver."
+    @debug "Could not query the system driver (see above for details); using system driver."
     return
 end
 @debug "System driver version: $(system_driver_info.version)"

--- a/C/CUDA/CUDA_Driver/src/cuda_inspect_driver.c
+++ b/C/CUDA/CUDA_Driver/src/cuda_inspect_driver.c
@@ -1,4 +1,19 @@
-/* Script to check the usability of CUDA drivers. */
+/* Helper binary to check the usability of CUDA drivers.
+ *
+ * Loads the given driver library (after preloading any dependent libraries)
+ * in this throw-away process and calls `cuInit` to verify the driver actually
+ * works, which e.g. dlopen or `cuDriverGetVersion` alone do not prove: a
+ * user-mode driver that mismatches the loaded kernel-mode driver typically
+ * loads and reports a version just fine, and only fails at `cuInit`.
+ *
+ * On success, prints to stdout:
+ *   <resolved driver path>
+ *   <driver version "major.minor.patch">
+ *   [one "major.minor" compute capability per device, with <inspect_devices>]
+ * On failure, exits with a distinct nonzero status per failure stage and
+ * prints a diagnostic to stderr identifying what failed; callers surface that
+ * diagnostic (e.g. in debug logs) so that a rejected driver can be told apart
+ * from one that merely failed to load. */
 
 /* On glibc-based Linux, dlinfo/RTLD_DI_LINKMAP require _GNU_SOURCE. The build
  * script passes -D_GNU_SOURCE in CFLAGS. */
@@ -24,6 +39,10 @@
       }
       return 0;
   }
+  static void lib_error(const char *what, const char *path) {
+      fprintf(stderr, "could not load %s %s: error %lu\n", what, path,
+              GetLastError());
+  }
 #else
   #include <dlfcn.h>
   #include <link.h>
@@ -48,7 +67,24 @@
       out[out_size - 1] = '\0';
       return 0;
   }
+  static void lib_error(const char *what, const char *path) {
+      const char *err = dlerror();
+      fprintf(stderr, "could not load %s %s: %s\n", what, path,
+              err ? err : "unknown error");
+  }
 #endif
+
+/* Exit codes, one per failure stage. */
+enum {
+    EXIT_USAGE = 1,
+    EXIT_DEP_LOAD_FAILED,
+    EXIT_DRIVER_LOAD_FAILED,
+    EXIT_DRIVER_PATH_FAILED,
+    EXIT_SYMBOL_MISSING,
+    EXIT_CUINIT_FAILED,
+    EXIT_VERSION_FAILED,
+    EXIT_DEVICE_FAILED,
+};
 
 const int DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR = 75;
 const int DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR = 76;
@@ -63,7 +99,7 @@ typedef int (*cuDeviceGetAttribute_t)(int *, unsigned int, int);
 int main(int argc, char *argv[]) {
     if (argc < 3) {
         fprintf(stderr, "Usage: %s <driver> <inspect_devices> [deps...]\n", argv[0]);
-        return -1;
+        return EXIT_USAGE;
     }
 
     const char *driver = argv[1];
@@ -71,13 +107,15 @@ int main(int argc, char *argv[]) {
 
     for (int i = 3; i < argc; i++) {
         if (lib_open(argv[i]) == NULL) {
-            return -1;
+            lib_error("dependent library", argv[i]);
+            return EXIT_DEP_LOAD_FAILED;
         }
     }
 
     lib_handle_t library_handle = lib_open(driver);
     if (library_handle == NULL) {
-        return -1;
+        lib_error("driver", driver);
+        return EXIT_DRIVER_LOAD_FAILED;
     }
 
     /* Report the resolved absolute path of the loaded driver, so that callers
@@ -85,27 +123,32 @@ int main(int argc, char *argv[]) {
      * having to dlopen the library themselves. */
     char path_buf[4096];
     if (lib_path(library_handle, path_buf, sizeof(path_buf)) != 0) {
-        return -1;
+        fprintf(stderr, "could not resolve the path of the loaded driver\n");
+        return EXIT_DRIVER_PATH_FAILED;
     }
     printf("%s\n", path_buf);
 
     cuInit_t cuInit = (cuInit_t)lib_sym(library_handle, "cuInit");
     if (cuInit == NULL) {
-        return -2;
+        fprintf(stderr, "driver does not provide cuInit\n");
+        return EXIT_SYMBOL_MISSING;
     }
     int status = cuInit(0);
     if (status != 0) {
-        return -2;
+        fprintf(stderr, "cuInit failed with status %d\n", status);
+        return EXIT_CUINIT_FAILED;
     }
 
     cuDriverGetVersion_t cuDriverGetVersion = (cuDriverGetVersion_t)lib_sym(library_handle, "cuDriverGetVersion");
     if (cuDriverGetVersion == NULL) {
-        return -3;
+        fprintf(stderr, "driver does not provide cuDriverGetVersion\n");
+        return EXIT_SYMBOL_MISSING;
     }
     int version;
     status = cuDriverGetVersion(&version);
     if (status != 0) {
-        return -3;
+        fprintf(stderr, "cuDriverGetVersion failed with status %d\n", status);
+        return EXIT_VERSION_FAILED;
     }
     int major = version / 1000;
     int ver = version % 1000;
@@ -116,37 +159,43 @@ int main(int argc, char *argv[]) {
     if (inspect_devices) {
         cuDeviceGetCount_t cuDeviceGetCount = (cuDeviceGetCount_t)lib_sym(library_handle, "cuDeviceGetCount");
         if (cuDeviceGetCount == NULL) {
-            return -4;
+            fprintf(stderr, "driver does not provide cuDeviceGetCount\n");
+            return EXIT_SYMBOL_MISSING;
         }
         int device_count;
         status = cuDeviceGetCount(&device_count);
         if (status != 0) {
-            return -4;
+            fprintf(stderr, "cuDeviceGetCount failed with status %d\n", status);
+            return EXIT_DEVICE_FAILED;
         }
 
         cuDeviceGet_t cuDeviceGet = (cuDeviceGet_t)lib_sym(library_handle, "cuDeviceGet");
         cuDeviceGetAttribute_t cuDeviceGetAttribute = (cuDeviceGetAttribute_t)lib_sym(library_handle, "cuDeviceGetAttribute");
         if (cuDeviceGet == NULL || cuDeviceGetAttribute == NULL) {
-            return -5;
+            fprintf(stderr, "driver does not provide cuDeviceGet/cuDeviceGetAttribute\n");
+            return EXIT_SYMBOL_MISSING;
         }
 
         for (int i = 0; i < device_count; i++) {
             int device = -1;
             status = cuDeviceGet(&device, i);
             if (status != 0) {
-                return -5;
+                fprintf(stderr, "cuDeviceGet failed with status %d\n", status);
+                return EXIT_DEVICE_FAILED;
             }
 
             int dev_major;
             status = cuDeviceGetAttribute(&dev_major, DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device);
             if (status != 0) {
-                return -6;
+                fprintf(stderr, "cuDeviceGetAttribute failed with status %d\n", status);
+                return EXIT_DEVICE_FAILED;
             }
 
             int dev_minor;
             status = cuDeviceGetAttribute(&dev_minor, DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device);
             if (status != 0) {
-                return -7;
+                fprintf(stderr, "cuDeviceGetAttribute failed with status %d\n", status);
+                return EXIT_DEVICE_FAILED;
             }
 
             printf("%d.%d\n", dev_major, dev_minor);

--- a/C/CUDA/CUDA_Driver/tegra_detection.jl
+++ b/C/CUDA/CUDA_Driver/tegra_detection.jl
@@ -1,0 +1,70 @@
+# Private Tegra platform detection used while selecting CUDA_Driver_jll's own
+# artifact. This code runs in Pkg's standalone artifact-selection subprocess,
+# where CUDA_Driver_jll cannot import itself. The artifact-independent
+# `is_tegra` and `l4t_version` helpers are exposed publicly from `toplevel.jl`.
+
+function _is_tegra()
+    if isfile("/etc/nv_tegra_release")
+        return true
+    end
+    if isfile("/proc/device-tree/compatible") &&
+        contains(read("/proc/device-tree/compatible", String), "tegra")
+        return true
+    end
+    return false
+end
+
+function _parse_l4t_version(release)
+    m = match(r"^# R(\d+) \(release\), REVISION: ([0-9]+(?:\.[0-9]+)*)", release)
+    m === nothing && return nothing
+    return tryparse(VersionNumber, string(m.captures[1], ".", m.captures[2]))
+end
+
+function _l4t_version()
+    try
+        isfile("/etc/nv_tegra_release") || return nothing
+        return _parse_l4t_version(read("/etc/nv_tegra_release", String))
+    catch
+        return nothing
+    end
+end
+
+# _tegra_artifact_generation()
+#
+# Return the value of the `tegra` platform tag for the current host: "none" on
+# non-Tegra systems, or the L4T major version (the kernel-mode driver generation,
+# e.g. "35" for JetPack 5) bucketed to the generations we ship artifacts for:
+# "32" (JetPack 4 and earlier: no compat driver exists), "35" (JetPack 5: compat
+# drivers up to CUDA 12.2), "36" (JetPack 6: up to CUDA 12.9), and "38" (JetPack
+# 7 and later, and unidentifiable L4T versions: no compat driver applies).
+# This function never throws.
+function _tegra_artifact_generation()
+    tegra = try
+        _is_tegra()
+    catch
+        false
+    end
+    tegra || return "none"
+
+    try
+        l4t = _l4t_version()
+        l4t === nothing && return "38"
+        if l4t.major < 35
+            return "32"
+        elseif l4t.major == 35
+            return "35"
+        elseif 36 <= l4t.major < 38
+            return "36"
+        else
+            # JetPack 7+ (r38/r39), or a Tegra system whose L4T version we
+            # cannot determine: no compat driver applies, so route to the
+            # helper-only artifact.
+            return "38"
+        end
+    catch
+        # We already identified this as a Tegra host. If its L4T release cannot
+        # be read, route it to a helper-only artifact rather than risk selecting
+        # the incompatible SBSA driver.
+        return "38"
+    end
+end

--- a/C/CUDA/CUDA_Driver/toplevel.jl
+++ b/C/CUDA/CUDA_Driver/toplevel.jl
@@ -14,45 +14,60 @@ const selection_api = v"1"
 
 using Base: thismajor, thisminor
 
-# Precompile the process-spawning and version-parsing hot path of `inspect_driver`,
-# because platform augmentation hooks call it from Pkg's `select_artifacts.jl`
-# subprocess, which runs with `--compile=min`.
+# Precompile statements for the process-spawning and version-parsing hot path of
+# `inspect_driver`, because platform augmentation hooks call it from Pkg's
+# `select_artifacts.jl` subprocess, which runs with `--compile=min`. The entry
+# points are precompiled at the bottom of this file (which caches their inferable
+# callees as well); Base methods only reached through dynamic dispatch are listed
+# here explicitly.
 precompile(Tuple{typeof(Base.cmd_gen), Tuple{Tuple{Base.Cmd}, Tuple{String}, Tuple{Bool}, Tuple{Array{String, 1}}}})
 precompile(Tuple{typeof(Base.arg_gen), Bool})
-precompile(Tuple{typeof(Base.read), Base.Cmd, Type{String}})
-precompile(Tuple{typeof(Base.readlines), Base.IOBuffer})
 precompile(Tuple{typeof(Base.push!), Array{Base.VersionNumber, 1}, Base.VersionNumber})
-precompile(Tuple{typeof(Base.Iterators.enumerate), Array{Base.VersionNumber, 1}})
-precompile(Tuple{typeof(Base.iterate), Base.Iterators.Enumerate{Array{Base.VersionNumber, 1}}})
-precompile(Tuple{typeof(Base.iterate), Base.Iterators.Enumerate{Array{Base.VersionNumber, 1}}, Tuple{Int64, Int64}})
-precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Int64, Base.VersionNumber}, Int64})
-precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Int64, Base.VersionNumber}, Int64, Int64})
 
 """
     inspect_driver(driver, deps=String[]; inspect_devices=false)
 
 Invoke the `cuda_inspect_driver` helper in a subprocess to query a CUDA driver
-without dlopen'ing it in the caller's process. Returns `nothing` on failure,
-otherwise a NamedTuple `(; path, version, capabilities)` where `path` is the
-resolved absolute path to the driver, `version` is the driver's reported
-version, and `capabilities` is a `Vector{VersionNumber}` of device compute
-capabilities — empty when `inspect_devices` is `false`.
+without dlopen'ing it in the caller's process. The helper verifies the driver
+actually works by calling `cuInit` (dlopen and `cuDriverGetVersion` succeed even
+on a driver that mismatches the loaded kernel-mode driver). Returns `nothing` on
+failure, logging the helper's diagnostic at debug level so that e.g. a driver
+failing `cuInit` can be told apart from one that failed to load; otherwise a
+NamedTuple `(; path, version, capabilities)` where `path` is the resolved
+absolute path to the driver, `version` is the driver's reported version, and
+`capabilities` is a `Vector{VersionNumber}` of device compute capabilities —
+empty when `inspect_devices` is `false`.
 """
 function inspect_driver(driver, deps=String[]; inspect_devices::Bool=false)
     # the helper executable is an artifact product, which does not exist on platforms
     # without a matching artifact (or before this module has been initialized).
     @isdefined(cuda_inspect_driver_path) || return nothing
     cmd = `$cuda_inspect_driver_path $driver $inspect_devices $deps`
-    output = try
-        read(cmd, String)
+    out = IOBuffer()
+    err = IOBuffer()
+    proc = try
+        run(pipeline(ignorestatus(cmd); stdout=out, stderr=err))
     catch _
+        # spawn failure (e.g. missing or non-executable helper)
+        @debug "Could not launch the driver inspection helper for $driver"
         return nothing
     end
-    lines = readlines(IOBuffer(output))
-    length(lines) < 2 && return nothing
+    if !success(proc)
+        reason = strip(String(take!(err)))
+        @debug "Inspection of driver $driver failed" * (isempty(reason) ? "" : ": $reason")
+        return nothing
+    end
+    lines = readlines(seekstart(out))
+    if length(lines) < 2
+        @debug "Inspection of driver $driver returned unexpected output"
+        return nothing
+    end
     path = lines[1]
     version = tryparse(VersionNumber, lines[2])
-    version === nothing && return nothing
+    if version === nothing
+        @debug "Inspection of driver $driver reported an unparseable version: $(lines[2])"
+        return nothing
+    end
     capabilities = VersionNumber[]
     if inspect_devices
         for i in 3:length(lines)
@@ -227,3 +242,10 @@ function select_cuda_toolkit(toolkits::Vector{VersionNumber},
     @debug "Selected CUDA toolkit: $cuda_toolkit"
     return cuda_toolkit
 end
+
+# precompile the entry points used by platform augmentation hooks (see above)
+precompile(inspect_driver, (String,))
+precompile(inspect_driver, (String, Vector{String}))
+precompile(Core.kwcall, (@NamedTuple{inspect_devices::Bool}, typeof(inspect_driver), String))
+precompile(get_driver_info, ())
+precompile(select_cuda_toolkit, (Vector{VersionNumber}, Vector{VersionNumber}))

--- a/C/CUDA/CUDA_Driver/toplevel.jl
+++ b/C/CUDA/CUDA_Driver/toplevel.jl
@@ -14,6 +14,25 @@ const selection_api = v"1"
 
 using Base: thismajor, thisminor
 
+"""
+    is_tegra()
+
+Return whether the host is an NVIDIA Tegra system. This definition is available
+even when CUDA_Driver_jll has no matching artifact.
+"""
+is_tegra() = _is_tegra()
+
+"""
+    l4t_version()
+
+Return the NVIDIA Linux for Tegra release as a `VersionNumber`, or `nothing` if
+it is unavailable or cannot be parsed. Unlike CUDA_Driver_jll's private artifact
+routing tag, this reports the complete release (for example, `v"35.6.5"`) without
+clamping. This definition is available even when CUDA_Driver_jll has no matching
+artifact.
+"""
+l4t_version() = _l4t_version()
+
 # Precompile statements for the process-spawning and version-parsing hot path of
 # `inspect_driver`, because platform augmentation hooks call it from Pkg's
 # `select_artifacts.jl` subprocess, which runs with `--compile=min`. The entry


### PR DESCRIPTION
Add L4T compatibility-driver artifacts to CUDA_Driver_jll and select them using a new `tegra=<generation>` platform tag.

- `tegra=35`: CUDA 12.2.34086590 compatibility driver
- `tegra=36`: CUDA 12.9.40580548 compatibility driver
- `tegra=32` and `tegra=38`: inspection-helper-only artifacts
- `tegra=none`: existing datacenter/SBSA compatibility driver

Known Tegra systems with an unreadable or unsupported L4T release select the safe helper-only artifact rather than the incompatible SBSA driver.