### PR TITLE
MUMPS: add a `_metis64` flavour ordered with the 64-bit-index METIS/ParMETIS

### DIFF
--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -5,7 +5,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MUMPS"
 version = v"5.9.1"
-ygg_version = v"5.9.2"
+ygg_version = v"5.9.3"
 
 sources = [
   ArchiveSource("https://mumps-solver.org/MUMPS_$(version).tar.gz",
@@ -93,14 +93,10 @@ FSCOTCH="-Dscotch"
 # LSCOTCH="-lptesmumps -lptscotch -lptscotcherr"
 # FSCOTCH="-Dptscotch"
 
-make_args+=(PLAT="par" \
-            OPTF="-O3 -fopenmp" \
+# Make arguments shared by both flavours below.
+make_args+=(OPTF="-O3 -fopenmp" \
             OPTL="-O3 -l${OMP} ${EXTRA_LDFLAGS[*]}" \
-            OPTC="-O3 -fopenmp" \
             CDEFS=-DAdd_ \
-            LMETISDIR="${libdir}" \
-            IMETIS="-I${includedir}" \
-            LMETIS="-L${libdir} -lparmetis -lmetis" \
             LSCOTCHDIR=${libdir} \
             ISCOTCH="-I${includedir}" \
             LSCOTCH="${LSCOTCH}" \
@@ -112,16 +108,47 @@ make_args+=(PLAT="par" \
             FC="${MPIFC} ${FFLAGS[@]}" \
             FL="${MPIFL}" \
             RANLIB="echo" \
-            LPORD="-L./PORD/lib -lpordpar" \
             LIBBLAS="${BLAS_LAPACK}" \
             LAPACK="${BLAS_LAPACK}" \
             SCALAP="-L${libdir} -lscalapack32" \
             INCPAR="-I${includedir}" \
             LIBPAR="-L${libdir} -lscalapack32 ${BLAS_LAPACK} ${MPILIBS[*]}")
 
-make -j${nproc} allshared "${make_args[@]}"
+# Flavour 1 (stock): lib{s,d,c,z}mumpspar, libmumps_commonpar, libpordpar,
+# ordered with the 32-bit-index libmetis/libparmetis.
+make -j${nproc} allshared "${make_args[@]}" \
+    PLAT="par" \
+    OPTC="-O3 -fopenmp" \
+    LMETISDIR="${libdir}" \
+    IMETIS="-I${includedir}" \
+    LMETIS="-L${libdir} -lparmetis -lmetis" \
+    LPORD="-L./PORD/lib -lpordpar"
 
 cp include/*.h ${includedir}
+cp lib/*.${dlext} ${libdir}
+
+# Flavour 2: lib{s,d,c,z}mumpspar_metis64, libmumps_commonpar_metis64,
+# libpordpar_metis64.  Same 32-bit MUMPS integers and identical headers,
+# but ordered with the 64-bit-index libmetis_Int64_Real32 /
+# libparmetis_Int64_Real32 (MUMPS >= 5.7 converts its 32-bit arrays for
+# a METIS/ParMETIS with IDXTYPEWIDTH=64).  Intended for consumers that
+# also load SuperLU_DIST_jll's libsuperlu_dist_Int64 -- e.g. the
+# 64-bit-PetscInt variants of PETSc_jll: that library needs the 64-bit
+# METIS, and since both METIS flavours export identical symbol names only
+# one of them can live in a process.  METIS_jll's metis.h only defaults
+# IDXTYPEWIDTH/REALTYPEWIDTH when they are undefined, hence the explicit
+# -D flags.
+(cd src && make clean)
+(cd examples && make clean)
+rm -f PORD/lib/*.o lib/*.${dlext}
+make -j${nproc} allshared "${make_args[@]}" \
+    PLAT="par_metis64" \
+    OPTC="-O3 -fopenmp -DIDXTYPEWIDTH=64 -DREALTYPEWIDTH=32" \
+    LMETISDIR="${libdir}/metis/metis_Int64_Real32/lib" \
+    IMETIS="-I${libdir}/metis/metis_Int64_Real32/include -I${includedir}" \
+    LMETIS="-L${libdir} -lparmetis_Int64_Real32 -L${libdir}/metis/metis_Int64_Real32/lib -lmetis_Int64_Real32" \
+    LPORD="-L./PORD/lib -lpordpar_metis64"
+
 cp lib/*.${dlext} ${libdir}
 """
 
@@ -141,6 +168,11 @@ products = [
     LibraryProduct("libdmumpspar", :libdmumpspar),
     LibraryProduct("libcmumpspar", :libcmumpspar),
     LibraryProduct("libzmumpspar", :libzmumpspar),
+    # Same MUMPS, ordered with the 64-bit-index METIS/ParMETIS (see script)
+    LibraryProduct("libsmumpspar_metis64", :libsmumpspar_metis64),
+    LibraryProduct("libdmumpspar_metis64", :libdmumpspar_metis64),
+    LibraryProduct("libcmumpspar_metis64", :libcmumpspar_metis64),
+    LibraryProduct("libzmumpspar_metis64", :libzmumpspar_metis64),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
Builds MUMPS a second time (`PLAT=par_metis64`) against `libmetis_Int64_Real32`/`libparmetis_Int64_Real32`, with `-DIDXTYPEWIDTH=64 -DREALTYPEWIDTH=32`. The result keeps MUMPS's stock 32-bit integers and identical headers; MUMPS >= 5.7 converts its arrays for a 64-bit METIS/ParMETIS internally ("mixed" mode). New products: `lib{s,d,c,z}mumpspar_metis64`, plus the shipped `libmumps_commonpar_metis64` and `libpordpar_metis64`. The stock libraries are unchanged. `ygg_version` bumped to 5.9.3.

## Why
PETSc_jll (#13691) links MUMPS_jll and SuperLU_DIST_jll's `libsuperlu_dist_Int64` in its 64-bit-PetscInt variants. That SuperLU_DIST library needs the 64-bit-index METIS, and both METIS flavours export identical `METIS_*`/`ParMETIS_*` symbol names, so only one of them can live in a process. With the stock MUMPS libraries (32-bit METIS) the dynamic linker binds SuperLU_DIST's `METIS_NodeND` to the 32-bit METIS and the factorization corrupts memory or hangs (`munmap_chunk(): invalid pointer`, and the 6-hour hangs in test_PETSc_jll CI); preloading the 64-bit METIS instead breaks MUMPS's METIS/ParMETIS orderings (SEGV, INFO(1)=-50). PETSc refuses full 64-bit MUMPS (`#error` in imumps.c), so MUMPS64_jll is not an option (and see the separate issue about MUMPS64_jll's MPI Fortran integer mismatch). With this flavour, the Int64 PETSc variants can link MUMPS and SuperLU_DIST that agree on the METIS integer width; the Int32 variants keep the stock flavour.

## Verified locally (x86_64-linux-gnu-libgfortran5-mpi+mpich)
- Both flavours build; `mumps_metis_idxsize` reports 32 for `libmumps_commonpar` and 64 for `libmumps_commonpar_metis64`.
- A C driver (tridiagonal system, n=2000) solves correctly on 1, 2 and 4 ranks with automatic, METIS (`ICNTL(7)=5`) and ParMETIS (`ICNTL(28)=2, ICNTL(29)=2`, `INFOG(32)=2`) orderings, also with `libsuperlu_dist_Int64` loaded in the same process.
- PETSc_jll 3.25.4 built against this JLL passes test_PETSc_jll (ex19/ex42/ex4 with MUMPS and SuperLU_DIST, Int64 and Int32) -- see #13691.
