### PR TITLE
[libLLVM] Bump to 18.1.7+6

### DIFF
--- a/L/LLVM/libLLVM@18/build_tarballs.jl
+++ b/L/LLVM/libLLVM@18/build_tarballs.jl
@@ -1,5 +1,5 @@
 name = "libLLVM"
-version = v"18.1.7+5"
+version = v"18.1.7+6"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms


### PR DESCRIPTION
Extract `libLLVM` 18.1.7+6 from the `LLVM_full_jll` / `LLVM_full_assert_jll` 18.1.7+6 builds produced by #14706, which moved LLVM 18 to the `julia-18.1.7-5` tag.

### Why

That tag carries the backport of

> [IRCE] Check loop clone legality before attempting to do so — llvm/llvm-project#151062

Without it, IRCE clones loops whose bodies contain token-producing calls; tokens cannot be PHI'd, so after the pre/post-loop split the `gc_preserve_end` calls reference tokens defined in a block that no longer dominates them. On Julia 1.12 this miscompiles silently in release builds and aborts assertion builds inside `AllocOpt`'s IR verifier (JuliaLang/julia#48918). LLVM 20+ already has the fix; this brings the 18 line, used by Julia 1.12, in sync.

### Dependencies

Both build dependencies are registered:

- `LLVM_full_assert_jll` v18.1.7+6 — JuliaRegistries/General#167512
- `LLVM_full_jll` v18.1.7+6 — JuliaRegistries/General#167516

Same two-step pattern as #11208 → #11319.

### Follow-up

Once `libLLVM_jll` 18.1.7+6 registers, JuliaLang/julia `backports-release-1.12` should set `LLVM_ASSERT_JLL_VER := 18.1.7+6` and move `LLVM_BRANCH`/`LLVM_SHA1`/`LLVM_JULIA_REF` to `julia-18.1.7-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)