### PR TITLE
[SPIRV_LLVM_Translator] Ship libllvm_spirv instead of llvm-spirv

### DIFF
--- a/S/SPIRV_LLVM_Translator/build_tarballs.jl
+++ b/S/SPIRV_LLVM_Translator/build_tarballs.jl
@@ -8,26 +8,40 @@ include(joinpath(YGGDRASIL_DIR, "fancy_toys.jl"))
 include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "SPIRV_LLVM_Translator"
-version = v"22.1.4"
-llvm_version = v"22.1.1+0"
+version = v"23.1.1"
+llvm_version = v"23.1.1+0"
+
+# This JLL ships `libllvm_spirv`, a shared library exposing a small, typed C API
+# (see bundled/libllvm_spirv.h) over a statically linked, symbol-hidden build of
+# the Khronos translator (LLVM IR -> SPIR-V), replacing the `llvm-spirv`
+# executable. The package version tracks the embedded LLVM's and the
+# translator's release (also reported at runtime by `LLVMSPIRVGetLLVMVersion`).
 
 # Collection of sources required to build the package
 sources = [
     GitSource(
         "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",
-        "c88a2e4a1ec77f7adc8916940afd9754c3a30fab"),
+        "c808623558686b7b285cabfa71542a93a5390f55"),
     DirectorySource("bundled"),
-    # LLVM 15+ requires macOS SDK 10.14
-    get_macos_sdk_sources("10.14")...
+    # LLVM 22 raised its minimum macOS deployment target to 11.0, and LLVM 23's
+    # headers no longer compile against the older SDK's libc++.
+    get_macos_sdk_sources("11.0")...
 ]
 
 # Bash recipe for building across all platforms
-get_script(llvm_version) = get_macos_sdk_script("10.14") * raw"""
+get_script(llvm_version) = get_macos_sdk_script("11.0") * raw"""
 cd SPIRV-LLVM-Translator
 atomic_patch -p1 ../phi-duplicate-predecessors.patch
 install_license LICENSE.TXT
 
 CMAKE_FLAGS=()
+
+# glibc treats STB_GNU_UNIQUE symbols as process-unique regardless of
+# visibility, which would let two LLVMs in one process share state. The flag is
+# GCC-only (FreeBSD and macOS build with clang, which never emits them).
+if [[ "${target}" == *-linux-* ]]; then
+    CMAKE_FLAGS+=(-DCMAKE_CXX_FLAGS=-fno-gnu-unique)
+fi
 
 # Release build for best performance
 CMAKE_FLAGS+=(-DCMAKE_BUILD_TYPE=Release)
@@ -66,7 +80,80 @@ if [[ "${target}" == *-apple-darwin* ]]; then
 else
     cmake -B build -S . -GNinja ${CMAKE_FLAGS[@]}
 fi
