### PR TITLE
[Enzyme] Enable riscv64

### DIFF
--- a/E/Enzyme/build_tarballs.jl
+++ b/E/Enzyme/build_tarballs.jl
@@ -30,9 +30,6 @@ platforms = expand_cxxstring_abis(supported_platforms())
 # Exclude aarch64 FreeBSD for the time being
 filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms)
 
-# Disable riscv for now
-platforms = filter!(p -> arch(p) != "riscv64", platforms)
-
 # Exclude i686-linux-musl.
 platforms = filter!(p -> !(arch(p) == "i686" && libc(p) == "musl"), platforms)
 


### PR DESCRIPTION
LLVM_full_jll has riscv64 artifacts for every LLVM version this recipe builds against, and the recipe cross-compiles cleanly.