### PR TITLE
[Clp] Bump the version offset to 0.0.1

### DIFF
--- a/C/Coin-OR/Clp/build_tarballs.jl
+++ b/C/Coin-OR/Clp/build_tarballs.jl
@@ -1,7 +1,7 @@
 # In addition to coin-or-common.jl, we need to modify this file to trigger a
 # rebuild.
 #
-# Last updated: 2026-09-02
+# Last updated: 2026-09-02 (again)
 
 include("../coin-or-common.jl")
 

--- a/C/Coin-OR/coin-or-common.jl
+++ b/C/Coin-OR/coin-or-common.jl
@@ -67,7 +67,7 @@ Cbc_gitsha = "8e898d0a4ab7bb5b202c2ebbf3f2d2c0823c1e9d"
 Cgl_version = offset_version(v"0.60.10", v"0.0.0")
 Cgl_gitsha = "1a63715dbb33997701b896f62afec7651a2b3cac"
 
-Clp_version = offset_version(v"1.17.11", v"0.0.0")
+Clp_version = offset_version(v"1.17.11", v"0.0.1")
 Clp_gitsha = "9310c186d546e21d482be3455166ee6fb4cd6302"
 
 Osi_version = offset_version(v"0.108.12", v"0.0.0")


### PR DESCRIPTION
JuliaRegistries/General#166916 cannot be merged: registering Clp_jll v100.1700.1100+1 leaves `jll/C/Clp_jll/Compat.toml` with overlapping ranges for METIS_jll. The registry expresses compat as version *ranges*, and a range's bounds carry no build number, so v100.1700.1100+0 and +1 are indistinguishable there. #14648 rebuilt Clp under the same upstream version while moving the METIS pin from `=5.1.2` to `=5.1.3`, and those two entries cannot both describe 100.1700.1100.

Bump the offset instead, which is what it is for: 100.1700.1101 is a version the registry can hold a separate compat entry for. The downstream Coin-OR recipes bound Clp with a caret, so none of them need a matching change.