### PR TITLE
0_RootFS: Add LLVM 23.1.1 bootstrap shard

### DIFF
--- a/0_RootFS/LLVMBootstrap@23/build_tarballs.jl
+++ b/0_RootFS/LLVMBootstrap@23/build_tarballs.jl
@@ -1,0 +1,16 @@
+# Include everything common between our LLVM versions (That's a lot)
+include("../llvm_common.jl")
+
+# Build the tarballs, then upload to Yggdrasil releases
+
+name = "LLVMBootstrap"
+version = v"23.1.1"
+sources, script, products, dependencies = llvm_build_args(;version=version)
+ndARGS, deploy_target = find_deploy_arg(ARGS)
+# Earlier versions of GCC can cause Clang to fail with `error: unknown target CPU 'x86-64'`
+# https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/112#issuecomment-776940748
+build_info = build_tarballs(ndARGS, name, version, sources, script, [host_platform], products, dependencies;
+                            skip_audit=true, preferred_gcc_version=v"8")
+if deploy_target !== nothing
+    upload_and_insert_shards(deploy_target, name, version, build_info)
+end

--- a/0_RootFS/LLVMBootstrap@23/bundled/patches/cpuidex-mingw.patch
+++ b/0_RootFS/LLVMBootstrap@23/bundled/patches/cpuidex-mingw.patch
@@ -1,0 +1,1 @@
+../../../LLVMBootstrap@19/bundled/patches/cpuidex-mingw.patch

--- a/0_RootFS/LLVMBootstrap@23/bundled/patches/install-prefix.patch
+++ b/0_RootFS/LLVMBootstrap@23/bundled/patches/install-prefix.patch
@@ -1,0 +1,1 @@
+../../../LLVMBootstrap@15/bundled/patches/install-prefix.patch

--- a/0_RootFS/llvm_common.jl
+++ b/0_RootFS/llvm_common.jl
@@ -46,6 +46,7 @@ llvm_tags = Dict(
     v"20.1.2" => "58df0ef89dd64126512e4ee27b4ac3fd8ddf6247",
     v"21.1.8" => "2078da43e25a4623cab2d0d60decddf709aaea28",
     v"22.1.7" => "a255c1ed36a1d06f79bd2633ba9f8d900153007c",
+    v"23.1.1" => "6dfe1677ab8dffbc6ec13d53a1e0215d75147689",
 )
 
 function llvm_sources(;version = "v8.0.1", kwargs...)


### PR DESCRIPTION
Adds `0_RootFS/LLVMBootstrap@23`, pinned to the upstream `llvmorg-23.1.1` commit. Recipe and patches (install prefix, mingw `__cpuidex`) are unchanged from 22; both patches still apply.

The x86_64-linux-musl shard is built and uploaded to the [`LLVMBootstrap-v23.1.1`](https://github.com/JuliaPackaging/Yggdrasil/releases/tag/LLVMBootstrap-v23.1.1) release (unpacked + squashfs + logs). The matching BinaryBuilderBase.jl Artifacts.toml entries are in JuliaPackaging/BinaryBuilderBase.jl#498.

Smoke-tested by compiling and linking C and C++ programs with the new clang for aarch64-apple-darwin, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-apple-darwin, x86_64-linux-gnu, x86_64-linux-musl, x86_64-unknown-freebsd, i686-w64-mingw32 and x86_64-w64-mingw32 (mingw also with `-fuse-ld=lld`).

Companion to #14738 (LLVM_full 23).
