### PR TITLE
[Zix] New recipe: v0.8.2

### DIFF
--- a/Z/Zix/build_tarballs.jl
+++ b/Z/Zix/build_tarballs.jl
@@ -1,0 +1,42 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+# Zix: a lightweight C library of portability wrappers and data structures
+# (https://gitlab.com/drobilla/zix), ISC. A dependency of sord and lilv.
+name = "Zix"
+version = v"0.8.2"
+
+sources = [
+    ArchiveSource("https://download.drobilla.net/zix-$(version).tar.xz",
+                  "4c73aab0f8cbbfe56b00c8c6d648316021e699c5ae6cbf254391ef309047e67b"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/zix-*
+install_license COPYING
+if [[ "${target}" == *-apple-* ]]; then
+    # The cross file names the cctools ld64 as the linker, which meson cannot
+    # identify (it rejects --version and prints its banner to stdout), while
+    # the clang wrapper links with lld, which meson detects fine. Let meson use
+    # the compiler's linker.
+    sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"
+fi
+meson setup build --cross-file="${MESON_TARGET_TOOLCHAIN}" --buildtype=release \
+    -Ddefault_library=shared \
+    -Dbenchmarks=disabled -Ddocs=disabled -Dtests=disabled -Dtests_cpp=disabled
+meson compile -C build -j${nproc}
+meson install -C build
+"""
+
+platforms = supported_platforms()
+
+products = [
+    LibraryProduct(["libzix-0", "libzix", "zix-0"], :libzix),   # on Windows BB parses libfoo-0.dll as "libfoo"
+]
+
+dependencies = Dependency[
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")

--- a/Z/Zix/build_tarballs.jl
+++ b/Z/Zix/build_tarballs.jl
@@ -15,13 +15,6 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/zix-*
 install_license COPYING
-if [[ "${target}" == *-apple-* ]]; then
-    # The cross file names the cctools ld64 as the linker, which meson cannot
-    # identify (it rejects --version and prints its banner to stdout), while
-    # the clang wrapper links with lld, which meson detects fine. Let meson use
-    # the compiler's linker.
-    sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"
-fi
 meson setup build --cross-file="${MESON_TARGET_TOOLCHAIN}" --buildtype=release \
     -Ddefault_library=shared \
     -Dbenchmarks=disabled -Ddocs=disabled -Dtests=disabled -Dtests_cpp=disabled


### PR DESCRIPTION
> Draft — please ignore until reviewed by @ChrisRackauckas.

Recipe by @pankgeorg. This replaces #14603, whose branch lives on a fork we cannot push to. The only change versus #14603 is the removal of the macOS meson linker workaround (`sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"` under `if [[ "${target}" == *-apple-* ]]`): it is unnecessary now that JuliaPackaging/BinaryBuilderBase.jl#490 has merged (commit 2c2320dbcf) and Yggdrasil's `.ci/Manifest.toml` picked it up in #14667 (BinaryBuilderBase tree `81277785b19c1ab6acf7082d083773f02796e1c6`, which is that commit's tree). pankgeorg's recipe commit is cherry-picked unchanged so authorship is preserved; the removal is a separate commit on top.

Dependency order of the chain: Zix (this PR), lv2 and Serd are independent → Sord → Sratom → Lilv → LV2Host (#14610).

### Why the workaround can go: before/after with the same recipe

Recipe from this PR (workaround removed), `aarch64-apple-darwin`, built locally with BinaryBuilder 0.6.6.

### BEFORE (registered BinaryBuilderBase, recipe without the workaround, aarch64-apple-darwin)
```
[07:49:25] Build type: cross build
[07:49:25] Project name: zix
[07:49:25] Project version: 0.8.2
[07:49:25] 
[07:49:25] meson.build:4:0: ERROR: Unable to detect linker for compiler `/opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang -Wl,--version -L/workspace/destdir/lib -fuse-ld=/opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-ld`
[07:49:25] stdout: 
[07:49:25] stderr: ld: warning: directory not found for option '-L/workspace/destdir/lib'
[07:49:25] ld: unknown option: --version
[07:49:25] clang: error: linker command failed with exit code 1 (use -v to see invocation)
[07:49:25] 
Zix-aarch64-apple-darwin-env exit=1
```

### AFTER (BinaryBuilderBase 2c2320dbcf = #490, same recipe)
```
[07:49:43] Project version: 0.8.2
[07:49:43] C compiler for the host machine: /opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang (clang 22.1.7 "clang version 22.1.7 (/home/tim/.cache/BinaryBuilder/download
[07:49:43] C linker for the host machine: /opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang ld64.lld 22.1.7
[07:49:43] C compiler for the build machine: /opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-gcc (gcc 12.1.0 "x86_64-linux-musl-gcc (GCC) 12.1.0")
[07:49:43] C linker for the build machine: /opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-gcc ld.bfd 2.38
[07:49:43] Build machine cpu family: x86_64
157:[ Info: lib/libzix-0.0.dylib matches our search criteria of libzix-0
163:[ Info: Timings: setup: 16.23s, build: 7.25s, audit: 11.59s, packaging: 1.26s
Zix-aarch64-apple-darwin-env2 exit=0
```

### Local build and audit, BinaryBuilderBase at 2c2320dbcf (#490), BinaryBuilder 0.6.6

<details><summary><code>aarch64-apple-darwin</code> — Timings: setup: 16.23s, build: 7.25s, audit: 11.59s, packaging: 1.26s</summary>

```
[07:49:43] C linker for the host machine: /opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang ld64.lld 22.1.7
[ Info: lib/libzix-0.0.dylib already has SONAME "@rpath/libzix-0.0.dylib"
[ Info: Found license file(s): COPYING
[ Info: lib/libzix-0.0.dylib matches our search criteria of libzix-0
Timings: setup: 16.23s, build: 7.25s, audit: 11.59s, packaging: 1.26s
Zix-aarch64-apple-darwin exit=0
```
</details>

<details><summary><code>x86_64-apple-darwin</code> — Timings: setup: 17.21s, build: 6.5s, audit: 11.97s, packaging: 1.27s</summary>

```
[07:51:30] C linker for the host machine: /opt/bin/x86_64-apple-darwin14-libgfortran3-cxx03/x86_64-apple-darwin14-clang ld64 530
[ Info: lib/libzix-0.0.dylib already has SONAME "@rpath/libzix-0.0.dylib"
[ Info: Found license file(s): COPYING
[ Info: lib/libzix-0.0.dylib matches our search criteria of libzix-0
Timings: setup: 17.21s, build: 6.5s, audit: 11.97s, packaging: 1.27s
Zix-x86_64-apple-darwin exit=0
```
</details>

<details><summary><code>x86_64-linux-gnu</code> — Timings: setup: 16.85s, build: 5.48s, audit: 13.08s, packaging: 1.34s</summary>

```
[07:51:28] C linker for the host machine: /opt/bin/x86_64-linux-gnu-libgfortran3-cxx03/x86_64-linux-gnu-gcc ld.bfd 2.24
[ Info: Checking shared library lib/libzix-0.so.0.8.2
[ Info: lib/libzix-0.so.0.8.2 already has SONAME "libzix-0.so.0"
[ Info: Found license file(s): COPYING
[ Info: lib/libzix-0.so matches our search criteria of libzix-0
Timings: setup: 16.85s, build: 5.48s, audit: 13.08s, packaging: 1.34s
Zix-x86_64-linux-gnu exit=0
```
</details>

Not run locally: the remaining Yggdrasil platforms (linux-musl, FreeBSD, mingw, riscv64) — those are left to CI, as with #14603.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_012dmNxmZWobCKsLS5kagmDZ
