### PR TITLE
LLVM: Add v23.1.1 toolchain

### DIFF
--- a/L/LLVM/LLVM_full@23/build_tarballs.jl
+++ b/L/LLVM/LLVM_full@23/build_tarballs.jl
@@ -1,0 +1,10 @@
+version = v"23.1.1"
+
+include("../common.jl")
+
+# Built with GCC 10, matching LLVM 15-22 (see LLVM_full@22 for why GCC 13 was
+# tried and reverted). preferred_llvm_version=v"18" because the aarch64 backend of
+# the clang 16 bootstrap cannot codegen compiler-rt's `preserve_all` handlers.
+build_tarballs(ARGS, configure_build(ARGS, version; experimental_platforms=true)...;
+               preferred_gcc_version=v"10", preferred_llvm_version=v"18", julia_compat="1.6")
+# Build trigger: 1

--- a/L/LLVM/LLVM_full@23/bundled/libcxx_patches/7005_libcxx_musl.patch
+++ b/L/LLVM/LLVM_full@23/bundled/libcxx_patches/7005_libcxx_musl.patch
@@ -1,0 +1,22 @@
+diff --git a/include/__cxx03/locale b/include/__cxx03/locale
+index 6360bbc2f6b6..add75d2fc6f5 100644
+--- a/include/__cxx03/locale
++++ b/include/__cxx03/locale
+@@ -727,7 +727,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end, ios_base::iostat
+     __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
+     errno                                                     = 0;
+     char* __p2;
+-    long long __ll                                               = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++    long long __ll                                               = strtoll_l(__a, &__p2, __base);
+     __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
+     if (__current_errno == 0)
+       errno = __save_errno;
+@@ -759,7 +759,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end, ios_base::iost
+     __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
+     errno                                                     = 0;
+     char* __p2;
+-    unsigned long long __ll                                      = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++    unsigned long long __ll                                      = strtoull_l(__a, &__p2, __base);
+     __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
+     if (__current_errno == 0)
+       errno = __save_errno;

--- a/L/LLVM/LLVM_full@23/bundled/patches/0100-llvm-12-musl-bb.patch
+++ b/L/LLVM/LLVM_full@23/bundled/patches/0100-llvm-12-musl-bb.patch
@@ -1,0 +1,37 @@
+From f1901de14ff1f1abcc729c4adccfbd5017e30357 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 7 May 2021 13:54:41 -0400
+Subject: [PATCH] [Compiler-RT] Fix compilation on musl
+
+---
+ compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp                    | 1 +
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.cpp     | 1 -
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+index b87798603fda..452a08aafe0e 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerInterceptors.cpp
+@@ -27,6 +27,7 @@
+ #include <cassert>
+ #include <cstddef> // for size_t
+ #include <cstdint>
++#include <stddef.h>
+ #include <dlfcn.h> // for dlsym()
+
+ static void *getFuncAddr(const char *name, uintptr_t wrapper_addr) {
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 12dd39e674ac..bb0f7a2daa8c 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -69,7 +69,6 @@
+ #include <malloc.h>
+ #include <mntent.h>
+ #include <netinet/ether.h>
+-#include <sys/sysinfo.h>
+ #include <sys/vt.h>
+ #include <linux/cdrom.h>
+ #include <linux/fd.h>
+--
+2.31.1
+

--- a/L/LLVM/LLVM_full@23/bundled/patches/0200-templates.patch
+++ b/L/LLVM/LLVM_full@23/bundled/patches/0200-templates.patch
@@ -1,0 +1,40 @@
+From ad520c15cc2dae3231c38cca916f93c8347c1bd9 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Tue, 8 Nov 2022 13:18:59 -0500
+Subject: [PATCH] handle template weirdness
+
+---
+ lld/ELF/InputFiles.cpp        |    2 +-
+ lld/ELF/SyntheticSections.cpp |    2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lld/ELF/InputFiles.cpp b/lld/ELF/InputFiles.cpp
+index 6c7ef27cbd49..7dcf1cc5b877 100644
+--- a/lld/ELF/InputFiles.cpp
++++ b/lld/ELF/InputFiles.cpp
+@@ -310,7 +310,7 @@ template <class ELFT> static void doParseFile(InputFile *file) {
+     ctx.objectFiles.push_back(cast<ELFFileBase>(file));
+     cast<ObjFile<ELFT>>(file)->parse();
+   } else if (auto *f = dyn_cast<SharedFile>(file)) {
+-    f->parse<ELFT>();
++    f->template parse<ELFT>();
+   } else if (auto *f = dyn_cast<BitcodeFile>(file)) {
+     ctx.bitcodeFiles.push_back(f);
+     f->parse();
+
+diff --git a/lld/ELF/SyntheticSections.cpp b/lld/ELF/SyntheticSections.cpp
+index b359c2e7bcea..812d38ca81de 100644
+--- a/lld/ELF/SyntheticSections.cpp
++++ b/lld/ELF/SyntheticSections.cpp
+@@ -3360,7 +3360,7 @@ template <class ELFT> void elf::splitSections() {
+       if (auto *s = dyn_cast<MergeInputSection>(sec))
+         s->splitIntoPieces();
+       else if (auto *eh = dyn_cast<EhInputSection>(sec))
+-        eh->split<ELFT>();
++        eh->template split<ELFT>();
+     }
+   });
+ }
+--
+2.38.1
+

