### PR TITLE
[ASL] Link the archive whole under lld

### DIFF
--- a/A/ASL/build_tarballs.jl
+++ b/A/ASL/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder
 
 name = "ASL"
-version = v"0.1.4"
+version = v"0.1.5"
 
 # Collection of sources required to build ThinASLBuilder
 sources = [
@@ -41,11 +41,14 @@ elif [[ "${target}" == *-mingw* ]]; then
     makefile="$WORKSPACE/srcdir/asl-extra/makefile.mingw"
 elif [[ "${target}" == *-apple-* ]]; then
     all_load="-all_load"
-    noall_load="-noall_load"
+    # No -noall_load: cctools ld64 applies these positionally, but ld64.lld keeps one
+    # global flag and takes the last occurrence, so a trailing -noall_load turns the
+    # whole-archive load off again. Nothing follows the archive anyway.
+    noall_load=""
 fi
 
 make -f $makefile CC="$CC" CFLAGS="-O -fPIC $cflags"
-c++ -fPIC -shared -I$WORKSPACE/srcdir/asl-extra -I. $WORKSPACE/srcdir/asl-extra/aslinterface.cc -Wl,${all_load} amplsolver.a -Wl,${noall_load} -o libasl.${dlext}
+c++ -fPIC -shared -I$WORKSPACE/srcdir/asl-extra -I. $WORKSPACE/srcdir/asl-extra/aslinterface.cc -Wl,${all_load} amplsolver.a ${noall_load:+-Wl,${noall_load}} -o libasl.${dlext}
 cp libasl.${dlext} ${libdir}
 cp *.h ${includedir}
 cp *.hd ${includedir}


### PR DESCRIPTION
`ASL_jll v0.1.4+0`'s aarch64-apple-darwin artifact exports 240 symbols where 0.1.3 exported 386: `getstub.c`, `avltree.c`, `sos.c`, `qpcheck.c` and the whole `fg`/`fgh` family are gone. Linking anything against the raw ASL API on macOS arm64 now fails — Ipopt's AMPL interface cannot resolve `C_val_ASL`, `D_val_ASL`, `I_val_ASL`, `WS_val_ASL` or `getstops_ASL`.

The netlib source bump is not the cause. Against 0.1.3, 0.1.4 removes no ASL symbol on any other platform; the only other deltas are `_end`/`__bss_start` on FreeBSD and mingw CRT internals. What changed is the linker: `LC_BUILD_VERSION` records `tool ld` for the 0.1.3 arm64 dylib and `tool lld` for 0.1.4, so this target now links with `ld64.lld` while x86_64-apple-darwin still uses cctools. cctools `ld64` applies `-all_load`/`-noall_load` positionally; `ld64.lld` keeps one global flag and takes the last occurrence (`config->allLoad = args.hasFlag(OPT_all_load, OPT_noall_load, false)`), so the trailing `-noall_load` switched whole-archive off and the link fell back to pulling only the members `aslinterface.cc` reaches. Drop it — nothing follows the archive, and it is the default anyway. The GNU spellings are positional under both linkers, which is why no ELF target was affected.