### PR TITLE
[aws_c_s3] Update to version 1.1.1

### DIFF
--- a/A/aws_c_s3/build_tarballs.jl
+++ b/A/aws_c_s3/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder, Pkg
 
 name = "aws_c_s3"
-version = v"1.0.0"
+version = v"1.1.1"
 
 # Collection of sources required to complete build
 sources = [
-    GitSource("https://github.com/awslabs/aws-c-s3.git", "8d7d4aeab6b9710cda5a6f44904d6ec3faf8861f"),
+    GitSource("https://github.com/awslabs/aws-c-s3.git", "977386498668154d6fe2a4f067cfa8d62d310858"),
 ]
 
 # Bash recipe for building across all platforms
@@ -40,7 +40,7 @@ dependencies = [
     Dependency("aws_c_http_jll"; compat="1.0.0"),
     Dependency("aws_c_auth_jll"; compat="1.0.0"),
     Dependency("aws_c_common_jll"; compat="1.0.0"),
-    Dependency("s2n_tls_jll"; compat="1.7.8"),    
+    Dependency("s2n_tls_jll"; compat="1.7.9"),    
     BuildDependency("aws_lc_jll"),
 ]
 


### PR DESCRIPTION
This PR updates aws_c_s3 to version 1.1.1.

All runtime deps pinned at latest known.
- `aws_c_auth_jll`: 1.0.0
- `aws_c_common_jll`: 1.0.0
- `aws_c_http_jll`: 1.0.0
- `aws_checksums_jll`: 1.0.0
- `s2n_tls_jll`: 1.7.9

cc: @Octogonapus