### PR TITLE
[SCS] update to 3.3.1

### DIFF
--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/scs*
-flags="DLONG=1 USE_OPENMP=1 USE_SPECTRAL_CONES=1"
+flags="DLONG=1 USE_OPENMP=1 USE_SPECTRAL_CONES=1 OPT=-O3"
 if [[ "${target}" == *-mingw* ]]; then
     LBT=blastrampoline-5
 else

--- a/S/SCS/build_tarballs.jl
+++ b/S/SCS/build_tarballs.jl
@@ -2,11 +2,11 @@ using Pkg
 using BinaryBuilder
 
 name = "SCS"
-version = v"300.200.1100"
+version = v"300.300.100"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "e2f2148b6db2055fbdea58ceae28a29b07cc681d")
+    GitSource("https://github.com/cvxgrp/scs.git", "cc244ebc4bff620e2e228e99a4e2e24ab12f9e3b")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -16,7 +16,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/scs*
-flags="DLONG=0 USE_OPENMP=1 USE_SPECTRAL_CONES=1"
+flags="DLONG=0 USE_OPENMP=1 USE_SPECTRAL_CONES=1 OPT=-O3"
 if [[ "${target}" == *-mingw* ]]; then
     LBT=blastrampoline-5
 else

--- a/S/SCS_GPU/build_tarballs.jl
+++ b/S/SCS_GPU/build_tarballs.jl
@@ -6,11 +6,11 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "SCS_GPU"
-version = v"300.200.1100"
+version = v"300.300.100"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "e2f2148b6db2055fbdea58ceae28a29b07cc681d")
+    GitSource("https://github.com/cvxgrp/scs.git", "cc244ebc4bff620e2e228e99a4e2e24ab12f9e3b")
 ]
 
 # Bash recipe for building across all platforms
@@ -33,7 +33,7 @@ cp out/libscs*.${dlext} ${libdir}
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 
-platforms = CUDA.supported_platforms(max_version = v"12")
+platforms = CUDA.supported_platforms()
 filter!(p -> arch(p) == "x86_64", platforms)
 
 # The products that we will ensure are always built

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -2,11 +2,11 @@ using Pkg
 using BinaryBuilder
 
 name = "SCS_MKL"
-version = v"300.200.1100"
+version = v"300.300.100"
 
 # Collection of sources required to build SCSBuilder
 sources = [
-    GitSource("https://github.com/cvxgrp/scs.git", "e2f2148b6db2055fbdea58ceae28a29b07cc681d")
+    GitSource("https://github.com/cvxgrp/scs.git", "cc244ebc4bff620e2e228e99a4e2e24ab12f9e3b")
 ]
 
 # Bash recipe for building across all platforms

--- a/S/SCS_MKL/build_tarballs.jl
+++ b/S/SCS_MKL/build_tarballs.jl
@@ -12,7 +12,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir/scs*
-scsflags="DLONG=1 USE_OPENMP=1 BLAS32=1 NOBLASSUFFIX=1 USE_SPECTRAL_CONES=1"
+scsflags="DLONG=1 USE_OPENMP=1 BLAS32=1 NOBLASSUFFIX=1 USE_SPECTRAL_CONES=1 OPT=-O3"
 mklflags="-L${prefix}/lib -Wl,--no-as-needed -lmkl_rt -lmkl_core -lpthread -lm -ldl"
 
 make ${scsflags} MKLFLAGS="${mklflags}" out/libscsmkl.${dlext}


### PR DESCRIPTION
@odow @kalmarek

The SCS devs were so kind to diagnose the problem with CUDA 13: Yggdrasil only pulls cuda_nvcc, but SCS also needs cuda_crt and cuda_cccl, which used to be included within cuda_nvcc but no longer. See https://github.com/cvxgrp/scs/issues/322

I suppose that one would need to hack https://github.com/JuliaPackaging/Yggdrasil/blob/master/platforms/cuda.jl to include these components, but since that is used by several packages I'll leave to someone who knows what they're doing.