### PR TITLE
[MUMPS] macOS: link with -commons,use_dylibs so MPICH recognizes MPI_IN_PLACE / MPI_STATUS_IGNORE / MPI_BOTTOM

### DIFF
--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -71,15 +71,7 @@ if [[ "${target}" == *x86_64-w64-mingw* ]]; then
     EXTRA_LDFLAGS+=("-Wl,--disable-runtime-pseudo-reloc")
 fi
 if [[ "${target}" == *-apple-* ]]; then
-    # MPICH's Fortran sentinels (MPI_IN_PLACE, MPI_BOTTOM, MPI_STATUS_IGNORE, ...) are
-    # members of COMMON blocks (/MPIPRIV1/ etc.) that every Fortran object including
-    # mpif.h defines, and libmpifort recognizes them by address.  With macOS' two-level
-    # namespace each dylib keeps its own copy of these commons, so the sentinels MUMPS
-    # passes are never recognized by MPICH: every multi-rank run corrupts memory
-    # (SIGBUS/SIGSEGV in the solve phase, garbage from MPI_IN_PLACE reductions, ParMETIS
-    # "empty subgraph").  MPICH's own `mpifort` wrapper links with -commons,use_dylibs on
-    # Darwin for exactly this reason; we link with $FC -lmpifort directly, so add it here
-    # (the linker then resolves the commons against libmpifort's definitions).
+    # let MPICH's Fortran sentinel COMMON blocks resolve to libmpifort's copies
     EXTRA_LDFLAGS+=("-Wl,-commons,use_dylibs")
 fi
 

--- a/M/MUMPS/MUMPS@5/build_tarballs.jl
+++ b/M/MUMPS/MUMPS@5/build_tarballs.jl
@@ -5,7 +5,7 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "MUMPS"
 version = v"5.9.1"
-ygg_version = v"5.9.2"
+ygg_version = v"5.9.3"
 
 sources = [
   ArchiveSource("https://mumps-solver.org/MUMPS_$(version).tar.gz",
@@ -69,6 +69,18 @@ if [[ "${target}" == *x86_64-w64-mingw* ]]; then
     # pseudo-relocs fixes the crash and keeps ASLR fully enabled. (The link would
     # fail here if any such data import genuinely needed a runtime fixup.)
     EXTRA_LDFLAGS+=("-Wl,--disable-runtime-pseudo-reloc")
+fi
+if [[ "${target}" == *-apple-* ]]; then
+    # MPICH's Fortran sentinels (MPI_IN_PLACE, MPI_BOTTOM, MPI_STATUS_IGNORE, ...) are
+    # members of COMMON blocks (/MPIPRIV1/ etc.) that every Fortran object including
+    # mpif.h defines, and libmpifort recognizes them by address.  With macOS' two-level
+    # namespace each dylib keeps its own copy of these commons, so the sentinels MUMPS
+    # passes are never recognized by MPICH: every multi-rank run corrupts memory
+    # (SIGBUS/SIGSEGV in the solve phase, garbage from MPI_IN_PLACE reductions, ParMETIS
+    # "empty subgraph").  MPICH's own `mpifort` wrapper links with -commons,use_dylibs on
+    # Darwin for exactly this reason; we link with $FC -lmpifort directly, so add it here
+    # (the linker then resolves the commons against libmpifort's definitions).
+    EXTRA_LDFLAGS+=("-Wl,-commons,use_dylibs")
 fi
 
 # Override MPItrampoline's built-in compiler paths


### PR DESCRIPTION

On macOS every multi-rank MUMPS run built against MPICH_jll crashes (SIGBUS/SIGSEGV in the solve phase, garbage from `MPI_IN_PLACE` reductions, ParMETIS `Internal error empty subgraph`); 1-rank runs, Linux and the `+mpiabi` build are fine.

**Cause.** MPICH keeps the Fortran sentinels (`MPI_IN_PLACE`, `MPI_BOTTOM`, `MPI_STATUS_IGNORE`, ...) in COMMON blocks that every Fortran object including `mpif.h` defines, and libmpifort recognizes them by address. With macOS' two-level namespace `libdmumpspar.dylib` keeps its own copy of those commons (`nm` shows `_mpipriv1_` etc. *defined* in it), so the addresses MUMPS passes are never recognized.

**Fix.** Link with `-Wl,-commons,use_dylibs` on Apple targets -- exactly what MPICH's own `mpifort` wrapper does on Darwin; the recipe links `$FC -lmpifort` directly and never got it. After the rebuild the commons are undefined in all MUMPS dylibs and PETSc_jll's parallel MUMPS tests pass on native x86_64 and arm64 macOS. Bumps `ygg_version` to 5.9.3.

<details>
<summary>Evidence and details</summary>

- `nm -m` on the 5.9.2 tarballs: `libdmumpspar.dylib` (aarch64 and x86_64 `+mpich`) defines `_mpipriv1_ _mpipriv2_
  _mpiprivc_ _mpifcmb5_ _mpifcmb9_ _mpifcmba_`; `libmpifort.12.dylib` defines them too; PETSc_jll's `libpetsc_*.dylib`
  (linked through the `mpifort` wrapper) has them undefined; the `+mpiabi` MUMPS build has none.
- MPICH_jll `bin/mpifort` for macOS: `final_ldflags="  -Wl,-commons,use_dylibs"`.
- Before, with https://github.com/boriskaus/test_PETSc_jll (PETSc_jll 3.25.4; MUMPS with METIS/ParMETIS orderings,
  fieldsplit, 2-4 ranks, Int32/Int64): https://github.com/boriskaus/test_PETSc_jll/actions/runs/34616593035 --
  `macos-15-intel` 11/46 testsets error, `macos-14` arm64 10/46, all multi-rank MUMPS (plus one unrelated SuperLU_DIST case).
- After, with this build: https://github.com/boriskaus/test_PETSc_jll/actions/runs/34625783762 (both native runners pass every
  MUMPS testset) and https://github.com/boriskaus/test_PETSc_jll/actions/runs/34626827080 (fully green on Linux, Windows,
  native x86_64 and arm64 macOS); a native M4 MacBook gives the same result.
- `-mat_mumps_icntl_20 0` (centralized RHS, no sentinels on that path) was the workaround that pointed at the cause.
- Same exposure in other recipes linking `-lmpifort` directly: `V/VMEC`, `T/TDEP` (`M/MUMPS/MUMPS64@5` uses the `mpifort`
  wrapper; `S/SCALAPACK/*` dylibs have no such commons since BLACS is C). Precedent for the flag: `M/MPItrampoline`,
  `A/AMReX`, `P/p3a`, `T/TauDEM`.
</details>

---
🤖 **This PR -- the analysis, the fix, its verification and this text -- was created by Claude Fable 5.1 (Anthropic) running
in Claude Code, directed and reviewed by @boriskaus, who stands behind the conclusions.**
🤖 Generated with [Claude Code](https://claude.com/claude-code)
