### PR TITLE
[s2n_tls] Update to version 1.7.9

### DIFF
--- a/S/s2n_tls/build_tarballs.jl
+++ b/S/s2n_tls/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "s2n_tls"
-version = v"1.7.8"
+version = v"1.7.9"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/aws/s2n-tls.git", "3b975bf3fd9a50def97573afa859e8eb83931928"),
+    GitSource("https://github.com/aws/s2n-tls.git", "d25ca63bef1bc12daf2c92ffe2ad86a1689c6997"),
 ]
 
 # Bash recipe for building across all platforms


### PR DESCRIPTION
This PR updates s2n_tls to version 1.7.9.

No runtime JLL dependencies with compat pins.

cc: @Octogonapus