### PR TITLE
[Ipopt] Enable riscv64

### DIFF
--- a/C/Coin-OR/Ipopt/build_tarballs.jl
+++ b/C/Coin-OR/Ipopt/build_tarballs.jl
@@ -65,7 +65,6 @@ platforms = expand_gfortran_versions(platforms)
 # Disable aarch64-freebsd until we recompile the dependencies.
 filter!(p -> !(os(p) == "freebsd" && arch(p) == "aarch64"), platforms)
 filter!(p -> !(Sys.islinux(p) && libc(p) == "musl" && libgfortran_version(p) == v"4" && arch(p) == "aarch64"), platforms)
-filter!(p -> arch(p) != "riscv64", platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -99,7 +99,7 @@ SHOT_version = offset_version(v"1.1.0", v"0.0.0")
 
 # Third-party packages needed by COIN-OR libraries.
 Julia_compat_version = "1.6"
-ASL_version = v"0.1.3"
+ASL_version = v"0.1.4"
 METIS_version = v"5.1.3"
 MUMPS_seq_version_LBT = v"500.900.100"
 SPRAL_version_LBT = v"2025.9.18"

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -99,7 +99,7 @@ SHOT_version = offset_version(v"1.1.0", v"0.0.0")
 
 # Third-party packages needed by COIN-OR libraries.
 Julia_compat_version = "1.6"
-ASL_version = v"0.1.4"
+ASL_version = v"0.1.5"
 METIS_version = v"5.1.3"
 MUMPS_seq_version_LBT = v"500.900.100"
 SPRAL_version_LBT = v"2025.9.18"


### PR DESCRIPTION
Drop the recipe's own riscv64 filter and move the Coin-OR ASL pin to 0.1.4, the first ASL_jll with a riscv64 artifact; SPRAL_jll and MUMPS_seq_jll already have one.