### PR TITLE
[SPRAL] Enable riscv64

### DIFF
--- a/S/SPRAL/build_tarballs.jl
+++ b/S/SPRAL/build_tarballs.jl
@@ -39,7 +39,6 @@ meson install -C builddir
 # platforms are passed in on the command line
 platforms = supported_platforms()
 platforms = expand_gfortran_versions(platforms)
-filter!(p -> arch(p) != "riscv64", platforms)
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
All dependencies have riscv64 artifacts; Ipopt needs this one.