### PR TITLE
[CUDA] Fix CUDA 10.2 and Xavier artifact use on Jetson

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_10.2.jl
+++ b/C/CUDA/CUDA_Compiler/build_10.2.jl
@@ -1,0 +1,57 @@
+# CUDA 10.2 has no redistributable archives, so like CUDA_Runtime_jll we repackage the
+# relevant parts of the CUDA_SDK_jll build (which comes from the toolkit installers, and
+# from the L4T apt packages on Jetson).
+
+get_script() = raw"""
+# First, find (true) CUDA toolkit directory in ~/.artifacts somewhere
+CUDA_ARTIFACT_DIR=$(dirname $(dirname $(realpath $prefix/cuda/bin/ptxas${exeext})))
+cd ${CUDA_ARTIFACT_DIR}
+
+# Clear out our prefix
+rm -rf ${prefix}/*
+
+# license
+install_license EULA.txt
+
+# binaries
+mkdir -p ${bindir} ${libdir} ${prefix}/lib ${prefix}/share ${prefix}/nvvm
+if [[ ${target} == *-linux-gnu ]]; then
+    mv lib64/libcudadevrt.a ${libdir}
+
+    mv nvvm/libdevice ${prefix}/nvvm
+    mv nvvm/lib64 ${prefix}/nvvm
+
+    mv bin/ptxas ${bindir}
+    mv bin/nvlink ${bindir}
+    mv bin/nvdisasm ${bindir}
+
+    mv lib64/libnvrtc.so* ${libdir}
+    mv lib64/libnvrtc-builtins.so* ${libdir}
+elif [[ ${target} == x86_64-w64-mingw32 ]]; then
+    mv lib/x64/cudadevrt.lib ${prefix}/lib
+
+    mv nvvm/libdevice ${prefix}/nvvm
+    mv nvvm/bin ${prefix}/nvvm
+
+    mv bin/ptxas.exe ${bindir}
+    mv bin/nvlink.exe ${bindir}
+    mv bin/nvdisasm.exe ${bindir}
+
+    mv bin/nvrtc64_* ${bindir}
+    mv bin/nvrtc-builtins64_* ${bindir}
+
+    # Fix permissions
+    chmod +x ${bindir}/*.exe ${bindir}/*.dll ${prefix}/nvvm/bin/*.dll
+fi
+"""
+
+get_products() = [
+    FileProduct(["lib/libcudadevrt.a", "lib/cudadevrt.lib"], :libcudadevrt),
+    FileProduct("nvvm/libdevice/libdevice.10.bc", :libdevice),
+    LibraryProduct(["libnvvm", "nvvm64_33_0"], :libnvvm, ["nvvm/lib64", "nvvm/bin"]),
+    LibraryProduct(["libnvrtc", "nvrtc64_102_0"], :libnvrtc),
+    LibraryProduct(["libnvrtc-builtins", "nvrtc-builtins64_102"], :libnvrtc_builtins),
+    ExecutableProduct("ptxas", :ptxas),
+    ExecutableProduct("nvdisasm", :nvdisasm),
+    ExecutableProduct("nvlink", :nvlink),
+]

--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -7,10 +7,13 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Compiler"
-version = v"0.6.1"
+version = v"0.6.2"
 
 const toolkit_versions = [CUDA.cuda_full_versions; CUDA.cuda_prerelease_versions]
-const compiler_versions = filter(v -> v >= v"11.4", toolkit_versions)
+const compiler_versions = filter(v -> v >= v"11.4" || Base.thisminor(v) == v"10.2", toolkit_versions)
+
+# CUDA 10.2 is repackaged from CUDA_SDK_jll (no redistributables exist for it)
+include("build_10.2.jl")
 
 # preferences are read from our own namespace first, falling back to CUDA_Runtime_jll's:
 # LocalPreferences.toml files predating the runtime/compiler split only pin the runtime,
@@ -130,6 +133,9 @@ function get_platforms(version::VersionNumber)
         arch(platform) == "aarch64" || return true
 
         minor = Base.thisminor(version)
+        if minor == v"10.2" && platform["cuda_platform"] != "jetson"
+            return false
+        end
         if v"11" <= minor < v"11.8" && platform["cuda_platform"] == "jetson"
             return false
         end
@@ -207,10 +213,24 @@ for version in compiler_versions
         augmented_platform["cuda"] = CUDA.platform(version)
         should_build_platform(triplet(augmented_platform)) || continue
 
-        push!(builds,
-            (; script, platforms=[augmented_platform], products=get_products(version), init_block,
-               sources=get_sources("cuda", components; version, platform=augmented_platform),
-        ))
+        if Base.thisminor(version) == v"10.2"
+            # our CUDA 10.2 SDK build only provides Jetson binaries on aarch64
+            if arch(platform) == "aarch64" && platform["cuda_platform"] != "jetson"
+                continue
+            end
+            push!(builds,
+                (; script=get_script(), platforms=[augmented_platform], products=get_products(),
+                   init_block, sources=[],
+                   dependencies=[dependencies;
+                                 BuildDependency(PackageSpec(name="CUDA_SDK_jll", version="10.2.89"))],
+            ))
+        else
+            push!(builds,
+                (; script, platforms=[augmented_platform], products=get_products(version), init_block,
+                   sources=get_sources("cuda", components; version, platform=augmented_platform),
+                   dependencies,
+            ))
+        end
     end
 end
 
