### PR TITLE
[CI] Share git source clones between agents

### DIFF
--- a/.buildkite/utils.jl
+++ b/.buildkite/utils.jl
@@ -65,6 +65,7 @@ function build_step(NAME, PLATFORM, PROJECT, IS_PR)
         "BINARYBUILDER_USE_CCACHE" => "true",
         "BINARYBUILDER_STORAGE_DIR" => "/cache/yggdrasil",
         "BINARYBUILDER_CCACHE_DIR" => "/sharedcache/ccache",
+        "BINARYBUILDER_CLONES_DIR" => "/sharedcache/clones",
         "BINARYBUILDER_NPROC" => "16", # Limit parallelism somewhat to avoid OOM for LLVM
         "AWS_DEFAULT_REGION" => "us-east-1",
     ))

--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -42,8 +42,8 @@ uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 version = "0.6.6"
 
 [[deps.BinaryBuilderBase]]
-deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "69c8db52a2158a3a2260c4bb4666048ff8235bdb"
+deps = ["Bzip2_jll", "CodecZlib", "Downloads", "FileWatching", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll"]
+git-tree-sha1 = "c1e995d5f5d3f3b214e90db07921532455bbdd2a"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"


### PR DESCRIPTION
Bumps BinaryBuilderBase to master (JuliaPackaging/BinaryBuilderBase.jl#496), which makes `cached_git_clone` safe for concurrent builders and adds `BINARYBUILDER_CLONES_DIR`, and points that at `/sharedcache/clones` so the 16 agents on amdci7 share one bare clone of each git source instead of each keeping, and re-cloning, their own.

Context: cloning llvm-project takes 20 to 30 minutes per agent. In build #32580 fifteen agents did it at once after the hourly cache cleanup had evicted the per-agent clones, for 378 agent-minutes of cloning. With a shared, locked cache that happens at most once per host.

The shared directory has been pre-seeded with the current llvm-project clone on amdci7. Only the `clones` subdirectory moves; tarball downloads and the compiler-shard depot stay per agent. Rollback is reverting the one env line, the per-agent clone directories are still in place.