### PR TITLE
[Clp] Enable riscv64

### DIFF
--- a/C/Coin-OR/Clp/build_tarballs.jl
+++ b/C/Coin-OR/Clp/build_tarballs.jl
@@ -1,7 +1,7 @@
 # In addition to coin-or-common.jl, we need to modify this file to trigger a
 # rebuild.
 #
-# Last updated: 2026-05-04
+# Last updated: 2026-09-02
 
 include("../coin-or-common.jl")
 

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -100,7 +100,7 @@ SHOT_version = offset_version(v"1.1.0", v"0.0.0")
 # Third-party packages needed by COIN-OR libraries.
 Julia_compat_version = "1.6"
 ASL_version = v"0.1.3"
-METIS_version = v"5.1.2"
+METIS_version = v"5.1.3"
 MUMPS_seq_version_LBT = v"500.900.100"
 SPRAL_version_LBT = v"2025.9.18"
 OpenBLAS32_version = v"0.3.26"


### PR DESCRIPTION
Rebuild now that CoinUtils_jll and Osi_jll have riscv64 artifacts. METIS_jll 5.1.2 has none, so move the Coin-OR pin to 5.1.3, which is the same METIS source rebuilt for riscv64 (#10256); Clp is its only user.