### PR TITLE
[acados] New recipe: acados v0.6.0

### DIFF
--- a/A/acados/build_tarballs.jl
+++ b/A/acados/build_tarballs.jl
@@ -95,11 +95,14 @@ platforms = [
     filter(p -> Sys.isfreebsd(p) && arch(p) == "x86_64", supported_platforms());
 ]
 
-# On Windows the CMake builds drop the `lib` prefix (acados.dll, hpipm.dll, blasfeo.dll)
+# On Windows the CMake builds drop the `lib` prefix (acados.dll, hpipm.dll, blasfeo.dll). The libraries
+# are not dlopened at init: libacados depends on libhpipm and libblasfeo, and the wrapper would open
+# libacados first, so an LD_LIBRARY_PATH pointing at another acados installation (common for acados
+# users) would supply the dependencies. Consumers open blasfeo, hpipm, acados by path in that order.
 products = [
-    LibraryProduct(["libacados", "acados"], :libacados),
-    LibraryProduct(["libhpipm", "hpipm"], :libhpipm),
-    LibraryProduct(["libblasfeo", "blasfeo"], :libblasfeo),
+    LibraryProduct(["libacados", "acados"], :libacados; dont_dlopen = true),
+    LibraryProduct(["libhpipm", "hpipm"], :libhpipm; dont_dlopen = true),
+    LibraryProduct(["libblasfeo", "blasfeo"], :libblasfeo; dont_dlopen = true),
     FileProduct("share/acados/c_templates_tera/acados_solver.in.c", :acados_solver_template),   # dirname(...) is the templates dir
 ]
 

--- a/A/acados/build_tarballs.jl
+++ b/A/acados/build_tarballs.jl
@@ -95,14 +95,13 @@ platforms = [
     filter(p -> Sys.isfreebsd(p) && arch(p) == "x86_64", supported_platforms());
 ]
 
-# On Windows the CMake builds drop the `lib` prefix (acados.dll, hpipm.dll, blasfeo.dll). The libraries
-# are not dlopened at init: libacados depends on libhpipm and libblasfeo, and the wrapper would open
-# libacados first, so an LD_LIBRARY_PATH pointing at another acados installation (common for acados
-# users) would supply the dependencies. Consumers open blasfeo, hpipm, acados by path in that order.
+# On Windows the CMake builds drop the `lib` prefix (acados.dll, hpipm.dll, blasfeo.dll). Listed in
+# dependency order (libacados needs libhpipm and libblasfeo), so that the wrapper opens the dependencies
+# first and an LD_LIBRARY_PATH pointing at another acados installation cannot supply them.
 products = [
-    LibraryProduct(["libacados", "acados"], :libacados; dont_dlopen = true),
-    LibraryProduct(["libhpipm", "hpipm"], :libhpipm; dont_dlopen = true),
-    LibraryProduct(["libblasfeo", "blasfeo"], :libblasfeo; dont_dlopen = true),
+    LibraryProduct(["libblasfeo", "blasfeo"], :libblasfeo),
+    LibraryProduct(["libhpipm", "hpipm"], :libhpipm),
+    LibraryProduct(["libacados", "acados"], :libacados),
     FileProduct("share/acados/c_templates_tera/acados_solver.in.c", :acados_solver_template),   # dirname(...) is the templates dir
 ]
 

--- a/A/acados/build_tarballs.jl
+++ b/A/acados/build_tarballs.jl
@@ -25,14 +25,17 @@ sources = [
 ]
 
 # BLASFEO's kernels are selected at compile time by TARGET (no runtime dispatch), so the recipe
