### PR TITLE
[METIS] Give each integer/real-width variant its own ELF symbol version

### DIFF
--- a/M/METIS/METIS@5/build_tarballs.jl
+++ b/M/METIS/METIS@5/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "METIS"
-version = v"5.1.3" # <-- This is a lie, we're bumping to 5.1.1 to create a Julia v1.6+ release with experimental platforms
+version = v"5.1.4" # <-- This is a lie (upstream is 5.1.0/5.1.1): 5.1.4 = per-variant ELF symbol versions, so that consumers can pin it
 
 # Collection of sources required to build METIS
 sources = [
@@ -30,6 +30,20 @@ build_metis()
 {
     METIS_PREFIX=${4:-${libdir}/metis/${1}}
     mkdir -p ${METIS_PREFIX}
+    # All four variants export the same symbol names (METIS_*, libmetis__*, gk_*).  On ELF
+    # the dynamic linker resolves a name once per process, so two variants loaded together
+    # (e.g. libmetis via MUMPS and libmetis_Int64_Real32 via SuperLU_DIST's Int64 library)
+    # silently share one implementation and corrupt memory.  Give each variant its own
+    # symbol version node: consumers linked against it carry versioned references that
+    # cannot bind to another variant, while dlsym() by name keeps working (default
+    # versions).  macOS (two-level namespace) and Windows (imports bound to a DLL name)
+    # do not have this problem and have no symbol versioning, so ELF targets only.
+    LINKER_FLAGS=""
+    if [[ "${target}" != *-apple-* && "${target}" != *-mingw* ]]; then
+        VERSION_NODE=$(echo "${1}" | tr '[:lower:]' '[:upper:]')
+        echo "${VERSION_NODE} { global: *; };" > ${WORKSPACE}/srcdir/${1}.map
+        LINKER_FLAGS="-Wl,--version-script=${WORKSPACE}/srcdir/${1}.map"
+    fi
     cmake $WORKSPACE/srcdir/METIS/ \
         -DCMAKE_INSTALL_PREFIX=${METIS_PREFIX} \
         -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \
@@ -37,6 +51,7 @@ build_metis()
         -DGKLIB_PATH=$WORKSPACE/srcdir/METIS/GKlib \
         -DSHARED=1 \
         -DCMAKE_C_FLAGS="-DIDXTYPEWIDTH=${2} -DREALTYPEWIDTH=${3}" \
+        -DCMAKE_SHARED_LINKER_FLAGS="${LINKER_FLAGS}" \
         -DBINARY_NAME="${1}"
     make -j${nproc} install
 }
@@ -68,4 +83,4 @@ dependencies = Dependency[]
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
 
-# Build trigger: 2
+# Build trigger: 3 (symbol versions per variant)

--- a/M/METIS/METIS@5/build_tarballs.jl
+++ b/M/METIS/METIS@5/build_tarballs.jl
@@ -44,6 +44,12 @@ build_metis()
         echo "${VERSION_NODE} { global: *; };" > ${WORKSPACE}/srcdir/${1}.map
         LINKER_FLAGS="-Wl,--version-script=${WORKSPACE}/srcdir/${1}.map"
     fi
+    if [[ "${target}" == *-freebsd* ]]; then
+        # GKlib's error.c calls backtrace(), which FreeBSD keeps in libexecinfo rather
+        # than libc.  Without it libmetis.so carries unresolved references and lld
+        # refuses to link the METIS programs against it (--no-allow-shlib-undefined).
+        LINKER_FLAGS="${LINKER_FLAGS} -lexecinfo"
+    fi
     cmake $WORKSPACE/srcdir/METIS/ \
         -DCMAKE_INSTALL_PREFIX=${METIS_PREFIX} \
         -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TARGET_TOOLCHAIN}" \

