### PR TITLE
[LLVMOpenMP] Update to v23.1.1, bump BinaryBuilderBase to 1.48.0

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -43,11 +43,11 @@ version = "0.6.6"
 
 [[deps.BinaryBuilderBase]]
 deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "5dce3ed3d13b191a3f6b742919a818a15095f43b"
+git-tree-sha1 = "bf6320ed952549d1d5bcc7593c3aef529520e307"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "1.47.0"
+version = "1.48.0"
 
 [[deps.Binutils_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll", "Zstd_jll"]
@@ -105,7 +105,7 @@ version = "4.18.1"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.3.0+1"
+version = "1.3.1+2"
 
 [[deps.ConcurrentUtilities]]
 deps = ["Serialization", "Sockets"]
@@ -385,7 +385,7 @@ version = "1.6.1"
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.4+0"
+version = "3.5.6+0"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "05f45c2e0de6259db764adbfd2f1dc6d3f8de13c"

--- a/L/LLVMOpenMP/build_tarballs.jl
+++ b/L/LLVMOpenMP/build_tarballs.jl
@@ -3,28 +3,28 @@
 using BinaryBuilder, Pkg
 
 name = "LLVMOpenMP"
-version = v"22.1.7"
+version = v"23.1.1"
 ygg_version = version
 
 sources = [
     ArchiveSource(
         "https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/llvm-project-$(version).src.tar.xz",
-        "5cc4a3f12bba50b6bdfb4b61bdc852117a0ff2517807c3902fc13267fb93562e"
+        "ebe9be46fe8756d58c5b198ffad0fa2a766257add81a4dc52179bfacc7888ee6"
     ),
     DirectorySource("./bundled"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/llvm-project-*/openmp
+cd $WORKSPACE/srcdir/llvm-project-*/
 # https://github.com/msys2/MINGW-packages/blob/d440dcb738/mingw-w64-clang/0901-cast-to-make-gcc-happy.patch
-atomic_patch -p1 $WORKSPACE/srcdir/patches/0901-cast-to-make-gcc-happy.patch
+atomic_patch -p1 --directory=openmp $WORKSPACE/srcdir/patches/0901-cast-to-make-gcc-happy.patch
 
 platform_config=()
 if [[ "${target}" == *-mingw* ]]; then
     # backport https://gitlab.kitware.com/cmake/cmake/-/commit/78f758a463516a78a9ec8d472080c6e61cb89c7f
     sed -i "s@/c  */Fo@-c -Fo@" /usr/share/cmake/Modules/CMakeASM_MASMInformation.cmake
-    sed -i "s@libomp_append(asmflags_local /@libomp_append(asmflags_local -@" cmake/modules/LibompHandleFlags.cmake
+    sed -i "s@libomp_append(asmflags_local /@libomp_append(asmflags_local -@" openmp/cmake/modules/LibompHandleFlags.cmake
     if [[ "${target}" == *x86_64* ]]; then
         platform_config+=(-DLIBOMP_ASMFLAGS="-win64")
     fi
@@ -34,17 +34,22 @@ elif [[ "${target}" == aarch64-apple-* ]]; then
     # `libclang_rt.osx.a` from LLVM compiler-rt.
     platform_config+=(-DCMAKE_SHARED_LINKER_FLAGS="-L${libdir}/darwin -lclang_rt.osx")
 fi
+# LLVM 23 removed the standalone `openmp/` build; go through `runtimes/` instead.
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
+    -DLLVM_ENABLE_RUNTIMES=openmp \
+    -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DLLVM_INCLUDE_DOCS=OFF \
     -DLIBOMP_INSTALL_ALIASES=OFF \
     -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
     "${platform_config[@]}" \
-    ..
+    ../runtimes
 make -j${nproc}
 make install
 
-install_license ../LICENSE.TXT
+install_license ../openmp/LICENSE.TXT
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Follow-up to #14739 / JuliaPackaging/BinaryBuilderBase.jl#498, same pairing as #14192 did for LLVM 22.

- Bumps the CI manifest to BinaryBuilderBase 1.48.0 (master, unreleased), which adds the LLVM 23.1.1 bootstrap shard. That shard becomes the default Clang for recipes that do not pin `preferred_llvm_version`.
- Bumps LLVMOpenMP to 23.1.1 alongside it, so `-fopenmp` builds with the new compiler link against a matching libomp (cf. https://github.com/JuliaPackaging/Yggdrasil/pull/14131#issuecomment-4883536444).

LLVM 23 removed the standalone `openmp/` build, so the recipe now configures `runtimes/` with `LLVM_ENABLE_RUNTIMES=openmp`. Verified locally on x86_64-linux-gnu-cxx11 and x86_64-w64-mingw32; tarball contents are identical to the v22 layout.
