### PR TITLE
[Serd] Update to v0.32.10, switch waf → meson

### DIFF
--- a/S/Serd/build_tarballs.jl
+++ b/S/Serd/build_tarballs.jl
@@ -16,13 +16,6 @@ sources = [
 script = raw"""
 cd ${WORKSPACE}/srcdir/serd-*
 install_license COPYING
-if [[ "${target}" == *-apple-* ]]; then
-    # The cross file names the cctools ld64 as the linker, which meson cannot
-    # identify (it rejects --version and prints its banner to stdout), while
-    # the clang wrapper links with lld, which meson detects fine. Let meson use
-    # the compiler's linker.
-    sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"
-fi
 meson setup build --cross-file="${MESON_TARGET_TOOLCHAIN}" --buildtype=release \
     -Ddefault_library=shared \
     -Ddocs=disabled -Dman=disabled -Dtests=disabled -Dtools=enabled

--- a/S/Serd/build_tarballs.jl
+++ b/S/Serd/build_tarballs.jl
@@ -1,40 +1,44 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
-using BinaryBuilder, Pkg
+using BinaryBuilder
 
+# Serd: a lightweight C library for RDF syntax (Turtle, NTriples, NQuads,
+# TriG) (https://gitlab.com/drobilla/serd), ISC. The base of sord, sratom
+# and lilv.
 name = "Serd"
-# <-- this is a lie, we're building v0.30.10, but we need to bump version to build for julia v1.6
-version_fake = v"0.30.11"
-version = v"0.30.10"
+version = v"0.32.10"
 
-# Collection of sources required to complete build
 sources = [
-    ArchiveSource("http://download.drobilla.net/serd-$(version).tar.bz2", "affa80deec78921f86335e6fc3f18b80aefecf424f6a5755e9f2fa0eb0710edf")
+    ArchiveSource("https://download.drobilla.net/serd-$(version).tar.xz",
+                  "b0e93b49e52f01a049475b7886ef140407115a32d3b1e5dc5f95141c88275d1c"),
 ]
 
-# Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/serd*/
-
+cd ${WORKSPACE}/srcdir/serd-*
 install_license COPYING
-./waf configure --prefix=$prefix
-./waf
-./waf install
-exit
+if [[ "${target}" == *-apple-* ]]; then
+    # The cross file names the cctools ld64 as the linker, which meson cannot
+    # identify (it rejects --version and prints its banner to stdout), while
+    # the clang wrapper links with lld, which meson detects fine. Let meson use
+    # the compiler's linker.
+    sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"
+fi
+meson setup build --cross-file="${MESON_TARGET_TOOLCHAIN}" --buildtype=release \
+    -Ddefault_library=shared \
+    -Ddocs=disabled -Dman=disabled -Dtests=disabled -Dtools=enabled
+meson compile -C build -j${nproc}
+meson install -C build
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = supported_platforms(; experimental=true)
+platforms = supported_platforms()
 
-# The products that we will ensure are always built
 products = [
-    LibraryProduct(["libserd-0", "serd"], :libserd)
+    LibraryProduct(["libserd-0", "libserd", "serd-0"], :libserd),   # on Windows BB parses libfoo-0.dll as "libfoo"
+    ExecutableProduct("serdi", :serdi),
 ]
 
-# Dependencies that must be installed before this package can be built
 dependencies = Dependency[
 ]
 
-# Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version_fake, sources, script, platforms, products, dependencies, julia_compat="1.6")
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.6")


### PR DESCRIPTION
> Draft — please ignore until reviewed by @ChrisRackauckas.

Recipe by @pankgeorg. This replaces #14605, whose branch lives on a fork we cannot push to. The only change versus #14605 is the removal of the macOS meson linker workaround (`sed -i -E '/^[a-z_]*ld = /d' "${MESON_TARGET_TOOLCHAIN}"` under `if [[ "${target}" == *-apple-* ]]`): it is unnecessary now that JuliaPackaging/BinaryBuilderBase.jl#490 has merged (commit 2c2320dbcf) and Yggdrasil's `.ci/Manifest.toml` picked it up in #14667 (BinaryBuilderBase tree `81277785b19c1ab6acf7082d083773f02796e1c6`, which is that commit's tree). pankgeorg's recipe commit is cherry-picked unchanged so authorship is preserved; the removal is a separate commit on top.

Dependency order of the chain: Zix (#14668), lv2 and Serd are independent → Sord → Sratom → Lilv → LV2Host (#14610).

### Local build and audit, BinaryBuilderBase at 2c2320dbcf (#490), BinaryBuilder 0.6.6

<details><summary><code>aarch64-apple-darwin</code> — Timings: setup: 16.94s, build: 6.55s, audit: 13.01s, packaging: 1.28s</summary>

```
[07:51:28] C linker for the host machine: /opt/bin/aarch64-apple-darwin20-libgfortran5-cxx11/aarch64-apple-darwin20-clang ld64.lld 22.1.7
[ Info: lib/libserd-0.0.dylib already has SONAME "@rpath/libserd-0.0.dylib"
[ Info: Found license file(s): COPYING
[ Info: lib/libserd-0.0.dylib matches our search criteria of libserd-0
[ Info: bin/serdi matches our search criteria of ["serdi"]
Timings: setup: 16.94s, build: 6.55s, audit: 13.01s, packaging: 1.28s
Serd-aarch64-apple-darwin exit=0
```
</details>

<details><summary><code>x86_64-apple-darwin</code> — Timings: setup: 17.35s, build: 6.08s, audit: 12.95s, packaging: 1.29s</summary>

```
[07:51:29] C linker for the host machine: /opt/bin/x86_64-apple-darwin14-libgfortran3-cxx03/x86_64-apple-darwin14-clang ld64 530
[ Info: lib/libserd-0.0.dylib already has SONAME "@rpath/libserd-0.0.dylib"
[ Info: Found license file(s): COPYING
[ Info: lib/libserd-0.0.dylib matches our search criteria of libserd-0
[ Info: bin/serdi matches our search criteria of ["serdi"]
Timings: setup: 17.35s, build: 6.08s, audit: 12.95s, packaging: 1.29s
Serd-x86_64-apple-darwin exit=0
```
</details>

<details><summary><code>x86_64-linux-gnu</code> — Timings: setup: 17.27s, build: 6.16s, audit: 14.25s, packaging: 1.32s</summary>

```
[07:51:28] C linker for the host machine: /opt/bin/x86_64-linux-gnu-libgfortran3-cxx03/x86_64-linux-gnu-gcc ld.bfd 2.24
[ Info: Checking shared library lib/libserd-0.so.0.32.10
[ Info: lib/libserd-0.so.0.32.10 already has SONAME "libserd-0.so.0"
[ Info: Found license file(s): COPYING
[ Info: lib/libserd-0.so matches our search criteria of libserd-0
[ Info: bin/serdi matches our search criteria of ["serdi"]
Timings: setup: 17.27s, build: 6.16s, audit: 14.25s, packaging: 1.32s
Serd-x86_64-linux-gnu exit=0
```
</details>

Not run locally: the remaining Yggdrasil platforms (linux-musl, FreeBSD, mingw, riscv64) — those are left to CI, as with #14605.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_012dmNxmZWobCKsLS5kagmDZ