--- a/M/METIS/METIS@5/build_tarballs.jl
+++ b/M/METIS/METIS@5/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "METIS"
-version = v"5.1.4" # <-- This is a lie (upstream is 5.1.0/5.1.1): 5.1.4 = per-variant ELF symbol versions, so that consumers can pin it
+version = v"5.1.4" # <-- This is a lie: upstream is 5.1.0, bumped for the per-variant ELF symbol versions
 
 # Collection of sources required to build METIS
 sources = [
@@ -30,14 +30,7 @@ build_metis()
 {
     METIS_PREFIX=${4:-${libdir}/metis/${1}}
     mkdir -p ${METIS_PREFIX}
-    # All four variants export the same symbol names (METIS_*, libmetis__*, gk_*).  On ELF
-    # the dynamic linker resolves a name once per process, so two variants loaded together
-    # (e.g. libmetis via MUMPS and libmetis_Int64_Real32 via SuperLU_DIST's Int64 library)
-    # silently share one implementation and corrupt memory.  Give each variant its own
-    # symbol version node: consumers linked against it carry versioned references that
-    # cannot bind to another variant, while dlsym() by name keeps working (default
-    # versions).  macOS (two-level namespace) and Windows (imports bound to a DLL name)
-    # do not have this problem and have no symbol versioning, so ELF targets only.
+    # one ELF symbol version per variant, so that two variants can coexist in a process
     LINKER_FLAGS=""
     if [[ "${target}" != *-apple-* && "${target}" != *-mingw* ]]; then
         VERSION_NODE=$(echo "${1}" | tr '[:lower:]' '[:upper:]')
@@ -45,9 +38,7 @@ build_metis()
         LINKER_FLAGS="-Wl,--version-script=${WORKSPACE}/srcdir/${1}.map"
     fi
     if [[ "${target}" == *-freebsd* ]]; then
-        # GKlib's error.c calls backtrace(), which FreeBSD keeps in libexecinfo rather
-        # than libc.  Without it libmetis.so carries unresolved references and lld
-        # refuses to link the METIS programs against it (--no-allow-shlib-undefined).
+        # backtrace() lives in libexecinfo on FreeBSD
         LINKER_FLAGS="${LINKER_FLAGS} -lexecinfo"
     fi
     cmake $WORKSPACE/srcdir/METIS/ \
@@ -89,4 +80,4 @@ dependencies = Dependency[]
 # Build the tarballs
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
 
-# Build trigger: 3 (symbol versions per variant)
+# Build trigger: 3


### PR DESCRIPTION
METIS_jll ships four builds of the same library (libmetis, libmetis_Int32_Real64, libmetis_Int64_Real32, libmetis_Int64_Real64) that export identical symbol names.  On ELF the dynamic linker resolves a name once per process, so as soon as two variants are loaded together -- e.g. libmetis through MUMPS_jll and libmetis_Int64_Real32 through SuperLU_DIST_jll's Int64 library, as in PETSc_jll's Int64 variants -- one consumer silently calls the other variant's METIS_NodeND with the wrong index width and corrupts the heap (PETSc_jll: every Int64 SuperLU_DIST factorization crashed or hung; a two-consumer test process dies with "malloc(): invalid size").

Link each variant with a version script (`METIS`, `METIS_INT32_REAL64`, `METIS_INT64_REAL32`, `METIS_INT64_REAL64`; `global: *`).  Consumers relinked against these libraries carry versioned references that cannot bind to another variant; dlsym() by name keeps working (default versions), so Metis.jl and consumers of the default libmetis are not affected.  macOS (two-level namespace) and Windows (imports bound to a DLL name) do not have the problem and get no version script.  Version bumped to 5.1.4 so that consumers can require the versioned build.

Verified on x86_64-linux-gnu: `METIS_NodeND@@METIS_INT64_REAL32` etc. in the built libraries, and two consumers of different index width loaded into one process now both run correctly (they abort with heap corruption against the current 5.1.3 build).

---
🤖 **This PR -- the analysis, the fix, its verification and this text -- was created by Claude Fable 5.1 (Anthropic) running in Claude Code, directed and reviewed by @boriskaus, who stands behind the conclusions.**
