### PR TITLE
[Osi] Enable riscv64

### DIFF
--- a/C/Coin-OR/Osi/build_tarballs.jl
+++ b/C/Coin-OR/Osi/build_tarballs.jl
@@ -1,7 +1,7 @@
 # In addition to coin-or-common.jl, we need to modify this file to trigger a
 # rebuild.
 #
-# Last updated: 2026-05-04
+# Last updated: 2026-09-02
 
 include("../coin-or-common.jl")
 


### PR DESCRIPTION
Rebuild now that CoinUtils_jll has a riscv64 artifact.