### PR TITLE
[DuckDB] Statically link icu, autocomplete and the excel extension

### DIFF
--- a/D/DuckDB/build_tarballs.jl
+++ b/D/DuckDB/build_tarballs.jl
@@ -10,10 +10,58 @@ version = v"1.5.5"
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/duckdb/duckdb.git", "d8cdaa33fda8df955cc76ef58a280f68f4cd43fa"),
+    # The excel extension lives out-of-tree; this is the commit duckdb v1.5.5
+    # pins in .github/config/extensions/excel.cmake
+    GitSource("https://github.com/duckdb/duckdb-excel.git", "f4c72b5ef04a03b3a78a95b5a2ee94ba93e3178d"),
+    # minizip-ng 4.0.7, the version duckdb-excel's vcpkg manifest pins
+    GitSource("https://github.com/zlib-ng/minizip-ng.git", "fe5fedc365f7824ada0cf9a84fb79b30d5fc97a8"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
+# Static minizip-ng for the excel extension (there is no minizip-ng JLL); it is
+# absorbed into libduckdb, so nothing from it ships in the tarball.
+cmake -S $WORKSPACE/srcdir/minizip-ng -B $WORKSPACE/srcdir/minizip-build \
+      -DCMAKE_INSTALL_PREFIX=$WORKSPACE/deps \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -DMZ_LIB_SUFFIX=-ng \
+      -DMZ_FETCH_LIBS=OFF \
+      -DMZ_ZLIB=ON \
+      -DZLIB_ROOT=${prefix} \
+      -DMZ_BZIP2=OFF \
+      -DMZ_LZMA=OFF \
+      -DMZ_ZSTD=OFF \
+      -DMZ_OPENSSL=OFF \
+      -DMZ_LIBBSD=OFF \
+      -DMZ_ICONV=OFF \
+      -DMZ_PKCRYPT=OFF \
+      -DMZ_WZAES=OFF \
+      -DMZ_LIBCOMP=OFF \
+      -DMZ_BUILD_TESTS=OFF
+# minizip-ng silently disables deflate when it fails to find zlib, which breaks
+# every read_xlsx/write at runtime — fail the build instead
+if grep -rq "MZ_ZIP_NO_COMPRESSION" $WORKSPACE/srcdir/minizip-build/CMakeFiles/*.dir/flags.make; then
+    echo "ERROR: minizip-ng configured without zlib (no compression support)" >&2
+    exit 1
+fi
+
+cmake --build $WORKSPACE/srcdir/minizip-build --parallel ${nproc}
+cmake --install $WORKSPACE/srcdir/minizip-build
+
+# Out-of-tree extension config. The stock .github/config/extensions/excel.cmake
+# would git-clone at configure time; this loads the pre-fetched source instead.
+# excel must NOT also appear in BUILD_EXTENSIONS, or the stock config wins.
+cat > $WORKSPACE/srcdir/extension_config.cmake <<EOF
+duckdb_extension_load(excel
+    SOURCE_DIR $WORKSPACE/srcdir/duckdb-excel
+    INCLUDE_DIR $WORKSPACE/srcdir/duckdb-excel/src/excel/include
+    EXTENSION_VERSION f4c72b5
+)
+EOF
+
 cd $WORKSPACE/srcdir/duckdb/
 
 export DUCKDB_TARGET="${target}"
@@ -40,10 +88,13 @@ echo "Compiling for DuckDB Target - $DUCKDB_TARGET"
 cmake -B build \
       -DCMAKE_INSTALL_PREFIX=${prefix} \
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+      -DCMAKE_PREFIX_PATH=$WORKSPACE/deps \
+      -DCMAKE_CXX_FLAGS="-I$WORKSPACE/deps/include" \
       -DCMAKE_BUILD_TYPE=Release \
       -DENABLE_SANITIZER=FALSE \
-      -DBUILD_EXTENSIONS='parquet;json' \
-      -DSKIP_EXTENSIONS=jemalloc \
+      -DBUILD_EXTENSIONS='parquet;json;icu;autocomplete' \
+      -DDUCKDB_EXTENSION_CONFIGS=$WORKSPACE/srcdir/extension_config.cmake \
+      -DENABLE_JEMALLOC=OFF \
       -DENABLE_EXTENSION_AUTOLOADING=1 \
       -DENABLE_EXTENSION_AUTOINSTALL=1 \
       -DBUILD_UNITTESTS=FALSE \
@@ -73,7 +124,10 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[
+dependencies = [
+    # Needed by the excel extension
+    Dependency("Expat_jll"; compat="2.6.5"),
+    Dependency("Zlib_jll"),
 ]
 
 # The default macOS 10.12 SDK (and even 10.15) has a libc++ that doesn't provide
@@ -82,4 +136,6 @@ dependencies = Dependency[
 sources, script = require_macos_sdk("14.0", sources, script; deployment_target="11.0")
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"6.1.0", julia_compat="1.6")
+# GCC 10 (not older): the autocomplete extension needs a newer libstdc++ than
+# GCC 6.1's, and upstream builds its mingw binaries with GCC 10 as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; preferred_gcc_version = v"10.2.0", julia_compat="1.6")


### PR DESCRIPTION
This PR statically links the `icu`, `autocomplete` and (out-of-tree) `excel` extensions into libduckdb, alongside the already-bundled `parquet` and `json`. This matches the set DuckDB links into its own release binaries (`.github/config/bundled_extensions.cmake`: icu, json, parquet, autocomplete), plus `excel`.

### Motivation: extension autoinstall is broken (crashes) on Windows

DuckDB_jll builds with `DUCKDB_EXPLICIT_PLATFORM=windows_amd64_mingw`, so on first use of e.g. `read_xlsx` DuckDB autoinstalls the official `windows_amd64_mingw` extension binaries from extensions.duckdb.org. Those binaries are built with the Rtools toolchain (GCC 10, UCRT) for the R ecosystem, while this recipe builds libduckdb with the BinaryBuilder mingw toolchain. Loading one into the other mixes two C++ ABIs / CRT heaps, and the process dies with heap corruption (STATUS_HEAP_CORRUPTION, access violation in `RtlFreeHeap` while the excel extension's `LoadInternal` reallocates a `std::vector<ReplacementScan>` owned by libduckdb). Reproducible on Windows with DuckDB.jl v1.5.2 / DuckDB_jll v1.5.5+0 via a plain `LOAD excel`.

Statically linked extensions sidestep the problem entirely: they are registered at `duckdb_open` time, involve no DLL boundary, no download, and work offline on all platforms.

Related: duckdb/duckdb#10853, duckdb/duckdb#20719, and the earlier unmerged attempts #9737 / #9775 here.

### What the diff does

- Adds the `excel` extension source ([duckdb/duckdb-excel](https://github.com/duckdb/duckdb-excel) @ `f4c72b5`, the exact commit duckdb v1.5.5 pins in `.github/config/extensions/excel.cmake`) as a `GitSource`, loaded via a `DUCKDB_EXTENSION_CONFIGS` file pointing at the pre-fetched tree — the stock config would `git clone` at configure time, which the build sandbox cannot do.
- excel needs expat, zlib and minizip-ng: `Expat_jll` and `Zlib_jll` become dependencies; minizip-ng (4.0.7, the version duckdb-excel's vcpkg manifest pins) has no JLL, so it is built inline as a static PIC library and absorbed into libduckdb — nothing from it ships in the tarball.
- Adds `icu;autocomplete` to `BUILD_EXTENSIONS` (both in-tree, no new sources).
- Replaces the deprecated `-DSKIP_EXTENSIONS=jemalloc` (now a warning alias) with `-DENABLE_JEMALLOC=OFF` — same behavior.

### Open question for maintainers (no diff included)

Even with these extensions bundled, any *other* extension autoinstalled on Windows still fetches Rtools-built `windows_amd64_mingw` binaries into a BinaryBuilder-built libduckdb, with the crash mode described above. Would it be preferable to set an unpublished platform string (e.g. `windows_amd64_mingw_julia`) on Windows so autoinstall fails with a catchable `IOException` instead of undefined behavior? Left out of this PR since it changes behavior for all Windows users and upstream may prefer a different route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
