### PR TITLE
[HiGHS] Enable riscv64

### DIFF
--- a/H/HiGHS/build_tarballs.jl
+++ b/H/HiGHS/build_tarballs.jl
@@ -16,8 +16,7 @@ sources = [
 # platforms are passed in on the command line
 platforms = supported_platforms()
 
-# Disable riscv and powerpc for now
-platforms = filter!(p -> arch(p) != "riscv64", platforms)
+# Disable powerpc for now
 platforms = filter!(p -> arch(p) != "powerpc64le", platforms)
 
 script = raw"""


### PR DESCRIPTION
All dependencies have riscv64 artifacts; the recipe cross-compiles cleanly.