-# builds one variant per microarchitecture tag, as B/blasfeo does: GENERIC C code as the fallback,
-# X64_INTEL_SANDY_BRIDGE for avx, X64_INTEL_HASWELL for avx2 (also what avx512 hosts get), and
-# ARMV8A_APPLE_M1 on Apple silicon. HPIPM has AVX and GENERIC variants.
+# builds one variant per microarchitecture tag, as B/blasfeo does (the tag must match the host's
+# exactly, so every x86_64 tag is built): GENERIC C code as the fallback, X64_INTEL_SANDY_BRIDGE for
+# avx, X64_INTEL_HASWELL for avx2 and avx512 (BLASFEO's AVX-512 targets are tuned for specific chips),
+# and ARMV8A_APPLE_M1 on Apple silicon. HPIPM has AVX and GENERIC variants.
 function get_script(; platform::Platform)
     if arch(platform) == "x86_64" && haskey(platform, "march")
         blasfeo_target, hpipm_target = if platform["march"] == "avx"
-            "X64_INTEL_SANDY_BRIDGE", "AVX"
-        elseif platform["march"] == "avx2"
+            # BLASFEO's Sandy Bridge target misses single-precision kernels under MinGW (undefined
+            # kernel_sgemm_nt_16x4_lib8), so Windows gets the generic kernels there
+            Sys.iswindows(platform) ? "GENERIC" : "X64_INTEL_SANDY_BRIDGE", "AVX"
+        elseif platform["march"] in ("avx2", "avx512")
             "X64_INTEL_HASWELL", "AVX"
         else
             "GENERIC", "GENERIC"
