### PR TITLE
[LV2Host] New recipe: v1.1.0 (headless LV2 host from AudioPlugins.jl)

### DIFF
--- a/L/LV2Host/build_tarballs.jl
+++ b/L/LV2Host/build_tarballs.jl
@@ -1,0 +1,48 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+# The headless LV2 host from AudioPlugins.jl (https://github.com/SciML/AudioPlugins.jl):
+# one C translation unit, `csrc/lv2_host.c`, exposing a C ABI of scalar doubles
+# for hosting LV2 audio plugins, with discovery through lilv. The companion of
+# CLAPHost (C/CLAPHost); the version tracks the AudioPlugins.jl release whose
+# `csrc/` is built.
+name = "LV2Host"
+version = v"1.2.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/SciML/AudioPlugins.jl.git",
+              "c3239f3c339ba80c56b15e9a720d10e17518abfd"),  # SciML/AudioPlugins.jl PR "LV2 host: discovery through lilv" -- update to the merge commit if squashed
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/AudioPlugins.jl
+install_license LICENSE csrc/vendor/LV2-ISC-LICENSE
+
+mkdir -p "${libdir}" "${includedir}"
+# The host includes <lv2/...> through the include path so that it and lilv.h
+# resolve to the same copy; lilv's own headers come from Lilv_jll.
+${CC} -std=gnu99 -O2 -fPIC -shared -Wall -Wextra \
+    -Icsrc/vendor -I"${includedir}/lilv-0" -I"${includedir}" \
+    -o "${libdir}/liblv2_host.${dlext}" csrc/lv2_host.c \
+    -L"${libdir}" -llilv-0 -lm
+install -Dm644 csrc/lv2_host.h "${includedir}/lv2_host.h"
+"""
+
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("liblv2_host", :liblv2_host),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Lilv_jll"; compat="0.28.0"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.10")

--- a/L/LV2Host/build_tarballs.jl
+++ b/L/LV2Host/build_tarballs.jl
@@ -8,7 +8,7 @@ using BinaryBuilder
 # CLAPHost (C/CLAPHost); the version tracks the AudioPlugins.jl release whose
 # `csrc/` is built.
 name = "LV2Host"
-version = v"1.2.0"
+version = v"1.1.0"
 
 # Collection of sources required to complete build
 sources = [


### PR DESCRIPTION
> Draft — please ignore until reviewed by @ChrisRackauckas.

**Renumbering note:** AudioPlugins.jl was registered at v1.0.0 (https://github.com/JuliaRegistries/General/pull/167090) because a new package's first version must be a standard initial version, so the AudioPlugins release carrying the LV2 Julia layer becomes v1.1.0 instead of v1.2.0, and this JLL, whose version tracks that release, is v1.1.0. The only change on top of pankgeorg's commit is `version = v"1.2.0"` → `v"1.1.0"`; the source pin `c3239f3c` is unchanged.

Recipe by @pankgeorg, replacing the now-closed #14610 (same recipe commit, cherry-picked unchanged so authorship is preserved; no further changes — it is a plain `${CC}` build, no meson, so the macOS linker workaround removed in the sibling PRs never applied here). **Draft by design until `Lilv_jll` (#14673) is registered.**

Source pin: SciML/AudioPlugins.jl `c3239f3c` (SciML/AudioPlugins.jl#3). That PR was merged with a merge commit, so `c3239f3c` is reachable from `main` and no hash update is needed.

Dependency order of the chain: Zix (#14668), lv2 (#14669) and Serd (#14670) are independent → Sord (#14671) → Sratom (#14672) → Lilv (#14673) → LV2Host (this PR).

CI on this PR is expected red on `Unable to resolve Lilv_jll` until #14673 is registered. Locally it was built and audited against a locally built `Lilv_jll` (the #14673 recipe with its chain, deployed with `--deploy=local` into a local registry).

### Local build and audit, BinaryBuilderBase at 2c2320dbcf (#490), BinaryBuilder 0.6.6

<details><summary><code>x86_64-linux-gnu</code> — Timings: setup: 25.47s, build: 0.54s, audit: 14.44s, packaging: 1.26s</summary>

```
[ Info: Checking lib/liblv2_host.so with RPath list AbstractString[]
[ Info: lib/liblv2_host.so: Ignored system libraries libm.so.6, libc.so.6
[ Info: Checking shared library lib/liblv2_host.so
[ Info: Found license file(s): LICENSE, LV2-ISC-LICENSE
[ Info: lib/liblv2_host.so matches our search criteria of liblv2_host
Timings: setup: 25.47s, build: 0.54s, audit: 14.44s, packaging: 1.26s
LV2Host-x86_64-linux-gnu exit=0
```
</details>

<details><summary><code>aarch64-apple-darwin</code> — Timings: setup: 26.04s, build: 0.68s, audit: 13.77s, packaging: 1.31s</summary>

```
[ Info: Checking lib/liblv2_host.dylib with RPath list String[]
[ Info: lib/liblv2_host.dylib: Ignored system libraries /usr/lib/libSystem.B.dylib
[ Info: lib/liblv2_host.dylib already has SONAME "@rpath/liblv2_host.dylib"
[ Info: Found license file(s): LICENSE, LV2-ISC-LICENSE
[ Info: lib/liblv2_host.dylib matches our search criteria of liblv2_host
Timings: setup: 26.04s, build: 0.68s, audit: 13.77s, packaging: 1.31s
LV2Host-aarch64-apple-darwin exit=0
```
</details>

<details><summary><code>x86_64-apple-darwin</code> — Timings: setup: 26.48s, build: 0.58s, audit: 12.73s, packaging: 1.28s</summary>

```
[ Info: Checking lib/liblv2_host.dylib with RPath list String[]
[ Info: lib/liblv2_host.dylib: Ignored system libraries /usr/lib/libSystem.B.dylib
[ Info: lib/liblv2_host.dylib already has SONAME "@rpath/liblv2_host.dylib"
[ Info: Found license file(s): LICENSE, LV2-ISC-LICENSE
[ Info: lib/liblv2_host.dylib matches our search criteria of liblv2_host
Timings: setup: 26.48s, build: 0.58s, audit: 12.73s, packaging: 1.28s
LV2Host-x86_64-apple-darwin exit=0
```
</details>

Not run locally: the remaining Yggdrasil platforms — those are left to CI once `Lilv_jll` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_012dmNxmZWobCKsLS5kagmDZ