--- a/L/LLVM/LLVM_full@23/bundled/patches/0300-mingw-mlir-visibility-hidden.patch
+++ b/L/LLVM/LLVM_full@23/bundled/patches/0300-mingw-mlir-visibility-hidden.patch
@@ -1,0 +1,17 @@
+diff --git a/mlir/CMakeLists.txt b/mlir/CMakeLists.txt
+index c91e9cd93dc8..9260cdc1c83e 100644
+--- a/mlir/CMakeLists.txt
++++ b/mlir/CMakeLists.txt
+@@ -17,6 +17,12 @@ endif()
+ include(GNUInstallDirs)
+ set(CMAKE_CXX_STANDARD 17)
+ 
++if(MINGW OR CYGWIN)
++  set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
++  set(CMAKE_C_VISIBILITY_PRESET hidden)
++  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
++endif()
++
+ if(MLIR_STANDALONE_BUILD)
+   find_package(LLVM CONFIG REQUIRED)
+   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${LLVM_CMAKE_DIR})

--- a/L/LLVM/LLVM_full@23/bundled/patches/0400-MLIR-Disable-tblgen-lsp-server-and-tblgen-to-irdl.patch
+++ b/L/LLVM/LLVM_full@23/bundled/patches/0400-MLIR-Disable-tblgen-lsp-server-and-tblgen-to-irdl.patch
@@ -1,0 +1,51 @@
+From f3d0b3b681d1e3955e08dc1adf26040094a6df70 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mos=C3=A8=20Giordano?= <mose@gnu.org>
+Date: Fri, 3 May 2024 12:47:19 +0100
+Subject: [PATCH] [MLIR] Disable `tblgen-lsp-server` and `tblgen-to-irdl`
+
+---
+ mlir/lib/Tools/CMakeLists.txt | 2 +-
+ mlir/test/CMakeLists.txt      | 4 ++--
+ mlir/tools/CMakeLists.txt     | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/mlir/lib/Tools/CMakeLists.txt b/mlir/lib/Tools/CMakeLists.txt
+index 01270fa4b0fc..7688c31bf26b 100644
+--- a/mlir/lib/Tools/CMakeLists.txt
++++ b/mlir/lib/Tools/CMakeLists.txt
+@@ -8,4 +8,4 @@ add_subdirectory(mlir-tblgen)
+ add_subdirectory(mlir-translate)
+ add_subdirectory(PDLL)
+ add_subdirectory(Plugins)
+-add_subdirectory(tblgen-lsp-server)
++# add_subdirectory(tblgen-lsp-server)
+diff --git a/mlir/test/CMakeLists.txt b/mlir/test/CMakeLists.txt
+index 69c2e5978689..1a5dabd33e3f 100644
+--- a/mlir/test/CMakeLists.txt
++++ b/mlir/test/CMakeLists.txt
+@@ -117,8 +117,8 @@ set(MLIR_TEST_DEPENDS
+   mlir-rewrite
+   mlir-tblgen
+   mlir-translate
+-  tblgen-lsp-server
+-  tblgen-to-irdl
++  # tblgen-lsp-server
++  # tblgen-to-irdl
+   )
+ if(NOT MLIR_STANDALONE_BUILD)
+   list(APPEND MLIR_TEST_DEPENDS FileCheck count not split-file)
+diff --git a/mlir/tools/CMakeLists.txt b/mlir/tools/CMakeLists.txt
+index 72a857b114fb..c606a3b3dd1d 100644
+--- a/mlir/tools/CMakeLists.txt
++++ b/mlir/tools/CMakeLists.txt
+@@ -7,8 +7,8 @@ add_subdirectory(mlir-reduce)
+ add_subdirectory(mlir-rewrite)
+ add_subdirectory(mlir-shlib)
+ add_subdirectory(mlir-translate)
+-add_subdirectory(tblgen-lsp-server)
+-add_subdirectory(tblgen-to-irdl)
++# add_subdirectory(tblgen-lsp-server)
++# add_subdirectory(tblgen-to-irdl)
+
+ # mlir-cpu-runner requires ExecutionEngine.
+ if(MLIR_ENABLE_EXECUTION_ENGINE)

