### PR TITLE
[iceberg_rust_ffi] Bump to 0.9.3

### DIFF
--- a/I/iceberg_rust_ffi/build_tarballs.jl
+++ b/I/iceberg_rust_ffi/build_tarballs.jl
@@ -1,10 +1,10 @@
 using BinaryBuilder
 
 name = "iceberg_rust_ffi"
-version = v"0.9.2"
+version = v"0.9.3"
 
 sources = [
-    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "208160ac5b133b771d4520970165cc16bcae994b"),
+    GitSource("https://github.com/RelationalAI/RustyIceberg.jl.git", "5c8767f37451c31a43205a9bd93c4255b0e727a1"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
Bumps `iceberg_rust_ffi` to 0.9.3, pointing at the latest RustyIceberg.jl main commit.

This picks up two fixes in the underlying iceberg-rust dependency around anonymous/unsigned access to public object storage:
- S3: `s3.allow-anonymous` was unconditionally skipping request signing even when real credentials were also configured, silently making every request go out unsigned.
- ADLS/Azure: there was previously no way to read a genuinely public/anonymous Azure Blob container at all; a new opt-in `adls.allow-anonymous` property now mirrors the S3 behavior.

No build-recipe changes beyond the version/source bump.