### PR TITLE
[PARMETIS] Per-variant ELF symbol versions; require the versioned METIS_jll 5.1.4

### DIFF
--- a/P/PARMETIS/build_tarballs.jl
+++ b/P/PARMETIS/build_tarballs.jl
@@ -4,7 +4,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "PARMETIS"
-version = v"4.0.8" # <-- This is a lie, we're bumping to 4.0.8 since we are adding new dependencies and building all library versions.
+version = v"4.0.9" # <-- This is a lie: 4.0.9 = rebuild with per-variant ELF symbol versions against the versioned METIS_jll 5.1.4
 parmetis_version = v"4.0.3"
 
 # Collection of sources required to build PARMETIS.
@@ -54,6 +54,15 @@ build_parmetis()
         PARMETIS_NAME="par${METIS_NAME}"
         METIS_PATH="${libdir}/metis/${METIS_NAME}"
     fi
+    # The four ParMETIS variants export identical symbol names (ParMETIS_V3_*, libparmetis__*);
+    # like METIS_jll, give each its own ELF symbol version so that two variants can coexist in
+    # one process (see the comment in M/METIS/METIS@5).  ELF targets only.
+    LINKER_FLAGS=""
+    if [[ "${target}" != *-apple-* && "${target}" != *-mingw* ]]; then
+        VERSION_NODE=$(echo "${PARMETIS_NAME}" | tr '[:lower:]' '[:upper:]')
+        echo "${VERSION_NODE} { global: *; };" > ${WORKSPACE}/srcdir/${PARMETIS_NAME}.map
+        LINKER_FLAGS="-Wl,--version-script=${WORKSPACE}/srcdir/${PARMETIS_NAME}.map"
+    fi
     cmake .. \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
@@ -64,6 +73,7 @@ build_parmetis()
     -DMPI_INCLUDE_PATH="${prefix}/include" \
     -DMPI_LIBRARIES="${mpi_libraries}" \
     -DCMAKE_C_FLAGS="-DIDXTYPEWIDTH=${1} -DREALTYPEWIDTH=${2}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${LINKER_FLAGS}" \
     -DBINARY_NAME="${PARMETIS_NAME}" \
     -DMETIS_LIBRARY="${METIS_NAME}"
     
@@ -98,7 +108,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="METIS_jll", uuid="d00139f3-1899-568f-a2f0-47f597d42d70"); compat="5.1.3"),
+    Dependency(PackageSpec(name="METIS_jll", uuid="d00139f3-1899-568f-a2f0-47f597d42d70"); compat="5.1.4"),
 ]
 append!(dependencies, platform_dependencies)
 

--- a/P/PARMETIS/build_tarballs.jl
+++ b/P/PARMETIS/build_tarballs.jl
@@ -4,7 +4,7 @@ const YGGDRASIL_DIR = "../.."
 include(joinpath(YGGDRASIL_DIR, "platforms", "mpi.jl"))
 
 name = "PARMETIS"
-version = v"4.0.9" # <-- This is a lie: 4.0.9 = rebuild with per-variant ELF symbol versions against the versioned METIS_jll 5.1.4
+version = v"4.0.9" # <-- This is a lie: upstream is 4.0.3, bumped for the per-variant ELF symbol versions
 parmetis_version = v"4.0.3"
 
 # Collection of sources required to build PARMETIS.
@@ -54,9 +54,7 @@ build_parmetis()
         PARMETIS_NAME="par${METIS_NAME}"
         METIS_PATH="${libdir}/metis/${METIS_NAME}"
     fi
-    # The four ParMETIS variants export identical symbol names (ParMETIS_V3_*, libparmetis__*);
-    # like METIS_jll, give each its own ELF symbol version so that two variants can coexist in
-    # one process (see the comment in M/METIS/METIS@5).  ELF targets only.
+    # one ELF symbol version per variant, as in METIS_jll
     LINKER_FLAGS=""
     if [[ "${target}" != *-apple-* && "${target}" != *-mingw* ]]; then
         VERSION_NODE=$(echo "${PARMETIS_NAME}" | tr '[:lower:]' '[:upper:]')


### PR DESCRIPTION
Same defect and fix as METIS_jll: the four ParMETIS variants export identical symbol names (ParMETIS_V3_*, libparmetis__*), so two of them cannot coexist in one process on ELF.  Link each with its own version script (`PARMETIS`, `PARMETIS_INT32_REAL64`, ...); ELF targets only. Rebuilding against METIS_jll 5.1.4 also gives the ParMETIS libraries versioned references to the matching METIS variant.  Version 4.0.9.

*Depends on #14765: the recipe requires METIS_jll 5.1.4, so CI here only passes once that is registered.*

---
🤖 **This PR -- the analysis, the fix, its verification and this text -- was created by Claude Fable 5.1 (Anthropic) running in Claude Code, directed and reviewed by @boriskaus, who stands behind the conclusions.**
