### PR TITLE
[TetGen] Windows: link libstdc++/libgcc statically to fix the load-time abort

### DIFF
--- a/T/TetGen/TetGen@1.5/build_tarballs.jl
+++ b/T/TetGen/TetGen@1.5/build_tarballs.jl
@@ -49,11 +49,16 @@ sed -e "s/class tetgenio {/class tetgenio { void * operator new(size_t n) {  ret
 mv tetgen.cxx tmp.cxx
 sed -e "s/tetrahedrons->items \* 10/(tetrahedrons->items + 100) * 10/g" tmp.cxx > tetgen.cxx
 
-# Compile and link together with C wrapper
 ${CXX} -c -fPIC -std=c++11 -O3 -c -DTETLIBRARY -I. ${WORKSPACE}/srcdir/cwrapper/cwrapper.cxx -o cwrapper.o
 ${CXX} -c -fPIC -std=c++11 -O3 -c -DTETLIBRARY tetgen.cxx -o tetgen.o
 ${CXX} -c -fPIC -std=c++11 -O3 -c -DTETLIBRARY predicates.cxx -o predicates.o
-${CXX} $LDFLAGS -shared -fPIC tetgen.o predicates.o  cwrapper.o -o ${libdir}/libtet.${dlext}
+# Compile and link together with C wrapper
+EXTRA_LDFLAGS=()
+if [[ "${target}" == x86_64-w64-mingw32 ]]; then
+    # Avoid the 32-bit runtime pseudo-relocation into libstdc++-6.dll that aborts at load.
+    EXTRA_LDFLAGS+=(-static-libstdc++ -static-libgcc)
+fi
+${CXX} $LDFLAGS "${EXTRA_LDFLAGS[@]}" -shared -fPIC tetgen.o predicates.o  cwrapper.o -o ${libdir}/libtet.${dlext}
 
 install_license LICENSE
 """
@@ -63,6 +68,8 @@ platforms = supported_platforms()
 products = [
     LibraryProduct("libtet", :libtet)
 ]
-dependencies = Dependency[]
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
+]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.6")

--- a/T/TetGen/TetGen@1.6/build_tarballs.jl
+++ b/T/TetGen/TetGen@1.6/build_tarballs.jl
@@ -34,11 +34,16 @@ sed -e "s/class tetgenio {/class tetgenio { void * operator new(size_t n) {  ret
 mv tetgen.cxx tmp.cxx
 sed -e "s/tetrahedrons->items \* 10/(tetrahedrons->items + 100) * 10/g" tmp.cxx > tetgen.cxx
 
-# Compile and link together with C wrapper
 ${CXX} -c -fPIC -std=c++11 -O3 -c -DTETLIBRARY -I. ${WORKSPACE}/srcdir/cwrapper/cwrapper.cxx -o cwrapper.o
 ${CXX} -c -fPIC -std=c++11 -O3 -c -DTETLIBRARY tetgen.cxx -o tetgen.o
 ${CXX} -c -fPIC -std=c++11 -O3 -c -DTETLIBRARY predicates.cxx -o predicates.o
-${CXX} $LDFLAGS -shared -fPIC tetgen.o predicates.o cwrapper.o -o ${libdir}/libtet.${dlext}
+# Compile and link together with C wrapper
+EXTRA_LDFLAGS=()
+if [[ "${target}" == x86_64-w64-mingw32 ]]; then
+    # Avoid the 32-bit runtime pseudo-relocation into libstdc++-6.dll that aborts at load.
+    EXTRA_LDFLAGS+=(-static-libstdc++ -static-libgcc)
+fi
+${CXX} $LDFLAGS "${EXTRA_LDFLAGS[@]}" -shared -fPIC tetgen.o predicates.o cwrapper.o -o ${libdir}/libtet.${dlext}
 
 install -Dm644 tetgen.h ${includedir}/tetgen.h
 
@@ -50,6 +55,8 @@ platforms = supported_platforms()
 products = [
     LibraryProduct("libtet", :libtet)
 ]
-dependencies = Dependency[]
+dependencies = [
+    Dependency("CompilerSupportLibraries_jll"),
+]
 
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies, julia_compat="1.6")


### PR DESCRIPTION
TetGen_jll 1.6.0+1 cannot be loaded on Windows x86_64:

    Mingw-w64 runtime failure:
    32 bit pseudo relocation at 000000006D6C13A4 out of range,
    targeting 00007FFDF97476B0, yielding the value 00007FFD8C086308

libtet.dll (ImageBase 0x6d6c0000) imports `typeinfo for int` (_ZTIi) from libstdc++-6.dll: TetGen reports errors with `throw 1;` and the C wrapper catches `int`.  That is a data import, which mingw resolves with a 32-bit runtime pseudo-relocation; when libstdc++-6.dll is mapped more than 2 GB away (high-entropy ASLR), the fixup overflows and the CRT aborts in DllMain, i.e. every `using TetGen_jll` (and every dependent, e.g. PETSc_jll >= 3.24.6) dies.  `-Wl,--disable-runtime-pseudo-reloc` (the fix used for MUMPS in #14380) fails to link here with
`undefined reference to 'unknown_iname'`, because the import genuinely needs the runtime fixup.

Link libstdc++ and libgcc statically on x86_64-w64-mingw32 instead: the DLL then imports only KERNEL32, msvcrt and libwinpthread-1, and there is no cross-DLL data reference left.  Declare CompilerSupportLibraries_jll, which the library already needed for libstdc++ on every platform and now for libwinpthread on Windows.

Verified with such a rebuild (deployed as 1.6.0+2 on a fork) in https://github.com/boriskaus/test_PETSc_jll/actions/runs/34616126474: `using PETSc_jll` loads and its Windows tests pass on Julia 1.12, 1.13 and nightly, where the registered 1.6.0+1 aborted.