-ninja -C build -j ${nproc} llvm-spirv install
+# Only the static translator library is needed; the tool is not shipped.
+ninja -C build -j ${nproc} LLVMSPIRVLib
+
+# Build libllvm_spirv: one translation unit over the static translator library
+# and LLVM_full_jll's static component archives, with every LLVM and translator
+# symbol hidden so only the LLVMSPIRV* API is exported. That isolation is what
+# allows loading the library next to Julia's own LLVM (or a sibling back-end
+# library) in one process. The API TU is compiled with exceptions so that a
+# `report_fatal_error` can be turned into an error return.
+cd ${WORKSPACE}/srcdir
+COMMON_FLAGS=(-O2 -std=c++17 -fPIC
+    -fvisibility=hidden -fvisibility-inlines-hidden -fno-rtti -fexceptions
+    -ffunction-sections -fdata-sections
+    -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+    -I${prefix}/include -ISPIRV-LLVM-Translator/include)
+# LLVM_full_jll's component archives; on Windows the glob would also match the
+# import library of libLLVM.dll, whose symbols duplicate the archives'.
+LLVM_ARCHIVES=($(ls ${prefix}/lib/libLLVM*.a | grep -v '\.dll\.a$'))
+if [[ "${target}" == *-apple-* ]]; then
+    # ld64 resolves across archives on its own and has no --start-group.
+    LLVM_LIBS=(SPIRV-LLVM-Translator/build/lib/SPIRV/libLLVMSPIRVLib.a ${LLVM_ARCHIVES[@]})
+else
+    LLVM_LIBS=(-Wl,--start-group SPIRV-LLVM-Translator/build/lib/SPIRV/libLLVMSPIRVLib.a ${LLVM_ARCHIVES[@]} -Wl,--end-group)
+fi
+# LLVM_full_jll is built with zlib, and with zstd on some platforms.
+SYSTEM_LIBS=(-L${prefix}/lib -lz)
+if ls ${prefix}/lib/libzstd.* >/dev/null 2>&1; then
+    SYSTEM_LIBS+=(-lzstd)
+fi
+# The functions declared in the header are exactly what gets exported.
+API=$(sed -n 's/.*\b\(LLVMSPIRV[A-Za-z0-9]*\)(.*/\1/p' libllvm_spirv.h | sort -u)
+if [[ "${target}" == *mingw* ]]; then
+    # Clang/LLD like the translator build above. Export only the dllexport'd
+    # API: auto-export would overflow the 64K PE export limit with the static
+    # LLVM.
+    LINKER=${target}-clang++
+    COMMON_FLAGS+=(-pthread)
+    LINK_FLAGS=(-Wl,--exclude-all-symbols -Wl,--gc-sections
+        ${SYSTEM_LIBS[@]} -lole32 -luuid -lpsapi -lshell32 -ladvapi32 -lws2_32 -lntdll)
+elif [[ "${target}" == *-apple-* ]]; then
+    LINKER=${CXX}
+    printf '_%s\n' ${API} > libllvm_spirv.exports
+    LINK_FLAGS=(-Wl,-exported_symbols_list,libllvm_spirv.exports -Wl,-dead_strip
+        ${SYSTEM_LIBS[@]} -lpthread -ldl -lm)
+else
+    LINKER=${CXX}
+    if [[ "${target}" == *-linux-* ]]; then
+        COMMON_FLAGS+=(-fno-gnu-unique)
+    fi
+    echo "{ global: $(printf '%s; ' ${API}) local: *; };" > libllvm_spirv.map
+    LINK_FLAGS=(-Wl,--exclude-libs,ALL -Wl,-Bsymbolic -Wl,--gc-sections
+        -Wl,--version-script=libllvm_spirv.map
+        ${SYSTEM_LIBS[@]} -lpthread -lm)
+    if [[ "${target}" == *-freebsd* ]]; then
+        # No -z defs: `environ`, which LLVM's process support references, is
+        # defined by the executable's startup code on FreeBSD, not by libc.
+        LINK_FLAGS+=(-lexecinfo)
+    else
+        LINK_FLAGS+=(-Wl,-z,defs -ldl)
+    fi
+fi
+mkdir -p ${libdir} ${includedir}
+${LINKER} -shared -o ${libdir}/libllvm_spirv.${dlext} ${COMMON_FLAGS[@]} libllvm_spirv.cpp \
+    ${LLVM_LIBS[@]} ${LINK_FLAGS[@]}
+install -Dm644 libllvm_spirv.h ${includedir}/libllvm_spirv.h
+
+# Show what got exported: only the LLVMSPIRV* API, and (on ELF) no
+# STB_GNU_UNIQUE symbols, which would defeat the isolation.
+if [[ "${target}" == *-linux-* || "${target}" == *-freebsd* ]]; then
+    echo "exported symbols:"; nm -D --defined-only ${libdir}/libllvm_spirv.${dlext} | grep -v ' [wv] '
+    echo "STB_GNU_UNIQUE symbols: $(readelf -Ws ${libdir}/libllvm_spirv.${dlext} | grep -c UNIQUE)"
+elif [[ "${target}" == *-apple-* ]]; then
+    echo "exported symbols:"; nm -gU ${libdir}/libllvm_spirv.${dlext}
+fi
 """
 
 # These are the platforms we will build for by default, unless further
@@ -83,9 +170,11 @@ platforms = expand_cxxstring_abis(supported_platforms())
 #                                   ^
 filter!(p -> !(arch(p) == "i686" && libc(p) == "musl"), platforms)
 
-# The products that we will ensure are always built
+# The products that we will ensure are always built. `libllvm_spirv` is not
+# dlopen'ed at `__init__` time: it is tens of MB, and the first `ccall` into it
+# loads it on demand.
 products = Product[
-    ExecutableProduct("llvm-spirv", :llvm_spirv)
+    LibraryProduct("libllvm_spirv", :libllvm_spirv; dont_dlopen=true),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/S/SPIRV_LLVM_Translator/bundled/libllvm_spirv.cpp
+++ b/S/SPIRV_LLVM_Translator/bundled/libllvm_spirv.cpp
@@ -1,0 +1,248 @@
+//===-- libllvm_spirv.cpp - In-process Khronos SPIR-V translator ----------===//
+//
+// Implements the C API in libllvm_spirv.h on top of LLVMSPIRVLib: what
+// `llvm-spirv --spirv-max-version=X.Y --spirv-ext=... --spirv-debug-info-version=...`
+// does, without the driver, the command-line parser, or the file system. The
+// translator takes all its options as a `SPIRV::TranslatorOpts` struct, so this
+// is a direct mapping.
+//
+// No `cl::opt` is registered by this file. All LLVM and translator symbols are
+// hidden at link time, so the library loads next to Julia's own LLVM (or a
+// sibling back-end library) in one process.
+//
+//===----------------------------------------------------------------------===//
+
+#include "libllvm_spirv.h"
+
+#include "LLVMSPIRVLib.h"
+#include "LLVMSPIRVOpts.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace llvm;
+
+namespace {
+
+std::mutex APILock;
+
+// `report_fatal_error` is turned into a C++ exception so the caller gets a
+// message instead of an abort. The unwind passes through frames compiled with
+// -fno-exceptions, whose cleanups are skipped, so the state of the failing
+// call must not be destroyed afterwards (see `State` below).
+struct FatalError {
+  std::string Message;
+};
+[[noreturn]] void throwingFatalErrorHandler(void *, const char *Reason, bool) {
+  throw FatalError{Reason};
+}
+
+struct MemoryBufferImpl {
+  std::string Data;
+};
+
+// Everything owned by one translation, in one heap block: deleted on a normal
+// return, deliberately leaked after a recovered fatal error.
+struct State {
+  LLVMContext Context;
+  std::unique_ptr<Module> M;
+  std::ostringstream Output;
+};
+
+char *makeMessage(const std::string &S) {
+  char *P = static_cast<char *>(std::malloc(S.size() + 1));
+  if (P)
+    std::memcpy(P, S.c_str(), S.size() + 1);
+  return P;
+}
+
+const std::map<std::string, SPIRV::ExtensionID> &extensionsByName() {
+  static const std::map<std::string, SPIRV::ExtensionID> Map = [] {
+    std::map<std::string, SPIRV::ExtensionID> M;
+#define EXT(X) M[#X] = SPIRV::ExtensionID::X;
+#include "LLVMSPIRVExtensions.inc"
+#undef EXT
+    return M;
+  }();
+  return Map;
+}
+
+// Parses the option's extension list like llvm-spirv's parseSPVExtOption;
+// returns an error message, or empty.
+std::string parseExtensions(const char *List,
+                            SPIRV::TranslatorOpts::ExtensionsStatusMap &Status) {
+  const auto &Known = extensionsByName();
+  // Generating SPIR-V: every known extension starts out disallowed.
+  for (const auto &KV : Known)
+    Status[KV.second] = std::nullopt;
+  if (!List || !*List)
+    return std::string();
+  SmallVector<StringRef, 8> Tokens;
+  StringRef(List).split(Tokens, ',', -1, /*KeepEmpty=*/false);
+  for (StringRef Token : Tokens) {
+    Token = Token.trim();
+    bool Allow = true;
+    if (Token.starts_with("+") || Token.starts_with("-")) {
+      Allow = Token[0] == '+';
+      Token = Token.drop_front();
+    }
+    if (Token.empty())
+      return "invalid extension list entry";
+    if (Token == "all") {
+      for (const auto &KV : Known)
+        Status[KV.second] = Allow;
+      continue;
+    }
+    auto It = Known.find(Token.str());
+    if (It == Known.end())
+      return "unknown SPIR-V extension: " + Token.str();
+    Status[It->second] = Allow;
+  }
+  return std::string();
+}
+
+} // namespace
+
+extern "C" {
+
+void LLVMSPIRVGetLLVMVersion(unsigned *Major, unsigned *Minor, unsigned *Patch) {
+  if (Major) *Major = LLVM_VERSION_MAJOR;
+  if (Minor) *Minor = LLVM_VERSION_MINOR;
+  if (Patch) *Patch = LLVM_VERSION_PATCH;
+}
+
+void LLVMSPIRVDisposeMessage(char *Message) { std::free(Message); }
+
+const char *LLVMSPIRVGetBufferStart(LLVMSPIRVMemoryBufferRef Buffer) {
+  return reinterpret_cast<MemoryBufferImpl *>(Buffer)->Data.data();
+}
+size_t LLVMSPIRVGetBufferSize(LLVMSPIRVMemoryBufferRef Buffer) {
+  return reinterpret_cast<MemoryBufferImpl *>(Buffer)->Data.size();
+}
+void LLVMSPIRVDisposeMemoryBuffer(LLVMSPIRVMemoryBufferRef Buffer) {
+  delete reinterpret_cast<MemoryBufferImpl *>(Buffer);
+}
+
+const char **LLVMSPIRVGetExtensions(size_t *Count) {
+  std::lock_guard<std::mutex> Guard(APILock);
+  static std::vector<const char *> Names = [] {
+    std::vector<const char *> R;
+    for (const auto &KV : extensionsByName())
+      R.push_back(KV.first.c_str()); // the map is static: stable
+    return R;
+  }();
+  if (Count) *Count = Names.size();
+  return Names.data();
+}
+
+int LLVMSPIRVTranslate(const char *Bitcode, size_t Length,
+                       const LLVMSPIRVTranslateOptions *Options,
+                       LLVMSPIRVMemoryBufferRef *OutSPIRV, char **OutMessage) {
+  std::lock_guard<std::mutex> Guard(APILock);
+  if (OutMessage) *OutMessage = nullptr;
+  if (OutSPIRV) *OutSPIRV = nullptr;
+
+  State *S = nullptr;
+  auto fail = [&](const std::string &Message) {
+    if (OutMessage) *OutMessage = makeMessage(Message);
+    delete S;
+    S = nullptr;
+    return 1;
+  };
+
+  // 1. Options, as llvm-spirv derives them from its flags.
+  if (!Options)
+    return fail("no options given");
+  SPIRV::VersionNumber MaxVersion = SPIRV::VersionNumber::MaximumVersion;
+  if (Options->MaxVersionMajor != 0 || Options->MaxVersionMinor != 0) {
+    MaxVersion = static_cast<SPIRV::VersionNumber>(
+        (Options->MaxVersionMajor << 16) | (Options->MaxVersionMinor << 8));
+    if (!SPIRV::isSPIRVVersionKnown(MaxVersion))
+      return fail("unsupported SPIR-V version " +
+                  std::to_string(Options->MaxVersionMajor) + "." +
+                  std::to_string(Options->MaxVersionMinor));
+  }
+  SPIRV::TranslatorOpts::ExtensionsStatusMap Extensions;
+  {
+    std::string Error = parseExtensions(Options->Extensions, Extensions);
+    if (!Error.empty())
+      return fail(Error);
+  }
+  SPIRV::TranslatorOpts Opts(MaxVersion, Extensions);
+  switch (Options->DebugInfoVersion) {
+  case LLVMSPIRVDebugInfoSPIRV:
+    Opts.setDebugInfoEIS(SPIRV::DebugInfoEIS::SPIRV_Debug);
+    break;
+  case LLVMSPIRVDebugInfoOpenCL100:
+    Opts.setDebugInfoEIS(SPIRV::DebugInfoEIS::OpenCL_DebugInfo_100);
+    break;
+  case LLVMSPIRVDebugInfoNonSemanticShader100:
+    Opts.setDebugInfoEIS(SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_100);
+    Opts.setAllowedToUseExtension(SPIRV::ExtensionID::SPV_KHR_non_semantic_info);
+    break;
+  case LLVMSPIRVDebugInfoNonSemanticShader200:
+    Opts.setDebugInfoEIS(SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_200);
+    Opts.setAllowExtraDIExpressionsEnabled(true);
+    Opts.setAllowedToUseExtension(SPIRV::ExtensionID::SPV_KHR_non_semantic_info);
+    break;
+  default:
+    return fail("invalid debug info version");
+  }
+
+  // 2. Translate. `State` is leaked after a fatal error (see above), and the
+  //    thread-local pretty-stack list is repaired since its RAII entries
+  //    were skipped by the unwind too.
+  S = new State;
+  const void *PrettyStack = SavePrettyStackState();
+  ScopedFatalErrorHandler FatalGuard(throwingFatalErrorHandler);
+  try {
+    // The IR parser requires a null-terminated buffer: copy.
+    SMDiagnostic ParseError;
+    auto Buffer = MemoryBuffer::getMemBufferCopy(StringRef(Bitcode, Length),
+                                                 "<input>");
+    S->M = parseIR(Buffer->getMemBufferRef(), ParseError, S->Context);
+    if (!S->M) {
+      std::string Message;
+      raw_string_ostream OS(Message);
+      ParseError.print(nullptr, OS, false);
+      if (!Message.empty() && Message.back() == '\n')
+        Message.pop_back();
+      return fail(Message);
+    }
+
+    std::string Error;
+    if (!writeSpirv(S->M.get(), Opts, S->Output, Error))
+      return fail(Error.empty() ? "SPIR-V translation failed" : Error);
+
+    auto *Out = new MemoryBufferImpl;
+    Out->Data = S->Output.str();
+    if (OutSPIRV)
+      *OutSPIRV = reinterpret_cast<LLVMSPIRVMemoryBufferRef>(Out);
+    else
+      delete Out;
+    delete S;
+    return 0;
+  } catch (FatalError &E) {
+    RestorePrettyStackState(PrettyStack);
+    S = nullptr; // leaked on purpose
+    while (!E.Message.empty() && E.Message.back() == '\n')
+      E.Message.pop_back();
+    return fail("LLVM ERROR: " + E.Message);
+  }
+}
+
+} // extern "C"

--- a/S/SPIRV_LLVM_Translator/bundled/libllvm_spirv.h
+++ b/S/SPIRV_LLVM_Translator/bundled/libllvm_spirv.h
@@ -1,0 +1,80 @@
+/*===-- libllvm_spirv.h - In-process Khronos SPIR-V translator ----*- C -*-===*\
+|*                                                                            *|
+|* A small, typed C API over a statically linked, symbol-hidden build of the  *|
+|* Khronos SPIRV-LLVM-Translator (LLVM IR -> SPIR-V direction only). It       *|
+|* replaces spawning the `llvm-spirv` executable: bitcode in, SPIR-V binary   *|
+|* out, plus a query for the extensions the translator knows.                 *|
+|*                                                                            *|
+|* Conventions follow llvm-c: status as return value (0 = success), an error  *|
+|* message returned through `OutMessage` only on failure (free it with        *|
+|* LLVMSPIRVDisposeMessage), results as opaque memory buffers, and string     *|
+|* lists owned by the library. Every call is serialised by an internal mutex. *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LIBLLVM_SPIRV_H
+#define LIBLLVM_SPIRV_H
+
+#include <stddef.h>
+
+#if defined(_WIN32)
+#define LLVMSPIRV_API __declspec(dllexport)
+#else
+#define LLVMSPIRV_API __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct LLVMSPIRVOpaqueMemoryBuffer *LLVMSPIRVMemoryBufferRef;
+
+/* The `--spirv-debug-info-version` choices. */
+typedef enum {
+  LLVMSPIRVDebugInfoSPIRV = 0,                 /* "spirv-debug" (the default) */
+  LLVMSPIRVDebugInfoOpenCL100 = 1,             /* "ocl-100" */
+  LLVMSPIRVDebugInfoNonSemanticShader100 = 2,  /* "nonsemantic-shader-100" */
+  LLVMSPIRVDebugInfoNonSemanticShader200 = 3   /* "nonsemantic-shader-200" */
+} LLVMSPIRVDebugInfoVersion;
+
+typedef struct {
+  /* Highest SPIR-V version to emit (`--spirv-max-version`), e.g. 1 and 4.
+   * 0/0 selects the translator's maximum. */
+  unsigned MaxVersionMajor, MaxVersionMinor;
+  /* Comma-separated extension list in `--spirv-ext` syntax: "+NAME" allows,
+   * "-NAME" disallows, "all" stands for every known extension; a bare name
+   * means "+NAME". NULL/"" allows none. Names are validated against
+   * LLVMSPIRVGetExtensions; an unknown one is an error. */
+  const char *Extensions;
+  /* Debug info representation to emit. */
+  LLVMSPIRVDebugInfoVersion DebugInfoVersion;
+} LLVMSPIRVTranslateOptions;
+
+/* Translate a module (bitcode or textual IR, `Length` bytes at `Bitcode`,
+ * targeting spir64/spir-unknown-unknown as its own triple says) to a SPIR-V
+ * binary. Bitcode from any LLVM older than the one embedded is auto-upgraded
+ * on load. On success returns 0 and sets `*OutSPIRV`; on failure returns
+ * nonzero and sets `*OutMessage`. A fatal LLVM error (`report_fatal_error`)
+ * is reported the same way and leaves the library usable, at the cost of
+ * leaking that call's state. */
+LLVMSPIRV_API int LLVMSPIRVTranslate(const char *Bitcode, size_t Length,
+                                     const LLVMSPIRVTranslateOptions *Options,
+                                     LLVMSPIRVMemoryBufferRef *OutSPIRV,
+                                     char **OutMessage);
+
+/* Queries. Lists are owned by the library, valid for its lifetime. */
+LLVMSPIRV_API const char **LLVMSPIRVGetExtensions(size_t *Count);
+LLVMSPIRV_API void LLVMSPIRVGetLLVMVersion(unsigned *Major, unsigned *Minor,
+                                           unsigned *Patch);
+
+/* Memory management. */
+LLVMSPIRV_API const char *LLVMSPIRVGetBufferStart(LLVMSPIRVMemoryBufferRef Buffer);
+LLVMSPIRV_API size_t LLVMSPIRVGetBufferSize(LLVMSPIRVMemoryBufferRef Buffer);
+LLVMSPIRV_API void LLVMSPIRVDisposeMemoryBuffer(LLVMSPIRVMemoryBufferRef Buffer);
+LLVMSPIRV_API void LLVMSPIRVDisposeMessage(char *Message);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBLLVM_SPIRV_H */

--- a/S/SPIRV_LLVM_Translator/bundled/phi-duplicate-predecessors.patch
+++ b/S/SPIRV_LLVM_Translator/bundled/phi-duplicate-predecessors.patch
@@ -1,8 +1,8 @@
 diff --git a/lib/SPIRV/SPIRVWriter.cpp b/lib/SPIRV/SPIRVWriter.cpp
-index a3bcaf97..3363a13f 100644
+index d2b564a6..9dfe6bb0 100644
 --- a/lib/SPIRV/SPIRVWriter.cpp
 +++ b/lib/SPIRV/SPIRVWriter.cpp
-@@ -2551,8 +2551,16 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
+@@ -2650,8 +2650,16 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                                     FuncTransMode::Pointer);
        if (Val->getType() != Ty)
          Val = BM->addUnaryInst(OpBitcast, Ty, Val, BB);


### PR DESCRIPTION
Same design as the back-end JLLs (#14727): one shared library, `libllvm_spirv`, with a typed C API (bundled/libllvm_spirv.h) over a statically linked, symbol-hidden build of the Khronos translator, replacing the `llvm-spirv` executable. LLVMSPIRVTranslate maps directly onto SPIRV::TranslatorOpts (maximum SPIR-V version, extension list in the --spirv-ext syntax, debug info representation, with the same side-effects on non-semantic debug info as the tool) and calls writeSpirv on an in-memory module. LLVMSPIRVGetExtensions lists the extensions the translator knows; unknown names are an error.

The recipe builds only the static LLVMSPIRVLib with CMake and links the API translation unit over it and LLVM_full_jll's component archives.

Moves to the translator's v23.1.1 over LLVM_full_jll 23.1.1+0, so the version becomes 23.1.1 and keeps tracking LLVM like the back-ends. The PHI duplicate-predecessor patch is still needed and was refreshed; the macOS SDK goes to 11.0, as LLVM 23's headers need it.