### PR TITLE
[LV2Host] new recipe v1.0.0

### DIFF
--- a/L/LV2Host/build_tarballs.jl
+++ b/L/LV2Host/build_tarballs.jl
@@ -1,0 +1,59 @@
+# Note that this script can accept some limited command-line arguments, run
+# `julia build_tarballs.jl --help` to see a usage message.
+using BinaryBuilder
+
+# The headless LV2 host from AudioPlugins.jl (https://github.com/SciML/AudioPlugins.jl):
+# one C translation unit, `csrc/lv2_host.c`, exposing a C ABI of scalar doubles
+# for hosting LV2 audio plugins. It is the LV2 counterpart of CLAPHost_jll.
+#
+# Unlike CLAP, LV2 describes a plugin's ports in Turtle manifests next to the
+# binary rather than in the binary, so this needs a manifest reader: lilv, which
+# brings serd, sord, sratom and zix. `lv2_jll` supplies both the LV2 headers
+# (lilv-0.pc has `Requires: lv2`) and, at run time, the LV2 specification
+# bundles under `lib/lv2` that lilv needs to classify ports.
+name = "LV2Host"
+version = v"1.0.0"
+
+# Collection of sources required to complete build
+sources = [
+    GitSource("https://github.com/SciML/AudioPlugins.jl.git",
+              "54f3cfd011edc33c71b702d888a2d6fab056e331"),  # v1.1.2 (registered)
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/AudioPlugins.jl
+install_license LICENSE csrc/vendor/LV2-ISC-LICENSE
+
+# On FreeBSD the meson-built JLLs (Lilv, Zix, Serd, lv2, Sord, ...) ship their
+# pkg-config files in libdata/pkgconfig, which is not on the default search path.
+export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}${prefix}/libdata/pkgconfig"
+
+mkdir -p "${libdir}" "${includedir}"
+# No -Icsrc/vendor here: the vendored LV2 headers are for a standalone build
+# that has only lilv. `pkg-config --cflags lilv-0` pulls in lv2_jll's copy, and
+# lilv.h and lv2_host.c must resolve <lv2/core/lv2.h> to the same one.
+${CC} -std=gnu99 -O2 -fPIC -shared -Wall -Wextra \
+    -o "${libdir}/liblv2_host.${dlext}" csrc/lv2_host.c \
+    $(pkg-config --cflags --libs lilv-0) -lm
+install -Dm644 csrc/lv2_host.h "${includedir}/lv2_host.h"
+"""
+
+# Lilv_jll 0.28.0 builds for every one of these 18 triplets, so there is
+# nothing to filter out.
+platforms = supported_platforms()
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("liblv2_host", :liblv2_host),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+    Dependency("Lilv_jll"; compat="0.28.0"),
+    Dependency("lv2_jll"),
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies;
+               julia_compat="1.10")


### PR DESCRIPTION
New recipe for `LV2Host_jll`: the headless LV2 host from
[AudioPlugins.jl](https://github.com/SciML/AudioPlugins.jl), one C translation
unit (`csrc/lv2_host.c`, MIT) compiled against lilv. It is the LV2 counterpart
of [`CLAPHost_jll`](https://github.com/JuliaPackaging/Yggdrasil/blob/master/C/CLAPHost/build_tarballs.jl)
and follows that recipe's shape: a `GitSource` at a pinned commit, one `${CC}`
invocation, `supported_platforms()`.

Source is pinned at `54f3cfd011edc33c71b702d888a2d6fab056e331`, AudioPlugins.jl
v1.1.2 as registered.

Dependencies are `Lilv_jll` and `lv2_jll`. `lv2_jll` is not only there for the
headers — `lilv-0.pc` carries `Requires: lv2`, so `pkg-config` needs it to
resolve at all, and lilv wants the LV2 specification bundles at run time.

The script does **not** pass `-Icsrc/vendor`. The repository vendors three LV2
headers so that a standalone build only has to find lilv, but here `lilv.h`
(which includes `<lv2/core/lv2.h>` itself) and `lv2_host.c` must resolve that
header to the same copy, and `pkg-config --cflags lilv-0` supplies `lv2_jll`'s.

## Verification

Built locally with this repository's `Project.toml` on Julia 1.12.7, in
BinaryBuilder's unprivileged-container sandbox.

All 18 platforms, no filtering and no audit warnings:

```
$ ls products/ | grep -v logs | grep tar.gz | sed 's/LV2Host.v1.0.0.//;s/.tar.gz//'
aarch64-apple-darwin        aarch64-linux-gnu       aarch64-linux-musl
aarch64-unknown-freebsd     armv6l-linux-gnueabihf  armv6l-linux-musleabihf
armv7l-linux-gnueabihf      armv7l-linux-musleabihf i686-linux-gnu
i686-linux-musl             i686-w64-mingw32        powerpc64le-linux-gnu
riscv64-linux-gnu           x86_64-apple-darwin     x86_64-linux-gnu
x86_64-linux-musl           x86_64-unknown-freebsd  x86_64-w64-mingw32
```

`platforms = supported_platforms()` is unfiltered because `Lilv_jll` v0.28.0
itself ships all 18 — its `Artifacts.toml` has exactly the same triplet set, so
there is no intersection to take.

The x86_64-linux-gnu tarball:

```
$ tar tzf LV2Host.v1.0.0.x86_64-linux-gnu.tar.gz
include/lv2_host.h
lib/liblv2_host.so
share/licenses/LV2Host/LICENSE
share/licenses/LV2Host/LV2-ISC-LICENSE

$ readelf -d lib/liblv2_host.so | grep NEEDED
 (NEEDED)  Shared library: [liblilv-0.so.0]
 (NEEDED)  Shared library: [libm.so.6]
 (NEEDED)  Shared library: [libc.so.6]
```

and the Windows one links the import library correctly, which is the case worth
checking by hand given lilv's `libfoo-0` naming:

```
$ objdump -p bin/liblv2_host.dll | grep 'DLL Name'
	DLL Name: KERNEL32.dll
	DLL Name: msvcrt.dll
	DLL Name: liblilv-0.dll
```

The product was then exercised, not merely dlopened: the x86_64-linux-gnu build
was deployed locally (`--deploy=local`), `Pkg.develop`ed into a scratch
environment next to AudioPlugins.jl, and the package's LV2 host test suite run
against it — 82 passed, 0 failed, hosting three LV2 plugins built from the
package's own sources (scan, open, port and parameter discovery from the Turtle
manifests, block processing arithmetic, reported latency, state across blocks).

I did not verify anything at run time on the other 17 platforms; only this
machine's x86_64-linux-gnu build was loaded and run.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01F2unayESuKijcX1jwtj16q
