### PR TITLE
[SuiteSparse] Link libblastrampoline by its versioned name

### DIFF
--- a/S/SuiteSparse/SuiteSparse32@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse32@7/build_tarballs.jl
@@ -1,4 +1,4 @@
-# Build counter: 0
+# Build counter: 1
 include("../common.jl")
 
 name = "SuiteSparse32"

--- a/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
+++ b/S/SuiteSparse/SuiteSparse@7/build_tarballs.jl
@@ -1,4 +1,4 @@
-# Build counter: 0
+# Build counter: 1
 include("../common.jl")
 
 name = "SuiteSparse"

--- a/S/SuiteSparse/common.jl
+++ b/S/SuiteSparse/common.jl
@@ -171,26 +171,6 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 cmake --build . --parallel ${nproc}
 cmake --install .
 
-# For now, we'll have to adjust the name of the Lbt library on macOS and FreeBSD.
-# Eventually, this should be fixed upstream
-if [[ ${target} == *-apple-* ]] || [[ ${target} == *freebsd* ]]; then
-    echo "-- Modifying library name for libblastrampoline"
-
-    BLAS_NAME=blastrampoline
-    for nm in libcholmod libspqr libumfpack; do
-        if [[ *"${nm}"* == PROJECTS_TO_BUILD ]]; then
-            # Figure out what version it probably latched on to:
-            if [[ ${target} == *-apple-* ]]; then
-                LBT_LINK=$(otool -L ${libdir}/${nm}.dylib | grep lib${BLAS_NAME} | awk '{ print $1 }')
-                install_name_tool -change ${LBT_LINK} @rpath/lib${BLAS_NAME}.dylib ${libdir}/${nm}.dylib
-            elif [[ ${target} == *freebsd* ]]; then
-                LBT_LINK=$(readelf -d ${libdir}/${nm}.so | grep lib${BLAS_NAME} | sed -e 's/.*\[\(.*\)\].*/\1/')
-                patchelf --replace-needed ${LBT_LINK} lib${BLAS_NAME}.so ${libdir}/${nm}.so
-            fi
-        fi
-    done
-fi
-
 # Delete the extra soversion libraries built. https://github.com/JuliaPackaging/Yggdrasil/issues/7
 if [[ "${target}" == *-mingw* ]]; then
     rm -f ${libdir}/lib*.*.${dlext}


### PR DESCRIPTION
Since #6035 this explicitly builds against LBTv5.

As a result, I think we can drop this unversioning hack since it confounds BB2's dependency tracking (although that may be worth some fix-ups upstream)

This commit was written with the assistance of generative AI (Claude).