### PR TITLE
[aws_lc] Update to version 5.8.0

### DIFF
--- a/A/aws_lc/build_tarballs.jl
+++ b/A/aws_lc/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_lc"
-version = v"5.6.0"
+version = v"5.8.0"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-lc.git", "51cbeccf8ea55db59a5e53f405e17a5468d9f62b"),
+    GitSource("https://github.com/awslabs/aws-lc.git", "a3d1e685552f05a9ad04a2946962c03e97bdecac"),
     DirectorySource("./bundled"),
 ]
 


### PR DESCRIPTION
This PR updates aws_lc to version 5.8.0.

No runtime JLL dependencies with compat pins.

cc: @Octogonapus