--- a/L/LLVM/LLVM_full@23/bundled/patches/0704-no-codesign.patch
+++ b/L/LLVM/LLVM_full@23/bundled/patches/0704-no-codesign.patch
@@ -1,0 +1,25 @@
+From 811bde347d425929813cbf40620f497b924c2c45 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Tue, 8 Nov 2022 19:52:32 -0500
+Subject: [PATCH] no codesign
+
+---
+ compiler-rt/cmake/Modules/AddCompilerRT.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/cmake/Modules/AddCompilerRT.cmake b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+index 298093462f80..34b9daf97400 100644
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -413,7 +413,7 @@ function(add_compiler_rt_runtime name type)
+
+         add_custom_command(TARGET ${libname}
+           POST_BUILD
+-          COMMAND ${CODESIGN} --sign - ${EXTRA_CODESIGN_ARGUMENTS} $<TARGET_FILE:${libname}>
++          # COMMAND ${CODESIGN} --sign - ${EXTRA_CODESIGN_ARGUMENTS} $<TARGET_FILE:${libname}>
+           WORKING_DIRECTORY ${COMPILER_RT_OUTPUT_LIBRARY_DIR}
+           COMMAND_EXPAND_LISTS
+         )
+--
+2.38.1
+

--- a/L/LLVM/LLVM_full@23/bundled/patches/0800-mingw-fix.patch
+++ b/L/LLVM/LLVM_full@23/bundled/patches/0800-mingw-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp b/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
+index dfc32ac9db29..7d0c7573f2e0 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerExtFunctionsWindows.cpp
+@@ -24,7 +24,7 @@ using namespace fuzzer;
+ #if LIBFUZZER_MSVC
+ #define GET_FUNCTION_ADDRESS(fn) &fn
+ #else
+-#define GET_FUNCTION_ADDRESS(fn) __builtin_function_start(fn)
++#define GET_FUNCTION_ADDRESS(fn) (void *)(&fn)
+ #endif // LIBFUZER_MSVC
+
+ // Copied from compiler-rt/lib/sanitizer_common/sanitizer_win_defs.h