@@ -84,9 +87,9 @@ install_license LICENSE LICENSE-blasfeo.txt LICENSE-hpipm.txt
 end
 
 platforms = [
-    expand_microarchitectures(filter(p -> Sys.islinux(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2"]);
-    expand_microarchitectures(filter(p -> Sys.iswindows(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2"]);
-    expand_microarchitectures(filter(p -> Sys.isapple(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2"]);
+    expand_microarchitectures(filter(p -> Sys.islinux(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2", "avx512"]);
+    expand_microarchitectures(filter(p -> Sys.iswindows(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2", "avx512"]);
+    expand_microarchitectures(filter(p -> Sys.isapple(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2", "avx512"]);
     expand_microarchitectures(filter(p -> Sys.isapple(p) && arch(p) == "aarch64", supported_platforms()), ["apple_m1"]);
     filter(p -> Sys.islinux(p) && arch(p) == "aarch64", supported_platforms());
     filter(p -> Sys.isfreebsd(p) && arch(p) == "x86_64", supported_platforms());

--- a/A/acados/build_tarballs.jl
+++ b/A/acados/build_tarballs.jl
@@ -1,0 +1,118 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+using Base.BinaryPlatforms: arch, os
+
+const YGGDRASIL_DIR = "../.."
+# For MicroArchitectures
+include(joinpath(YGGDRASIL_DIR, "platforms", "microarchitectures.jl"))
+# For should_build_platform
+include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
+
+name = "acados"
+version = v"0.6.0"
+
+# acados (https://github.com/acados/acados) with the BLASFEO and HPIPM versions it pins as
+# submodules (the sandbox cannot fetch submodules, so they are separate sources moved into place).
+# Only the HPIPM QP solver is built; the optional third-party QP solvers (qpOASES, DAQP, OSQP,
+# qpDUNES, HPMPC, Clarabel) are left out. Besides the libraries and headers, the artifact carries
+# acados' Tera C templates (`share/acados/c_templates_tera`), which together with `tera_renderer_jll`
+# render standalone C solvers without the Python `acados_template` package.
+sources = [
+    GitSource("https://github.com/acados/acados.git", "503364817c872d474ab5bed219c26760ac267769"),   # v0.6.0
+    GitSource("https://github.com/giaf/blasfeo.git", "d6251233923c9b475fe894fb729fb63ab693e301"),   # external/blasfeo at v0.6.0
+    GitSource("https://github.com/giaf/hpipm.git", "e3a56c1caddd7f12d125d84f337b9a9e5c186271"),     # external/hpipm at v0.6.0
+]
+
+# BLASFEO's kernels are selected at compile time by TARGET (no runtime dispatch), so the recipe
+# builds one variant per microarchitecture tag, as B/blasfeo does: GENERIC C code as the fallback,
+# X64_INTEL_SANDY_BRIDGE for avx, X64_INTEL_HASWELL for avx2 (also what avx512 hosts get), and
+# ARMV8A_APPLE_M1 on Apple silicon. HPIPM has AVX and GENERIC variants.
+function get_script(; platform::Platform)
+    if arch(platform) == "x86_64" && haskey(platform, "march")
+        blasfeo_target, hpipm_target = if platform["march"] == "avx"
+            "X64_INTEL_SANDY_BRIDGE", "AVX"
+        elseif platform["march"] == "avx2"
+            "X64_INTEL_HASWELL", "AVX"
+        else
+            "GENERIC", "GENERIC"
+        end
+    elseif arch(platform) == "aarch64" && os(platform) == "macos" && haskey(platform, "march") && platform["march"] == "apple_m1"
+        blasfeo_target, hpipm_target = "ARMV8A_APPLE_M1", "GENERIC"
+    else
+        blasfeo_target, hpipm_target = "GENERIC", "GENERIC"
+    end
+    return "BLASFEO_TARGET=$(blasfeo_target)\nHPIPM_TARGET=$(hpipm_target)\n" * raw"""
+cd ${WORKSPACE}/srcdir/acados
+rm -rf external/blasfeo external/hpipm
+mv ../blasfeo external/blasfeo
+mv ../hpipm external/hpipm
+
+# MinGW's header is windows.h (case-sensitive file systems)
+sed -i 's/<Windows.h>/<windows.h>/' acados/utils/timing.h
+
+cmake -B build \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DACADOS_INSTALL_DIR=${prefix} \
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBLASFEO_TARGET=${BLASFEO_TARGET} \
+    -DHPIPM_TARGET=${HPIPM_TARGET} \
+    -DLA=HIGH_PERFORMANCE \
+    -DACADOS_WITH_QPOASES=OFF \
+    -DACADOS_WITH_DAQP=OFF \
+    -DACADOS_WITH_OSQP=OFF \
+    -DACADOS_WITH_QPDUNES=OFF \
+    -DACADOS_WITH_HPMPC=OFF \
+    -DACADOS_WITH_CLARABEL=OFF \
+    -DACADOS_WITH_OPENMP=OFF \
+    -DACADOS_EXAMPLES=OFF \
+    -DACADOS_UNIT_TESTS=OFF \
+    -DACADOS_SILENT=ON
+cmake --build build --parallel ${nproc}
+cmake --install build
+
+# The C templates acados_template renders solvers from (used with tera_renderer_jll)
+mkdir -p ${prefix}/share/acados
+cp -r interfaces/acados_template/acados_template/c_templates_tera ${prefix}/share/acados/
+
+cp external/blasfeo/LICENSE.txt LICENSE-blasfeo.txt
+cp external/hpipm/LICENSE.txt LICENSE-hpipm.txt
+install_license LICENSE LICENSE-blasfeo.txt LICENSE-hpipm.txt
+"""
+end
+
+platforms = [
+    expand_microarchitectures(filter(p -> Sys.islinux(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2"]);
+    expand_microarchitectures(filter(p -> Sys.iswindows(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2"]);
+    expand_microarchitectures(filter(p -> Sys.isapple(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2"]);
+    expand_microarchitectures(filter(p -> Sys.isapple(p) && arch(p) == "aarch64", supported_platforms()), ["apple_m1"]);
+    filter(p -> Sys.islinux(p) && arch(p) == "aarch64", supported_platforms());
+    filter(p -> Sys.isfreebsd(p) && arch(p) == "x86_64", supported_platforms());
+]
+
+# On Windows the CMake builds drop the `lib` prefix (acados.dll, hpipm.dll, blasfeo.dll)
+products = [
+    LibraryProduct(["libacados", "acados"], :libacados),
+    LibraryProduct(["libhpipm", "hpipm"], :libhpipm),
+    LibraryProduct(["libblasfeo", "blasfeo"], :libblasfeo),
+    FileProduct("share/acados/c_templates_tera/acados_solver.in.c", :acados_solver_template),   # dirname(...) is the templates dir
+]
+
+# augment_platform so the fastest matching microarchitecture variant is selected
+augment_platform_block = """
+$(MicroArchitectures.augment)
+
+function augment_platform!(platform::Platform)
+    augment_microarchitecture!(platform)
+end
+"""
+
+dependencies = Dependency[]
+
+for platform in platforms
+    should_build_platform(platform) || continue
+    build_tarballs(ARGS, name, version, sources, get_script(; platform), [platform], products, dependencies;
+                   julia_compat = "1.6", augment_platform_block, lock_microarchitecture = false)
+end

--- a/A/acados/build_tarballs.jl
+++ b/A/acados/build_tarballs.jl
@@ -1,7 +1,7 @@
 # Note that this script can accept some limited command-line arguments, run
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder, Pkg
-using Base.BinaryPlatforms: arch, os
+using Base.BinaryPlatforms: arch
 
 const YGGDRASIL_DIR = "../.."
 # For MicroArchitectures
@@ -12,47 +12,42 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 name = "acados"
 version = v"0.6.0"
 
-# acados (https://github.com/acados/acados) with the BLASFEO and HPIPM versions it pins as
-# submodules (the sandbox cannot fetch submodules, so they are separate sources moved into place).
-# Only the HPIPM QP solver is built; the optional third-party QP solvers (qpOASES, DAQP, OSQP,
-# qpDUNES, HPMPC, Clarabel) are left out. Besides the libraries and headers, the artifact carries
-# acados' Tera C templates (`share/acados/c_templates_tera`), which together with `tera_renderer_jll`
-# render standalone C solvers without the Python `acados_template` package.
+# acados (https://github.com/acados/acados) built against blasfeo_jll and hpipm_jll instead of the
+# copies it carries as submodules. Only the HPIPM QP solver is built; the optional third-party QP
+# solvers (qpOASES, DAQP, OSQP, qpDUNES, HPMPC, Clarabel) are left out. Besides the library and the
+# headers, the artifact carries acados' Tera C templates (`share/acados/c_templates_tera`), which
+# together with `tera_renderer_jll` render standalone C solvers without the Python `acados_template`
+# package.
 sources = [
     GitSource("https://github.com/acados/acados.git", "503364817c872d474ab5bed219c26760ac267769"),   # v0.6.0
-    GitSource("https://github.com/giaf/blasfeo.git", "d6251233923c9b475fe894fb729fb63ab693e301"),   # external/blasfeo at v0.6.0
-    GitSource("https://github.com/giaf/hpipm.git", "e3a56c1caddd7f12d125d84f337b9a9e5c186271"),     # external/hpipm at v0.6.0
+    DirectorySource("./bundled"),
 ]
 
-# BLASFEO's kernels are selected at compile time by TARGET (no runtime dispatch), so the recipe
-# builds one variant per microarchitecture tag, as B/blasfeo does (the tag must match the host's
-# exactly, so every x86_64 tag is built): GENERIC C code as the fallback, X64_INTEL_SANDY_BRIDGE for
-# avx, X64_INTEL_HASWELL for avx2 and avx512 (BLASFEO's AVX-512 targets are tuned for specific chips),
-# and ARMV8A_APPLE_M1 on Apple silicon. HPIPM has AVX and GENERIC variants.
-function get_script(; platform::Platform)
-    if arch(platform) == "x86_64" && haskey(platform, "march")
-        blasfeo_target, hpipm_target = if platform["march"] == "avx"
-            # BLASFEO's Sandy Bridge target misses single-precision kernels under MinGW (undefined
-            # kernel_sgemm_nt_16x4_lib8), so Windows gets the generic kernels there
-            Sys.iswindows(platform) ? "GENERIC" : "X64_INTEL_SANDY_BRIDGE", "AVX"
-        elseif platform["march"] in ("avx2", "avx512")
-            "X64_INTEL_HASWELL", "AVX"
-        else
-            "GENERIC", "GENERIC"
-        end
-    elseif arch(platform) == "aarch64" && os(platform) == "macos" && haskey(platform, "march") && platform["march"] == "apple_m1"
-        blasfeo_target, hpipm_target = "ARMV8A_APPLE_M1", "GENERIC"
-    else
-        blasfeo_target, hpipm_target = "GENERIC", "GENERIC"
-    end
-    return "BLASFEO_TARGET=$(blasfeo_target)\nHPIPM_TARGET=$(hpipm_target)\n" * raw"""
+# acados can be pointed at an installed BLASFEO with `ACADOS_WITH_SYSTEM_BLASFEO`, but it always
+# compiles the HPIPM submodule, so one patch adds the matching `ACADOS_WITH_SYSTEM_HPIPM` option. A few
+# includes spell the BLASFEO headers relative to the submodule directory instead of flat as the rest of
+# the sources do, which only resolves for the bundled copy; the other patch makes them flat as well.
+#
+# blasfeo_jll is built with BLASFEO's own Makefile, which installs into ${prefix}/blasfeo and ships no
+# CMake package configuration, so the script writes one for `find_package(blasfeo)`. hpipm_jll ships
+# the configuration CMake exported for it.
+script = raw"""
 cd ${WORKSPACE}/srcdir/acados
-rm -rf external/blasfeo external/hpipm
-mv ../blasfeo external/blasfeo
-mv ../hpipm external/hpipm
+for p in ${WORKSPACE}/srcdir/patches/*.patch; do
+    atomic_patch -p1 ${p}
+done
 
 # MinGW's header is windows.h (case-sensitive file systems)
 sed -i 's/<Windows.h>/<windows.h>/' acados/utils/timing.h
+
+mkdir -p ${WORKSPACE}/srcdir/blasfeo-cmake
+cat > ${WORKSPACE}/srcdir/blasfeo-cmake/blasfeoConfig.cmake <<EOF
+add_library(blasfeo SHARED IMPORTED GLOBAL)
+set_target_properties(blasfeo PROPERTIES
+    IMPORTED_LOCATION "${prefix}/blasfeo/lib/libblasfeo.${dlext}"
+    IMPORTED_IMPLIB "${prefix}/blasfeo/lib/libblasfeo.${dlext}"
+    INTERFACE_INCLUDE_DIRECTORIES "${prefix}/blasfeo/include")
+EOF
 
 cmake -B build \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
@@ -60,9 +55,10 @@ cmake -B build \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
-    -DBLASFEO_TARGET=${BLASFEO_TARGET} \
-    -DHPIPM_TARGET=${HPIPM_TARGET} \
-    -DLA=HIGH_PERFORMANCE \
+    -DACADOS_WITH_SYSTEM_BLASFEO=ON \
+    -Dblasfeo_DIR=${WORKSPACE}/srcdir/blasfeo-cmake \
+    -DACADOS_WITH_SYSTEM_HPIPM=ON \
+    -Dhpipm_DIR=${prefix}/cmake \
     -DACADOS_WITH_QPOASES=OFF \
     -DACADOS_WITH_DAQP=OFF \
     -DACADOS_WITH_OSQP=OFF \
@@ -80,32 +76,26 @@ cmake --install build
 mkdir -p ${prefix}/share/acados
 cp -r interfaces/acados_template/acados_template/c_templates_tera ${prefix}/share/acados/
 
-cp external/blasfeo/LICENSE.txt LICENSE-blasfeo.txt
-cp external/hpipm/LICENSE.txt LICENSE-hpipm.txt
-install_license LICENSE LICENSE-blasfeo.txt LICENSE-hpipm.txt
+install_license LICENSE
 """
-end
 
+# BLASFEO selects its kernels at compile time and its target determines the panel size the acados
+# structures are laid out with, so one variant is built per microarchitecture, matching the variants
+# blasfeo_jll and hpipm_jll provide.
 platforms = [
     expand_microarchitectures(filter(p -> Sys.islinux(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2", "avx512"]);
     expand_microarchitectures(filter(p -> Sys.iswindows(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2", "avx512"]);
-    expand_microarchitectures(filter(p -> Sys.isapple(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2", "avx512"]);
+    expand_microarchitectures(filter(p -> Sys.isapple(p) && arch(p) == "x86_64", supported_platforms()), ["x86_64", "avx", "avx2"]);
     expand_microarchitectures(filter(p -> Sys.isapple(p) && arch(p) == "aarch64", supported_platforms()), ["apple_m1"]);
-    filter(p -> Sys.islinux(p) && arch(p) == "aarch64", supported_platforms());
-    filter(p -> Sys.isfreebsd(p) && arch(p) == "x86_64", supported_platforms());
 ]
 
-# On Windows the CMake builds drop the `lib` prefix (acados.dll, hpipm.dll, blasfeo.dll). Listed in
-# dependency order (libacados needs libhpipm and libblasfeo), so that the wrapper opens the dependencies
-# first and an LD_LIBRARY_PATH pointing at another acados installation cannot supply them.
+# On Windows the CMake build drops the `lib` prefix (acados.dll)
 products = [
-    LibraryProduct(["libblasfeo", "blasfeo"], :libblasfeo),
-    LibraryProduct(["libhpipm", "hpipm"], :libhpipm),
     LibraryProduct(["libacados", "acados"], :libacados),
     FileProduct("share/acados/c_templates_tera/acados_solver.in.c", :acados_solver_template),   # dirname(...) is the templates dir
 ]
 
-# augment_platform so the fastest matching microarchitecture variant is selected
+# augment_platform so the microarchitecture variant matching the host is selected
 augment_platform_block = """
 $(MicroArchitectures.augment)
 
@@ -114,10 +104,13 @@ function augment_platform!(platform::Platform)
 end
 """
 
-dependencies = Dependency[]
+dependencies = [
+    Dependency("blasfeo_jll"; compat = "0.1.4"),
+    Dependency("hpipm_jll"; compat = "0.1.4"),
+]
 
 for platform in platforms
     should_build_platform(platform) || continue
-    build_tarballs(ARGS, name, version, sources, get_script(; platform), [platform], products, dependencies;
-                   julia_compat = "1.6", augment_platform_block, lock_microarchitecture = false)
+    build_tarballs(ARGS, name, version, sources, script, [platform], products, dependencies;
+                   julia_compat = "1.6", augment_platform_block)
 end

--- a/A/acados/build_tarballs.jl
+++ b/A/acados/build_tarballs.jl
@@ -111,6 +111,10 @@ dependencies = [
 
 for platform in platforms
     should_build_platform(platform) || continue
+    # mingw-gcc before v10 fails to assemble the AVX-512 code ("invalid register for .seh_savexmm"),
+    # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782. As in B/blasfeo, v"10" is the value
+    # `preferred_gcc_version` needs to select a compiler without the bug.
+    gcc_version = Sys.iswindows(platform) && platform["march"] == "avx512" ? v"10" : nothing
     build_tarballs(ARGS, name, version, sources, script, [platform], products, dependencies;
-                   julia_compat = "1.6", augment_platform_block)
+                   julia_compat = "1.6", augment_platform_block, preferred_gcc_version = gcc_version)
 end

--- a/A/acados/bundled/patches/flat-blasfeo-includes.patch
+++ b/A/acados/bundled/patches/flat-blasfeo-includes.patch
@@ -1,0 +1,32 @@
+diff --git a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+index 297afc80..144a9421 100644
+--- a/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
++++ b/acados/ocp_nlp/ocp_nlp_sqp_with_feasible_qp.c
+@@ -42,9 +42,9 @@
+ #endif
+ 
+ // blasfeo
+-#include "blasfeo/include/blasfeo_d_aux.h"
+-#include "blasfeo/include/blasfeo_d_aux_ext_dep.h"
+-#include "blasfeo/include/blasfeo_d_blas.h"
++#include "blasfeo_d_aux.h"
++#include "blasfeo_d_aux_ext_dep.h"
++#include "blasfeo_d_blas.h"
+ 
+ // acados
+ #include "acados/ocp_nlp/ocp_nlp_common.h"
+diff --git a/interfaces/acados_c/ocp_nlp_interface.c b/interfaces/acados_c/ocp_nlp_interface.c
+index f342da07..73d48771 100644
+--- a/interfaces/acados_c/ocp_nlp_interface.c
++++ b/interfaces/acados_c/ocp_nlp_interface.c
+@@ -66,8 +66,8 @@
+ #include "acados/utils/strsep.h"
+ 
+ // blasfeo
+-#include "blasfeo/include/blasfeo_d_blas.h"
+-#include "blasfeo/include/blasfeo_d_aux.h"
++#include "blasfeo_d_blas.h"
++#include "blasfeo_d_aux.h"
+ 
+ /************************************************
+ * plan

--- a/A/acados/bundled/patches/system-hpipm.patch
+++ b/A/acados/bundled/patches/system-hpipm.patch
@@ -1,0 +1,77 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea7ae62a..d6b21e4b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -101,6 +101,11 @@ mark_as_advanced(ACADOS_WITH_SYSTEM_BLASFEO)
+ if(ACADOS_WITH_SYSTEM_BLASFEO)
+     message(WARNING "The ACADOS_WITH_SYSTEM_BLASFEO option is enabled. ACADOS is tested by its developers only with ACADOS_WITH_SYSTEM_BLASFEO=OFF, when using an external blasfeo may sure that everything works as expected.")
+ endif()
++option(ACADOS_WITH_SYSTEM_HPIPM "If ON, use hpipm found via find_package(hpipm) instead of compiling it" OFF)
++mark_as_advanced(ACADOS_WITH_SYSTEM_HPIPM)
++if(ACADOS_WITH_SYSTEM_HPIPM)
++    message(WARNING "The ACADOS_WITH_SYSTEM_HPIPM option is enabled. ACADOS is tested by its developers only with ACADOS_WITH_SYSTEM_HPIPM=OFF, when using an external hpipm make sure that everything works as expected.")
++endif()
+ 
+ # Set custom path
+ set(EXTERNAL_SRC_DIR ${PROJECT_SOURCE_DIR}/external)
+diff --git a/acados/CMakeLists.txt b/acados/CMakeLists.txt
+index 282f0d66..ff3ebbf0 100644
+--- a/acados/CMakeLists.txt
++++ b/acados/CMakeLists.txt
+@@ -75,11 +75,15 @@ add_library(acados ${ACADOS_SRC})
+ 
+ target_include_directories(acados PUBLIC
+         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> # to be able to include "acados/header.h"
+-        $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}/hpipm/include>
+         $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}>
+         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interfaces>
+         $<INSTALL_INTERFACE:include>)
+ 
++if(NOT ACADOS_WITH_SYSTEM_HPIPM)
++    target_include_directories(acados PUBLIC
++        $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}/hpipm/include>)
++endif()
++
+ if(NOT ACADOS_WITH_SYSTEM_BLASFEO)
+     target_include_directories(acados PUBLIC
+         $<BUILD_INTERFACE:${EXTERNAL_SRC_DIR}/blasfeo/include>)
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index 20460c2b..2198e8b7 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -49,16 +49,27 @@ else()
+ endif()
+ 
+ # When HPIPM is used as part of acados
+-if(ACADOS_WITH_SYSTEM_BLASFEO)
+-    set(HPIPM_FIND_BLASFEO ON CACHE BOOL "" FORCE)
++if(ACADOS_WITH_SYSTEM_HPIPM)
++    find_package(hpipm REQUIRED)
++    # the acados library is defined in a sibling directory, which only sees a global imported target
++    set_target_properties(hpipm PROPERTIES IMPORTED_GLOBAL TRUE)
++    # acados includes the HPIPM headers as "hpipm/include/<header>.h", that is, relative to the
++    # parent of the directory the installed headers live in
++    get_target_property(HPIPM_SYSTEM_INCLUDE_DIR hpipm INTERFACE_INCLUDE_DIRECTORIES)
++    get_filename_component(HPIPM_SYSTEM_INCLUDE_ROOT "${HPIPM_SYSTEM_INCLUDE_DIR}/../.." ABSOLUTE)
++    target_include_directories(hpipm INTERFACE ${HPIPM_SYSTEM_INCLUDE_ROOT})
+ else()
+-    set(HPIPM_BLASFEO_PATH ${BLASFEO_SRC_DIR} CACHE STRING "Set CPU architecture target" FORCE)
++    if(ACADOS_WITH_SYSTEM_BLASFEO)
++        set(HPIPM_FIND_BLASFEO ON CACHE BOOL "" FORCE)
++    else()
++        set(HPIPM_BLASFEO_PATH ${BLASFEO_SRC_DIR} CACHE STRING "Set CPU architecture target" FORCE)
++    endif()
++    set(HPIPM_BLASFEO_LIB OFF CACHE BOOL "Turn off BLASFEO from HPIPM" FORCE)
++    set(HPIPM_HEADERS_INSTALLATION_DIRECTORY "include/hpipm/include" CACHE STRING "")
++    set(TARGET ${HPIPM_TARGET} CACHE STRING "Set CPU architecture target" FORCE)
++    set(HPIPM_TESTING OFF CACHE BOOL "Tests disabled" FORCE)
++    add_subdirectory(hpipm)
+ endif()
+-set(HPIPM_BLASFEO_LIB OFF CACHE BOOL "Turn off BLASFEO from HPIPM" FORCE)
+-set(HPIPM_HEADERS_INSTALLATION_DIRECTORY "include/hpipm/include" CACHE STRING "")
+-set(TARGET ${HPIPM_TARGET} CACHE STRING "Set CPU architecture target" FORCE)
+-set(HPIPM_TESTING OFF CACHE BOOL "Tests disabled" FORCE)
+-add_subdirectory(hpipm)
+ 
+ if(ACADOS_WITH_HPMPC)
+ 	# TODO: The following definition should go ASAP!


### PR DESCRIPTION
New recipe for [acados](https://github.com/acados/acados) v0.6.0, the embedded nonlinear MPC solver, built against `blasfeo_jll` and the new `hpipm_jll` (JuliaPackaging/Yggdrasil#14725) instead of the copies acados carries as submodules. Only the HPIPM QP solver is enabled; the optional third-party QP solvers are left out.

Contents of the artifact:
- `libacados` (on Windows the CMake build produces an unprefixed `acados.dll`, so the `LibraryProduct` lists both names) and the headers.
- acados' Tera C templates under `share/acados/c_templates_tera` (exposed through a `FileProduct` on one of them), which with `t_renderer` (recipe in a separate PR) render standalone C solvers without the Python `acados_template` package.

Two patches are applied. acados exposes `ACADOS_WITH_SYSTEM_BLASFEO` but always compiles the HPIPM submodule, so the first adds the matching `ACADOS_WITH_SYSTEM_HPIPM` option. A few includes spell the BLASFEO headers relative to the submodule directory (`"blasfeo/include/<header>.h"`) instead of flat as the rest of the sources do, a form that only resolves for the bundled copy; the second makes them flat as well. Both are candidates for upstreaming. The one remaining source fix is `<Windows.h>` → `<windows.h>` for MinGW.

`blasfeo_jll` is built with BLASFEO's own Makefile, which installs into `${prefix}/blasfeo` and ships no CMake package configuration, so the script writes one for `find_package(blasfeo)`. `hpipm_jll` ships the configuration CMake exported for it.

BLASFEO selects its kernels at compile time and its target determines the panel size the acados structures are laid out with, so one variant is built per microarchitecture, matching the variants `blasfeo_jll` and `hpipm_jll` provide; the microarchitecture augmentation then selects matching variants of the three libraries. Following `blasfeo_jll` means the platform list is now its own: aarch64 Linux and FreeBSD, which the previous revision of this PR built with a bundled BLASFEO, are no longer covered. I am happy to open a separate PR adding those platforms to `B/blasfeo` if that is wanted.

Built locally for x86_64 Linux (glibc avx2, musl avx512), x86_64 Windows (x86_64, avx2), x86_64 macOS and aarch64 macOS. The acados solver and C-export test suites of a downstream package pass against the x86_64 Linux artifact.

This PR needs JuliaPackaging/Yggdrasil#14725 (hpipm) to be merged and registered first; until then its CI cannot resolve `hpipm_jll`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)