### PR TITLE
[lv2] New recipe: v1.18.10 (LV2 specification)

### DIFF
--- a/L/lv2/build_tarballs.jl
+++ b/L/lv2/build_tarballs.jl
@@ -1,0 +1,45 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+# The LV2 audio plugin specification (https://lv2plug.in): C headers plus the
+# Turtle bundles that define the core ontology, ISC. Needed to build sratom
+# and lilv, and at run time by lilv to describe plugin classes and ports.
+# Example plugins are not built.
+name = "lv2"
+version = v"1.18.10"
+
+sources = [
+    ArchiveSource("https://lv2plug.in/spec/lv2-$(version).tar.xz",
+                  "78c51bcf21b54e58bb6329accbb4dae03b2ed79b520f9a01e734bd9de530953f"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/lv2-*
+install_license COPYING
+if [[ "${target}" == *-apple-* ]]; then
+    # The cross file names the cctools ld64 as the linker, which meson cannot
+    # identify (it rejects --version and prints its banner to stdout), while
+    # the clang wrapper links with lld, which meson detects fine. Let meson use
+    # the compiler's linker.
+    sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"
+fi
+meson setup build --cross-file="${MESON_TARGET_TOOLCHAIN}" --buildtype=release \
+    -Ddocs=disabled -Dplugins=disabled -Dtests=disabled -Dold_headers=true \
+    -Dlv2dir="${prefix}/lib/lv2"
+meson compile -C build -j${nproc}
+meson install -C build
+"""
+
+platforms = supported_platforms()
+
+products = [
+    FileProduct("include/lv2/core/lv2.h", :lv2_h),
+    FileProduct("lib/lv2/core.lv2/manifest.ttl", :lv2_core_manifest),
+]
+
+dependencies = Dependency[
+]
+
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")

--- a/L/lv2/build_tarballs.jl
+++ b/L/lv2/build_tarballs.jl
@@ -17,13 +17,6 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/lv2-*
 install_license COPYING
-if [[ "${target}" == *-apple-* ]]; then
-    # The cross file names the cctools ld64 as the linker, which meson cannot
-    # identify (it rejects --version and prints its banner to stdout), while
-    # the clang wrapper links with lld, which meson detects fine. Let meson use
-    # the compiler's linker.
-    sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"
-fi
 meson setup build --cross-file="${MESON_TARGET_TOOLCHAIN}" --buildtype=release \
     -Ddocs=disabled -Dplugins=disabled -Dtests=disabled -Dold_headers=true \
     -Dlv2dir="${prefix}/lib/lv2"


### PR DESCRIPTION
> Draft — please ignore until reviewed by @ChrisRackauckas.

Recipe by @pankgeorg. This replaces #14604, whose branch lives on a fork we cannot push to. The only change versus #14604 is the removal of the macOS meson linker workaround (`sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"` under `if [[ "${target}" == *-apple-* ]]`): it is unnecessary now that JuliaPackaging/BinaryBuilderBase.jl#490 has merged (commit 2c2320dbcf) and Yggdrasil's `.ci/Manifest.toml` picked it up in #14667 (BinaryBuilderBase tree `81277785b19c1ab6acf7082d083773f02796e1c6`, which is that commit's tree). pankgeorg's recipe commit is cherry-picked unchanged so authorship is preserved; the removal is a separate commit on top.

Dependency order of the chain: Zix (#14668), lv2 and Serd are independent → Sord → Sratom → Lilv → LV2Host (#14610).

### Local build and audit, BinaryBuilderBase at 2c2320dbcf (#490), BinaryBuilder 0.6.6

<details><summary><code>aarch64-apple-darwin</code> — Timings: setup: 17.24s, build: 4.86s, audit: 5.68s, packaging: 1.4s</summary>

```
[07:51:28] C linker for the host machine: /opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang ld64.lld 22.1.7
[ Info: Found license file(s): COPYING
Timings: setup: 17.24s, build: 4.86s, audit: 5.68s, packaging: 1.4s
lv2-aarch64-apple-darwin exit=0
```
</details>

<details><summary><code>x86_64-apple-darwin</code> — Timings: setup: 17.15s, build: 4.77s, audit: 5.47s, packaging: 1.38s</summary>

```
[07:51:28] C linker for the host machine: /opt/bin/x86_64-apple-darwin14-libgfortran3-cxx03/x86_64-apple-darwin14-clang ld64 530
[ Info: Found license file(s): COPYING
Timings: setup: 17.15s, build: 4.77s, audit: 5.47s, packaging: 1.38s
lv2-x86_64-apple-darwin exit=0
```
</details>

<details><summary><code>x86_64-linux-gnu</code> — Timings: setup: 16.92s, build: 4.32s, audit: 5.49s, packaging: 1.35s</summary>

```
[07:51:27] C linker for the host machine: /opt/bin/x86_64-linux-gnu-libgfortran3-cxx03/x86_64-linux-gnu-gcc ld.bfd 2.24
[ Info: Found license file(s): COPYING
Timings: setup: 16.92s, build: 4.32s, audit: 5.49s, packaging: 1.35s
lv2-x86_64-linux-gnu exit=0
```
</details>

Not run locally: the remaining Yggdrasil platforms (linux-musl, FreeBSD, mingw, riscv64) — those are left to CI, as with #14604.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_012dmNxmZWobCKsLS5kagmDZ
