### PR TITLE
[GPU back-ends] Pin the C locale and catch all C++ exceptions

### DIFF
--- a/A/AMDGPU_LLVM_Backend/build_tarballs.jl
+++ b/A/AMDGPU_LLVM_Backend/build_tarballs.jl
@@ -201,3 +201,5 @@ dependencies = [
 build_tarballs(ARGS, name, version, sources, script,
                platforms, products, dependencies;
                preferred_gcc_version=v"10", julia_compat="1.6")
+
+# bump

--- a/A/AMDGPU_LLVM_Backend/bundled/libamdgpu.cpp
+++ b/A/AMDGPU_LLVM_Backend/bundled/libamdgpu.cpp
@@ -42,8 +42,10 @@
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Triple.h"
 
+#include <clocale>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -102,6 +104,32 @@ struct FatalError {
 [[noreturn]] void throwingFatalErrorHandler(void *, const char *Reason, bool) {
   throw FatalError{Reason};
 }
+
+// Pin the calling thread's C locale to "C" for the duration of a call. The host
+// sets the locale from the user's environment (Julia calls setlocale(LC_ALL, "")),
+// and with a non-"C" LC_COLLATE msvcrt's strxfrm fails, which libstdc++ 15 turns
+// into a std::system_error from std::regex (used by the SPIR-V back-end's
+// builtin lookup, see JuliaGPU/GPUCompiler.jl#930). msvcrt's locale is per thread
+// once so configured, so this does not touch the host's other threads.
+#if defined(_WIN32)
+struct ScopedCLocale {
+  int PrevConfig;
+  std::string Prev;
+  ScopedCLocale() : PrevConfig(_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)) {
+    if (const char *L = setlocale(LC_ALL, nullptr))
+      Prev = L;
+    setlocale(LC_ALL, "C");
+  }
+  ~ScopedCLocale() {
+    if (!Prev.empty())
+      setlocale(LC_ALL, Prev.c_str());
+    if (PrevConfig != -1)
+      _configthreadlocale(PrevConfig);
+  }
+};
+#else
+struct ScopedCLocale {};
+#endif
 
 // Formats diagnostics exactly like llc's LLCDiagnosticHandler and routes them
 // to the user's callback, remembering errors for the failure message.
@@ -296,6 +324,7 @@ int AMDGPUCompile(const char *Bitcode, size_t Length,
                   AMDGPUDiagnosticCallback Handler, void *HandlerContext,
                   AMDGPUMemoryBufferRef *OutBuffer, char **OutMessage) {
   std::lock_guard<std::mutex> Guard(APILock);
+  ScopedCLocale Locale;
   initializeTarget();
   if (OutMessage) *OutMessage = nullptr;
   if (OutBuffer) *OutBuffer = nullptr;
@@ -417,6 +446,12 @@ int AMDGPUCompile(const char *Bitcode, size_t Length,
     while (!E.Message.empty() && E.Message.back() == '\n')
       E.Message.pop_back();
     return fail("LLVM ERROR: " + E.Message);
+  } catch (std::exception &E) {
+    // e.g. libstdc++ throwing from std::regex. Never let a C++ exception unwind
+    // into the host: on Windows that dies with STATUS_BAD_FUNCTION_TABLE.
+    RestorePrettyStackState(PrettyStack);
+    S = nullptr; // leaked on purpose
+    return fail(std::string("C++ exception: ") + E.what());
   }
 }
 

--- a/C/CUDA/NVPTX_LLVM_Backend/build_tarballs.jl
+++ b/C/CUDA/NVPTX_LLVM_Backend/build_tarballs.jl
@@ -175,3 +175,5 @@ dependencies = [
 build_tarballs(ARGS, name, version, sources, script,
                platforms, products, dependencies;
                preferred_gcc_version=v"10", julia_compat="1.6")
+
+# bump

--- a/C/CUDA/NVPTX_LLVM_Backend/bundled/libnvptx.cpp
+++ b/C/CUDA/NVPTX_LLVM_Backend/bundled/libnvptx.cpp
@@ -37,8 +37,10 @@
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Triple.h"
 
+#include <clocale>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -86,6 +88,32 @@ struct FatalError {
 [[noreturn]] void throwingFatalErrorHandler(void *, const char *Reason, bool) {
   throw FatalError{Reason};
 }
+
+// Pin the calling thread's C locale to "C" for the duration of a call. The host
+// sets the locale from the user's environment (Julia calls setlocale(LC_ALL, "")),
+// and with a non-"C" LC_COLLATE msvcrt's strxfrm fails, which libstdc++ 15 turns
+// into a std::system_error from std::regex (used by the SPIR-V back-end's
+// builtin lookup, see JuliaGPU/GPUCompiler.jl#930). msvcrt's locale is per thread
+// once so configured, so this does not touch the host's other threads.
+#if defined(_WIN32)
+struct ScopedCLocale {
+  int PrevConfig;
+  std::string Prev;
+  ScopedCLocale() : PrevConfig(_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)) {
+    if (const char *L = setlocale(LC_ALL, nullptr))
+      Prev = L;
+    setlocale(LC_ALL, "C");
+  }
+  ~ScopedCLocale() {
+    if (!Prev.empty())
+      setlocale(LC_ALL, Prev.c_str());
+    if (PrevConfig != -1)
+      _configthreadlocale(PrevConfig);
+  }
+};
+#else
+struct ScopedCLocale {};
+#endif
 
 // Formats diagnostics exactly like llc's LLCDiagnosticHandler and routes them
 // to the user's callback, remembering errors for the failure message.
