### PR TITLE
[RootFS/Rust] Ship an abort-only `std` for `i686-pc-windows-gnu`

### DIFF
--- a/0_RootFS/Rust/build_tarballs.jl
+++ b/0_RootFS/Rust/build_tarballs.jl
@@ -12,6 +12,7 @@ using BinaryBuilderBase, BinaryBuilder, Pkg.Artifacts
 using BinaryBuilderBase: map_rust_target
 
 include("../common.jl")
+include("windows_abort_std.jl")
 
 # We first download Rustup, and use that to install rust
 rustup_name = "RustStage1"
@@ -21,13 +22,13 @@ rustup_version = v"1.24.3"
 
 # This is the version of the Rust toolchain we install
 version = v"1.97.0"
-# NOTE: The commit won't be necessary once the aarch64-unknown-freebsd workaround is removed
 rust_commit = "2d8144b7880597b6e6d3dfd63a9a9efae3f533d3"
 
+# We'll use rustup to install rust
+rustup_source = FileSource("https://static.rust-lang.org/rustup/archive/$(rustup_version)/x86_64-unknown-linux-musl/rustup-init",
+                           "bdf022eb7cba403d0285bb62cbc47211f610caec24589a72af70e1e900663be9")
 sources = [
-    # We'll use rustup to install rust
-    FileSource("https://static.rust-lang.org/rustup/archive/$(rustup_version)/x86_64-unknown-linux-musl/rustup-init",
-               "bdf022eb7cba403d0285bb62cbc47211f610caec24589a72af70e1e900663be9"),
+    rustup_source,
     # We'll temporarily use this to install the `aarch64-unknown-freebsd` target, which has
     # release assets, but not in the expected location, which means they're not installable
     # via `rustup` in the same way as for other platforms.
@@ -101,6 +102,9 @@ build_info = build_tarballs(ndARGS, rustup_name, rustup_version, sources, script
 # We don't actually need the .tar.gz it creates, so delete that to save space
 rm(joinpath("products", first(values(build_info))[1]))
 
+# Rebuild std for i686-pc-windows-gnu with panic=abort (see windows_abort_std.jl)
+abort_std_path = build_abort_std(ndARGS, version, rust_commit, rustup_source)
+
 # Take the hash of the unpacked Rustup artifact, then split it into a bunch of smaller ones
 mega_rust_path = artifact_path(first(values(build_info))[3])
 rust_host = Platform("x86_64", "linux"; libc="musl")
@@ -113,6 +117,9 @@ for target_platform in rust_platforms
     @info("Generating artifacts for $(rust_target_triplet)...")
     unpacked_hash = create_artifact() do dir
         srcpath = joinpath(mega_rust_path, "toolchains", "$(version)-$(rust_host_triplet)", "lib", "rustlib", rust_target_triplet)
+        if platforms_match(target_platform, abort_std_platform)
+            srcpath = abort_std_path
+        end
         dstpath = joinpath(dir, "toolchains", "$(version)-$(rust_host_triplet)", "lib", "rustlib")
         mkpath(dstpath)
         cp(srcpath, joinpath(dstpath, rust_target_triplet))

--- a/0_RootFS/Rust/bundled/bootstrap.toml
+++ b/0_RootFS/Rust/bundled/bootstrap.toml
@@ -1,0 +1,40 @@
+# Settings match src/ci/run.sh for dist builds. The rustup toolchain in
+# ${WORKSPACE}/rust is the stage0 compiler (local-rebuild), via its proxies.
+[build]
+build = "x86_64-unknown-linux-musl"
+host = ["x86_64-unknown-linux-musl"]
+target = ["i686-pc-windows-gnu"]
+rustc = "/workspace/rust/bin/rustc"
+cargo = "/workspace/rust/bin/cargo"
+local-rebuild = true
+vendor = true
+docs = false
+extended = false
+patch-binaries-for-nix = false
+optimized-compiler-builtins = true
+
+[llvm]
+download-ci-llvm = false
+
+[rust]
+channel = "stable"
+remap-debuginfo = true
+codegen-units-std = 1
+debuginfo-level-std = 1
+
+[dist]
+compression-formats = ["gz"]
+
+[target.x86_64-unknown-linux-musl]
+cc = "x86_64-linux-musl-gcc"
+cxx = "x86_64-linux-musl-g++"
+ar = "x86_64-linux-musl-ar"
+linker = "x86_64-linux-musl-gcc"
+musl-root = "/opt/x86_64-linux-musl/x86_64-linux-musl/sys-root/usr"
+
+[target.i686-pc-windows-gnu]
+cc = "i686-w64-mingw32-gcc"
+cxx = "i686-w64-mingw32-g++"
+ar = "i686-w64-mingw32-ar"
+ranlib = "i686-w64-mingw32-ranlib"
+linker = "i686-w64-mingw32-gcc"

--- a/0_RootFS/Rust/bundled/patches/rtstartup-no-eh-frame-registration.patch
+++ b/0_RootFS/Rust/bundled/patches/rtstartup-no-eh-frame-registration.patch
@@ -1,0 +1,13 @@
+--- a/library/rtstartup/rsbegin.rs
++++ b/library/rtstartup/rsbegin.rs
+@@ -54,7 +54,9 @@
+ // enumerating currently loaded modules via the dl_iterate_phdr() API and
+ // finding their ".eh_frame" sections); Others, like Windows, require modules
+ // to actively register their unwind info sections via unwinder API.
+-#[cfg(all(target_os = "windows", target_arch = "x86", target_env = "gnu"))]
++// BinaryBuilder: nothing unwinds here (panic=abort, SJLJ libgcc), so do not
++// register .eh_frame with libgcc's DWARF unwinder on startup.
++#[cfg(any())]
+ pub mod eh_frames {
+     #[no_mangle]
+     #[unsafe(link_section = ".eh_frame")]

--- a/0_RootFS/Rust/bundled/patches/std-personality-panic-abort-stub.patch
+++ b/0_RootFS/Rust/bundled/patches/std-personality-panic-abort-stub.patch
@@ -1,0 +1,18 @@
+--- a/library/std/src/sys/personality/mod.rs
++++ b/library/std/src/sys/personality/mod.rs
+@@ -14,6 +14,15 @@
+ 
+ #[cfg(not(any(test, doctest)))]
+ cfg_select! {
++    // BinaryBuilder: our i686-w64-mingw32 libgcc is SJLJ and does not
++    // implement the DWARF-2 unwinder ABI. With panic=abort nothing unwinds
++    // through Rust frames, so use an aborting stub as for msvc and wasm.
++    all(panic = "abort", target_os = "windows", target_env = "gnu") => {
++        #[lang = "eh_personality"]
++        fn rust_eh_personality() {
++            core::intrinsics::abort()
++        }
++    }
+     target_os = "emscripten" => {
+         mod emcc;
+     }

--- a/0_RootFS/Rust/windows_abort_std.jl
+++ b/0_RootFS/Rust/windows_abort_std.jl
@@ -1,0 +1,54 @@
+# Rebuild std for i686-pc-windows-gnu with panic=abort.
+#
+# Our i686-w64-mingw32 GCC uses SJLJ exceptions, which Rust does not support.
+# BinaryBuilderBase forces `-C panic=abort` on this platform, so nothing
+# unwinds, but the prebuilt `libstd` still calls `_Unwind_Resume` from its
+# landing pads and personality routine, and the SJLJ libgcc does not define
+# it. So we rebuild std with panic=abort, with the personality routine and
+# the startup `.eh_frame` registration patched out (see bundled/patches).
+#
+# We use rust-lang/rust's own build system in local-rebuild mode (the rustup
+# toolchain of the same version is the stage0 compiler) and take its
+# `rust-std` dist tarball, so the result matches the prebuilt component in
+# layout and codegen settings. It is a cross build because the raw-dylib
+# imports in std need the mingw `dlltool`.
+
+const abort_std_platform = Platform("i686", "windows")
+
+const abort_std_script = raw"""
+cd ${WORKSPACE}/srcdir
+export CARGO_HOME=${WORKSPACE}/rust RUSTUP_HOME=${WORKSPACE}/rust
+chmod +x rustup-init
+./rustup-init -y --no-modify-path --profile minimal --default-host=${rust_host} --default-toolchain ${version}
+
+cd rustc-${version}-src
+for p in ${WORKSPACE}/srcdir/patches/*.patch; do atomic_patch -p1 ${p}; done
+cp ${WORKSPACE}/srcdir/bootstrap.toml .
+export RUSTFLAGS_BOOTSTRAP="-C panic=abort" RUSTFLAGS_NOT_BOOTSTRAP="-C panic=abort"
+# bootstrap remaps Rust paths itself; this does the same for the compiler-rt C objects
+export CFLAGS_$(echo ${rust_target} | tr - _)="-fdebug-prefix-map=${PWD}=/rustc/${commit}"
+# Host build scripts must not link with the target `cc`
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
+python3 x.py dist rust-std --stage 0 --host ${rust_host} --target ${rust_target}
+
+tar -C ${WORKSPACE} -xzf build/dist/rust-std-${version}-${rust_target}.tar.gz
+mkdir -p ${prefix}/lib/rustlib
+cp -r ${WORKSPACE}/rust-std-${version}-${rust_target}/rust-std-${rust_target}/lib/rustlib/${rust_target} ${prefix}/lib/rustlib/
+"""
+
+# Returns the path of the rebuilt `lib/rustlib/i686-pc-windows-gnu` tree
+function build_abort_std(ARGS, version, commit, rustup_source)
+    sources = [
+        rustup_source,
+        ArchiveSource("https://static.rust-lang.org/dist/rustc-$(version)-src.tar.xz",
+                      "de002ee301c1b7422b0a7b09d7c4cb4924cd3224e6cfb24f065dad786dd3ed12"),
+        DirectorySource("./bundled"),
+    ]
+    script = "version=$(version)\ncommit=$(commit)\n" * abort_std_script
+    # GCC 12 matches the shard whose crt2.o build_tarballs.jl copies in
+    build_info = build_tarballs(ARGS, "RustAbortStd", version, sources, script, [abort_std_platform], Product[], Dependency[];
+                                skip_audit=true, preferred_gcc_version=v"12")
+    # We don't actually need the .tar.gz it creates, so delete that to save space
+    rm(joinpath("products", first(values(build_info))[1]))
+    return joinpath(artifact_path(first(values(build_info))[3]), "lib", "rustlib", map_rust_target(abort_std_platform))
+end


### PR DESCRIPTION
Our `i686-w64-mingw32` GCC is configured with SJLJ exceptions, which Rust does not support.

We already force `-C panic=abort` when building Rust applications on this target, but `std` needs to be rebuilt with the same flag so that we do not inherit a reliance on the DWARF-2 exception ABI (`_Unwind_Resume`) via its pre-built libraries.

The alternative would be to do something like:
```
*-mingw*)
        export CXXSTDLIB=""
        export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+crt-static"
        if [[ "${target}" == i686-* ]]; then
            # Rust does not support SJLJ exceptions on i686 Windows.
            #
            # However BinaryBuilder forces -C panic=abort on i686 mingw, so Rust
            # code never unwind and we can sidestep the ABI issue by simply
            # replacing _Unwind_Resume with an _abort alias.
            export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-Wl,--defsym=__Unwind_Resume=_abort"
        fi
        ;;
```

but it seems preferable to just avoid emitting the unsupported exception ABI in the first place.

Patch prepared by Claude Fable 5.1 🤖 