--- a/L/LLVM/LLVM_full@23/bundled/patches/0900-mlir-openacc-assert-comma.patch
+++ b/L/LLVM/LLVM_full@23/bundled/patches/0900-mlir-openacc-assert-comma.patch
@@ -1,0 +1,23 @@
+Wrap an assert whose expression contains an unparenthesized comma.
+
+ACC_COMPUTE_CONSTRUCT_AND_LOOP_OPS expands to a comma-separated list of op
+types, so the preprocessor sees `assert` (and glibc's `__STRING`) being handed
+four arguments instead of one:
+
+  ACCRecipeMaterialization.cpp:432:56: error: macro "__STRING" passed 4
+      arguments, but takes just 1
+
+That only breaks builds with assertions enabled, which is why LLVM_full_assert
+fails while LLVM_full succeeds. Still unfixed upstream as of llvmorg-23.1.1.
+
+--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
++++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
+@@ -429,7 +429,7 @@ template <typename OpTy>
+ LogicalResult ACCRecipeMaterialization::materializeForACCOp(
+     OpTy accOp, acc::OpenACCSupport &accSupport,
+     acc::ACCToGPUMappingPolicy &policy) const {
+-  assert(isa<ACC_COMPUTE_CONSTRUCT_AND_LOOP_OPS>(accOp));
++  assert((isa<ACC_COMPUTE_CONSTRUCT_AND_LOOP_OPS>(accOp)));
+ 
+   if (!accOp.getFirstprivateOperands().empty()) {
+     // Clear the firstprivate operands list so there will be no uses after

--- a/L/LLVM/LLVM_full_assert@23/build_tarballs.jl
+++ b/L/LLVM/LLVM_full_assert@23/build_tarballs.jl
@@ -1,0 +1,8 @@
+version = v"23.1.1"
+
+include("../common.jl")
+
+# Built with GCC 10; see LLVM_full@23 for rationale.
+build_tarballs(ARGS, configure_build(ARGS, version; assert=true, experimental_platforms=true)...;
+               preferred_gcc_version=v"10", preferred_llvm_version=v"18", julia_compat="1.6")
+# Build trigger: 1

--- a/L/LLVM/LLVM_full_assert@23/bundled
+++ b/L/LLVM/LLVM_full_assert@23/bundled
@@ -1,0 +1,1 @@
+../LLVM_full@23/bundled/

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -30,6 +30,7 @@ const llvm_tags = Dict(
     v"20.1.8" => "24bdfdd813f4117f0464fd0dac5b4bce43ed1388", # julia-20.1.8-2
     v"21.1.8" => "151034ef71856c7406f58c150dba7d419dbd063d", # julia-21.1.8-1
     v"22.1.8" => "4df0bb28e9e4d59f293433a1e325a46479da5174", # julia-22.1.8-1
+    v"23.1.1" => "7f450553756e4c9604cba4a79caf59afa07c0e39", # julia-23.1.1-0
 )
 
 const buildscript = raw"""

--- a/L/LLVM/common.jl
+++ b/L/LLVM/common.jl
@@ -30,7 +30,7 @@ const llvm_tags = Dict(
     v"20.1.8" => "24bdfdd813f4117f0464fd0dac5b4bce43ed1388", # julia-20.1.8-2
     v"21.1.8" => "151034ef71856c7406f58c150dba7d419dbd063d", # julia-21.1.8-1
     v"22.1.8" => "4df0bb28e9e4d59f293433a1e325a46479da5174", # julia-22.1.8-1
-    v"23.1.1" => "7f450553756e4c9604cba4a79caf59afa07c0e39", # julia-23.1.1-0
+    v"23.1.1" => "5ab773a1ba20e4e289b8343283b62d7bd64b8642", # julia-23.1.1-1
 )
 
 const buildscript = raw"""


### PR DESCRIPTION
Stage 1 of the LLVM 23 bump (same split as v22: #14053, then #14300 / #14304 for the extraction packages, which have to wait for `LLVM_full_jll` 23 to register because they look it up in the registry).

Adds `LLVM_full@23` and `LLVM_full_assert@23`, built from the new [`julia-23.1.1-0`](https://github.com/JuliaLang/llvm-project/releases/tag/julia-23.1.1-0) tag of JuliaLang/llvm-project. That tag is `llvmorg-23.1.1` plus the six Julia patches from `julia-release/22.x` that are not yet upstream (prologue/epilogue unwinding, forced `.eh_frame` on AArch64, `SimplifySelectOps` disable, ittapi checkout fix, IRCE clone-legality check, SROA non-integral memset fix); the other four 22.x patches are already in 23.1.1.

Compared to the v22 recipe, `0050-unique_function_clang-sa.patch` is dropped: LLVM 23 rewrote `unique_function`'s move constructor and the `if (!RHS) return;` the patch wrapped for clang-analyzer no longer exists. All other patches apply unchanged, and the host build requirements (CMake, GCC floor, native tablegen tools) are the same as for 22, so `common.jl` only gains the `llvm_tags` entry. Still GCC 10 and `preferred_llvm_version=v"18"`, for the same reasons as v22.

Verified locally: full x86_64-linux-gnu-cxx11 build and audit (`llvm-config --version` = `23.1.1jl`, NVPTX/AMDGPU targets present). First-run Linux CI jobs will likely hit the cold-ccache timeout as they did for v22; retries finish.

Note for stage 2: `bugpoint` was removed upstream in 23, so the `LLVM_utils` tool list will change (branch `tb/llvm23-stage2`, to be opened after this registers).