@@ -238,6 +266,7 @@ int NVPTXCompile(const char *Bitcode, size_t Length,
                  NVPTXDiagnosticCallback Handler, void *HandlerContext,
                  NVPTXMemoryBufferRef *OutPTX, char **OutMessage) {
   std::lock_guard<std::mutex> Guard(APILock);
+  ScopedCLocale Locale;
   initializeTarget();
   if (OutMessage) *OutMessage = nullptr;
   if (OutPTX) *OutPTX = nullptr;
@@ -367,6 +396,12 @@ int NVPTXCompile(const char *Bitcode, size_t Length,
     while (!E.Message.empty() && E.Message.back() == '\n')
       E.Message.pop_back();
     return fail("LLVM ERROR: " + E.Message);
+  } catch (std::exception &E) {
+    // e.g. libstdc++ throwing from std::regex. Never let a C++ exception unwind
+    // into the host: on Windows that dies with STATUS_BAD_FUNCTION_TABLE.
+    RestorePrettyStackState(PrettyStack);
+    S = nullptr; // leaked on purpose
+    return fail(std::string("C++ exception: ") + E.what());
   }
 }
 

--- a/S/SPIRV_LLVM_Backend/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Backend/build_tarballs.jl
@@ -214,3 +214,5 @@ sources, script = require_macos_sdk("11.0", sources, script)
 build_tarballs(ARGS, name, version, sources, script,
                platforms, products, dependencies;
                preferred_gcc_version=v"10", julia_compat="1.6")
+
+# bump

--- a/S/SPIRV_LLVM_Backend/bundled/libspirv.cpp
+++ b/S/SPIRV_LLVM_Backend/bundled/libspirv.cpp
@@ -45,8 +45,10 @@
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Triple.h"
 
+#include <clocale>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -93,6 +95,32 @@ struct FatalError {
 [[noreturn]] void throwingFatalErrorHandler(void *, const char *Reason, bool) {
   throw FatalError{Reason};
 }
+
+// Pin the calling thread's C locale to "C" for the duration of a call. The host
+// sets the locale from the user's environment (Julia calls setlocale(LC_ALL, "")),
+// and with a non-"C" LC_COLLATE msvcrt's strxfrm fails, which libstdc++ 15 turns
+// into a std::system_error from std::regex (used by the SPIR-V back-end's
+// builtin lookup, see JuliaGPU/GPUCompiler.jl#930). msvcrt's locale is per thread
+// once so configured, so this does not touch the host's other threads.
+#if defined(_WIN32)
+struct ScopedCLocale {
+  int PrevConfig;
+  std::string Prev;
+  ScopedCLocale() : PrevConfig(_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)) {
+    if (const char *L = setlocale(LC_ALL, nullptr))
+      Prev = L;
+    setlocale(LC_ALL, "C");
+  }
+  ~ScopedCLocale() {
+    if (!Prev.empty())
+      setlocale(LC_ALL, Prev.c_str());
+    if (PrevConfig != -1)
+      _configthreadlocale(PrevConfig);
+  }
+};
+#else
+struct ScopedCLocale {};
+#endif
 
 // Formats diagnostics exactly like llc's LLCDiagnosticHandler and routes them
 // to the user's callback, remembering errors for the failure message.
@@ -246,6 +274,7 @@ int SPIRVCompile(const char *Bitcode, size_t Length,
                  SPIRVDiagnosticCallback Handler, void *HandlerContext,
                  SPIRVMemoryBufferRef *OutSPIRV, char **OutMessage) {
   std::lock_guard<std::mutex> Guard(APILock);
+  ScopedCLocale Locale;
   initializeTarget();
   if (OutMessage) *OutMessage = nullptr;
   if (OutSPIRV) *OutSPIRV = nullptr;
@@ -366,6 +395,12 @@ int SPIRVCompile(const char *Bitcode, size_t Length,
     while (!E.Message.empty() && E.Message.back() == '\n')
       E.Message.pop_back();
     return fail("LLVM ERROR: " + E.Message);
+  } catch (std::exception &E) {
+    // e.g. libstdc++ throwing from std::regex. Never let a C++ exception unwind
+    // into the host: on Windows that dies with STATUS_BAD_FUNCTION_TABLE.
+    RestorePrettyStackState(PrettyStack);
+    S = nullptr; // leaked on purpose
+    return fail(std::string("C++ exception: ") + E.what());
   }
 }
 


### PR DESCRIPTION
On Windows, Julia sets the C runtime locale from the user's environment (setlocale(LC_ALL, "")), and with a non-"C" LC_COLLATE msvcrt's strxfrm fails. libstdc++ 15, which Julia 1.13 ships, turns that into a std::system_error thrown from std::regex, which the SPIR-V back-end uses for its builtin lookup (SPIRVBuiltins.cpp). The exception escaped SPIRVCompile and unwound into Julia's JIT frames, killing the process with STATUS_BAD_FUNCTION_TABLE and no message: the spirv test crash on Windows Julia 1.13/nightly in JuliaGPU/GPUCompiler.jl#930. Reproduced with a 15-line script on Julia 1.13.0-rc4; setting LC_ALL to "C" before the call makes it pass, Julia 1.12 (libstdc++ 14) is unaffected.

Pin the calling thread's locale to "C" for the duration of a call (msvcrt locales are per thread once configured, so the host's other threads are untouched), and report any std::exception through the error return instead of letting it cross the API boundary. Both applied to the three back-end libraries; the downgrader builds against LLVM_full_jll and has no regex on its paths.