### PR TITLE
[LIEF_Patchelf] Enable build for i686-w64-mingw32

### DIFF
--- a/L/LIEF_Patchelf/build_tarballs.jl
+++ b/L/LIEF_Patchelf/build_tarballs.jl
@@ -123,9 +123,6 @@ install_license LICENSE
 """
 
 platforms = supported_platforms()
-# The 32-bit mingw libgcc unwinds with SJLJ and so defines no _Unwind_Resume,
-# which the prebuilt i686-pc-windows-gnu std references.
-filter!(p -> !(Sys.iswindows(p) && arch(p) == "i686"), platforms)
 
 products = [
     ExecutableProduct("lief-patchelf", :lief_patchelf),


### PR DESCRIPTION
Drops the `i686-w64-mingw32` filter added in #14631, so `LIEF_Patchelf` now
builds for all 18 supported platforms.

The reason for the filter was fixed in #14663, which removed the requirement for it.

### Verified locally

Built against BinaryBuilderBase master (RustToolchain `1.97.0+1`,
GCCBootstrap 14.3.0):

I confirmed the unwinder situation is unchanged on the GCC side, for the
record: `libgcc_eh.a` in both the 14.3.0 and 15.2.0 i686 mingw shards exports
only `__Unwind_SjLj_*`. The fix is entirely on the Rust side, so no
`preferred_gcc_version` change is needed.

### One note for #14663 / BinaryBuilderBase

`47fcc3d` sets the platform flags as `[target.<triple>] rustflags` in the
generated cargo config. Cargo treats `RUSTFLAGS` and `target.*.rustflags` as
mutually exclusive sources, first match wins, so **any recipe that exports
`RUSTFLAGS` silently discards them**:

```
without RUSTFLAGS env:  CONFIG-RUSTFLAGS APPLIED
with RUSTFLAGS env set: CONFIG-RUSTFLAGS IGNORED
```

This recipe exports `RUSTFLAGS` on mingw for `+crt-static`, so it never sees
the config's `-C panic=abort`. It builds anyway because LIEF's own
`tools/Cargo.toml` sets `panic = "abort"` in `[profile.release]` — but that's
incidental, not by design. Flagging it because it affects every Rust recipe
that sets `RUSTFLAGS` on `i686-w64-mingw32` or `aarch64-linux-musl`, not just
this one. Happy to add `-C panic=abort` here explicitly if you'd prefer the
belt and braces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsxsiLWFcGVPPmjVHrvtYS
