### PR TITLE
[LEMON] Restore legacy wrapper names in v1.3.7

### DIFF
--- a/L/LEMON/build_tarballs.jl
+++ b/L/LEMON/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "LEMON"
-version = v"1.3.6"
+version = v"1.3.7"
 upstreamversion = v"1.3.1"
 min_jl_version = v"1.9"
 

--- a/L/LEMON/bundled/cxxwrap/lemoncxxwrap.cpp
+++ b/L/LEMON/bundled/cxxwrap/lemoncxxwrap.cpp
@@ -209,6 +209,12 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
   mod.add_type<jlcxx::Parametric<jlcxx::TypeVar<1>>>("ListDigraphArcMap")
     .apply_combination<ApplyArcMap<ListDigraph>, ValueTypes>(WrapArcMapListDigraph());
 
+  // Keep the concrete names used before the maps became parametric.
+  mod.set_const("ListGraphNodeMapInt", static_cast<jl_datatype_t*>(jlcxx::julia_base_type<ListGraph::NodeMap<int>>()));
+  mod.set_const("ListDigraphNodeMapInt", static_cast<jl_datatype_t*>(jlcxx::julia_base_type<ListDigraph::NodeMap<int>>()));
+  mod.set_const("ListGraphEdgeMapInt", static_cast<jl_datatype_t*>(jlcxx::julia_base_type<ListGraph::EdgeMap<int>>()));
+  mod.set_const("ListDigraphArcMapInt", static_cast<jl_datatype_t*>(jlcxx::julia_base_type<ListDigraph::ArcMap<int>>()));
+
   mod.method("ListGraphNodeFromId", [](int i) { return ListGraph::nodeFromId(i); });
   mod.method("ListGraphEdgeFromId", [](int i) { return ListGraph::edgeFromId(i); });
   mod.method("ListDigraphNodeFromId", [](int i) { return ListDigraph::nodeFromId(i); });
@@ -256,9 +262,14 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
   REGISTER_MCF_ALGO(CapacityScaling3,"CapacityScaling", ValueTypesNoNarrow, ValueTypesNoNarrow)
   REGISTER_MCF_ALGO(CycleCanceling,  "CycleCanceling",  ValueTypes,         ValueTypes)
 
+  mod.set_const("NetworkSimplexListDigraphIntInt", static_cast<jl_datatype_t*>(jlcxx::julia_base_type<NetworkSimplex<ListDigraph, int, int>>()));
+
   // ProblemType constants are the same for all algorithms — register once
   using AnyAlgo = NetworkSimplex<ListDigraph, int32_t, int32_t>;
   mod.method("ProblemTypeInfeasible", []() { return static_cast<int>(AnyAlgo::INFEASIBLE); });
   mod.method("ProblemTypeOptimal",    []() { return static_cast<int>(AnyAlgo::OPTIMAL);    });
   mod.method("ProblemTypeUnbounded",  []() { return static_cast<int>(AnyAlgo::UNBOUNDED);  });
+  mod.method("NetworkSimplexProblemTypeInfeasible", []() { return static_cast<int>(AnyAlgo::INFEASIBLE); });
+  mod.method("NetworkSimplexProblemTypeOptimal",    []() { return static_cast<int>(AnyAlgo::OPTIMAL);    });
+  mod.method("NetworkSimplexProblemTypeUnbounded",  []() { return static_cast<int>(AnyAlgo::UNBOUNDED);  });
 }


### PR DESCRIPTION
Fixes JuliaGraphs/LEMONGraphs.jl#29 by restoring the legacy integer map and NetworkSimplex names alongside the parametric API in LEMON_jll 1.3.7.

Tested all releases compatible with LEMONGraphs 0.1.1: 1.3.2+0–1.3.5+0 work; 1.3.6+0 fails. The regression came from #13994 (merged 2026-07-01), released as LEMON_jll 1.3.6+0 and registered 2026-07-04.
