### PR TITLE
[CUDA_Driver] Report the driver we loaded, not always the system one

### DIFF
--- a/C/CUDA/CUDA_Driver/build_tarballs.jl
+++ b/C/CUDA/CUDA_Driver/build_tarballs.jl
@@ -21,8 +21,9 @@ driver_version = "610.43.02"
 # package resolution cannot distinguish build numbers). 13.3.1: introduction of the
 # toolkit selection library in the toplevel block. 13.3.2: detailed driver-inspection
 # failure diagnostics and the `tegra` platform tag with per-KMD-generation artifacts
-# shipping the L4T compatibility drivers.
-version = v"13.3.2"
+# shipping the L4T compatibility drivers. 13.3.3: report the driver we actually load,
+# rather than always the system one, when selecting a CUDA toolkit.
+version = v"13.3.3"
 
 # the Tegra compat drivers to ship, per kernel-mode driver generation (the `tegra`
 # platform tag; see tegra_detection.jl). NVIDIA built L4T compat UMDs against the r35

--- a/C/CUDA/CUDA_Driver/init.jl
+++ b/C/CUDA/CUDA_Driver/init.jl
@@ -59,8 +59,9 @@ end
 
 # collect the compat driver's dependent libraries. not every artifact declares
 # every product (helper-only builds declare none, and the L4T compat drivers lack
-# the newer desktop-only libraries), so only reference those that exist.
-libcuda_deps = String[]
+# the newer desktop-only libraries), so only reference those that exist. this is a
+# global because `get_driver_info` needs the same list to inspect the driver we load.
+global libcuda_deps = String[]
 for dep in [:libcuda_debugger, :libnvidia_nvvm, :libnvidia_ptxjitcompiler,
             :libnvidia_gpucomp, :libnvidia_tileiras]
     isdefined(@__MODULE__, dep) || continue

--- a/C/CUDA/CUDA_Driver/toplevel.jl
+++ b/C/CUDA/CUDA_Driver/toplevel.jl
@@ -12,6 +12,14 @@
 # last-resort version marker for consumers to check.
 const selection_api = v"1"
 
+# `__init__` picks between the system driver and the bundled forwards-compatible one
+# based on this preference, and `get_driver_info` reports whichever it picked, so
+# dependent JLLs bake the preference into the artifact they select. Base keys
+# compile-time preferences by the recording module's own UUID, so they cannot register
+# it themselves; recording it here invalidates our cache, and theirs along with it.
+Base.record_compiletime_preference(Base.UUID("4ee394cb-3365-5eb0-8335-949819d2adfc"),
+                                   "compat")
+
 using Base: thismajor, thisminor
 
 """
@@ -101,22 +109,31 @@ end
 """
     get_driver_info()
 
-Query the system CUDA driver, returning `nothing` on failure, or a tuple
+Query the CUDA driver, returning `nothing` on failure, or a tuple
 `(driver_version, device_capabilities)`.
+
+This inspects `libcuda`, i.e. whichever of the system driver and the bundled
+forwards-compatible driver `__init__` settled on, so that the reported version is the
+one code in this session will actually be running against.
 
 When called during precompilation (e.g. from a dependent JLL's platform augmentation
 hook), the resolved driver path is registered as an include dependency, invalidating
 the precompilation cache when the user upgrades their NVIDIA driver.
 """
 function get_driver_info()
-    # inspect the system driver (rather than `libcuda`, which may be the
-    # forwards-compatible driver bundled in our artifact and which has private deps the
-    # inspection subprocess wouldn't preload). only the system driver actually changes
-    # when the user upgrades their NVIDIA driver, and it's the one we want to depend on
-    # for cache invalidation.
-    libcuda_system = Sys.iswindows() ? "nvcuda" : "libcuda.so.1"
+    # `libcuda` is set by `__init__`, so it does not exist on platforms without a
+    # matching artifact (where there is no driver to speak of anyway).
+    @isdefined(libcuda) || return nothing
 
-    info = inspect_driver(libcuda_system; inspect_devices=true)
+    # the forwards-compatible driver has private dependencies that the inspection
+    # subprocess has to preload; `__init__` collected them while probing it.
+    deps = if @isdefined(libcuda_compat) && libcuda == libcuda_compat
+        libcuda_deps
+    else
+        String[]
+    end
+
+    info = inspect_driver(libcuda, deps; inspect_devices=true)
     info === nothing && return nothing
 
     @debug "Adding include dependency on $(info.path)"


### PR DESCRIPTION
`__init__` probes the system driver and the bundled forwards-compatible one and loads whichever works, but `get_driver_info` always inspected `libcuda.so.1`. On a JetPack 5 AGX Xavier that means we load the L4T compatibility driver and then tell CUDA_Runtime_jll and CUDA_Compiler_jll the driver is 11.4, so they select an 11.x toolkit and the compatibility driver buys the user nothing:

```
libcuda              = …/artifacts/d52b82b5…/lib/libcuda.so   # the 12.2 one
get_driver_info      = (v"11.4.0", …)                          # says 11.4
runtime tag          = cuda+11.8 jetson
cudaDriverGetVersion -> 12020                                  # actually 12.2
```

Inspect `libcuda` instead. The two mechanical reasons the old code named the system driver are handled here: the compatibility driver's private dependencies have to be preloaded in the inspection subprocess, so `libcuda_deps` becomes a module global and is passed along; and the resolved path is still registered as an include dependency, now pointing at whichever driver was loaded.

The `compat` preference decides which driver that is, so it is registered as a compile-time preference. Dependent JLLs bake the resulting toolkit into `host_platform` at precompile time, and Base keys compile-time preferences by the recording module's own UUID, so they cannot register it themselves.

No new API, and no changes in CUDA_Runtime_jll or CUDA_Compiler_jll: they already call `select_cuda_toolkit`, which now sees the right version. Artifact content is untouched — all seven tree hashes are identical to 13.3.2's.

Tested with a `--deploy=local` Driver against the **released** CUDA_Runtime_jll 0.24.2 and CUDA_Compiler_jll 0.6.0, Julia 1.10 and 1.12:

| host | loaded driver | before | after |
|---|---|---|---|
| x86_64, RTX 5080, driver 13.3 | system 13.3 | `cuda+13.3` | `cuda+13.3` |
| Jetson Nano, r32.7.6, sm_53 | system 10.2 | `cuda+10.2` jetson | `cuda+10.2` jetson |
| AGX Xavier, r35.6.5, sm_72 | compat 12.2 | `cuda+11.8` jetson | `cuda+12.9` jetson |
| AGX Xavier, `compat=false` | system 11.4 | `cuda+11.8` jetson | `cuda+11.8` jetson |
| Orin Nano, r39.2.1, sm_87 | system 13.2 | `cuda+13.3` | `cuda+13.3` |

Xavier's runtime smoke test (device count, allocation, memset, synchronization, free) passes on both routes: CUDA 12.9 against driver 12020 by default, CUDA 11.8 against driver 11040 with `compat=false`, and the preference flips selection in both directions. Where no artifact matches, `get_driver_info` returns `nothing` rather than erroring on the undefined `libcuda`.

Note this also affects non-Tegra hosts that load the datacenter forward-compatibility driver (system 12.x + bundled 13.3 on sm_75+ hardware): they now select a 13.x toolkit instead of 12.x. Those hosts currently upgrade the driver but leave selection sized on the old one, so it is the same fix.