### PR TITLE
[vst3sdk] New recipe: v3.8.1 (Steinberg VST 3 SDK, MIT)

### DIFF
--- a/V/vst3sdk/build_tarballs.jl
+++ b/V/vst3sdk/build_tarballs.jl
@@ -1,0 +1,156 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+# The Steinberg VST 3 SDK (https://github.com/steinbergmedia/vst3sdk), MIT
+# since version 3.8 (LICENSE.txt at the pinned tag is the MIT text; older
+# tags carried a GPLv3 / proprietary dual licence and must not be used).
+#
+# What this ships, for hosts and for plugin authors alike:
+#   * the headers: pluginterfaces/, base/, public.sdk/source/ (the SDK is
+#     used as a source tree, so the tree is installed under include/vst3sdk
+#     with the .cpp files that plugins and hosts compile directly -- the
+#     per-platform module entry, vstsinglecomponenteffect.cpp,
+#     hosting/plugprovider.cpp, hosting/module_<os>.cpp);
+#   * the static libraries: base, pluginterfaces, sdk, sdk_common,
+#     sdk_hosting (lib/vst3sdk/);
+#   * two GUI-free example plugin bundles (lib/vst3/*.vst3):
+#     `again-sample-accurate.vst3`, the SDK's gain example, and `adelay.vst3`,
+#     so a host can be tested against a real plugin without a compiler.
+# VSTGUI, the hosting examples and the validator are not built, and no
+# moduleinfo.json is generated (moduleinfotool is built for the target and
+# cannot run while cross-compiling; hosts do not need the file).
+name = "vst3sdk"
+version = v"3.8.1"
+
+# The SDK repository is a shell around git submodules; each is pinned to the
+# commit the v3.8.1_build_84 tag references.
+sources = [
+    GitSource("https://github.com/steinbergmedia/vst3sdk.git",
+              "3cdf9ca5d1f5b1b21e0a86832aa4abe55607bd96"),   # v3.8.1_build_84
+    GitSource("https://github.com/steinbergmedia/vst3_base.git",
+              "fcf9da0bd27a16f7f03773a3a39822f28f5c8477"),
+    GitSource("https://github.com/steinbergmedia/vst3_pluginterfaces.git",
+              "4f547e8e102b47de4a8b8aaf343c73b700786372"),
+    GitSource("https://github.com/steinbergmedia/vst3_public_sdk.git",
+              "586dc5e6c8012c3e4b01c79389375cbe96bdb1da"),
+    GitSource("https://github.com/steinbergmedia/vst3_cmake.git",
+              "054c9143cbb8d47fc4694e473f2ee3b4d951a8f5"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/vst3sdk
+# Put the submodules where the SDK's CMake expects them.
+rmdir base pluginterfaces public.sdk cmake 2>/dev/null || true
+mv ../vst3_base base
+mv ../vst3_pluginterfaces pluginterfaces
+mv ../vst3_public_sdk public.sdk
+mv ../vst3_cmake cmake
+# vstgui4, doc and tutorials stay empty: not built, not shipped.
+mkdir -p vstgui4 doc tutorials
+
+install_license LICENSE.txt
+
+if [[ "${target}" == *-apple-* ]]; then
+    # std::aligned_alloc is not in libc++'s std:: for the macOS SDK the
+    # toolchain uses; the SDK already has a posix_memalign path for older
+    # deployment targets, so use it on every macOS target.
+    sed -i '/#if SMTG_OS_MACOS && defined(MAC_OS_X_VERSION_MIN_REQUIRED)/{N;s/.*/#if SMTG_OS_MACOS \/* BinaryBuilder: posix_memalign on every macOS target *\//}' \
+        public.sdk/source/vst/utility/alignedalloc.h
+elif [[ "${target}" == *-mingw* ]]; then
+    # mingw's libstdc++ has no std::aligned_alloc either; the SDK's MSVC path
+    # (_aligned_malloc / _aligned_free from <malloc.h>) works with mingw too.
+    sed -i 's/defined(_MSC_VER)/defined(_WIN32)/g' public.sdk/source/vst/utility/alignedalloc.h
+fi
+
+# The SDK wants CMake >= 3.25: use the CMake_jll host build dependency
+# rather than the rootfs's older one.
+apk del cmake
+
+# The SDK runs its platform detection (APPLE / WIN32 -> SMTG_MAC / SMTG_WIN)
+# before project(), i.e. before the toolchain file is loaded, so a cross
+# build is classified as the build host (Linux) unless told otherwise.
+PLATFORM_FLAGS=()
+if [[ "${target}" == *-apple-* ]]; then
+    # xcodebuild is not available: give the SDK an Xcode version so it does
+    # not abort; one architecture per build; no code signing.
+    export XCODE_VERSION=15.0
+    # The SDK's bundle post-build step calls codesign unconditionally; a
+    # no-op codesign shim stands in for it (nothing is signed here anyway).
+    mkdir -p ${WORKSPACE}/shim-bin
+    printf '#!/bin/sh\nexit 0\n' > ${WORKSPACE}/shim-bin/codesign
+    chmod +x ${WORKSPACE}/shim-bin/codesign
+    export PATH="${WORKSPACE}/shim-bin:${PATH}"
+    PLATFORM_FLAGS+=(-DAPPLE=ON -DXCODE_VERSION=15.0 -DSMTG_BUILD_UNIVERSAL_BINARY=OFF -DSMTG_DISABLE_CODE_SIGNING=ON)
+elif [[ "${target}" == *-mingw* ]]; then
+    # UNIX is true on the build host before project() and the SDK's macro
+    # checks it before WIN32, so make the macro look at WIN32 first (the
+    # file has CRLF line endings, hence the CR strip).
+    sed -i 's/\r$//' cmake/modules/SMTG_DetectPlatform.cmake
+    sed -i 's/^    if(APPLE)$/    if(WIN32)\n        set(SMTG_WIN TRUE CACHE INTERNAL ${SMTG_PLATFORM_DETECTION_COMMENT})\n    elseif(APPLE)/' \
+        cmake/modules/SMTG_DetectPlatform.cmake
+    PLATFORM_FLAGS+=(-DWIN32=ON)
+fi
+
+cmake -B build -G Ninja "${PLATFORM_FLAGS[@]}" \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DSMTG_ENABLE_VSTGUI_SUPPORT=OFF \
+    -DSMTG_ENABLE_VST3_HOSTING_EXAMPLES=OFF \
+    -DSMTG_ENABLE_VST3_PLUGIN_EXAMPLES=ON \
+    -DSMTG_RUN_VST_VALIDATOR=OFF \
+    -DSMTG_CREATE_PLUGIN_LINK=OFF \
+    -DSMTG_CREATE_BUNDLE_FOR_WINDOWS=OFF \
+    -DSMTG_CREATE_MODULE_INFO=OFF \
+    -DSMTG_ENABLE_IOS_TARGETS=OFF
+# The libraries, plus two GUI-free examples: the SDK's gain example (the
+# sample-accurate variant) and a delay. The rest of the examples (mda-vst3
+# and friends) are large and not needed by anyone hosting.
+cmake --build build --parallel ${nproc} --target \
+    base pluginterfaces sdk sdk_common sdk_hosting again-sample-accurate adelay
+
+# Static libraries.
+mkdir -p ${prefix}/lib/vst3sdk
+cp build/lib/Release/*.a ${prefix}/lib/vst3sdk/ 2>/dev/null || cp build/lib/*.a ${prefix}/lib/vst3sdk/
+
+# The source tree as headers + directly-compiled sources.
+mkdir -p ${includedir}/vst3sdk
+cp -r pluginterfaces base public.sdk ${includedir}/vst3sdk/
+rm -rf ${includedir}/vst3sdk/public.sdk/samples/vst/mda-vst3/*/media \
+       ${includedir}/vst3sdk/public.sdk/samples/vst-hosting \
+       ${includedir}/vst3sdk/base/build ${includedir}/vst3sdk/*/.git*
+find ${includedir}/vst3sdk -name '*.png' -o -name '*.jpg' -o -name '*.uidesc' -o -name '*.rc' | xargs rm -f
+
+# Example plugin bundles (GUI-free), for hosting tests.
+mkdir -p ${prefix}/lib/vst3
+if [[ -d build/VST3/Release ]]; then
+    cp -r build/VST3/Release/*.vst3 ${prefix}/lib/vst3/
+else
+    cp -r build/VST3/*.vst3 ${prefix}/lib/vst3/
+fi
+"""
+
+# The SDK targets Linux, macOS and Windows; nothing else.
+platforms = filter(p -> Sys.islinux(p) || Sys.isapple(p) || Sys.iswindows(p), supported_platforms())
+platforms = expand_cxxstring_abis(platforms)
+
+products = [
+    FileProduct("include/vst3sdk/pluginterfaces/base/funknown.h", :funknown_h),
+    FileProduct("include/vst3sdk/public.sdk/source/vst/hosting/module.h", :hosting_module_h),
+    FileProduct("lib/vst3sdk/libbase.a", :libbase_a),
+    FileProduct("lib/vst3sdk/libpluginterfaces.a", :libpluginterfaces_a),
+    FileProduct("lib/vst3sdk/libsdk.a", :libsdk_a),
+    FileProduct("lib/vst3sdk/libsdk_common.a", :libsdk_common_a),
+    FileProduct("lib/vst3sdk/libsdk_hosting.a", :libsdk_hosting_a),
+    FileProduct("lib/vst3/again-sample-accurate.vst3", :again_sample_accurate_vst3),
+]
+
+dependencies = [
+    HostBuildDependency(PackageSpec(; name="CMake_jll")),   # the SDK wants CMake >= 3.25
+]
+
+# C++17 with std::filesystem in the hosting code: GCC 9 or newer.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.10", preferred_gcc_version=v"9")

--- a/V/vst3sdk/build_tarballs.jl
+++ b/V/vst3sdk/build_tarballs.jl
@@ -2,6 +2,9 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
 
+const YGGDRASIL_DIR = "../.."
+include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
+
 # The Steinberg VST 3 SDK (https://github.com/steinbergmedia/vst3sdk), MIT
 # since version 3.8 (LICENSE.txt at the pinned tag is the MIT text; older
 # tags carried a GPLv3 / proprietary dual licence and must not be used).
@@ -36,9 +39,6 @@ sources = [
               "586dc5e6c8012c3e4b01c79389375cbe96bdb1da"),
     GitSource("https://github.com/steinbergmedia/vst3_cmake.git",
               "054c9143cbb8d47fc4694e473f2ee3b4d951a8f5"),
-    # std::aligned_alloc (C++) needs the macOS 11.3 SDK; the rootfs SDK is older.
-    FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
-               "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4"),
 ]
 
 script = raw"""
@@ -54,29 +54,7 @@ mkdir -p vstgui4 doc tutorials
 
 install_license LICENSE.txt
 
-if [[ "${target}" == *-apple-* ]]; then
-    # std::aligned_alloc (and, on x86_64, std::filesystem in the hosting code)
-    # need the 11.3 SDK. Replacing System in the rootfs sys-root fails on the
-    # current CI rootfs (rm: I/O error, see S/SLEEF), so build a scratch copy
-    # of the sys-root with the SDK in it and point the toolchain there.
-    apple_sysroot=${WORKSPACE}/srcdir/sysroot
-    cp -a /opt/${target}/${target}/sys-root ${apple_sysroot}
-    tar --extract --file=${WORKSPACE}/srcdir/MacOSX11.3.sdk.tar.xz \
-        --directory=${WORKSPACE}/srcdir --warning=no-unknown-keyword \
-        MacOSX11.3.sdk/System MacOSX11.3.sdk/usr
-    rm -rf ${apple_sysroot}/System ${apple_sysroot}/usr/include/c++ ${apple_sysroot}/usr/include/libxml2
-    cp -ra ${WORKSPACE}/srcdir/MacOSX11.3.sdk/System ${apple_sysroot}/.
-    cp -ra ${WORKSPACE}/srcdir/MacOSX11.3.sdk/usr/* ${apple_sysroot}/usr/.
-    sed -i "s!/opt/${target}/${target}/sys-root!${apple_sysroot}!g" \
-        ${CMAKE_TARGET_TOOLCHAIN} /opt/bin/${bb_full_target}/${target}-{cc,c++,clang,clang++}
-    # clang turns SDKROOT into -isysroot, which beats --sysroot for headers.
-    export SDKROOT=${apple_sysroot}
-    if [[ "${target}" == x86_64-* ]]; then
-        # std::filesystem (used by the hosting code) and std::aligned_alloc
-        # are available from macOS 10.15; aarch64 already targets 11.0.
-        export MACOSX_DEPLOYMENT_TARGET=10.15
-    fi
-elif [[ "${target}" == *-mingw* ]]; then
+if [[ "${target}" == *-mingw* ]]; then
     # mingw's libstdc++ has no std::aligned_alloc either; the SDK's MSVC path
     # (_aligned_malloc / _aligned_free from <malloc.h>) works with mingw too.
     sed -i 's/defined(_MSC_VER)/defined(_WIN32)/g' public.sdk/source/vst/utility/alignedalloc.h
@@ -160,6 +138,10 @@ find ${includedir}/vst3sdk -type f \
 mkdir -vp ${prefix}/lib/vst3
 cp -vr ${BUILD_VST3DIR}/{again-sample-accurate,adelay}.vst3 ${prefix}/lib/vst3/
 """
+
+# std::aligned_alloc, and std::filesystem in the hosting code, need a newer SDK
+# than the rootfs default; both are available from macOS 10.15.
+sources, script = require_macos_sdk("11.3", sources, script; deployment_target="10.15")
 
 # The SDK targets Linux, macOS and Windows; nothing else.
 platforms = filter(p -> Sys.islinux(p) || Sys.isapple(p) || Sys.iswindows(p), supported_platforms())

--- a/V/vst3sdk/build_tarballs.jl
+++ b/V/vst3sdk/build_tarballs.jl
@@ -36,9 +36,9 @@ sources = [
               "586dc5e6c8012c3e4b01c79389375cbe96bdb1da"),
     GitSource("https://github.com/steinbergmedia/vst3_cmake.git",
               "054c9143cbb8d47fc4694e473f2ee3b4d951a8f5"),
-    # For std::aligned_alloc: the C++ version is new in the 11.3 SDK's libc++.
-    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
-                  "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4"),
+    # std::aligned_alloc (C++) needs the macOS 11.3 SDK; the rootfs SDK is older.
+    FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
+               "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4"),
 ]
 
 script = raw"""
@@ -55,15 +55,25 @@ mkdir -p vstgui4 doc tutorials
 install_license LICENSE.txt
 
 if [[ "${target}" == *-apple-* ]]; then
-    # Update SDK version: std::aligned_alloc (and, on x86_64, std::filesystem
-    # in the hosting code) need the 11.3 SDK and a 10.15 deployment target.
-    pushd ${WORKSPACE}/srcdir/MacOSX11.*.sdk
-    rm -rf /opt/${target}/${target}/sys-root/System
-    rm -rf /opt/${target}/${target}/sys-root/usr/include/libxml2/libxml
-    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
-    cp -ra System "/opt/${target}/${target}/sys-root/."
-    popd
+    # std::aligned_alloc (and, on x86_64, std::filesystem in the hosting code)
+    # need the 11.3 SDK. Replacing System in the rootfs sys-root fails on the
+    # current CI rootfs (rm: I/O error, see S/SLEEF), so build a scratch copy
+    # of the sys-root with the SDK in it and point the toolchain there.
+    apple_sysroot=${WORKSPACE}/srcdir/sysroot
+    cp -a /opt/${target}/${target}/sys-root ${apple_sysroot}
+    tar --extract --file=${WORKSPACE}/srcdir/MacOSX11.3.sdk.tar.xz \
+        --directory=${WORKSPACE}/srcdir --warning=no-unknown-keyword \
+        MacOSX11.3.sdk/System MacOSX11.3.sdk/usr
+    rm -rf ${apple_sysroot}/System ${apple_sysroot}/usr/include/c++ ${apple_sysroot}/usr/include/libxml2
+    cp -ra ${WORKSPACE}/srcdir/MacOSX11.3.sdk/System ${apple_sysroot}/.
+    cp -ra ${WORKSPACE}/srcdir/MacOSX11.3.sdk/usr/* ${apple_sysroot}/usr/.
+    sed -i "s!/opt/${target}/${target}/sys-root!${apple_sysroot}!g" \
+        ${CMAKE_TARGET_TOOLCHAIN} /opt/bin/${bb_full_target}/${target}-{cc,c++,clang,clang++}
+    # clang turns SDKROOT into -isysroot, which beats --sysroot for headers.
+    export SDKROOT=${apple_sysroot}
     if [[ "${target}" == x86_64-* ]]; then
+        # std::filesystem (used by the hosting code) and std::aligned_alloc
+        # are available from macOS 10.15; aarch64 already targets 11.0.
         export MACOSX_DEPLOYMENT_TARGET=10.15
     fi
 elif [[ "${target}" == *-mingw* ]]; then

--- a/V/vst3sdk/build_tarballs.jl
+++ b/V/vst3sdk/build_tarballs.jl
@@ -36,9 +36,9 @@ sources = [
               "586dc5e6c8012c3e4b01c79389375cbe96bdb1da"),
     GitSource("https://github.com/steinbergmedia/vst3_cmake.git",
               "054c9143cbb8d47fc4694e473f2ee3b4d951a8f5"),
-    # std::aligned_alloc (C++) needs the macOS 11.3 SDK; the rootfs SDK is older.
-    FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
-               "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4"),
+    # For std::aligned_alloc: the C++ version is new in the 11.3 SDK's libc++.
+    ArchiveSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
+                  "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4"),
 ]
 
 script = raw"""
@@ -55,27 +55,15 @@ mkdir -p vstgui4 doc tutorials
 install_license LICENSE.txt
 
 if [[ "${target}" == *-apple-* ]]; then
-    # alignedalloc.h uses std::aligned_alloc from a 10.15 deployment target on
-    # (aarch64 targets 11.0) and posix_memalign below it; the rootfs SDK has
-    # neither aligned_alloc nor MAC_OS_X_VERSION_10_15, so both paths need the
-    # 11.3 SDK. The rootfs sys-root is a read-only overlay layer whose
-    # directories cannot be replaced, so install the SDK into a scratch copy
-    # of it and point the toolchain there (as P/pocl and S/SLEEF do).
-    apple_sysroot=${WORKSPACE}/srcdir/sysroot
-    cp -a /opt/${target}/${target}/sys-root ${apple_sysroot}
-    tar --extract --file=${WORKSPACE}/srcdir/MacOSX11.3.sdk.tar.xz \
-        --directory=${WORKSPACE}/srcdir --warning=no-unknown-keyword \
-        MacOSX11.3.sdk/System MacOSX11.3.sdk/usr
-    rm -rf ${apple_sysroot}/System ${apple_sysroot}/usr/include/c++ ${apple_sysroot}/usr/include/libxml2
-    cp -ra ${WORKSPACE}/srcdir/MacOSX11.3.sdk/System ${apple_sysroot}/.
-    cp -ra ${WORKSPACE}/srcdir/MacOSX11.3.sdk/usr/* ${apple_sysroot}/usr/.
-    sed -i "s!/opt/${target}/${target}/sys-root!${apple_sysroot}!g" \
-        ${CMAKE_TARGET_TOOLCHAIN} /opt/bin/${bb_full_target}/${target}-{cc,c++,clang,clang++}
-    # clang turns SDKROOT into -isysroot, which beats --sysroot for headers.
-    export SDKROOT=${apple_sysroot}
+    # Update SDK version: std::aligned_alloc (and, on x86_64, std::filesystem
+    # in the hosting code) need the 11.3 SDK and a 10.15 deployment target.
+    pushd ${WORKSPACE}/srcdir/MacOSX11.*.sdk
+    rm -rf /opt/${target}/${target}/sys-root/System
+    rm -rf /opt/${target}/${target}/sys-root/usr/include/libxml2/libxml
+    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
+    cp -ra System "/opt/${target}/${target}/sys-root/."
+    popd
     if [[ "${target}" == x86_64-* ]]; then
-        # std::filesystem (used by the hosting code) and std::aligned_alloc
-        # are available from macOS 10.15; aarch64 already targets 11.0.
         export MACOSX_DEPLOYMENT_TARGET=10.15
     fi
 elif [[ "${target}" == *-mingw* ]]; then

--- a/V/vst3sdk/build_tarballs.jl
+++ b/V/vst3sdk/build_tarballs.jl
@@ -36,12 +36,15 @@ sources = [
               "586dc5e6c8012c3e4b01c79389375cbe96bdb1da"),
     GitSource("https://github.com/steinbergmedia/vst3_cmake.git",
               "054c9143cbb8d47fc4694e473f2ee3b4d951a8f5"),
+    # std::aligned_alloc (C++) needs the macOS 11.3 SDK; the rootfs SDK is older.
+    FileSource("https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz",
+               "cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4"),
 ]
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/vst3sdk
 # Put the submodules where the SDK's CMake expects them.
-rmdir base pluginterfaces public.sdk cmake 2>/dev/null || true
+rmdir base pluginterfaces public.sdk cmake
 mv ../vst3_base base
 mv ../vst3_pluginterfaces pluginterfaces
 mv ../vst3_public_sdk public.sdk
@@ -52,11 +55,29 @@ mkdir -p vstgui4 doc tutorials
 install_license LICENSE.txt
 
 if [[ "${target}" == *-apple-* ]]; then
-    # std::aligned_alloc is not in libc++'s std:: for the macOS SDK the
-    # toolchain uses; the SDK already has a posix_memalign path for older
-    # deployment targets, so use it on every macOS target.
-    sed -i '/#if SMTG_OS_MACOS && defined(MAC_OS_X_VERSION_MIN_REQUIRED)/{N;s/.*/#if SMTG_OS_MACOS \/* BinaryBuilder: posix_memalign on every macOS target *\//}' \
-        public.sdk/source/vst/utility/alignedalloc.h
+    # alignedalloc.h uses std::aligned_alloc from a 10.15 deployment target on
+    # (aarch64 targets 11.0) and posix_memalign below it; the rootfs SDK has
+    # neither aligned_alloc nor MAC_OS_X_VERSION_10_15, so both paths need the
+    # 11.3 SDK. The rootfs sys-root is a read-only overlay layer whose
+    # directories cannot be replaced, so install the SDK into a scratch copy
+    # of it and point the toolchain there (as P/pocl and S/SLEEF do).
+    apple_sysroot=${WORKSPACE}/srcdir/sysroot
+    cp -a /opt/${target}/${target}/sys-root ${apple_sysroot}
+    tar --extract --file=${WORKSPACE}/srcdir/MacOSX11.3.sdk.tar.xz \
+        --directory=${WORKSPACE}/srcdir --warning=no-unknown-keyword \
+        MacOSX11.3.sdk/System MacOSX11.3.sdk/usr
+    rm -rf ${apple_sysroot}/System ${apple_sysroot}/usr/include/c++ ${apple_sysroot}/usr/include/libxml2
+    cp -ra ${WORKSPACE}/srcdir/MacOSX11.3.sdk/System ${apple_sysroot}/.
+    cp -ra ${WORKSPACE}/srcdir/MacOSX11.3.sdk/usr/* ${apple_sysroot}/usr/.
+    sed -i "s!/opt/${target}/${target}/sys-root!${apple_sysroot}!g" \
+        ${CMAKE_TARGET_TOOLCHAIN} /opt/bin/${bb_full_target}/${target}-{cc,c++,clang,clang++}
+    # clang turns SDKROOT into -isysroot, which beats --sysroot for headers.
+    export SDKROOT=${apple_sysroot}
+    if [[ "${target}" == x86_64-* ]]; then
+        # std::filesystem (used by the hosting code) and std::aligned_alloc
+        # are available from macOS 10.15; aarch64 already targets 11.0.
+        export MACOSX_DEPLOYMENT_TARGET=10.15
+    fi
 elif [[ "${target}" == *-mingw* ]]; then
     # mingw's libstdc++ has no std::aligned_alloc either; the SDK's MSVC path
     # (_aligned_malloc / _aligned_free from <malloc.h>) works with mingw too.
@@ -111,25 +132,35 @@ cmake -B build -G Ninja "${PLATFORM_FLAGS[@]}" \
 cmake --build build --parallel ${nproc} --target \
     base pluginterfaces sdk sdk_common sdk_hosting again-sample-accurate adelay
 
+# The SDK's CMake (SMTG_ConfigureCmakeGenerator.cmake) drops the per-config
+# subdirectory on Windows.
+if [[ "${target}" == *-mingw* ]]; then
+    BUILD_LIBDIR=build/lib
+    BUILD_VST3DIR=build/VST3
+else
+    BUILD_LIBDIR=build/lib/Release
+    BUILD_VST3DIR=build/VST3/Release
+fi
+
 # Static libraries.
-mkdir -p ${prefix}/lib/vst3sdk
-cp build/lib/Release/*.a ${prefix}/lib/vst3sdk/ 2>/dev/null || cp build/lib/*.a ${prefix}/lib/vst3sdk/
+mkdir -vp ${prefix}/lib/vst3sdk
+cp -v ${BUILD_LIBDIR}/*.a ${prefix}/lib/vst3sdk/
 
 # The source tree as headers + directly-compiled sources.
-mkdir -p ${includedir}/vst3sdk
-cp -r pluginterfaces base public.sdk ${includedir}/vst3sdk/
-rm -rf ${includedir}/vst3sdk/public.sdk/samples/vst/mda-vst3/*/media \
-       ${includedir}/vst3sdk/public.sdk/samples/vst-hosting \
-       ${includedir}/vst3sdk/base/build ${includedir}/vst3sdk/*/.git*
-find ${includedir}/vst3sdk -name '*.png' -o -name '*.jpg' -o -name '*.uidesc' -o -name '*.rc' | xargs rm -f
+mkdir -vp ${includedir}/vst3sdk
+cp -vr pluginterfaces base public.sdk ${includedir}/vst3sdk/
+rm -rfv ${includedir}/vst3sdk/public.sdk/samples/vst/mda-vst3/*/media \
+        ${includedir}/vst3sdk/public.sdk/samples/vst-hosting \
+        ${includedir}/vst3sdk/base/build ${includedir}/vst3sdk/*/.git*
+find ${includedir}/vst3sdk -type f \
+    \( -name '*.png' -o -name '*.jpg' -o -name '*.uidesc' -o -name '*.rc' -o -name '.git*' \) \
+    -print -delete
 
-# Example plugin bundles (GUI-free), for hosting tests.
-mkdir -p ${prefix}/lib/vst3
-if [[ -d build/VST3/Release ]]; then
-    cp -r build/VST3/Release/*.vst3 ${prefix}/lib/vst3/
-else
-    cp -r build/VST3/*.vst3 ${prefix}/lib/vst3/
-fi
+# Example plugin bundles (GUI-free), for hosting tests. Only the two built
+# above: on macOS the SDK's CMake lays out a bundle skeleton for every
+# plugin target at configure time.
+mkdir -vp ${prefix}/lib/vst3
+cp -vr ${BUILD_VST3DIR}/{again-sample-accurate,adelay}.vst3 ${prefix}/lib/vst3/
 """
 
 # The SDK targets Linux, macOS and Windows; nothing else.
@@ -149,6 +180,8 @@ products = [
 
 dependencies = [
     HostBuildDependency(PackageSpec(; name="CMake_jll")),   # the SDK wants CMake >= 3.25
+    # The example plugin bundles link libstdc++/libgcc_s.
+    Dependency(PackageSpec(name="CompilerSupportLibraries_jll", uuid="e66e0078-7015-5450-92f7-15fbd957f2ae")),
 ]
 
 # C++17 with std::filesystem in the hosting code: GCC 9 or newer.


### PR DESCRIPTION
> Draft — please ignore until reviewed by @ChrisRackauckas.

Replacement for https://github.com/JuliaPackaging/Yggdrasil/pull/14612 (`[vst3sdk] New recipe: v3.8.1`). The recipe is @pankgeorg's — his commit is cherry-picked unchanged as the first commit of this branch, so authorship is preserved — and the second commit addresses @giordano's review there. The original branch lives on a fork none of us can push to, hence a new PR; a maintainer may want to close #14612 in favour of this one.

This is step 1 of a chain: https://github.com/JuliaPackaging/Yggdrasil/pull/14613 (`VST3Host_jll`) uses `vst3sdk_jll` as a `BuildDependency`.

## Review points from #14612 and how they are addressed

1. **`rmdir base pluginterfaces public.sdk cmake 2>/dev/null || true`** (hides errors) — now a plain `rmdir base pluginterfaces public.sdk cmake`. The four paths are the empty submodule stubs `git` creates on checkout of the top-level repository; verified on all four platforms below (the step passes and the build fails loudly if the layout changes).
2. **macOS `sed` of `alignedalloc.h`** ("`std::aligned_alloc` is in the macOS SDK 11.3, can use that instead") — the patch is gone; the recipe now uses the MacOSX 11.3 SDK (same phracker archive and sha256 as `C/charon` and `T/Trilinos`, which add it for the same symbol). Details, since it was less simple than swapping an SDK:
   * `alignedalloc.h` uses `std::aligned_alloc` from a 10.15 deployment target and `posix_memalign` below it. The rootfs sys-root on both Apple targets ships libc++ 8 headers (no `using ::aligned_alloc`), and the x86_64 one is a pre-10.15 SDK without `aligned_alloc` at all and without `MAC_OS_X_VERSION_10_15`, so the header's own gate misfires there too. Both paths need the 11.3 SDK.
   * The SDK is installed the way `P/pocl` and `S/SLEEF` do it: into a scratch copy of the sys-root (`System`, `usr/include/c++`, `usr/include/libxml2` replaced by the SDK's), with the CMake toolchain file, the four clang wrapper scripts and `SDKROOT` redirected at it. `SDKROOT` matters: clang turns it into `-isysroot`, which beats the wrappers' `--sysroot` for header search. The classic `rm -rf /opt/${target}/${target}/sys-root/System` form cannot run in an unprivileged user-namespace sandbox (removing lower-layer directories of the overlay fails with `I/O error`), which is why pocl/SLEEF went this way; it also lets non-Apple builds skip extracting the SDK (it is a `FileSource`, extracted only in the Apple branch).
   * `x86_64-apple-darwin` sets `MACOSX_DEPLOYMENT_TARGET=10.15` (as charon and Trilinos do). With libc++ 12 headers the hosting code's `std::filesystem` is availability-gated to 10.15 anyway, so the library could never have run on older macOS; aarch64 already targets 11.0 and is unchanged. **Reviewer judgment call:** this raises the minimum macOS for the x86_64 artifact from BinaryBuilder's default to 10.15.
   * The mingw `sed` (`_MSC_VER` → `_WIN32`) is kept as in #14612.
3. **`cp build/lib/Release/*.a … 2>/dev/null || cp build/lib/*.a …`** — no fallback any more: the SDK's `SMTG_ConfigureCmakeGenerator.cmake` puts Windows outputs directly in `lib/` and `VST3/` and everything else under `lib/Release/` and `VST3/Release/`, so the recipe picks the directory per platform and copies with `cp -v`. Confirmed by the four local builds (the old fallback branch was the one that ran on mingw).
4. **`mkdir -vp` / `cp -vr` for the include tree** — applied, and `-v` on the other `mkdir`/`cp`/`rm` steps too. The media cleanup is now `find -type f \( … \) -print -delete` instead of `find | xargs rm -f`, which silently skipped `note_expression_synth/resource/knob big.png` (a space in the name) and left a nested `.gitignore`; both are gone from the tarballs now.
5. **"What do you do with the static libraries?"** — they are linked by the companion `VST3Host_jll` recipe (https://github.com/JuliaPackaging/Yggdrasil/pull/14613): `-L${prefix}/lib/vst3sdk -lsdk_hosting -lsdk_common -lsdk -lbase -lpluginterfaces`, with `vst3sdk_jll` as a `BuildDependency` so the host library is self-contained. They are also what any Julia-side VST3 plugin author cross-compiling against the SDK links; the SDK is designed to be consumed as static libraries plus source tree, it has no shared-library form.

## Additions beyond the review

* `Dependency(CompilerSupportLibraries_jll)`: the example plugin bundles are C++ shared libraries linking `libgcc_s`; without it the audit warned `lib/vst3/*.vst3/Contents/x86_64-linux/*.so: Linked library libgcc_s.so.1 could not be resolved and could not be auto-mapped`. With it, zero audit warnings on all four platforms.
* Only the two built bundles (`again-sample-accurate.vst3`, `adelay.vst3`) are copied. On macOS the SDK's CMake lays out an `Info.plist`-only bundle skeleton for every plugin target at configure time, and the `*.vst3` glob in #14612 shipped nine empty bundles.

## Verification (local BinaryBuilder builds, x86_64 host, `--verbose`)

Before the changes, the unmodified #14612 recipe built and audited fine for `x86_64-linux-gnu-cxx11`; with its macOS `sed` removed, both Apple targets fail with `alignedalloc.h:59:9: error: no member named 'aligned_alloc' in namespace 'std'` (at `MACOSX_DEPLOYMENT_TARGET=11.0` on aarch64 and `10.10` on x86_64), which is the failure the SDK swap addresses.

With this branch, `julia --project build_tarballs.jl --verbose <triplet>` for each of the four triplets that exercise every branch of the script — all four exit 0, audit clean, tarballs contain `include/vst3sdk/{pluginterfaces,base,public.sdk}` (959 files: 400 headers, 266 `.cpp`), the five `lib/vst3sdk/*.a`, the two `lib/vst3/*.vst3` bundles with their binaries, and the license; no `.png`/`.uidesc`/`.rc`/`.git*` leftovers:

```
--- x86_64-linux-gnu-cxx11
[ Info: FileProduct include/vst3sdk/pluginterfaces/base/funknown.h found at <destdir>/include/vst3sdk/pluginterfaces/base/funknown.h
[ Info: FileProduct lib/vst3sdk/libsdk_hosting.a found at <destdir>/lib/vst3sdk/libsdk_hosting.a
[ Info: FileProduct lib/vst3/again-sample-accurate.vst3 found at <destdir>/lib/vst3/again-sample-accurate.vst3
[ Info: Tree hash of contents of vst3sdk.v3.8.1.x86_64-linux-gnu-cxx11.tar.gz: 55472a98846087757a7d3c0682e2a751331f9d37
[ Info: SHA256 of vst3sdk.v3.8.1.x86_64-linux-gnu-cxx11.tar.gz: e28ead7ad2c7a48fbfa9ce3e38ca62e6d0b8eb643a5823926e523112300d978e
[ Info: Timings: setup: 31.46s, build: 6.73s, audit: 18.37s, packaging: 1.97s
--- x86_64-w64-mingw32-cxx11
[ Info: FileProduct include/vst3sdk/pluginterfaces/base/funknown.h found at <destdir>/include/vst3sdk/pluginterfaces/base/funknown.h
[ Info: FileProduct lib/vst3sdk/libsdk_hosting.a found at <destdir>/lib/vst3sdk/libsdk_hosting.a
[ Info: FileProduct lib/vst3/again-sample-accurate.vst3 found at <destdir>/lib/vst3/again-sample-accurate.vst3
[ Info: Tree hash of contents of vst3sdk.v3.8.1.x86_64-w64-mingw32-cxx11.tar.gz: 00ea61480a2db37ae9d26473a1d6cab993f3e4b5
[ Info: SHA256 of vst3sdk.v3.8.1.x86_64-w64-mingw32-cxx11.tar.gz: 17b5097bf0e3bc66239299eb188abf7a86c253455fe35666f0647bb3c99af586
[ Info: Timings: setup: 31.84s, build: 8.29s, audit: 14.16s, packaging: 1.98s
--- x86_64-apple-darwin
[ Info: FileProduct include/vst3sdk/pluginterfaces/base/funknown.h found at <destdir>/include/vst3sdk/pluginterfaces/base/funknown.h
[ Info: FileProduct lib/vst3sdk/libsdk_hosting.a found at <destdir>/lib/vst3sdk/libsdk_hosting.a
[ Info: FileProduct lib/vst3/again-sample-accurate.vst3 found at <destdir>/lib/vst3/again-sample-accurate.vst3
[ Info: Tree hash of contents of vst3sdk.v3.8.1.x86_64-apple-darwin.tar.gz: edc2eda4352348d24063179b15a254e9b60abc70
[ Info: SHA256 of vst3sdk.v3.8.1.x86_64-apple-darwin.tar.gz: a26e7244bdf60f3a60ba6d530292d6acfdf59336fa49734b536152c50cfc607b
[ Info: Timings: setup: 34.49s, build: 36.36s, audit: 12.65s, packaging: 2.02s
--- aarch64-apple-darwin
[ Info: FileProduct include/vst3sdk/pluginterfaces/base/funknown.h found at <destdir>/include/vst3sdk/pluginterfaces/base/funknown.h
[ Info: FileProduct lib/vst3sdk/libsdk_hosting.a found at <destdir>/lib/vst3sdk/libsdk_hosting.a
[ Info: FileProduct lib/vst3/again-sample-accurate.vst3 found at <destdir>/lib/vst3/again-sample-accurate.vst3
[ Info: Tree hash of contents of vst3sdk.v3.8.1.aarch64-apple-darwin.tar.gz: 0e50bf3b7a7a24226c0ec89db07b2879849c8e5a
[ Info: SHA256 of vst3sdk.v3.8.1.aarch64-apple-darwin.tar.gz: fa48ae89a06a3909d285abc0ff1ce3410cd5a2b7a706f1fed3c348a9916e8d02
[ Info: Timings: setup: 33.29s, build: 40.04s, audit: 12.18s, packaging: 2.01s
```

`typos` on the recipe: clean.

## Not verified

Only the four triplets above were built locally; the remaining platforms (other Linux arches and libcs, cxx03 variants, i686 Windows) rely on CI; FreeBSD is filtered out of the platform list as in #14612. The produced plugins were not loaded in a host (that is what `VST3Host_jll` in #14613 is for).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_012dmNxmZWobCKsLS5kagmDZ
