### PR TITLE
[CoinUtils] Enable riscv64

### DIFF
--- a/C/Coin-OR/CoinUtils/build_tarballs.jl
+++ b/C/Coin-OR/CoinUtils/build_tarballs.jl
@@ -1,7 +1,7 @@
 # In addition to coin-or-common.jl, we need to modify this file to trigger a
 # rebuild.
 #
-# Last updated: 2026-05-04
+# Last updated: 2026-09-02
 
 include("../coin-or-common.jl")
 

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -111,4 +111,3 @@ OpenBLAS32_version = v"0.3.26"
 # platforms are passed in on the command line
 platforms = expand_cxxstring_abis(supported_platforms())
 platforms = filter!(!Sys.isfreebsd, platforms)
-filter!(p -> arch(p) != "riscv64", platforms)


### PR DESCRIPTION
Drop the riscv64 filter from coin-or-common.jl. All dependencies have riscv64 artifacts, and CoinUtils_jll shipped riscv64 once before the filter was added. The downstream Coin-OR packages follow once this artifact is registered.