### PR TITLE
[LLVM] Bump dependent LLVM 18 packages to 18.1.7+6

### DIFF
--- a/L/LLVM/Clang@18/build_tarballs.jl
+++ b/L/LLVM/Clang@18/build_tarballs.jl
@@ -1,6 +1,6 @@
 name = "Clang"
-llvm_full_version = v"18.1.7+5"
-libllvm_version = v"18.1.7+5"
+llvm_full_version = v"18.1.7+6"
+libllvm_version = v"18.1.7+6"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms

--- a/L/LLVM/LLD@18/build_tarballs.jl
+++ b/L/LLVM/LLD@18/build_tarballs.jl
@@ -1,6 +1,6 @@
 name = "LLD"
-llvm_full_version = v"18.1.7+5"
-libllvm_version = v"18.1.7+5"
+llvm_full_version = v"18.1.7+6"
+libllvm_version = v"18.1.7+6"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms

--- a/L/LLVM/LLVM@18/build_tarballs.jl
+++ b/L/LLVM/LLVM@18/build_tarballs.jl
@@ -1,6 +1,6 @@
 name = "LLVM"
-llvm_full_version = v"18.1.7+5"
-libllvm_version = v"18.1.7+5"
+llvm_full_version = v"18.1.7+6"
+libllvm_version = v"18.1.7+6"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms

--- a/L/LLVM/MLIR@18/build_tarballs.jl
+++ b/L/LLVM/MLIR@18/build_tarballs.jl
@@ -1,6 +1,6 @@
 name = "MLIR"
-llvm_full_version = v"18.1.7+5"
-libllvm_version = v"18.1.7+5"
+llvm_full_version = v"18.1.7+6"
+libllvm_version = v"18.1.7+6"
 
 using BinaryBuilder, Pkg
 using Base.BinaryPlatforms


### PR DESCRIPTION
Move the LLVM 18 dependent recipes — `LLD@18`, `Clang@18`, `LLVM@18` (tools) and `MLIR@18` — onto the `LLVM_full_jll` / `libLLVM_jll` 18.1.7+6 builds, by bumping both `llvm_full_version` and `libllvm_version` in each from `+5` to `+6`.

### Why

Those builds come from the `julia-18.1.7-5` tag (#14706, #14722), which carries the backport of

> [IRCE] Check loop clone legality before attempting to do so — llvm/llvm-project#151062

Without it IRCE clones loops containing token-producing calls, so after the pre/post-loop split the `gc_preserve_end` calls reference tokens defined in a block that no longer dominates them. On Julia 1.12 that miscompiles silently in release builds and aborts assertion builds in `AllocOpt`'s IR verifier (JuliaLang/julia#48918). Julia 1.12 consumes `LLD_jll`, `Clang_jll` and `LLVM_jll` alongside `libLLVM_jll`, so these need to move together for the `backports-release-1.12` bump.

### Dependencies

All registered:

- `LLVM_full_jll` v18.1.7+6 — JuliaRegistries/General#167516
- `LLVM_full_assert_jll` v18.1.7+6 — JuliaRegistries/General#167512
- `libLLVM_jll` v18.1.7+6 — JuliaRegistries/General#167535

Same third step as #11326 after #11208 and #11319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)