### PR TITLE
[AppImageRuntime] New recipe v2025.11.8

### DIFF
--- a/A/AppImageRuntime/build_tarballs.jl
+++ b/A/AppImageRuntime/build_tarballs.jl
@@ -1,0 +1,129 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder, Pkg
+
+# The AppImage type 2 runtime: the ELF that is prepended to a squashfs image to form an
+# AppImage. It mounts the appended filesystem through FUSE and executes AppRun from the mount
+# point, so an application is run without ever being unpacked.
+name = "AppImageRuntime"
+version = v"2025.11.8"
+
+# libfuse, squashfuse and zstd are built here rather than taken from their own JLLs, mirroring how
+# upstream builds the runtime. Two reasons:
+#
+#  * the runtime is fully static, and needs static archives of all of them. Zstd_jll ships only
+#    libzstd.so, with no archive to link against, so zstd is built here too;
+#  * libfuse is patched so that `fusermount3` is located through $FUSERMOUNT_PROG instead of a
+#    path fixed at compile time. That patch is specific to AppImage — a general purpose libfuse
+#    should not carry it — so it is applied to a private copy here.
+sources = [
+    GitSource("https://github.com/AppImage/type2-runtime.git",
+              "dd6cebedcbddde9c82f89b011e8e1d40b6e43868"),
+    ArchiveSource("https://github.com/libfuse/libfuse/releases/download/fuse-3.15.0/fuse-3.15.0.tar.xz",
+                  "70589cfd5e1cff7ccd6ac91c86c01be340b227285c5e200baa284e401eea2ca0"),
+    ArchiveSource("https://github.com/vasi/squashfuse/releases/download/0.5.2/squashfuse-0.5.2.tar.gz",
+                  "54e4baaa20796e86a214a1f62bab07c7c361fb7a598375576d585712691178f5"),
+    ArchiveSource("https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz",
+                  "eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3"),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir
+
+install_license type2-runtime/LICENSE
+
+# The vendored dependencies are staged outside ${prefix} so the shipped artifact contains the
+# runtime alone, rather than the static archives and headers used to build it.
+DEPS=${WORKSPACE}/deps
+
+export CFLAGS="-ffunction-sections -fdata-sections -Os"
+
+# zstd, static. Built before squashfuse so its configure finds the archive.
+cd ${WORKSPACE}/srcdir/zstd-1.5.7
+make -C lib -j${nproc} libzstd.a
+install -Dm644 lib/libzstd.a ${DEPS}/lib/libzstd.a
+install -Dm644 lib/zstd.h lib/zdict.h lib/zstd_errors.h -t ${DEPS}/include
+
+export PKG_CONFIG_PATH="${DEPS}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+
+# libfuse, static, with the AppImage patch that resolves fusermount3 from $FUSERMOUNT_PROG
+cd ${WORKSPACE}/srcdir/fuse-3.15.0
+patch -p1 < ${WORKSPACE}/srcdir/type2-runtime/patches/libfuse/mount.c.diff
+
+# libfuse probes at configure time whether getmntent unescapes, by *running* a test binary. Meson
+# cannot do that when cross compiling, so the probe is removed and its outcome supplied directly:
+# every platform here is musl, and on musl the probe reports that escaping is needed.
+sed -i '/^result = cc.run(detect_getmntent_needs_unescape)/,/^endif$/d' meson.build
+
+CFLAGS="${CFLAGS} -DGETMNTENT_NEEDS_UNESCAPING" \
+meson setup build --cross-file="${MESON_TARGET_TOOLCHAIN}" --buildtype=release \
+    --prefix=${DEPS} --default-library=static \
+    -Dexamples=false -Dtests=false -Dutils=false
+meson compile -C build -j${nproc}
+meson install -C build
+
+# squashfuse, static. The runtime uses the low level (_ll) interface.
+cd ${WORKSPACE}/srcdir/squashfuse-0.5.2
+# zstd lives in ${DEPS} and installs no pkg-config file, so its location has to be given
+# explicitly. Without it configure silently builds squashfuse without zstd support, and the
+# resulting runtime fails to mount any zstd compressed AppImage.
+./configure --prefix=${DEPS} --host=${target} \
+    --disable-shared --enable-static \
+    --with-zlib=${prefix} --with-zstd=${DEPS} \
+    --without-lzo --without-lz4 --without-xz
+make -j${nproc}
+make install
+# The runtime includes private headers that `make install` does not ship
+install -Dm644 ./*.h -t ${DEPS}/include/squashfuse
+
+# The runtime itself.
+cd ${WORKSPACE}/srcdir/type2-runtime/src/runtime
+
+# The link is done directly rather than through upstream's Makefile, which hardcodes clang and
+# absolute include paths. Upstream additionally links mimalloc purely as an allocator
+# optimisation; it is left out so the build stays limited to the sources carried here.
+#
+# GIT_COMMIT is single quoted so the inner double quotes survive: a raw Julia string turns \" into
+# a bare quote, which the shell would then consume, leaving GCC a bare identifier.
+# runtime.c includes <squashfuse/ll.h>, so ${DEPS}/include has to be on the search path in its own
+# right. It is not added implicitly the way ${prefix}/include is.
+${CC} -I${DEPS}/include -I${DEPS}/include/squashfuse -I${DEPS}/include/fuse3 \
+    -std=gnu99 -Os -D_FILE_OFFSET_BITS=64 \
+    -DGIT_COMMIT='"dd6cebedcbddde9c82f89b011e8e1d40b6e43868"' \
+    -T data_sections.ld -ffunction-sections -fdata-sections -Wl,--gc-sections \
+    -static \
+    runtime.c \
+    -L${DEPS}/lib -L${prefix}/lib -lsquashfuse -lsquashfuse_ll -lzstd -lz -lfuse3 -lpthread -ldl \
+    -o runtime
+
+strip --strip-debug --strip-unneeded runtime
+
+# The "classic" magic bytes cannot be placed by the linker script and have to be written after
+# stripping, since objcopy and strip rewrite the header. AppImage tooling identifies a file as an
+# AppImage by these three bytes at offset 8.
+printf 'AI\x02' | dd of=runtime bs=1 count=3 seek=8 conv=notrunc
+
+install -Dm755 runtime ${bindir}/runtime
+"""
+
+# The runtime has to run on any Linux the AppImage is copied to, so it is built fully static.
+# While musl is preferred for static linking (and used by upstream), we build for all supported Linux
+# platforms (including gnu) so that the JLL is installable by Pkg on standard gnu systems.
+platforms = filter(Sys.islinux, supported_platforms())
+
+products = [
+    ExecutableProduct("runtime", :runtime),
+]
+
+# Zlib_jll ships libz.a, so it can be linked statically as a normal dependency. Zstd_jll ships
+# only a shared library, which is why zstd is built from source above.
+dependencies = [
+    Dependency("Zlib_jll"),
+]
+
+# The runtime is prepended to every AppImage built with it, so its size is paid on each one.
+# BinaryBuilder's default compiler is old enough that dead code elimination barely fires here:
+# the same sources give a 2.76 MB binary with the default and 668 KB with GCC 9, measured on
+# x86_64-linux-musl.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat = "1.6", preferred_gcc_version = v"12")


### PR DESCRIPTION
The [AppImage](https://appimage.org/) type 2 runtime: the ELF that is prepended to a squashfs image to form an AppImage. It mounts the appended filesystem through FUSE and executes `AppRun` from the mount point, so an application runs without ever being unpacked.

The motivation is HPC. Distributing a Julia application means shipping tens of thousands of small files, and writing those onto a network filesystem is the expensive part of every other format. An AppImage never unpacks, so it does not pay that cost. Downstream discussion: [AppBundler.jl#42](https://github.com/PeaceFounder/AppBundler.jl/issues/42), where "figure out a clean and robust way to retrieve AppImage runtimes" is an open item — today the alternative is downloading the binary at build time and caching it.

## Built and verified

All four platforms build. Artifacts contain `bin/runtime` and the licence, nothing else:

| platform | size | `AI\x02` @ 8 | AppImage sections |
|---|---|---|---|
| x86_64-linux-musl | 668 024 | ✅ | 4/4 |
| i686-linux-musl | 675 424 | ✅ | 4/4 |
| aarch64-linux-musl | 717 120 | ✅ | 4/4 |
| armv7l-linux-musleabihf | 626 384 | ✅ | 4/4 |

On x86_64 I assembled real AppImages with it and ran them: `--appimage-offset` returns exactly the runtime size, and both zstd and gzip payloads mount and execute.

**Only x86_64 was executed.** The other three are built and structurally correct — right ELF class and machine, magic bytes, all four AppImage sections — but I cannot run an ARM binary here, so that is inspection rather than proof.

## Things a reviewer should know

**The binary is not PIE, unlike upstream's.** Upstream builds `-static-pie` in Alpine. That is not possible here: BinaryBuilder's musl `libc.a` is not compiled `-fPIE`, so the link fails with `relocation R_X86_64_32S ... can not be used when making a PIE object` across most of libc. Plain `-static` works and the runtime is fully functional; it just loses ASLR on the runtime itself. If a PIE-capable musl sysroot is something you would consider, I am happy to revisit.

**Three dependencies are vendored rather than taken from JLLs.** The runtime is fully static and needs archives of all of them:

- `libfuse` carries an AppImage specific patch resolving `fusermount3` through `$FUSERMOUNT_PROG` instead of a compile time path. A general purpose libfuse should not have that, so it is applied to a private copy.
- `squashfuse` has no JLL.
- **`Zstd_jll` ships only `libzstd.so`, with no archive to link against.** If you would rather this recipe depend on it, `Z/Zstd` needs `--default-library=both`; I have that change built and checked on linux-gnu, linux-musl and mingw and can open it as a separate PR. Say the word and I will — I did not want to change a widely depended on artifact on my own initiative for a single consumer.

`Zlib_jll` does ship `libz.a`, so it stays a normal dependency.

**`preferred_gcc_version = v"9.1.0"` is about size, not correctness.** The build succeeds with the default compiler, but dead code elimination barely fires there: the same sources give 2.76 MB with the default and 668 KB with GCC 9 on x86_64-linux-musl. Since this runtime is prepended to every AppImage built with it, that factor of four is paid on each one.

**Two build steps needed adjusting for cross compilation**, both commented in the recipe:

- libfuse probes at configure time whether `getmntent` unescapes by *running* a test binary, which meson cannot do when cross compiling. The probe is removed and its outcome supplied directly — every platform here is musl, and the probe reports "needs escaping" on musl when it can run (verified on x86_64, where the sandbox can execute target binaries).
- squashfuse's `configure` silently builds without zstd support when it cannot find it, producing a runtime that fails to mount any zstd compressed AppImage. `--with-zstd` is passed explicitly. This one only surfaced through the functional test; the build was green and the binary looked correct.

## Versioning

Upstream tags by date. `v2025.11.8` corresponds to tag `20251108`, pinned by commit rather than by the moving `continuous` tag so the artifact stays reproducible.

Assisted-by: AI
