### PR TITLE
[CUDA] Accept a boolean `local` preference in the augmentation

### DIFF
--- a/C/CUDA/CUDNN@8/build_tarballs.jl
+++ b/C/CUDA/CUDNN@8/build_tarballs.jl
@@ -65,7 +65,7 @@ for cuda_version in [v"11", v"12"], platform in platforms
     augmented_platform["cuda"] = CUDA.platform(cuda_version)
     should_build_platform(triplet(augmented_platform)) || continue
 
-    sources = get_sources("cudnn", ["cudnn"]; version, platform,
+    sources = get_sources("cudnn", ["cudnn"]; version, platform=augmented_platform,
                            variant="cuda$(cuda_version.major)")
 
     if platform == Platform("x86_64", "windows")
@@ -91,3 +91,4 @@ for (i,build) in enumerate(builds)
                    julia_compat="1.6", augment_platform_block, dont_dlopen=true)
 end
 
+# bump

--- a/C/CUDA/CUDNN@9/build_tarballs.jl
+++ b/C/CUDA/CUDNN@9/build_tarballs.jl
@@ -111,3 +111,4 @@ for (i,build) in enumerate(builds)
                    julia_compat="1.6", augment_platform_block, dont_dlopen=true)
 end
 
+# bump

--- a/C/CUDA/CUTENSOR/build_tarballs.jl
+++ b/C/CUDA/CUTENSOR/build_tarballs.jl
@@ -84,3 +84,5 @@ for (i,build) in enumerate(builds)
                    build.platforms, products, dependencies;
                    julia_compat="1.6", augment_platform_block, dont_dlopen=true)
 end
+
+# bump

--- a/C/CUDA/cuQuantum/build_tarballs.jl
+++ b/C/CUDA/cuQuantum/build_tarballs.jl
@@ -69,3 +69,5 @@ for (i, build) in enumerate(builds)
         build.platforms, products, dependencies;
         julia_compat="1.6", augment_platform_block, dont_dlopen=true)
 end
+
+# bump

--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -25,7 +25,11 @@ const augment = """
     const preferences = Base.get_preferences(CUDA_Runtime_jll_uuid)
     Base.record_compiletime_preference(CUDA_Runtime_jll_uuid, "version")
     Base.record_compiletime_preference(CUDA_Runtime_jll_uuid, "local")
-    const local_toolkit = something(tryparse(Bool, get(preferences, "local", "false")), false)
+    # the `local` preference is a boolean, but CUDA.jl's `set_runtime_version!` writes it
+    # as a string, and hand-written LocalPreferences.toml files use either spelling.
+    const local_toolkit = let pref = get(preferences, "local", false)
+        pref isa Bool ? pref : something(tryparse(Bool, pref), false)
+    end
 
     function cuda_comparison_strategy(_a::String, _b::String, a_requested::Bool, b_requested::Bool)
         # if we're using a local toolkit, we can't use artifacts


### PR DESCRIPTION
The `local` preference is a boolean. CUDA.jl's `set_runtime_version!` writes it stringified, and CUDA_Runtime_jll's own hook accepts either spelling, but the block that CUDNN, CUTENSOR and cuQuantum splice in only handles the string:

    julia> Pkg.resolve()   # with `local = true` in LocalPreferences.toml
    ERROR: LoadError: MethodError: no method matching tryparse(::Type{Bool}, ::Bool)
    @ .../CUTENSOR_jll/lv28L/.pkg/platform_augmentation.jl:15

which makes every Pkg operation fail. Handle both, like CUDA_Runtime_jll does.