### PR TITLE
[CLAPHost] v1.0.1: rebuild from the registered AudioPlugins v1.0.0, add Windows

### DIFF
--- a/C/CLAPHost/build_tarballs.jl
+++ b/C/CLAPHost/build_tarballs.jl
@@ -7,14 +7,17 @@ using BinaryBuilder
 # for hosting CLAP audio plugins. CLAP itself is header-only (MIT) and vendored
 # in the same repository, so this builds with nothing but a C compiler.
 #
-# The version tracks the AudioPlugins.jl release whose `csrc/` is built.
+# CLAPHost_jll 1.0.0 was built from an earlier AudioPlugins.jl commit that
+# already carried Project.toml version 1.0.0, so the JLL version can no longer
+# equal the package version: 1.0.1 is the registered AudioPlugins v1.0.0
+# sources, with Windows.
 name = "CLAPHost"
-version = v"1.0.0"
+version = v"1.0.1"
 
 # Collection of sources required to complete build
 sources = [
     GitSource("https://github.com/SciML/AudioPlugins.jl.git",
-              "a371d82d5a5a476280f8d0ef0571f2768b5f70c8"),  # v1.0.0
+              "1ba3d23b08c0159f66782a831f89cb729339d325"),  # v1.0.0 (registered)
 ]
 
 # Bash recipe for building across all platforms
@@ -32,9 +35,7 @@ ${CC} -std=gnu99 -O2 -fPIC -shared -Wall -Wextra \
 install -Dm644 csrc/clap_host.h "${includedir}/clap_host.h"
 """
 
-# The host resolves plugins with dlopen(); Windows needs a LoadLibrary shim
-# that the sources do not have yet, so it is excluded until they do.
-platforms = filter(!Sys.iswindows, supported_platforms())
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = [


### PR DESCRIPTION
Rebuild the headless CLAP host from the sources AudioPlugins v1.0.0 was registered from (https://github.com/JuliaRegistries/General/pull/167090, commit `1ba3d23b08c0159f66782a831f89cb729339d325`), and add the Windows platforms. The host now resolves plugin bundles with `LoadLibraryExW`/`GetProcAddress`/`FreeLibrary` under `_WIN32` (https://github.com/SciML/AudioPlugins.jl/pull/10), so the `filter(!Sys.iswindows, …)` and its comment go; `-ldl` stays Linux-only and mingw needs nothing else on the link line.

**Version numbering.** CLAPHost_jll 1.0.0 already exists, built from an earlier AudioPlugins.jl commit that also carried `Project.toml` version 1.0.0, so the JLL version can no longer equal the package version. 1.0.1 means "the registered AudioPlugins v1.0.0 sources, with Windows"; the recipe comment says the same.

## Local build and audit (BinaryBuilder 0.6.6, Julia 1.12.7)

```
=== x86_64-linux-gnu ===
[ Info: lib/libclap_host.so: Ignored system libraries libm.so.6, libc.so.6, libdl.so.2
[ Info: Found a valid dl path libclap_host.so while looking for libclap_host
[ Info: Tree hash of contents of CLAPHost.v1.0.1.x86_64-linux-gnu.tar.gz: 6b8edc08b8c0b253acd52e3087d748e1a320895c
[ Info: Timings: setup: 15.7s, build: 0.54s, audit: 14.56s, packaging: 1.38s
=== x86_64-w64-mingw32 ===
[ Info: bin/libclap_host.dll: Ignored system libraries msvcrt.dll, KERNEL32.dll
[ Info: Found a valid dl path libclap_host.dll while looking for libclap_host
[ Info: Tree hash of contents of CLAPHost.v1.0.1.x86_64-w64-mingw32.tar.gz: 110edd38e2d2633c0c8a1a636f86ce7e32f8b8c0
[ Info: Timings: setup: 15.87s, build: 0.87s, audit: 12.37s, packaging: 1.41s
=== i686-w64-mingw32 ===
[ Info: bin/libclap_host.dll: Ignored system libraries msvcrt.dll, KERNEL32.dll, libgcc_s_sjlj-1.dll
[ Info: Found a valid dl path libclap_host.dll while looking for libclap_host
[ Info: Tree hash of contents of CLAPHost.v1.0.1.i686-w64-mingw32.tar.gz: a51f920a0c5bd51d91c2625cbb722d419324a6c6
[ Info: Timings: setup: 16.01s, build: 0.84s, audit: 12.4s, packaging: 1.4s
=== aarch64-apple-darwin ===
[ Info: lib/libclap_host.dylib: Ignored system libraries /usr/lib/libSystem.B.dylib
[ Info: Found a valid dl path libclap_host.dylib while looking for libclap_host
[ Info: Tree hash of contents of CLAPHost.v1.0.1.aarch64-apple-darwin.tar.gz: 469024d15e3b50fb6c5befac5699948367507ca2
[ Info: Timings: setup: 15.9s, build: 0.65s, audit: 12.89s, packaging: 1.39s
```
The only compiler diagnostic on the mingw targets is `warning: -fPIC ignored for target (all code is position independent)`, from the recipe's existing flags. `git diff b58ef743 1ba3d23b08c0159f66782a831f89cb729339d325 -- csrc/` in AudioPlugins.jl is empty (only `Project.toml` differs), and the tree hashes match the ones built from the #10 branch.

## Not verified

Real Windows execution of the host happened only in AudioPlugins.jl's CI `probe-windows` jobs (MINGW64 and MINGW32, `test/probe.c` against a mingw-built `.clap`): https://github.com/SciML/AudioPlugins.jl/actions/runs/33620085262. The DLLs built here were audited, not run (no wine on the build machine). Other platforms are left to Yggdrasil CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_012dmNxmZWobCKsLS5kagmDZ
