### PR TITLE
[CI] Use Julia v1.12.7 and update BinaryBuilderBase

### DIFF
--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.4"
+julia_version = "1.12.7"
 manifest_format = "2.0"
 project_hash = "5023fc07bb1b56800f97a2d66fbd8bd8c9c8d7a1"
 
@@ -19,7 +19,7 @@ version = "1.11.0"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.3.0+1"
+version = "1.3.1+2"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -101,7 +101,7 @@ version = "1.3.0"
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.4+0"
+version = "3.5.6+0"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     plugins:
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled
-          version: "1.12.6"
+          version: "1.12.7"
           artifacts_size_limit: "187904819200" # 175GiB
       - JuliaCI/merge-commit: ~
       - JuliaCI/forerunner#v1:

--- a/.buildkite/register_pipeline.yml
+++ b/.buildkite/register_pipeline.yml
@@ -36,7 +36,7 @@ steps:
     plugins:
       - JuliaCI/julia#v1:
           persist_depot_dirs: packages,artifacts,compiled
-          version: "1.12.4"
+          version: "1.12.7"
       - JuliaCI/merge-commit: ~
     timeout_in_minutes: 90
     # Do not let two builds choose a wrapper version for the same package concurrently.

--- a/.buildkite/utils.jl
+++ b/.buildkite/utils.jl
@@ -32,7 +32,7 @@ agent() = Dict(
 plugins() = Pair{String, Union{Nothing, Dict}}[
     "JuliaCI/julia#v1" => Dict(
         "persist_depot_dirs" => "packages,artifacts,compiled",
-        "version" => "1.12.4",
+        "version" => "1.12.7",
         "artifacts_size_limit" => string(120 << 30), # 120 GiB
     ),
     "JuliaCI/merge-commit" => nothing

--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.6"
+julia_version = "1.12.7"
 manifest_format = "2.0"
 project_hash = "7c094f9c3a913dbadcc8fbeaad95282e9b58d959"
 
@@ -43,7 +43,7 @@ version = "0.6.6"
 
 [[deps.BinaryBuilderBase]]
 deps = ["Bzip2_jll", "CodecZlib", "Downloads", "Gzip_jll", "HistoricalStdlibVersions", "InteractiveUtils", "JLLWrappers", "JSON", "LibGit2", "LibGit2_jll", "Libdl", "Logging", "OrderedCollections", "OutputCollectors", "Pkg", "Printf", "ProgressMeter", "REPL", "Random", "RegistryInstances", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "Tar_jll", "UUIDs", "XZ_jll", "Zstd_jll", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "bf6320ed952549d1d5bcc7593c3aef529520e307"
+git-tree-sha1 = "e72a0380fb258570da46b91faf490c80d65fa385"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"

--- a/.github/workflows/update_manifest.yml
+++ b/.github/workflows/update_manifest.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
-          version: '1.12.6' # Use the version of Julia used on the build machine
+          version: '1.12.7' # Use the version of Julia used on the build machine
           arch: x64
       - uses: julia-actions/cache@a7bed9df697e5d7309d68afe7542a87621a8b6c8 # v3.3.0
         with:


### PR DESCRIPTION
Both changes target the same recurring hang: the BinaryBuilder auditor calls `Libdl.dllist()` from many threads at once, and on Julia < 1.12.7 the `dl_iterate_phdr` callback can trigger a GC while holding glibc's dynamic linker lock, deadlocking against threads blocked on that lock (JuliaLang/julia#62121). Jobs then sit idle until the 5 hour timeout.

Julia 1.12.7 carries the fix, and BinaryBuilderBase no longer goes through `dllist()` to find libc in `uname()`
(JuliaPackaging/BinaryBuilderBase.jl#499).

Notable changes:
* https://github.com/JuliaPackaging/BinaryBuilderBase.jl/compare/891400836a30b91265c5f5eea04150811161fb10...028b2da4a02b6aa80197c740f21ace41ea3281cb