@@ -226,7 +246,7 @@ end
 for (i,build) in enumerate(builds)
     build_tarballs(i == lastindex(builds) ? non_platform_ARGS : non_reg_ARGS,
                    name, version, build.sources, build.script,
-                   build.platforms, build.products, dependencies;
+                   build.platforms, build.products, build.dependencies;
                    julia_compat="1.10", lazy_artifacts=true,
                    augment_platform_block, build.init_block)
 end

--- a/C/CUDA/CUDA_Runtime/build_10.2.jl
+++ b/C/CUDA/CUDA_Runtime/build_10.2.jl
@@ -89,6 +89,7 @@ function get_products(platform)
         LibraryProduct(["libcudart", "cudart64_102"], :libcudart),
         LibraryProduct(["libcufft", "cufft64_10"], :libcufft),
         LibraryProduct(["libcublas", "cublas64_10"], :libcublas),
+        LibraryProduct(["libcublasLt", "cublasLt64_10"], :libcublasLt),
         LibraryProduct(["libcusparse", "cusparse64_10"], :libcusparse),
         LibraryProduct(["libcusolver", "cusolver64_10"], :libcusolver),
         LibraryProduct(["libcurand", "curand64_10"], :libcurand),

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.24.3"
+version = v"0.24.4"
 
 # we ship artifacts for both GA and EA/preview toolkits; the platform augmentation only
 # ever selects the latter when the user asks for it through the "version" preference.

--- a/C/CUDA/CUDA_Runtime/toolkit_selection.jl
+++ b/C/CUDA/CUDA_Runtime/toolkit_selection.jl
@@ -301,6 +301,18 @@ const cuda_cap_db = Dict{VersionNumber, NTuple{2, VersionNumber}}(
     v"12.1"  => (v"12.9",  v"99"),
 )
 
+# Jetson library ceilings. NVIDIA builds the Tegra (`linux-aarch64`) redistributables for
+# the JetPack generation they belong to: from CUDA 12.6 on, the Jetson cuBLAS binaries
+# only carry SASS for sm_87 (Orin) and newer, dropping Xavier (sm_7.2) even though the
+# toolkit's ptxas still targets it (`cuda_cap_db` says 12.9). Code CUDA.jl compiles itself
+# keeps working, but every vendor library fails with CUBLAS_STATUS_ARCH_MISMATCH or a
+# launch failure. So on Tegra hosts, a device additionally bounds the selection by the
+# newest Jetson redistributable that still ships its SASS. Measured with
+# `cuobjdump --list-elf` on the Jetson artifacts of CUDA_Runtime_jll.
+const jetson_cap_db = Dict{VersionNumber, NTuple{2, VersionNumber}}(
+    v"7.2"   => (v"9.2",   v"12.5"),
+)
+
 # select the best CUDA toolkit from `toolkits` (an ascending list of candidate versions)
 # for the driver and its devices, or `nothing` if the driver cannot be queried or no
 # candidate is compatible. Toolkits listed in `prerelease_toolkits` are never selected
@@ -357,6 +369,9 @@ function select_cuda_toolkit(toolkits::Vector{VersionNumber},
             # in our list is known to handle them.
             haskey(cuda_cap_db, cap) || return false
             lo, hi = cuda_cap_db[cap]
+            if is_tegra() && haskey(jetson_cap_db, cap)
+                lo, hi = jetson_cap_db[cap]
+            end
             lo <= minor <= hi
         end
         for cap in sort(unique(device_capabilities); rev=true)


### PR DESCRIPTION
CUDA_Runtime_jll 0.24.4 and CUDA_Compiler_jll 0.6.2, from validating the Tegra work on a Jetson Nano (JetPack 4, CUDA 10.2) and an AGX Xavier (JetPack 5, r35).

- The CUDA 10.2 runtime artifact moved libcublasLt into the tarball but never declared it as a product, so cuBLAS.jl's `__init__` failed with `libcublasLt not defined` on every artifact-based 10.2 install (the library was meanwhile picked up from the system CUDA through the linker path, which CUDA.jl warns about). Declare it.

- Add a CUDA 10.2 build of CUDA_Compiler_jll, repackaged from CUDA_SDK_jll like the runtime, so that a JetPack 4 board can use artifacts at all: without it, the Compiler hook found no candidate for a 10.2 driver, logged an error during every Pkg operation, and the user ended up with a runtime and no compiler.

- NVIDIA builds the Jetson (`linux-aarch64`) library redistributables for the JetPack generation they belong to: from CUDA 12.6 on, the Jetson cuBLAS binaries only carry SASS for sm_87 and newer, and 12.8/12.9 are sm_87/sm_101 only. `cuda_cap_db`, which describes ptxas, still admits sm_72 through 12.9, so a JetPack 5 Xavier running the bundled 12.2 compatibility driver selected CUDA 12.9: its own kernels ran, but every vendor library failed with CUBLAS_STATUS_ARCH_MISMATCH or a launch failure. Add a Jetson-specific ceiling (`jetson_cap_db`, sm_7.2 through 12.5, measured with `cuobjdump --list-elf` on every Jetson artifact) that the selection consults on Tegra.