### PR TITLE
[HYPRE64] Name the library libHYPRE64 at link time (fixes the Windows DLL name)

### DIFF
--- a/H/HYPRE/HYPRE64/build_tarballs.jl
+++ b/H/HYPRE/HYPRE64/build_tarballs.jl
@@ -25,6 +25,15 @@ sed -i '$i\
 #define hypre_F90_NAME_LAPACK(name,NAME) name##_64_\
 ' utilities/_hypre_fortran.h
 
+# Name the library libHYPRE64 at link time rather than renaming libHYPRE
+# afterwards: the ELF SONAME, the Mach-O install name and the PE export
+# directory name are all derived from the output name, and a DLL renamed
+# after linking keeps "libHYPRE.dll" in its export directory, so every
+# Windows consumer linked against it imports HYPRE_jll's 32-bit-integer
+# libHYPRE.dll at run time instead.
+sed -i '/^add_library(${PROJECT_NAME})$/a set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME HYPRE64)' CMakeLists.txt
+grep -q "OUTPUT_NAME HYPRE64" CMakeLists.txt
+
 if [[ "${target}" == *mingw* ]]; then
     LBT=(-lblastrampoline-5)
 else
@@ -62,19 +71,6 @@ cmake .. \
 make -j${nproc}
 make install
 
-cd ${libdir}
-old_files=$(ls libHYPRE.* 2>/dev/null || true)
-for f in $old_files; do
-    new=${f/libHYPRE/libHYPRE64}
-    if [ -L "$f" ]; then
-        tgt=$(readlink "$f")
-        rm -f "$f"
-        ln -sf "${tgt/libHYPRE/libHYPRE64}" "$new"
-    elif [ -f "$f" ]; then
-        mv -v "$f" "$new"
-    fi
-done
-
 # Move the headers into their own subdirectory: stock HYPRE_jll installs
 # the same header names (notably HYPRE_config.h, which records the
 # integer width) into ${includedir}, and the two packages must be
@@ -82,21 +78,6 @@ done
 # (e.g. PETSc).
 mkdir -p ${includedir}/HYPRE64
 mv ${includedir}/HYPRE*.h ${includedir}/HYPRE64/
-
-if [[ "${target}" == *apple* ]]; then
-    install_name_tool -id "@rpath/libHYPRE64.${dlext}" ${libdir}/libHYPRE64.${dlext}
-elif [[ "${target}" == *mingw* ]]; then
-    :
-else
-    real_lib=$(find ${libdir} -maxdepth 1 -name 'libHYPRE64.so.*' -not -type l | head -1)
-    if [ -n "$real_lib" ]; then
-        soname=$(patchelf --print-soname "$real_lib")
-        case "$soname" in
-            libHYPRE64.*) ;;
-            libHYPRE.*) patchelf --set-soname "${soname/libHYPRE/libHYPRE64}" "$real_lib" ;;
-        esac
-    fi
-fi
 """
 
 augment_platform_block = """


### PR DESCRIPTION
The HYPRE64 recipe builds `libHYPRE` and renames the files afterwards, patching the SONAME on Linux and the install name on macOS but leaving the Windows DLL alone. A DLL renamed after linking keeps `libHYPRE.dll` in its export directory, so every consumer linked against `libHYPRE64.dll` records an import of `libHYPRE.dll` and loads HYPRE_jll's 32-bit-integer library at run time. We ran into this while enabling hypre in PETSc_jll's Int64 variants on Windows (JuliaPackaging/Yggdrasil#13691):

```
$ objdump -p libHYPRE64.dll | grep '^Name'        # registered HYPRE64_jll 3.1.0+2, x86_64-w64-mingw32-mpi+microsoftmpi
Name                    00000000xxxxxxxx libHYPRE.dll
$ objdump -p libpetsc_double_real_Int64.dll | grep 'DLL Name'   # PETSc linked against it
        DLL Name: libHYPRE.dll
```

This PR sets the cmake `OUTPUT_NAME` of the target to `HYPRE64` before building, which gives all three platforms the right name directly, and drops the rename block (the `mv` loop, `patchelf --set-soname` and `install_name_tool -id`).

<details>
<summary>Verification (local BinaryBuilder builds of this recipe for three platforms)</summary>

| platform | registered 3.1.0+2 | this PR |
|---|---|---|
| x86_64-w64-mingw32-mpi+microsoftmpi | export-directory name `libHYPRE.dll`, import library `lib/libHYPRE.dll.a` | `libHYPRE64.dll`, `lib/libHYPRE64.dll.a`, 0 runtime pseudo-relocations |
| x86_64-linux-gnu-mpi+mpich | SONAME `libHYPRE64.so.301` (patched in) | `libHYPRE64.so.301` (native) |
| aarch64-apple-darwin-mpi+mpich | install name `@rpath/libHYPRE64.dylib` (patched in) | `@rpath/libHYPRE64.301.dylib` (native; `libHYPRE64.dylib` symlink still installed) |

The Linux SONAME is unchanged, so existing consumers keep working. On macOS the install name gains the SOVERSION, as cmake produces it; consumers built against the old `@rpath/libHYPRE64.dylib` still find that file through the symlink. The installed cmake package files (`lib/cmake/HYPRE/`) now point at `libHYPRE64.*` too; before they referenced `libHYPRE.*` files that the tarball did not contain.
</details>

---
🤖 **This PR -- the analysis, the fix, its verification and this text -- was created by Claude Fable 5.1 (Anthropic) running
in Claude Code, directed and reviewed by @boriskaus, who stands behind the conclusions.**
🤖 Generated with [Claude Code](https://claude.com/claude-code)
