### PR TITLE
CUDA: Bump toolkit to 13.4 (GA).

### DIFF
--- a/C/CUDA/CUDA_Compiler/build_tarballs.jl
+++ b/C/CUDA/CUDA_Compiler/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Compiler"
-version = v"0.6.2"
+version = v"0.6.3"
 
 const toolkit_versions = [CUDA.cuda_full_versions; CUDA.cuda_prerelease_versions]
 const compiler_versions = filter(v -> v >= v"11.4" || Base.thisminor(v) == v"10.2", toolkit_versions)

--- a/C/CUDA/CUDA_Runtime/build_tarballs.jl
+++ b/C/CUDA/CUDA_Runtime/build_tarballs.jl
@@ -7,7 +7,7 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "cuda.jl"))
 
 name = "CUDA_Runtime"
-version = v"0.24.4"
+version = v"0.25.0"
 
 # we ship artifacts for both GA and EA/preview toolkits; the platform augmentation only
 # ever selects the latter when the user asks for it through the "version" preference.
@@ -159,11 +159,12 @@ for version in reverse(toolkit_versions)
                 end"""
             # CUDA_Compiler_jll is only needed at run time (see the init block above), so it
             # is not installed in the build prefix. That also means building does not require
-            # a registered CUDA_Compiler_jll compatible with the CUDA_Driver_jll we depend on
-            # (0.6.1 is the first version that allows CUDA_Driver_jll 13.3.4).
+            # a registered CUDA_Compiler_jll compatible with the CUDA_Driver_jll we depend on.
+            # 0.6.3 is the first version that auto-selects the same toolkits we do (13.4 GA);
+            # an older compiler would trigger the "runtime newer than compiler" warning above.
             push!(builds,
                 (; dependencies=[Dependency("CUDA_Driver_jll", v"13.3.4"; compat="13.3.4 - 13"),
-                                 RuntimeDependency("CUDA_Compiler_jll"; compat="0.6.1")],
+                                 RuntimeDependency("CUDA_Compiler_jll"; compat="0.6.3")],
                    script, platforms=[augmented_platform], products=get_products(platform),
                    sources=get_sources("cuda", components; version, platform=augmented_platform),
                    init_block

--- a/C/CUDA/CUDA_SDK@13.4/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK@13.4/build_tarballs.jl
@@ -14,3 +14,5 @@ platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "windows")]
 
 build_sdk(name, version, platforms; static=false)
+
+# bump

--- a/C/CUDA/CUDA_SDK_static@13.4/build_tarballs.jl
+++ b/C/CUDA/CUDA_SDK_static@13.4/build_tarballs.jl
@@ -14,3 +14,5 @@ platforms = [Platform("x86_64", "linux"),
              Platform("x86_64", "windows")]
 
 build_sdk(name, version, platforms; static=true)
+
+# bump

--- a/platforms/cuda.jl
+++ b/platforms/cuda.jl
@@ -161,16 +161,15 @@ const cuda_full_versions = [
     v"13.0.2",
     v"13.1.1",
     v"13.2.1",
-    v"13.3.1"
+    v"13.3.1",
+    v"13.4.1"
 ]
 
 # EA/preview toolkits. We do build JLLs for these, so that they can be used explicitly,
 # but they are never selected automatically: they are left out of `supported_platforms`
 # unless asked for, and CUDA_Runtime_jll's platform augmentation only ever picks one when
 # the user requests it through the "version" preference.
-const cuda_prerelease_versions = [
-    v"13.4.0"
-]
+const cuda_prerelease_versions = VersionNumber[]
 
 function full_version(ver::VersionNumber)
     ver == Base.thisminor(ver) || error("Cannot specify a patch version")
@@ -351,9 +350,9 @@ function cuda_nvcc_redist_source(cuda_ver, arch)
             ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-13.2.51-archive.tar.xz",
                           "706b996fefc59dc8d64d317fdf48d0aa84c4ae004eff43009dd918f40c5cc66a")
         elseif cuda_ver == "13.4"
-            # See https://packages.nvidia.com/bin-archive/release/cuda/redist/redistrib_13.4.0.json
-            ArchiveSource("https://packages.nvidia.com/bin-archive/pool/linux-x86_64/5B515474-7E78-11F1-8656-C51E4F4B317F/cuda_nvcc-linux-x86_64-13.4.46-archive.tar.xz",
-                          "52e355da195b4a7ee910429680a69cdeea31834041cb65df738e0c561d5c4d69")
+            # See https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.4.1.json
+            ArchiveSource("https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-13.4.59-archive.tar.xz",
+                          "0c08d1df80b5d0bd081778d392446ab50a6a54b047c0136b39c8dbfdf2cfed3f")
         else
             error("No CUDA redist available for CUDA version $cuda_ver on arch $arch")
         end


### PR DESCRIPTION
CUDA 13.4 went GA on 2026-09-09 as 13.4.1, superseding the 13.4.0 developer preview we have been shipping as an opt-in toolkit since #14372/#14373. The GA manifest is on the classic redist host (developer.download.nvidia.com); packages.nvidia.com's bin-archive still only carries the 13.4.0 preview, which `get_sources` handles by trying the classic root first, so no hosting changes are needed.

13.4.1 moves from `cuda_prerelease_versions` to `cuda_full_versions`, which makes it a regular toolkit: `supported_platforms()` returns it, and the Runtime/Compiler platform augmentation auto-selects it on r580+ drivers (the prerelease guard stays in place for the next EA, with an empty list). CUDA_SDK_jll/CUDA_SDK_static_jll 13.4.1 are rebuilt from the GA archives. CUDA_Runtime_jll goes to 0.25.0 (minor bump for a new toolkit, as always, so that CUDA.jl opts in through its compat), CUDA_Compiler_jll to 0.6.3, and the Runtime now requires Compiler ≥ 0.6.3 so both agree on what "newest toolkit" means.

No product names changed between EA and GA (verified against the Windows archives: `cupti64_2026.3.0`, `nvrtc-builtins64_134`, `nvJitLink_130_0`), and CUDA_Driver_jll is untouched: NVIDIA has not published a 13.4 forward-compatibility driver (the 13.4.1 manifest carries no `cuda_compat`/`nvidia_driver`, and the r615.71.09 driver redist released the same day ships no `cuda_compat` either). 13.4 runs on r580+ via minor version compatibility, exactly like the EA did. The Runtime/Compiler dependency on the Driver stays at `13.3.4 - 13`: that floor is the first Driver defining `libcuda` on every platform, which is all the hooks need, and is not tied to the toolkit.

Verified with `--meta-json` for all recipes and platforms, and local builds of the 13.4 Runtime/Compiler artifacts for x86_64-w64-mingw32 and x86_64-linux-gnu.
