### PR TITLE
[ASL] Bump to the current netlib sources and enable riscv64

### DIFF
--- a/A/ASL/build_tarballs.jl
+++ b/A/ASL/build_tarballs.jl
@@ -3,12 +3,12 @@
 using BinaryBuilder
 
 name = "ASL"
-version = v"0.1.3"
+version = v"0.1.4"
 
 # Collection of sources required to build ThinASLBuilder
 sources = [
     ArchiveSource("http://netlib.org/ampl/solvers.tgz",
-                  "2d599272e22fc66673cb03d2065f53f587140493fb50501adde5acf6be2adc93"),
+                  "92bf92a8db0712c0e42c12f912151128dd192e8409ba1fea6f4b44cd5141a1de"),
     DirectorySource("./bundled")
 ]
 

--- a/A/ASL/bundled/asl-extra/arith.h.riscv64-linux-gnu
+++ b/A/ASL/bundled/asl-extra/arith.h.riscv64-linux-gnu
@@ -1,0 +1,8 @@
+#define IEEE_8087
+#define Arith_Kind_ASL 1
+#define Long int
+#define Intcast (int)(long)
+#define Double_Align
+#define X64_bit_pointers
+#define QNaN0 0x0
+#define QNaN1 0x7ff80000


### PR DESCRIPTION
The netlib solvers.tgz is unversioned and its contents moved on (20251121), so the recorded hash no longer verifies and the recipe cannot be rebuilt at all. Take the current tarball, and add an arith.h for riscv64 (little-endian IEEE with a positive canonical NaN, the same as aarch64) since the generated one needs to run a probe on the target. Ipopt needs the riscv64 artifact.